### PR TITLE
Prefilter review-source exports by quote grade

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -162,6 +162,10 @@ the list above in its plan doc.
 The review-source readiness and Postgres smoke closeouts do not create a new
 active Content Ops implementation backlog. G2 can use the existing exporter,
 source-row import, DB-backed draft persistence, and draft export path.
-Capterra and TrustRadius have quote-grade inventory but have not yet been run
-through the Postgres smoke. Trustpilot is blocked on data quality, not
-extractor code.
+Capterra and TrustRadius now also pass the Postgres smoke. The TrustRadius run
+surfaced and closed a row-export gap: summary counts found 31 quote-grade rows
+while the row exporter returned 0 because quote-grade filtering happened after
+the first urgency/date scan window. The row exporter now applies the same
+quote-grade predicate in SQL before ordering/paging, and a live TrustRadius
+run imported 1 BambooHR review source row and persisted 2 offline deterministic
+drafts. Trustpilot is blocked on data quality, not extractor code.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T01:38Z by codex-2026-05-18
+Last updated: 2026-05-19T01:52Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| pending | Content Ops review-source quote-grade row prefilter | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `extracted_content_pipeline/STATUS.md`, `plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md` | codex-2026-05-18 | Avoid editing the review-source exporter SQL row query or review-source readiness/backlog docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-19T01:38Z by codex-2026-05-18
+Last updated: 2026-05-19T01:52Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #598 | — | Review-source G2 path is live-proven through export, source-row import, DB-backed offline draft persistence, and draft export. Next Content Ops work should come from a real host export fixture or a concrete live provider/run gap. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #599 | pending | Align review-source row export with summary quote-grade filtering; Capterra and TrustRadius now pass local Postgres smoke after the exporter fix. | `scripts/export_content_ops_review_sources.py` |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -94,7 +94,9 @@ source of truth for what remains.
 - `scripts/export_content_ops_review_sources.py --source-summary` reports
   canonical, enriched, export-candidate, and quote-grade row counts for
   scraped review sources before operators choose a source for Content Ops
-  ingestion.
+  ingestion. The source-row export query applies the same quote-grade
+  predicate as the summary so lower-ranked sources such as TrustRadius are not
+  skipped when the first scan window has no eligible phrases.
 - `scripts/smoke_content_ops_review_source_generation.py` runs the live
   review-source readiness/export path through source-row ingestion inspection
   and offline campaign draft generation, so operators can prove a source such

--- a/plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md
+++ b/plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md
@@ -1,0 +1,66 @@
+# PR-Content-Ops-Review-Source-Quote-Grade-Prefilter
+
+## Why this slice exists
+
+After #599, Capterra passed the review-source Postgres smoke, but TrustRadius
+did not. The source summary reported 31 quote-grade TrustRadius rows, while
+the source-row exporter returned 0 rows. The mismatch is in the exporter:
+`fetch_review_source_rows()` reads a small urgency/date window and only then
+applies quote-grade phrase filtering in Python, so eligible lower-ranked rows
+can be missed.
+
+## Scope (this PR)
+
+- Add the same quote-grade phrase predicate used by source summary to the
+  row-export SQL query.
+- Keep the existing Python quote-grade conversion as a defensive second gate.
+- Update row-query tests for vendor-scoped and source-wide exports.
+- Record the Capterra pass and TrustRadius gap in status/backlog docs.
+
+### Files touched
+
+- `scripts/export_content_ops_review_sources.py`
+- `tests/test_export_content_ops_review_sources.py`
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md`
+
+## Mechanism
+
+`build_review_source_query()` now accepts `allowed_polarities` and
+`allowed_fields`, appends those as SQL parameters, and adds an `EXISTS` clause
+over `enrichment->'phrase_metadata'` requiring subject-vendor, verbatim,
+allowed polarity, and allowed field. `fetch_review_source_rows()` passes
+through its existing phrase filter arguments.
+
+## Intentional
+
+- No change to summary semantics.
+- No change to generated draft behavior.
+- No removal of the Python quote-grade gate.
+- TrustRadius closeout is included because the fixed exporter was rerun live.
+
+## Deferred
+
+- Broader review-source ranking changes beyond quote-grade eligibility.
+- Trustpilot data re-enrichment.
+
+## Verification
+
+- Focused review-source exporter/Postgres smoke tests -> `21 passed`.
+- Python compile check for exporter script/tests -> passed.
+- Live Capterra Postgres smoke -> passed.
+- Live TrustRadius Postgres smoke -> passed after the SQL prefilter.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Exporter query | 35 |
+| Tests | 45 |
+| Docs/status | 25 |
+| Coordination and plan | 65 |
+| Total | 170 |

--- a/scripts/export_content_ops_review_sources.py
+++ b/scripts/export_content_ops_review_sources.py
@@ -212,6 +212,8 @@ def build_review_source_query(
     vendor_name: str | None,
     min_review_text_chars: int,
     require_review_url: bool,
+    allowed_polarities: Sequence[str] = DEFAULT_POLARITIES,
+    allowed_fields: Sequence[str] = DEFAULT_PHRASE_FIELDS,
 ) -> tuple[str, list[Any]]:
     """Build the read-only Atlas review query and parameter list."""
 
@@ -229,6 +231,35 @@ def build_review_source_query(
         where.append(f"LOWER(r.vendor_name) = LOWER(${len(args)})")
     if require_review_url:
         where.append("NULLIF(BTRIM(r.source_url), '') IS NOT NULL")
+    args.append([polarity.strip().lower() for polarity in allowed_polarities if polarity.strip()])
+    polarity_placeholder = f"${len(args)}"
+    args.append([field.strip() for field in allowed_fields if field.strip()])
+    field_placeholder = f"${len(args)}"
+    phrase_metadata_expr = """
+        CASE
+            WHEN jsonb_typeof(r.enrichment->'phrase_metadata') = 'array'
+            THEN r.enrichment->'phrase_metadata'
+            ELSE '[]'::jsonb
+        END
+    """
+    where.append(
+        f"""
+        EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements({phrase_metadata_expr}) pm
+            WHERE lower(BTRIM(pm->>'subject')) = 'subject_vendor'
+              AND pm->'verbatim' = 'true'::jsonb
+              AND (
+                  cardinality({polarity_placeholder}::text[]) = 0
+                  OR lower(BTRIM(pm->>'polarity')) = ANY({polarity_placeholder}::text[])
+              )
+              AND (
+                  cardinality({field_placeholder}::text[]) = 0
+                  OR BTRIM(pm->>'field') = ANY({field_placeholder}::text[])
+              )
+        )
+        """
+    )
     args.extend([0, 0])
     limit_placeholder = f"${len(args) - 1}"
     offset_placeholder = f"${len(args)}"
@@ -335,6 +366,8 @@ async def fetch_review_source_rows(
         vendor_name=vendor_name,
         min_review_text_chars=min_review_text_chars,
         require_review_url=require_review_url,
+        allowed_polarities=allowed_polarities,
+        allowed_fields=allowed_fields,
     )
     fetch_limit_index = len(args) - 2
     fetch_offset_index = len(args) - 1

--- a/tests/test_export_content_ops_review_sources.py
+++ b/tests/test_export_content_ops_review_sources.py
@@ -182,9 +182,52 @@ def test_build_review_source_query_filters_canonical_enriched_g2_rows() -> None:
     assert "length(r.review_text) >= $2" in query
     assert "LOWER(r.vendor_name) = LOWER($3)" in query
     assert "NULLIF(BTRIM(r.source_url), '') IS NOT NULL" in query
-    assert "LIMIT $4" in query
-    assert "OFFSET $5" in query
-    assert args == ["g2", 120, "HubSpot", 0, 0]
+    assert "jsonb_array_elements" in query
+    assert "lower(BTRIM(pm->>'subject')) = 'subject_vendor'" in query
+    assert "pm->'verbatim' = 'true'::jsonb" in query
+    assert "lower(BTRIM(pm->>'polarity')) = ANY($4::text[])" in query
+    assert "BTRIM(pm->>'field') = ANY($5::text[])" in query
+    assert "LIMIT $6" in query
+    assert "OFFSET $7" in query
+    assert args == [
+        "g2",
+        120,
+        "HubSpot",
+        ["negative", "mixed"],
+        [
+            "specific_complaints",
+            "pricing_phrases",
+            "feature_gaps",
+            "recommendation_language",
+        ],
+        0,
+        0,
+    ]
+
+
+def test_build_review_source_query_applies_quote_grade_filter_without_vendor() -> None:
+    query, args = mod.build_review_source_query(
+        source="trustradius",
+        vendor_name=None,
+        min_review_text_chars=80,
+        require_review_url=False,
+        allowed_polarities=("negative",),
+        allowed_fields=("specific_complaints",),
+    )
+
+    assert "LOWER(r.vendor_name)" not in query
+    assert "NULLIF(BTRIM(r.source_url), '') IS NOT NULL" not in query
+    assert "jsonb_array_elements" in query
+    assert "LIMIT $5" in query
+    assert "OFFSET $6" in query
+    assert args == [
+        "trustradius",
+        80,
+        ["negative"],
+        ["specific_complaints"],
+        0,
+        0,
+    ]
 
 
 def test_build_review_source_summary_query_counts_quote_grade_rows() -> None:
@@ -233,6 +276,7 @@ async def test_fetch_review_source_rows_dedupes_and_filters_after_fetch() -> Non
     assert "FROM b2b_reviews r" in query
     assert args[0] == "g2"
     assert args[-2:] == (6, 0)
+    assert args[-4:-2] == (["negative", "mixed"], list(mod.DEFAULT_PHRASE_FIELDS))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR-Content-Ops-Review-Source-Quote-Grade-Prefilter

## Why this slice exists

After #599, Capterra passed the review-source Postgres smoke, but TrustRadius
did not. The source summary reported 31 quote-grade TrustRadius rows, while
the source-row exporter returned 0 rows. The mismatch is in the exporter:
`fetch_review_source_rows()` reads a small urgency/date window and only then
applies quote-grade phrase filtering in Python, so eligible lower-ranked rows
can be missed.

## Scope (this PR)

- Add the same quote-grade phrase predicate used by source summary to the
  row-export SQL query.
- Keep the existing Python quote-grade conversion as a defensive second gate.
- Update row-query tests for vendor-scoped and source-wide exports.
- Record the Capterra pass and TrustRadius gap in status/backlog docs.

### Files touched

- `scripts/export_content_ops_review_sources.py`
- `tests/test_export_content_ops_review_sources.py`
- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
- `extracted_content_pipeline/STATUS.md`
- `plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md`

## Mechanism

`build_review_source_query()` now accepts `allowed_polarities` and
`allowed_fields`, appends those as SQL parameters, and adds an `EXISTS` clause
over `enrichment->'phrase_metadata'` requiring subject-vendor, verbatim,
allowed polarity, and allowed field. `fetch_review_source_rows()` passes
through its existing phrase filter arguments.

## Intentional

- No change to summary semantics.
- No change to generated draft behavior.
- No removal of the Python quote-grade gate.
- TrustRadius closeout is included because the fixed exporter was rerun live.

## Deferred

- Broader review-source ranking changes beyond quote-grade eligibility.
- Trustpilot data re-enrichment.

## Verification

- Focused review-source exporter/Postgres smoke tests -> `21 passed`.
- Python compile check for exporter script/tests -> passed.
- Live Capterra Postgres smoke -> passed.
- Live TrustRadius Postgres smoke -> passed after the SQL prefilter.
- `git diff --check` -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Exporter query | 35 |
| Tests | 45 |
| Docs/status | 25 |
| Coordination and plan | 65 |
| Total | 170 |
