### PR TITLE
Close out review-source prefilter slice

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T01:52Z by codex-2026-05-18
+Last updated: 2026-05-19T02:00Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| pending | Content Ops review-source quote-grade row prefilter | `scripts/export_content_ops_review_sources.py`, `tests/test_export_content_ops_review_sources.py`, `docs/extraction/coordination/inflight.md`, `docs/extraction/coordination/state.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `extracted_content_pipeline/STATUS.md`, `plans/PR-Content-Ops-Review-Source-Quote-Grade-Prefilter.md` | codex-2026-05-18 | Avoid editing the review-source exporter SQL row query or review-source readiness/backlog docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-19T01:52Z by codex-2026-05-18
+Last updated: 2026-05-19T02:00Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #599 | pending | Align review-source row export with summary quote-grade filtering; Capterra and TrustRadius now pass local Postgres smoke after the exporter fix. | `scripts/export_content_ops_review_sources.py` |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #601 | — | Review-source G2, Capterra, and TrustRadius paths are live-proven through source export, source-row import, DB-backed offline draft persistence, and draft export-ready rows. Next Content Ops work should come from a real host export fixture, live provider run gap, or the separate reasoning-core productization track. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/plans/PR-Content-Ops-Review-Source-Prefilter-Closeout.md
+++ b/plans/PR-Content-Ops-Review-Source-Prefilter-Closeout.md
@@ -1,0 +1,50 @@
+# PR-Content-Ops-Review-Source-Prefilter-Closeout
+
+## Why this slice exists
+
+PR #601 closed the review-source row-export mismatch that blocked TrustRadius
+from the Postgres smoke. The coordination docs still show that work as pending,
+so other sessions could avoid a stale hot zone.
+
+## Scope (this PR)
+
+- Remove the merged quote-grade prefilter row from the in-flight ledger.
+- Update Content Ops product state to point at #601.
+- Mark the review-source hot zone clear.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `plans/PR-Content-Ops-Review-Source-Prefilter-Closeout.md`
+
+## Mechanism
+
+Documentation and coordination only. The active backlog already records that
+G2, Capterra, and TrustRadius are live-proven through the review-source
+Postgres path, while Trustpilot remains data-quality blocked.
+
+## Intentional
+
+- No code changes.
+- No new Content Ops implementation backlog item.
+- No change to review-source readiness policy.
+
+## Deferred
+
+- Trustpilot v4 phrase-metadata re-enrichment.
+- Any new source adapter work until a real host export fixture appears.
+- Live provider generation over imported review-source rows.
+
+## Verification
+
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh --allow-dirty` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination docs | 7 |
+| Plan | 50 |
+| Total | 57 |


### PR DESCRIPTION
# PR-Content-Ops-Review-Source-Prefilter-Closeout

## Why this slice exists

PR #601 closed the review-source row-export mismatch that blocked TrustRadius
from the Postgres smoke. The coordination docs still show that work as pending,
so other sessions could avoid a stale hot zone.

## Scope (this PR)

- Remove the merged quote-grade prefilter row from the in-flight ledger.
- Update Content Ops product state to point at #601.
- Mark the review-source hot zone clear.

### Files touched

- `docs/extraction/coordination/inflight.md`
- `docs/extraction/coordination/state.md`
- `plans/PR-Content-Ops-Review-Source-Prefilter-Closeout.md`

## Mechanism

Documentation and coordination only. The active backlog already records that
G2, Capterra, and TrustRadius are live-proven through the review-source
Postgres path, while Trustpilot remains data-quality blocked.

## Intentional

- No code changes.
- No new Content Ops implementation backlog item.
- No change to review-source readiness policy.

## Deferred

- Trustpilot v4 phrase-metadata re-enrichment.
- Any new source adapter work until a real host export fixture appears.
- Live provider generation over imported review-source rows.

## Verification

- `git diff --check` -> passed.
- `scripts/local_pr_review.sh --allow-dirty` -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Coordination docs | 7 |
| Plan | 50 |
| Total | 57 |
