### PR TITLE
Expose extracted LLM service registry namespace

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,5 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-LLM-Registry-Service-Export | `extracted_llm_infrastructure/services/__init__.py`, `extracted_content_pipeline/campaign_llm_client.py`, `tests/test_extracted_llm_infrastructure_registry_export.py`, `tests/test_extracted_campaign_llm_client.py`, `plans/PR-LLM-Registry-Service-Export.md` | codex-2026-05-18 | extracted LLM namespace/package init work; content LLM adapter chat message normalization |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -6,6 +6,7 @@ import inspect
 import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 from .campaign_ports import LLMMessage, LLMResponse
@@ -141,7 +142,7 @@ class PipelineLLMClient:
     ) -> Any:
         if hasattr(llm, "chat"):
             return llm.chat(
-                messages,
+                _to_chat_messages(messages),
                 max_tokens=max_tokens,
                 temperature=temperature,
             )
@@ -191,6 +192,18 @@ def _messages_to_prompt(messages: Sequence[LLMMessage]) -> tuple[str | None, str
         else:
             prompt_parts.append(content)
     return "\n\n".join(system_parts) or None, "\n\n".join(prompt_parts)
+
+
+def _to_chat_messages(messages: Sequence[LLMMessage]) -> list[Any]:
+    return [
+        SimpleNamespace(
+            role=str(getattr(message, "role", "") or ""),
+            content=str(getattr(message, "content", "") or ""),
+            tool_calls=getattr(message, "tool_calls", None),
+            tool_call_id=getattr(message, "tool_call_id", None),
+        )
+        for message in messages
+    ]
 
 
 def _to_response(result: Any, *, llm: Any) -> LLMResponse:

--- a/extracted_llm_infrastructure/services/__init__.py
+++ b/extracted_llm_infrastructure/services/__init__.py
@@ -1,0 +1,10 @@
+"""Service namespace exports for the extracted LLM infrastructure package."""
+
+from __future__ import annotations
+
+from .registry import llm_registry, register_llm
+
+__all__ = [
+    "llm_registry",
+    "register_llm",
+]

--- a/plans/PR-LLM-Registry-Service-Export.md
+++ b/plans/PR-LLM-Registry-Service-Export.md
@@ -1,0 +1,91 @@
+# PR-LLM-Registry-Service-Export
+
+## Why this slice exists
+
+Live provider generation for imported review-source rows fails before saving
+provider-backed drafts because two adapter seams are incomplete:
+
+1. `extracted_llm_infrastructure.pipelines.llm` imports `llm_registry` from
+   `extracted_llm_infrastructure.services`, while the package namespace does
+   not re-export the registry bridge.
+2. After the registry seam is fixed, the OpenRouter backend receives extracted
+   `LLMMessage` objects that lack optional host-backend chat fields such as
+   `tool_calls`.
+
+Both failures happen before useful generation output. This slice exposes the
+existing registry bridge and normalizes extracted chat messages into the
+duck-typed shape expected by live LLM backends.
+
+## Scope (this PR)
+
+1. Re-export `llm_registry` and `register_llm` from
+   `extracted_llm_infrastructure.services`.
+2. Normalize `PipelineLLMClient` chat messages before provider `.chat()` calls.
+3. Add a regression test that the standalone pipeline resolver can traverse the
+   package-level registry import without Atlas.
+4. Add a regression test that chat-path messages include optional tool fields.
+
+### Files touched
+
+- `extracted_llm_infrastructure/services/__init__.py`
+- `extracted_content_pipeline/campaign_llm_client.py`
+- `tests/test_extracted_llm_infrastructure_registry_export.py`
+- `tests/test_extracted_campaign_llm_client.py`
+- `plans/PR-LLM-Registry-Service-Export.md`
+- `docs/extraction/coordination/inflight.md`
+
+## Mechanism
+
+`services.registry` already selects the Atlas-backed registry in repo mode and
+the local `_standalone.registry` implementation when
+`EXTRACTED_LLM_INFRA_STANDALONE=1`. The package `__init__` now imports and
+re-exports those two public names so existing package-level imports work:
+
+```python
+from .registry import llm_registry, register_llm
+```
+
+The regression test runs the `local_fast` resolver path in standalone mode with
+Ollama auto-activation disabled. That path exists only to return the active
+registry value, so the test catches the prior import failure without making any
+network or provider call.
+
+`PipelineLLMClient` now wraps extracted `LLMMessage` values in
+`SimpleNamespace(role, content, tool_calls, tool_call_id)` before calling
+provider `.chat()`. This mirrors the Atlas host bridge and keeps generated
+prompt fallback behavior unchanged.
+
+## Intentional
+
+- This PR does not change provider routing or activation behavior. It only
+  exposes the registry bridge at the namespace the resolver already uses.
+- This PR does not add tool-call support to extracted campaign generation. It
+  only supplies `None` defaults for optional fields that existing backends read.
+- The test disables local model activation so it remains a pure import/runtime
+  seam check.
+
+## Deferred
+
+- None. After merge, rerun live provider generation over the imported
+  review-source rows.
+
+## Verification
+
+To run before push:
+
+```bash
+pytest tests/test_extracted_llm_infrastructure_registry_export.py
+pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_llm_infrastructure_registry_export.py
+python -m py_compile extracted_llm_infrastructure/services/__init__.py extracted_content_pipeline/campaign_llm_client.py tests/test_extracted_llm_infrastructure_registry_export.py tests/test_extracted_campaign_llm_client.py
+bash scripts/local_pr_review.sh
+```
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Namespace export | ~10 |
+| Chat message normalization | ~15 |
+| Regression tests | ~75 |
+| Plan + coordination | ~110 |
+| **Total** | **~210** |

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -87,6 +87,24 @@ async def test_pipeline_llm_client_resolves_and_normalizes_chat_response():
 
 
 @pytest.mark.asyncio
+async def test_pipeline_llm_client_chat_messages_include_tool_fields():
+    llm = _ChatLLM()
+    client = PipelineLLMClient(resolver=lambda **_: llm)
+
+    await client.complete(
+        [LLMMessage(role="user", content="Write the email")],
+        max_tokens=200,
+        temperature=0.2,
+    )
+
+    message = llm.calls[0]["messages"][0]
+    assert message.role == "user"
+    assert message.content == "Write the email"
+    assert message.tool_calls is None
+    assert message.tool_call_id is None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_llm_client_accepts_async_chat_result():
     client = PipelineLLMClient(resolver=lambda **_: _AsyncChatLLM())
 

--- a/tests/test_extracted_llm_infrastructure_registry_export.py
+++ b/tests/test_extracted_llm_infrastructure_registry_export.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_LLM_INFRA_ENV_VAR = "EXTRACTED_LLM_INFRA_STANDALONE"
+
+
+def _drop_package_attr(package_name: str, attr_name: str) -> None:
+    package = sys.modules.get(package_name)
+    if package is not None and hasattr(package, attr_name):
+        delattr(package, attr_name)
+
+
+def _reset_modules() -> None:
+    for module_name in (
+        "extracted_llm_infrastructure._standalone.registry",
+        "extracted_llm_infrastructure.services",
+        "extracted_llm_infrastructure.services.registry",
+        "extracted_llm_infrastructure.pipelines.llm",
+        "atlas_brain.services.registry",
+    ):
+        sys.modules.pop(module_name, None)
+    _drop_package_attr("extracted_llm_infrastructure", "services")
+    _drop_package_attr("extracted_llm_infrastructure.pipelines", "llm")
+
+
+def test_services_namespace_exports_standalone_llm_registry(monkeypatch) -> None:
+    monkeypatch.setenv(_LLM_INFRA_ENV_VAR, "1")
+    _reset_modules()
+
+    services = importlib.import_module("extracted_llm_infrastructure.services")
+    registry = importlib.import_module(
+        "extracted_llm_infrastructure.services.registry"
+    )
+
+    assert services.llm_registry is registry.llm_registry
+    assert services.register_llm is registry.register_llm
+
+
+def test_pipeline_local_fast_resolver_uses_services_registry_export(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(_LLM_INFRA_ENV_VAR, "1")
+    _reset_modules()
+
+    llm = importlib.import_module("extracted_llm_infrastructure.pipelines.llm")
+
+    assert (
+        llm.get_pipeline_llm(
+            workload="local_fast",
+            auto_activate_ollama=False,
+        )
+        is None
+    )
+    assert "atlas_brain.services.registry" not in sys.modules


### PR DESCRIPTION
Plan: plans/PR-LLM-Registry-Service-Export.md

Live provider generation for imported review-source rows fails before saving provider-backed drafts because two adapter seams are incomplete: the LLM infra pipeline imports `llm_registry` from the package namespace that did not re-export it, and live chat backends expect optional `tool_calls` / `tool_call_id` fields on messages. This exposes the existing registry bridge and normalizes extracted campaign chat messages into the duck-typed provider shape.

## Intentional
- Provider routing and activation behavior are unchanged; this only exposes the existing registry bridge at the package namespace.
- This does not add tool-call support to campaign generation. It only supplies `None` defaults for optional fields that existing backends read.
- The registry regression test disables local model activation so it remains a pure import/runtime seam check.

## Deferred
- None. After merge, rerun live provider generation over the imported review-source rows.

## Verification
- `pytest tests/test_extracted_llm_infrastructure_registry_export.py` -> 2 passed
- `pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_llm_infrastructure_registry_export.py` -> 14 passed
- `python -m py_compile extracted_llm_infrastructure/services/__init__.py extracted_content_pipeline/campaign_llm_client.py tests/test_extracted_llm_infrastructure_registry_export.py tests/test_extracted_campaign_llm_client.py` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
6 files, +191 / -1
