### PR TITLE
Add read-only invoicing OAuth discovery smoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,6 +527,11 @@ python -m atlas_brain.mcp.invoicing_readonly_server --sse
 python scripts/check_invoicing_readonly_mcp_connector.py \
   --url http://127.0.0.1:8065/mcp \
   --token "$ATLAS_MCP_AUTH_TOKEN"
+
+# OAuth public-discovery smoke (metadata + 401 challenge; no invoice reads)
+python scripts/check_invoicing_readonly_oauth_discovery.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp
 ```
 
 Tools: `get_invoice`, `list_invoices`, `search_invoices`,
@@ -547,11 +552,16 @@ before attaching a ChatGPT-style connector.
 ChatGPT online should use OAuth mode, not raw bearer mode. OAuth mode adds MCP
 authorization-server metadata, protected-resource metadata, dynamic client
 registration, and an operator approval page at `/oauth/approve`. The approval
-page requires `ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`, so the
-connector is not silently auto-approved. Because the current public URL is
-path-prefixed under `/invoicing-readonly`, the OAuth `/.well-known/...`
-metadata routes may require an additional Tailscale serve route or a dedicated
-hostname before ChatGPT can discover the OAuth server.
+page posts back to the current external URL, so a path-prefixed public approval
+URL keeps its prefix on submit. The page still requires
+`ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`, so the connector is not
+silently auto-approved.
+
+Run `scripts/check_invoicing_readonly_oauth_discovery.py` against the public
+issuer/resource URLs before attaching ChatGPT. The current public URL is
+path-prefixed under `/invoicing-readonly`; if the smoke cannot reach the OAuth
+`/.well-known/...` routes, add the missing Tailscale serve route or use a
+dedicated hostname before retrying the connector.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/atlas_brain/mcp/invoicing_readonly_oauth.py
+++ b/atlas_brain/mcp/invoicing_readonly_oauth.py
@@ -216,7 +216,7 @@ def approval_page(
     provider: InvoicingReadonlyOAuthProvider,
     request_id: str,
     *,
-    form_action: str = "",
+    form_action: str | None = None,
 ) -> Response:
     pending = provider.pending_authorization(request_id)
     if pending is None:
@@ -227,7 +227,9 @@ def approval_page(
     client = escape(pending.client_id)
     scopes = escape(", ".join(pending.scopes))
     request_value = escape(request_id)
-    action_value = escape(form_action, quote=True)
+    action_attr = ""
+    if form_action is not None:
+        action_attr = f' action="{escape(form_action, quote=True)}"'
     return HTMLResponse(
         f"""
 <!doctype html>
@@ -238,7 +240,7 @@ def approval_page(
     <p>Client: <code>{client}</code></p>
     <p>Scopes: <code>{scopes}</code></p>
     <p>This grants read-only invoice review tools. It does not grant invoice creation, sending, payment recording, voiding, or service mutation tools.</p>
-    <form method="post" action="{action_value}">
+    <form method="post"{action_attr}>
       <input type="hidden" name="request_id" value="{request_value}" />
       <label>Approval token <input name="approval_token" type="password" /></label>
       <button type="submit">Approve connector</button>
@@ -253,7 +255,7 @@ async def handle_approval_request(provider: InvoicingReadonlyOAuthProvider, requ
     """Handle GET/POST requests for the operator approval page."""
     if request.method == "GET":
         request_id = request.query_params.get("request_id", "")
-        return approval_page(provider, request_id, form_action=request.scope.get("root_path", "") + request.url.path)
+        return approval_page(provider, request_id)
 
     form: FormData = await request.form()
     request_id = str(form.get("request_id") or "")

--- a/plans/PR-Invoicing-Readonly-OAuth-Discovery-Smoke.md
+++ b/plans/PR-Invoicing-Readonly-OAuth-Discovery-Smoke.md
@@ -1,0 +1,87 @@
+## Why this slice exists
+
+PR #600 added OAuth mode for the read-only invoicing MCP server, but the
+remaining operational risk is discovery: ChatGPT has to reach OAuth metadata,
+protected-resource metadata, and the operator approval page through the public
+URL shape. The current hosted URL is path-prefixed under `/invoicing-readonly`,
+so a local green provider test does not prove the public connector URL works.
+
+This slice adds a small public-discovery smoke and removes the approval form's
+dependency on ASGI `root_path` so proxied path prefixes do not get dropped on
+form submit.
+
+## Scope (this PR)
+
+1. Make the OAuth approval form submit back to the current external URL by
+   omitting the absolute `action` attribute.
+2. Add a read-only smoke script that validates OAuth authorization-server
+   metadata, protected-resource metadata, and the unauthenticated MCP 401
+   challenge.
+3. Add focused tests for URL construction, smoke failure behavior, and the
+   prefix-safe approval form.
+4. Document the smoke command alongside the ChatGPT OAuth setup notes.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_readonly_oauth.py`
+- `tests/test_invoicing_readonly_oauth.py`
+- `scripts/check_invoicing_readonly_oauth_discovery.py`
+- `tests/test_check_invoicing_readonly_oauth_discovery.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-OAuth-Discovery-Smoke.md`
+
+## Mechanism
+
+The approval page renders `<form method="post">` with a hidden `request_id`.
+Browsers submit a form with no `action` to the current document URL, preserving
+whatever public prefix the proxy exposed. This is safer than trying to rebuild
+the public prefix from `request.scope["root_path"]`, which may be absent behind
+Tailscale or another path-stripping proxy.
+
+The new smoke script derives:
+
+```text
+<issuer>/.well-known/oauth-authorization-server
+<resource-origin>/.well-known/oauth-protected-resource<resource-path>
+```
+
+It fetches both JSON documents, validates the expected issuer/resource/scopes,
+then probes the MCP URL without credentials and requires a 401 with a
+`resource_metadata` challenge pointing at the protected-resource metadata URL.
+
+## Intentional
+
+- The smoke does not complete a full OAuth code exchange. It is a public
+  routing/discovery check that requires no approval token and reads no invoice
+  data.
+- The approval form keeps the hidden `request_id`; no state is moved into query
+  parsing during POST.
+
+## Deferred
+
+- A full browser/ChatGPT OAuth connection test remains operational because it
+  needs the live public host and manual operator approval token.
+- Durable OAuth token/client persistence remains deferred from PR #600.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_oauth.py scripts/check_invoicing_readonly_oauth_discovery.py
+.venv/bin/python -m pytest tests/test_invoicing_readonly_oauth.py tests/test_check_invoicing_readonly_oauth_discovery.py
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Approval form adjustment | ~10 |
+| Discovery smoke script | ~170 |
+| Tests | ~160 |
+| Docs/plan | ~110 |
+| **Total** | **~450** |
+
+This is slightly over the soft cap because the smoke script ships with fixture
+tests instead of being an untested operational helper.

--- a/scripts/check_invoicing_readonly_oauth_discovery.py
+++ b/scripts/check_invoicing_readonly_oauth_discovery.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Verify public OAuth discovery for the read-only invoicing MCP connector.
+
+This check is intentionally read-only. It validates public routing and metadata
+only; it does not complete OAuth approval, exchange tokens, or call invoice
+tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+
+DEFAULT_SCOPE = "invoices.read"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check OAuth discovery for the read-only invoicing MCP connector."
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", ""),
+        help="Public OAuth issuer URL. Defaults to ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", ""),
+        help=(
+            "Public Streamable HTTP MCP resource URL. Defaults to "
+            "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL."
+        ),
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.strip().rstrip("/")
+
+
+def _authorization_metadata_url(issuer_url: str) -> str:
+    return f"{_strip_trailing_slash(issuer_url)}/.well-known/oauth-authorization-server"
+
+
+def _protected_resource_metadata_url(resource_url: str) -> str:
+    parsed = urllib.parse.urlparse(_strip_trailing_slash(resource_url))
+    resource_path = parsed.path if parsed.path != "/" else ""
+    return urllib.parse.urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            f"/.well-known/oauth-protected-resource{resource_path}",
+            "",
+            "",
+            "",
+        )
+    )
+
+
+def _fetch_json(url: str, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{url} did not return JSON") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{url} returned non-object JSON")
+    return data
+
+
+def _probe_mcp_unauthenticated(url: str, timeout: float) -> tuple[int, Mapping[str, str]]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _list_value(data: Mapping[str, Any], key: str) -> list[Any]:
+    value = data.get(key)
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _metadata_errors(
+    *,
+    issuer_url: str,
+    resource_url: str,
+    scope: str,
+    auth_metadata: Mapping[str, Any],
+    resource_metadata: Mapping[str, Any],
+    mcp_status: int,
+    mcp_headers: Mapping[str, str],
+) -> list[str]:
+    issuer = _strip_trailing_slash(issuer_url)
+    resource = _strip_trailing_slash(resource_url)
+    protected_url = _protected_resource_metadata_url(resource)
+    errors: list[str] = []
+
+    expected_auth = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "registration_endpoint": f"{issuer}/register",
+    }
+    for key, expected in expected_auth.items():
+        if str(auth_metadata.get(key) or "").rstrip("/") != expected:
+            errors.append(f"authorization metadata {key} != {expected}")
+
+    if scope not in _list_value(auth_metadata, "scopes_supported"):
+        errors.append(f"authorization metadata missing scope {scope}")
+    if "authorization_code" not in _list_value(auth_metadata, "grant_types_supported"):
+        errors.append("authorization metadata missing authorization_code grant")
+
+    if str(resource_metadata.get("resource") or "").rstrip("/") != resource:
+        errors.append(f"resource metadata resource != {resource}")
+    if issuer not in [str(item).rstrip("/") for item in _list_value(resource_metadata, "authorization_servers")]:
+        errors.append(f"resource metadata missing authorization server {issuer}")
+    if scope not in _list_value(resource_metadata, "scopes_supported"):
+        errors.append(f"resource metadata missing scope {scope}")
+
+    if mcp_status != 401:
+        errors.append(f"unauthenticated MCP probe returned {mcp_status}, expected 401")
+
+    authenticate = mcp_headers.get("www-authenticate") or mcp_headers.get("WWW-Authenticate") or ""
+    if protected_url not in authenticate:
+        errors.append(f"WWW-Authenticate header missing resource_metadata={protected_url}")
+
+    return errors
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    if not issuer_url:
+        print("--issuer-url or ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL is required", file=sys.stderr)
+        return 2
+    if not resource_url:
+        print(
+            "--resource-url or ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    auth_url = _authorization_metadata_url(issuer_url)
+    protected_url = _protected_resource_metadata_url(resource_url)
+    try:
+        auth_metadata = _fetch_json(auth_url, args.timeout)
+        resource_metadata = _fetch_json(protected_url, args.timeout)
+        mcp_status, mcp_headers = _probe_mcp_unauthenticated(resource_url, args.timeout)
+    except Exception as exc:
+        print(f"OAuth discovery smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _metadata_errors(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        scope=args.scope,
+        auth_metadata=auth_metadata,
+        resource_metadata=resource_metadata,
+        mcp_status=mcp_status,
+        mcp_headers=mcp_headers,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: read-only invoicing OAuth discovery is routable")
+    print(f"- authorization metadata: {auth_url}")
+    print(f"- protected resource metadata: {protected_url}")
+    print(f"- MCP resource: {resource_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_readonly_oauth_discovery.py
+++ b/tests/test_check_invoicing_readonly_oauth_discovery.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_readonly_oauth_discovery.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_readonly_oauth_discovery",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_authorization_metadata_url_preserves_path_prefixed_issuer() -> None:
+    module = _load_script_module()
+
+    assert module._authorization_metadata_url("https://atlas.example.com/invoicing-readonly/") == (
+        "https://atlas.example.com/invoicing-readonly/.well-known/oauth-authorization-server"
+    )
+
+
+def test_protected_resource_metadata_url_uses_resource_path() -> None:
+    module = _load_script_module()
+
+    assert module._protected_resource_metadata_url("https://atlas.example.com/invoicing-readonly/mcp") == (
+        "https://atlas.example.com/.well-known/oauth-protected-resource/invoicing-readonly/mcp"
+    )
+
+
+def test_metadata_errors_accept_expected_discovery_documents() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-readonly"
+    resource = "https://atlas.example.com/invoicing-readonly/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope="invoices.read",
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": ["invoices.read"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.read"],
+        },
+        mcp_status=401,
+        mcp_headers={
+            "www-authenticate": (
+                'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                'oauth-protected-resource/invoicing-readonly/mcp"'
+            )
+        },
+    )
+
+    assert errors == []
+
+
+def test_metadata_errors_reject_missing_resource_challenge() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-readonly"
+    resource = "https://atlas.example.com/invoicing-readonly/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope="invoices.read",
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": ["invoices.read"],
+            "grant_types_supported": ["authorization_code"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.read"],
+        },
+        mcp_status=401,
+        mcp_headers={"www-authenticate": "Bearer"},
+    )
+
+    assert errors == [
+        "WWW-Authenticate header missing resource_metadata="
+        "https://atlas.example.com/.well-known/oauth-protected-resource/invoicing-readonly/mcp"
+    ]
+
+
+def test_main_requires_urls_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", raising=False)
+    monkeypatch.setattr(module, "_fetch_json", fail_fetch)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--issuer-url" in captured.err
+
+
+def test_main_reports_success_for_valid_public_discovery(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-readonly"
+    resource = "https://atlas.example.com/invoicing-readonly/mcp"
+
+    def fake_fetch(url: str, _timeout: float):
+        if url.endswith("/.well-known/oauth-authorization-server"):
+            return {
+                "issuer": issuer,
+                "authorization_endpoint": f"{issuer}/authorize",
+                "token_endpoint": f"{issuer}/token",
+                "registration_endpoint": f"{issuer}/register",
+                "scopes_supported": ["invoices.read"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+            }
+        return {
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.read"],
+        }
+
+    monkeypatch.setattr(module, "_fetch_json", fake_fetch)
+    monkeypatch.setattr(
+        module,
+        "_probe_mcp_unauthenticated",
+        lambda *_args: (
+            401,
+            {
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                    'oauth-protected-resource/invoicing-readonly/mcp"'
+                )
+            },
+        ),
+    )
+
+    result = module._main(["--issuer-url", issuer, "--resource-url", resource])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "OAuth discovery is routable" in captured.out

--- a/tests/test_invoicing_readonly_oauth.py
+++ b/tests/test_invoicing_readonly_oauth.py
@@ -11,6 +11,7 @@ from atlas_brain.mcp import invoicing_readonly_server as readonly
 from atlas_brain.mcp.invoicing_readonly_oauth import (
     DEFAULT_READONLY_SCOPE,
     InvoicingReadonlyOAuthProvider,
+    PendingAuthorization,
     validate_oauth_settings,
 )
 from mcp.server.auth.provider import AuthorizationParams, TokenError
@@ -235,7 +236,7 @@ def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(mo
         assert "resource_metadata=" in response.headers["www-authenticate"]
 
 
-def test_approval_page_uses_current_request_path_for_prefixed_mount(monkeypatch):
+def test_approval_page_omits_absolute_form_action_for_prefixed_mount(monkeypatch):
     monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "oauth")
     monkeypatch.setenv(
         "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL",
@@ -253,22 +254,21 @@ def test_approval_page_uses_current_request_path_for_prefixed_mount(monkeypatch)
     app = readonly._streamable_http_app()
     provider = readonly._oauth_provider
     assert provider is not None
-    pending = type(
-        "Pending",
-        (),
-        {
-            "client_id": "client-1",
-            "scopes": [DEFAULT_READONLY_SCOPE],
-            "expires_at": 9999999999,
-        },
-    )()
-    provider._pending["request-1"] = pending  # type: ignore[assignment]
+    provider._pending["request-1"] = PendingAuthorization(
+        request_id="request-1",
+        client_id="client-1",
+        params=_params(),
+        scopes=[DEFAULT_READONLY_SCOPE],
+        expires_at=9999999999,
+    )
 
     with TestClient(app, root_path="/invoicing-readonly") as client:
         response = client.get("/oauth/approve?request_id=request-1")
 
     assert response.status_code == 200
-    assert 'action="/invoicing-readonly/oauth/approve"' in response.text
+    assert '<form method="post">' in response.text
+    assert 'action="/oauth/approve"' not in response.text
+    assert 'action="/invoicing-readonly/oauth/approve"' not in response.text
 
 
 def test_streamable_http_app_rejects_invalid_auth_mode(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-OAuth-Discovery-Smoke.md

PR #600 added OAuth mode for the read-only invoicing MCP server; this slice closes the next operational gap by making the approval form prefix-safe and adding a public-discovery smoke for the exact OAuth metadata + MCP challenge URLs ChatGPT needs.

## Intentional
- The smoke validates public OAuth metadata and the unauthenticated MCP 401 challenge only; it does not perform approval, token exchange, or invoice reads.
- The approval form omits an action attribute so browser submission preserves any external path prefix supplied by the proxy.

## Deferred
- Full ChatGPT connector authorization remains operational because it requires the live public host and manual operator approval token.
- Durable OAuth client/token persistence remains deferred from PR #600.

## Verification
- `.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_readonly_oauth.py scripts/check_invoicing_readonly_oauth_discovery.py tests/test_check_invoicing_readonly_oauth_discovery.py tests/test_invoicing_readonly_oauth.py`
- `.venv/bin/python -m pytest tests/test_invoicing_readonly_oauth.py tests/test_check_invoicing_readonly_oauth_discovery.py` -> 14 passed
- `git diff --check`
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- pre-push hook `scripts/local_pr_review.sh` -> passed

## Diff size
6 files, +496 / -21
