### PR TITLE
Add read-only invoicing OAuth e2e smoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,7 +529,12 @@ python scripts/check_invoicing_readonly_mcp_connector.py \
   --token "$ATLAS_MCP_AUTH_TOKEN"
 
 # OAuth public-discovery smoke (metadata + 401 challenge; no invoice reads)
-python scripts/check_invoicing_readonly_oauth_discovery.py \
+.venv/bin/python scripts/check_invoicing_readonly_oauth_discovery.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp
+
+# OAuth e2e smoke (registration + approval + token + list_tools; no invoice reads)
+.venv/bin/python scripts/check_invoicing_readonly_oauth_e2e.py \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp
 ```
@@ -562,6 +567,23 @@ issuer/resource URLs before attaching ChatGPT. The current public URL is
 path-prefixed under `/invoicing-readonly`; if the smoke cannot reach the OAuth
 `/.well-known/...` routes, add the missing Tailscale serve route or use a
 dedicated hostname before retrying the connector.
+
+For the current Tailscale Funnel shape, the protected-resource metadata route
+must preserve the backend path:
+
+```bash
+tailscale funnel --bg --yes \
+  --set-path /.well-known/oauth-protected-resource \
+  http://127.0.0.1:8065/.well-known/oauth-protected-resource
+```
+
+After discovery passes, run
+`scripts/check_invoicing_readonly_oauth_e2e.py`. It dynamically registers a
+temporary OAuth client, approves it with
+`ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`, exchanges the authorization
+code for a bearer token, and lists the MCP tools. It must report exactly the
+eight read-only tools above and does not call invoice/service/balance/payment
+tools.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/plans/PR-Invoicing-Readonly-OAuth-E2E-Smoke.md
+++ b/plans/PR-Invoicing-Readonly-OAuth-E2E-Smoke.md
@@ -1,0 +1,85 @@
+## Why this slice exists
+
+PR #604 proved OAuth metadata discovery is routable, and the follow-up manual
+check proved the full public flow works through token exchange and MCP
+`list_tools`. That manual command is not durable: after a restart, Funnel route
+change, or ChatGPT connector failure, we need a repeatable operator smoke that
+separates Atlas OAuth breakage from ChatGPT-specific behavior.
+
+This slice captures the no-invoice OAuth e2e verification as a reusable script.
+
+## Scope (this PR)
+
+1. Add a read-only e2e smoke for the public OAuth connector flow.
+2. Validate dynamic client registration, authorization redirect, operator
+   approval, token exchange, and OAuth-authenticated MCP `list_tools`.
+3. Require the exact eight read-only invoicing tools and reject mutating/extra
+   tools.
+4. Add fixture tests for helper behavior and failure modes.
+5. Document the command and the required Tailscale route shape.
+
+### Files touched
+
+- `scripts/check_invoicing_readonly_oauth_e2e.py`
+- `tests/test_check_invoicing_readonly_oauth_e2e.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-OAuth-E2E-Smoke.md`
+
+## Mechanism
+
+The script performs the same public flow ChatGPT needs, but stops at tool
+listing:
+
+```text
+POST /register
+GET /authorize -> /oauth/approve?request_id=...
+POST /oauth/approve with operator approval token
+POST /token with PKCE verifier
+MCP initialize + list_tools with the returned bearer token
+```
+
+It uses `https://chat.openai.com/aip/callback` as the default redirect URI, but
+never follows that redirect. It extracts the authorization code locally and
+uses it at the token endpoint. The final MCP check only lists tools; it does
+not call invoice/service/balance/payment tools.
+
+## Intentional
+
+- The script requires an approval token because it exercises the actual
+  operator approval boundary. It never prints the approval token, client secret,
+  access token, refresh token, or authorization code.
+- The script does not persist OAuth clients or tokens; the server remains the
+  single-process in-memory provider from PR #600.
+- The script is separate from `check_invoicing_readonly_oauth_discovery.py` so
+  a cheap metadata-only smoke is still available when the operator does not
+  want to approve a client.
+
+## Deferred
+
+- Durable OAuth client/token persistence remains deferred until multi-process
+  or restart-resilient connector sessions are needed.
+- A real ChatGPT connector click-through remains operational/manual because it
+  requires the ChatGPT UI.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile scripts/check_invoicing_readonly_oauth_e2e.py tests/test_check_invoicing_readonly_oauth_e2e.py
+.venv/bin/python -m pytest tests/test_check_invoicing_readonly_oauth_e2e.py
+.venv/bin/python scripts/check_invoicing_readonly_oauth_e2e.py --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| E2E smoke script | ~260 |
+| Tests | ~200 |
+| Docs/plan | ~100 |
+| **Total** | **~560** |
+
+This exceeds the soft cap because a networked e2e operator script needs enough
+helper seams to test failure behavior without hitting the live connector.

--- a/scripts/check_invoicing_readonly_oauth_e2e.py
+++ b/scripts/check_invoicing_readonly_oauth_e2e.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Run a no-invoice OAuth e2e smoke for the read-only invoicing MCP connector."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_SCOPE = "invoices.read"
+DEFAULT_REDIRECT_URI = "https://chat.openai.com/aip/callback"
+EXPECTED_READONLY_TOOLS = {
+    "customer_balance",
+    "get_invoice",
+    "get_service",
+    "list_invoices",
+    "list_pending_drafts",
+    "list_services",
+    "payment_history",
+    "search_invoices",
+}
+KNOWN_MUTATING_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "export_invoice_pdf",
+    "mark_void",
+    "record_payment",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+_NO_REDIRECT = urllib.request.build_opener(_NoRedirect)
+
+
+@dataclass(frozen=True)
+class OAuthE2EConfig:
+    issuer_url: str
+    resource_url: str
+    approval_token: str
+    redirect_uri: str
+    scope: str
+    timeout: float
+
+
+@dataclass(frozen=True)
+class RegisteredClient:
+    client_id: str
+    client_secret: str
+
+
+@dataclass(frozen=True)
+class AuthorizationRequest:
+    approval_url: str
+    request_id: str
+    verifier: str
+
+
+@dataclass(frozen=True)
+class TokenResult:
+    access_token: str
+    scope: str
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a public OAuth e2e smoke for the read-only invoicing MCP connector. "
+            "This lists tools only and does not read invoice data."
+        )
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", ""),
+        help="Public OAuth issuer URL. Defaults to ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", ""),
+        help=(
+            "Public Streamable HTTP MCP resource URL. Defaults to "
+            "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL."
+        ),
+    )
+    parser.add_argument(
+        "--approval-token",
+        default=os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", ""),
+        help="Operator approval token. Defaults to ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN.",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default=DEFAULT_REDIRECT_URI,
+        help=f"OAuth redirect URI to register. Default: {DEFAULT_REDIRECT_URI}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.strip().rstrip("/")
+
+
+def _config_from_args(args: argparse.Namespace) -> OAuthE2EConfig:
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    approval_token = args.approval_token.strip()
+    redirect_uri = args.redirect_uri.strip()
+    scope = args.scope.strip()
+    missing: list[str] = []
+    if not issuer_url:
+        missing.append("--issuer-url or ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL")
+    if not resource_url:
+        missing.append("--resource-url or ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL")
+    if not approval_token:
+        missing.append("--approval-token or ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN")
+    if not redirect_uri:
+        missing.append("--redirect-uri")
+    if not scope:
+        missing.append("--scope")
+    if missing:
+        raise ValueError("missing required values: " + ", ".join(missing))
+    return OAuthE2EConfig(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        approval_token=approval_token,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        timeout=args.timeout,
+    )
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _post_json(url: str, payload: Mapping[str, Any], timeout: float) -> tuple[int, Mapping[str, str], dict[str, Any]]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with _NO_REDIRECT.open(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            data = json.loads(body) if body else {}
+            if not isinstance(data, dict):
+                raise RuntimeError(f"{url} returned non-object JSON")
+            return response.status, response.headers, data
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{url} did not return JSON") from exc
+
+
+def _post_form(
+    url: str,
+    payload: Mapping[str, str],
+    timeout: float,
+    *,
+    follow_redirects: bool = False,
+) -> tuple[int, Mapping[str, str], str]:
+    request = urllib.request.Request(
+        url,
+        data=urllib.parse.urlencode(payload).encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    opener = urllib.request.urlopen if follow_redirects else _NO_REDIRECT.open
+    try:
+        with opener(request, timeout=timeout) as response:
+            return response.status, response.headers, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {302, 303, 307, 308}:
+            return exc.code, exc.headers, exc.read().decode("utf-8")
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _get_no_redirect(url: str, timeout: float) -> tuple[int, Mapping[str, str], str]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with _NO_REDIRECT.open(request, timeout=timeout) as response:
+            return response.status, response.headers, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {302, 303, 307, 308}:
+            return exc.code, exc.headers, exc.read().decode("utf-8")
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _register_client(config: OAuthE2EConfig) -> RegisteredClient:
+    status, _headers, body = _post_json(
+        f"{config.issuer_url}/register",
+        {
+            "client_name": "Atlas read-only invoicing OAuth e2e smoke",
+            "redirect_uris": [config.redirect_uri],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": config.scope,
+        },
+        config.timeout,
+    )
+    if status not in {200, 201}:
+        raise RuntimeError(f"client registration returned HTTP {status}")
+    client_id = str(body.get("client_id") or "")
+    client_secret = str(body.get("client_secret") or "")
+    if not client_id or not client_secret:
+        raise RuntimeError("client registration response missing client_id or client_secret")
+    return RegisteredClient(client_id=client_id, client_secret=client_secret)
+
+
+def _start_authorization(config: OAuthE2EConfig, client: RegisteredClient) -> AuthorizationRequest:
+    verifier = secrets.token_urlsafe(48)
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": client.client_id,
+            "redirect_uri": config.redirect_uri,
+            "scope": config.scope,
+            "state": secrets.token_urlsafe(16),
+            "code_challenge": _pkce_challenge(verifier),
+            "code_challenge_method": "S256",
+            "resource": config.resource_url,
+        }
+    )
+    status, headers, _body = _get_no_redirect(f"{config.issuer_url}/authorize?{query}", config.timeout)
+    if status not in {302, 303}:
+        raise RuntimeError(f"authorization endpoint returned HTTP {status}")
+    approval_url = str(headers.get("Location") or headers.get("location") or "")
+    if not approval_url.startswith(f"{config.issuer_url}/oauth/approve?"):
+        raise RuntimeError("authorization endpoint did not redirect to the approval page")
+    request_id = urllib.parse.parse_qs(urllib.parse.urlparse(approval_url).query).get("request_id", [""])[0]
+    if not request_id:
+        raise RuntimeError("approval redirect missing request_id")
+    return AuthorizationRequest(
+        approval_url=approval_url,
+        request_id=request_id,
+        verifier=verifier,
+    )
+
+
+def _approve_authorization(config: OAuthE2EConfig, auth: AuthorizationRequest) -> str:
+    status, headers, _body = _post_form(
+        f"{config.issuer_url}/oauth/approve",
+        {
+            "request_id": auth.request_id,
+            "approval_token": config.approval_token,
+        },
+        config.timeout,
+    )
+    if status not in {302, 303}:
+        raise RuntimeError(f"approval endpoint returned HTTP {status}")
+    redirect_location = str(headers.get("Location") or headers.get("location") or "")
+    code = urllib.parse.parse_qs(urllib.parse.urlparse(redirect_location).query).get("code", [""])[0]
+    if not code:
+        raise RuntimeError("approval redirect missing authorization code")
+    return code
+
+
+def _exchange_token(
+    config: OAuthE2EConfig,
+    client: RegisteredClient,
+    auth: AuthorizationRequest,
+    code: str,
+) -> TokenResult:
+    status, _headers, body = _post_form(
+        f"{config.issuer_url}/token",
+        {
+            "grant_type": "authorization_code",
+            "client_id": client.client_id,
+            "client_secret": client.client_secret,
+            "code": code,
+            "redirect_uri": config.redirect_uri,
+            "code_verifier": auth.verifier,
+            "resource": config.resource_url,
+        },
+        config.timeout,
+        follow_redirects=True,
+    )
+    if status != 200:
+        raise RuntimeError(f"token endpoint returned HTTP {status}")
+    try:
+        token = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("token endpoint did not return JSON") from exc
+    if not isinstance(token, dict):
+        raise RuntimeError("token endpoint returned non-object JSON")
+    if token.get("token_type") != "Bearer":
+        raise RuntimeError("token endpoint did not return a Bearer token")
+    access_token = str(token.get("access_token") or "")
+    scope = str(token.get("scope") or "")
+    if not access_token:
+        raise RuntimeError("token endpoint response missing access_token")
+    if config.scope not in scope.split():
+        raise RuntimeError(f"token endpoint response missing scope {config.scope}")
+    return TokenResult(access_token=access_token, scope=scope)
+
+
+async def _list_mcp_tools(config: OAuthE2EConfig, access_token: str) -> set[str]:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(
+        config.resource_url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=config.timeout,
+        sse_read_timeout=config.timeout,
+    ) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            return {tool.name for tool in result.tools}
+
+
+def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(EXPECTED_READONLY_TOOLS - tool_names)
+    extra = sorted(tool_names - EXPECTED_READONLY_TOOLS)
+    mutating = sorted(tool_names & KNOWN_MUTATING_TOOLS)
+    if missing:
+        errors.append("missing read-only tools: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected tools exposed: " + ", ".join(extra))
+    if mutating:
+        errors.append("mutating tools exposed: " + ", ".join(mutating))
+    return errors
+
+
+async def _run_smoke(config: OAuthE2EConfig) -> set[str]:
+    client = _register_client(config)
+    auth = _start_authorization(config, client)
+    code = _approve_authorization(config, auth)
+    token = _exchange_token(config, client, auth, code)
+    return await _list_mcp_tools(config, token.access_token)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = _config_from_args(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    try:
+        tool_names = asyncio.run(_run_smoke(config))
+    except Exception as exc:
+        print(f"OAuth e2e smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _tool_surface_errors(tool_names)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: read-only invoicing OAuth e2e smoke completed")
+    print("- dynamic client registration succeeded")
+    print("- operator approval and token exchange succeeded")
+    print(f"- OAuth-authenticated MCP session exposes {len(tool_names)} read-only tools")
+    for name in sorted(tool_names):
+        print(f"- {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_readonly_oauth_e2e.py
+++ b/tests/test_check_invoicing_readonly_oauth_e2e.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_readonly_oauth_e2e.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_readonly_oauth_e2e",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "issuer_url": "https://atlas.example.com/invoicing-readonly",
+        "resource_url": "https://atlas.example.com/invoicing-readonly/mcp",
+        "approval_token": "approval-token-with-enough-entropy",
+        "redirect_uri": "https://chat.openai.com/aip/callback",
+        "scope": "invoices.read",
+        "timeout": 10.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_config_from_args_requires_values() -> None:
+    module = _load_script_module()
+
+    try:
+        module._config_from_args(
+            _args(
+                issuer_url="",
+                resource_url="",
+                approval_token="",
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+    assert "--issuer-url" in message
+    assert "--resource-url" in message
+    assert "--approval-token" in message
+
+
+def test_pkce_challenge_uses_s256_urlsafe_without_padding() -> None:
+    module = _load_script_module()
+
+    expected = base64.urlsafe_b64encode(hashlib.sha256(b"verifier-1").digest()).decode().rstrip("=")
+
+    assert module._pkce_challenge("verifier-1") == expected
+    assert not module._pkce_challenge("verifier-1").endswith("=")
+
+
+def test_tool_surface_errors_accept_exact_readonly_tools() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors(set(module.EXPECTED_READONLY_TOOLS)) == []
+
+
+def test_tool_surface_errors_reject_extra_and_mutating_tools() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_READONLY_TOOLS)
+    tools.update({"approve_and_send", "surprise_tool"})
+
+    errors = module._tool_surface_errors(tools)
+
+    assert "unexpected tools exposed: approve_and_send, surprise_tool" in errors
+    assert "mutating tools exposed: approve_and_send" in errors
+
+
+def test_register_client_requires_client_secret(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+
+    monkeypatch.setattr(module, "_post_json", lambda *_args, **_kwargs: (201, {}, {"client_id": "client-1"}))
+
+    try:
+        module._register_client(config)
+    except RuntimeError as exc:
+        assert "missing client_id or client_secret" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_start_authorization_requires_approval_redirect(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    client = module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+
+    monkeypatch.setattr(module, "_get_no_redirect", lambda *_args, **_kwargs: (302, {"Location": "https://bad.example.com"}, ""))
+
+    try:
+        module._start_authorization(config, client)
+    except RuntimeError as exc:
+        assert "did not redirect to the approval page" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_approve_authorization_extracts_code_without_following_chatgpt_redirect(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    auth = module.AuthorizationRequest(
+        approval_url="https://atlas.example.com/invoicing-readonly/oauth/approve?request_id=req-1",
+        request_id="req-1",
+        verifier="verifier-1",
+    )
+
+    def fake_post_form(url, payload, timeout, *, follow_redirects=False):
+        assert url == "https://atlas.example.com/invoicing-readonly/oauth/approve"
+        assert payload["approval_token"] == "approval-token-with-enough-entropy"
+        assert follow_redirects is False
+        return 302, {"Location": "https://chat.openai.com/aip/callback?code=code-1&state=state-1"}, ""
+
+    monkeypatch.setattr(module, "_post_form", fake_post_form)
+
+    assert module._approve_authorization(config, auth) == "code-1"
+
+
+def test_exchange_token_requires_bearer_access_token(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    client = module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+    auth = module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    monkeypatch.setattr(
+        module,
+        "_post_form",
+        lambda *_args, **_kwargs: (200, {}, '{"token_type":"Bearer","scope":"invoices.read"}'),
+    )
+
+    try:
+        module._exchange_token(config, client, auth, "code-1")
+    except RuntimeError as exc:
+        assert "missing access_token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_main_requires_config_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fail_run(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", raising=False)
+    monkeypatch.setattr(module, "_run_smoke", fail_run)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--issuer-url" in captured.err
+
+
+def test_main_reports_success_without_printing_secrets(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return set(module.EXPECTED_READONLY_TOOLS)
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/invoicing-readonly",
+            "--resource-url",
+            "https://atlas.example.com/invoicing-readonly/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "OAuth e2e smoke completed" in captured.out
+    assert "secret-approval-token-value" not in captured.out
+    assert "get_invoice" in captured.out
+
+
+def test_main_reports_tool_surface_errors(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"get_invoice", "approve_and_send"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/invoicing-readonly",
+            "--resource-url",
+            "https://atlas.example.com/invoicing-readonly/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "missing read-only tools:" in captured.err
+    assert "mutating tools exposed: approve_and_send" in captured.err
+
+
+def test_run_smoke_sequence_uses_token_for_tool_list(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    calls: list[str] = []
+
+    def fake_register(_config):
+        calls.append("register")
+        return module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+
+    def fake_start(_config, client):
+        calls.append(f"authorize:{client.client_id}")
+        return module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    def fake_approve(_config, auth):
+        calls.append(f"approve:{auth.request_id}")
+        return "code-1"
+
+    def fake_exchange(_config, client, auth, code):
+        calls.append(f"token:{client.client_id}:{auth.request_id}:{code}")
+        return module.TokenResult(access_token="access-token-1", scope="invoices.read")
+
+    async def fake_list(_config, token):
+        calls.append(f"list:{token}")
+        return set(module.EXPECTED_READONLY_TOOLS)
+
+    monkeypatch.setattr(module, "_register_client", fake_register)
+    monkeypatch.setattr(module, "_start_authorization", fake_start)
+    monkeypatch.setattr(module, "_approve_authorization", fake_approve)
+    monkeypatch.setattr(module, "_exchange_token", fake_exchange)
+    monkeypatch.setattr(module, "_list_mcp_tools", fake_list)
+
+    result = asyncio.run(module._run_smoke(config))
+
+    assert result == set(module.EXPECTED_READONLY_TOOLS)
+    assert calls == [
+        "register",
+        "authorize:client-1",
+        "approve:req-1",
+        "token:client-1:req-1:code-1",
+        "list:access-token-1",
+    ]


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-OAuth-E2E-Smoke.md

PR #604 made OAuth discovery repeatable. This slice captures the full no-invoice public OAuth handshake as an operator smoke: dynamic client registration, authorization redirect, approval, token exchange, and OAuth-authenticated MCP `list_tools`.

## Intentional
- The smoke exercises registration, approval, token exchange, and MCP `list_tools` only; it does not read invoice data.
- The approval token is required to test the real operator boundary but is never printed.
- The discovery smoke stays separate so operators can run a cheap metadata/routing check without approving a client.

## Deferred
- Durable OAuth client/token persistence remains deferred until multi-process or restart-resilient sessions are needed.
- Real ChatGPT UI click-through remains manual because it requires the ChatGPT connector UI.

## Verification
- `.venv/bin/python -m py_compile scripts/check_invoicing_readonly_oauth_e2e.py tests/test_check_invoicing_readonly_oauth_e2e.py`
- `.venv/bin/python -m pytest tests/test_check_invoicing_readonly_oauth_e2e.py` -> 12 passed
- live public e2e smoke via `.venv/bin/python scripts/check_invoicing_readonly_oauth_e2e.py --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp` -> passed
- `git diff --check`
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- pre-push hook `scripts/local_pr_review.sh` -> passed

## Diff size
4 files, +779 / -1
