### PR TITLE
Add CFPB source ingestion smoke for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T02:00Z by codex-2026-05-18
+Last updated: 2026-05-19T02:35Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-LLM-Registry-Service-Export | `extracted_llm_infrastructure/services/__init__.py`, `extracted_content_pipeline/campaign_llm_client.py`, `tests/test_extracted_llm_infrastructure_registry_export.py`, `tests/test_extracted_campaign_llm_client.py`, `plans/PR-LLM-Registry-Service-Export.md` | codex-2026-05-18 | extracted LLM namespace/package init work; content LLM adapter chat message normalization |
+| TBD | PR-Content-Ops-CFPB-Source | `scripts/export_content_ops_cfpb_sources.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `tests/test_export_content_ops_cfpb_sources.py`, `tests/test_smoke_content_ops_cfpb_source_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `plans/PR-Content-Ops-CFPB-Source.md` | codex-2026-05-18 | Content Ops source ingestion scripts/docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-CFPB-Source | `scripts/export_content_ops_cfpb_sources.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `tests/test_export_content_ops_cfpb_sources.py`, `tests/test_smoke_content_ops_cfpb_source_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `plans/PR-Content-Ops-CFPB-Source.md` | codex-2026-05-18 | Content Ops source ingestion scripts/docs |
+| TBD | PR-Content-Ops-CFPB-Source | `scripts/export_content_ops_cfpb_sources.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/campaign_example.py`, `tests/test_export_content_ops_cfpb_sources.py`, `tests/test_smoke_content_ops_cfpb_source_postgres.py`, `tests/test_extracted_campaign_generation_example.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `plans/PR-Content-Ops-CFPB-Source.md` | codex-2026-05-18 | Content Ops source ingestion scripts/docs |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -199,6 +199,31 @@ python scripts/smoke_content_ops_review_source_postgres.py \
   --json
 ```
 
+Public CFPB complaint narratives can also seed the same source-row path when
+you want support-ticket-like evidence without using seller or review-site data.
+The exporter reads CFPB's public CSV endpoint, keeps narrative-bearing
+complaints, and emits `source_type="support_ticket"` rows. Account and contact
+binding still comes from host defaults:
+
+```bash
+python scripts/export_content_ops_cfpb_sources.py \
+  --company "Example Bank" \
+  --search-term fees \
+  --limit 25 \
+  --output cfpb_sources.jsonl
+```
+
+```bash
+python scripts/smoke_content_ops_cfpb_source_postgres.py \
+  --company "Example Bank" \
+  --search-term fees \
+  --limit 1 \
+  --account-id acct_123 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
 Before converting or importing a customer export, inspect ingestion readiness:
 
 ```bash

--- a/extracted_content_pipeline/campaign_example.py
+++ b/extracted_content_pipeline/campaign_example.py
@@ -120,8 +120,12 @@ class StaticCampaignSkillStore:
         return self.prompt
 
 
-def _opportunity_uses_review_evidence(opportunity: Mapping[str, Any]) -> bool:
-    if str(opportunity.get("source_type") or "").strip().lower() == "review":
+def _opportunity_uses_source_type(
+    opportunity: Mapping[str, Any],
+    source_type: str,
+) -> bool:
+    expected = str(source_type or "").strip().lower()
+    if str(opportunity.get("source_type") or "").strip().lower() == expected:
         return True
     evidence = opportunity.get("evidence")
     if not isinstance(evidence, Sequence) or isinstance(evidence, (str, bytes, bytearray)):
@@ -129,7 +133,7 @@ def _opportunity_uses_review_evidence(opportunity: Mapping[str, Any]) -> bool:
     for row in evidence:
         if not isinstance(row, Mapping):
             continue
-        if str(row.get("source_type") or "").strip().lower() == "review":
+        if str(row.get("source_type") or "").strip().lower() == expected:
             return True
     return False
 
@@ -162,10 +166,16 @@ class DeterministicCampaignLLM:
         pains = opportunity.get("pain_points") or []
         pain = str(pains[0]) if pains else "workflow friction"
         subject = f"{company}: {pain}"[:80]
-        if _opportunity_uses_review_evidence(opportunity):
+        if _opportunity_uses_source_type(opportunity, "review"):
             body = (
                 f"<p>Teams evaluating {vendor} are reporting pain around {pain}.</p>"
                 f"<p>{company} can pair that market signal with your own data "
+                "and approval rules for a focused account sequence.</p>"
+            )
+        elif _opportunity_uses_source_type(opportunity, "support_ticket"):
+            body = (
+                f"<p>Support-ticket evidence around {vendor} points to {pain}.</p>"
+                f"<p>{company} can pair that service signal with your own data "
                 "and approval rules for a focused account sequence.</p>"
             )
         else:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -499,6 +499,34 @@ python scripts/smoke_content_ops_review_source_postgres.py \
   --json
 ```
 
+CFPB complaint narratives are the public support-ticket-like smoke path. Use
+them when the host needs a non-review source before wiring CRM notes, call
+transcripts, support tickets, or case exports. The exporter keeps only rows
+with complaint narratives and writes Content Ops source-row JSONL:
+
+```bash
+python scripts/export_content_ops_cfpb_sources.py \
+  --company "Example Bank" \
+  --search-term fees \
+  --limit 25 \
+  --output cfpb_sources.jsonl
+```
+
+The DB smoke fetches CFPB rows, inspects source-row ingestion, imports them
+under the provided account id, and persists offline generated drafts through
+the Postgres runner:
+
+```bash
+python scripts/smoke_content_ops_cfpb_source_postgres.py \
+  --company "Example Bank" \
+  --search-term fees \
+  --limit 1 \
+  --account-id acct_123 \
+  --default-field company_name="Acme Logistics" \
+  --default-field contact_email=ops@example.com \
+  --json
+```
+
 ```bash
 python scripts/load_extracted_campaign_opportunities.py \
   g2_review_sources.jsonl \

--- a/plans/PR-Content-Ops-CFPB-Source.md
+++ b/plans/PR-Content-Ops-CFPB-Source.md
@@ -21,13 +21,17 @@ only the exporter would leave the support-ticket ingestion path unproven.
 2. Add a Postgres/offline smoke that fetches CFPB rows, inspects ingestion,
    imports opportunities, and generates deterministic drafts.
 3. Document CFPB as a real support-ticket-like ingestion source.
+4. Make the offline deterministic generator avoid buyer-intent copy for
+   support-ticket evidence, so the smoke can keep its unsupported-claim guard.
 
 ### Files touched
 
 - `scripts/export_content_ops_cfpb_sources.py`
 - `scripts/smoke_content_ops_cfpb_source_postgres.py`
+- `extracted_content_pipeline/campaign_example.py`
 - `tests/test_export_content_ops_cfpb_sources.py`
 - `tests/test_smoke_content_ops_cfpb_source_postgres.py`
+- `tests/test_extracted_campaign_generation_example.py`
 - `scripts/run_extracted_pipeline_checks.sh`
 - `extracted_content_pipeline/README.md`
 - `extracted_content_pipeline/docs/host_install_runbook.md`
@@ -50,6 +54,8 @@ pain_category = row["Issue"]
 The smoke reuses existing source-row ingestion, `campaign_opportunities`
 import, and offline `generate_campaign_drafts_from_postgres` paths. Target
 account/contact fields continue to come from `--default-field`, not CFPB data.
+The deterministic offline LLM now treats `source_type="support_ticket"` as
+service evidence instead of buyer intent.
 
 ## Intentional
 
@@ -60,17 +66,23 @@ account/contact fields continue to come from `--default-field`, not CFPB data.
   to prove the ingestion seam without spending provider tokens.
 - The stale merged `PR-LLM-Registry-Service-Export` coordination row is removed
   while claiming this slice.
+- The CFPB smoke keeps `appears to be weighing` as a forbidden phrase; the
+  deterministic support-ticket copy path was fixed instead of weakening the
+  smoke guard.
 
 ## Deferred
 
 - Quality gates for unsupported claims and CTA policy stay separate.
 - A second non-commercial support-tweet adapter can follow after this CFPB path
   is proven.
+- Shared Postgres smoke helper extraction is deferred. The CFPB smoke mirrors
+  the existing review-source smoke to keep this already-large source slice
+  focused on ingestion behavior rather than refactoring test harnesses.
 
 ## Verification
 
-- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py -q` -> 68 passed.
-- `python -m py_compile scripts/export_content_ops_cfpb_sources.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> passed.
+- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py -q` -> 91 passed.
+- `python -m py_compile scripts/export_content_ops_cfpb_sources.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_generation_example.py extracted_content_pipeline/campaign_example.py` -> passed.
 - `bash scripts/check_ascii_python.sh` -> passed.
 - `grep -nP '[^\x00-\x7F]' <edited files>` -> no matches.
 - `bash scripts/local_pr_review.sh` -> passed.
@@ -82,6 +94,7 @@ account/contact fields continue to come from `--default-field`, not CFPB data.
 |---|---:|
 | CFPB exporter | ~275 |
 | CFPB Postgres smoke | ~505 |
-| Tests | ~485 |
-| CI runner + docs + coordination | ~160 |
-| **Total** | **~1425** |
+| Deterministic support-ticket copy | ~35 |
+| Tests | ~525 |
+| CI runner + docs + coordination | ~180 |
+| **Total** | **~1520** |

--- a/plans/PR-Content-Ops-CFPB-Source.md
+++ b/plans/PR-Content-Ops-CFPB-Source.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-CFPB-Source
+
+## Why this slice exists
+
+AI Content Ops can already normalize source rows such as support tickets,
+complaints, conversations, and cases, but the review-source smoke still proves
+only scraped review rows. We need a real public support-ticket-like dataset
+without coupling seller/product context to the source evidence. CFPB complaint
+narratives are public, stable, and can be represented as support-ticket source
+rows while keeping target account/contact fields supplied separately by host
+defaults.
+
+This slice exceeds the 400 LOC target because the exporter, DB-backed smoke,
+tests, and host docs are indivisible for a useful end-to-end proof. Shipping
+only the exporter would leave the support-ticket ingestion path unproven.
+
+## Scope (this PR)
+
+1. Add a read-only CFPB complaint exporter that writes Content Ops source-row
+   JSONL.
+2. Add a Postgres/offline smoke that fetches CFPB rows, inspects ingestion,
+   imports opportunities, and generates deterministic drafts.
+3. Document CFPB as a real support-ticket-like ingestion source.
+
+### Files touched
+
+- `scripts/export_content_ops_cfpb_sources.py`
+- `scripts/smoke_content_ops_cfpb_source_postgres.py`
+- `tests/test_export_content_ops_cfpb_sources.py`
+- `tests/test_smoke_content_ops_cfpb_source_postgres.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-CFPB-Source.md`
+
+## Mechanism
+
+The exporter reads CFPB's public complaint CSV endpoint, stops after enough
+narrative-bearing rows are collected, and emits source rows with:
+
+```python
+source_type = "support_ticket"
+source_system = "cfpb"
+vendor_name = row["Company"]
+text = row["Consumer complaint narrative"]
+pain_category = row["Issue"]
+```
+
+The smoke reuses existing source-row ingestion, `campaign_opportunities`
+import, and offline `generate_campaign_drafts_from_postgres` paths. Target
+account/contact fields continue to come from `--default-field`, not CFPB data.
+
+## Intentional
+
+- CFPB rows are support-ticket-like public complaint evidence, not seller-side
+  offer data.
+- The exporter uses standard-library HTTP/CSV only; no new dependency.
+- Live provider generation is not part of this PR. Offline generation is enough
+  to prove the ingestion seam without spending provider tokens.
+- The stale merged `PR-LLM-Registry-Service-Export` coordination row is removed
+  while claiming this slice.
+
+## Deferred
+
+- Quality gates for unsupported claims and CTA policy stay separate.
+- A second non-commercial support-tweet adapter can follow after this CFPB path
+  is proven.
+
+## Verification
+
+- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py -q` -> 66 passed.
+- `python -m py_compile scripts/export_content_ops_cfpb_sources.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> passed.
+- `bash scripts/check_ascii_python.sh` -> passed.
+- `grep -nP '[^\x00-\x7F]' <edited files>` -> no matches.
+- `bash scripts/local_pr_review.sh` -> passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1413 passed for `extracted_content_pipeline`, 295 passed for `extracted_reasoning_core`, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| CFPB exporter | ~265 |
+| CFPB Postgres smoke | ~475 |
+| Tests | ~420 |
+| CI runner + docs + coordination | ~160 |
+| **Total** | **~1320** |

--- a/plans/PR-Content-Ops-CFPB-Source.md
+++ b/plans/PR-Content-Ops-CFPB-Source.md
@@ -69,7 +69,7 @@ account/contact fields continue to come from `--default-field`, not CFPB data.
 
 ## Verification
 
-- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py -q` -> 66 passed.
+- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py -q` -> 68 passed.
 - `python -m py_compile scripts/export_content_ops_cfpb_sources.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> passed.
 - `bash scripts/check_ascii_python.sh` -> passed.
 - `grep -nP '[^\x00-\x7F]' <edited files>` -> no matches.
@@ -80,8 +80,8 @@ account/contact fields continue to come from `--default-field`, not CFPB data.
 
 | Area | Estimated LOC |
 |---|---:|
-| CFPB exporter | ~265 |
-| CFPB Postgres smoke | ~475 |
-| Tests | ~420 |
+| CFPB exporter | ~275 |
+| CFPB Postgres smoke | ~505 |
+| Tests | ~485 |
 | CI runner + docs + coordination | ~160 |
-| **Total** | **~1320** |
+| **Total** | **~1425** |

--- a/scripts/export_content_ops_cfpb_sources.py
+++ b/scripts/export_content_ops_cfpb_sources.py
@@ -72,15 +72,17 @@ def cfpb_row_to_source_row(
     if not narrative or not complaint_id:
         return {}
 
+    namespaced_id = f"{source_system}:{complaint_id}"
     product = _clean_text(row.get(FIELD_PRODUCT))
     issue = _clean_text(row.get(FIELD_ISSUE))
     source_title = " - ".join(part for part in (product, issue) if part)
     out: dict[str, Any] = {
-        "id": complaint_id,
-        "source_id": complaint_id,
+        "id": namespaced_id,
+        "source_id": namespaced_id,
         "source": source_system,
         "source_system": source_system,
         "source_type": source_type,
+        "complaint_id": complaint_id,
         "vendor_name": _clean_text(row.get(FIELD_COMPANY)),
         "text": narrative,
         "pain_category": issue,

--- a/scripts/export_content_ops_cfpb_sources.py
+++ b/scripts/export_content_ops_cfpb_sources.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Export CFPB complaint narratives as Content Ops source-row JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import io
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+DEFAULT_API_URL = (
+    "https://www.consumerfinance.gov/data-research/consumer-complaints/"
+    "search/api/v1/"
+)
+DEFAULT_DETAIL_URL_BASE = (
+    "https://www.consumerfinance.gov/data-research/consumer-complaints/"
+    "search/detail"
+)
+DEFAULT_LIMIT = 25
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_MAX_ROWS_SCANNED = 500
+DEFAULT_SOURCE_SYSTEM = "cfpb"
+DEFAULT_SOURCE_TYPE = "support_ticket"
+
+
+FIELD_COMPLAINT_ID = "Complaint ID"
+FIELD_NARRATIVE = "Consumer complaint narrative"
+FIELD_COMPANY = "Company"
+FIELD_PRODUCT = "Product"
+FIELD_SUB_PRODUCT = "Sub-product"
+FIELD_ISSUE = "Issue"
+FIELD_SUB_ISSUE = "Sub-issue"
+FIELD_DATE_RECEIVED = "Date received"
+FIELD_DATE_SENT = "Date sent to company"
+FIELD_PUBLIC_RESPONSE = "Company public response"
+FIELD_COMPANY_RESPONSE = "Company response to consumer"
+FIELD_TIMELY = "Timely response?"
+FIELD_CONSUMER_DISPUTED = "Consumer disputed?"
+FIELD_CONSENT = "Consumer consent provided?"
+FIELD_SUBMITTED_VIA = "Submitted via"
+FIELD_STATE = "State"
+FIELD_TAGS = "Tags"
+
+
+def _clean_text(value: Any) -> str:
+    return html.unescape(str(value or "").strip())
+
+
+def _optional_text(value: Any) -> str | None:
+    text = _clean_text(value)
+    return text or None
+
+
+def cfpb_row_to_source_row(
+    row: Mapping[str, Any],
+    *,
+    source_system: str = DEFAULT_SOURCE_SYSTEM,
+    source_type: str = DEFAULT_SOURCE_TYPE,
+    detail_url_base: str = DEFAULT_DETAIL_URL_BASE,
+) -> dict[str, Any]:
+    """Convert one CFPB CSV row into a Content Ops source row."""
+
+    narrative = _clean_text(row.get(FIELD_NARRATIVE))
+    complaint_id = _clean_text(row.get(FIELD_COMPLAINT_ID))
+    if not narrative or not complaint_id:
+        return {}
+
+    product = _clean_text(row.get(FIELD_PRODUCT))
+    issue = _clean_text(row.get(FIELD_ISSUE))
+    source_title = " - ".join(part for part in (product, issue) if part)
+    out: dict[str, Any] = {
+        "id": complaint_id,
+        "source_id": complaint_id,
+        "source": source_system,
+        "source_system": source_system,
+        "source_type": source_type,
+        "vendor_name": _clean_text(row.get(FIELD_COMPANY)),
+        "text": narrative,
+        "pain_category": issue,
+    }
+    optional = {
+        "source_title": source_title,
+        "source_url": _detail_url(detail_url_base, complaint_id),
+        "product": product,
+        "category": product,
+        "sub_product": row.get(FIELD_SUB_PRODUCT),
+        "issue": issue,
+        "sub_issue": row.get(FIELD_SUB_ISSUE),
+        "date_received": row.get(FIELD_DATE_RECEIVED),
+        "date_sent_to_company": row.get(FIELD_DATE_SENT),
+        "company_public_response": row.get(FIELD_PUBLIC_RESPONSE),
+        "company_response": row.get(FIELD_COMPANY_RESPONSE),
+        "timely_response": row.get(FIELD_TIMELY),
+        "consumer_disputed": row.get(FIELD_CONSUMER_DISPUTED),
+        "consumer_consent_provided": row.get(FIELD_CONSENT),
+        "submitted_via": row.get(FIELD_SUBMITTED_VIA),
+        "state": row.get(FIELD_STATE),
+        "tags": row.get(FIELD_TAGS),
+    }
+    for key, value in optional.items():
+        text = _optional_text(value)
+        if text:
+            out[key] = text
+    return out
+
+
+def _detail_url(base_url: str, complaint_id: str) -> str:
+    base = str(base_url or "").rstrip("/")
+    if not base or not complaint_id:
+        return ""
+    return f"{base}/{complaint_id}"
+
+
+def build_cfpb_query(
+    *,
+    company: str | None = None,
+    product: str | None = None,
+    issue: str | None = None,
+    search_term: str | None = None,
+    date_received_min: str | None = None,
+    date_received_max: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Build CFPB complaint API query params."""
+
+    params: dict[str, Any] = {
+        "format": "csv",
+        "field": "all",
+        "no_aggs": "true",
+        "sort": "created_date_desc",
+        "size": max(int(limit), 1),
+    }
+    for key, value in (
+        ("company", company),
+        ("product", product),
+        ("issue", issue),
+        ("search_term", search_term),
+        ("date_received_min", date_received_min),
+        ("date_received_max", date_received_max),
+    ):
+        text = _optional_text(value)
+        if text:
+            params[key] = text
+    return params
+
+
+def build_cfpb_url(api_url: str, params: Mapping[str, Any]) -> str:
+    separator = "&" if "?" in api_url else "?"
+    return f"{api_url}{separator}{urlencode(params, doseq=True)}"
+
+
+def fetch_cfpb_source_rows(
+    *,
+    api_url: str = DEFAULT_API_URL,
+    company: str | None = None,
+    product: str | None = None,
+    issue: str | None = None,
+    search_term: str | None = None,
+    date_received_min: str | None = None,
+    date_received_max: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    max_rows_scanned: int = DEFAULT_MAX_ROWS_SCANNED,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    source_system: str = DEFAULT_SOURCE_SYSTEM,
+    source_type: str = DEFAULT_SOURCE_TYPE,
+    detail_url_base: str = DEFAULT_DETAIL_URL_BASE,
+) -> list[dict[str, Any]]:
+    """Fetch CFPB complaint rows and return Content Ops source rows."""
+
+    params = build_cfpb_query(
+        company=company,
+        product=product,
+        issue=issue,
+        search_term=search_term,
+        date_received_min=date_received_min,
+        date_received_max=date_received_max,
+        limit=max(limit, max_rows_scanned),
+    )
+    request = Request(
+        build_cfpb_url(api_url, params),
+        headers={"User-Agent": "Atlas-Content-Ops-CFPB-Source/1.0"},
+    )
+    rows: list[dict[str, Any]] = []
+    with urlopen(request, timeout=timeout) as response:
+        stream = io.TextIOWrapper(response, encoding="utf-8-sig", newline="")
+        reader = csv.DictReader(stream)
+        for scanned, row in enumerate(reader, start=1):
+            source_row = cfpb_row_to_source_row(
+                row,
+                source_system=source_system,
+                source_type=source_type,
+                detail_url_base=detail_url_base,
+            )
+            if source_row:
+                rows.append(source_row)
+            if len(rows) >= limit or scanned >= max_rows_scanned:
+                break
+    return rows
+
+
+def render_jsonl(rows: Sequence[Mapping[str, Any]]) -> str:
+    return "\n".join(json.dumps(dict(row), sort_keys=True) for row in rows)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export CFPB complaints as Content Ops source-row JSONL."
+    )
+    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--company", default=None)
+    parser.add_argument("--product", default=None)
+    parser.add_argument("--issue", default=None)
+    parser.add_argument("--search-term", default=None)
+    parser.add_argument("--date-received-min", default=None)
+    parser.add_argument("--date-received-max", default=None)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--max-rows-scanned", type=int, default=DEFAULT_MAX_ROWS_SCANNED)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--source-system", default=DEFAULT_SOURCE_SYSTEM)
+    parser.add_argument("--source-type", default=DEFAULT_SOURCE_TYPE)
+    parser.add_argument("--detail-url-base", default=DEFAULT_DETAIL_URL_BASE)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.limit) < 1:
+        raise SystemExit("--limit must be positive")
+    if int(args.max_rows_scanned) < 1:
+        raise SystemExit("--max-rows-scanned must be positive")
+    if int(args.max_rows_scanned) < int(args.limit):
+        raise SystemExit("--max-rows-scanned must be >= --limit")
+    if float(args.timeout) <= 0:
+        raise SystemExit("--timeout must be positive")
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    rows = fetch_cfpb_source_rows(
+        api_url=str(args.api_url),
+        company=args.company,
+        product=args.product,
+        issue=args.issue,
+        search_term=args.search_term,
+        date_received_min=args.date_received_min,
+        date_received_max=args.date_received_max,
+        limit=int(args.limit),
+        max_rows_scanned=int(args.max_rows_scanned),
+        timeout=float(args.timeout),
+        source_system=str(args.source_system),
+        source_type=str(args.source_type),
+        detail_url_base=str(args.detail_url_base),
+    )
+    payload = render_jsonl(rows)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -27,6 +27,8 @@ pytest \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_export_content_ops_review_sources.py \
+  tests/test_export_content_ops_cfpb_sources.py \
+  tests/test_smoke_content_ops_cfpb_source_postgres.py \
   tests/test_extracted_content_ingestion_diagnostics.py \
   tests/test_extracted_blog_generation.py \
   tests/test_extracted_blog_blueprint_ingest.py \

--- a/scripts/smoke_content_ops_cfpb_source_postgres.py
+++ b/scripts/smoke_content_ops_cfpb_source_postgres.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Smoke-test CFPB source rows through Postgres-backed draft persistence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_example import (  # noqa: E402
+    DeterministicCampaignLLM,
+    StaticCampaignSkillStore,
+)
+from extracted_content_pipeline.campaign_generation import (  # noqa: E402
+    CampaignGenerationConfig,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
+    generate_campaign_drafts_from_postgres,
+)
+from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
+    import_campaign_opportunities,
+)
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
+    inspect_ingestion_file,
+)
+
+
+def _load_cfpb_exporter_module():
+    path = ROOT / "scripts" / "export_content_ops_cfpb_sources.py"
+    spec = importlib.util.spec_from_file_location("content_ops_cfpb_exporter", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load CFPB source exporter: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_cfpb_exporter = _load_cfpb_exporter_module()
+DEFAULT_CHANNELS = ("email_cold", "email_followup")
+DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
+DEFAULT_API_URL = _cfpb_exporter.DEFAULT_API_URL
+DEFAULT_MAX_ROWS_SCANNED = _cfpb_exporter.DEFAULT_MAX_ROWS_SCANNED
+DEFAULT_SOURCE_SYSTEM = _cfpb_exporter.DEFAULT_SOURCE_SYSTEM
+DEFAULT_SOURCE_TYPE = _cfpb_exporter.DEFAULT_SOURCE_TYPE
+DEFAULT_TIMEOUT_SECONDS = _cfpb_exporter.DEFAULT_TIMEOUT_SECONDS
+fetch_cfpb_source_rows = _cfpb_exporter.fetch_cfpb_source_rows
+render_jsonl = _cfpb_exporter.render_jsonl
+
+
+def _default_database_url() -> str | None:
+    return os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the CFPB Postgres smoke; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _csv_list(value: str | Sequence[str]) -> tuple[str, ...]:
+    raw = value.split(",") if isinstance(value, str) else value
+    return tuple(str(item or "").strip() for item in raw if str(item or "").strip())
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test CFPB complaint rows through Content Ops source export, "
+            "Postgres import, and DB-backed offline draft generation."
+        )
+    )
+    parser.add_argument("--company", default=None)
+    parser.add_argument("--product", default=None)
+    parser.add_argument("--issue", default=None)
+    parser.add_argument("--search-term", default=None)
+    parser.add_argument("--date-received-min", default=None)
+    parser.add_argument("--date-received-max", default=None)
+    parser.add_argument("--api-url", default=DEFAULT_API_URL)
+    parser.add_argument("--limit", type=int, default=1)
+    parser.add_argument("--max-rows-scanned", type=int, default=DEFAULT_MAX_ROWS_SCANNED)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--source-system", default=DEFAULT_SOURCE_SYSTEM)
+    parser.add_argument("--source-type", default=DEFAULT_SOURCE_TYPE)
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument("--min-drafts", type=int, default=None)
+    parser.add_argument("--allow-ingestion-warnings", action="store_true")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help="Fallback metadata applied to every CFPB source row. Repeat as key=value.",
+    )
+    parser.add_argument(
+        "--account-id",
+        required=True,
+        help="Tenant/account id used to scope imported opportunities and drafts.",
+    )
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--opportunity-table", default="campaign_opportunities")
+    parser.add_argument("--keep-existing-opportunities", action="store_true")
+    parser.add_argument(
+        "--forbidden-phrase",
+        action="append",
+        default=list(DEFAULT_FORBIDDEN_PHRASES),
+    )
+    parser.add_argument("--output-source-rows", type=Path, default=None)
+    parser.add_argument("--output-result", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.limit) < 1:
+        raise SystemExit("--limit must be positive")
+    if int(args.max_rows_scanned) < int(args.limit):
+        raise SystemExit("--max-rows-scanned must be >= --limit")
+    if float(args.timeout) <= 0:
+        raise SystemExit("--timeout must be positive")
+    if args.min_drafts is not None and int(args.min_drafts) < 1:
+        raise SystemExit("--min-drafts must be positive")
+    if not _csv_list(args.channels):
+        raise SystemExit("--channels must include at least one channel")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+async def run_cfpb_source_postgres_smoke(
+    args: argparse.Namespace,
+    *,
+    source_rows_path: Path,
+) -> tuple[int, dict[str, Any]]:
+    default_fields = parse_default_fields_or_exit(args.default_field)
+    channels = _csv_list(args.channels)
+    min_drafts = (
+        int(args.min_drafts)
+        if args.min_drafts is not None
+        else int(args.limit) * len(channels)
+    )
+    pool = await _create_pool(str(args.database_url))
+    source_rows: list[dict[str, Any]] = []
+    ingestion_report: dict[str, Any] | None = None
+    import_result: dict[str, Any] | None = None
+    drafts_result: dict[str, Any] | None = None
+    saved_drafts: list[dict[str, Any]] = []
+    imported_target_ids: list[str] = []
+    errors: list[str] = []
+    try:
+        try:
+            source_rows = fetch_cfpb_source_rows(
+                api_url=str(args.api_url),
+                company=args.company,
+                product=args.product,
+                issue=args.issue,
+                search_term=args.search_term,
+                date_received_min=args.date_received_min,
+                date_received_max=args.date_received_max,
+                limit=int(args.limit),
+                max_rows_scanned=int(args.max_rows_scanned),
+                timeout=float(args.timeout),
+                source_system=str(args.source_system),
+                source_type=str(args.source_type),
+            )
+            if len(source_rows) < int(args.limit):
+                errors.append(
+                    f"expected {int(args.limit)} CFPB source row(s), got {len(source_rows)}"
+                )
+            if not errors:
+                _write_jsonl(source_rows, source_rows_path)
+                report = inspect_ingestion_file(
+                    source_rows_path,
+                    source_rows=True,
+                    source_format="jsonl",
+                    target_mode=str(args.target_mode),
+                    default_fields=default_fields,
+                )
+                ingestion_report = report.as_dict()
+                if not report.ok:
+                    errors.append("ingestion inspection failed")
+                if report.warnings and not bool(args.allow_ingestion_warnings):
+                    errors.append(
+                        "ingestion inspection produced warnings; provide --default-field "
+                        "bindings or pass --allow-ingestion-warnings"
+                    )
+            if not errors:
+                errors.extend(await _schema_readiness_errors(pool, args))
+            if not errors:
+                loaded = load_source_campaign_opportunities_from_file(
+                    source_rows_path,
+                    file_format="jsonl",
+                    target_mode=str(args.target_mode),
+                    default_fields=default_fields,
+                )
+                imported = await import_campaign_opportunities(
+                    pool,
+                    loaded.opportunities,
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    target_mode=str(args.target_mode),
+                    opportunity_table=str(args.opportunity_table),
+                    replace_existing=not bool(args.keep_existing_opportunities),
+                    normalize=False,
+                    warnings=loaded.warnings,
+                    source=loaded.source,
+                )
+                import_result = imported.as_dict()
+                imported_target_ids = list(imported.target_ids)
+                if imported.skipped:
+                    errors.append(f"import skipped {imported.skipped} row(s)")
+            if not errors:
+                drafts_result = await _generate_imported_target_drafts(
+                    pool=pool,
+                    args=args,
+                    channels=channels,
+                    target_ids=imported_target_ids,
+                )
+                saved_drafts = await _fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
+                errors.extend(_generation_errors(drafts_result))
+                errors.extend(_draft_errors(
+                    {"drafts": saved_drafts},
+                    min_drafts=min_drafts,
+                    forbidden_phrases=args.forbidden_phrase,
+                ))
+                errors.extend(_saved_draft_target_errors(saved_drafts, imported_target_ids))
+        except Exception as exc:  # pragma: no cover - exercised by live hosts
+            errors.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    payload = {
+        "ok": not errors,
+        "source": "cfpb",
+        "source_rows": len(source_rows),
+        "source_rows_path": str(source_rows_path),
+        "ingestion": ingestion_report,
+        "import": import_result,
+        "drafts": drafts_result,
+        "saved_drafts": saved_drafts,
+        "errors": errors,
+    }
+    if args.output_result:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+    return (0 if not errors else 1), payload
+
+
+def _write_jsonl(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = render_jsonl(rows)
+    path.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
+
+
+async def _generate_imported_target_drafts(
+    *,
+    pool: Any,
+    args: argparse.Namespace,
+    channels: Sequence[str],
+    target_ids: Sequence[str],
+) -> dict[str, Any]:
+    saved_ids: list[str] = []
+    errors: list[Mapping[str, Any]] = []
+    generated = 0
+    skipped = 0
+    requested = 0
+    for target_id in target_ids:
+        result = await generate_campaign_drafts_from_postgres(
+            pool,
+            scope={"account_id": args.account_id, "user_id": args.user_id},
+            target_mode=str(args.target_mode),
+            channel=channels[0],
+            channels=tuple(channels),
+            limit=1,
+            filters={"target_id": target_id},
+            llm=DeterministicCampaignLLM(),
+            skills=StaticCampaignSkillStore(),
+            config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
+            opportunity_table=str(args.opportunity_table),
+        )
+        data = result.as_dict()
+        requested += int(data.get("requested") or 0)
+        generated += int(data.get("generated") or 0)
+        skipped += int(data.get("skipped") or 0)
+        saved_ids.extend(str(item) for item in data.get("saved_ids") or ())
+        errors.extend(error for error in data.get("errors") or () if isinstance(error, Mapping))
+    return {
+        "requested": requested,
+        "generated": generated,
+        "skipped": skipped,
+        "saved_ids": saved_ids,
+        "errors": [dict(error) for error in errors],
+    }
+
+
+def _generation_errors(result: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(result, Mapping):
+        return ["generation result missing"]
+    errors: list[str] = []
+    reported_errors = result.get("errors") or []
+    if reported_errors:
+        errors.append(f"generation reported {len(reported_errors)} error(s)")
+    if int(result.get("skipped") or 0):
+        errors.append(f"generation skipped {result.get('skipped')} draft(s)")
+    return errors
+
+
+async def _schema_readiness_errors(pool: Any, args: argparse.Namespace) -> list[str]:
+    missing: list[str] = []
+    for table_name in (str(args.opportunity_table), "b2b_campaigns"):
+        if not await _relation_exists(pool, table_name):
+            missing.append(table_name)
+    if not missing:
+        return []
+    command = (
+        "python scripts/run_extracted_content_pipeline_migrations.py "
+        "--database-url \"$EXTRACTED_DATABASE_URL\""
+    )
+    return [
+        "required Content Ops table(s) missing: "
+        f"{', '.join(missing)}. Run {command} before this smoke."
+    ]
+
+
+async def _relation_exists(pool: Any, table_name: str) -> bool:
+    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
+    return bool(value)
+
+
+async def _fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:
+    ids = [str(item) for item in saved_ids if str(item or "").strip()]
+    if not ids:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT id, subject, body, target_mode, channel, metadata
+          FROM b2b_campaigns
+         WHERE id::text = ANY($1::text[])
+        """,
+        ids,
+    )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        metadata = _metadata_object(_row_value(row, "metadata"))
+        source_opportunity = metadata.get("source_opportunity")
+        if not isinstance(source_opportunity, Mapping):
+            source_opportunity = {}
+        out.append({
+            "id": str(_row_value(row, "id") or ""),
+            "target_id": str(metadata.get("target_id") or source_opportunity.get("target_id") or ""),
+            "subject": _row_value(row, "subject"),
+            "body": _row_value(row, "body"),
+            "target_mode": _row_value(row, "target_mode"),
+            "channel": _row_value(row, "channel"),
+        })
+    return out
+
+
+def _draft_errors(
+    result: Mapping[str, Any],
+    *,
+    min_drafts: int,
+    forbidden_phrases: Sequence[str],
+) -> list[str]:
+    drafts = result.get("drafts")
+    if not isinstance(drafts, list):
+        return ["result.drafts is missing or not a list"]
+    if len(drafts) < min_drafts:
+        return [f"expected at least {min_drafts} draft(s), got {len(drafts)}"]
+    errors: list[str] = []
+    forbidden = [phrase.lower() for phrase in forbidden_phrases if phrase]
+    for index, draft in enumerate(drafts[:min_drafts], start=1):
+        if not isinstance(draft, Mapping):
+            errors.append(f"draft {index} is not an object")
+            continue
+        for field in ("subject", "body", "target_id", "channel"):
+            if not str(draft.get(field) or "").strip():
+                errors.append(f"draft {index} missing {field}")
+        body = str(draft.get("body") or "").lower()
+        for phrase in forbidden:
+            if phrase in body:
+                errors.append(f"draft {index} contains forbidden phrase: {phrase}")
+    return errors
+
+
+def _saved_draft_target_errors(
+    saved_drafts: Sequence[Mapping[str, Any]],
+    imported_target_ids: Sequence[str],
+) -> list[str]:
+    imported = {str(target_id) for target_id in imported_target_ids}
+    errors: list[str] = []
+    for draft in saved_drafts:
+        target_id = str(draft.get("target_id") or "")
+        if not target_id:
+            errors.append(f"persisted draft missing target_id metadata: {draft.get('id') or '<unknown>'}")
+            continue
+        if target_id not in imported:
+            errors.append(f"persisted draft target_id was not imported: {target_id}")
+    return errors
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return row[key]
+
+
+def _metadata_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if payload.get("ok"):
+        imported = payload.get("import") if isinstance(payload.get("import"), Mapping) else {}
+        drafts = payload.get("drafts") if isinstance(payload.get("drafts"), Mapping) else {}
+        print(
+            "Content Ops CFPB Postgres smoke passed: "
+            f"source_rows={payload.get('source_rows')} "
+            f"imported={imported.get('inserted', 0)} "
+            f"generated={drafts.get('generated', 0)}"
+        )
+        return
+    print("Content Ops CFPB Postgres smoke failed:", file=sys.stderr)
+    for error in payload.get("errors") or []:
+        print(f"- {error}", file=sys.stderr)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    if args.output_source_rows:
+        code, payload = await run_cfpb_source_postgres_smoke(
+            args,
+            source_rows_path=args.output_source_rows,
+        )
+    else:
+        with tempfile.TemporaryDirectory(prefix="content-ops-cfpb-source-db-") as tmpdir:
+            code, payload = await run_cfpb_source_postgres_smoke(
+                args,
+                source_rows_path=Path(tmpdir) / "cfpb_sources.jsonl",
+            )
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/smoke_content_ops_cfpb_source_postgres.py
+++ b/scripts/smoke_content_ops_cfpb_source_postgres.py
@@ -40,6 +40,11 @@ from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
 )
 
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
 
 def _load_cfpb_exporter_module():
     path = ROOT / "scripts" / "export_content_ops_cfpb_sources.py"
@@ -53,7 +58,7 @@ def _load_cfpb_exporter_module():
 
 _cfpb_exporter = _load_cfpb_exporter_module()
 DEFAULT_CHANNELS = ("email_cold", "email_followup")
-DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
+DEFAULT_FORBIDDEN_PHRASES: tuple[str, ...] = ()
 DEFAULT_API_URL = _cfpb_exporter.DEFAULT_API_URL
 DEFAULT_MAX_ROWS_SCANNED = _cfpb_exporter.DEFAULT_MAX_ROWS_SCANNED
 DEFAULT_SOURCE_SYSTEM = _cfpb_exporter.DEFAULT_SOURCE_SYSTEM
@@ -64,7 +69,21 @@ render_jsonl = _cfpb_exporter.render_jsonl
 
 
 def _default_database_url() -> str | None:
-    return os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    dsn = str(getattr(db_settings, "dsn", "") or "").strip()
+    return dsn or None
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
 
 
 async def _create_pool(database_url: str):
@@ -463,6 +482,7 @@ def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
 
 
 async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
     args = _parse_args(argv)
     _validate_args(args)
     if args.output_source_rows:

--- a/scripts/smoke_content_ops_cfpb_source_postgres.py
+++ b/scripts/smoke_content_ops_cfpb_source_postgres.py
@@ -58,7 +58,7 @@ def _load_cfpb_exporter_module():
 
 _cfpb_exporter = _load_cfpb_exporter_module()
 DEFAULT_CHANNELS = ("email_cold", "email_followup")
-DEFAULT_FORBIDDEN_PHRASES: tuple[str, ...] = ()
+DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
 DEFAULT_API_URL = _cfpb_exporter.DEFAULT_API_URL
 DEFAULT_MAX_ROWS_SCANNED = _cfpb_exporter.DEFAULT_MAX_ROWS_SCANNED
 DEFAULT_SOURCE_SYSTEM = _cfpb_exporter.DEFAULT_SOURCE_SYSTEM

--- a/tests/test_export_content_ops_cfpb_sources.py
+++ b/tests/test_export_content_ops_cfpb_sources.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/export_content_ops_cfpb_sources.py"
+SPEC = importlib.util.spec_from_file_location(
+    "export_content_ops_cfpb_sources",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+exporter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(exporter)
+
+
+def _cfpb_row(**overrides):
+    row = {
+        "Complaint ID": "12345",
+        "Company": "Example Bank",
+        "Product": "Checking or savings account",
+        "Sub-product": "Checking account",
+        "Issue": "Managing an account",
+        "Sub-issue": "Problem using a debit or ATM card",
+        "Consumer complaint narrative": "The bank kept charging fees after I closed the account.",
+        "Date received": "2026-01-15",
+        "Date sent to company": "2026-01-16",
+        "Company public response": "Company believes it acted appropriately.",
+        "Company response to consumer": "Closed with explanation",
+        "Timely response?": "Yes",
+        "Consumer disputed?": "N/A",
+        "Consumer consent provided?": "Consent provided",
+        "Submitted via": "Web",
+        "State": "TX",
+        "Tags": "Older American",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_cfpb_row_to_source_row_maps_public_complaint_fields():
+    source_row = exporter.cfpb_row_to_source_row(_cfpb_row())
+
+    assert source_row["id"] == "12345"
+    assert source_row["source_id"] == "12345"
+    assert source_row["source"] == "cfpb"
+    assert source_row["source_system"] == "cfpb"
+    assert source_row["source_type"] == "support_ticket"
+    assert source_row["vendor_name"] == "Example Bank"
+    assert source_row["text"].startswith("The bank kept charging fees")
+    assert source_row["pain_category"] == "Managing an account"
+    assert source_row["source_title"] == "Checking or savings account - Managing an account"
+    assert source_row["source_url"].endswith("/12345")
+    assert source_row["category"] == "Checking or savings account"
+    assert source_row["submitted_via"] == "Web"
+
+
+def test_cfpb_row_to_source_row_drops_rows_without_narrative_or_id():
+    assert exporter.cfpb_row_to_source_row(_cfpb_row(**{"Consumer complaint narrative": ""})) == {}
+    assert exporter.cfpb_row_to_source_row(_cfpb_row(**{"Complaint ID": ""})) == {}
+
+
+def test_build_cfpb_query_keeps_filters_parametric():
+    query = exporter.build_cfpb_query(
+        company="Example Bank",
+        product="Credit card",
+        issue="Fees",
+        search_term="late fee",
+        date_received_min="2026-01-01",
+        date_received_max="2026-02-01",
+        limit=3,
+    )
+
+    assert query["format"] == "csv"
+    assert query["field"] == "all"
+    assert query["no_aggs"] == "true"
+    assert query["size"] == 3
+    assert query["company"] == "Example Bank"
+    assert query["product"] == "Credit card"
+    assert query["issue"] == "Fees"
+    assert query["search_term"] == "late fee"
+    assert query["date_received_min"] == "2026-01-01"
+    assert query["date_received_max"] == "2026-02-01"
+
+
+def test_build_cfpb_url_preserves_existing_query_string():
+    url = exporter.build_cfpb_url(
+        "https://example.test/api?existing=1",
+        {"format": "csv", "search_term": "late fee"},
+    )
+
+    assert url == "https://example.test/api?existing=1&format=csv&search_term=late+fee"
+
+
+class _Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def test_fetch_cfpb_source_rows_streams_until_limit(monkeypatch):
+    csv_payload = (
+        "Complaint ID,Company,Product,Issue,Consumer complaint narrative\n"
+        "1,Example Bank,Checking,Fees,\n"
+        "2,Example Bank,Checking,Fees,First usable complaint.\n"
+        "3,Example Bank,Checking,Access,Second usable complaint.\n"
+        "4,Example Bank,Checking,Access,Third usable complaint.\n"
+    ).encode("utf-8")
+    calls = []
+
+    def fake_urlopen(request, timeout):
+        calls.append({"url": request.full_url, "timeout": timeout, "headers": request.headers})
+        return _Response(csv_payload)
+
+    monkeypatch.setattr(exporter, "urlopen", fake_urlopen)
+
+    rows = exporter.fetch_cfpb_source_rows(
+        api_url="https://example.test/cfpb",
+        company="Example Bank",
+        search_term="fees",
+        limit=2,
+        max_rows_scanned=4,
+        timeout=7.5,
+    )
+
+    assert [row["id"] for row in rows] == ["2", "3"]
+    assert calls[0]["timeout"] == 7.5
+    assert "company=Example+Bank" in calls[0]["url"]
+    assert "search_term=fees" in calls[0]["url"]
+    assert calls[0]["headers"]["User-agent"] == "Atlas-Content-Ops-CFPB-Source/1.0"
+
+
+def test_render_jsonl_outputs_one_sorted_json_object_per_row():
+    payload = exporter.render_jsonl([
+        {"source": "cfpb", "id": "2"},
+        {"source": "cfpb", "id": "3"},
+    ])
+
+    assert payload.splitlines() == [
+        '{"id": "2", "source": "cfpb"}',
+        '{"id": "3", "source": "cfpb"}',
+    ]

--- a/tests/test_export_content_ops_cfpb_sources.py
+++ b/tests/test_export_content_ops_cfpb_sources.py
@@ -43,11 +43,12 @@ def _cfpb_row(**overrides):
 def test_cfpb_row_to_source_row_maps_public_complaint_fields():
     source_row = exporter.cfpb_row_to_source_row(_cfpb_row())
 
-    assert source_row["id"] == "12345"
-    assert source_row["source_id"] == "12345"
+    assert source_row["id"] == "cfpb:12345"
+    assert source_row["source_id"] == "cfpb:12345"
     assert source_row["source"] == "cfpb"
     assert source_row["source_system"] == "cfpb"
     assert source_row["source_type"] == "support_ticket"
+    assert source_row["complaint_id"] == "12345"
     assert source_row["vendor_name"] == "Example Bank"
     assert source_row["text"].startswith("The bank kept charging fees")
     assert source_row["pain_category"] == "Managing an account"
@@ -127,7 +128,7 @@ def test_fetch_cfpb_source_rows_streams_until_limit(monkeypatch):
         timeout=7.5,
     )
 
-    assert [row["id"] for row in rows] == ["2", "3"]
+    assert [row["id"] for row in rows] == ["cfpb:2", "cfpb:3"]
     assert calls[0]["timeout"] == 7.5
     assert "company=Example+Bank" in calls[0]["url"]
     assert "search_term=fees" in calls[0]["url"]

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -123,6 +123,37 @@ async def test_example_generates_drafts_from_customer_opportunity_payload() -> N
 
 
 @pytest.mark.asyncio
+async def test_example_avoids_buyer_intent_for_support_ticket_sources() -> None:
+    payload = {
+        "scope": {"account_id": "acct-1"},
+        "target_mode": "vendor_retention",
+        "limit": 1,
+        "opportunities": [
+            {
+                "id": "cfpb:1",
+                "company": "Acme Logistics",
+                "vendor": "Example Bank",
+                "email": "ops@example.com",
+                "source_type": "support_ticket",
+                "pain_category": "Fees",
+                "evidence": [
+                    {
+                        "source_type": "support_ticket",
+                        "text": "The bank kept charging fees after I closed the account.",
+                    }
+                ],
+            }
+        ],
+    }
+
+    result = await generate_campaign_drafts_from_payload(payload)
+
+    body = result["drafts"][0]["body"]
+    assert "Support-ticket evidence around Example Bank points to Fees." in body
+    assert "appears to be weighing" not in body
+
+
+@pytest.mark.asyncio
 async def test_example_accepts_host_llm_and_skill_store_overrides() -> None:
     llm = _InjectedLLM()
     payload = {

--- a/tests/test_smoke_content_ops_cfpb_source_postgres.py
+++ b/tests/test_smoke_content_ops_cfpb_source_postgres.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_cfpb_source_postgres.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_cfpb_source_postgres",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        opportunity_rows=None,
+        saved_draft_rows=None,
+        existing_relations=None,
+    ):
+        self.opportunity_rows = list(opportunity_rows or [])
+        self.saved_draft_rows = list(saved_draft_rows or [])
+        self.existing_relations = set(
+            existing_relations or ("campaign_opportunities", "b2b_campaigns")
+        )
+        self.fetch_calls = []
+        self.execute_calls = []
+        self.fetchval_calls = []
+        self.fetchval_results = ["campaign-1", "campaign-2"]
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        if len(self.fetch_calls) == 1:
+            return self.opportunity_rows
+        return self.saved_draft_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return "EXECUTE"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        if "to_regclass" in str(query):
+            return args[0] if args and args[0] in self.existing_relations else None
+        return self.fetchval_results.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+async def _return_pool(pool):
+    return pool
+
+
+def _source_row():
+    return {
+        "id": "cfpb-1",
+        "source_id": "cfpb-1",
+        "source": "cfpb",
+        "source_system": "cfpb",
+        "source_type": "support_ticket",
+        "vendor_name": "Example Bank",
+        "text": "The bank kept charging fees after I closed the account.",
+        "pain_category": "Fees",
+        "source_title": "Checking account - Fees",
+        "source_url": "https://example.test/cfpb/cfpb-1",
+    }
+
+
+def _opportunity_row():
+    return {
+        "target_id": "cfpb-1",
+        "company_name": "Acme Logistics",
+        "vendor_name": "Example Bank",
+        "contact_email": "ops@example.com",
+        "contact_name": "Jordan Lee",
+        "pain_points": ["Fees"],
+        "evidence": [
+            {
+                "source_id": "cfpb-1",
+                "source_type": "support_ticket",
+                "text": "The bank kept charging fees after I closed the account.",
+            }
+        ],
+        "raw_payload": {
+            "target_id": "cfpb-1",
+            "company_name": "Acme Logistics",
+            "vendor_name": "Example Bank",
+            "contact_email": "ops@example.com",
+            "source_type": "support_ticket",
+        },
+    }
+
+
+def _saved_draft_row(*, body=None):
+    return {
+        "id": "campaign-1",
+        "subject": "Acme Logistics: Fees",
+        "body": body or "<p>Teams evaluating Example Bank are reporting pain around Fees.</p>",
+        "target_mode": "vendor_retention",
+        "channel": "email_cold",
+        "metadata": {
+            "target_id": "cfpb-1",
+            "source_opportunity": {
+                "target_id": "cfpb-1",
+            },
+        },
+    }
+
+
+def _args(**overrides):
+    values = {
+        "company": "Example Bank",
+        "product": None,
+        "issue": "Fees",
+        "search_term": "fees",
+        "date_received_min": None,
+        "date_received_max": None,
+        "api_url": "https://example.test/cfpb",
+        "limit": 1,
+        "max_rows_scanned": 5,
+        "timeout": 3.5,
+        "source_system": "cfpb",
+        "source_type": "support_ticket",
+        "target_mode": "vendor_retention",
+        "channels": "email_cold",
+        "min_drafts": None,
+        "allow_ingestion_warnings": False,
+        "default_field": [
+            "company_name=Acme Logistics",
+            "contact_email=ops@example.com",
+            "contact_name=Jordan Lee",
+        ],
+        "account_id": "acct-smoke",
+        "user_id": None,
+        "opportunity_table": "campaign_opportunities",
+        "keep_existing_opportunities": False,
+        "forbidden_phrase": list(smoke.DEFAULT_FORBIDDEN_PHRASES),
+        "output_source_rows": None,
+        "output_result": None,
+        "json": False,
+        "database_url": "postgres://example",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_imports_and_persists(monkeypatch, tmp_path):
+    pool = _Pool(
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    fetch_calls = []
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    def fake_fetch(**kwargs):
+        fetch_calls.append(kwargs)
+        return [_source_row()]
+
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", fake_fetch)
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source"] == "cfpb"
+    assert payload["source_rows"] == 1
+    assert payload["import"]["inserted"] == 1
+    assert payload["import"]["replace_existing"] is True
+    assert payload["drafts"]["generated"] == 1
+    assert payload["saved_drafts"][0]["target_id"] == "cfpb-1"
+    assert pool.closed is True
+    assert fetch_calls[0]["api_url"] == "https://example.test/cfpb"
+    assert fetch_calls[0]["timeout"] == 3.5
+    assert fetch_calls[0]["source_type"] == "support_ticket"
+    assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]
+    assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
+    assert pool.fetch_calls[0]["args"] == ("vendor_retention", "acct-smoke", "cfpb-1", 1)
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_fails_before_import_when_schema_missing(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(existing_relations={"b2b_campaigns"})
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("required Content Ops table(s) missing" in error for error in payload["errors"])
+    assert any("campaign_opportunities" in error for error in payload["errors"])
+    assert pool.execute_calls == []
+    assert all("INSERT INTO b2b_campaigns" not in call["query"] for call in pool.fetchval_calls)
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_can_keep_existing_opportunities(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(keep_existing_opportunities=True),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["import"]["replace_existing"] is False
+    assert all("DELETE FROM" not in call["query"] for call in pool.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_fails_on_ingestion_warnings(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool()
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(default_field=[]),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("ingestion inspection produced warnings" in error for error in payload["errors"])
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_fails_on_forbidden_persisted_body(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row(body="<p>Acme appears to be weighing Example Bank.</p>")],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 1
+    assert any("forbidden phrase" in error for error in payload["errors"])

--- a/tests/test_smoke_content_ops_cfpb_source_postgres.py
+++ b/tests/test_smoke_content_ops_cfpb_source_postgres.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import importlib.util
 from pathlib import Path
+import sys
+import types
 
 import pytest
 
@@ -63,22 +65,23 @@ async def _return_pool(pool):
 
 def _source_row():
     return {
-        "id": "cfpb-1",
-        "source_id": "cfpb-1",
+        "id": "cfpb:1",
+        "source_id": "cfpb:1",
         "source": "cfpb",
         "source_system": "cfpb",
         "source_type": "support_ticket",
+        "complaint_id": "1",
         "vendor_name": "Example Bank",
         "text": "The bank kept charging fees after I closed the account.",
         "pain_category": "Fees",
         "source_title": "Checking account - Fees",
-        "source_url": "https://example.test/cfpb/cfpb-1",
+        "source_url": "https://example.test/cfpb/1",
     }
 
 
 def _opportunity_row():
     return {
-        "target_id": "cfpb-1",
+        "target_id": "cfpb:1",
         "company_name": "Acme Logistics",
         "vendor_name": "Example Bank",
         "contact_email": "ops@example.com",
@@ -86,13 +89,13 @@ def _opportunity_row():
         "pain_points": ["Fees"],
         "evidence": [
             {
-                "source_id": "cfpb-1",
+                "source_id": "cfpb:1",
                 "source_type": "support_ticket",
                 "text": "The bank kept charging fees after I closed the account.",
             }
         ],
         "raw_payload": {
-            "target_id": "cfpb-1",
+            "target_id": "cfpb:1",
             "company_name": "Acme Logistics",
             "vendor_name": "Example Bank",
             "contact_email": "ops@example.com",
@@ -109,9 +112,9 @@ def _saved_draft_row(*, body=None):
         "target_mode": "vendor_retention",
         "channel": "email_cold",
         "metadata": {
-            "target_id": "cfpb-1",
+            "target_id": "cfpb:1",
             "source_opportunity": {
-                "target_id": "cfpb-1",
+                "target_id": "cfpb:1",
             },
         },
     }
@@ -181,14 +184,14 @@ async def test_cfpb_source_postgres_smoke_imports_and_persists(monkeypatch, tmp_
     assert payload["import"]["inserted"] == 1
     assert payload["import"]["replace_existing"] is True
     assert payload["drafts"]["generated"] == 1
-    assert payload["saved_drafts"][0]["target_id"] == "cfpb-1"
+    assert payload["saved_drafts"][0]["target_id"] == "cfpb:1"
     assert pool.closed is True
     assert fetch_calls[0]["api_url"] == "https://example.test/cfpb"
     assert fetch_calls[0]["timeout"] == 3.5
     assert fetch_calls[0]["source_type"] == "support_ticket"
     assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]
     assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
-    assert pool.fetch_calls[0]["args"] == ("vendor_retention", "acct-smoke", "cfpb-1", 1)
+    assert pool.fetch_calls[0]["args"] == ("vendor_retention", "acct-smoke", "cfpb:1", 1)
 
 
 @pytest.mark.asyncio
@@ -201,7 +204,7 @@ async def test_cfpb_source_postgres_smoke_fails_before_import_when_schema_missin
     monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
 
     code, payload = await smoke.run_cfpb_source_postgres_smoke(
-        _args(),
+        _args(forbidden_phrase=["appears to be weighing"]),
         source_rows_path=tmp_path / "cfpb_sources.jsonl",
     )
 
@@ -266,9 +269,56 @@ async def test_cfpb_source_postgres_smoke_fails_on_forbidden_persisted_body(
     monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
 
     code, payload = await smoke.run_cfpb_source_postgres_smoke(
-        _args(),
+        _args(forbidden_phrase=["appears to be weighing"]),
         source_rows_path=tmp_path / "cfpb_sources.jsonl",
     )
 
     assert code == 1
     assert any("forbidden phrase" in error for error in payload["errors"])
+
+
+def test_default_database_url_falls_back_to_atlas_settings(monkeypatch):
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    fake_config = types.SimpleNamespace(
+        db_settings=types.SimpleNamespace(dsn="postgres://settings")
+    )
+    monkeypatch.setitem(sys.modules, "atlas_brain.storage.config", fake_config)
+
+    assert smoke._default_database_url() == "postgres://settings"
+
+
+@pytest.mark.asyncio
+async def test_main_loads_dotenv_before_database_url_default(monkeypatch, tmp_path, capsys):
+    pool = _Pool(
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+
+    def fake_load_dotenv(path, override=False):
+        if path.name == ".env.local":
+            monkeypatch.setenv("EXTRACTED_DATABASE_URL", "postgres://dotenv")
+        return True
+
+    monkeypatch.setattr(smoke, "load_dotenv", fake_load_dotenv)
+
+    code = await smoke._main([
+        "--account-id",
+        "acct-smoke",
+        "--default-field",
+        "company_name=Acme Logistics",
+        "--default-field",
+        "contact_email=ops@example.com",
+        "--output-source-rows",
+        str(tmp_path / "cfpb_sources.jsonl"),
+        "--channels",
+        "email_cold",
+        "--json",
+    ])
+
+    assert code == 0
+    assert capsys.readouterr().out


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-CFPB-Source.md

Adds a real public support-ticket-like source path for AI Content Ops by exporting CFPB complaint narratives as source-row JSONL, then proving those rows can be inspected, imported into Postgres, and used for offline deterministic draft persistence. Also fixes the offline deterministic generator so support-ticket evidence does not produce unsupported buyer-intent copy.

## Intentional
- CFPB rows are treated as public support-ticket-like evidence, not seller-side data.
- Account and contact binding remains host-supplied through `--default-field`.
- Live provider generation is deferred; this slice proves ingestion and persistence offline without spending provider tokens.
- Removes a stale merged coordination row while claiming this slice.
- Keeps `appears to be weighing` as a forbidden phrase in the CFPB smoke; the deterministic support-ticket copy path was fixed instead of weakening the guard.

## Deferred
- Quality gates for unsupported claims and CTA policy stay separate.
- Additional non-commercial source adapters can follow once this CFPB path is proven.
- Shared Postgres smoke helper extraction is deferred to keep this already-large source slice focused on ingestion behavior rather than refactoring test harnesses.

## Verification
- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py -q` -> 91 passed.
- `python -m py_compile scripts/export_content_ops_cfpb_sources.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_source_postgres.py tests/test_extracted_campaign_generation_example.py extracted_content_pipeline/campaign_example.py` -> passed.
- `bash scripts/check_ascii_python.sh` -> passed.
- `grep -nP '[^\\x00-\\x7F]' <edited files>` -> no matches.
- `bash scripts/local_pr_review.sh` -> passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1413 passed for `extracted_content_pipeline`, 295 passed for `extracted_reasoning_core`, 1 existing torch/pynvml warning.

## Diff size
11 files, about +1457 / -2