### PR TITLE
Add read-only invoicing OAuth operator launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,6 +523,9 @@ ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL=https://atlas-brain.tailc7bd29.t
 ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=<long-operator-token> \
 python -m atlas_brain.mcp.invoicing_readonly_server --sse
 
+# Operator launcher (loads .env/.env.local, validates OAuth config, prints smokes)
+.venv/bin/python scripts/start_invoicing_readonly_oauth_server.py
+
 # connector boundary smoke (auth + exact read-only tool list; no invoice reads)
 python scripts/check_invoicing_readonly_mcp_connector.py \
   --url http://127.0.0.1:8065/mcp \
@@ -584,6 +587,12 @@ temporary OAuth client, approves it with
 code for a bearer token, and lists the MCP tools. It must report exactly the
 eight read-only tools above and does not call invoice/service/balance/payment
 tools.
+
+Use `scripts/start_invoicing_readonly_oauth_server.py` for local operator
+startup instead of shell-sourcing `.env` manually. The launcher loads `.env` and
+`.env.local`, forces OAuth mode, validates required public URLs and approval
+token length, starts the read-only server in the foreground, and prints the
+discovery/e2e smoke commands. It masks bearer and approval tokens in output.
 
 ### Intelligence MCP Server (33 tools)
 ```bash

--- a/plans/PR-Invoicing-Readonly-OAuth-Operator-Launcher.md
+++ b/plans/PR-Invoicing-Readonly-OAuth-Operator-Launcher.md
@@ -1,0 +1,81 @@
+## Why this slice exists
+
+The read-only invoicing OAuth connector now has discovery and e2e smokes, but
+starting the server is still too fragile. In the last live test, shell-sourcing
+`.env` failed in the interactive environment, so we had to use an ad hoc Python
+launcher to pass OAuth env vars into the server process.
+
+This slice turns that ad hoc launch path into a reusable operator script.
+
+## Scope (this PR)
+
+1. Add an operator launcher for the read-only invoicing OAuth MCP server.
+2. Load `.env` and `.env.local` without printing secrets.
+3. Validate OAuth mode, issuer URL, resource URL, approval token length, and
+   port before starting.
+4. Start `atlas_brain.mcp.invoicing_readonly_server --sse` with the current
+   Python interpreter.
+5. Print the follow-up discovery/e2e smoke commands and the required Tailscale
+   Funnel route.
+6. Add unit tests for env loading, validation, command construction, dry-run,
+   and secret-safe output.
+
+### Files touched
+
+- `scripts/start_invoicing_readonly_oauth_server.py`
+- `tests/test_start_invoicing_readonly_oauth_server.py`
+- `CLAUDE.md`
+- `plans/PR-Invoicing-Readonly-OAuth-Operator-Launcher.md`
+
+## Mechanism
+
+The launcher reads simple `KEY=value` dotenv lines from `.env` and `.env.local`
+with `.env.local` taking precedence. It overlays those values on the current
+environment, forces `ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=oauth`, validates
+the required OAuth keys, then calls:
+
+```bash
+<python> -m atlas_brain.mcp.invoicing_readonly_server --sse
+```
+
+By default it runs in the foreground so the operator can see uvicorn logs. A
+`--dry-run` mode validates configuration and prints the command/smoke guidance
+without starting the process.
+
+## Intentional
+
+- The script does not manage Tailscale Funnel state. It prints the exact route
+  command, but the operator still controls public exposure.
+- The script does not daemonize or write a PID file. Foreground execution is
+  simpler and safer for this local operator workflow.
+- The script never prints `ATLAS_MCP_AUTH_TOKEN` or
+  `ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN`.
+
+## Deferred
+
+- Process supervision/systemd integration is deferred until the connector needs
+  unattended uptime.
+- Durable OAuth client/token persistence remains deferred until restart
+  resilience is actually needed.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile scripts/start_invoicing_readonly_oauth_server.py tests/test_start_invoicing_readonly_oauth_server.py
+.venv/bin/python -m pytest tests/test_start_invoicing_readonly_oauth_server.py
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Launcher script | ~210 |
+| Tests | ~190 |
+| Docs/plan | ~110 |
+| **Total** | **~510** |
+
+This exceeds the soft cap because the operator helper ships with parser and
+secret-safety tests.

--- a/scripts/start_invoicing_readonly_oauth_server.py
+++ b/scripts/start_invoicing_readonly_oauth_server.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Start the read-only invoicing MCP server in OAuth mode."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = "8065"
+DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly"
+DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp"
+MIN_APPROVAL_TOKEN_LENGTH = 24
+SECRET_KEYS = {
+    "ATLAS_MCP_AUTH_TOKEN",
+    "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
+}
+REQUIRED_KEYS = (
+    "ATLAS_MCP_INVOICING_READONLY_AUTH_MODE",
+    "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL",
+    "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL",
+    "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
+)
+
+
+@dataclass(frozen=True)
+class LaunchConfig:
+    env: dict[str, str]
+    python: str
+    host: str
+    port: str
+    dry_run: bool
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load Atlas dotenv files and start the read-only invoicing MCP "
+            "server in ChatGPT-compatible OAuth mode."
+        )
+    )
+    parser.add_argument(
+        "--env-file",
+        action="append",
+        default=None,
+        help="Dotenv file to load. May be repeated. Defaults to .env then .env.local.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used to launch the MCP server. Defaults to the current interpreter.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help=f"Bind host. Defaults to env ATLAS_MCP_HOST or {DEFAULT_HOST}.",
+    )
+    parser.add_argument(
+        "--port",
+        default=None,
+        help=f"Bind port. Defaults to env ATLAS_MCP_INVOICING_READONLY_PORT or {DEFAULT_PORT}.",
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=None,
+        help=f"OAuth issuer URL. Defaults to env value or {DEFAULT_ISSUER_URL}.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=None,
+        help=f"OAuth resource URL. Defaults to env value or {DEFAULT_RESOURCE_URL}.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print the launch/smoke commands without starting the server.",
+    )
+    return parser
+
+
+def _parse_dotenv_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    if not key:
+        return None
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return key, value
+
+
+def _load_dotenv_files(paths: list[Path]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in paths:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            parsed = _parse_dotenv_line(line)
+            if parsed is None:
+                continue
+            key, value = parsed
+            values[key] = value
+    return values
+
+
+def _masked_env_report(env: Mapping[str, str], keys: tuple[str, ...] = REQUIRED_KEYS) -> list[str]:
+    lines: list[str] = []
+    for key in keys:
+        value = env.get(key, "")
+        if key in SECRET_KEYS:
+            state = f"SET len={len(value)}" if value else "MISSING"
+        else:
+            state = value or "MISSING"
+        lines.append(f"{key}={state}")
+    return lines
+
+
+def _validate_env(env: Mapping[str, str]) -> list[str]:
+    errors: list[str] = []
+    mode = env.get("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "").strip().lower()
+    if mode != "oauth":
+        errors.append("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE must be oauth")
+    issuer = env.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", "").strip()
+    if not issuer.startswith(("https://", "http://localhost", "http://127.0.0.1")):
+        errors.append("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL must be HTTPS or localhost HTTP")
+    resource = env.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", "").strip()
+    if not resource.startswith(("https://", "http://localhost", "http://127.0.0.1")):
+        errors.append("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL must be HTTPS or localhost HTTP")
+    approval_token = env.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", "").strip()
+    if len(approval_token) < MIN_APPROVAL_TOKEN_LENGTH:
+        errors.append(
+            "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN must be at least "
+            f"{MIN_APPROVAL_TOKEN_LENGTH} characters"
+        )
+    port = env.get("ATLAS_MCP_INVOICING_READONLY_PORT", DEFAULT_PORT).strip()
+    try:
+        parsed_port = int(port)
+    except ValueError:
+        errors.append("ATLAS_MCP_INVOICING_READONLY_PORT must be an integer")
+    else:
+        if parsed_port <= 0 or parsed_port > 65535:
+            errors.append("ATLAS_MCP_INVOICING_READONLY_PORT must be between 1 and 65535")
+    return errors
+
+
+def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
+    env_files = [Path(path) for path in (args.env_file or [".env", ".env.local"])]
+    env = _load_dotenv_files(env_files)
+    env.update(os.environ)
+    env["ATLAS_MCP_INVOICING_READONLY_AUTH_MODE"] = "oauth"
+    env["ATLAS_MCP_HOST"] = (args.host or env.get("ATLAS_MCP_HOST") or DEFAULT_HOST).strip()
+    env["ATLAS_MCP_INVOICING_READONLY_PORT"] = (
+        args.port or env.get("ATLAS_MCP_INVOICING_READONLY_PORT") or DEFAULT_PORT
+    ).strip()
+    env["ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL"] = (
+        args.issuer_url
+        or env.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL")
+        or DEFAULT_ISSUER_URL
+    ).strip()
+    env["ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL"] = (
+        args.resource_url
+        or env.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL")
+        or DEFAULT_RESOURCE_URL
+    ).strip()
+    return LaunchConfig(
+        env=env,
+        python=args.python,
+        host=env["ATLAS_MCP_HOST"],
+        port=env["ATLAS_MCP_INVOICING_READONLY_PORT"],
+        dry_run=args.dry_run,
+    )
+
+
+def _server_command(config: LaunchConfig) -> list[str]:
+    return [
+        config.python,
+        "-m",
+        "atlas_brain.mcp.invoicing_readonly_server",
+        "--sse",
+    ]
+
+
+def _print_operator_guidance(config: LaunchConfig) -> None:
+    issuer_url = config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL"]
+    resource_url = config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL"]
+    print("Read-only invoicing OAuth launch configuration:")
+    for line in _masked_env_report(config.env):
+        print(f"- {line}")
+    print(f"- ATLAS_MCP_HOST={config.host}")
+    print(f"- ATLAS_MCP_INVOICING_READONLY_PORT={config.port}")
+    print()
+    print("Required Funnel route for protected-resource metadata:")
+    print("tailscale funnel --bg --yes \\")
+    print("  --set-path /.well-known/oauth-protected-resource \\")
+    print(f"  http://127.0.0.1:{config.port}/.well-known/oauth-protected-resource")
+    print()
+    print("After startup, verify public discovery:")
+    print(".venv/bin/python scripts/check_invoicing_readonly_oauth_discovery.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+    print()
+    print("Then verify OAuth token exchange and read-only MCP tools:")
+    print(".venv/bin/python scripts/check_invoicing_readonly_oauth_e2e.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = _build_launch_config(args)
+    errors = _validate_env(config.env)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+
+    _print_operator_guidance(config)
+    command = _server_command(config)
+    print()
+    print("Starting server:")
+    print(" ".join(command))
+    if config.dry_run:
+        print("dry-run: server not started")
+        return 0
+
+    return subprocess.call(command, env=config.env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_start_invoicing_readonly_oauth_server.py
+++ b/tests/test_start_invoicing_readonly_oauth_server.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/start_invoicing_readonly_oauth_server.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "start_invoicing_readonly_oauth_server",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "env_file": [],
+        "python": "/venv/bin/python",
+        "host": None,
+        "port": None,
+        "issuer_url": None,
+        "resource_url": None,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _valid_env():
+    return {
+        "ATLAS_MCP_INVOICING_READONLY_AUTH_MODE": "oauth",
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL": "https://atlas.example.com/invoicing-readonly",
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL": "https://atlas.example.com/invoicing-readonly/mcp",
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN": "approval-token-with-enough-entropy",
+        "ATLAS_MCP_INVOICING_READONLY_PORT": "8065",
+    }
+
+
+def test_parse_dotenv_line_handles_quotes_comments_and_empty_lines() -> None:
+    module = _load_script_module()
+
+    assert module._parse_dotenv_line("KEY=value") == ("KEY", "value")
+    assert module._parse_dotenv_line("KEY='quoted value'") == ("KEY", "quoted value")
+    assert module._parse_dotenv_line('KEY="quoted value"') == ("KEY", "quoted value")
+    assert module._parse_dotenv_line("# comment") is None
+    assert module._parse_dotenv_line("") is None
+
+
+def test_load_dotenv_files_applies_later_file_override(tmp_path) -> None:
+    module = _load_script_module()
+    first = tmp_path / ".env"
+    second = tmp_path / ".env.local"
+    first.write_text("KEY=base\nOTHER=value\n")
+    second.write_text("KEY=local\n")
+
+    values = module._load_dotenv_files([first, second])
+
+    assert values == {"KEY": "local", "OTHER": "value"}
+
+
+def test_validate_env_accepts_oauth_config() -> None:
+    module = _load_script_module()
+
+    assert module._validate_env(_valid_env()) == []
+
+
+def test_validate_env_rejects_short_token_and_bad_port() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN"] = "short"
+    env["ATLAS_MCP_INVOICING_READONLY_PORT"] = "70000"
+
+    errors = module._validate_env(env)
+
+    assert any("APPROVAL_TOKEN" in error for error in errors)
+    assert any("between 1 and 65535" in error for error in errors)
+
+
+def test_build_launch_config_loads_env_files_and_forces_oauth(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_READONLY_AUTH_MODE=bearer",
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", raising=False)
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)], port="9000"))
+
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_AUTH_MODE"] == "oauth"
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_PORT"] == "9000"
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL"] == module.DEFAULT_ISSUER_URL
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-with-enough-entropy"
+    )
+
+
+def test_build_launch_config_process_env_overrides_env_file(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=approval-token-from-file",
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL=https://file.example.com/invoicing-readonly",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
+        "approval-token-from-process-env",
+    )
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)]))
+
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-from-process-env"
+    )
+    assert config.env["ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL"] == (
+        "https://file.example.com/invoicing-readonly"
+    )
+
+
+def test_server_command_uses_current_config_python() -> None:
+    module = _load_script_module()
+    config = module.LaunchConfig(
+        env=_valid_env(),
+        python="/custom/python",
+        host="0.0.0.0",
+        port="8065",
+        dry_run=False,
+    )
+
+    assert module._server_command(config) == [
+        "/custom/python",
+        "-m",
+        "atlas_brain.mcp.invoicing_readonly_server",
+        "--sse",
+    ]
+
+
+def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_AUTH_TOKEN"] = "bearer-token-value-that-must-not-print"
+    config = module.LaunchConfig(
+        env=env,
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="9000",
+        dry_run=True,
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "SET len=34" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+    assert "bearer-token-value-that-must-not-print" not in captured.out
+    assert "http://127.0.0.1:9000/.well-known/oauth-protected-resource" in captured.out
+    assert "http://127.0.0.1:8065/.well-known/oauth-protected-resource" not in captured.out
+    assert "check_invoicing_readonly_oauth_e2e.py" in captured.out
+
+
+def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL=https://atlas.example.com/invoicing-readonly",
+                "ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL=https://atlas.example.com/invoicing-readonly/mcp",
+            ]
+        )
+        + "\n"
+    )
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "dry-run: server not started" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+
+
+def test_main_returns_validation_errors_before_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN=short\n")
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file)])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "APPROVAL_TOKEN" in captured.err
+    assert "short" not in captured.err


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Readonly-OAuth-Operator-Launcher.md

The OAuth connector now has discovery and e2e smokes, but startup was still fragile because shell-sourcing `.env` failed in the operator session. This slice adds a reusable launcher that loads dotenv files, validates OAuth config, starts the read-only server, and prints the exact follow-up smoke commands without exposing secrets.

## Intentional
- The launcher loads dotenv files, validates OAuth config, and runs the server in the foreground rather than daemonizing.
- The launcher prints follow-up smoke commands but never prints bearer or approval tokens.
- Tailscale Funnel configuration remains operator-controlled; the script prints the required route but does not mutate public exposure.

## Deferred
- Process supervision/systemd integration is deferred until unattended uptime is needed.
- Durable OAuth client/token persistence remains deferred until restart resilience is needed.

## Verification
- `.venv/bin/python -m py_compile scripts/start_invoicing_readonly_oauth_server.py tests/test_start_invoicing_readonly_oauth_server.py`
- `.venv/bin/python -m pytest tests/test_start_invoicing_readonly_oauth_server.py` -> 9 passed
- `.venv/bin/python scripts/start_invoicing_readonly_oauth_server.py --dry-run` -> validated local `.env`, printed masked config and smoke commands
- `git diff --check`
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- pre-push hook `scripts/local_pr_review.sh` -> passed

## Diff size
4 files, +524 / -0
