### PR TITLE
Add support-ticket copy policy for Content Ops prompts

### DIFF
--- a/atlas_brain/skills/digest/b2b_campaign_generation.md
+++ b/atlas_brain/skills/digest/b2b_campaign_generation.md
@@ -96,7 +96,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 
 1. **Personalize to their pain**: Reference their specific pain points (pricing, features, reliability, support) naturally. Do NOT be generic.
 
-2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. Do not say the target company itself said, did, evaluated, or intends the thing unless account-specific reasoning or CRM evidence explicitly supports that.
+2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, CFPB, or monitoring. Frame all knowledge as "industry research", "market trends", "service signal analysis", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. When evidence has `source_type: "support_ticket"`, `source_type: "complaint"`, `source_type: "case"`, or `source_type: "conversation"`, treat it as service evidence, not buying-intent evidence. Do not say the target company itself said, did, evaluated, is buying, is switching, is considering, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
 
 3. **Match tone to role_type**:
    - `economic_buyer` / `decision_maker`: Executive tone, focus on ROI, TCO, strategic value

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T02:35Z by codex-2026-05-18
+Last updated: 2026-05-19T03:35Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-CFPB-Source | `scripts/export_content_ops_cfpb_sources.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `extracted_content_pipeline/campaign_example.py`, `tests/test_export_content_ops_cfpb_sources.py`, `tests/test_smoke_content_ops_cfpb_source_postgres.py`, `tests/test_extracted_campaign_generation_example.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `plans/PR-Content-Ops-CFPB-Source.md` | codex-2026-05-18 | Content Ops source ingestion scripts/docs |
+| TBD | PR-Content-Ops-Support-Ticket-Copy-Policy | `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md`, `extracted_content_pipeline/skills/digest/landing_page_generation.md`, `tests/test_extracted_campaign_skill_registry.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md` | codex-2026-05-18 | Content Ops packaged prompt policy |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
+++ b/extracted_content_pipeline/skills/digest/b2b_campaign_generation.md
@@ -96,7 +96,7 @@ Return a JSON object with the generated content. The structure depends on the ch
 
 1. **Personalize to their pain**: Reference their specific pain points (pricing, features, reliability, support) naturally. Do NOT be generic.
 
-2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, or monitoring. Frame all knowledge as "industry research", "market trends", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. Do not say the target company itself said, did, evaluated, or intends the thing unless account-specific reasoning or CRM evidence explicitly supports that.
+2. **Never reveal the source**: Never mention reviews, G2, Capterra, scraping, CFPB, or monitoring. Frame all knowledge as "industry research", "market trends", "service signal analysis", or "we work with companies in your space". When the opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence. When evidence has `source_type: "support_ticket"`, `source_type: "complaint"`, `source_type: "case"`, or `source_type: "conversation"`, treat it as service evidence, not buying-intent evidence. Do not say the target company itself said, did, evaluated, is buying, is switching, is considering, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
 
 3. **Match tone to role_type**:
    - `economic_buyer` / `decision_maker`: Executive tone, focus on ROI, TCO, strategic value

--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -48,4 +48,9 @@ Field rules:
 
 When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids`. Persona-tailor the headline + subheadline for `campaign.persona`.
 
+Source-row evidence policy:
+- If campaign evidence or opportunity context has `source_type: "support_ticket"`, `source_type: "complaint"`, `source_type: "case"`, or `source_type: "conversation"`, treat it as service evidence, not buying-intent evidence.
+- Use service framing such as "support evidence points to..." or "complaint narratives describe..." and do not claim the target account is evaluating, buying, switching, or considering a vendor unless account-specific CRM, call, or meeting evidence supports it.
+- If source rows are reviews, use market-evidence framing rather than naming exact review sites.
+
 Avoid: weasel words ("powerful", "robust", "leverage"), promises that can't be backed up, comparative claims about specific competitors unless the campaign provides them.

--- a/extracted_content_pipeline/skills/digest/report_generation.md
+++ b/extracted_content_pipeline/skills/digest/report_generation.md
@@ -35,3 +35,4 @@ Review/source-row evidence policy:
 - If opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence.
 - Do not say the target account itself said, did, evaluated, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
 - Use market framing such as "teams evaluating this vendor are reporting..." or "review evidence points to..." and cite the relevant evidence ids.
+- If opportunity evidence has `source_type: "support_ticket"`, `source_type: "complaint"`, `source_type: "case"`, or `source_type: "conversation"`, treat it as service evidence, not buying-intent evidence. Use service framing such as "support evidence points to..." or "complaint narratives describe..." and do not claim the target account is evaluating, buying, switching, or considering a vendor unless account-specific evidence supports it.

--- a/extracted_content_pipeline/skills/digest/sales_brief_generation.md
+++ b/extracted_content_pipeline/skills/digest/sales_brief_generation.md
@@ -56,3 +56,4 @@ Review/source-row evidence policy:
 - If opportunity evidence has `source_type: "review"` or came from source rows, treat it as third-party market evidence.
 - Do not say the target account itself said, did, evaluated, or intends the thing unless account-specific reasoning, CRM evidence, call evidence, or meeting evidence explicitly supports that.
 - Use sales-facing market framing such as "buyers evaluating this vendor are reporting..." or "market evidence points to..." and cite the relevant evidence ids.
+- If opportunity evidence has `source_type: "support_ticket"`, `source_type: "complaint"`, `source_type: "case"`, or `source_type: "conversation"`, treat it as service evidence, not buying-intent evidence. Use rep-safe framing such as "support evidence points to..." or "complaint narratives describe..." and do not claim the target account is evaluating, buying, switching, or considering a vendor unless account-specific evidence supports it.

--- a/plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md
+++ b/plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-Support-Ticket-Copy-Policy
+
+## Why this slice exists
+
+PR #606 added CFPB complaint rows as support-ticket-like source evidence and
+fixed the offline deterministic generator so the smoke does not claim the
+target account is evaluating the complained-about vendor. The packaged LLM
+prompts still mostly describe review/source-row evidence as market evidence,
+and landing pages have no source-row copy policy at all. Real provider output
+needs the same support-ticket guard as the deterministic smoke.
+
+## Scope (this PR)
+
+1. Add support-ticket/complaint source-row framing to packaged campaign,
+   report, sales brief, and landing page prompts.
+2. Lock the policy in skill-registry tests.
+3. Remove the merged CFPB coordination row while claiming this slice.
+
+### Files touched
+
+- `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`
+- `atlas_brain/skills/digest/b2b_campaign_generation.md`
+- `extracted_content_pipeline/skills/digest/report_generation.md`
+- `extracted_content_pipeline/skills/digest/sales_brief_generation.md`
+- `extracted_content_pipeline/skills/digest/landing_page_generation.md`
+- `tests/test_extracted_campaign_skill_registry.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md`
+
+## Mechanism
+
+Each affected prompt gets an explicit source-row evidence rule:
+
+```text
+support_ticket / complaint / case / conversation rows are service evidence,
+not buying-intent evidence.
+```
+
+The rule tells the LLM to use service framing such as "support evidence points
+to..." and to avoid claims that the target account is evaluating, buying,
+switching, or considering a vendor unless account-specific CRM, call, or
+meeting evidence supports that claim.
+
+## Intentional
+
+- This is prompt policy only. The source adapter and CFPB exporter already
+  provide the `source_type` metadata needed by the prompts.
+- `b2b_campaign_generation.md` is synced from the Atlas canonical skill file,
+  so the Atlas source is edited and the extracted copy is refreshed by sync.
+- Blog prompts stay out of scope because the current blog path is blueprint and
+  review-intelligence oriented, not direct opportunity source-row generation.
+- The merged CFPB coordination row is removed in this PR because #606 has
+  landed.
+
+## Deferred
+
+- Prompt policy for future source families should be driven by real host
+  exports or live provider failures, not speculative source taxonomy expansion.
+- Shared Postgres smoke helper extraction remains a separate follow-up from
+  PR #606.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_skill_registry.py -q` -> 12 passed.
+- `python -m py_compile tests/test_extracted_campaign_skill_registry.py` -> passed.
+- `grep -nP '[^\x00-\x7F]' tests/test_extracted_campaign_skill_registry.py` -> no matches.
+- `bash scripts/local_pr_review.sh` -> pending after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Prompt policy text | ~35 |
+| Tests | ~35 |
+| Plan + coordination | ~80 |
+| **Total** | **~150** |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -27,6 +27,24 @@ def test_packaged_report_prompt_frames_review_evidence_as_market_signal() -> Non
     assert "Do not say the target account itself" in prompt
 
 
+def test_packaged_campaign_prompt_frames_support_tickets_as_service_evidence() -> None:
+    prompt = get_skill_registry().get_prompt("digest/b2b_campaign_generation")
+
+    assert prompt is not None
+    assert 'source_type: "support_ticket"' in prompt
+    assert "service evidence, not buying-intent evidence" in prompt
+    assert "is buying, is switching, is considering" in prompt
+
+
+def test_packaged_report_prompt_frames_support_tickets_as_service_evidence() -> None:
+    prompt = get_skill_registry().get_prompt("digest/report_generation")
+
+    assert prompt is not None
+    assert 'source_type: "support_ticket"' in prompt
+    assert "service evidence, not buying-intent evidence" in prompt
+    assert "complaint narratives describe" in prompt
+
+
 def test_packaged_sales_brief_prompt_frames_review_evidence_as_market_signal() -> None:
     prompt = get_skill_registry().get_prompt("digest/sales_brief_generation")
 
@@ -34,6 +52,24 @@ def test_packaged_sales_brief_prompt_frames_review_evidence_as_market_signal() -
     assert 'source_type: "review"' in prompt
     assert "third-party market evidence" in prompt
     assert "Do not say the target account itself" in prompt
+
+
+def test_packaged_sales_brief_prompt_frames_support_tickets_as_service_evidence() -> None:
+    prompt = get_skill_registry().get_prompt("digest/sales_brief_generation")
+
+    assert prompt is not None
+    assert 'source_type: "support_ticket"' in prompt
+    assert "service evidence, not buying-intent evidence" in prompt
+    assert "rep-safe framing" in prompt
+
+
+def test_packaged_landing_page_prompt_frames_support_tickets_as_service_evidence() -> None:
+    prompt = get_skill_registry().get_prompt("digest/landing_page_generation")
+
+    assert prompt is not None
+    assert 'source_type: "support_ticket"' in prompt
+    assert "service evidence, not buying-intent evidence" in prompt
+    assert "evaluating, buying, switching, or considering" in prompt
 
 
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md

Adds packaged prompt policy so support-ticket, complaint, case, and conversation source rows are framed as service evidence rather than buying-intent evidence across campaign, report, sales brief, and landing page generation.

## Intentional
- Prompt-only policy; source metadata is already present from ingestion and CFPB export.
- `b2b_campaign_generation.md` is edited at the Atlas canonical source and synced into extracted Content Ops.
- Blog prompts stay out of scope because the current blog path is blueprint/review-intelligence oriented, not direct opportunity source-row generation.
- Removes the merged CFPB coordination row while claiming this slice.

## Deferred
- Future source-family prompt policy should follow real host exports or live provider failures.
- Shared Postgres smoke helper extraction remains separate.

## Verification
- `pytest tests/test_extracted_campaign_skill_registry.py -q` -> 12 passed.
- `python -m py_compile tests/test_extracted_campaign_skill_registry.py` -> passed.
- `grep -nP '[^\\x00-\\x7F]' tests/test_extracted_campaign_skill_registry.py` -> no matches.
- `bash scripts/local_pr_review.sh` -> passed.

## Diff size
8 files, +123 / -4