### PR TITLE
Document invoicing MCP write-access guardrails

### DIFF
--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -1,0 +1,183 @@
+# Invoicing MCP write-access guardrails
+
+This is the contract for exposing invoice writes through ChatGPT or any other
+remote MCP client.
+
+The read-only invoicing connector is proven. Write access should not reuse the
+full `atlas-invoicing` server as-is because that server intentionally includes
+local-operator tools with send, payment, void, service, and file-write side
+effects.
+
+## Decision
+
+The first write-capable ChatGPT connector must be a separate draft-only server:
+
+```text
+atlas_brain.mcp.invoicing_draft_writer_server
+```
+
+It should expose the smallest useful surface:
+
+- `create_draft_invoice`
+- `update_draft_invoice`
+- `get_invoice`
+- `list_pending_drafts`
+
+It must not expose the full `atlas_brain.mcp.invoicing_server` tool surface.
+
+## Why separate server
+
+The existing full server is designed for trusted local operators. It contains
+tools that can create drafts, update drafts, send invoices, record payments,
+void invoices, mutate service agreements, generate PDFs, and write files to
+disk.
+
+For a hosted ChatGPT connector, safety should come from the process/tool
+boundary, not from model instructions.
+
+A separate server gives us:
+
+- Exact tool allowlist smoke tests.
+- Independent OAuth scope and approval copy.
+- Separate env prefix and public route.
+- Lower chance that a future full-server tool accidentally becomes remote.
+- A clean path to add more writes later behind explicit PRs.
+
+## Allowed first write surface
+
+### `create_draft_invoice`
+
+Creates an invoice in `draft` status only.
+
+Required behavior:
+
+- Requires an idempotency key or stable `source_ref`.
+- Writes `source="chatgpt_draft_writer"` or an equivalent explicit source.
+- Writes metadata identifying the connector and operator-review requirement.
+- Does not send email.
+- Does not mark the invoice sent.
+- Does not record payment.
+- Does not void anything.
+- Does not export or save a PDF.
+- Does not mutate services.
+
+Important implementation detail: do not delegate blindly to the existing
+`create_invoice` MCP tool if that would trigger CRM contact resolution or CRM
+logging. The draft writer should either call the repository directly with
+explicit metadata or use a shared helper that guarantees no external side
+effects.
+
+### `update_draft_invoice`
+
+Updates only existing draft invoices.
+
+Required behavior:
+
+- Rejects non-draft invoices.
+- Accepts only draft-safe fields such as line items, due date, notes, tax,
+  discount, invoice description, and contact name.
+- Does not send, approve, void, record payment, export PDF, or mutate service
+  state.
+- Preserves metadata that marks the invoice as connector-created or
+  connector-touched.
+
+### Read helpers
+
+The write connector may include enough read tools to let the operator inspect
+the drafts it creates:
+
+- `get_invoice`
+- `list_pending_drafts`
+
+Do not copy the full read-only surface unless there is a clear need. The
+read-only connector already handles broader invoice review.
+
+## Denied in the first write connector
+
+These full-server tools must not appear in the first write-access connector:
+
+- `approve_and_send`
+- `send_invoice`
+- `record_payment`
+- `mark_void`
+- `export_invoice_pdf`
+- `create_service`
+- `update_service`
+- `set_service_status`
+
+These are not small variations of draft write access. They carry external,
+financial, or file-system side effects and need separate design.
+
+## OAuth contract
+
+Use a separate OAuth scope:
+
+```text
+invoices.draft.write
+```
+
+Use a separate env prefix:
+
+```bash
+ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE=oauth
+ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer
+ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=<long-random-token>
+ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT=<dedicated-port>
+```
+
+The approval page copy must say draft-write access, not read-only access.
+
+The connector must not share the read-only approval token. Separate scopes and
+separate approval tokens make accidental privilege expansion easier to detect.
+
+## Required implementation tests
+
+The server PR must include tests that prove:
+
+- The exposed MCP tool set equals the draft-writer allowlist exactly.
+- All denied tools are absent.
+- HTTP mode fails closed without auth.
+- OAuth mode uses the `invoices.draft.write` scope.
+- `create_draft_invoice` creates only `draft` invoices.
+- `create_draft_invoice` is idempotent for the same idempotency key/source ref.
+- `create_draft_invoice` does not touch CRM or email providers.
+- `update_draft_invoice` rejects non-draft invoices.
+
+The public smoke scripts must mirror the read-only connector pattern:
+
+- Discovery smoke checks metadata and unauthenticated `401`.
+- OAuth e2e smoke completes the flow and calls only `list_tools`.
+- Tool-surface check rejects denied tools by name.
+
+## Required audit metadata
+
+Drafts created or touched through the connector should include metadata similar
+to:
+
+```json
+{
+  "mcp_connector": "invoicing_draft_writer",
+  "operator_review_required": true,
+  "created_by_remote_connector": true,
+  "idempotency_key": "<operator-provided-key>"
+}
+```
+
+This is not a security boundary. It is an audit and operations affordance so
+read-only tools, pending-draft review, and later reports can distinguish
+ChatGPT-created drafts from local/manual drafts.
+
+## Later write surfaces
+
+Do not add these until draft-only write access has real usage:
+
+- Send/approve invoice.
+- Record payment.
+- Void invoice.
+- Export and persist PDF.
+- Mutate service agreements.
+
+Each later write surface needs its own confirmation model. In particular,
+payment and send actions should require stronger operator confirmation than
+draft creation because they affect customer-facing or financial state.

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -65,6 +65,12 @@ For read-only surfaces, add a boundary smoke equivalent to
 
 Do not call real data tools in connector boundary smoke.
 
+For invoicing write access, do not expose the full `atlas-invoicing` server.
+Use the draft-only contract in
+`docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md` before adding any mutating
+ChatGPT connector. The first write surface is draft creation/update only;
+send, payment, void, PDF export, and service mutation stay out of scope.
+
 ## Step 2: add OAuth mode
 
 Use `atlas_brain/mcp/invoicing_readonly_oauth.py` as the template. The minimum

--- a/plans/PR-Invoicing-MCP-Write-Access-Guardrails.md
+++ b/plans/PR-Invoicing-MCP-Write-Access-Guardrails.md
@@ -1,0 +1,56 @@
+# PR-Invoicing-MCP-Write-Access-Guardrails
+
+## Why this slice exists
+
+The read-only invoicing MCP connector now works in ChatGPT through OAuth. The next step is write access, but the existing full `atlas-invoicing` MCP server mixes draft creation with high-risk operations: sending invoices, recording payments, voiding invoices, mutating services, and exporting PDFs to disk.
+
+This slice creates the guardrail contract before any write-capable ChatGPT connector is exposed. The goal is to make the safe path explicit: write access starts with a separate draft-only connector, not by publishing the full invoicing MCP server.
+
+## Scope (this PR)
+
+1. Document the allowed first write surface for invoicing MCP access.
+2. Document the denied tool classes that must stay out of the first write connector.
+3. Define the required OAuth, audit, idempotency, and verification gates for the later implementation PR.
+4. Cross-link the new guardrail doc from the existing ChatGPT OAuth rollout runbook.
+
+### Files touched
+
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-MCP-Write-Access-Guardrails.md`
+
+## Mechanism
+
+The new guardrail document classifies the current full invoicing MCP tools into:
+
+- Safe reads already covered by `atlas-invoicing-readonly`.
+- Candidate draft-only writes for a future `atlas-invoicing-draft-writer` server.
+- Explicitly denied operations for the first write rollout.
+
+It also defines the minimum implementation gates the future code PR must ship: separate server module, separate OAuth scope/env prefix, exact tool allowlist smoke, no send/payment/void/PDF/service tools, idempotency key for draft creation, metadata/audit tagging, and tests that assert the connector cannot expose denied tools.
+
+## Intentional
+
+- No production write tool is added in this slice. The risk is high enough that the contract should land before implementation.
+- The first write surface is draft-only. Sending invoices, recording payments, voiding invoices, PDF export, and service mutation remain out of scope.
+- The write connector is specified as a separate server instead of adding flags to the full invoicing server. Separate process/tool surface is easier to audit and harder to misconfigure.
+
+## Deferred
+
+- `PR-Invoicing-Draft-Writer-MCP`: add the first draft-only write MCP server and boundary smoke.
+- `PR-Invoicing-Draft-Writer-OAuth`: add public OAuth discovery/e2e/launcher for that server if it is not bundled with the server PR.
+- Any send/payment/void tools are deferred until draft-only write access has real usage and a stronger confirmation/audit flow.
+
+## Verification
+
+- `git diff --check`
+- `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md` | ~184 |
+| `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md` | ~6 |
+| `plans/PR-Invoicing-MCP-Write-Access-Guardrails.md` | ~58 |
+| **Total** | **~248** |


### PR DESCRIPTION
Plan: plans/PR-Invoicing-MCP-Write-Access-Guardrails.md

This docs-only slice defines the safe path for ChatGPT invoicing write access before any mutating MCP tools are exposed. The first write surface is a separate draft-only connector, not the full atlas-invoicing server.

## Intentional
- No production write tool is added in this slice.
- First write access is constrained to draft invoice creation/update in a separate future server.
- Send, payment, void, PDF export, and service mutation are explicitly out of scope.

## Deferred
- PR-Invoicing-Draft-Writer-MCP: add the actual draft-only server and boundary smoke.
- PR-Invoicing-Draft-Writer-OAuth: add public OAuth discovery/e2e/launcher if not bundled with the server PR.
- Any customer-facing or financial-state writes remain deferred until draft-only usage proves stable.

## Verification
- git diff --check
- bash scripts/local_pr_review.sh

## Diff size
3 files, +245 / -0