### PR TITLE
Extract shared source Postgres smoke helpers

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T03:35Z by codex-2026-05-18
+Last updated: 2026-05-19T03:43Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Support-Ticket-Copy-Policy | `atlas_brain/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/b2b_campaign_generation.md`, `extracted_content_pipeline/skills/digest/report_generation.md`, `extracted_content_pipeline/skills/digest/sales_brief_generation.md`, `extracted_content_pipeline/skills/digest/landing_page_generation.md`, `tests/test_extracted_campaign_skill_registry.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Support-Ticket-Copy-Policy.md` | codex-2026-05-18 | Content Ops packaged prompt policy |
+| TBD | PR-Content-Ops-Source-Smoke-Shared-Helpers | `scripts/content_ops_source_postgres_smoke_helpers.py`, `scripts/smoke_content_ops_review_source_postgres.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `tests/test_content_ops_source_postgres_smoke_helpers.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md` | codex-2026-05-18 | Content Ops source Postgres smoke helpers |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md
+++ b/plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md
@@ -1,0 +1,95 @@
+# PR-Content-Ops-Source-Smoke-Shared-Helpers
+
+## Why this slice exists
+
+The review-source and CFPB Postgres smokes now exercise the same host-facing
+path: source export, source-row ingestion, Postgres import, deterministic draft
+generation, persisted draft fetch, and target-id verification. Their Postgres
+readiness and persisted-draft checks were copied independently. That is the
+kind of smoke-test drift that will slow the next source family, such as support
+tickets from CRM or help desk exports.
+
+This slice extracts the shared Postgres smoke logic before adding more source
+adapters.
+
+## Scope (this PR)
+
+1. Add a shared helper module for source-row Postgres smoke checks.
+2. Refactor the review-source and CFPB Postgres smoke scripts to call the
+   shared helper while preserving source-specific export/import flow.
+3. Add focused tests for the helper behavior.
+4. Ensure the full extracted pipeline check runs both Postgres source smokes
+   and the new helper tests.
+5. Remove the merged support-ticket prompt-policy coordination row while
+   claiming this slice.
+
+### Files touched
+
+- `scripts/content_ops_source_postgres_smoke_helpers.py`
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `scripts/smoke_content_ops_cfpb_source_postgres.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_source_postgres_smoke_helpers.py`
+- `tests/test_smoke_content_ops_review_source_postgres.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md`
+
+## Mechanism
+
+The helper module owns only source-agnostic Postgres smoke behavior:
+
+```python
+await generate_imported_target_drafts(...)
+await schema_readiness_errors(...)
+await fetch_saved_drafts(...)
+generation_errors(...)
+draft_errors(...)
+saved_draft_target_errors(...)
+```
+
+Each smoke script still owns source-specific argument parsing, source export,
+ingestion inspection, import, and final payload shape. The scripts pass plain
+values into the helper instead of passing their full `argparse.Namespace`.
+
+## Intentional
+
+- This is a refactor plus test coverage update, not a runtime behavior change.
+- The helper stays under `scripts/` because it supports host smoke commands,
+  not the packaged product runtime.
+- CFPB keeps its local dotenv/database-url bootstrap. Review-source continues
+  to reuse the review-generation smoke bootstrap.
+- The full extracted check gains the review-source Postgres smoke test because
+  it was present but not included in the current check list.
+
+## Deferred
+
+- No new source family is added here. Support-ticket/CRM/call-transcript source
+  adapters remain follow-up slices.
+- No live Postgres smoke is added to CI; these tests keep using fake pools and
+  deterministic generation seams.
+
+## Verification
+
+- `pytest tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py -q` -> 20 passed.
+- `python -m py_compile scripts/content_ops_source_postgres_smoke_helpers.py scripts/smoke_content_ops_review_source_postgres.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> passed.
+- `grep -nP '[^\x00-\x7F]' scripts/content_ops_source_postgres_smoke_helpers.py scripts/smoke_content_ops_review_source_postgres.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> no matches.
+- `rg -n "campaign_opportunities|b2b_campaigns|EXTRACTED_DATABASE_URL|appears to be weighing|TODO|FIXME|pass$" scripts/content_ops_source_postgres_smoke_helpers.py scripts/smoke_content_ops_review_source_postgres.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> only existing table/env/forbidden-phrase fixtures and no TODO/FIXME/pass placeholders.
+- `git diff --check` -> passed.
+- `bash scripts/local_pr_review.sh` -> passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1433 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Shared helper | ~190 |
+| Smoke script refactors | ~410 |
+| Helper tests | ~160 |
+| Runner + coordination + plan | ~110 |
+| **Total** | **~870** |
+
+The diff exceeds the soft 400 LOC budget because the refactor removes two
+existing duplicate helper blocks while adding one shared helper and direct
+helper regression coverage. Net production code shrinks, and splitting the
+tests from the extraction would make review harder without reducing product
+risk.

--- a/scripts/content_ops_source_postgres_smoke_helpers.py
+++ b/scripts/content_ops_source_postgres_smoke_helpers.py
@@ -1,0 +1,192 @@
+"""Shared helpers for Content Ops source-row Postgres smoke commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from extracted_content_pipeline.campaign_example import (
+    DeterministicCampaignLLM,
+    StaticCampaignSkillStore,
+)
+from extracted_content_pipeline.campaign_generation import CampaignGenerationConfig
+from extracted_content_pipeline.campaign_postgres_generation import (
+    generate_campaign_drafts_from_postgres,
+)
+
+
+async def generate_imported_target_drafts(
+    *,
+    pool: Any,
+    account_id: str,
+    user_id: str | None,
+    target_mode: str,
+    channels: Sequence[str],
+    target_ids: Sequence[str],
+    opportunity_table: str,
+) -> dict[str, Any]:
+    saved_ids: list[str] = []
+    errors: list[Mapping[str, Any]] = []
+    requested = 0
+    generated = 0
+    skipped = 0
+    reasoning_contexts_used = 0
+    for target_id in target_ids:
+        result = await generate_campaign_drafts_from_postgres(
+            pool,
+            scope={"account_id": account_id, "user_id": user_id},
+            target_mode=target_mode,
+            channel=channels[0],
+            channels=tuple(channels),
+            limit=1,
+            filters={"target_id": target_id},
+            llm=DeterministicCampaignLLM(),
+            skills=StaticCampaignSkillStore(),
+            config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
+            opportunity_table=opportunity_table,
+        )
+        data = result.as_dict()
+        requested += int(data.get("requested") or 0)
+        generated += int(data.get("generated") or 0)
+        skipped += int(data.get("skipped") or 0)
+        reasoning_contexts_used += int(data.get("reasoning_contexts_used") or 0)
+        saved_ids.extend(str(item) for item in data.get("saved_ids") or ())
+        errors.extend(error for error in data.get("errors") or () if isinstance(error, Mapping))
+    return {
+        "requested": requested,
+        "generated": generated,
+        "skipped": skipped,
+        "reasoning_contexts_used": reasoning_contexts_used,
+        "saved_ids": saved_ids,
+        "errors": [dict(error) for error in errors],
+    }
+
+
+def generation_errors(result: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(result, Mapping):
+        return ["generation result missing"]
+    errors: list[str] = []
+    reported_errors = result.get("errors") or []
+    if reported_errors:
+        errors.append(f"generation reported {len(reported_errors)} error(s)")
+    if int(result.get("skipped") or 0):
+        errors.append(f"generation skipped {result.get('skipped')} draft(s)")
+    return errors
+
+
+async def schema_readiness_errors(pool: Any, *, opportunity_table: str) -> list[str]:
+    missing: list[str] = []
+    for table_name in (opportunity_table, "b2b_campaigns"):
+        if not await relation_exists(pool, table_name):
+            missing.append(table_name)
+    if not missing:
+        return []
+    command = (
+        "python scripts/run_extracted_content_pipeline_migrations.py "
+        "--database-url \"$EXTRACTED_DATABASE_URL\""
+    )
+    return [
+        "required Content Ops table(s) missing: "
+        f"{', '.join(missing)}. Run {command} before this smoke."
+    ]
+
+
+async def relation_exists(pool: Any, table_name: str) -> bool:
+    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
+    return bool(value)
+
+
+async def fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:
+    if not isinstance(saved_ids, Sequence) or isinstance(saved_ids, (str, bytes)):
+        return []
+    ids = [str(item) for item in saved_ids if str(item or "").strip()]
+    if not ids:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT id, subject, body, target_mode, channel, metadata
+          FROM b2b_campaigns
+         WHERE id::text = ANY($1::text[])
+        """,
+        ids,
+    )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        metadata = metadata_object(row_value(row, "metadata"))
+        source_opportunity = metadata.get("source_opportunity")
+        if not isinstance(source_opportunity, Mapping):
+            source_opportunity = {}
+        target_id = metadata.get("target_id") or source_opportunity.get("target_id")
+        out.append({
+            "id": str(row_value(row, "id") or ""),
+            "target_id": str(target_id or ""),
+            "subject": row_value(row, "subject"),
+            "body": row_value(row, "body"),
+            "target_mode": row_value(row, "target_mode"),
+            "channel": row_value(row, "channel"),
+        })
+    return out
+
+
+def draft_errors(
+    result: Mapping[str, Any],
+    *,
+    min_drafts: int,
+    forbidden_phrases: Sequence[str],
+) -> list[str]:
+    drafts = result.get("drafts")
+    if not isinstance(drafts, list):
+        return ["result.drafts is missing or not a list"]
+    if len(drafts) < min_drafts:
+        return [f"expected at least {min_drafts} draft(s), got {len(drafts)}"]
+    errors: list[str] = []
+    forbidden = [phrase.lower() for phrase in forbidden_phrases if phrase]
+    for index, draft in enumerate(drafts[:min_drafts], start=1):
+        if not isinstance(draft, Mapping):
+            errors.append(f"draft {index} is not an object")
+            continue
+        for field in ("subject", "body", "target_id", "channel"):
+            if not str(draft.get(field) or "").strip():
+                errors.append(f"draft {index} missing {field}")
+        body = str(draft.get("body") or "").lower()
+        for phrase in forbidden:
+            if phrase in body:
+                errors.append(f"draft {index} contains forbidden phrase: {phrase}")
+    return errors
+
+
+def saved_draft_target_errors(
+    saved_drafts: Sequence[Mapping[str, Any]],
+    imported_target_ids: Sequence[str],
+) -> list[str]:
+    imported = {str(target_id) for target_id in imported_target_ids}
+    errors: list[str] = []
+    for draft in saved_drafts:
+        draft_id_value = draft.get("id")
+        draft_id = str(draft_id_value) if draft_id_value is not None else ""
+        target_id_value = draft.get("target_id")
+        target_id = str(target_id_value) if target_id_value is not None else ""
+        if not target_id:
+            errors.append(f"persisted draft missing target_id metadata: {draft_id or '<unknown>'}")
+            continue
+        if target_id not in imported:
+            errors.append(f"persisted draft target_id was not imported: {target_id}")
+    return errors
+
+
+def row_value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return row[key]
+
+
+def metadata_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -28,6 +28,8 @@ pytest \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \
+  tests/test_content_ops_source_postgres_smoke_helpers.py \
+  tests/test_smoke_content_ops_review_source_postgres.py \
   tests/test_smoke_content_ops_cfpb_source_postgres.py \
   tests/test_extracted_content_ingestion_diagnostics.py \
   tests/test_extracted_blog_generation.py \

--- a/scripts/smoke_content_ops_cfpb_source_postgres.py
+++ b/scripts/smoke_content_ops_cfpb_source_postgres.py
@@ -18,17 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from extracted_content_pipeline.campaign_example import (  # noqa: E402
-    DeterministicCampaignLLM,
-    StaticCampaignSkillStore,
-)
-from extracted_content_pipeline.campaign_generation import (  # noqa: E402
-    CampaignGenerationConfig,
-)
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
-from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
-    generate_campaign_drafts_from_postgres,
-)
 from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
     import_campaign_opportunities,
 )
@@ -39,11 +29,19 @@ from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
 from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
 )
-
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - host dependency
     load_dotenv = None
+
+
+def _load_script_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_cfpb_exporter_module():
@@ -56,6 +54,10 @@ def _load_cfpb_exporter_module():
     return module
 
 
+_source_postgres_helpers = _load_script_module(
+    "content_ops_source_postgres_smoke_helpers",
+    ROOT / "scripts" / "content_ops_source_postgres_smoke_helpers.py",
+)
 _cfpb_exporter = _load_cfpb_exporter_module()
 DEFAULT_CHANNELS = ("email_cold", "email_followup")
 DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
@@ -66,6 +68,12 @@ DEFAULT_SOURCE_TYPE = _cfpb_exporter.DEFAULT_SOURCE_TYPE
 DEFAULT_TIMEOUT_SECONDS = _cfpb_exporter.DEFAULT_TIMEOUT_SECONDS
 fetch_cfpb_source_rows = _cfpb_exporter.fetch_cfpb_source_rows
 render_jsonl = _cfpb_exporter.render_jsonl
+draft_errors = _source_postgres_helpers.draft_errors
+fetch_saved_drafts = _source_postgres_helpers.fetch_saved_drafts
+generate_imported_target_drafts = _source_postgres_helpers.generate_imported_target_drafts
+generation_errors = _source_postgres_helpers.generation_errors
+saved_draft_target_errors = _source_postgres_helpers.saved_draft_target_errors
+schema_readiness_errors = _source_postgres_helpers.schema_readiness_errors
 
 
 def _default_database_url() -> str | None:
@@ -225,7 +233,12 @@ async def run_cfpb_source_postgres_smoke(
                         "bindings or pass --allow-ingestion-warnings"
                     )
             if not errors:
-                errors.extend(await _schema_readiness_errors(pool, args))
+                errors.extend(
+                    await schema_readiness_errors(
+                        pool,
+                        opportunity_table=str(args.opportunity_table),
+                    )
+                )
             if not errors:
                 loaded = load_source_campaign_opportunities_from_file(
                     source_rows_path,
@@ -249,20 +262,23 @@ async def run_cfpb_source_postgres_smoke(
                 if imported.skipped:
                     errors.append(f"import skipped {imported.skipped} row(s)")
             if not errors:
-                drafts_result = await _generate_imported_target_drafts(
+                drafts_result = await generate_imported_target_drafts(
                     pool=pool,
-                    args=args,
+                    account_id=str(args.account_id),
+                    user_id=args.user_id,
+                    target_mode=str(args.target_mode),
                     channels=channels,
                     target_ids=imported_target_ids,
+                    opportunity_table=str(args.opportunity_table),
                 )
-                saved_drafts = await _fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
-                errors.extend(_generation_errors(drafts_result))
-                errors.extend(_draft_errors(
+                saved_drafts = await fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
+                errors.extend(generation_errors(drafts_result))
+                errors.extend(draft_errors(
                     {"drafts": saved_drafts},
                     min_drafts=min_drafts,
                     forbidden_phrases=args.forbidden_phrase,
                 ))
-                errors.extend(_saved_draft_target_errors(saved_drafts, imported_target_ids))
+                errors.extend(saved_draft_target_errors(saved_drafts, imported_target_ids))
         except Exception as exc:  # pragma: no cover - exercised by live hosts
             errors.append(f"{type(exc).__name__}: {exc}")
     finally:
@@ -295,172 +311,6 @@ def _write_jsonl(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = render_jsonl(rows)
     path.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
-
-
-async def _generate_imported_target_drafts(
-    *,
-    pool: Any,
-    args: argparse.Namespace,
-    channels: Sequence[str],
-    target_ids: Sequence[str],
-) -> dict[str, Any]:
-    saved_ids: list[str] = []
-    errors: list[Mapping[str, Any]] = []
-    generated = 0
-    skipped = 0
-    requested = 0
-    for target_id in target_ids:
-        result = await generate_campaign_drafts_from_postgres(
-            pool,
-            scope={"account_id": args.account_id, "user_id": args.user_id},
-            target_mode=str(args.target_mode),
-            channel=channels[0],
-            channels=tuple(channels),
-            limit=1,
-            filters={"target_id": target_id},
-            llm=DeterministicCampaignLLM(),
-            skills=StaticCampaignSkillStore(),
-            config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
-            opportunity_table=str(args.opportunity_table),
-        )
-        data = result.as_dict()
-        requested += int(data.get("requested") or 0)
-        generated += int(data.get("generated") or 0)
-        skipped += int(data.get("skipped") or 0)
-        saved_ids.extend(str(item) for item in data.get("saved_ids") or ())
-        errors.extend(error for error in data.get("errors") or () if isinstance(error, Mapping))
-    return {
-        "requested": requested,
-        "generated": generated,
-        "skipped": skipped,
-        "saved_ids": saved_ids,
-        "errors": [dict(error) for error in errors],
-    }
-
-
-def _generation_errors(result: Mapping[str, Any] | None) -> list[str]:
-    if not isinstance(result, Mapping):
-        return ["generation result missing"]
-    errors: list[str] = []
-    reported_errors = result.get("errors") or []
-    if reported_errors:
-        errors.append(f"generation reported {len(reported_errors)} error(s)")
-    if int(result.get("skipped") or 0):
-        errors.append(f"generation skipped {result.get('skipped')} draft(s)")
-    return errors
-
-
-async def _schema_readiness_errors(pool: Any, args: argparse.Namespace) -> list[str]:
-    missing: list[str] = []
-    for table_name in (str(args.opportunity_table), "b2b_campaigns"):
-        if not await _relation_exists(pool, table_name):
-            missing.append(table_name)
-    if not missing:
-        return []
-    command = (
-        "python scripts/run_extracted_content_pipeline_migrations.py "
-        "--database-url \"$EXTRACTED_DATABASE_URL\""
-    )
-    return [
-        "required Content Ops table(s) missing: "
-        f"{', '.join(missing)}. Run {command} before this smoke."
-    ]
-
-
-async def _relation_exists(pool: Any, table_name: str) -> bool:
-    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
-    return bool(value)
-
-
-async def _fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:
-    ids = [str(item) for item in saved_ids if str(item or "").strip()]
-    if not ids:
-        return []
-    rows = await pool.fetch(
-        """
-        SELECT id, subject, body, target_mode, channel, metadata
-          FROM b2b_campaigns
-         WHERE id::text = ANY($1::text[])
-        """,
-        ids,
-    )
-    out: list[dict[str, Any]] = []
-    for row in rows:
-        metadata = _metadata_object(_row_value(row, "metadata"))
-        source_opportunity = metadata.get("source_opportunity")
-        if not isinstance(source_opportunity, Mapping):
-            source_opportunity = {}
-        out.append({
-            "id": str(_row_value(row, "id") or ""),
-            "target_id": str(metadata.get("target_id") or source_opportunity.get("target_id") or ""),
-            "subject": _row_value(row, "subject"),
-            "body": _row_value(row, "body"),
-            "target_mode": _row_value(row, "target_mode"),
-            "channel": _row_value(row, "channel"),
-        })
-    return out
-
-
-def _draft_errors(
-    result: Mapping[str, Any],
-    *,
-    min_drafts: int,
-    forbidden_phrases: Sequence[str],
-) -> list[str]:
-    drafts = result.get("drafts")
-    if not isinstance(drafts, list):
-        return ["result.drafts is missing or not a list"]
-    if len(drafts) < min_drafts:
-        return [f"expected at least {min_drafts} draft(s), got {len(drafts)}"]
-    errors: list[str] = []
-    forbidden = [phrase.lower() for phrase in forbidden_phrases if phrase]
-    for index, draft in enumerate(drafts[:min_drafts], start=1):
-        if not isinstance(draft, Mapping):
-            errors.append(f"draft {index} is not an object")
-            continue
-        for field in ("subject", "body", "target_id", "channel"):
-            if not str(draft.get(field) or "").strip():
-                errors.append(f"draft {index} missing {field}")
-        body = str(draft.get("body") or "").lower()
-        for phrase in forbidden:
-            if phrase in body:
-                errors.append(f"draft {index} contains forbidden phrase: {phrase}")
-    return errors
-
-
-def _saved_draft_target_errors(
-    saved_drafts: Sequence[Mapping[str, Any]],
-    imported_target_ids: Sequence[str],
-) -> list[str]:
-    imported = {str(target_id) for target_id in imported_target_ids}
-    errors: list[str] = []
-    for draft in saved_drafts:
-        target_id = str(draft.get("target_id") or "")
-        if not target_id:
-            errors.append(f"persisted draft missing target_id metadata: {draft.get('id') or '<unknown>'}")
-            continue
-        if target_id not in imported:
-            errors.append(f"persisted draft target_id was not imported: {target_id}")
-    return errors
-
-
-def _row_value(row: Any, key: str) -> Any:
-    if isinstance(row, Mapping):
-        return row.get(key)
-    return row[key]
-
-
-def _metadata_object(value: Any) -> dict[str, Any]:
-    if isinstance(value, Mapping):
-        return dict(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        return dict(parsed) if isinstance(parsed, Mapping) else {}
-    return {}
-
 
 def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
     if as_json:

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -10,24 +10,14 @@ import json
 from pathlib import Path
 import sys
 import tempfile
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from extracted_content_pipeline.campaign_example import (  # noqa: E402
-    DeterministicCampaignLLM,
-    StaticCampaignSkillStore,
-)
-from extracted_content_pipeline.campaign_generation import (  # noqa: E402
-    CampaignGenerationConfig,
-)
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
-from extracted_content_pipeline.campaign_postgres_generation import (  # noqa: E402
-    generate_campaign_drafts_from_postgres,
-)
 from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
     import_campaign_opportunities,
 )
@@ -39,7 +29,6 @@ from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
 )
 
-
 def _load_script_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
@@ -49,6 +38,10 @@ def _load_script_module(name: str, path: Path):
     return module
 
 
+_source_postgres_helpers = _load_script_module(
+    "content_ops_source_postgres_smoke_helpers",
+    ROOT / "scripts" / "content_ops_source_postgres_smoke_helpers.py",
+)
 _source_smoke = _load_script_module(
     "content_ops_review_source_generation_smoke",
     ROOT / "scripts" / "smoke_content_ops_review_source_generation.py",
@@ -62,12 +55,17 @@ DEFAULT_SUMMARY_SOURCES = _source_smoke.DEFAULT_SUMMARY_SOURCES
 _create_pool = _source_smoke._create_pool
 _csv_list = _source_smoke._csv_list
 _default_database_url = _source_smoke._default_database_url
-_draft_errors = _source_smoke._draft_errors
 _load_dotenv_files = _source_smoke._load_dotenv_files
 _row_for_source = _source_smoke._row_for_source
 _write_jsonl = _source_smoke._write_jsonl
 fetch_review_source_rows = _source_smoke.fetch_review_source_rows
 fetch_review_source_summary = _source_smoke.fetch_review_source_summary
+draft_errors = _source_postgres_helpers.draft_errors
+fetch_saved_drafts = _source_postgres_helpers.fetch_saved_drafts
+generate_imported_target_drafts = _source_postgres_helpers.generate_imported_target_drafts
+generation_errors = _source_postgres_helpers.generation_errors
+saved_draft_target_errors = _source_postgres_helpers.saved_draft_target_errors
+schema_readiness_errors = _source_postgres_helpers.schema_readiness_errors
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -237,7 +235,12 @@ async def run_review_source_postgres_smoke(
                     )
 
             if not errors:
-                errors.extend(await _schema_readiness_errors(pool, args))
+                errors.extend(
+                    await schema_readiness_errors(
+                        pool,
+                        opportunity_table=str(args.opportunity_table),
+                    )
+                )
 
             if not errors:
                 loaded = load_source_campaign_opportunities_from_file(
@@ -268,21 +271,19 @@ async def run_review_source_postgres_smoke(
                     )
 
             if not errors:
-                drafts_result = await _generate_imported_target_drafts(
+                drafts_result = await generate_imported_target_drafts(
                     pool=pool,
-                    args=args,
+                    account_id=str(args.account_id),
+                    user_id=args.user_id,
+                    target_mode=str(args.target_mode),
                     channels=channels,
                     target_ids=imported_target_ids,
+                    opportunity_table=str(args.opportunity_table),
                 )
-                saved_drafts = await _fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
-                if drafts_result.get("errors"):
-                    errors.append(
-                        f"generation reported {len(drafts_result.get('errors') or [])} error(s)"
-                    )
-                if int(drafts_result.get("skipped") or 0):
-                    errors.append(f"generation skipped {drafts_result.get('skipped')} draft(s)")
+                saved_drafts = await fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
+                errors.extend(generation_errors(drafts_result))
                 errors.extend(
-                    _draft_errors(
+                    draft_errors(
                         {"drafts": saved_drafts},
                         min_drafts=min_drafts,
                         forbidden_phrases=args.forbidden_phrase,
@@ -293,7 +294,7 @@ async def run_review_source_postgres_smoke(
                         f"expected at least {min_drafts} persisted draft(s), "
                         f"got {drafts_result.get('generated', 0)}"
                     )
-                errors.extend(_saved_draft_target_errors(saved_drafts, imported_target_ids))
+                errors.extend(saved_draft_target_errors(saved_drafts, imported_target_ids))
         except Exception as exc:  # pragma: no cover - exercised by live host DBs
             errors.append(f"{type(exc).__name__}: {exc}")
     finally:
@@ -323,147 +324,6 @@ async def run_review_source_postgres_smoke(
             encoding="utf-8",
         )
     return (0 if not errors else 1), payload
-
-
-async def _generate_imported_target_drafts(
-    *,
-    pool: Any,
-    args: argparse.Namespace,
-    channels: Sequence[str],
-    target_ids: Sequence[str],
-) -> dict[str, Any]:
-    saved_ids: list[str] = []
-    errors: list[Mapping[str, Any]] = []
-    requested = 0
-    generated = 0
-    skipped = 0
-    reasoning_contexts_used = 0
-    for target_id in target_ids:
-        result = await generate_campaign_drafts_from_postgres(
-            pool,
-            scope={"account_id": args.account_id, "user_id": args.user_id},
-            target_mode=str(args.target_mode),
-            channel=channels[0],
-            channels=tuple(channels),
-            limit=1,
-            filters={"target_id": target_id},
-            llm=DeterministicCampaignLLM(),
-            skills=StaticCampaignSkillStore(),
-            config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
-            opportunity_table=str(args.opportunity_table),
-        )
-        data = result.as_dict()
-        requested += int(data.get("requested") or 0)
-        generated += int(data.get("generated") or 0)
-        skipped += int(data.get("skipped") or 0)
-        reasoning_contexts_used += int(data.get("reasoning_contexts_used") or 0)
-        saved_ids.extend(str(item) for item in data.get("saved_ids") or ())
-        errors.extend(error for error in data.get("errors") or () if isinstance(error, Mapping))
-    return {
-        "requested": requested,
-        "generated": generated,
-        "skipped": skipped,
-        "reasoning_contexts_used": reasoning_contexts_used,
-        "saved_ids": saved_ids,
-        "errors": [dict(error) for error in errors],
-    }
-
-
-async def _schema_readiness_errors(pool: Any, args: argparse.Namespace) -> list[str]:
-    required_tables = (
-        str(args.opportunity_table),
-        "b2b_campaigns",
-    )
-    missing: list[str] = []
-    for table_name in required_tables:
-        exists = await _relation_exists(pool, table_name)
-        if not exists:
-            missing.append(table_name)
-    if not missing:
-        return []
-    command = (
-        "python scripts/run_extracted_content_pipeline_migrations.py "
-        "--database-url \"$EXTRACTED_DATABASE_URL\""
-    )
-    return [
-        "required Content Ops table(s) missing: "
-        f"{', '.join(missing)}. Run {command} before this smoke."
-    ]
-
-
-async def _relation_exists(pool: Any, table_name: str) -> bool:
-    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
-    return bool(value)
-
-
-async def _fetch_saved_drafts(pool: Any, saved_ids: Sequence[Any]) -> list[dict[str, Any]]:
-    if not isinstance(saved_ids, Sequence) or isinstance(saved_ids, (str, bytes)):
-        return []
-    ids = [str(item) for item in saved_ids if str(item or "").strip()]
-    if not ids:
-        return []
-    rows = await pool.fetch(
-        """
-        SELECT id, subject, body, target_mode, channel, metadata
-          FROM b2b_campaigns
-         WHERE id::text = ANY($1::text[])
-        """,
-        ids,
-    )
-    out: list[dict[str, Any]] = []
-    for row in rows:
-        metadata = _metadata_object(_row_value(row, "metadata"))
-        source_opportunity = metadata.get("source_opportunity")
-        if not isinstance(source_opportunity, Mapping):
-            source_opportunity = {}
-        target_id = metadata.get("target_id") or source_opportunity.get("target_id")
-        out.append({
-            "id": str(_row_value(row, "id") or ""),
-            "target_id": str(target_id or ""),
-            "subject": _row_value(row, "subject"),
-            "body": _row_value(row, "body"),
-            "target_mode": _row_value(row, "target_mode"),
-            "channel": _row_value(row, "channel"),
-        })
-    return out
-
-
-def _row_value(row: Any, key: str) -> Any:
-    if isinstance(row, Mapping):
-        return row.get(key)
-    return row[key]
-
-
-def _metadata_object(value: Any) -> dict[str, Any]:
-    if isinstance(value, Mapping):
-        return dict(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        return dict(parsed) if isinstance(parsed, Mapping) else {}
-    return {}
-
-
-def _saved_draft_target_errors(
-    saved_drafts: Sequence[Mapping[str, Any]],
-    imported_target_ids: Sequence[str],
-) -> list[str]:
-    imported = {str(target_id) for target_id in imported_target_ids}
-    errors: list[str] = []
-    for draft in saved_drafts:
-        draft_id_value = draft.get("id")
-        draft_id = str(draft_id_value) if draft_id_value is not None else ""
-        target_id_value = draft.get("target_id")
-        target_id = str(target_id_value) if target_id_value is not None else ""
-        if not target_id:
-            errors.append(f"persisted draft missing target_id metadata: {draft_id or '<unknown>'}")
-            continue
-        if target_id not in imported:
-            errors.append(f"persisted draft target_id was not imported: {target_id}")
-    return errors
-
 
 def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
     if as_json:

--- a/tests/test_content_ops_source_postgres_smoke_helpers.py
+++ b/tests/test_content_ops_source_postgres_smoke_helpers.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/content_ops_source_postgres_smoke_helpers.py"
+SPEC = importlib.util.spec_from_file_location(
+    "content_ops_source_postgres_smoke_helpers",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+helpers = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(helpers)
+
+
+class _Pool:
+    def __init__(self, *, existing_relations=None, rows=None):
+        self.existing_relations = set(
+            existing_relations or ("campaign_opportunities", "b2b_campaigns")
+        )
+        self.rows = list(rows or [])
+        self.fetch_calls = []
+        self.fetchval_calls = []
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        if "to_regclass" in str(query):
+            return args[0] if args and args[0] in self.existing_relations else None
+        return None
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.rows
+
+
+class _GenerationResult:
+    def __init__(self, data: dict[str, Any]):
+        self._data = dict(data)
+
+    def as_dict(self):
+        return dict(self._data)
+
+
+@pytest.mark.asyncio
+async def test_schema_readiness_errors_reports_missing_tables():
+    pool = _Pool(existing_relations={"b2b_campaigns"})
+
+    errors = await helpers.schema_readiness_errors(
+        pool,
+        opportunity_table="campaign_opportunities",
+    )
+
+    assert len(errors) == 1
+    assert "campaign_opportunities" in errors[0]
+    assert "run_extracted_content_pipeline_migrations.py" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_saved_drafts_reads_target_id_from_metadata_json():
+    pool = _Pool(rows=[
+        {
+            "id": "campaign-1",
+            "subject": "Subject",
+            "body": "Body",
+            "target_mode": "vendor_retention",
+            "channel": "email_cold",
+            "metadata": json.dumps({
+                "source_opportunity": {
+                    "target_id": "source-1",
+                }
+            }),
+        }
+    ])
+
+    drafts = await helpers.fetch_saved_drafts(pool, ["campaign-1"])
+
+    assert drafts == [{
+        "id": "campaign-1",
+        "target_id": "source-1",
+        "subject": "Subject",
+        "body": "Body",
+        "target_mode": "vendor_retention",
+        "channel": "email_cold",
+    }]
+    assert "FROM b2b_campaigns" in pool.fetch_calls[0]["query"]
+
+
+def test_draft_errors_enforces_minimum_required_fields_and_forbidden_phrases():
+    errors = helpers.draft_errors(
+        {
+            "drafts": [
+                {
+                    "subject": "Subject",
+                    "body": "Acme appears to be weighing a switch.",
+                    "target_id": "",
+                    "channel": "email_cold",
+                }
+            ]
+        },
+        min_drafts=1,
+        forbidden_phrases=["appears to be weighing"],
+    )
+
+    assert "draft 1 missing target_id" in errors
+    assert "draft 1 contains forbidden phrase: appears to be weighing" in errors
+
+
+def test_saved_draft_target_errors_require_imported_target_id():
+    errors = helpers.saved_draft_target_errors(
+        [
+            {"id": "campaign-1", "target_id": ""},
+            {"id": "campaign-2", "target_id": "other-source"},
+        ],
+        ["source-1"],
+    )
+
+    assert "persisted draft missing target_id metadata: campaign-1" in errors
+    assert "persisted draft target_id was not imported: other-source" in errors
+
+
+@pytest.mark.asyncio
+async def test_generate_imported_target_drafts_aggregates_multiple_targets(monkeypatch):
+    calls = []
+
+    async def fake_generate(*_args, **kwargs):
+        calls.append(kwargs)
+        index = len(calls)
+        return _GenerationResult({
+            "requested": 1,
+            "generated": 1,
+            "skipped": index - 1,
+            "reasoning_contexts_used": index,
+            "saved_ids": [f"campaign-{index}"],
+            "errors": [{"target_id": "source-2", "reason": "bad"}] if index == 2 else [],
+        })
+
+    monkeypatch.setattr(helpers, "generate_campaign_drafts_from_postgres", fake_generate)
+
+    result = await helpers.generate_imported_target_drafts(
+        pool=object(),
+        account_id="acct",
+        user_id=None,
+        target_mode="vendor_retention",
+        channels=("email_cold", "email_followup"),
+        target_ids=("source-1", "source-2"),
+        opportunity_table="campaign_opportunities",
+    )
+
+    assert result["requested"] == 2
+    assert result["generated"] == 2
+    assert result["skipped"] == 1
+    assert result["reasoning_contexts_used"] == 3
+    assert result["saved_ids"] == ["campaign-1", "campaign-2"]
+    assert result["errors"] == [{"target_id": "source-2", "reason": "bad"}]
+    assert calls[0]["filters"] == {"target_id": "source-1"}
+    assert calls[0]["channels"] == ("email_cold", "email_followup")

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -155,14 +155,6 @@ def _saved_draft_row(*, body=None):
     }
 
 
-class _GenerationResult:
-    def __init__(self, data):
-        self._data = dict(data)
-
-    def as_dict(self):
-        return dict(self._data)
-
-
 def _args(**overrides):
     values = {
         "source": "g2",
@@ -346,17 +338,17 @@ async def test_review_source_postgres_smoke_fails_on_generation_errors_and_skips
     )
     monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
 
-    async def generate_with_error(*_args, **_kwargs):
-        return _GenerationResult({
+    async def generate_with_error(**_kwargs):
+        return {
             "requested": 1,
             "generated": 1,
             "skipped": 1,
             "reasoning_contexts_used": 0,
             "saved_ids": ["campaign-1"],
             "errors": [{"target_id": "review-1", "reason": "bad"}],
-        })
+        }
 
-    monkeypatch.setattr(smoke, "generate_campaign_drafts_from_postgres", generate_with_error)
+    monkeypatch.setattr(smoke, "generate_imported_target_drafts", generate_with_error)
 
     code, payload = await smoke.run_review_source_postgres_smoke(
         _args(min_drafts=1),


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md

Extracts duplicated source-row Postgres smoke checks into a shared scripts helper so review-source and CFPB smokes validate the same DB readiness, deterministic generation, persisted-draft fetch, and target-id contract without parallel copies.

## Intentional
- Helper stays under scripts because it supports host smoke commands, not packaged runtime code.
- Source-specific export, ingestion inspection, import, and payload behavior remain in the existing smoke scripts.
- Full extracted check now includes the review-source Postgres smoke test alongside CFPB and the new helper tests.

## Deferred
- New CRM/support-ticket/call-transcript source adapters stay in follow-up slices.
- Live Postgres smoke execution remains outside CI.

## Verification
- pytest tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py -q -> 20 passed.
- python -m py_compile scripts/content_ops_source_postgres_smoke_helpers.py scripts/smoke_content_ops_review_source_postgres.py scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py -> passed.
- grep -nP '[^\\x00-\\x7F]' <edited Python/test files> -> no matches.\n- git diff --check -> passed.\n- bash scripts/local_pr_review.sh -> passed.\n- bash scripts/run_extracted_pipeline_checks.sh -> 1433 passed, 1 existing torch/pynvml warning.\n\n## Diff size\n8 files, +517 / -364