### PR TITLE
Add regression tests + baseline audit for blog generator HTML hygiene

### DIFF
--- a/reports/published-posts-audit-baseline.json
+++ b/reports/published-posts-audit-baseline.json
@@ -1,0 +1,3418 @@
+{
+  "repo": "/home/juan-canfield/Desktop/Atlas-blog-generator-safety-net/atlas-churn-ui",
+  "generated": "2026-05-19T03:55:55.457Z",
+  "posts_scanned": 79,
+  "reports": [
+    {
+      "slug": "amazon-web-services-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "asana-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "azure-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "azure-vs-salesforce-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "b2b-software-landscape-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "b2b-software-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "basecamp-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "best-b2b-software-for-1000-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'best_fit_guide' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "best-crm-for-51-200-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'best_fit_guide' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "best-hr-hcm-for-51-200-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- Office Manager, verified reviewer</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 10,
+          "examples": [
+            "<p>Yes, if: - You're a US-only company with stable headcount (under 300) - You want straightfor",
+            "<p>No, if: - You're planning international expansion - You need advanced payroll, tax, or bene",
+            "<p>Yes, if: - Payroll accuracy and tax compliance are your top priority - You want a single pla",
+            "<p>No, if: - You need a highly customizable, modern interface - You want to keep payroll and H",
+            "<p>Yes, if: - You want a single platform for HR, payroll, and IT management - Your team has str",
+            "<p>No, if: - You want a simple, easy-to-use interface - You need immediate, responsive support",
+            "<p>Yes, if: - You have 1000+ employees across multiple countries - You need advanced reporting,",
+            "<p>No, if: - You're a 51–200 person team - You want quick time-to-value - You need responsive,",
+            "<p>Both Gusto and Rippling face support complaints. If you need responsive support: - Budget for a dedicated HR admin or",
+            "<p>All four vendors have contract lock-in. Before you sign: - Understand data export and migration capabilities - Negoti"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'best_fit_guide' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "best-project-management-for-201-1000-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: year is the live timing trigger, $10.99 is the concrete spend anchor, the core pressure showing up in t"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 1,
+          "examples": [
+            "<p>Per-seat pricing scales unpredictably. One Reddit reviewer compared vendors and found: - Jira: 92× multiplier at $9.0"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'best_fit_guide' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "brevo-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on TrustPilot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 3,
+          "examples": [
+            "<p>Pricing complaints dominate the recent review window. Reviewers report: - Escalating costs as contact volume grows pa",
+            "<p>Reviewers report friction around: - Difficulty downgrading plans mid-cycle - Feature availability tied to plan tier r",
+            "<p>Reviewers explicitly ask for a $100–200/month tier with: - 25,000–50,000 contact limits - Basic automation (not full "
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "clickup-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "close-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 5,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 1,
+          "examples": [
+            "<p>Key findings: - 34 reviews showed churn or switching intent - Economic buyers surfaced the strong"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "close-vs-zoho-crm-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "communication-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, th"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "copper-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "crm-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "fortinet-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "gusto-vs-workday-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 10,
+          "examples": [
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- CEO, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Owner, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "help-scout-vs-zendesk-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 9,
+          "examples": [
+            "<blockquote>\n<p>-- Customer Success Manager, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Customer Success Manager, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Software Advice</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 5,
+          "examples": [
+            "<p>Help Scout signals include: - 1 economic buyer - 1 champion - 1 evaluator",
+            "<p>Zendesk signals include: - 2 economic buyers - 2 champions - 2 end users",
+            "<p>The data does not include explicit company size or industry breakdowns, but the quotable phrases and witness highligh",
+            "<p>For buyers evaluating between Help Scout and Zendesk: - If your team is under 20 employees and does not require deep ",
+            "<p>For vendors targeting Help Scout or Zendesk accounts: - Help Scout accounts are vulnerable on integration depth and w"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "helpdesk-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: two months is the live timing trigger, $500,000 is the concrete spend anchor, HubSpot is the competitiv"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "hr-hcm-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Office Manager on TrustRadius</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "hubspot-deep-dive-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "hubspot-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "hubspot-vs-power-bi-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 8,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "insightly-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on G2</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 1,
+          "examples": [
+            "<p>Priority timing triggers include: - One-year contract renewal approaching - Just over one year tenure - 2.1-2 years t"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "insightly-vs-zoho-crm-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "intercom-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "jira-vs-mondaycom-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 10,
+          "examples": [
+            "<blockquote>\n<p>-- Client service manager, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Twitter/X</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Diretor de arte sênior, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Twitter/X</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Diretor de arte sênior, verified reviewer on G2</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "jira-vs-trello-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "linode-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Twitter</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 6,
+          "examples": [
+            "<p>The relatively low mention frequency across use cases suggests either: - Review data doesn't capture the full breadth",
+            "<p>However, account-level intent data shows a significant gap. The account packet reports zero accounts across all metri",
+            "<p>However, the temporal signal data shows significant gaps. Evaluation deadline signals, contract end signals, renewal ",
+            "<p>This data gap has several possible explanations: - Privacy filtering may be removing identifiable account information",
+            "<p>The absence of account-level metrics prevents answering critical questions: - Which named accounts are showing churn ",
+            "<p>For vendors competing against Linode, the competitive landscape suggests positioning around: - Feature breadth (if yo"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "looker-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Mechanical Design Engineer, Mid-Market (51-1000 emp.), Design industry, verified reviewer on G2</p>\n<",
+            "<blockquote>\n<p>-- Mechanical Design Engineer, Mid-Market (51-1000 emp.), Design industry, verified reviewer on G2</p>\n<",
+            "<blockquote>\n<p>-- reviewer on Twitter/X</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "magento-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "mailchimp-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "marketing-automation-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 24/7 is the live timing trigger, $800 m is the concrete spend anchor, unknown is the competitive altern"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 2,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>",
+            "<h2 id=\"conclusion\">Conclusion</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "metabase-vs-tableau-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 6,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Mechanical Design Engineer, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Mechanical Design Engineer, verified reviewer on G2</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "microsoft-defender-for-endpoint-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "microsoft-teams-vs-notion-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 6,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Solution Architect, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Student and Owner, verified reviewer on G2</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, th"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "microsoft-teams-vs-salesforce-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 10,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on software_advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Solution Architect, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on software_advice</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, th"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "notion-vs-salesforce-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "pipedrive-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 2 months is the live timing trigger, $15/user is the concrete spend anchor, Nutshell is the competitive"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "power-bi-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: today is the live timing trigger, $5/month is the concrete spend anchor, Tableau is the competitive alt"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 3,
+          "examples": [
+            "<p>Power BI makes sense for teams that: - Are already embedded in Microsoft 365 and value Excel, Teams, and SharePoint i",
+            "<p>Power BI does not make sense for teams that: - Are consolidating on Google Cloud Platform or AWS and want cloud-nativ",
+            "<p>The March-May 2026 window is the most critical decision period for Power BI customers. April 15 scorecard hierarchy d"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "project-management-landscape-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: year is the live timing trigger, $10.99 is the concrete spend anchor, the core pressure showing up in t"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'market_landscape' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "real-cost-of-copper-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: $12 is the concrete spend anchor, Aluminum is the competitive alternative in the witness-backed record,"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pricing_reality_check' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "real-cost-of-shopify-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pricing_reality_check' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "real-cost-of-woocommerce-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: this week is the live timing trigger, $29/mo is the concrete spend anchor, Shopify is the competitive a"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pricing_reality_check' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "salesforce-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "sentinelone-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 5,
+          "examples": [
+            "<p>Top integrations by mention count: - SentinelOne (6 mentions) - Huntress (5 mentions) - AWS (4 mentions) - Intune (4 ",
+            "<p>Top use cases by mention count and urgency: - SentinelOne Singularity Endpoint (6 mentions, 1.2 urgency) - SentinelOn",
+            "<p>Top buyer roles by review count: - Evaluator, evaluation stage: 57 reviews - Economic buyer, post-purchase: 5 review",
+            "<p>Key timing metrics: - 2 active evaluation signals visible now - 2 evaluation deadline signals present -",
+            "<p>CrowdStrike appears as the primary comparison point, mentioned in multiple reviewer contexts. The competitive positio"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "shopify-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "slack-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "slack-vs-zoom-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 1,
+          "examples": [
+            "<blockquote>\n<p>-- network security engineer, verified reviewer on g2</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'vendor_showdown' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-asana-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-clickup-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-clickup-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 6,
+          "examples": [
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: month is the live timing trigger, $29 is the concrete spend anchor, the core pressure showing up in the"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 12,
+          "examples": [
+            "<p>For example, a team might migrate from: - Trello for task management - Notion for documentation - Zapier for workflow",
+            "<p>Reviewers leaving Trello, Asana, and Jira frequently cite UX regression. The complaints cluster around: - Navigation ",
+            "<p>Teams leaving Notion and Airtable cite feature gaps around: - Advanced automation - Native time tracking - Resource c",
+            "<p>ClickUp addresses some of these gaps with built-in features. However, integration depth varies. The most frequently m",
+            "<p>Performance issues rank fourth among migration triggers. Reviewers leaving Notion and Airtable report: - Slow load ti",
+            "<p>Onboarding friction appears in both outbound signals (teams leaving rigid tools like Jira) and inbound caution (teams",
+            "<p>ClickUp supports CSV imports and native connectors for Trello, Asana, Jira, and other platforms. However, reviewers r",
+            "<p>This suggests teams should invest time in hierarchy planning before migration. Common patterns include: - Folders for",
+            "<p>Teams should expect: - Initial productivity dip during the learning phase - Gradual productivity recover",
+            "<p>The data supports migration for: - Teams outgrowing simpler tools like Trello or Todoist - Teams consolidating multi",
+            "<p>The data flags caution for: - Teams expecting plug-and-play simplicity - Teams with limited admin capacity for ",
+            "<p>The reasoning context flags low confidence for timing intelligence, migration proof, and category reasoning. This mea"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-klaviyo-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-salesforce-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-sentinelone-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-shopify-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 1,
+          "examples": [
+            "<p>For teams evaluating Shopify, the data suggests asking: - How much technical control do we need versus operational si"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-shopify-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-woocommerce-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 1
+    },
+    {
+      "slug": "switch-to-zoho-crm-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 5,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 5,
+          "examples": [
+            "<p>Common data migration challenges include: - Field mapping between your current CRM and Zoho CRM's schema - Custom fie",
+            "<p>For teams considering whether to migrate, the review data suggests Zoho CRM works best when: - You're consolidating m",
+            "<p>The consolidation opportunity is strongest when: - You're currently paying for multiple tools that Zoho CRM can repla",
+            "<p>Reviewer experience suggests Zoho CRM works best for: - Small-to-midsize teams (under 50 users) - Teams consolidating",
+            "<p>Zoho CRM may not fit if: - You require complex contact segmentation or account-based filtering - You need en"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "tableau-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "teamwork-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 0,
+          "examples": []
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 0
+    },
+    {
+      "slug": "top-complaint-every-b2b-software-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-communication-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Solution Architect, verified reviewer on G2</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Trustpilot</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, th"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-crm-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 6,
+          "examples": [
+            "That quote is from a compensation discussion, not a",
+            "misattributed in the source data",
+            "quote is from a compensation discussion, not a CRM review",
+            "quote is from a personal finance discussion, not a CRM review",
+            "quote is from a payment platform discussion, not a CRM review, but it reflects a common pattern: review",
+            "quote is misattributed"
+          ]
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 4,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-e-commerce-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 3,
+          "examples": [
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Director of Technology, verified reviewer on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Director of Technology, verified reviewer on TrustRadius</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-helpdesk-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Twitter</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Twitter</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: two months is the live timing trigger, $500,000 is the concrete spend anchor, HubSpot is the competitiv"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-marketing-automation-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 6,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>",
+            "<blockquote>\n<p>-- software reviewer</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 1,
+          "examples": [
+            "Evidence anchor: 24/7 is the live timing trigger, $800 m is the concrete spend anchor, unknown is the competitive altern"
+          ]
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "top-complaint-every-project-management-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on PeerSpot</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Software Advice</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'pain_point_roundup' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "why-teams-leave-azure-2026-03",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'switching_story' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "why-teams-leave-azure-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- verified reviewer on Capterra</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'switching_story' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "why-teams-leave-slack-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 4,
+          "examples": [
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>",
+            "<blockquote>\n<p>-- reviewer on Reddit</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 3,
+          "examples": [
+            "<p>Full replacement makes sense when: - Cost pressure is severe and Microsoft 365 is already deployed - Infrastructure o",
+            "<p>Workflow migration makes sense when: - Specific workflows (design reviews, project documentation, decision records) a",
+            "<p>Stay on Slack when: - Real-time coordination is genuinely critical to your workflows - Integration ecos"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 1,
+          "examples": [
+            "topic_type: 'switching_story' (not in valid enum)"
+          ]
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 3,
+      "highCount": 1
+    },
+    {
+      "slug": "woocommerce-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 1,
+          "examples": [
+            "<p>This means the analysis cannot assess: - Which specific companies are evaluating WooCommerce alternatives - Whether p"
+          ]
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 2,
+          "examples": [
+            "affiliate_url: https://example.com/atlas-live-test-partner",
+            "affiliate partner name: Atlas Live Test Partner"
+          ]
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 2,
+      "highCount": 1
+    },
+    {
+      "slug": "workday-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "wrike-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 2,
+          "examples": [
+            "<blockquote>\n<p>-- Event Production Manager on TrustRadius</p>\n</blockquote>",
+            "<blockquote>\n<p>-- Event Production Manager on TrustRadius</p>\n</blockquote>"
+          ]
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 0,
+          "examples": []
+        }
+      },
+      "criticalCount": 1,
+      "highCount": 0
+    },
+    {
+      "slug": "zoho-crm-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    },
+    {
+      "slug": "zoom-deep-dive-2026-04",
+      "findings": {
+        "empty_blockquote": {
+          "count": 0,
+          "examples": []
+        },
+        "evidence_anchor": {
+          "count": 0,
+          "examples": []
+        },
+        "markdown_in_html": {
+          "count": 0,
+          "examples": []
+        },
+        "misattribution_disclaimer": {
+          "count": 0,
+          "examples": []
+        },
+        "placeholder_affiliate": {
+          "count": 0,
+          "examples": []
+        },
+        "invalid_topic_type": {
+          "count": 0,
+          "examples": []
+        },
+        "generic_intro_h2": {
+          "count": 1,
+          "examples": [
+            "<h2 id=\"introduction\">Introduction</h2>"
+          ]
+        }
+      },
+      "criticalCount": 0,
+      "highCount": 1
+    }
+  ]
+}

--- a/reports/published-posts-audit-baseline.md
+++ b/reports/published-posts-audit-baseline.md
@@ -1,0 +1,105 @@
+# Published Posts Audit
+
+Repo: `/home/juan-canfield/Desktop/Atlas-blog-generator-safety-net/atlas-churn-ui`
+Posts scanned: 79
+Generated: 2026-05-19T03:55:55.418Z
+
+## Per-post findings
+
+| slug | empty_blockquote | evidence_anchor | markdown_in_html | misattribution_disclaimer | placeholder_affiliate | invalid_topic_type | generic_intro_h2 | severity |
+|---|---|---|---|---|---|---|---|---|
+| best-project-management-for-201-1000-2026-04 | 4 | 1 | 1 |  |  | 1 | 1 | CRITICAL |
+| microsoft-teams-vs-notion-2026-04 | 6 | 1 |  |  | 2 | 1 | 1 | CRITICAL |
+| microsoft-teams-vs-salesforce-2026-04 | 10 | 1 |  |  | 2 | 1 | 1 | CRITICAL |
+| power-bi-deep-dive-2026-04 | 1 | 1 | 3 |  | 2 |  | 1 | CRITICAL |
+| real-cost-of-copper-2026-04 | 4 | 1 |  |  | 2 | 1 | 1 | CRITICAL |
+| real-cost-of-woocommerce-2026-04 | 2 | 1 |  |  | 2 | 1 | 1 | CRITICAL |
+| switch-to-clickup-2026-04 | 6 | 1 | 12 |  | 2 |  | 1 | CRITICAL |
+| top-complaint-every-crm-2026-04 | 4 | 1 |  | 6 |  | 1 | 1 | CRITICAL |
+| best-crm-for-51-200-2026-04 | 3 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| best-hr-hcm-for-51-200-2026-04 | 1 |  | 10 |  |  | 1 | 1 | CRITICAL |
+| close-deep-dive-2026-04 | 5 | 1 | 1 |  |  |  | 1 | CRITICAL |
+| crm-landscape-2026-04 | 2 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| help-scout-vs-zendesk-2026-04 | 9 |  | 5 |  |  | 1 | 1 | CRITICAL |
+| helpdesk-landscape-2026-04 | 1 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| hubspot-vs-power-bi-2026-04 | 8 |  |  |  | 2 | 1 | 1 | CRITICAL |
+| project-management-landscape-2026-04 | 4 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| sentinelone-deep-dive-2026-04 | 3 |  | 5 |  | 2 |  | 1 | CRITICAL |
+| top-complaint-every-communication-2026-04 | 4 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| top-complaint-every-helpdesk-2026-04 | 4 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| top-complaint-every-marketing-automation-2026-04 | 6 | 1 |  |  |  | 1 | 1 | CRITICAL |
+| why-teams-leave-azure-2026-04 | 4 |  |  |  | 2 | 1 | 1 | CRITICAL |
+| why-teams-leave-slack-2026-04 | 4 |  | 3 |  |  | 1 | 1 | CRITICAL |
+| azure-deep-dive-2026-04 | 4 |  |  |  | 2 |  | 1 | CRITICAL |
+| azure-vs-salesforce-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| b2b-software-landscape-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| b2b-software-landscape-2026-04 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| best-b2b-software-for-1000-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| brevo-deep-dive-2026-04 | 3 |  | 3 |  |  |  | 1 | CRITICAL |
+| clickup-deep-dive-2026-04 | 3 |  |  |  | 2 |  | 1 | CRITICAL |
+| communication-landscape-2026-04 |  | 1 |  |  |  | 1 | 1 | CRITICAL |
+| gusto-vs-workday-2026-04 | 10 |  |  |  |  | 1 | 1 | CRITICAL |
+| hr-hcm-landscape-2026-04 | 4 |  |  |  |  | 1 | 1 | CRITICAL |
+| insightly-deep-dive-2026-04 | 1 |  | 1 |  |  |  | 1 | CRITICAL |
+| insightly-vs-zoho-crm-2026-04 | 3 |  |  |  |  | 1 | 1 | CRITICAL |
+| jira-vs-mondaycom-2026-04 | 10 |  |  |  |  | 1 | 1 | CRITICAL |
+| linode-deep-dive-2026-04 | 3 |  | 6 |  |  |  | 1 | CRITICAL |
+| marketing-automation-landscape-2026-04 |  | 1 |  |  |  | 1 | 2 | CRITICAL |
+| metabase-vs-tableau-2026-04 | 6 |  |  |  |  | 1 | 1 | CRITICAL |
+| notion-vs-salesforce-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| slack-vs-zoom-2026-04 | 1 |  |  |  |  | 1 | 1 | CRITICAL |
+| switch-to-sentinelone-2026-04 | 3 |  |  |  | 2 |  | 1 | CRITICAL |
+| switch-to-zoho-crm-2026-04 | 5 |  | 5 |  |  |  | 1 | CRITICAL |
+| top-complaint-every-b2b-software-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| top-complaint-every-e-commerce-2026-04 | 3 |  |  |  |  | 1 | 1 | CRITICAL |
+| top-complaint-every-project-management-2026-04 | 4 |  |  |  |  | 1 | 1 | CRITICAL |
+| why-teams-leave-azure-2026-03 |  |  |  |  | 2 | 1 | 1 | CRITICAL |
+| woocommerce-deep-dive-2026-04 |  |  | 1 |  | 2 |  | 1 | CRITICAL |
+| asana-deep-dive-2026-04 | 1 |  |  |  |  |  | 1 | CRITICAL |
+| close-vs-zoho-crm-2026-04 |  |  |  |  |  | 1 | 1 | CRITICAL |
+| copper-deep-dive-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| fortinet-deep-dive-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| jira-vs-trello-2026-03 |  |  |  |  |  | 1 | 1 | CRITICAL |
+| looker-deep-dive-2026-04 | 4 |  |  |  |  |  | 1 | CRITICAL |
+| magento-deep-dive-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| microsoft-defender-for-endpoint-deep-dive-2026-04 | 2 |  |  |  |  |  | 1 | CRITICAL |
+| pipedrive-deep-dive-2026-04 |  | 1 |  |  |  |  | 1 | CRITICAL |
+| real-cost-of-shopify-2026-04 |  |  |  |  |  | 1 | 1 | CRITICAL |
+| salesforce-deep-dive-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| shopify-deep-dive-2026-04 | 2 |  |  |  |  |  | 1 | CRITICAL |
+| slack-deep-dive-2026-04 | 2 |  |  |  |  |  | 1 | CRITICAL |
+| switch-to-clickup-2026-03 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| switch-to-salesforce-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| switch-to-shopify-2026-03 |  |  | 1 |  |  |  | 1 | CRITICAL |
+| switch-to-shopify-2026-04 | 3 |  |  |  |  |  | 1 | CRITICAL |
+| switch-to-woocommerce-2026-04 |  |  |  |  | 2 |  | 1 | CRITICAL |
+| wrike-deep-dive-2026-04 | 2 |  |  |  |  |  |  | CRITICAL |
+| amazon-web-services-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| basecamp-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| hubspot-deep-dive-2026-03 |  |  |  |  |  |  | 1 | HIGH |
+| hubspot-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| intercom-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| mailchimp-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| switch-to-asana-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| switch-to-klaviyo-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| tableau-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| workday-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| zoho-crm-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| zoom-deep-dive-2026-04 |  |  |  |  |  |  | 1 | HIGH |
+| teamwork-deep-dive-2026-04 |  |  |  |  |  |  |  | CLEAN |
+
+## Aggregate
+
+- Total posts: **79**
+- Clean posts: **1**
+- Posts with at least one CRITICAL finding: **66**
+
+| Detector | Posts affected | Total occurrences | Severity |
+|---|---|---|---|
+| Empty blockquotes | 44 | 174 | critical |
+| Evidence anchor placeholder | 19 | 19 | critical |
+| Markdown in <p> tags | 14 | 57 | critical |
+| Misattribution disclaimer | 1 | 6 | critical |
+| Placeholder affiliate data | 27 | 54 | critical |
+| Invalid topic_type | 38 | 38 | critical |
+| Generic <h2>Introduction</h2> | 77 | 78 | high |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -298,6 +298,136 @@ def test_validator_handles_markdown_without_blockquotes():
 
 
 # ---------------------------------------------------------------------------
+# Regression: multi-line blockquote orphan-attribution bug
+#
+# These tests document the CURRENT line-by-line stripping behavior. They
+# capture the failure mode that produces empty <blockquote><p>-- attribution
+# </p></blockquote> elements in 44 of 80 published posts. When the stripper
+# is fixed to operate on contiguous blockquote BLOCKS, these tests will
+# need to be inverted (asserting full block removal + no orphan attribution).
+# ---------------------------------------------------------------------------
+
+
+def test_regression_full_block_stripped_when_pool_empty():
+    """REGRESSION baseline: with empty source_quotes, the fail-closed
+    path correctly strips both lines of a multi-line blockquote.
+
+    This works because empty source_quotes short-circuits before
+    _extract_quote_body is called -- every line matching _BLOCKQUOTE_RE
+    is removed regardless of content. The bug only manifests when the
+    pool is populated AND a specific quote line doesn't match. See the
+    next test.
+    """
+    markdown = (
+        "## Section\n"
+        "\n"
+        "One reviewer noted:\n"
+        "\n"
+        "> \"A fabricated quote that won't match the source pool\"\n"
+        "> -- Group Director, verified reviewer on TrustRadius\n"
+        "\n"
+        "More prose continues here.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, [])
+    assert removed == 2
+    assert "fabricated quote" not in out
+    assert "Group Director" not in out
+
+
+def test_regression_orphan_attribution_left_when_pool_populated_no_match():
+    """REGRESSION: the orphan-attribution bug surfaces when
+    source_quotes is populated and the quote-line doesn't match.
+
+    Per b2b_blog_post_generation.py lines 1567-1582, the stripper goes
+    line-by-line:
+      * Quote line: _extract_quote_body() returns the quote text, fails
+        _quote_matches_source, line is stripped.
+      * Attribution line: _extract_quote_body() splits on '--' and takes
+        the part BEFORE, returning empty string for an attribution-only
+        line. The conditional `if quote and not _quote_matches_source(...)`
+        is FALSY because `quote` is empty -- the attribution line is
+        PRESERVED.
+
+    Result: an orphan `> -- Attribution` line in markdown, which renders
+    as `<blockquote><p>-- Attribution</p></blockquote>` in the final
+    HTML. Confirmed in 44 of 80 published posts at the time of writing.
+
+    The fix is to operate on contiguous blockquote BLOCKS instead of
+    individual lines. When that fix lands, this test should be inverted:
+    `removed == 2` and `"Group Director" not in out`.
+    """
+    source = ["something else entirely that won't match"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> \"A quote the LLM made up\"\n"
+        "> -- Group Director, verified reviewer on TrustRadius\n"
+        "\n"
+        "More prose.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    # CURRENT (buggy) behavior: only the quote line is stripped.
+    # The attribution line passes through because _extract_quote_body
+    # returns empty string for it, falsifying the removal condition.
+    assert removed == 1, (
+        "Orphan-attribution bug: only the quote line is removed. "
+        "The attribution line `> -- Group Director...` is preserved "
+        "because _extract_quote_body returns an empty string for an "
+        "attribution-only line, falsifying the removal condition."
+    )
+    # The attribution line survives -- this is the visible bug:
+    assert "-- Group Director, verified reviewer on TrustRadius" in out
+    # And the made-up quote was correctly removed:
+    assert "made up" not in out
+
+
+def test_regression_introductory_prose_orphaned_when_quote_stripped():
+    """REGRESSION: prose introducing a blockquote is not cleaned up
+    when the blockquote itself gets stripped.
+
+    Even if the multi-line blockquote bug were fixed (full block
+    removal), this orphan would remain:
+
+        One reviewer on Reddit noted:
+
+        [blockquote was here, now gone]
+
+        That quote is from a compensation discussion, not a CRM review,
+        but it surfaced in the same complaint pattern analysis.
+
+    Both the introduction ("One reviewer noted:") and the disclaimer
+    ("That quote is from a...") survive stripping because they aren't
+    blockquote-prefixed lines. They reference content that no longer
+    exists, producing dangling prose readers see as broken.
+
+    This documents the gap. A complete fix needs to also detect and
+    remove orphan introductory/disclaimer prose adjacent to stripped
+    blocks. The seo-geo-aeo-blog-post skill v1.4.0 added regex patterns
+    that catch the disclaimer pattern in audit mode; upstream detection
+    in the generator should mirror them.
+    """
+    source: list[str] = []  # fail-closed: all blockquotes stripped
+    markdown = (
+        "## Section\n"
+        "\n"
+        "One reviewer on Reddit noted:\n"
+        "\n"
+        "> a quote that gets stripped because source pool is empty\n"
+        "\n"
+        "That quote is from a compensation discussion, not a CRM review, but it surfaced in the same complaint pattern analysis.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 1
+    assert "gets stripped" not in out
+    # CURRENT BUG: both the intro and the disclaimer prose are kept.
+    # In a fixed implementation, both should be removed (or the post
+    # should be flagged for review, since the disclaimer pattern itself
+    # signals data-pipeline trouble per the v1.4.0 skill regex).
+    assert "One reviewer on Reddit noted:" in out
+    assert "That quote is from a compensation discussion" in out
+
+
+# ---------------------------------------------------------------------------
 # _blueprint_pricing_reality_check pilot integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Builds a safety net for fixing the blog generator's HTML-hygiene bugs **before** changing any pipeline code. Adds 3 regression tests that pin the current (buggy) behavior of \`_remove_unmatched_quote_lines\`, and a static analyzer that measures bug prevalence across all published posts.

## Baseline (from analyzer output committed in \`reports/\`)

**66 of 79 published posts (84%)** have at least one CRITICAL HTML-hygiene finding:

| Detector | Posts affected | Total occurrences |
|---|---|---|
| Empty blockquotes (line-level stripper leaving orphan attribution) | 44 | 174 |
| Invalid \`topic_type\` (outside the 5-value enum) | 38 | 38 |
| Placeholder affiliate data (\`example.com\` URLs, "test" partner names) | 27 | 54 |
| "Evidence anchor:" placeholder text in rendered content | 19 | 19 |
| Markdown syntax leaking into \`<p>\` tags | 14 | 57 |
| Acknowledged-misattribution disclaimer prose | 1 | 6 |
| Generic \`<h2>Introduction</h2>\` (anti-pattern) | 77 | 78 |

## Files

- \`tests/test_b2b_blog_post_generation_quote_gate.py\` — 3 new regression tests appended; existing 5 stripper tests still pass. All 8 green.
- \`reports/published-posts-audit-baseline.{md,json}\` — frozen baseline measurement.

The analyzer itself lives in the \`seo-geo-aeo-blog-post\` Claude Code skill at \`~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js\` (portable, runnable against any blog repo via \`--repo=<path>\`).

## Why this is the right shape

Before this PR there were zero tests covering multi-line \`> "quote"\\n> -- attribution\` markdown — the exact pattern producing 174 broken blockquotes across 44 published posts. Any fix to the stripper without these tests is a hope, not a verified change.

After this PR, any future stripper fix has to:
1. Update the regression tests to assert new correct behavior
2. Pass the new tests
3. Re-run the analyzer and show the empty-blockquote count dropping

## Test plan

- [x] All 8 stripper tests pass: \`ATLAS_SAAS_ENABLED=false ATLAS_DB_ENABLED=false pytest tests/test_b2b_blog_post_generation_quote_gate.py -k "validator or regression"\`
- [x] Analyzer runs against atlas-churn-ui and produces the baseline numbers above
- [ ] No pipeline code changed — generator behavior is unchanged

## Notes

- The \`ATLAS_SAAS_ENABLED=false\` env var is needed to skip BYOK encryption validation that triggers a circular import in the test environment. Documented in the commit body.
- 38 posts have \`topic_type\` outside the enum (\`pain_point_roundup\`, \`pricing_reality_check\`, \`migration_playbook\`, etc.). These need normalization in a follow-up.
- 27 posts have \`affiliate_url\` pointing to \`example.com\` and partner names containing "test"/"placeholder". These need real partner data or \`data_context: undefined\` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)