### PR TITLE
Add packaged support-ticket source examples

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T03:43Z by codex-2026-05-18
+Last updated: 2026-05-19T03:58Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Source-Smoke-Shared-Helpers | `scripts/content_ops_source_postgres_smoke_helpers.py`, `scripts/smoke_content_ops_review_source_postgres.py`, `scripts/smoke_content_ops_cfpb_source_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `tests/test_content_ops_source_postgres_smoke_helpers.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-Smoke-Shared-Helpers.md` | codex-2026-05-18 | Content Ops source Postgres smoke helpers |
+| TBD | PR-Content-Ops-Support-Ticket-Examples | `extracted_content_pipeline/examples/support_ticket_sources.csv`, `extracted_content_pipeline/examples/support_ticket_bundle.json`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Support-Ticket-Examples.md` | codex-2026-05-18 | Content Ops support-ticket ingestion examples |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -149,6 +149,23 @@ subscription, complaint, support-ticket, conversation, case, survey, NPS, CSAT,
 and document source rows can be converted into the same opportunity payload
 first. Source rows can be JSON, JSONL, or CSV:
 
+For a customer-owned support-ticket export, start with the packaged CSV or JSON
+bundle examples. The CSV uses provider-style labels such as `Ticket ID`,
+`Account Name`, `Vendor Name`, `Subject`, and `Description`; the JSON bundle
+shows shared account metadata with multiple `support_tickets`:
+
+```bash
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --format csv \
+  --output support_ticket_opportunities.json
+
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/support_ticket_bundle.json \
+  --format json \
+  --output support_ticket_bundle_opportunities.json
+```
+
 If Atlas already has scraped B2B review rows, export one reliable source as
 Content Ops source rows before generation. The G2 path is read-only, keeps only
 canonical enriched reviews, and exports the negative/mixed quote-grade phrase
@@ -273,6 +290,11 @@ python scripts/run_extracted_campaign_generation_example.py \
   extracted_content_pipeline/examples/campaign_source_bundle.json \
   --source-rows \
   --source-format json
+
+python scripts/run_extracted_campaign_generation_example.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-rows \
+  --source-format csv
 ```
 
 They can also be loaded directly into the Postgres opportunity table:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -167,6 +167,11 @@ python scripts/smoke_extracted_content_pipeline_host.py \
   extracted_content_pipeline/examples/campaign_source_bundle.json \
   --source-rows \
   --source-format json
+
+python scripts/smoke_extracted_content_pipeline_host.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-rows \
+  --source-format csv
 ```
 
 For source-row CSV exports, pass `--source-format csv` to the same smoke
@@ -206,6 +211,16 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
   extracted_content_pipeline/examples/campaign_source_bundle.json \
   --format json \
   --output customer_bundle_opportunities.json
+
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --format csv \
+  --output support_ticket_opportunities.json
+
+python scripts/build_extracted_campaign_opportunities_from_sources.py \
+  extracted_content_pipeline/examples/support_ticket_bundle.json \
+  --format json \
+  --output support_ticket_bundle_opportunities.json
 ```
 
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,

--- a/extracted_content_pipeline/examples/support_ticket_bundle.json
+++ b/extracted_content_pipeline/examples/support_ticket_bundle.json
@@ -1,0 +1,34 @@
+{
+  "account_id": "acct_support_demo",
+  "company": "Riverbend Supply",
+  "vendor": "LegacyCRM",
+  "email": "ops@riverbend.example",
+  "contact_name": "Avery Morgan",
+  "title": "Director of Operations",
+  "segment": "industrial distribution",
+  "support_tickets": [
+    {
+      "ticket_id": "support-riverbend-1",
+      "subject": "Attribution export blocked",
+      "description": "The operations team cannot export campaign attribution data before the renewal review.",
+      "pain_category": "reporting friction",
+      "source_url": "https://example.com/tickets/riverbend-1"
+    },
+    {
+      "ticket_id": "support-riverbend-2",
+      "subject": "Manual sequence cleanup after demos",
+      "comments": [
+        {
+          "author": "Customer",
+          "body": "Every demo follow-up still has to be rebuilt by hand."
+        },
+        {
+          "role": "Agent",
+          "message": "The workflow automation feature is not available on the current plan."
+        }
+      ],
+      "pain_category": "manual follow-up",
+      "source_url": "https://example.com/tickets/riverbend-2"
+    }
+  ]
+}

--- a/extracted_content_pipeline/examples/support_ticket_sources.csv
+++ b/extracted_content_pipeline/examples/support_ticket_sources.csv
@@ -1,0 +1,3 @@
+Ticket ID,Account Name,Vendor Name,Contact Email,Contact Name,Contact Title,Subject,Description,Pain Category,Source URL
+ticket-acme-1,Acme Logistics,HubSpot,ops@example.com,Jordan Lee,VP Revenue Operations,Reporting export blocked before renewal,The operations team cannot export campaign attribution data without upgrading to a higher tier.,reporting friction,https://example.com/tickets/acme-1
+ticket-northstar-1,Northstar Foods,LegacyCRM,growth@example.com,Riley Chen,Director of Growth,Sequence handoff errors keep recurring,Support notes show campaign handoffs are still being reconciled manually after every webinar.,manual follow-up,https://example.com/tickets/northstar-1

--- a/plans/PR-Content-Ops-Support-Ticket-Examples.md
+++ b/plans/PR-Content-Ops-Support-Ticket-Examples.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-Support-Ticket-Examples
+
+## Why this slice exists
+
+Content Ops can already ingest support-ticket-like rows through the generic
+source adapter, and the CFPB smoke proves a public complaint source can feed
+that path. Hosts still do not have a packaged support-ticket CSV or JSON bundle
+they can run locally when wiring Zendesk, Intercom, Freshdesk, Salesforce case,
+or help desk exports.
+
+This slice adds concrete packaged support-ticket examples and locks them
+through the existing conversion and offline smoke commands.
+
+## Scope (this PR)
+
+1. Add a packaged support-ticket CSV example with provider-style column labels.
+2. Add a packaged support-ticket JSON bundle with shared account metadata and
+   multiple ticket rows.
+3. Add tests proving both packaged examples load and the CLI can convert them.
+4. Document the support-ticket examples in the README and host install runbook.
+5. Remove the merged source-smoke helper coordination row while claiming this
+   slice.
+
+### Files touched
+
+- `extracted_content_pipeline/examples/support_ticket_sources.csv`
+- `extracted_content_pipeline/examples/support_ticket_bundle.json`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Support-Ticket-Examples.md`
+
+## Mechanism
+
+The examples use existing source adapter semantics:
+
+```text
+Ticket ID / Account Name / Vendor Name / Subject / Description / Pain Category
+```
+
+The CSV path verifies lenient provider-style field labels. The JSON bundle path
+verifies shared account/contact metadata inherited by multiple
+`support_tickets` rows.
+
+## Intentional
+
+- No adapter code changes. This is a packaged example and regression-test
+  slice around behavior that already exists.
+- Examples avoid product/seller data coupling. They model customer support
+  evidence only.
+- The examples are small and synthetic fixture data, not a fabricated live
+  customer dataset.
+
+## Deferred
+
+- Live customer support-ticket import from Zendesk/Intercom/Freshdesk APIs
+  remains a future connector slice.
+- Postgres import smoke coverage for packaged support-ticket examples remains
+  out of scope; the current offline conversion/generation path is enough for
+  schema guidance.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_source_adapters.py -q` -> 58 passed.
+- `python scripts/build_extracted_campaign_opportunities_from_sources.py extracted_content_pipeline/examples/support_ticket_sources.csv --format csv --output /tmp/support_ticket_opportunities.json` -> passed; wrote 2 support-ticket opportunities.
+- `python scripts/build_extracted_campaign_opportunities_from_sources.py extracted_content_pipeline/examples/support_ticket_bundle.json --format json --output /tmp/support_ticket_bundle_opportunities.json` -> passed; wrote 2 support-ticket opportunities.
+- `python scripts/smoke_extracted_content_pipeline_host.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-rows --source-format csv --min-drafts 2` -> passed.
+- `python -m py_compile tests/test_extracted_campaign_source_adapters.py` -> passed.
+- `grep -nP '[^\x00-\x7F]' tests/test_extracted_campaign_source_adapters.py` -> no matches.
+- `rg -n "TODO|FIXME|pass$|acct_support_demo|Acme|HubSpot|LegacyCRM|example.com|ops@example.com" extracted_content_pipeline/examples/support_ticket_sources.csv extracted_content_pipeline/examples/support_ticket_bundle.json extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md tests/test_extracted_campaign_source_adapters.py` -> only fixture/demo values and no TODO/FIXME/pass placeholders.
+- `git diff --check` -> passed.
+- `bash scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Examples | ~35 |
+| Tests | ~90 |
+| Docs + plan + coordination | ~115 |
+| **Total** | **~250** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -25,6 +25,12 @@ EXAMPLE_SOURCE_ROWS = (
 EXAMPLE_SOURCE_BUNDLE = (
     ROOT / "extracted_content_pipeline/examples/campaign_source_bundle.json"
 )
+EXAMPLE_SUPPORT_TICKET_CSV = (
+    ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+)
+EXAMPLE_SUPPORT_TICKET_BUNDLE = (
+    ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
+)
 
 
 def test_source_type_precedence_table_matches_current_contract() -> None:
@@ -773,6 +779,88 @@ def test_packaged_source_bundle_example_loads_all_collections() -> None:
         "nps_response",
     ]
     assert loaded.warnings == ()
+
+
+def test_packaged_support_ticket_csv_example_loads_provider_labels() -> None:
+    loaded = load_source_campaign_opportunities_from_file(
+        EXAMPLE_SUPPORT_TICKET_CSV,
+        file_format="csv",
+    )
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "ticket-acme-1",
+        "ticket-northstar-1",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "support_ticket",
+        "support_ticket",
+    ]
+    assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
+    assert loaded.opportunities[0]["vendor_name"] == "HubSpot"
+    assert loaded.opportunities[0]["source_title"] == "Reporting export blocked before renewal"
+    assert loaded.opportunities[0]["evidence"][0] == {
+        "text": (
+            "The operations team cannot export campaign attribution data without "
+            "upgrading to a higher tier."
+        ),
+        "source_id": "ticket-acme-1",
+        "source_type": "support_ticket",
+        "source_title": "Reporting export blocked before renewal",
+    }
+    assert loaded.warnings == ()
+
+
+def test_packaged_support_ticket_bundle_inherits_account_metadata() -> None:
+    loaded = load_source_campaign_opportunities_from_file(EXAMPLE_SUPPORT_TICKET_BUNDLE)
+
+    assert [row["target_id"] for row in loaded.opportunities] == [
+        "support-riverbend-1",
+        "support-riverbend-2",
+    ]
+    assert [row["company_name"] for row in loaded.opportunities] == [
+        "Riverbend Supply",
+        "Riverbend Supply",
+    ]
+    assert [row["source_type"] for row in loaded.opportunities] == [
+        "support_ticket",
+        "support_ticket",
+    ]
+    assert loaded.opportunities[1]["evidence"][0] == {
+        "text": (
+            "Customer: Every demo follow-up still has to be rebuilt by hand.\n"
+            "Agent: The workflow automation feature is not available on the current plan."
+        ),
+        "source_id": "support-riverbend-2",
+        "source_type": "support_ticket",
+        "source_title": "Manual sequence cleanup after demos",
+    }
+    assert loaded.warnings == ()
+
+
+def test_build_sources_cli_converts_packaged_support_ticket_csv(tmp_path: Path) -> None:
+    output = tmp_path / "support_ticket_opportunities.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(EXAMPLE_SUPPORT_TICKET_CSV),
+            "--format",
+            "csv",
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert result.stdout == ""
+    assert [row["target_id"] for row in payload["opportunities"]] == [
+        "ticket-acme-1",
+        "ticket-northstar-1",
+    ]
+    assert payload["opportunities"][0]["source_type"] == "support_ticket"
 
 
 def test_load_source_campaign_opportunities_from_support_ticket_object(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Support-Ticket-Examples.md

Adds executable support-ticket source examples so hosts can validate CSV and JSON support-ticket ingestion without inventing a schema from prose. The source adapter behavior is unchanged; this locks the packaged examples through conversion and offline smoke paths.

## Intentional
- No adapter code changes; this is examples, docs, and regression coverage around existing behavior.
- Examples model customer support-ticket evidence only, avoiding product/seller data coupling.
- Fixture data is small and synthetic, not a fabricated live customer dataset.

## Deferred
- Live Zendesk/Intercom/Freshdesk connectors stay in future slices.
- Postgres support-ticket smoke coverage remains separate from this offline example slice.

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py -q -> 58 passed.
- python scripts/build_extracted_campaign_opportunities_from_sources.py extracted_content_pipeline/examples/support_ticket_sources.csv --format csv --output /tmp/support_ticket_opportunities.json -> passed; wrote 2 support-ticket opportunities.
- python scripts/build_extracted_campaign_opportunities_from_sources.py extracted_content_pipeline/examples/support_ticket_bundle.json --format json --output /tmp/support_ticket_bundle_opportunities.json -> passed; wrote 2 support-ticket opportunities.
- python scripts/smoke_extracted_content_pipeline_host.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-rows --source-format csv --min-drafts 2 -> passed.
- python -m py_compile tests/test_extracted_campaign_source_adapters.py -> passed.
- grep -nP '[^\\x00-\\x7F]' tests/test_extracted_campaign_source_adapters.py -> no matches.\n- git diff --check -> passed.\n- bash scripts/local_pr_review.sh -> passed.\n\n## Diff size\n7 files, +246 / -2