### PR TITLE
Add draft-only invoicing MCP writer

### DIFF
--- a/atlas_brain/mcp/invoicing_draft_writer_server.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_server.py
@@ -1,0 +1,340 @@
+"""
+Draft-only Atlas Invoicing MCP Server.
+
+This server is intentionally separate from atlas_brain.mcp.invoicing_server.
+It exposes a narrow write surface for remote connector clients that may create
+or update draft invoices, but cannot send, approve, void, record payments,
+mutate services, or export PDFs.
+
+Run:
+    python -m atlas_brain.mcp.invoicing_draft_writer_server
+    ATLAS_MCP_AUTH_TOKEN=<token> python -m atlas_brain.mcp.invoicing_draft_writer_server --sse
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import sys
+from contextlib import asynccontextmanager
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from . import invoicing_server as _full
+from ..config_defaults import DEFAULT_MCP_HOST
+
+logger = logging.getLogger("atlas.mcp.invoicing.draft_writer")
+
+DEFAULT_DRAFT_WRITER_PORT = 8066
+_MIN_HTTP_AUTH_TOKEN_LENGTH = 24
+_PLACEHOLDER_HTTP_AUTH_TOKENS = {
+    "<token>",
+    "changeme",
+    "change-me",
+    "password",
+    "secret",
+    "test-token",
+    "token",
+}
+_MAX_LINE_ITEMS = 100
+_SOURCE = "chatgpt_draft_writer"
+_SOURCE_REF_PREFIX = "chatgpt_draft_writer"
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    """Initialize DB pool on startup, close on shutdown."""
+    from ..storage.database import close_database, init_database
+
+    await init_database()
+    logger.info("Draft-writer invoicing MCP: DB pool initialized")
+    yield
+    await close_database()
+
+
+mcp = FastMCP(
+    "atlas-invoicing-draft-writer",
+    instructions=(
+        "Draft-only invoicing server for Atlas. Create and update draft "
+        "invoices for operator review. This server cannot send, approve, "
+        "void, record payments, mutate services, or export PDFs."
+    ),
+    lifespan=_lifespan,
+)
+
+
+def _repo():
+    from ..storage.repositories.invoice import get_invoice_repo
+
+    return get_invoice_repo()
+
+
+def _json_error(message: str) -> str:
+    return json.dumps({"success": False, "error": message})
+
+
+def _parse_line_items(line_items: str | list[dict[str, Any]]) -> tuple[list[dict[str, Any]] | None, str | None]:
+    if isinstance(line_items, str):
+        try:
+            parsed = json.loads(line_items)
+        except json.JSONDecodeError:
+            return None, "Invalid line_items JSON"
+    else:
+        parsed = line_items
+
+    if not isinstance(parsed, list):
+        return None, "line_items must be a JSON array"
+    if not parsed:
+        return None, "At least one line item is required"
+    if len(parsed) > _MAX_LINE_ITEMS:
+        return None, f"Max {_MAX_LINE_ITEMS} line items per invoice"
+
+    items: list[dict[str, Any]] = []
+    for index, item in enumerate(parsed):
+        if not isinstance(item, dict):
+            return None, f"Line item {index + 1} must be an object"
+        description = str(item.get("description") or "").strip()
+        if not description:
+            return None, f"Line item {index + 1} description is required"
+        quantity, quantity_error = _coerce_non_negative_decimal(
+            item.get("quantity", 1),
+            f"Line item {index + 1} quantity",
+        )
+        if quantity_error:
+            return None, quantity_error
+        unit_price, price_error = _coerce_non_negative_decimal(
+            item.get("unit_price", 0),
+            f"Line item {index + 1} unit_price",
+        )
+        if price_error:
+            return None, price_error
+        amount = quantity * unit_price
+        items.append(
+            {
+                **item,
+                "description": description,
+                "quantity": float(quantity),
+                "unit_price": float(unit_price),
+                "amount": float(amount),
+            }
+        )
+    return items, None
+
+
+def _coerce_non_negative_decimal(value: Any, label: str) -> tuple[Decimal, str | None]:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return Decimal("0"), f"{label} must be numeric"
+    if not parsed.is_finite():
+        return Decimal("0"), f"{label} must be finite"
+    if parsed < 0:
+        return Decimal("0"), f"{label} must be non-negative"
+    return parsed, None
+
+
+def _coerce_bounded_float(value: Any, label: str, lower: float, upper: float) -> tuple[float, str | None]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return lower, f"{label} must be numeric"
+    if not math.isfinite(parsed):
+        return lower, f"{label} must be finite"
+    return max(lower, min(parsed, upper)), None
+
+
+def _source_ref_for_idempotency_key(idempotency_key: str) -> str:
+    digest = hashlib.sha256(idempotency_key.strip().encode("utf-8")).hexdigest()
+    return f"{_SOURCE_REF_PREFIX}:{digest}"
+
+
+def _draft_metadata(idempotency_key: str) -> dict[str, Any]:
+    return {
+        "mcp_connector": "invoicing_draft_writer",
+        "operator_review_required": True,
+        "created_by_remote_connector": True,
+        "idempotency_key": idempotency_key,
+    }
+
+
+@mcp.tool()
+async def create_draft_invoice(
+    customer_name: str,
+    line_items: str,
+    idempotency_key: str,
+    due_days: int = 30,
+    customer_email: Optional[str] = None,
+    customer_phone: Optional[str] = None,
+    customer_address: Optional[str] = None,
+    tax_rate: float = 0.0,
+    discount_amount: float = 0.0,
+    invoice_for: Optional[str] = None,
+    contact_name: Optional[str] = None,
+    notes: Optional[str] = None,
+    business_context_id: Optional[str] = None,
+) -> str:
+    """Create an idempotent draft invoice for operator review."""
+    customer = customer_name.strip() if customer_name else ""
+    if not customer:
+        return _json_error("customer_name is required")
+
+    key = idempotency_key.strip() if idempotency_key else ""
+    if not key:
+        return _json_error("idempotency_key is required")
+
+    items, item_error = _parse_line_items(line_items)
+    if item_error:
+        return _json_error(item_error)
+    assert items is not None
+
+    due_days = max(0, min(int(due_days), 365))
+    tax_rate, tax_error = _coerce_bounded_float(tax_rate, "tax_rate", 0.0, 1.0)
+    if tax_error:
+        return _json_error(tax_error)
+    discount_amount, discount_error = _coerce_bounded_float(
+        discount_amount,
+        "discount_amount",
+        0.0,
+        float("inf"),
+    )
+    if discount_error:
+        return _json_error(discount_error)
+    source_ref = _source_ref_for_idempotency_key(key)
+
+    try:
+        repo = _repo()
+        existing = await repo.get_by_source_ref(source_ref)
+        if existing is not None:
+            return json.dumps(
+                {"success": True, "created": False, "invoice": existing},
+                default=str,
+            )
+
+        invoice = await repo.create(
+            customer_name=customer,
+            due_date=date.today() + timedelta(days=due_days),
+            line_items=items,
+            customer_email=customer_email,
+            customer_phone=customer_phone,
+            customer_address=customer_address,
+            tax_rate=tax_rate,
+            discount_amount=discount_amount,
+            invoice_for=invoice_for,
+            contact_name=contact_name,
+            source=_SOURCE,
+            source_ref=source_ref,
+            business_context_id=business_context_id,
+            notes=notes,
+            metadata=_draft_metadata(key),
+        )
+        return json.dumps({"success": True, "created": True, "invoice": invoice}, default=str)
+    except Exception:
+        logger.exception("create_draft_invoice error")
+        return _json_error("Internal error")
+
+
+@mcp.tool()
+async def update_draft_invoice(
+    invoice_id: str,
+    line_items: Optional[str] = None,
+    due_date: Optional[str] = None,
+    notes: Optional[str] = None,
+    tax_rate: Optional[float] = None,
+    discount_amount: Optional[float] = None,
+    invoice_for: Optional[str] = None,
+    contact_name: Optional[str] = None,
+) -> str:
+    """Update an existing draft invoice. Non-draft invoices are rejected."""
+    try:
+        repo = _repo()
+        if _full._is_uuid(invoice_id):
+            invoice = await repo.get_by_id(_full._uuid.UUID(invoice_id))
+        else:
+            invoice = await repo.get_by_number(invoice_id)
+        if invoice is None:
+            return _json_error("Invoice not found")
+        if invoice.get("status") != "draft":
+            return _json_error("Invoice is not in draft status")
+
+        return await _full.update_invoice(
+            invoice_id=invoice_id,
+            line_items=line_items,
+            due_date=due_date,
+            notes=notes,
+            tax_rate=tax_rate,
+            discount_amount=discount_amount,
+            invoice_for=invoice_for,
+            contact_name=contact_name,
+        )
+    except Exception:
+        logger.exception("update_draft_invoice error")
+        return _json_error("Internal error")
+
+
+@mcp.tool()
+async def get_invoice(invoice_id: str) -> str:
+    """Fetch an invoice by UUID or invoice number."""
+    return await _full.get_invoice(invoice_id)
+
+
+@mcp.tool()
+async def list_pending_drafts(
+    contact_id: Optional[str] = None,
+    business_context_id: Optional[str] = None,
+    only_blocked: bool = False,
+    limit: int = 100,
+) -> str:
+    """List draft invoices annotated with send blockers and warnings."""
+    return await _full.list_pending_drafts(
+        contact_id=contact_id,
+        business_context_id=business_context_id,
+        only_blocked=only_blocked,
+        limit=limit,
+    )
+
+
+def _streamable_http_app():
+    """Build the authenticated streamable HTTP app for draft-write tools."""
+    from .auth import apply_auth_middleware
+
+    _require_http_auth_token()
+    return apply_auth_middleware(mcp.streamable_http_app())
+
+
+def _require_http_auth_token() -> str:
+    """Return a production-shaped auth token or fail before serving HTTP."""
+    token = os.environ.get("ATLAS_MCP_AUTH_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN is required for draft-writer invoicing HTTP "
+            "mode; these tools can create and update draft invoices."
+        )
+    if token.lower() in _PLACEHOLDER_HTTP_AUTH_TOKENS or token.startswith("<"):
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN must not be a placeholder value for "
+            "draft-writer invoicing HTTP mode."
+        )
+    if len(token) < _MIN_HTTP_AUTH_TOKEN_LENGTH:
+        raise RuntimeError(
+            "ATLAS_MCP_AUTH_TOKEN must be at least "
+            f"{_MIN_HTTP_AUTH_TOKEN_LENGTH} characters for draft-writer "
+            "invoicing HTTP mode."
+        )
+    return token
+
+
+if __name__ == "__main__":
+    if "--sse" in sys.argv:
+        import uvicorn
+
+        host = os.environ.get("ATLAS_MCP_HOST", DEFAULT_MCP_HOST)
+        port = int(os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT", DEFAULT_DRAFT_WRITER_PORT))
+        uvicorn.run(_streamable_http_app(), host=host, port=port)
+    else:
+        mcp.run()

--- a/plans/PR-Invoicing-Draft-Writer-MCP.md
+++ b/plans/PR-Invoicing-Draft-Writer-MCP.md
@@ -1,0 +1,91 @@
+# PR-Invoicing-Draft-Writer-MCP
+
+## Why this slice exists
+
+`docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md` defines the first safe write
+surface for ChatGPT invoicing access: draft-only invoice creation/update in a
+separate server. The existing full `atlas-invoicing` MCP server is too broad
+for remote write access because it also exposes send, payment, void, service,
+and PDF/file side effects.
+
+This slice implements the local draft-writer MCP boundary without public OAuth
+rollout. It gives us real code and tests for the safe write surface before
+adding ChatGPT-facing OAuth wiring.
+
+## Scope (this PR)
+
+1. Add a separate `atlas-invoicing-draft-writer` MCP server.
+2. Expose exactly four tools: create draft, update draft, get invoice, and
+   list pending drafts.
+3. Implement `create_draft_invoice` without CRM, email, send, payment, void,
+   PDF, or service side effects.
+4. Add a local connector boundary smoke for exact tool-surface validation.
+5. Add unit tests for tool allowlist, idempotent draft creation, and boundary
+   smoke failures.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_draft_writer_server.py`
+- `scripts/check_invoicing_draft_writer_mcp_connector.py`
+- `tests/test_invoicing_draft_writer_mcp.py`
+- `tests/test_check_invoicing_draft_writer_mcp_connector.py`
+- `plans/PR-Invoicing-Draft-Writer-MCP.md`
+
+## Mechanism
+
+The new server registers its own `FastMCP("atlas-invoicing-draft-writer")`
+instance and exposes only the guardrail-approved tools.
+
+`create_draft_invoice` parses and validates line items, derives a stable
+`source_ref` from the required idempotency key, returns the existing invoice on
+retry, and otherwise calls the invoice repository directly with explicit
+connector metadata. It does not delegate to `create_invoice` because that full
+MCP tool can resolve CRM contacts and log CRM interactions.
+
+`update_draft_invoice` delegates to the existing full-server `update_invoice`
+tool because that path already rejects non-draft invoices and has no external
+send/payment/file side effects.
+
+The boundary smoke mirrors the read-only connector check: unauthenticated HTTP
+must be rejected, authenticated `list_tools` must equal the exact allowlist,
+and known denied mutating tools must be absent.
+
+## Intentional
+
+- OAuth mode is deferred. This PR proves the write tool boundary locally first;
+  public ChatGPT exposure comes after the exact local surface is pinned.
+- The server does not include broader read-only tools such as `list_invoices`,
+  `customer_balance`, or `payment_history`. The existing read-only connector
+  covers that surface.
+- `create_draft_invoice` uses direct repository creation instead of the full
+  MCP `create_invoice` wrapper to avoid CRM side effects.
+
+## Deferred
+
+- `PR-Invoicing-Draft-Writer-OAuth`: add OAuth mode, discovery smoke, e2e
+  smoke, operator launcher, port docs, and ChatGPT connector setup.
+- Send/approve, payment, void, PDF export, and service mutation remain
+  deferred until draft-only write access is proven.
+
+## Verification
+
+- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_server.py scripts/check_invoicing_draft_writer_mcp_connector.py
+- .venv/bin/pytest tests/test_invoicing_draft_writer_mcp.py tests/test_check_invoicing_draft_writer_mcp_connector.py
+- git diff --check
+- bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `atlas_brain/mcp/invoicing_draft_writer_server.py` | ~340 |
+| `scripts/check_invoicing_draft_writer_mcp_connector.py` | ~139 |
+| `tests/test_invoicing_draft_writer_mcp.py` | ~270 |
+| `tests/test_check_invoicing_draft_writer_mcp_connector.py` | ~90 |
+| `plans/PR-Invoicing-Draft-Writer-MCP.md` | ~91 |
+| **Total** | **~930** |
+
+This intentionally exceeds the soft 400 LOC budget because the safe slice needs
+the server, exact boundary smoke, and regression tests together. Splitting the
+smoke/tests away from the server would temporarily create unpinned write
+surface code.

--- a/scripts/check_invoicing_draft_writer_mcp_connector.py
+++ b/scripts/check_invoicing_draft_writer_mcp_connector.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Verify the draft-writer invoicing MCP connector boundary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+DEFAULT_URL = "http://127.0.0.1:8066/mcp"
+EXPECTED_DRAFT_WRITER_TOOLS = {
+    "create_draft_invoice",
+    "update_draft_invoice",
+    "get_invoice",
+    "list_pending_drafts",
+}
+DENIED_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "customer_balance",
+    "export_invoice_pdf",
+    "list_invoices",
+    "list_services",
+    "mark_void",
+    "payment_history",
+    "record_payment",
+    "search_invoices",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check the authenticated draft-writer invoicing MCP connector."
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("ATLAS_INVOICING_DRAFT_WRITER_MCP_URL", DEFAULT_URL),
+        help=(
+            "Full Streamable HTTP MCP URL. Defaults to "
+            "ATLAS_INVOICING_DRAFT_WRITER_MCP_URL or http://127.0.0.1:8066/mcp."
+        ),
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("ATLAS_MCP_AUTH_TOKEN", ""),
+        help="Bearer token. Defaults to ATLAS_MCP_AUTH_TOKEN.",
+    )
+    return parser
+
+
+def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+    errors: list[str] = []
+    missing = EXPECTED_DRAFT_WRITER_TOOLS - tool_names
+    unexpected = tool_names - EXPECTED_DRAFT_WRITER_TOOLS
+    denied = DENIED_TOOLS & tool_names
+    if missing:
+        errors.append(f"missing draft-writer tools: {', '.join(sorted(missing))}")
+    if unexpected:
+        errors.append(f"unexpected tools exposed: {', '.join(sorted(unexpected))}")
+    if denied:
+        errors.append(f"denied tools exposed: {', '.join(sorted(denied))}")
+    return errors
+
+
+def _unauth_status_code(url: str) -> int:
+    try:
+        response = httpx.post(
+            url,
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+            timeout=10.0,
+        )
+    except httpx.RequestError as exc:
+        raise RuntimeError(f"unauthenticated probe failed: {exc}") from exc
+    return response.status_code
+
+
+async def _list_tools(url: str, token: str) -> set[str]:
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(url, headers=headers) as (
+        read_stream,
+        write_stream,
+        _get_session_id,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            return {tool.name for tool in tools.tools}
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    token = args.token.strip()
+    if not token:
+        print("ATLAS_MCP_AUTH_TOKEN or --token is required", file=sys.stderr)
+        return 2
+
+    try:
+        status_code = _unauth_status_code(args.url)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if status_code != 401:
+        print(
+            f"expected unauthenticated request to return 401, got {status_code}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        tool_names = asyncio.run(_list_tools(args.url, token))
+    except Exception as exc:
+        print(f"authenticated MCP tool-list failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _tool_surface_errors(tool_names)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"authenticated MCP connector exposes {len(tool_names)} draft-writer tools:")
+    for tool_name in sorted(tool_names):
+        print(f"- {tool_name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_draft_writer_mcp_connector.py
+++ b/tests/test_check_invoicing_draft_writer_mcp_connector.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_draft_writer_mcp_connector.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_mcp_connector",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tool_surface_errors_accept_exact_draft_writer_tools() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors(set(module.EXPECTED_DRAFT_WRITER_TOOLS)) == []
+
+
+def test_tool_surface_errors_reject_missing_draft_writer_tool() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+    tools.remove("create_draft_invoice")
+
+    errors = module._tool_surface_errors(tools)
+
+    assert errors == ["missing draft-writer tools: create_draft_invoice"]
+
+
+def test_tool_surface_errors_reject_extra_and_denied_tools() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+    tools.update({"send_invoice", "surprise_tool"})
+
+    errors = module._tool_surface_errors(tools)
+
+    assert "unexpected tools exposed: send_invoice, surprise_tool" in errors
+    assert "denied tools exposed: send_invoice" in errors
+
+
+def test_main_requires_token_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_probe(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(module, "_unauth_status_code", fail_probe)
+
+    result = module._main(["--url", "http://example.invalid/mcp"])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "ATLAS_MCP_AUTH_TOKEN or --token is required" in captured.err
+
+
+def test_main_rejects_non_401_unauthenticated_probe(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_unauth_status_code", lambda *_args: 200)
+
+    result = module._main(["--url", "http://example.invalid/mcp", "--token", "token-value"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "expected unauthenticated request to return 401, got 200" in captured.err
+
+
+def test_main_reports_authenticated_tool_surface(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "_unauth_status_code", lambda *_args: 401)
+
+    async def fake_list_tools(*_args, **_kwargs):
+        return set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+
+    monkeypatch.setattr(module, "_list_tools", fake_list_tools)
+
+    result = module._main(["--url", "http://example.invalid/mcp", "--token", "token-value"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "exposes 4 draft-writer tools" in captured.out
+    assert "- create_draft_invoice" in captured.out

--- a/tests/test_invoicing_draft_writer_mcp.py
+++ b/tests/test_invoicing_draft_writer_mcp.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from atlas_brain.mcp.auth import BearerAuthMiddleware
+from atlas_brain.mcp import invoicing_draft_writer_server as draft_writer
+
+
+DRAFT_WRITER_TOOLS = {
+    "create_draft_invoice",
+    "update_draft_invoice",
+    "get_invoice",
+    "list_pending_drafts",
+}
+
+DENIED_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "customer_balance",
+    "export_invoice_pdf",
+    "list_invoices",
+    "list_services",
+    "mark_void",
+    "payment_history",
+    "record_payment",
+    "search_invoices",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+class _FakeRepo:
+    def __init__(self, existing=None, invoice=None):
+        self.existing = existing
+        self.invoice = invoice
+        self.create_calls = []
+        self.source_refs = []
+
+    async def get_by_source_ref(self, source_ref):
+        self.source_refs.append(source_ref)
+        return self.existing
+
+    async def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return {
+            "id": "invoice-1",
+            "invoice_number": "INV-2026-May-0001",
+            "status": "draft",
+            **kwargs,
+        }
+
+    async def get_by_number(self, invoice_number):
+        return self.invoice
+
+    async def get_by_id(self, invoice_id):
+        return self.invoice
+
+
+def _tool_names() -> set[str]:
+    return set(draft_writer.mcp._tool_manager._tools)
+
+
+def test_invoicing_draft_writer_exposes_exact_safe_tool_surface():
+    assert _tool_names() == DRAFT_WRITER_TOOLS
+    assert _tool_names().isdisjoint(DENIED_TOOLS)
+
+
+@pytest.mark.asyncio
+async def test_create_draft_invoice_creates_draft_without_full_mcp_side_effects(monkeypatch):
+    repo = _FakeRepo()
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    def fail_crm():
+        raise AssertionError("CRM touched")
+
+    monkeypatch.setattr(draft_writer._full, "_crm", fail_crm)
+
+    result = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Mid Illinois Concrete",
+            line_items=json.dumps(
+                [{"description": "Monthly service", "quantity": 2, "unit_price": 125}]
+            ),
+            idempotency_key="mid-il-concrete-may-2026",
+            customer_email="billing@example.com",
+            invoice_for="May 2026 service",
+            business_context_id="mid-illinois-concrete",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["created"] is True
+    assert result["invoice"]["status"] == "draft"
+    assert len(repo.create_calls) == 1
+    call = repo.create_calls[0]
+    assert call["source"] == "chatgpt_draft_writer"
+    assert call["source_ref"].startswith("chatgpt_draft_writer:")
+    assert call["metadata"] == {
+        "mcp_connector": "invoicing_draft_writer",
+        "operator_review_required": True,
+        "created_by_remote_connector": True,
+        "idempotency_key": "mid-il-concrete-may-2026",
+    }
+    assert call["line_items"][0]["amount"] == 250.0
+
+
+@pytest.mark.asyncio
+async def test_create_draft_invoice_is_idempotent(monkeypatch):
+    existing = {"id": "invoice-existing", "status": "draft"}
+    repo = _FakeRepo(existing=existing)
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    result = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Firefly Grill",
+            line_items=json.dumps([{"description": "Hours", "quantity": 1, "unit_price": 50}]),
+            idempotency_key="firefly-may-2026",
+        )
+    )
+
+    assert result == {"success": True, "created": False, "invoice": existing}
+    assert repo.create_calls == []
+    assert repo.source_refs == [draft_writer._source_ref_for_idempotency_key("firefly-may-2026")]
+
+
+@pytest.mark.asyncio
+async def test_create_draft_invoice_rejects_missing_or_invalid_inputs(monkeypatch):
+    repo = _FakeRepo()
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    missing_key = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Customer",
+            line_items=json.dumps([{"description": "Service"}]),
+            idempotency_key="",
+        )
+    )
+    invalid_item = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Customer",
+            line_items=json.dumps([{"quantity": -1, "unit_price": 20}]),
+            idempotency_key="key-1",
+        )
+    )
+
+    assert missing_key == {"success": False, "error": "idempotency_key is required"}
+    assert invalid_item == {
+        "success": False,
+        "error": "Line item 1 description is required",
+    }
+    assert repo.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_draft_invoice_rejects_non_finite_numbers(monkeypatch):
+    repo = _FakeRepo()
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    bad_line_item = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Customer",
+            line_items=json.dumps(
+                [{"description": "Service", "quantity": "NaN", "unit_price": 20}]
+            ),
+            idempotency_key="key-1",
+        )
+    )
+    bad_tax = json.loads(
+        await draft_writer.create_draft_invoice(
+            customer_name="Customer",
+            line_items=json.dumps([{"description": "Service", "quantity": 1, "unit_price": 20}]),
+            idempotency_key="key-2",
+            tax_rate=float("nan"),
+        )
+    )
+
+    assert bad_line_item == {"success": False, "error": "Line item 1 quantity must be finite"}
+    assert bad_tax == {"success": False, "error": "tax_rate must be finite"}
+    assert repo.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_draft_invoice_delegates_to_existing_draft_only_update(monkeypatch):
+    calls = []
+    repo = _FakeRepo(invoice={"id": "invoice-1", "status": "draft"})
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    async def fake_update_invoice(**kwargs):
+        calls.append(kwargs)
+        return '{"success": true}'
+
+    monkeypatch.setattr(draft_writer._full, "update_invoice", fake_update_invoice)
+
+    result = await draft_writer.update_draft_invoice(
+        invoice_id="INV-2026-May-0001",
+        line_items='[{"description":"Service","quantity":1,"unit_price":10}]',
+        due_date="2026-06-01",
+        notes="Operator reviewed",
+        tax_rate=0.0,
+        discount_amount=0.0,
+        invoice_for="June service",
+        contact_name="Jane",
+    )
+
+    assert result == '{"success": true}'
+    assert calls == [
+        {
+            "invoice_id": "INV-2026-May-0001",
+            "line_items": '[{"description":"Service","quantity":1,"unit_price":10}]',
+            "due_date": "2026-06-01",
+            "notes": "Operator reviewed",
+            "tax_rate": 0.0,
+            "discount_amount": 0.0,
+            "invoice_for": "June service",
+            "contact_name": "Jane",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_draft_invoice_rejects_non_draft_before_full_update(monkeypatch):
+    calls = []
+    repo = _FakeRepo(invoice={"id": "invoice-1", "status": "sent"})
+    monkeypatch.setattr(draft_writer, "_repo", lambda: repo)
+
+    async def fail_update_invoice(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("full update touched")
+
+    monkeypatch.setattr(draft_writer._full, "update_invoice", fail_update_invoice)
+
+    result = json.loads(await draft_writer.update_draft_invoice(invoice_id="INV-2026-May-0001"))
+
+    assert result == {"success": False, "error": "Invoice is not in draft status"}
+    assert calls == []
+
+
+def test_invoicing_draft_writer_http_requires_bearer_token(monkeypatch):
+    monkeypatch.delenv("ATLAS_MCP_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="ATLAS_MCP_AUTH_TOKEN is required"):
+        draft_writer._streamable_http_app()
+
+
+def test_invoicing_draft_writer_http_wraps_with_bearer_auth(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "test-token-with-enough-entropy")
+
+    app = draft_writer._streamable_http_app()
+
+    assert isinstance(app, BearerAuthMiddleware)
+
+
+@pytest.mark.parametrize("token", ["<token>", "token", "test-token"])
+def test_invoicing_draft_writer_http_rejects_placeholder_tokens(monkeypatch, token):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", token)
+
+    with pytest.raises(RuntimeError, match="must not be a placeholder"):
+        draft_writer._streamable_http_app()
+
+
+def test_invoicing_draft_writer_http_rejects_short_tokens(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_AUTH_TOKEN", "short-token-value")
+
+    with pytest.raises(RuntimeError, match="at least 24 characters"):
+        draft_writer._streamable_http_app()


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-MCP.md

Adds the first write-access code slice for invoicing MCP: a separate draft-only server that can create/update draft invoices for operator review without exposing the full atlas-invoicing server.

## Intentional
- The server exposes exactly four tools: create_draft_invoice, update_draft_invoice, get_invoice, list_pending_drafts.
- create_draft_invoice calls the invoice repository directly instead of the full create_invoice MCP wrapper to avoid CRM/email side effects.
- Public OAuth rollout is deferred until this local write boundary is pinned.

## Deferred
- OAuth discovery/e2e/launcher and port docs for ChatGPT exposure.
- Send, payment, void, PDF export, and service mutation remain out of scope.

## Verification
- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_server.py scripts/check_invoicing_draft_writer_mcp_connector.py
- .venv/bin/pytest tests/test_invoicing_draft_writer_mcp.py tests/test_check_invoicing_draft_writer_mcp_connector.py -q -> 19 passed
- bash scripts/local_pr_review.sh

## Diff size
5 files, +930 / -0