### PR TITLE
Add OAuth rollout for draft-writer invoicing MCP

### DIFF
--- a/atlas_brain/mcp/invoicing_draft_writer_oauth.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_oauth.py
@@ -1,0 +1,111 @@
+"""OAuth support for the draft-writer invoicing MCP server."""
+
+from __future__ import annotations
+
+import time
+from html import escape
+
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, Response
+
+from .invoicing_readonly_oauth import (
+    InvoicingReadonlyOAuthProvider,
+    PendingAuthorization,
+    as_any_http_url,
+    handle_approval_request as _handle_approval_request,
+)
+
+
+DEFAULT_DRAFT_WRITE_SCOPE = "invoices.draft.write"
+
+
+class InvoicingDraftWriterOAuthProvider(InvoicingReadonlyOAuthProvider):
+    """Single-operator OAuth provider for draft invoice write access."""
+
+    def __init__(
+        self,
+        *,
+        issuer_url: str,
+        approval_token: str,
+        scopes: list[str] | None = None,
+        authorization_ttl_seconds: int = 300,
+        access_token_ttl_seconds: int = 3600,
+    ) -> None:
+        super().__init__(
+            issuer_url=issuer_url,
+            approval_token=approval_token,
+            scopes=scopes or [DEFAULT_DRAFT_WRITE_SCOPE],
+            authorization_ttl_seconds=authorization_ttl_seconds,
+            access_token_ttl_seconds=access_token_ttl_seconds,
+        )
+
+
+def approval_page(
+    provider: InvoicingDraftWriterOAuthProvider,
+    request_id: str,
+    *,
+    form_action: str | None = None,
+) -> Response:
+    pending = provider.pending_authorization(request_id)
+    if pending is None:
+        return HTMLResponse("<h1>Authorization request not found</h1>", status_code=404)
+    if pending.expires_at < time.time():
+        return HTMLResponse("<h1>Authorization request expired</h1>", status_code=410)
+
+    client = escape(pending.client_id)
+    scopes = escape(", ".join(pending.scopes))
+    request_value = escape(request_id)
+    action_attr = ""
+    if form_action is not None:
+        action_attr = f' action="{escape(form_action, quote=True)}"'
+    return HTMLResponse(
+        f"""
+<!doctype html>
+<html>
+  <head><title>Approve Atlas Draft Invoice Connector</title></head>
+  <body>
+    <h1>Approve Atlas draft invoice write access</h1>
+    <p>Client: <code>{client}</code></p>
+    <p>Scopes: <code>{scopes}</code></p>
+    <p>This grants draft invoice creation/update tools for operator review. It does not grant sending, payment recording, voiding, PDF export, or service mutation tools.</p>
+    <form method="post"{action_attr}>
+      <input type="hidden" name="request_id" value="{request_value}" />
+      <label>Approval token <input name="approval_token" type="password" /></label>
+      <button type="submit">Approve draft writer connector</button>
+    </form>
+  </body>
+</html>
+""".strip()
+    )
+
+
+async def handle_approval_request(provider: InvoicingDraftWriterOAuthProvider, request: Request) -> Response:
+    """Handle GET/POST requests for the draft-writer operator approval page."""
+    if request.method == "GET":
+        request_id = request.query_params.get("request_id", "")
+        return approval_page(provider, request_id)
+    return await _handle_approval_request(provider, request)
+
+
+def validate_oauth_settings(*, issuer_url: str, resource_server_url: str, approval_token: str) -> None:
+    """Fail fast on missing OAuth settings before exposing draft writes."""
+    if not issuer_url.strip():
+        raise RuntimeError("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL is required in oauth mode")
+    if not resource_server_url.strip():
+        raise RuntimeError("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL is required in oauth mode")
+    if len(approval_token.strip()) < 24:
+        raise RuntimeError(
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN must be at least "
+            "24 characters in oauth mode"
+        )
+
+
+__all__ = [
+    "DEFAULT_DRAFT_WRITE_SCOPE",
+    "InvoicingDraftWriterOAuthProvider",
+    "PendingAuthorization",
+    "approval_page",
+    "as_any_http_url",
+    "handle_approval_request",
+    "validate_oauth_settings",
+]

--- a/atlas_brain/mcp/invoicing_draft_writer_server.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_server.py
@@ -27,11 +27,20 @@ from typing import Any, Optional
 from mcp.server.fastmcp import FastMCP
 
 from . import invoicing_server as _full
+from .invoicing_draft_writer_oauth import (
+    DEFAULT_DRAFT_WRITE_SCOPE,
+    InvoicingDraftWriterOAuthProvider,
+    as_any_http_url,
+    handle_approval_request,
+    validate_oauth_settings,
+)
 from ..config_defaults import DEFAULT_MCP_HOST
 
 logger = logging.getLogger("atlas.mcp.invoicing.draft_writer")
 
 DEFAULT_DRAFT_WRITER_PORT = 8066
+_AUTH_MODE_BEARER = "bearer"
+_AUTH_MODE_OAUTH = "oauth"
 _MIN_HTTP_AUTH_TOKEN_LENGTH = 24
 _PLACEHOLDER_HTTP_AUTH_TOKENS = {
     "<token>",
@@ -45,6 +54,7 @@ _PLACEHOLDER_HTTP_AUTH_TOKENS = {
 _MAX_LINE_ITEMS = 100
 _SOURCE = "chatgpt_draft_writer"
 _SOURCE_REF_PREFIX = "chatgpt_draft_writer"
+_oauth_provider: InvoicingDraftWriterOAuthProvider | None = None
 
 
 @asynccontextmanager
@@ -67,6 +77,16 @@ mcp = FastMCP(
     ),
     lifespan=_lifespan,
 )
+
+
+@mcp.custom_route("/oauth/approve", methods=["GET", "POST"], include_in_schema=False)
+async def _oauth_approve(request):
+    """Operator approval page for ChatGPT-style OAuth connectors."""
+    if _oauth_provider is None:
+        from starlette.responses import HTMLResponse
+
+        return HTMLResponse("<h1>OAuth mode is not enabled</h1>", status_code=404)
+    return await handle_approval_request(_oauth_provider, request)
 
 
 def _repo():
@@ -303,8 +323,24 @@ def _streamable_http_app():
     """Build the authenticated streamable HTTP app for draft-write tools."""
     from .auth import apply_auth_middleware
 
+    if _http_auth_mode() == _AUTH_MODE_OAUTH:
+        _configure_oauth_auth()
+        return mcp.streamable_http_app()
+
     _require_http_auth_token()
     return apply_auth_middleware(mcp.streamable_http_app())
+
+
+def _http_auth_mode() -> str:
+    mode = os.environ.get(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE",
+        _AUTH_MODE_BEARER,
+    ).strip().lower()
+    if mode not in {_AUTH_MODE_BEARER, _AUTH_MODE_OAUTH}:
+        raise RuntimeError(
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE must be either 'bearer' or 'oauth'"
+        )
+    return mode
 
 
 def _require_http_auth_token() -> str:
@@ -327,6 +363,46 @@ def _require_http_auth_token() -> str:
             "invoicing HTTP mode."
         )
     return token
+
+
+def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
+    """Configure FastMCP's built-in OAuth auth for ChatGPT connectors."""
+    global _oauth_provider
+
+    if _oauth_provider is not None:
+        return _oauth_provider
+
+    from mcp.server.auth.provider import ProviderTokenVerifier
+    from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
+
+    issuer_url = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", "").strip()
+    resource_url = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", "").strip()
+    approval_token = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", "").strip()
+    validate_oauth_settings(
+        issuer_url=issuer_url,
+        resource_server_url=resource_url,
+        approval_token=approval_token,
+    )
+
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url=issuer_url,
+        approval_token=approval_token,
+        scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+    )
+    mcp.settings.auth = AuthSettings(
+        issuer_url=as_any_http_url(issuer_url),
+        resource_server_url=as_any_http_url(resource_url),
+        required_scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+            default_scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+        ),
+    )
+    mcp._auth_server_provider = provider
+    mcp._token_verifier = ProviderTokenVerifier(provider)
+    _oauth_provider = provider
+    return provider
 
 
 if __name__ == "__main__":

--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -131,6 +131,39 @@ The approval page copy must say draft-write access, not read-only access.
 The connector must not share the read-only approval token. Separate scopes and
 separate approval tokens make accidental privilege expansion easier to detect.
 
+## Draft-writer rollout commands
+
+Start the draft-writer OAuth server through the operator launcher:
+
+```bash
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py --dry-run
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py
+```
+
+The default public route is:
+
+```text
+https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Verify public discovery before connecting ChatGPT:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Then verify OAuth token exchange and the exact four-tool surface:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+The e2e smoke lists tools only. It must not create or update invoices.
+
 ## Required implementation tests
 
 The server PR must include tests that prove:

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -71,6 +71,24 @@ Use the draft-only contract in
 ChatGPT connector. The first write surface is draft creation/update only;
 send, payment, void, PDF export, and service mutation stay out of scope.
 
+The first write connector is `atlas-invoicing-draft-writer` at:
+
+```text
+https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Use the draft-writer launcher and smokes:
+
+```bash
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py --dry-run
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
 ## Step 2: add OAuth mode
 
 Use `atlas_brain/mcp/invoicing_readonly_oauth.py` as the template. The minimum

--- a/plans/PR-Invoicing-Draft-Writer-OAuth.md
+++ b/plans/PR-Invoicing-Draft-Writer-OAuth.md
@@ -1,0 +1,102 @@
+# PR-Invoicing-Draft-Writer-OAuth
+
+## Why this slice exists
+
+`atlas_brain.mcp.invoicing_draft_writer_server` now pins the first safe write
+surface for invoicing: draft-only creation/update plus two read helpers. The
+next step is making that server connectable from ChatGPT online without
+expanding the tool surface.
+
+The read-only invoicing connector proved the OAuth, Tailscale metadata, e2e
+smoke, and operator launcher pattern. This slice applies that proven pattern to
+the draft-writer server with its own scope and env prefix.
+
+## Scope (this PR)
+
+1. Add OAuth mode to the draft-writer MCP server.
+2. Use the draft-write scope `invoices.draft.write` and draft-writer-specific
+   env vars.
+3. Add discovery and OAuth e2e smoke scripts that validate the exact four-tool
+   draft-writer surface.
+4. Add an operator launcher for local/public startup guidance.
+5. Add tests for server OAuth metadata, smoke helpers, and launcher validation.
+6. Update docs with the public rollout commands while keeping send/payment/void
+   out of scope.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_draft_writer_oauth.py`
+- `atlas_brain/mcp/invoicing_draft_writer_server.py`
+- `scripts/check_invoicing_draft_writer_oauth_discovery.py`
+- `scripts/check_invoicing_draft_writer_oauth_e2e.py`
+- `scripts/start_invoicing_draft_writer_oauth_server.py`
+- `tests/test_invoicing_draft_writer_oauth.py`
+- `tests/test_check_invoicing_draft_writer_oauth_discovery.py`
+- `tests/test_check_invoicing_draft_writer_oauth_e2e.py`
+- `tests/test_start_invoicing_draft_writer_oauth_server.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-Draft-Writer-OAuth.md`
+
+## Mechanism
+
+The draft-writer OAuth provider subclasses the proven read-only provider but
+changes the default scope and approval-page copy. The server reads
+`ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE`; bearer mode remains the default,
+and OAuth mode configures FastMCP auth with `invoices.draft.write`.
+
+The discovery and e2e scripts mirror the read-only smokes with draft-writer env
+vars, resource URLs, scope, and exact tool allowlist. The e2e smoke still calls
+only `list_tools`, so it verifies OAuth and tool boundaries without creating or
+updating invoices.
+
+The operator launcher mirrors the read-only launcher and prints masked env,
+Tailscale protected-resource routing, and the two smoke commands.
+
+## Intentional
+
+- OAuth mode is added only to the draft-writer server. The full invoicing server
+  remains unchanged and is still not ChatGPT-facing.
+- The e2e smoke does not call `create_draft_invoice`; public connector smoke
+  should prove auth/tool surface, not mutate invoice data.
+- CLAUDE MCP tool-count docs are not updated in this slice because the
+  pre-existing auditor only tracks `### ... MCP Server` headings and the public
+  port docs for fully listed servers. The draft-writer public rollout commands
+  live in the guardrail/runbook docs until we decide to add it to the global MCP
+  inventory table.
+
+## Deferred
+
+- Live public Tailscale run and actual ChatGPT connector approval.
+- Adding the draft-writer server to global MCP inventory/port tables if we want
+  it documented alongside always-on servers.
+- Any send/approve/payment/void/PDF/service mutation OAuth scope.
+
+## Verification
+
+- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_oauth.py atlas_brain/mcp/invoicing_draft_writer_server.py scripts/check_invoicing_draft_writer_oauth_discovery.py scripts/check_invoicing_draft_writer_oauth_e2e.py scripts/start_invoicing_draft_writer_oauth_server.py
+- .venv/bin/pytest tests/test_invoicing_draft_writer_oauth.py tests/test_check_invoicing_draft_writer_oauth_discovery.py tests/test_check_invoicing_draft_writer_oauth_e2e.py tests/test_start_invoicing_draft_writer_oauth_server.py
+- git diff --check
+- bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `atlas_brain/mcp/invoicing_draft_writer_oauth.py` | ~111 |
+| `atlas_brain/mcp/invoicing_draft_writer_server.py` | ~76 |
+| `scripts/check_invoicing_draft_writer_oauth_discovery.py` | ~215 |
+| `scripts/check_invoicing_draft_writer_oauth_e2e.py` | ~401 |
+| `scripts/start_invoicing_draft_writer_oauth_server.py` | ~240 |
+| `tests/test_invoicing_draft_writer_oauth.py` | ~278 |
+| `tests/test_check_invoicing_draft_writer_oauth_discovery.py` | ~161 |
+| `tests/test_check_invoicing_draft_writer_oauth_e2e.py` | ~266 |
+| `tests/test_start_invoicing_draft_writer_oauth_server.py` | ~223 |
+| Docs + plan | ~153 |
+| **Total** | **~2,124** |
+
+This intentionally exceeds the 400 LOC soft cap because the safe OAuth rollout
+requires server wiring, discovery smoke, e2e smoke, launcher, and regression
+tests together. Splitting the smokes from the server would create an exposed
+OAuth path without the verification harness that made the read-only rollout
+safe.

--- a/scripts/check_invoicing_draft_writer_oauth_discovery.py
+++ b/scripts/check_invoicing_draft_writer_oauth_discovery.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Verify public OAuth discovery for the draft-writer invoicing MCP connector.
+
+This check is intentionally draft-writer. It validates public routing and metadata
+only; it does not complete OAuth approval, exchange tokens, or call invoice
+tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+
+DEFAULT_SCOPE = "invoices.draft.write"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check OAuth discovery for the draft-writer invoicing MCP connector."
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", ""),
+        help="Public OAuth issuer URL. Defaults to ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", ""),
+        help=(
+            "Public Streamable HTTP MCP resource URL. Defaults to "
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL."
+        ),
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.strip().rstrip("/")
+
+
+def _authorization_metadata_url(issuer_url: str) -> str:
+    return f"{_strip_trailing_slash(issuer_url)}/.well-known/oauth-authorization-server"
+
+
+def _protected_resource_metadata_url(resource_url: str) -> str:
+    parsed = urllib.parse.urlparse(_strip_trailing_slash(resource_url))
+    resource_path = parsed.path if parsed.path != "/" else ""
+    return urllib.parse.urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            f"/.well-known/oauth-protected-resource{resource_path}",
+            "",
+            "",
+            "",
+        )
+    )
+
+
+def _fetch_json(url: str, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{url} did not return JSON") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{url} returned non-object JSON")
+    return data
+
+
+def _probe_mcp_unauthenticated(url: str, timeout: float) -> tuple[int, Mapping[str, str]]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _list_value(data: Mapping[str, Any], key: str) -> list[Any]:
+    value = data.get(key)
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _metadata_errors(
+    *,
+    issuer_url: str,
+    resource_url: str,
+    scope: str,
+    auth_metadata: Mapping[str, Any],
+    resource_metadata: Mapping[str, Any],
+    mcp_status: int,
+    mcp_headers: Mapping[str, str],
+) -> list[str]:
+    issuer = _strip_trailing_slash(issuer_url)
+    resource = _strip_trailing_slash(resource_url)
+    protected_url = _protected_resource_metadata_url(resource)
+    errors: list[str] = []
+
+    expected_auth = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "registration_endpoint": f"{issuer}/register",
+    }
+    for key, expected in expected_auth.items():
+        if str(auth_metadata.get(key) or "").rstrip("/") != expected:
+            errors.append(f"authorization metadata {key} != {expected}")
+
+    if scope not in _list_value(auth_metadata, "scopes_supported"):
+        errors.append(f"authorization metadata missing scope {scope}")
+    if "authorization_code" not in _list_value(auth_metadata, "grant_types_supported"):
+        errors.append("authorization metadata missing authorization_code grant")
+
+    if str(resource_metadata.get("resource") or "").rstrip("/") != resource:
+        errors.append(f"resource metadata resource != {resource}")
+    if issuer not in [str(item).rstrip("/") for item in _list_value(resource_metadata, "authorization_servers")]:
+        errors.append(f"resource metadata missing authorization server {issuer}")
+    if scope not in _list_value(resource_metadata, "scopes_supported"):
+        errors.append(f"resource metadata missing scope {scope}")
+
+    if mcp_status != 401:
+        errors.append(f"unauthenticated MCP probe returned {mcp_status}, expected 401")
+
+    authenticate = mcp_headers.get("www-authenticate") or mcp_headers.get("WWW-Authenticate") or ""
+    if protected_url not in authenticate:
+        errors.append(f"WWW-Authenticate header missing resource_metadata={protected_url}")
+
+    return errors
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    if not issuer_url:
+        print("--issuer-url or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL is required", file=sys.stderr)
+        return 2
+    if not resource_url:
+        print(
+            "--resource-url or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    auth_url = _authorization_metadata_url(issuer_url)
+    protected_url = _protected_resource_metadata_url(resource_url)
+    try:
+        auth_metadata = _fetch_json(auth_url, args.timeout)
+        resource_metadata = _fetch_json(protected_url, args.timeout)
+        mcp_status, mcp_headers = _probe_mcp_unauthenticated(resource_url, args.timeout)
+    except Exception as exc:
+        print(f"OAuth discovery smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _metadata_errors(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        scope=args.scope,
+        auth_metadata=auth_metadata,
+        resource_metadata=resource_metadata,
+        mcp_status=mcp_status,
+        mcp_headers=mcp_headers,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: draft-writer invoicing OAuth discovery is routable")
+    print(f"- authorization metadata: {auth_url}")
+    print(f"- protected resource metadata: {protected_url}")
+    print(f"- MCP resource: {resource_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/check_invoicing_draft_writer_oauth_e2e.py
+++ b/scripts/check_invoicing_draft_writer_oauth_e2e.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Run a no-mutation OAuth e2e smoke for the draft-writer invoicing MCP connector."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_SCOPE = "invoices.draft.write"
+DEFAULT_REDIRECT_URI = "https://chat.openai.com/aip/callback"
+EXPECTED_DRAFT_WRITER_TOOLS = {
+    "create_draft_invoice",
+    "get_invoice",
+    "list_pending_drafts",
+    "update_draft_invoice",
+}
+KNOWN_MUTATING_TOOLS = {
+    "approve_and_send",
+    "create_invoice",
+    "create_service",
+    "export_invoice_pdf",
+    "mark_void",
+    "record_payment",
+    "send_invoice",
+    "set_service_status",
+    "update_invoice",
+    "update_service",
+}
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+_NO_REDIRECT = urllib.request.build_opener(_NoRedirect)
+
+
+@dataclass(frozen=True)
+class OAuthE2EConfig:
+    issuer_url: str
+    resource_url: str
+    approval_token: str
+    redirect_uri: str
+    scope: str
+    timeout: float
+
+
+@dataclass(frozen=True)
+class RegisteredClient:
+    client_id: str
+    client_secret: str
+
+
+@dataclass(frozen=True)
+class AuthorizationRequest:
+    approval_url: str
+    request_id: str
+    verifier: str
+
+
+@dataclass(frozen=True)
+class TokenResult:
+    access_token: str
+    scope: str
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a public OAuth e2e smoke for the draft-writer invoicing MCP connector. "
+            "This lists tools only and does not create or update invoice data."
+        )
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", ""),
+        help="Public OAuth issuer URL. Defaults to ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", ""),
+        help=(
+            "Public Streamable HTTP MCP resource URL. Defaults to "
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL."
+        ),
+    )
+    parser.add_argument(
+        "--approval-token",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", ""),
+        help="Operator approval token. Defaults to ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN.",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default=DEFAULT_REDIRECT_URI,
+        help=f"OAuth redirect URI to register. Default: {DEFAULT_REDIRECT_URI}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    return parser
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.strip().rstrip("/")
+
+
+def _config_from_args(args: argparse.Namespace) -> OAuthE2EConfig:
+    issuer_url = _strip_trailing_slash(args.issuer_url)
+    resource_url = _strip_trailing_slash(args.resource_url)
+    approval_token = args.approval_token.strip()
+    redirect_uri = args.redirect_uri.strip()
+    scope = args.scope.strip()
+    missing: list[str] = []
+    if not issuer_url:
+        missing.append("--issuer-url or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL")
+    if not resource_url:
+        missing.append("--resource-url or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL")
+    if not approval_token:
+        missing.append("--approval-token or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN")
+    if not redirect_uri:
+        missing.append("--redirect-uri")
+    if not scope:
+        missing.append("--scope")
+    if missing:
+        raise ValueError("missing required values: " + ", ".join(missing))
+    return OAuthE2EConfig(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+        approval_token=approval_token,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        timeout=args.timeout,
+    )
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _post_json(url: str, payload: Mapping[str, Any], timeout: float) -> tuple[int, Mapping[str, str], dict[str, Any]]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with _NO_REDIRECT.open(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            data = json.loads(body) if body else {}
+            if not isinstance(data, dict):
+                raise RuntimeError(f"{url} returned non-object JSON")
+            return response.status, response.headers, data
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{url} did not return JSON") from exc
+
+
+def _post_form(
+    url: str,
+    payload: Mapping[str, str],
+    timeout: float,
+    *,
+    follow_redirects: bool = False,
+) -> tuple[int, Mapping[str, str], str]:
+    request = urllib.request.Request(
+        url,
+        data=urllib.parse.urlencode(payload).encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    opener = urllib.request.urlopen if follow_redirects else _NO_REDIRECT.open
+    try:
+        with opener(request, timeout=timeout) as response:
+            return response.status, response.headers, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {302, 303, 307, 308}:
+            return exc.code, exc.headers, exc.read().decode("utf-8")
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _get_no_redirect(url: str, timeout: float) -> tuple[int, Mapping[str, str], str]:
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with _NO_REDIRECT.open(request, timeout=timeout) as response:
+            return response.status, response.headers, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code in {302, 303, 307, 308}:
+            return exc.code, exc.headers, exc.read().decode("utf-8")
+        raise RuntimeError(f"{url} returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{url} request failed: {exc.reason}") from exc
+
+
+def _register_client(config: OAuthE2EConfig) -> RegisteredClient:
+    status, _headers, body = _post_json(
+        f"{config.issuer_url}/register",
+        {
+            "client_name": "Atlas draft-writer invoicing OAuth e2e smoke",
+            "redirect_uris": [config.redirect_uri],
+            "token_endpoint_auth_method": "client_secret_post",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "scope": config.scope,
+        },
+        config.timeout,
+    )
+    if status not in {200, 201}:
+        raise RuntimeError(f"client registration returned HTTP {status}")
+    client_id = str(body.get("client_id") or "")
+    client_secret = str(body.get("client_secret") or "")
+    if not client_id or not client_secret:
+        raise RuntimeError("client registration response missing client_id or client_secret")
+    return RegisteredClient(client_id=client_id, client_secret=client_secret)
+
+
+def _start_authorization(config: OAuthE2EConfig, client: RegisteredClient) -> AuthorizationRequest:
+    verifier = secrets.token_urlsafe(48)
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": client.client_id,
+            "redirect_uri": config.redirect_uri,
+            "scope": config.scope,
+            "state": secrets.token_urlsafe(16),
+            "code_challenge": _pkce_challenge(verifier),
+            "code_challenge_method": "S256",
+            "resource": config.resource_url,
+        }
+    )
+    status, headers, _body = _get_no_redirect(f"{config.issuer_url}/authorize?{query}", config.timeout)
+    if status not in {302, 303}:
+        raise RuntimeError(f"authorization endpoint returned HTTP {status}")
+    approval_url = str(headers.get("Location") or headers.get("location") or "")
+    if not approval_url.startswith(f"{config.issuer_url}/oauth/approve?"):
+        raise RuntimeError("authorization endpoint did not redirect to the approval page")
+    request_id = urllib.parse.parse_qs(urllib.parse.urlparse(approval_url).query).get("request_id", [""])[0]
+    if not request_id:
+        raise RuntimeError("approval redirect missing request_id")
+    return AuthorizationRequest(
+        approval_url=approval_url,
+        request_id=request_id,
+        verifier=verifier,
+    )
+
+
+def _approve_authorization(config: OAuthE2EConfig, auth: AuthorizationRequest) -> str:
+    status, headers, _body = _post_form(
+        f"{config.issuer_url}/oauth/approve",
+        {
+            "request_id": auth.request_id,
+            "approval_token": config.approval_token,
+        },
+        config.timeout,
+    )
+    if status not in {302, 303}:
+        raise RuntimeError(f"approval endpoint returned HTTP {status}")
+    redirect_location = str(headers.get("Location") or headers.get("location") or "")
+    code = urllib.parse.parse_qs(urllib.parse.urlparse(redirect_location).query).get("code", [""])[0]
+    if not code:
+        raise RuntimeError("approval redirect missing authorization code")
+    return code
+
+
+def _exchange_token(
+    config: OAuthE2EConfig,
+    client: RegisteredClient,
+    auth: AuthorizationRequest,
+    code: str,
+) -> TokenResult:
+    status, _headers, body = _post_form(
+        f"{config.issuer_url}/token",
+        {
+            "grant_type": "authorization_code",
+            "client_id": client.client_id,
+            "client_secret": client.client_secret,
+            "code": code,
+            "redirect_uri": config.redirect_uri,
+            "code_verifier": auth.verifier,
+            "resource": config.resource_url,
+        },
+        config.timeout,
+        follow_redirects=True,
+    )
+    if status != 200:
+        raise RuntimeError(f"token endpoint returned HTTP {status}")
+    try:
+        token = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("token endpoint did not return JSON") from exc
+    if not isinstance(token, dict):
+        raise RuntimeError("token endpoint returned non-object JSON")
+    if token.get("token_type") != "Bearer":
+        raise RuntimeError("token endpoint did not return a Bearer token")
+    access_token = str(token.get("access_token") or "")
+    scope = str(token.get("scope") or "")
+    if not access_token:
+        raise RuntimeError("token endpoint response missing access_token")
+    if config.scope not in scope.split():
+        raise RuntimeError(f"token endpoint response missing scope {config.scope}")
+    return TokenResult(access_token=access_token, scope=scope)
+
+
+async def _list_mcp_tools(config: OAuthE2EConfig, access_token: str) -> set[str]:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async with streamablehttp_client(
+        config.resource_url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=config.timeout,
+        sse_read_timeout=config.timeout,
+    ) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            return {tool.name for tool in result.tools}
+
+
+def _tool_surface_errors(tool_names: set[str]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(EXPECTED_DRAFT_WRITER_TOOLS - tool_names)
+    extra = sorted(tool_names - EXPECTED_DRAFT_WRITER_TOOLS)
+    mutating = sorted(tool_names & KNOWN_MUTATING_TOOLS)
+    if missing:
+        errors.append("missing draft-writer tools: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected tools exposed: " + ", ".join(extra))
+    if mutating:
+        errors.append("mutating tools exposed: " + ", ".join(mutating))
+    return errors
+
+
+async def _run_smoke(config: OAuthE2EConfig) -> set[str]:
+    client = _register_client(config)
+    auth = _start_authorization(config, client)
+    code = _approve_authorization(config, auth)
+    token = _exchange_token(config, client, auth, code)
+    return await _list_mcp_tools(config, token.access_token)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = _config_from_args(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    try:
+        tool_names = asyncio.run(_run_smoke(config))
+    except Exception as exc:
+        print(f"OAuth e2e smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _tool_surface_errors(tool_names)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("OK: draft-writer invoicing OAuth e2e smoke completed")
+    print("- dynamic client registration succeeded")
+    print("- operator approval and token exchange succeeded")
+    print(f"- OAuth-authenticated MCP session exposes {len(tool_names)} draft-writer tools")
+    for name in sorted(tool_names):
+        print(f"- {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/start_invoicing_draft_writer_oauth_server.py
+++ b/scripts/start_invoicing_draft_writer_oauth_server.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Start the draft-writer invoicing MCP server in OAuth mode."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = "8066"
+DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer"
+DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp"
+MIN_APPROVAL_TOKEN_LENGTH = 24
+SECRET_KEYS = {
+    "ATLAS_MCP_AUTH_TOKEN",
+    "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+}
+REQUIRED_KEYS = (
+    "ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE",
+    "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL",
+    "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL",
+    "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+)
+
+
+@dataclass(frozen=True)
+class LaunchConfig:
+    env: dict[str, str]
+    python: str
+    host: str
+    port: str
+    dry_run: bool
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load Atlas dotenv files and start the draft-writer invoicing MCP "
+            "server in ChatGPT-compatible OAuth mode."
+        )
+    )
+    parser.add_argument(
+        "--env-file",
+        action="append",
+        default=None,
+        help="Dotenv file to load. May be repeated. Defaults to .env then .env.local.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used to launch the MCP server. Defaults to the current interpreter.",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help=f"Bind host. Defaults to env ATLAS_MCP_HOST or {DEFAULT_HOST}.",
+    )
+    parser.add_argument(
+        "--port",
+        default=None,
+        help=f"Bind port. Defaults to env ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT or {DEFAULT_PORT}.",
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=None,
+        help=f"OAuth issuer URL. Defaults to env value or {DEFAULT_ISSUER_URL}.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=None,
+        help=f"OAuth resource URL. Defaults to env value or {DEFAULT_RESOURCE_URL}.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print the launch/smoke commands without starting the server.",
+    )
+    return parser
+
+
+def _parse_dotenv_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    if not key:
+        return None
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return key, value
+
+
+def _load_dotenv_files(paths: list[Path]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for path in paths:
+        if not path.exists():
+            continue
+        for line in path.read_text().splitlines():
+            parsed = _parse_dotenv_line(line)
+            if parsed is None:
+                continue
+            key, value = parsed
+            values[key] = value
+    return values
+
+
+def _masked_env_report(env: Mapping[str, str], keys: tuple[str, ...] = REQUIRED_KEYS) -> list[str]:
+    lines: list[str] = []
+    for key in keys:
+        value = env.get(key, "")
+        if key in SECRET_KEYS:
+            state = f"SET len={len(value)}" if value else "MISSING"
+        else:
+            state = value or "MISSING"
+        lines.append(f"{key}={state}")
+    return lines
+
+
+def _validate_env(env: Mapping[str, str]) -> list[str]:
+    errors: list[str] = []
+    mode = env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "").strip().lower()
+    if mode != "oauth":
+        errors.append("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE must be oauth")
+    issuer = env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", "").strip()
+    if not issuer.startswith(("https://", "http://localhost", "http://127.0.0.1")):
+        errors.append("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL must be HTTPS or localhost HTTP")
+    resource = env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", "").strip()
+    if not resource.startswith(("https://", "http://localhost", "http://127.0.0.1")):
+        errors.append("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL must be HTTPS or localhost HTTP")
+    approval_token = env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", "").strip()
+    if len(approval_token) < MIN_APPROVAL_TOKEN_LENGTH:
+        errors.append(
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN must be at least "
+            f"{MIN_APPROVAL_TOKEN_LENGTH} characters"
+        )
+    port = env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT", DEFAULT_PORT).strip()
+    try:
+        parsed_port = int(port)
+    except ValueError:
+        errors.append("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT must be an integer")
+    else:
+        if parsed_port <= 0 or parsed_port > 65535:
+            errors.append("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT must be between 1 and 65535")
+    return errors
+
+
+def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
+    env_files = [Path(path) for path in (args.env_file or [".env", ".env.local"])]
+    env = _load_dotenv_files(env_files)
+    env.update(os.environ)
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE"] = "oauth"
+    env["ATLAS_MCP_HOST"] = (args.host or env.get("ATLAS_MCP_HOST") or DEFAULT_HOST).strip()
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT"] = (
+        args.port or env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT") or DEFAULT_PORT
+    ).strip()
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"] = (
+        args.issuer_url
+        or env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL")
+        or DEFAULT_ISSUER_URL
+    ).strip()
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL"] = (
+        args.resource_url
+        or env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL")
+        or DEFAULT_RESOURCE_URL
+    ).strip()
+    return LaunchConfig(
+        env=env,
+        python=args.python,
+        host=env["ATLAS_MCP_HOST"],
+        port=env["ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT"],
+        dry_run=args.dry_run,
+    )
+
+
+def _server_command(config: LaunchConfig) -> list[str]:
+    return [
+        config.python,
+        "-m",
+        "atlas_brain.mcp.invoicing_draft_writer_server",
+        "--sse",
+    ]
+
+
+def _print_operator_guidance(config: LaunchConfig) -> None:
+    issuer_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"]
+    resource_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL"]
+    print("Draft-writer invoicing OAuth launch configuration:")
+    for line in _masked_env_report(config.env):
+        print(f"- {line}")
+    print(f"- ATLAS_MCP_HOST={config.host}")
+    print(f"- ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT={config.port}")
+    print()
+    print("Required Funnel route for protected-resource metadata:")
+    print("tailscale funnel --bg --yes \\")
+    print("  --set-path /.well-known/oauth-protected-resource \\")
+    print(f"  http://127.0.0.1:{config.port}/.well-known/oauth-protected-resource")
+    print()
+    print("After startup, verify public discovery:")
+    print(".venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+    print()
+    print("Then verify OAuth token exchange and draft-writer MCP tools:")
+    print(".venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \\")
+    print(f"  --issuer-url {issuer_url} \\")
+    print(f"  --resource-url {resource_url}")
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = _build_launch_config(args)
+    errors = _validate_env(config.env)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+
+    _print_operator_guidance(config)
+    command = _server_command(config)
+    print()
+    print("Starting server:")
+    print(" ".join(command))
+    if config.dry_run:
+        print("dry-run: server not started")
+        return 0
+
+    return subprocess.call(command, env=config.env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_draft_writer_oauth_discovery.py
+++ b/tests/test_check_invoicing_draft_writer_oauth_discovery.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_draft_writer_oauth_discovery.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_oauth_discovery",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_authorization_metadata_url_preserves_path_prefixed_issuer() -> None:
+    module = _load_script_module()
+
+    assert module._authorization_metadata_url("https://atlas.example.com/invoicing-draft-writer/") == (
+        "https://atlas.example.com/invoicing-draft-writer/.well-known/oauth-authorization-server"
+    )
+
+
+def test_protected_resource_metadata_url_uses_resource_path() -> None:
+    module = _load_script_module()
+
+    assert module._protected_resource_metadata_url("https://atlas.example.com/invoicing-draft-writer/mcp") == (
+        "https://atlas.example.com/.well-known/oauth-protected-resource/invoicing-draft-writer/mcp"
+    )
+
+
+def test_metadata_errors_accept_expected_discovery_documents() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-draft-writer"
+    resource = "https://atlas.example.com/invoicing-draft-writer/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope="invoices.draft.write",
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": ["invoices.draft.write"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.draft.write"],
+        },
+        mcp_status=401,
+        mcp_headers={
+            "www-authenticate": (
+                'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                'oauth-protected-resource/invoicing-draft-writer/mcp"'
+            )
+        },
+    )
+
+    assert errors == []
+
+
+def test_metadata_errors_reject_missing_resource_challenge() -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-draft-writer"
+    resource = "https://atlas.example.com/invoicing-draft-writer/mcp"
+
+    errors = module._metadata_errors(
+        issuer_url=issuer,
+        resource_url=resource,
+        scope="invoices.draft.write",
+        auth_metadata={
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "registration_endpoint": f"{issuer}/register",
+            "scopes_supported": ["invoices.draft.write"],
+            "grant_types_supported": ["authorization_code"],
+        },
+        resource_metadata={
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.draft.write"],
+        },
+        mcp_status=401,
+        mcp_headers={"www-authenticate": "Bearer"},
+    )
+
+    assert errors == [
+        "WWW-Authenticate header missing resource_metadata="
+        "https://atlas.example.com/.well-known/oauth-protected-resource/invoicing-draft-writer/mcp"
+    ]
+
+
+def test_main_requires_urls_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", raising=False)
+    monkeypatch.setattr(module, "_fetch_json", fail_fetch)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--issuer-url" in captured.err
+
+
+def test_main_reports_success_for_valid_public_discovery(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+    issuer = "https://atlas.example.com/invoicing-draft-writer"
+    resource = "https://atlas.example.com/invoicing-draft-writer/mcp"
+
+    def fake_fetch(url: str, _timeout: float):
+        if url.endswith("/.well-known/oauth-authorization-server"):
+            return {
+                "issuer": issuer,
+                "authorization_endpoint": f"{issuer}/authorize",
+                "token_endpoint": f"{issuer}/token",
+                "registration_endpoint": f"{issuer}/register",
+                "scopes_supported": ["invoices.draft.write"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+            }
+        return {
+            "resource": resource,
+            "authorization_servers": [issuer],
+            "scopes_supported": ["invoices.draft.write"],
+        }
+
+    monkeypatch.setattr(module, "_fetch_json", fake_fetch)
+    monkeypatch.setattr(
+        module,
+        "_probe_mcp_unauthenticated",
+        lambda *_args: (
+            401,
+            {
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://atlas.example.com/.well-known/'
+                    'oauth-protected-resource/invoicing-draft-writer/mcp"'
+                )
+            },
+        ),
+    )
+
+    result = module._main(["--issuer-url", issuer, "--resource-url", resource])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "OAuth discovery is routable" in captured.out

--- a/tests/test_check_invoicing_draft_writer_oauth_e2e.py
+++ b/tests/test_check_invoicing_draft_writer_oauth_e2e.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_draft_writer_oauth_e2e.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_oauth_e2e",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "issuer_url": "https://atlas.example.com/invoicing-draft-writer",
+        "resource_url": "https://atlas.example.com/invoicing-draft-writer/mcp",
+        "approval_token": "approval-token-with-enough-entropy",
+        "redirect_uri": "https://chat.openai.com/aip/callback",
+        "scope": "invoices.draft.write",
+        "timeout": 10.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_config_from_args_requires_values() -> None:
+    module = _load_script_module()
+
+    try:
+        module._config_from_args(
+            _args(
+                issuer_url="",
+                resource_url="",
+                approval_token="",
+            )
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+    assert "--issuer-url" in message
+    assert "--resource-url" in message
+    assert "--approval-token" in message
+
+
+def test_pkce_challenge_uses_s256_urlsafe_without_padding() -> None:
+    module = _load_script_module()
+
+    expected = base64.urlsafe_b64encode(hashlib.sha256(b"verifier-1").digest()).decode().rstrip("=")
+
+    assert module._pkce_challenge("verifier-1") == expected
+    assert not module._pkce_challenge("verifier-1").endswith("=")
+
+
+def test_tool_surface_errors_accept_exact_draft_writer_tools() -> None:
+    module = _load_script_module()
+
+    assert module._tool_surface_errors(set(module.EXPECTED_DRAFT_WRITER_TOOLS)) == []
+
+
+def test_tool_surface_errors_reject_extra_and_mutating_tools() -> None:
+    module = _load_script_module()
+    tools = set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+    tools.update({"approve_and_send", "surprise_tool"})
+
+    errors = module._tool_surface_errors(tools)
+
+    assert "unexpected tools exposed: approve_and_send, surprise_tool" in errors
+    assert "mutating tools exposed: approve_and_send" in errors
+
+
+def test_register_client_requires_client_secret(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+
+    monkeypatch.setattr(module, "_post_json", lambda *_args, **_kwargs: (201, {}, {"client_id": "client-1"}))
+
+    try:
+        module._register_client(config)
+    except RuntimeError as exc:
+        assert "missing client_id or client_secret" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_start_authorization_requires_approval_redirect(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    client = module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+
+    monkeypatch.setattr(module, "_get_no_redirect", lambda *_args, **_kwargs: (302, {"Location": "https://bad.example.com"}, ""))
+
+    try:
+        module._start_authorization(config, client)
+    except RuntimeError as exc:
+        assert "did not redirect to the approval page" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_approve_authorization_extracts_code_without_following_chatgpt_redirect(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    auth = module.AuthorizationRequest(
+        approval_url="https://atlas.example.com/invoicing-draft-writer/oauth/approve?request_id=req-1",
+        request_id="req-1",
+        verifier="verifier-1",
+    )
+
+    def fake_post_form(url, payload, timeout, *, follow_redirects=False):
+        assert url == "https://atlas.example.com/invoicing-draft-writer/oauth/approve"
+        assert payload["approval_token"] == "approval-token-with-enough-entropy"
+        assert follow_redirects is False
+        return 302, {"Location": "https://chat.openai.com/aip/callback?code=code-1&state=state-1"}, ""
+
+    monkeypatch.setattr(module, "_post_form", fake_post_form)
+
+    assert module._approve_authorization(config, auth) == "code-1"
+
+
+def test_exchange_token_requires_bearer_access_token(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    client = module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+    auth = module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    monkeypatch.setattr(
+        module,
+        "_post_form",
+        lambda *_args, **_kwargs: (200, {}, '{"token_type":"Bearer","scope":"invoices.draft.write"}'),
+    )
+
+    try:
+        module._exchange_token(config, client, auth, "code-1")
+    except RuntimeError as exc:
+        assert "missing access_token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_main_requires_config_before_network(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fail_run(*_args, **_kwargs):
+        raise AssertionError("network touched")
+
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", raising=False)
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", raising=False)
+    monkeypatch.setattr(module, "_run_smoke", fail_run)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--issuer-url" in captured.err
+
+
+def test_main_reports_success_without_printing_secrets(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/invoicing-draft-writer",
+            "--resource-url",
+            "https://atlas.example.com/invoicing-draft-writer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "OAuth e2e smoke completed" in captured.out
+    assert "secret-approval-token-value" not in captured.out
+    assert "get_invoice" in captured.out
+
+
+def test_main_reports_tool_surface_errors(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_config):
+        return {"get_invoice", "approve_and_send"}
+
+    monkeypatch.setattr(module, "_run_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--issuer-url",
+            "https://atlas.example.com/invoicing-draft-writer",
+            "--resource-url",
+            "https://atlas.example.com/invoicing-draft-writer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "missing draft-writer tools:" in captured.err
+    assert "mutating tools exposed: approve_and_send" in captured.err
+
+
+def test_run_smoke_sequence_uses_token_for_tool_list(monkeypatch) -> None:
+    module = _load_script_module()
+    config = module._config_from_args(_args())
+    calls: list[str] = []
+
+    def fake_register(_config):
+        calls.append("register")
+        return module.RegisteredClient(client_id="client-1", client_secret="secret-1")
+
+    def fake_start(_config, client):
+        calls.append(f"authorize:{client.client_id}")
+        return module.AuthorizationRequest(approval_url="url", request_id="req-1", verifier="verifier-1")
+
+    def fake_approve(_config, auth):
+        calls.append(f"approve:{auth.request_id}")
+        return "code-1"
+
+    def fake_exchange(_config, client, auth, code):
+        calls.append(f"token:{client.client_id}:{auth.request_id}:{code}")
+        return module.TokenResult(access_token="access-token-1", scope="invoices.draft.write")
+
+    async def fake_list(_config, token):
+        calls.append(f"list:{token}")
+        return set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+
+    monkeypatch.setattr(module, "_register_client", fake_register)
+    monkeypatch.setattr(module, "_start_authorization", fake_start)
+    monkeypatch.setattr(module, "_approve_authorization", fake_approve)
+    monkeypatch.setattr(module, "_exchange_token", fake_exchange)
+    monkeypatch.setattr(module, "_list_mcp_tools", fake_list)
+
+    result = asyncio.run(module._run_smoke(config))
+
+    assert result == set(module.EXPECTED_DRAFT_WRITER_TOOLS)
+    assert calls == [
+        "register",
+        "authorize:client-1",
+        "approve:req-1",
+        "token:client-1:req-1:code-1",
+        "list:access-token-1",
+    ]

--- a/tests/test_invoicing_draft_writer_oauth.py
+++ b/tests/test_invoicing_draft_writer_oauth.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atlas_brain.mcp import invoicing_draft_writer_server as draft_writer
+from atlas_brain.mcp.invoicing_draft_writer_oauth import (
+    DEFAULT_DRAFT_WRITE_SCOPE,
+    InvoicingDraftWriterOAuthProvider,
+    PendingAuthorization,
+    validate_oauth_settings,
+)
+from mcp.server.auth.provider import AuthorizationParams, TokenError
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+def _client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="client-1",
+        client_secret="secret-1",
+        redirect_uris=["https://chat.openai.com/aip/callback"],
+        token_endpoint_auth_method="client_secret_post",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=DEFAULT_DRAFT_WRITE_SCOPE,
+    )
+
+
+def _other_client() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="client-2",
+        client_secret="secret-2",
+        redirect_uris=["https://chat.openai.com/aip/callback"],
+        token_endpoint_auth_method="client_secret_post",
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=DEFAULT_DRAFT_WRITE_SCOPE,
+    )
+
+
+def _params() -> AuthorizationParams:
+    return AuthorizationParams(
+        state="state-1",
+        scopes=None,
+        code_challenge=_challenge("verifier-1"),
+        redirect_uri="https://chat.openai.com/aip/callback",
+        redirect_uri_provided_explicitly=True,
+        resource="https://atlas.example.com/invoicing-draft-writer/mcp",
+    )
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def _reset_draft_writer_auth_state() -> None:
+    draft_writer._oauth_provider = None
+    draft_writer.mcp.settings.auth = None
+    draft_writer.mcp._auth_server_provider = None
+    draft_writer.mcp._token_verifier = None
+    draft_writer.mcp._session_manager = None
+
+
+@pytest.fixture(autouse=True)
+def reset_draft_writer_auth_state():
+    _reset_draft_writer_auth_state()
+    yield
+    _reset_draft_writer_auth_state()
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_requires_operator_approval_before_token_exchange():
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    await provider.register_client(client)
+
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+
+    with pytest.raises(PermissionError):
+        provider.approve_pending_authorization(
+            request_id=request_id,
+            approval_token="wrong-token",
+        )
+
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    token = await provider.exchange_authorization_code(client, auth_code)
+
+    assert token.token_type == "Bearer"
+    assert token.scope == DEFAULT_DRAFT_WRITE_SCOPE
+    access = await provider.load_access_token(token.access_token)
+    assert access is not None
+    assert access.scopes == [DEFAULT_DRAFT_WRITE_SCOPE]
+    assert access.resource == "https://atlas.example.com/invoicing-draft-writer/mcp"
+    assert await provider.load_authorization_code(client, code) is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_binds_authorization_codes_to_client():
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    other_client = _other_client()
+    await provider.register_client(client)
+    await provider.register_client(other_client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+
+    assert await provider.load_authorization_code(other_client, code) is None
+    assert await provider.load_authorization_code(client, code) is not None
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_refresh_token_issues_new_access_token():
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    await provider.register_client(client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    first_token = await provider.exchange_authorization_code(client, auth_code)
+    assert first_token.refresh_token is not None
+
+    refresh = await provider.load_refresh_token(client, first_token.refresh_token)
+    assert refresh is not None
+    second_token = await provider.exchange_refresh_token(client, refresh, [DEFAULT_DRAFT_WRITE_SCOPE])
+
+    assert second_token.access_token != first_token.access_token
+    assert second_token.refresh_token == first_token.refresh_token
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_binds_refresh_tokens_to_client():
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+    )
+    client = _client()
+    other_client = _other_client()
+    await provider.register_client(client)
+    await provider.register_client(other_client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    token = await provider.exchange_authorization_code(client, auth_code)
+    assert token.refresh_token is not None
+
+    assert await provider.load_refresh_token(other_client, token.refresh_token) is None
+    refresh = await provider.load_refresh_token(client, token.refresh_token)
+    assert refresh is not None
+
+    with pytest.raises(TokenError, match="refresh token does not belong to client"):
+        await provider.exchange_refresh_token(other_client, refresh, [DEFAULT_DRAFT_WRITE_SCOPE])
+
+
+def test_validate_oauth_settings_requires_approval_token():
+    with pytest.raises(RuntimeError, match="OAUTH_APPROVAL_TOKEN"):
+        validate_oauth_settings(
+            issuer_url="https://atlas.example.com/invoicing-draft-writer",
+            resource_server_url="https://atlas.example.com/invoicing-draft-writer/mcp",
+            approval_token="short",
+        )
+
+
+def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "oauth")
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL",
+        "https://atlas.example.com/invoicing-draft-writer",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL",
+        "https://atlas.example.com/invoicing-draft-writer/mcp",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+
+    app = draft_writer._streamable_http_app()
+
+    with TestClient(app) as client:
+        auth_metadata = client.get("/.well-known/oauth-authorization-server")
+        assert auth_metadata.status_code == 200
+        assert auth_metadata.json()["registration_endpoint"] == (
+            "https://atlas.example.com/invoicing-draft-writer/register"
+        )
+
+        resource_metadata = client.get(
+            "/.well-known/oauth-protected-resource/invoicing-draft-writer/mcp"
+        )
+        assert resource_metadata.status_code == 200
+        assert resource_metadata.json()["resource"] == (
+            "https://atlas.example.com/invoicing-draft-writer/mcp"
+        )
+
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        assert "resource_metadata=" in response.headers["www-authenticate"]
+
+
+def test_approval_page_omits_absolute_form_action_for_prefixed_mount(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "oauth")
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL",
+        "https://atlas.example.com/invoicing-draft-writer",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL",
+        "https://atlas.example.com/invoicing-draft-writer/mcp",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+
+    app = draft_writer._streamable_http_app()
+    provider = draft_writer._oauth_provider
+    assert provider is not None
+    provider._pending["request-1"] = PendingAuthorization(
+        request_id="request-1",
+        client_id="client-1",
+        params=_params(),
+        scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+        expires_at=9999999999,
+    )
+
+    with TestClient(app, root_path="/invoicing-draft-writer") as client:
+        response = client.get("/oauth/approve?request_id=request-1")
+
+    assert response.status_code == 200
+    assert '<form method="post">' in response.text
+    assert 'action="/oauth/approve"' not in response.text
+    assert 'action="/invoicing-draft-writer/oauth/approve"' not in response.text
+
+
+def test_streamable_http_app_rejects_invalid_auth_mode(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "open")
+
+    with pytest.raises(RuntimeError, match="AUTH_MODE"):
+        draft_writer._streamable_http_app()

--- a/tests/test_start_invoicing_draft_writer_oauth_server.py
+++ b/tests/test_start_invoicing_draft_writer_oauth_server.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/start_invoicing_draft_writer_oauth_server.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "start_invoicing_draft_writer_oauth_server",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "env_file": [],
+        "python": "/venv/bin/python",
+        "host": None,
+        "port": None,
+        "issuer_url": None,
+        "resource_url": None,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _valid_env():
+    return {
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE": "oauth",
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL": "https://atlas.example.com/invoicing-draft-writer",
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL": "https://atlas.example.com/invoicing-draft-writer/mcp",
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN": "approval-token-with-enough-entropy",
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT": "8065",
+    }
+
+
+def test_parse_dotenv_line_handles_quotes_comments_and_empty_lines() -> None:
+    module = _load_script_module()
+
+    assert module._parse_dotenv_line("KEY=value") == ("KEY", "value")
+    assert module._parse_dotenv_line("KEY='quoted value'") == ("KEY", "quoted value")
+    assert module._parse_dotenv_line('KEY="quoted value"') == ("KEY", "quoted value")
+    assert module._parse_dotenv_line("# comment") is None
+    assert module._parse_dotenv_line("") is None
+
+
+def test_load_dotenv_files_applies_later_file_override(tmp_path) -> None:
+    module = _load_script_module()
+    first = tmp_path / ".env"
+    second = tmp_path / ".env.local"
+    first.write_text("KEY=base\nOTHER=value\n")
+    second.write_text("KEY=local\n")
+
+    values = module._load_dotenv_files([first, second])
+
+    assert values == {"KEY": "local", "OTHER": "value"}
+
+
+def test_validate_env_accepts_oauth_config() -> None:
+    module = _load_script_module()
+
+    assert module._validate_env(_valid_env()) == []
+
+
+def test_validate_env_rejects_short_token_and_bad_port() -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"] = "short"
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT"] = "70000"
+
+    errors = module._validate_env(env)
+
+    assert any("APPROVAL_TOKEN" in error for error in errors)
+    assert any("between 1 and 65535" in error for error in errors)
+
+
+def test_build_launch_config_loads_env_files_and_forces_oauth(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE=bearer",
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", raising=False)
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)], port="9000"))
+
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE"] == "oauth"
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT"] == "9000"
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"] == module.DEFAULT_ISSUER_URL
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-with-enough-entropy"
+    )
+
+
+def test_build_launch_config_process_env_overrides_env_file(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=approval-token-from-file",
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL=https://file.example.com/invoicing-draft-writer",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+        "approval-token-from-process-env",
+    )
+
+    config = module._build_launch_config(_args(env_file=[str(env_file)]))
+
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-from-process-env"
+    )
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"] == (
+        "https://file.example.com/invoicing-draft-writer"
+    )
+
+
+def test_server_command_uses_current_config_python() -> None:
+    module = _load_script_module()
+    config = module.LaunchConfig(
+        env=_valid_env(),
+        python="/custom/python",
+        host="0.0.0.0",
+        port="8065",
+        dry_run=False,
+    )
+
+    assert module._server_command(config) == [
+        "/custom/python",
+        "-m",
+        "atlas_brain.mcp.invoicing_draft_writer_server",
+        "--sse",
+    ]
+
+
+def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_AUTH_TOKEN"] = "bearer-token-value-that-must-not-print"
+    config = module.LaunchConfig(
+        env=env,
+        python="/venv/bin/python",
+        host="0.0.0.0",
+        port="9000",
+        dry_run=True,
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "SET len=34" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+    assert "bearer-token-value-that-must-not-print" not in captured.out
+    assert "http://127.0.0.1:9000/.well-known/oauth-protected-resource" in captured.out
+    assert "http://127.0.0.1:8065/.well-known/oauth-protected-resource" not in captured.out
+    assert "check_invoicing_draft_writer_oauth_e2e.py" in captured.out
+
+
+def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=approval-token-with-enough-entropy",
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL=https://atlas.example.com/invoicing-draft-writer",
+                "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL=https://atlas.example.com/invoicing-draft-writer/mcp",
+            ]
+        )
+        + "\n"
+    )
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "dry-run: server not started" in captured.out
+    assert "approval-token-with-enough-entropy" not in captured.out
+
+
+def test_main_returns_validation_errors_before_subprocess(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_script_module()
+    env_file = tmp_path / ".env"
+    env_file.write_text("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=short\n")
+
+    def fail_call(*_args, **_kwargs):
+        raise AssertionError("subprocess touched")
+
+    monkeypatch.setattr(module.subprocess, "call", fail_call)
+
+    result = module._main(["--env-file", str(env_file)])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "APPROVAL_TOKEN" in captured.err
+    assert "short" not in captured.err


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-OAuth.md

Adds ChatGPT-compatible OAuth wiring for the already-separated draft-writer invoicing MCP server. The smoke scripts verify OAuth discovery, token exchange, and exact four-tool surface without creating or updating invoices.

## Intentional
- OAuth is added only to atlas-invoicing-draft-writer, not the full atlas-invoicing server.
- The e2e smoke lists tools only; it does not call create_draft_invoice or update_draft_invoice.
- The public path is /invoicing-draft-writer/mcp with scope invoices.draft.write.

## Deferred
- Live Tailscale/ChatGPT approval remains operator-run.
- Send, payment, void, PDF export, and service mutation scopes remain deferred.
- Adding this server to the global MCP inventory table is deferred until we decide it should be treated as an always-on server.

## Verification
- .venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_oauth.py atlas_brain/mcp/invoicing_draft_writer_server.py scripts/check_invoicing_draft_writer_oauth_discovery.py scripts/check_invoicing_draft_writer_oauth_e2e.py scripts/start_invoicing_draft_writer_oauth_server.py
- .venv/bin/pytest tests/test_invoicing_draft_writer_mcp.py tests/test_check_invoicing_draft_writer_mcp_connector.py tests/test_invoicing_draft_writer_oauth.py tests/test_check_invoicing_draft_writer_oauth_discovery.py tests/test_check_invoicing_draft_writer_oauth_e2e.py tests/test_start_invoicing_draft_writer_oauth_server.py -q -> 55 passed
- bash scripts/local_pr_review.sh

## Diff size
12 files, +2124 / -0