### PR TITLE
Add source-file Postgres smoke for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T03:58Z by codex-2026-05-18
+Last updated: 2026-05-19T04:11Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Support-Ticket-Examples | `extracted_content_pipeline/examples/support_ticket_sources.csv`, `extracted_content_pipeline/examples/support_ticket_bundle.json`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Support-Ticket-Examples.md` | codex-2026-05-18 | Content Ops support-ticket ingestion examples |
+| TBD | PR-Content-Ops-Source-File-Postgres-Smoke | `scripts/smoke_content_ops_source_file_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `tests/test_smoke_content_ops_source_file_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-File-Postgres-Smoke.md` | codex-2026-05-18 | Content Ops source-file Postgres smoke |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -241,6 +241,19 @@ python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --json
 ```
 
+For customer-owned source files such as the packaged support-ticket CSV, use
+the generic source-file Postgres smoke. It imports the file into
+`campaign_opportunities`, runs offline draft generation through the Postgres
+runner, and checks persisted draft target metadata:
+
+```bash
+python scripts/smoke_content_ops_source_file_postgres.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --account-id acct_123 \
+  --json
+```
+
 Before converting or importing a customer export, inspect ingestion readiness:
 
 ```bash

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -542,6 +542,26 @@ python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --json
 ```
 
+For customer-owned source files, use the generic source-file Postgres smoke.
+The default path is the packaged support-ticket CSV example, so a host can run
+it after migrations with only an account id:
+
+```bash
+python scripts/smoke_content_ops_source_file_postgres.py \
+  --account-id acct_123 \
+  --json
+```
+
+Pass a different JSON, JSONL, or CSV source export when validating a host file:
+
+```bash
+python scripts/smoke_content_ops_source_file_postgres.py \
+  customer_support_tickets.csv \
+  --source-format csv \
+  --account-id acct_123 \
+  --json
+```
+
 ```bash
 python scripts/load_extracted_campaign_opportunities.py \
   g2_review_sources.jsonl \

--- a/plans/PR-Content-Ops-Source-File-Postgres-Smoke.md
+++ b/plans/PR-Content-Ops-Source-File-Postgres-Smoke.md
@@ -1,0 +1,84 @@
+# PR-Content-Ops-Source-File-Postgres-Smoke
+
+## Why this slice exists
+
+PR-Content-Ops-Support-Ticket-Examples added packaged support-ticket CSV and
+JSON examples and proved they work through offline conversion/generation. The
+deferred gap is the Postgres-backed path: hosts still need one command that
+imports a source-row file into `campaign_opportunities`, generates offline
+drafts through the DB runner, and verifies persisted campaign target metadata.
+
+This slice adds that host-facing source-file Postgres smoke using the packaged
+support-ticket CSV as the default input.
+
+## Scope (this PR)
+
+1. Add a source-file Postgres smoke command that accepts JSON, JSONL, or CSV
+   source rows.
+2. Reuse the shared source Postgres smoke helpers for schema readiness,
+   generation, saved-draft fetch, and target-id validation.
+3. Add tests for the packaged support-ticket CSV path, schema fail-closed
+   behavior, and persisted-draft validation.
+4. Document the new command in README and the host install runbook.
+5. Remove the merged support-ticket examples coordination row while claiming
+   this slice.
+
+### Files touched
+
+- `scripts/smoke_content_ops_source_file_postgres.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_smoke_content_ops_source_file_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Source-File-Postgres-Smoke.md`
+
+## Mechanism
+
+The new smoke does:
+
+```text
+source file -> inspect_ingestion_file -> load_source_campaign_opportunities_from_file
+-> import_campaign_opportunities -> generate_imported_target_drafts
+-> fetch_saved_drafts -> target-id + draft-shape validation
+```
+
+It defaults to `extracted_content_pipeline/examples/support_ticket_sources.csv`
+with `--source-format csv`, but callers can point it at any source-row JSON,
+JSONL, or CSV file.
+
+## Intentional
+
+- This is a source-file smoke, not a Zendesk/Intercom/Freshdesk connector.
+- The command keeps deterministic/offline draft generation; no provider call is
+  introduced.
+- The script reuses `content_ops_source_postgres_smoke_helpers.py` instead of
+  copying the DB readiness and persisted-draft checks again.
+
+## Deferred
+
+- Live help desk API connectors remain future slices.
+- Live DB execution is still operator-run only; CI uses fake pools.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_source_file_postgres.py -q` -> 4 passed.
+- `python -m py_compile scripts/smoke_content_ops_source_file_postgres.py tests/test_smoke_content_ops_source_file_postgres.py` -> passed.
+- `grep -nP '[^\x00-\x7F]' scripts/smoke_content_ops_source_file_postgres.py tests/test_smoke_content_ops_source_file_postgres.py` -> no matches.
+- `rg -n "TODO|FIXME|pass$|campaign_opportunities|b2b_campaigns|EXTRACTED_DATABASE_URL|appears to be weighing|acct_123|customer_support_tickets" scripts/smoke_content_ops_source_file_postgres.py tests/test_smoke_content_ops_source_file_postgres.py extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md` -> only expected table/env/default/fixture/doc references and no TODO/FIXME/pass placeholders.
+- `git diff --check` -> passed.
+- `bash scripts/local_pr_review.sh` -> passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1440 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke script | ~290 |
+| Tests | ~220 |
+| Docs + runner + plan + coordination | ~120 |
+| **Total** | **~630** |
+
+This exceeds the soft 400 LOC budget because the slice adds a host-facing CLI
+and its fake-pool integration tests together. Splitting tests from the command
+would leave the new Postgres smoke under-reviewed.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \
   tests/test_content_ops_source_postgres_smoke_helpers.py \
+  tests/test_smoke_content_ops_source_file_postgres.py \
   tests/test_smoke_content_ops_review_source_postgres.py \
   tests/test_smoke_content_ops_cfpb_source_postgres.py \
   tests/test_extracted_content_ingestion_diagnostics.py \

--- a/scripts/smoke_content_ops_source_file_postgres.py
+++ b/scripts/smoke_content_ops_source_file_postgres.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Smoke-test source-row files through Postgres-backed draft persistence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
+    import_campaign_opportunities,
+)
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
+    inspect_ingestion_file,
+)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
+
+def _load_script_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_source_postgres_helpers = _load_script_module(
+    "content_ops_source_postgres_smoke_helpers",
+    ROOT / "scripts" / "content_ops_source_postgres_smoke_helpers.py",
+)
+
+DEFAULT_SOURCE_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+DEFAULT_CHANNELS = ("email_cold", "email_followup")
+DEFAULT_FORBIDDEN_PHRASES = ("appears to be weighing",)
+draft_errors = _source_postgres_helpers.draft_errors
+fetch_saved_drafts = _source_postgres_helpers.fetch_saved_drafts
+generate_imported_target_drafts = _source_postgres_helpers.generate_imported_target_drafts
+generation_errors = _source_postgres_helpers.generation_errors
+saved_draft_target_errors = _source_postgres_helpers.saved_draft_target_errors
+schema_readiness_errors = _source_postgres_helpers.schema_readiness_errors
+
+
+def _default_database_url() -> str | None:
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    dsn = str(getattr(db_settings, "dsn", "") or "").strip()
+    return dsn or None
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the source-file Postgres smoke; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _csv_list(value: str | Sequence[str]) -> tuple[str, ...]:
+    raw = value.split(",") if isinstance(value, str) else value
+    return tuple(str(item or "").strip() for item in raw if str(item or "").strip())
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test Content Ops source-row files through Postgres import "
+            "and DB-backed offline draft generation."
+        )
+    )
+    parser.add_argument("path", type=Path, nargs="?", default=DEFAULT_SOURCE_PATH)
+    parser.add_argument("--source-format", choices=("auto", "json", "jsonl", "csv"), default="csv")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument("--min-source-rows", type=int, default=1)
+    parser.add_argument("--min-drafts", type=int, default=None)
+    parser.add_argument("--allow-ingestion-warnings", action="store_true")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help="Fallback metadata applied to every source row. Repeat as key=value.",
+    )
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--opportunity-table", default="campaign_opportunities")
+    parser.add_argument("--keep-existing-opportunities", action="store_true")
+    parser.add_argument(
+        "--forbidden-phrase",
+        action="append",
+        default=list(DEFAULT_FORBIDDEN_PHRASES),
+    )
+    parser.add_argument("--output-result", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.min_source_rows) < 1:
+        raise SystemExit("--min-source-rows must be positive")
+    if args.min_drafts is not None and int(args.min_drafts) < 1:
+        raise SystemExit("--min-drafts must be positive")
+    if not _csv_list(args.channels):
+        raise SystemExit("--channels must include at least one channel")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+async def run_source_file_postgres_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    default_fields = parse_default_fields_or_exit(args.default_field)
+    channels = _csv_list(args.channels)
+    source_path = Path(args.path)
+    pool = await _create_pool(str(args.database_url))
+    ingestion_report: dict[str, Any] | None = None
+    import_result: dict[str, Any] | None = None
+    drafts_result: dict[str, Any] | None = None
+    saved_drafts: list[dict[str, Any]] = []
+    imported_target_ids: list[str] = []
+    source_rows = 0
+    min_drafts = int(args.min_drafts) if args.min_drafts is not None else 0
+    errors: list[str] = []
+    try:
+        try:
+            report = inspect_ingestion_file(
+                source_path,
+                source_rows=True,
+                source_format=str(args.source_format),
+                target_mode=str(args.target_mode),
+                default_fields=default_fields,
+            )
+            ingestion_report = report.as_dict()
+            source_rows = int(ingestion_report.get("opportunity_count") or 0)
+            if not report.ok:
+                errors.append("ingestion inspection failed")
+            if report.warnings and not bool(args.allow_ingestion_warnings):
+                errors.append(
+                    "ingestion inspection produced warnings; provide --default-field "
+                    "bindings or pass --allow-ingestion-warnings"
+                )
+            if source_rows < int(args.min_source_rows):
+                errors.append(
+                    f"expected at least {int(args.min_source_rows)} source row(s), got {source_rows}"
+                )
+            if min_drafts <= 0:
+                min_drafts = source_rows * len(channels)
+            if not errors:
+                errors.extend(
+                    await schema_readiness_errors(
+                        pool,
+                        opportunity_table=str(args.opportunity_table),
+                    )
+                )
+            if not errors:
+                loaded = load_source_campaign_opportunities_from_file(
+                    source_path,
+                    file_format=str(args.source_format),
+                    target_mode=str(args.target_mode),
+                    default_fields=default_fields,
+                )
+                imported = await import_campaign_opportunities(
+                    pool,
+                    loaded.opportunities,
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    target_mode=str(args.target_mode),
+                    opportunity_table=str(args.opportunity_table),
+                    replace_existing=not bool(args.keep_existing_opportunities),
+                    normalize=False,
+                    warnings=loaded.warnings,
+                    source=loaded.source,
+                )
+                import_result = imported.as_dict()
+                imported_target_ids = list(imported.target_ids)
+                if imported.skipped:
+                    errors.append(f"import skipped {imported.skipped} row(s)")
+                if imported.inserted < source_rows:
+                    errors.append(
+                        f"expected {source_rows} imported opportunity row(s), got {imported.inserted}"
+                    )
+            if not errors:
+                drafts_result = await generate_imported_target_drafts(
+                    pool=pool,
+                    account_id=str(args.account_id),
+                    user_id=args.user_id,
+                    target_mode=str(args.target_mode),
+                    channels=channels,
+                    target_ids=imported_target_ids,
+                    opportunity_table=str(args.opportunity_table),
+                )
+                saved_drafts = await fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
+                errors.extend(generation_errors(drafts_result))
+                errors.extend(draft_errors(
+                    {"drafts": saved_drafts},
+                    min_drafts=min_drafts,
+                    forbidden_phrases=args.forbidden_phrase,
+                ))
+                errors.extend(saved_draft_target_errors(saved_drafts, imported_target_ids))
+        except Exception as exc:  # pragma: no cover - exercised by live hosts
+            errors.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    payload = {
+        "ok": not errors,
+        "source": str(source_path),
+        "source_format": str(args.source_format),
+        "source_rows": source_rows,
+        "ingestion": ingestion_report,
+        "import": import_result,
+        "drafts": drafts_result,
+        "saved_drafts": saved_drafts,
+        "errors": errors,
+    }
+    if args.output_result:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+    return (0 if not errors else 1), payload
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if payload.get("ok"):
+        imported = payload.get("import") if isinstance(payload.get("import"), Mapping) else {}
+        drafts = payload.get("drafts") if isinstance(payload.get("drafts"), Mapping) else {}
+        print(
+            "Content Ops source-file Postgres smoke passed: "
+            f"source_rows={payload.get('source_rows')} "
+            f"imported={imported.get('inserted', 0)} "
+            f"generated={drafts.get('generated', 0)}"
+        )
+        return
+    print("Content Ops source-file Postgres smoke failed:", file=sys.stderr)
+    for error in payload.get("errors") or []:
+        print(f"- {error}", file=sys.stderr)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, payload = await run_source_file_postgres_smoke(args)
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_smoke_content_ops_source_file_postgres.py
+++ b/tests/test_smoke_content_ops_source_file_postgres.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_source_file_postgres.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_source_file_postgres",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        opportunity_rows=None,
+        saved_draft_rows=None,
+        existing_relations=None,
+    ):
+        self.opportunity_rows = list(opportunity_rows or [])
+        self.saved_draft_rows = list(saved_draft_rows or [])
+        self.existing_relations = set(
+            existing_relations or ("campaign_opportunities", "b2b_campaigns")
+        )
+        self.fetch_calls = []
+        self.execute_calls = []
+        self.fetchval_calls = []
+        self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        if self.opportunity_rows and len(self.fetch_calls) == 1:
+            return self.opportunity_rows
+        return self.saved_draft_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return "EXECUTE"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        if "to_regclass" in str(query):
+            return args[0] if args and args[0] in self.existing_relations else None
+        return "campaign-1"
+
+    async def close(self):
+        self.closed = True
+
+
+async def _return_pool(pool):
+    return pool
+
+
+def _opportunity_row(target_id="ticket-acme-1"):
+    return {
+        "target_id": target_id,
+        "company_name": "Acme Logistics",
+        "vendor_name": "HubSpot",
+        "contact_email": "ops@example.com",
+        "pain_points": ["reporting friction"],
+        "evidence": [
+            {
+                "source_id": target_id,
+                "source_type": "support_ticket",
+                "text": "The operations team cannot export campaign attribution data.",
+            }
+        ],
+        "raw_payload": {
+            "target_id": target_id,
+            "source_type": "support_ticket",
+        },
+    }
+
+
+def _saved_draft_row(target_id="ticket-acme-1", *, body=None):
+    return {
+        "id": f"campaign-{target_id}",
+        "subject": "Acme Logistics: reporting friction",
+        "body": body or "<p>Teams evaluating HubSpot are reporting export friction.</p>",
+        "target_mode": "vendor_retention",
+        "channel": "email_cold",
+        "metadata": {
+            "target_id": target_id,
+            "source_opportunity": {
+                "target_id": target_id,
+            },
+        },
+    }
+
+
+def _args(**overrides):
+    values = {
+        "path": SUPPORT_TICKET_CSV,
+        "source_format": "csv",
+        "target_mode": "vendor_retention",
+        "channels": "email_cold",
+        "min_source_rows": 2,
+        "min_drafts": None,
+        "allow_ingestion_warnings": False,
+        "default_field": [],
+        "account_id": "acct-smoke",
+        "user_id": None,
+        "opportunity_table": "campaign_opportunities",
+        "keep_existing_opportunities": False,
+        "forbidden_phrase": list(smoke.DEFAULT_FORBIDDEN_PHRASES),
+        "output_result": None,
+        "json": False,
+        "database_url": "postgres://example",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_source_file_postgres_smoke_imports_and_persists(monkeypatch):
+    pool = _Pool(
+        saved_draft_rows=[
+            _saved_draft_row("ticket-acme-1"),
+            _saved_draft_row("ticket-northstar-1"),
+        ],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    async def fake_generate_imported_target_drafts(**kwargs):
+        assert kwargs["target_ids"] == ["ticket-acme-1", "ticket-northstar-1"]
+        return {
+            "requested": 2,
+            "generated": 2,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-ticket-acme-1", "campaign-ticket-northstar-1"],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_imported_target_drafts",
+        fake_generate_imported_target_drafts,
+    )
+
+    code, payload = await smoke.run_source_file_postgres_smoke(_args())
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source_rows"] == 2
+    assert payload["import"]["inserted"] == 2
+    assert payload["drafts"]["generated"] == 2
+    assert [row["target_id"] for row in payload["saved_drafts"]] == [
+        "ticket-acme-1",
+        "ticket-northstar-1",
+    ]
+    assert pool.closed is True
+    assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]
+    assert "INSERT INTO \"campaign_opportunities\"" in pool.execute_calls[1]["query"]
+
+
+@pytest.mark.asyncio
+async def test_source_file_postgres_smoke_fails_before_import_when_schema_missing(monkeypatch):
+    pool = _Pool(existing_relations={"b2b_campaigns"})
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_source_file_postgres_smoke(_args())
+
+    assert code == 1
+    assert any("required Content Ops table(s) missing" in error for error in payload["errors"])
+    assert any("campaign_opportunities" in error for error in payload["errors"])
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_source_file_postgres_smoke_fails_on_wrong_persisted_target(monkeypatch):
+    pool = _Pool(
+        saved_draft_rows=[_saved_draft_row("wrong-ticket"), _saved_draft_row("ticket-northstar-1")],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    async def fake_generate_imported_target_drafts(**_kwargs):
+        return {
+            "requested": 2,
+            "generated": 2,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-wrong-ticket", "campaign-ticket-northstar-1"],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_imported_target_drafts",
+        fake_generate_imported_target_drafts,
+    )
+
+    code, payload = await smoke.run_source_file_postgres_smoke(_args())
+
+    assert code == 1
+    assert any("persisted draft target_id was not imported" in error for error in payload["errors"])
+
+
+def test_default_database_url_falls_back_to_atlas_settings(monkeypatch):
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    fake_config = types.SimpleNamespace(
+        db_settings=types.SimpleNamespace(dsn="postgres://settings")
+    )
+    monkeypatch.setitem(sys.modules, "atlas_brain.storage.config", fake_config)
+
+    assert smoke._default_database_url() == "postgres://settings"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Source-File-Postgres-Smoke.md

Adds a generic source-row file Postgres smoke that defaults to the packaged support-ticket CSV. The command imports source rows into campaign_opportunities, runs offline deterministic draft generation through the Postgres runner, and verifies persisted draft target metadata.

## Intentional
- This is a source-file smoke, not a Zendesk/Intercom/Freshdesk connector.
- Generation stays deterministic/offline; no provider path is introduced.
- The script reuses content_ops_source_postgres_smoke_helpers.py instead of copying DB readiness and persisted-draft checks again.

## Deferred
- Live help desk API connectors remain future slices.
- Live DB execution is still operator-run only; CI uses fake pools.

## Verification
- pytest tests/test_smoke_content_ops_source_file_postgres.py -q -> 4 passed.
- python -m py_compile scripts/smoke_content_ops_source_file_postgres.py tests/test_smoke_content_ops_source_file_postgres.py -> passed.
- grep -nP '[^\\x00-\\x7F]' scripts/smoke_content_ops_source_file_postgres.py tests/test_smoke_content_ops_source_file_postgres.py -> no matches.\n- git diff --check -> passed.\n- bash scripts/local_pr_review.sh -> passed.\n- bash scripts/run_extracted_pipeline_checks.sh -> 1440 passed, 1 existing torch/pynvml warning.\n\n## Diff size\n7 files, +628 / -2