### PR TITLE
Add token-file support for draft-writer OAuth ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ backups/
 
 # Secret keys
 .webui_secret_key
+.secrets/
 
 # Development scripts and test files (root level)
 run_dev.sh

--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -126,6 +126,20 @@ ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=<long-random-token>
 ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT=<dedicated-port>
 ```
 
+For local operator runs, prefer storing the approval token in a private file
+instead of passing it directly on the command line:
+
+```bash
+mkdir -p .secrets
+chmod 700 .secrets
+python - <<'PY' > .secrets/invoicing-draft-writer-approval-token
+import secrets
+
+print(secrets.token_urlsafe(32))
+PY
+chmod 600 .secrets/invoicing-draft-writer-approval-token
+```
+
 The approval page copy must say draft-write access, not read-only access.
 
 The connector must not share the read-only approval token. Separate scopes and
@@ -136,8 +150,11 @@ separate approval tokens make accidental privilege expansion easier to detect.
 Start the draft-writer OAuth server through the operator launcher:
 
 ```bash
-.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py --dry-run
-.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --dry-run
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token
 ```
 
 The default public route is:
@@ -158,6 +175,7 @@ Then verify OAuth token exchange and the exact four-tool surface:
 
 ```bash
 .venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 ```

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -80,11 +80,22 @@ https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 Use the draft-writer launcher and smokes:
 
 ```bash
-.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py --dry-run
+mkdir -p .secrets
+chmod 700 .secrets
+python - <<'PY' > .secrets/invoicing-draft-writer-approval-token
+import secrets
+
+print(secrets.token_urlsafe(32))
+PY
+chmod 600 .secrets/invoicing-draft-writer-approval-token
+.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --dry-run
 .venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 .venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 ```

--- a/plans/PR-Invoicing-Draft-Writer-OAuth-Token-File.md
+++ b/plans/PR-Invoicing-Draft-Writer-OAuth-Token-File.md
@@ -1,0 +1,79 @@
+## Why this slice exists
+
+The draft-writer invoicing OAuth launcher merged with the correct fail-closed
+approval-token validation, but the first operator dry-run immediately fails on
+a fresh checkout unless the approval token is already exported in the shell.
+
+Passing the token as a raw CLI value would be convenient, but it would expose a
+write-approval secret through shell history and process listings. This slice
+adds a safer operator path: store the approval token in a local file and pass
+the file path to the launcher and e2e smoke.
+
+## Scope (this PR)
+
+1. Add `--approval-token-file` to the draft-writer OAuth server launcher.
+2. Add `--approval-token-file` to the draft-writer OAuth e2e smoke.
+3. Keep existing env-var behavior unchanged.
+4. Document a `0600` local-token-file setup flow and keep `.secrets/` ignored.
+5. Add tests that prove file tokens are loaded and never printed.
+
+### Files touched
+
+- `scripts/start_invoicing_draft_writer_oauth_server.py`
+- `scripts/check_invoicing_draft_writer_oauth_e2e.py`
+- `tests/test_start_invoicing_draft_writer_oauth_server.py`
+- `tests/test_check_invoicing_draft_writer_oauth_e2e.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `.gitignore`
+- `plans/PR-Invoicing-Draft-Writer-OAuth-Token-File.md`
+
+## Mechanism
+
+Both scripts accept an optional `--approval-token-file <path>`. If provided,
+the script reads the first non-empty file contents, strips surrounding
+whitespace, and uses that value as
+`ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN` for validation/runtime.
+
+The env-var path remains the default, so existing operator and CI flows keep
+working.
+
+## Intentional
+
+- There is no raw `--approval-token` flag on the server launcher. Avoiding
+  shell-history/process-list exposure for the long-running process is worth one
+  extra local file.
+- The e2e smoke keeps its existing raw `--approval-token` option for direct
+  test compatibility, but docs route operators through `--approval-token-file`.
+- The token-file path is explicit. The scripts do not auto-discover secret
+  files because silent secret selection is harder to audit.
+- The launcher still refuses short tokens. File-based loading changes only how
+  the token is supplied, not the security contract.
+
+## Deferred
+
+- Automatic token rotation is deferred until the connector is run as an
+  unattended service.
+- Persisted OAuth client/token storage remains deferred; the current flow is
+  still local operator approval.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile scripts/start_invoicing_draft_writer_oauth_server.py scripts/check_invoicing_draft_writer_oauth_e2e.py tests/test_start_invoicing_draft_writer_oauth_server.py tests/test_check_invoicing_draft_writer_oauth_e2e.py
+.venv/bin/pytest tests/test_start_invoicing_draft_writer_oauth_server.py tests/test_check_invoicing_draft_writer_oauth_e2e.py -q
+bash scripts/local_pr_review.sh --allow-dirty
+git diff --check
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Scripts | ~45 |
+| Tests | ~70 |
+| Docs/plan | ~90 |
+| Git ignore | ~1 |
+| **Total** | **~206** |

--- a/scripts/check_invoicing_draft_writer_oauth_e2e.py
+++ b/scripts/check_invoicing_draft_writer_oauth_e2e.py
@@ -16,6 +16,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 
@@ -104,6 +105,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Operator approval token. Defaults to ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN.",
     )
     parser.add_argument(
+        "--approval-token-file",
+        default="",
+        help=(
+            "Read the operator approval token from this local file. Prefer this over "
+            "passing write-approval secrets directly on the command line."
+        ),
+    )
+    parser.add_argument(
         "--redirect-uri",
         default=DEFAULT_REDIRECT_URI,
         help=f"OAuth redirect URI to register. Default: {DEFAULT_REDIRECT_URI}.",
@@ -126,10 +135,25 @@ def _strip_trailing_slash(url: str) -> str:
     return url.strip().rstrip("/")
 
 
+def _read_secret_file(path: str) -> str:
+    secret_path = Path(path)
+    try:
+        value = secret_path.read_text().strip()
+    except OSError as exc:
+        raise ValueError(f"could not read approval token file {secret_path}") from exc
+    if not value:
+        raise ValueError(f"approval token file {secret_path} is empty")
+    return value
+
+
 def _config_from_args(args: argparse.Namespace) -> OAuthE2EConfig:
     issuer_url = _strip_trailing_slash(args.issuer_url)
     resource_url = _strip_trailing_slash(args.resource_url)
-    approval_token = args.approval_token.strip()
+    approval_token = (
+        _read_secret_file(args.approval_token_file)
+        if args.approval_token_file
+        else args.approval_token.strip()
+    )
     redirect_uri = args.redirect_uri.strip()
     scope = args.scope.strip()
     missing: list[str] = []
@@ -138,7 +162,10 @@ def _config_from_args(args: argparse.Namespace) -> OAuthE2EConfig:
     if not resource_url:
         missing.append("--resource-url or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL")
     if not approval_token:
-        missing.append("--approval-token or ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN")
+        missing.append(
+            "--approval-token-file, --approval-token, or "
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"
+        )
     if not redirect_uri:
         missing.append("--redirect-uri")
     if not scope:

--- a/scripts/start_invoicing_draft_writer_oauth_server.py
+++ b/scripts/start_invoicing_draft_writer_oauth_server.py
@@ -77,6 +77,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help=f"OAuth resource URL. Defaults to env value or {DEFAULT_RESOURCE_URL}.",
     )
     parser.add_argument(
+        "--approval-token-file",
+        default=None,
+        help=(
+            "Read ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN from this local file. "
+            "Prefer this over putting write-approval secrets in shell history."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Validate and print the launch/smoke commands without starting the server.",
@@ -110,6 +118,17 @@ def _load_dotenv_files(paths: list[Path]) -> dict[str, str]:
             key, value = parsed
             values[key] = value
     return values
+
+
+def _read_secret_file(path: str) -> str:
+    secret_path = Path(path)
+    try:
+        value = secret_path.read_text().strip()
+    except OSError as exc:
+        raise ValueError(f"could not read approval token file {secret_path}") from exc
+    if not value:
+        raise ValueError(f"approval token file {secret_path} is empty")
+    return value
 
 
 def _masked_env_report(env: Mapping[str, str], keys: tuple[str, ...] = REQUIRED_KEYS) -> list[str]:
@@ -171,6 +190,10 @@ def _build_launch_config(args: argparse.Namespace) -> LaunchConfig:
         or env.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL")
         or DEFAULT_RESOURCE_URL
     ).strip()
+    if args.approval_token_file:
+        env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"] = _read_secret_file(
+            args.approval_token_file
+        )
     return LaunchConfig(
         env=env,
         python=args.python,
@@ -217,7 +240,11 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
 def _main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    config = _build_launch_config(args)
+    try:
+        config = _build_launch_config(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     errors = _validate_env(config.env)
     if errors:
         for error in errors:

--- a/tests/test_check_invoicing_draft_writer_oauth_e2e.py
+++ b/tests/test_check_invoicing_draft_writer_oauth_e2e.py
@@ -30,6 +30,7 @@ def _args(**overrides):
         "issuer_url": "https://atlas.example.com/invoicing-draft-writer",
         "resource_url": "https://atlas.example.com/invoicing-draft-writer/mcp",
         "approval_token": "approval-token-with-enough-entropy",
+        "approval_token_file": "",
         "redirect_uri": "https://chat.openai.com/aip/callback",
         "scope": "invoices.draft.write",
         "timeout": 10.0,
@@ -57,6 +58,35 @@ def test_config_from_args_requires_values() -> None:
     assert "--issuer-url" in message
     assert "--resource-url" in message
     assert "--approval-token" in message
+
+
+def test_config_from_args_reads_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "draft-writer-token"
+    token_file.write_text("approval-token-from-local-secret-file\n")
+
+    config = module._config_from_args(
+        _args(
+            approval_token="",
+            approval_token_file=str(token_file),
+        )
+    )
+
+    assert config.approval_token == "approval-token-from-local-secret-file"
+
+
+def test_config_from_args_rejects_empty_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "draft-writer-token"
+    token_file.write_text("\n")
+
+    try:
+        module._config_from_args(_args(approval_token_file=str(token_file)))
+    except ValueError as exc:
+        assert "is empty" in str(exc)
+        assert "draft-writer-token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
 
 
 def test_pkce_challenge_uses_s256_urlsafe_without_padding() -> None:

--- a/tests/test_start_invoicing_draft_writer_oauth_server.py
+++ b/tests/test_start_invoicing_draft_writer_oauth_server.py
@@ -30,6 +30,7 @@ def _args(**overrides):
         "port": None,
         "issuer_url": None,
         "resource_url": None,
+        "approval_token_file": None,
         "dry_run": False,
     }
     values.update(overrides)
@@ -135,6 +136,35 @@ def test_build_launch_config_process_env_overrides_env_file(tmp_path, monkeypatc
     assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"] == (
         "https://file.example.com/invoicing-draft-writer"
     )
+
+
+def test_build_launch_config_reads_approval_token_file(tmp_path, monkeypatch) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "draft-writer-token"
+    token_file.write_text("approval-token-from-local-secret-file\n")
+    monkeypatch.delenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", raising=False)
+
+    config = module._build_launch_config(
+        _args(env_file=[], approval_token_file=str(token_file))
+    )
+
+    assert config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN"] == (
+        "approval-token-from-local-secret-file"
+    )
+
+
+def test_build_launch_config_rejects_empty_approval_token_file(tmp_path) -> None:
+    module = _load_script_module()
+    token_file = tmp_path / "draft-writer-token"
+    token_file.write_text("\n")
+
+    try:
+        module._build_launch_config(_args(env_file=[], approval_token_file=str(token_file)))
+    except ValueError as exc:
+        assert "is empty" in str(exc)
+        assert "draft-writer-token" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
 
 
 def test_server_command_uses_current_config_python() -> None:


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-OAuth-Token-File.md

The draft-writer invoicing OAuth launcher correctly fails closed without an approval token, but the operator path was awkward on a fresh checkout. This adds `--approval-token-file` to the long-running launcher and e2e smoke so write-approval secrets can live in a private local file instead of shell history or process arguments.

## Intentional
- No raw `--approval-token` flag was added to the server launcher; the long-running process should use env or a local token file.
- The e2e smoke keeps its existing raw token option for direct test compatibility, but docs route operators through `--approval-token-file`.
- `.secrets/` is ignored so the documented local token file is not accidentally staged.

## Deferred
- Token rotation and durable OAuth persistence remain deferred until unattended service operation is needed.

## Verification
- `.venv/bin/python -m py_compile scripts/start_invoicing_draft_writer_oauth_server.py scripts/check_invoicing_draft_writer_oauth_e2e.py tests/test_start_invoicing_draft_writer_oauth_server.py tests/test_check_invoicing_draft_writer_oauth_e2e.py`
- `.venv/bin/pytest tests/test_start_invoicing_draft_writer_oauth_server.py tests/test_check_invoicing_draft_writer_oauth_e2e.py -q` -> 26 passed
- Temp token-file dry-run passed and masked the token value
- `bash scripts/local_pr_review.sh` passed
- `git diff --check` passed

## Diff size
8 files, +229 / -6