### PR TITLE
Print draft-writer OAuth Funnel route guidance

### DIFF
--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -157,6 +157,17 @@ Start the draft-writer OAuth server through the operator launcher:
   --approval-token-file .secrets/invoicing-draft-writer-approval-token
 ```
 
+The path-prefixed public URL requires both Funnel routes:
+
+```bash
+tailscale funnel --bg --yes \
+  --set-path /invoicing-draft-writer \
+  http://127.0.0.1:8066
+tailscale funnel --bg --yes \
+  --set-path /.well-known/oauth-protected-resource \
+  http://127.0.0.1:8066/.well-known/oauth-protected-resource
+```
+
 The default public route is:
 
 ```text

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -91,6 +91,12 @@ chmod 600 .secrets/invoicing-draft-writer-approval-token
 .venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py \
   --approval-token-file .secrets/invoicing-draft-writer-approval-token \
   --dry-run
+tailscale funnel --bg --yes \
+  --set-path /invoicing-draft-writer \
+  http://127.0.0.1:8066
+tailscale funnel --bg --yes \
+  --set-path /.well-known/oauth-protected-resource \
+  http://127.0.0.1:8066/.well-known/oauth-protected-resource
 .venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp

--- a/plans/PR-Invoicing-Draft-Writer-Funnel-Route-Guidance.md
+++ b/plans/PR-Invoicing-Draft-Writer-Funnel-Route-Guidance.md
@@ -1,0 +1,77 @@
+## Why this slice exists
+
+The localhost draft-writer OAuth smoke passes when served at the app root, but
+the public ChatGPT URL is path-prefixed:
+
+```text
+https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Tailscale Funnel needs two routes for that shape: the primary
+`/invoicing-draft-writer` route and the host-root protected-resource metadata
+route. The launcher currently prints only the metadata route, leaving the
+operator to infer the primary connector route.
+
+## Scope (this PR)
+
+1. Teach the draft-writer OAuth launcher to derive the public app path from
+   `resource_url`.
+2. Print the required primary Funnel route before the metadata route.
+3. Update rollout docs with the two-route setup.
+4. Add tests for path-prefixed and root-resource guidance.
+
+### Files touched
+
+- `scripts/start_invoicing_draft_writer_oauth_server.py`
+- `tests/test_start_invoicing_draft_writer_oauth_server.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-Draft-Writer-Funnel-Route-Guidance.md`
+
+## Mechanism
+
+The launcher parses the configured resource URL path. If it ends with `/mcp`,
+the launcher treats the parent path as the public app path. For the default
+resource URL, that produces `/invoicing-draft-writer` and prints:
+
+```bash
+tailscale funnel --bg --yes \
+  --set-path /invoicing-draft-writer \
+  http://127.0.0.1:<PORT>
+```
+
+It still prints the protected-resource metadata route separately because the
+MCP library advertises that metadata at host root.
+
+## Intentional
+
+- This does not change server routing. FastMCP still serves endpoints at app
+  root; Tailscale owns the public prefix.
+- Root-resource local smoke guidance remains valid. When the resource path is
+  just `/mcp`, the launcher prints a root Funnel command instead of a path
+  prefix.
+
+## Deferred
+
+- Dedicated hostname support remains deferred. Path-prefix routing is the
+  current operator model because it matches the read-only connector setup.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile scripts/start_invoicing_draft_writer_oauth_server.py tests/test_start_invoicing_draft_writer_oauth_server.py
+.venv/bin/pytest tests/test_start_invoicing_draft_writer_oauth_server.py -q
+bash scripts/local_pr_review.sh --allow-dirty
+git diff --check
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Launcher | ~35 |
+| Tests | ~30 |
+| Docs/plan | ~100 |
+| **Total** | **~165** |

--- a/scripts/start_invoicing_draft_writer_oauth_server.py
+++ b/scripts/start_invoicing_draft_writer_oauth_server.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 DEFAULT_HOST = "0.0.0.0"
@@ -212,14 +213,30 @@ def _server_command(config: LaunchConfig) -> list[str]:
     ]
 
 
+def _funnel_app_path(resource_url: str) -> str:
+    path = urlparse(resource_url.strip()).path.rstrip("/")
+    if path.endswith("/mcp"):
+        path = path[: -len("/mcp")]
+    return path or "/"
+
+
 def _print_operator_guidance(config: LaunchConfig) -> None:
     issuer_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"]
     resource_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL"]
+    app_path = _funnel_app_path(resource_url)
     print("Draft-writer invoicing OAuth launch configuration:")
     for line in _masked_env_report(config.env):
         print(f"- {line}")
     print(f"- ATLAS_MCP_HOST={config.host}")
     print(f"- ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT={config.port}")
+    print()
+    print("Required Funnel route for the draft-writer connector path:")
+    print("tailscale funnel --bg --yes \\")
+    if app_path == "/":
+        print(f"  http://127.0.0.1:{config.port}")
+    else:
+        print(f"  --set-path {app_path} \\")
+        print(f"  http://127.0.0.1:{config.port}")
     print()
     print("Required Funnel route for protected-resource metadata:")
     print("tailscale funnel --bg --yes \\")

--- a/tests/test_start_invoicing_draft_writer_oauth_server.py
+++ b/tests/test_start_invoicing_draft_writer_oauth_server.py
@@ -185,6 +185,15 @@ def test_server_command_uses_current_config_python() -> None:
     ]
 
 
+def test_funnel_app_path_derives_parent_path_for_mcp_resource() -> None:
+    module = _load_script_module()
+
+    assert module._funnel_app_path("https://atlas.example.com/invoicing-draft-writer/mcp") == (
+        "/invoicing-draft-writer"
+    )
+    assert module._funnel_app_path("http://127.0.0.1:8066/mcp") == "/"
+
+
 def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
     module = _load_script_module()
     env = _valid_env()
@@ -203,9 +212,31 @@ def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
     assert "SET len=34" in captured.out
     assert "approval-token-with-enough-entropy" not in captured.out
     assert "bearer-token-value-that-must-not-print" not in captured.out
+    assert "--set-path /invoicing-draft-writer" in captured.out
+    assert "http://127.0.0.1:9000" in captured.out
     assert "http://127.0.0.1:9000/.well-known/oauth-protected-resource" in captured.out
     assert "http://127.0.0.1:8065/.well-known/oauth-protected-resource" not in captured.out
     assert "check_invoicing_draft_writer_oauth_e2e.py" in captured.out
+
+
+def test_guidance_prints_root_funnel_route_for_root_resource(capsys) -> None:
+    module = _load_script_module()
+    env = _valid_env()
+    env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL"] = "http://127.0.0.1:8066/mcp"
+    config = module.LaunchConfig(
+        env=env,
+        python="/venv/bin/python",
+        host="127.0.0.1",
+        port="8066",
+        dry_run=True,
+    )
+
+    module._print_operator_guidance(config)
+
+    captured = capsys.readouterr()
+    assert "Required Funnel route for the draft-writer connector path:" in captured.out
+    assert "  http://127.0.0.1:8066\n" in captured.out
+    assert "--set-path /\n" not in captured.out
 
 
 def test_main_dry_run_does_not_start_subprocess(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-Funnel-Route-Guidance.md

The draft-writer OAuth server works locally at the app root, while the public ChatGPT connector URL is path-prefixed under `/invoicing-draft-writer`. Tailscale needs a primary connector route plus the host-root protected-resource metadata route; the launcher only printed the metadata route. This adds the missing guidance and pins it in tests.

## Intentional
- Server routing stays rooted in FastMCP; Tailscale owns the public path prefix.
- Root-resource localhost guidance remains valid for local smoke runs.

## Deferred
- Dedicated hostname support remains deferred; path-prefix routing matches the current read-only connector setup.

## Verification
- `.venv/bin/python -m py_compile scripts/start_invoicing_draft_writer_oauth_server.py tests/test_start_invoicing_draft_writer_oauth_server.py`
- `.venv/bin/pytest tests/test_start_invoicing_draft_writer_oauth_server.py -q` -> 14 passed
- Temp token-file dry-run prints both Funnel routes
- Localhost root OAuth discovery/e2e smoke passed against `http://127.0.0.1:8066/mcp` before this docs/guidance fix
- `bash scripts/local_pr_review.sh` passed
- `git diff --check` passed

## Diff size
5 files, +142 / -0