### PR TITLE
Plan: PR-Content-Ops-Helpdesk-Source-Aliases

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T04:11Z by codex-2026-05-18
+Last updated: 2026-05-19T04:25Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Source-File-Postgres-Smoke | `scripts/smoke_content_ops_source_file_postgres.py`, `scripts/run_extracted_pipeline_checks.sh`, `tests/test_smoke_content_ops_source_file_postgres.py`, `extracted_content_pipeline/README.md`, `extracted_content_pipeline/docs/host_install_runbook.md`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Source-File-Postgres-Smoke.md` | codex-2026-05-18 | Content Ops source-file Postgres smoke |
+| TBD | PR-Content-Ops-Helpdesk-Source-Aliases | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Helpdesk-Source-Aliases.md` | codex-2026-05-18 | Content Ops source adapter help desk aliases |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -72,8 +72,12 @@ _SOURCE_ID_KEYS = (
     "subscription_id",
     "document_id",
     "ticket_id",
+    "ticket_number",
     "case_id",
+    "case_number",
     "conversation_id",
+    "conversation_number",
+    "request_id",
     "survey_id",
     "response_id",
     "feedback_id",
@@ -88,12 +92,17 @@ _TEXT_KEYS = (
     "complaint",
     "message",
     "description",
+    "issue_description",
     "summary",
     "notes",
     "feedback",
     "feedback_text",
     "response_text",
     "comment_text",
+    "latest_comment",
+    "initial_message",
+    "requester_message",
+    "customer_message",
     "open_ended_response",
 )
 _THREAD_KEYS = (
@@ -121,14 +130,37 @@ _THREAD_TEXT_KEYS = (
 )
 _THREAD_SPEAKER_KEYS = ("speaker", "author", "role", "name")
 _SOURCE_TYPE_KEYS = ("source_type", "type", "kind")
-_SOURCE_TITLE_KEYS = ("source_title", "ticket_subject", "subject", "title", "name")
-_SOURCE_TITLE_COLLISION_KEYS = ("subject", "ticket_subject", "title", "name")
+_SOURCE_TITLE_KEYS = (
+    "source_title",
+    "ticket_subject",
+    "ticket_title",
+    "case_subject",
+    "case_title",
+    "subject",
+    "title",
+    "name",
+)
+_SOURCE_TITLE_COLLISION_KEYS = (
+    "subject",
+    "ticket_subject",
+    "ticket_title",
+    "case_subject",
+    "case_title",
+    "title",
+    "name",
+)
 _PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
 _PARENT_EXCLUDE_KEYS = set(_ROW_LIST_KEYS) | set(_SOURCE_TITLE_COLLISION_KEYS)
 _COMPANY_KEYS = (
     "company_name",
     "company",
+    "account",
     "account_name",
+    "organization",
+    "organization_name",
+    "requester_company",
+    "requester_organization",
+    "customer_company",
     "reviewer_company",
     "customer_name",
 )
@@ -139,9 +171,31 @@ _VENDOR_KEYS = (
     "current_vendor",
     "product_name",
 )
-_CONTACT_NAME_KEYS = ("contact_name", "recipient_name", "person_name")
-_CONTACT_EMAIL_KEYS = ("contact_email", "recipient_email", "email")
-_CONTACT_TITLE_KEYS = ("contact_title", "recipient_title", "job_title")
+_CONTACT_NAME_KEYS = (
+    "contact_name",
+    "recipient_name",
+    "person_name",
+    "requester_name",
+    "requester",
+    "customer_contact_name",
+    "user_name",
+)
+_CONTACT_EMAIL_KEYS = (
+    "contact_email",
+    "recipient_email",
+    "email",
+    "requester_email",
+    "customer_email",
+    "user_email",
+)
+_CONTACT_TITLE_KEYS = (
+    "contact_title",
+    "recipient_title",
+    "job_title",
+    "requester_title",
+    "customer_title",
+    "user_title",
+)
 _NPS_SCORE_KEYS = ("nps_score", "nps")
 _CSAT_SCORE_KEYS = ("csat_score", "csat")
 _CANONICAL_TEXT_ALIAS_KEYS = (
@@ -169,9 +223,9 @@ _SOURCE_TYPE_PRECEDENCE = (
     (("contract_id",), "contract"),
     (("subscription_id",), "subscription"),
     (("complaint",), "complaint"),
-    (("ticket_id",), "support_ticket"),
-    (("case_id",), "case"),
-    (("conversation_id",), "conversation"),
+    (("ticket_id", "ticket_number", "request_id"), "support_ticket"),
+    (("case_id", "case_number"), "case"),
+    (("conversation_id", "conversation_number"), "conversation"),
     (("nps_score", "nps"), "nps_response"),
     (("csat_score", "csat"), "csat_response"),
     (("survey_id", "response_id"), "survey_response"),
@@ -410,7 +464,8 @@ def source_row_to_campaign_opportunity(
     opportunity = {
         str(key): value
         for key, value in row.items()
-        if value not in (None, "", [], {}) and key not in _SOURCE_TITLE_COLLISION_KEYS
+        if value not in (None, "", [], {})
+        and not _is_source_title_collision_key(str(key))
     }
     _copy_alias_text(opportunity, lookup, "company_name", _COMPANY_KEYS)
     _copy_alias_text(opportunity, lookup, "vendor_name", _VENDOR_KEYS)
@@ -690,6 +745,18 @@ def _copy_alias_value(
         if value not in (None, "", [], {}):
             opportunity[canonical_key] = value
             return
+
+
+def _is_source_title_collision_key(key: str) -> bool:
+    normalized_key = _normalized_field_key(key)
+    compact_key = _compact_field_key(key)
+    for alias in _SOURCE_TITLE_COLLISION_KEYS:
+        if (
+            _normalized_field_key(alias) == normalized_key
+            or _compact_field_key(alias) == compact_key
+        ):
+            return True
+    return False
 
 
 def _field_value(row: Mapping[str, Any], key: str) -> Any:

--- a/plans/PR-Content-Ops-Helpdesk-Source-Aliases.md
+++ b/plans/PR-Content-Ops-Helpdesk-Source-Aliases.md
@@ -1,0 +1,61 @@
+# PR-Content-Ops-Helpdesk-Source-Aliases
+
+## Why this slice exists
+
+The Content Ops ingestion path now accepts source-row JSON/JSONL/CSV and ships packaged support-ticket examples, but common help desk exports still require hosts to rename fields before import. This slice closes that friction by teaching the existing source adapter a small set of provider-style support aliases while preserving the current opportunity contract.
+
+## Scope (this PR)
+
+1. Extend the existing source-row alias tables for common help desk fields.
+2. Preserve the existing normalized-key lookup and source-row conversion flow.
+3. Add focused regression tests for help desk CSV-style field names.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Helpdesk-Source-Aliases.md`
+
+## Mechanism
+
+The adapter already normalizes source field labels by snake-case and compact comparisons. This PR adds aliases to the existing tuples rather than adding a new parser:
+
+- ticket/case/conversation number aliases map to source ids and source-type precedence.
+- requester/customer/user aliases map to contact fields.
+- organization/account aliases map to company fields.
+- issue/latest-comment/customer-message aliases map to evidence text.
+- ticket/case title aliases map to source title and are stripped from buyer/contact fields like existing `subject` and `title`.
+
+## Intentional
+
+- No new ingestion command. The existing file loader and Postgres smoke keep using the same adapter.
+- No provider-specific dependency or schema module. These are generic help desk export aliases.
+- No changes to function signatures or output shape.
+
+## Deferred
+
+- Provider-specific mappings for tools like Zendesk, Intercom, Salesforce Service Cloud, or Freshdesk can land later if real exports need fields beyond this generic set.
+- Multi-message support transcripts still use the existing `comments` / `messages` thread path.
+
+## Verification
+
+- Focused source-adapter pytest suite - 60 passed.
+- Source adapter and test py_compile - passed.
+- git diff whitespace check - passed.
+- Extracted content pipeline manifest validation - passed.
+- Extracted content pipeline Atlas reasoning import guard - passed.
+- Extracted standalone audit - passed.
+- Extracted content pipeline ASCII check - passed.
+- Local PR review - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Source adapter aliases | ~85 |
+| Tests | ~72 |
+| Plan + coordination | ~58 |
+| **Total** | **~215** |
+
+This is below the 400 LOC review budget.

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -46,9 +46,9 @@ def test_source_type_precedence_table_matches_current_contract() -> None:
         (("contract_id",), "contract"),
         (("subscription_id",), "subscription"),
         (("complaint",), "complaint"),
-        (("ticket_id",), "support_ticket"),
-        (("case_id",), "case"),
-        (("conversation_id",), "conversation"),
+        (("ticket_id", "ticket_number", "request_id"), "support_ticket"),
+        (("case_id", "case_number"), "case"),
+        (("conversation_id", "conversation_number"), "conversation"),
         (("nps_score", "nps"), "nps_response"),
         (("csat_score", "csat"), "csat_response"),
         (("survey_id", "response_id"), "survey_response"),
@@ -310,6 +310,72 @@ def test_source_row_accepts_provider_style_ticket_field_labels() -> None:
         "source_id": "ticket-1",
         "source_type": "support_ticket",
         "source_title": "Renewal pricing escalation",
+    }]
+
+
+def test_source_row_accepts_common_helpdesk_ticket_aliases() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "Ticket Number": "ZD-1001",
+        "Organization Name": "Acme Logistics",
+        "Vendor Name": "Zendesk",
+        "Requester Email": "ops@example.com",
+        "Requester Name": "Jordan Lee",
+        "Requester Title": "VP Revenue Operations",
+        "Ticket Title": "Attribution export blocked",
+        "Issue Description": (
+            "The support team cannot export campaign attribution data before renewal."
+        ),
+        "Pain Category": "reporting limits",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "ZD-1001"
+    assert opportunity["source_type"] == "support_ticket"
+    assert opportunity["company_name"] == "Acme Logistics"
+    assert opportunity["vendor_name"] == "Zendesk"
+    assert opportunity["contact_email"] == "ops@example.com"
+    assert opportunity["contact_name"] == "Jordan Lee"
+    assert opportunity["contact_title"] == "VP Revenue Operations"
+    assert opportunity["source_title"] == "Attribution export blocked"
+    assert "Ticket Title" not in opportunity
+    assert opportunity["pain_points"] == ["reporting limits"]
+    assert opportunity["evidence"] == [{
+        "text": (
+            "The support team cannot export campaign attribution data before renewal."
+        ),
+        "source_id": "ZD-1001",
+        "source_type": "support_ticket",
+        "source_title": "Attribution export blocked",
+    }]
+
+
+def test_source_row_accepts_case_aliases_and_latest_comment_text() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "Case Number": "CASE-42",
+        "Customer Company": "Northstar Finance",
+        "Customer Email": "admin@northstar.example",
+        "Customer Contact Name": "Maya Chen",
+        "Customer Title": "Director of Support",
+        "Current Vendor": "Intercom",
+        "Case Subject": "SLA export delays",
+        "Latest Comment": "The team cannot prove SLA history before renewal.",
+    })
+
+    assert warnings == ()
+    assert opportunity["target_id"] == "CASE-42"
+    assert opportunity["source_type"] == "case"
+    assert opportunity["company_name"] == "Northstar Finance"
+    assert opportunity["vendor_name"] == "Intercom"
+    assert opportunity["contact_email"] == "admin@northstar.example"
+    assert opportunity["contact_name"] == "Maya Chen"
+    assert opportunity["contact_title"] == "Director of Support"
+    assert opportunity["source_title"] == "SLA export delays"
+    assert "Case Subject" not in opportunity
+    assert opportunity["evidence"] == [{
+        "text": "The team cannot prove SLA history before renewal.",
+        "source_id": "CASE-42",
+        "source_type": "case",
+        "source_title": "SLA export delays",
     }]
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Helpdesk-Source-Aliases.md

Adds common help desk export aliases to the existing Content Ops source adapter so host CSV/JSON rows can use fields like Ticket Number, Organization Name, Requester Email, Issue Description, Case Subject, and Latest Comment without pre-renaming before ingestion.

## Intentional
- Extends the existing normalized alias tables instead of adding a provider-specific parser.
- Preserves source-row function signatures and normalized opportunity output.
- Keeps provider-specific Zendesk/Intercom/Freshdesk connector work deferred.

## Deferred
- Provider-specific mappings for real exports that need fields beyond this generic set.
- Multi-message support transcripts continue through the existing comments/messages thread path.

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py -q -> 60 passed
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_campaign_source_adapters.py -> passed
- git diff --check -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
4 files, +208 / -14