### PR TITLE
Plan: PR-Content-Ops-Ingestion-Default-Fields-UI

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -114,6 +114,7 @@ export interface ContentOpsIngestionInspectRequest {
   target_mode?: string | null                       // default "vendor_retention"
   max_source_text_chars?: number                    // 1..10000
   sample_limit?: number                             // 0..25
+  default_fields?: Record<string, unknown>
 }
 
 export interface ContentOpsIngestionImportRequest

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -183,6 +183,7 @@ export function toWireIngestionInspectRequest(
     target_mode: domain.targetMode,
     max_source_text_chars: domain.maxSourceTextChars,
     sample_limit: domain.sampleLimit,
+    default_fields: { ...domain.defaultFields },
   }
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -95,6 +95,7 @@ export interface ContentOpsIngestionInspectRequest {
   targetMode: string | null
   maxSourceTextChars: number
   sampleLimit: number
+  defaultFields: Record<string, unknown>
 }
 
 export interface ContentOpsIngestionImportRequest

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -88,6 +88,7 @@ type IngestionFileLoadState =
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_ROWS_JSON = '[\n  \n]'
+const DEFAULT_INGESTION_DEFAULT_FIELDS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_SOURCE = 'manual'
 const INGESTION_SAMPLE_LIMIT = 5
 const INGESTION_MAX_SOURCE_TEXT_CHARS = 1200
@@ -117,6 +118,8 @@ export default function ContentOpsNewRun() {
   const [ingestionRowsJson, setIngestionRowsJson] = useState<string>(
     DEFAULT_INGESTION_ROWS_JSON,
   )
+  const [ingestionDefaultFieldsJson, setIngestionDefaultFieldsJson] =
+    useState<string>(DEFAULT_INGESTION_DEFAULT_FIELDS_JSON)
   const [ingestionSourceRows, setIngestionSourceRows] = useState(false)
   const [ingestionSource, setIngestionSource] = useState(DEFAULT_INGESTION_SOURCE)
   const [ingestionDryRun, setIngestionDryRun] = useState(true)
@@ -365,6 +368,16 @@ export default function ContentOpsNewRun() {
       })
       return
     }
+    const parsedDefaultFields = parseIngestionDefaultFieldsJson(
+      ingestionDefaultFieldsJson,
+    )
+    if (!parsedDefaultFields.ok) {
+      setIngestionInspectState({
+        kind: 'invalid_input',
+        message: parsedDefaultFields.message,
+      })
+      return
+    }
 
     setIngestionInspectState({ kind: 'submitting' })
     try {
@@ -376,6 +389,7 @@ export default function ContentOpsNewRun() {
           targetMode: request.targetMode,
           maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
           sampleLimit: INGESTION_SAMPLE_LIMIT,
+          defaultFields: parsedDefaultFields.fields,
         }),
       )
       if (requestId !== ingestionInspectRequestIdRef.current) return
@@ -403,6 +417,16 @@ export default function ContentOpsNewRun() {
       })
       return
     }
+    const parsedDefaultFields = parseIngestionDefaultFieldsJson(
+      ingestionDefaultFieldsJson,
+    )
+    if (!parsedDefaultFields.ok) {
+      setIngestionImportState({
+        kind: 'invalid_input',
+        message: parsedDefaultFields.message,
+      })
+      return
+    }
 
     setIngestionImportState({ kind: 'submitting' })
     try {
@@ -414,6 +438,7 @@ export default function ContentOpsNewRun() {
           targetMode: request.targetMode,
           maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
           sampleLimit: INGESTION_SAMPLE_LIMIT,
+          defaultFields: parsedDefaultFields.fields,
           replaceExisting: ingestionReplaceExisting,
           dryRun: ingestionDryRun,
         }),
@@ -766,6 +791,20 @@ export default function ContentOpsNewRun() {
               <span className="text-slate-300">Replace existing targets</span>
             </label>
           </div>
+          <label className="mb-3 block text-sm">
+            <span className="text-slate-300">Fallback fields JSON</span>
+            <textarea
+              value={ingestionDefaultFieldsJson}
+              onChange={(e) => {
+                setIngestionDefaultFieldsJson(e.target.value)
+                markIngestionStale()
+              }}
+              rows={3}
+              spellCheck={false}
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs text-slate-200 focus:border-cyan-500 focus:outline-none"
+              placeholder='{"company_name": "Acme", "contact_email": "ops@example.com"}'
+            />
+          </label>
           <textarea
             value={ingestionRowsJson}
             onChange={(e) => {
@@ -1245,6 +1284,10 @@ type ParsedIngestionRows =
   | { ok: true; rows: Array<Record<string, unknown>> }
   | { ok: false; message: string }
 
+type ParsedIngestionDefaultFields =
+  | { ok: true; fields: Record<string, unknown> }
+  | { ok: false; message: string }
+
 function parseIngestionRowsJson(value: string): ParsedIngestionRows {
   let parsed: unknown
   try {
@@ -1262,6 +1305,24 @@ function parseIngestionRowsJson(value: string): ParsedIngestionRows {
     return { ok: false, message: 'Provide at least one row to inspect.' }
   }
   return rows
+}
+
+function parseIngestionDefaultFieldsJson(
+  value: string,
+): ParsedIngestionDefaultFields {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value.trim() || '{}')
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+    }
+  }
+  if (!isRecord(parsed)) {
+    return { ok: false, message: 'Fallback fields must be a JSON object.' }
+  }
+  return { ok: true, fields: { ...parsed } }
 }
 
 function parseIngestionFileRows(

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T04:25Z by codex-2026-05-18
+Last updated: 2026-05-19T04:45Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Helpdesk-Source-Aliases | `extracted_content_pipeline/campaign_source_adapters.py`, `tests/test_extracted_campaign_source_adapters.py`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Helpdesk-Source-Aliases.md` | codex-2026-05-18 | Content Ops source adapter help desk aliases |
+| TBD | PR-Content-Ops-Ingestion-Default-Fields-UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md` | codex-2026-05-18 | Content Ops ingestion default fields UI |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md
+++ b/plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md
@@ -1,0 +1,54 @@
+# PR-Content-Ops-Ingestion-Default-Fields-UI
+
+## Why this slice exists
+
+The hosted Content Ops ingestion API already supports `default_fields` for source-row imports, but the Atlas Intel New Run screen cannot send them. Operators loading real review, ticket, or transcript exports still have to edit source files to bind fallback account, vendor, or contact metadata. This slice exposes the existing backend contract in the UI without changing ingestion semantics.
+
+## Scope (this PR)
+
+1. Add `defaultFields` to the Atlas Intel Content Ops ingestion domain request types.
+2. Serialize that field as backend `default_fields` for inspect and import requests.
+3. Add a small default-fields JSON input to the New Run ingestion panel.
+4. Parse and validate the JSON input before inspect/import.
+
+### Files touched
+
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md`
+
+## Mechanism
+
+`ContentOpsNewRun` keeps a JSON draft string for fallback fields. Inspect and import parse that draft into an object and pass it through `toWireIngestionInspectRequest`, which now emits `default_fields`. Empty input stays `{}`. Invalid JSON or non-object values fail client-side before a request is sent.
+
+## Intentional
+
+- No backend changes: the FastAPI route and source adapter already support this contract.
+- No CSV-specific UI path: file loading still normalizes JSON/JSONL/CSV rows into the same rows textarea.
+- No provider-specific presets in this slice. Operators can paste the fallback fields they need.
+
+## Deferred
+
+- A richer key/value editor can replace the JSON input if repeated operator usage justifies it.
+- Source-specific saved presets remain separate from this generic fallback field surface.
+
+## Verification
+
+- `npm ci` in `atlas-intel-ui` - passed; npm reported 6 existing audit findings.
+- `npm run build` in `atlas-intel-ui` - passed.
+- `git diff --check` - passed.
+- Local PR review - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| UI domain/wire types | ~15 |
+| New Run panel parsing + input | ~80 |
+| Plan + coordination | ~60 |
+| **Total** | **~155** |
+
+This is below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md

Exposes the existing Content Ops ingestion default_fields backend contract in the Atlas Intel New Run screen, so operators can bind fallback account/contact/vendor metadata for source-row imports without editing every loaded export row.

## Intentional
- Reuses the existing backend default_fields contract; no backend behavior changes.
- Keeps the first UI as a compact JSON draft instead of a heavier key/value editor.
- Leaves saved source-specific presets for a later UX slice.

## Deferred
- Key/value editor for fallback fields if repeated operator usage justifies it.
- Source-specific saved presets.

## Verification
- npm ci in atlas-intel-ui -> passed; npm reported 6 existing audit findings
- npm run build in atlas-intel-ui -> passed
- git diff --check -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
6 files, +120 / -2