### PR TITLE
Affiliate hardening: placeholder guard + strip CRM-roundup mismatch

### DIFF
--- a/atlas-churn-ui/src/content/blog/top-complaint-every-crm-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-crm-2026-04.ts
@@ -71,12 +71,6 @@ const post: BlogPost = {
   }
 ],
   data_context: {
-  "affiliate_url": "https://hubspot.com/?ref=atlas",
-  "affiliate_partner": {
-    "name": "HubSpot Partner",
-    "product_name": "HubSpot",
-    "slug": "hubspot"
-  },
   "booking_url": "https://churnsignals.co"
 },
   seo_title: 'Top CRM Complaints 2026: 8 Vendors, 1202 Reviews Analyzed',

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -6508,6 +6508,42 @@ async def _fetch_affiliate_partner_by_category(pool, category: str) -> dict[str,
     return None
 
 
+# Defense-in-depth against placeholder/test rows reaching production.
+# Triggered after one such row ("Atlas Live Test Partner" with
+# affiliate_url=https://example.com/atlas-live-test-partner) lived in the
+# live affiliate_partners table for ~8 weeks and re-injected itself into
+# every category='B2B Software' post until manual cleanup. The DB row was
+# deleted, but a generator-side guard prevents recurrence if anyone
+# recreates a placeholder row by mistake.
+_PLACEHOLDER_PARTNER_URL_RE = re.compile(
+    r"(?:^|//)example\.com|test[-_]?partner|placeholder",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_PARTNER_NAME_RE = re.compile(
+    r"\btest\b|placeholder",
+    re.IGNORECASE,
+)
+
+
+def _is_placeholder_partner(partner: dict[str, Any]) -> bool:
+    """True if the partner row looks like test or placeholder data.
+
+    Checks affiliate_url for ``example.com`` / ``test-partner`` /
+    ``placeholder``, and name / product_name for whole-word ``test`` or
+    ``placeholder``. Partners flagged here are refused by the matcher.
+    """
+    url = partner.get("affiliate_url") or ""
+    name = partner.get("name") or ""
+    product = partner.get("product_name") or ""
+    if _PLACEHOLDER_PARTNER_URL_RE.search(str(url)):
+        return True
+    if _PLACEHOLDER_PARTNER_NAME_RE.search(str(name)):
+        return True
+    if _PLACEHOLDER_PARTNER_NAME_RE.search(str(product)):
+        return True
+    return False
+
+
 def _pick_affiliate_partner_for_vendors(
     partners: list[dict[str, Any]],
     vendor_names: list[str],
@@ -6521,10 +6557,16 @@ def _pick_affiliate_partner_for_vendors(
     matching handles cases like vendor "monday" matching alias "monday CRM"
     and vendor "Monday.com" matching product_name "Monday.com".
 
+    Partners that look like placeholder/test data are filtered out before
+    matching, so even if a placeholder row is present in the DB it won't
+    be injected -- see ``_is_placeholder_partner``.
+
     Iteration order matters: vendors are tried in priority order
     (the caller decides), and within each vendor partners are tried in
     the order supplied. Returns None if no partner matches any vendor.
     """
+    # Defense-in-depth: drop placeholder rows before matching.
+    partners = [p for p in partners if not _is_placeholder_partner(p)]
     for vendor in vendor_names:
         vendor_lower = (vendor or "").strip().lower()
         if not vendor_lower:

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -6508,6 +6508,42 @@ async def _fetch_affiliate_partner_by_category(pool, category: str) -> dict[str,
     return None
 
 
+# Defense-in-depth against placeholder/test rows reaching production.
+# Triggered after one such row ("Atlas Live Test Partner" with
+# affiliate_url=https://example.com/atlas-live-test-partner) lived in the
+# live affiliate_partners table for ~8 weeks and re-injected itself into
+# every category='B2B Software' post until manual cleanup. The DB row was
+# deleted, but a generator-side guard prevents recurrence if anyone
+# recreates a placeholder row by mistake.
+_PLACEHOLDER_PARTNER_URL_RE = re.compile(
+    r"(?:^|//)example\.com|test[-_]?partner|placeholder",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_PARTNER_NAME_RE = re.compile(
+    r"\btest\b|placeholder",
+    re.IGNORECASE,
+)
+
+
+def _is_placeholder_partner(partner: dict[str, Any]) -> bool:
+    """True if the partner row looks like test or placeholder data.
+
+    Checks affiliate_url for ``example.com`` / ``test-partner`` /
+    ``placeholder``, and name / product_name for whole-word ``test`` or
+    ``placeholder``. Partners flagged here are refused by the matcher.
+    """
+    url = partner.get("affiliate_url") or ""
+    name = partner.get("name") or ""
+    product = partner.get("product_name") or ""
+    if _PLACEHOLDER_PARTNER_URL_RE.search(str(url)):
+        return True
+    if _PLACEHOLDER_PARTNER_NAME_RE.search(str(name)):
+        return True
+    if _PLACEHOLDER_PARTNER_NAME_RE.search(str(product)):
+        return True
+    return False
+
+
 def _pick_affiliate_partner_for_vendors(
     partners: list[dict[str, Any]],
     vendor_names: list[str],
@@ -6521,10 +6557,16 @@ def _pick_affiliate_partner_for_vendors(
     matching handles cases like vendor "monday" matching alias "monday CRM"
     and vendor "Monday.com" matching product_name "Monday.com".
 
+    Partners that look like placeholder/test data are filtered out before
+    matching, so even if a placeholder row is present in the DB it won't
+    be injected -- see ``_is_placeholder_partner``.
+
     Iteration order matters: vendors are tried in priority order
     (the caller decides), and within each vendor partners are tried in
     the order supplied. Returns None if no partner matches any vendor.
     """
+    # Defense-in-depth: drop placeholder rows before matching.
+    partners = [p for p in partners if not _is_placeholder_partner(p)]
     for vendor in vendor_names:
         vendor_lower = (vendor or "").strip().lower()
         if not vendor_lower:

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -34,6 +34,7 @@ from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (  # noqa: E40
     _blueprint_pain_point_roundup,
     _blueprint_pricing_reality_check,
     _blueprint_vendor_showdown,
+    _is_placeholder_partner,
     _pick_affiliate_partner_for_vendors,
     _quote_grade_blueprint_phrases,
     _remove_unmatched_quote_lines,
@@ -445,13 +446,18 @@ def _partner(
     aliases: list[str] | None = None,
     category: str = "CRM",
     enabled: bool = True,
+    affiliate_url: str | None = None,
 ) -> dict[str, Any]:
+    # Note: do NOT use example.com here -- _is_placeholder_partner flags
+    # that domain as a placeholder signal. Use the product slug as a
+    # plausible-looking real referrer URL.
+    slug = product_name.lower().replace(' ', '-').replace('.', '-')
     return {
         "id": f"00000000-0000-0000-0000-{abs(hash(name)) % 10**12:012x}",
         "name": name,
         "product_name": product_name,
         "product_aliases": aliases or [],
-        "affiliate_url": f"https://example.com/{product_name.lower().replace(' ', '-')}",
+        "affiliate_url": affiliate_url or f"https://{slug}.test-affiliates.io/ref=atlas",
         "category": category,
         "enabled": enabled,
     }
@@ -582,6 +588,100 @@ def test_vendor_matcher_handles_none_aliases():
     partner["product_aliases"] = None
     out = _pick_affiliate_partner_for_vendors([partner], ["HubSpot"])
     assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Placeholder-partner defense-in-depth
+#
+# Triggered by the "Atlas Live Test Partner" incident: a test row with
+# affiliate_url=https://example.com/atlas-live-test-partner lived in the
+# live affiliate_partners table for ~8 weeks and re-injected itself into
+# every category='B2B Software' post until manual cleanup. The DB row was
+# deleted, but the matcher should also refuse such rows defensively.
+# ---------------------------------------------------------------------------
+
+
+def test_is_placeholder_partner_flags_example_com_url():
+    """The exact pattern from the production incident."""
+    partner = _partner(
+        "Atlas Live Test Partner",
+        "Atlas B2B Software Partner",
+    )
+    partner["affiliate_url"] = "https://example.com/atlas-live-test-partner"
+    assert _is_placeholder_partner(partner) is True
+
+
+def test_is_placeholder_partner_flags_test_in_name():
+    partner = _partner("Test Vendor", "Real Product")
+    assert _is_placeholder_partner(partner) is True
+
+
+def test_is_placeholder_partner_flags_test_in_product_name():
+    partner = _partner("Real Vendor", "Test Product")
+    assert _is_placeholder_partner(partner) is True
+
+
+def test_is_placeholder_partner_flags_placeholder_in_name():
+    partner = _partner("Placeholder Partner", "RealProduct")
+    assert _is_placeholder_partner(partner) is True
+
+
+def test_is_placeholder_partner_flags_test_partner_in_url():
+    partner = _partner("Some Name", "SomeProduct")
+    partner["affiliate_url"] = "https://realdomain.com/test-partner-ref"
+    assert _is_placeholder_partner(partner) is True
+
+
+def test_is_placeholder_partner_does_not_flag_real_data():
+    """Real partner rows should pass through cleanly."""
+    real_partners = [
+        _partner("HubSpot Partner", "HubSpot"),
+        _partner("Pipedrive Partner", "Pipedrive"),
+        _partner("Monday.com", "Monday.com", aliases=["monday CRM"]),
+        _partner("Amazon Associates", "Amazon"),
+        _partner("Shopify Affiliates", "Shopify"),
+        _partner("HelpDesk", "HelpDesk"),
+    ]
+    for p in real_partners:
+        assert _is_placeholder_partner(p) is False, (
+            f"Real partner {p['name']!r} should not be flagged as placeholder"
+        )
+
+
+def test_is_placeholder_partner_handles_attest_substring():
+    """`\\btest\\b` is whole-word, so partner names like 'Attestation
+    Service' should NOT flag (substring 'test' inside 'Attestation')."""
+    partner = _partner("Attestation Service", "Attest")
+    assert _is_placeholder_partner(partner) is False
+
+
+def test_vendor_matcher_drops_placeholder_partner_even_if_vendor_matches():
+    """If a placeholder row sneaks into the DB and somehow shares a vendor
+    name with the post, the matcher still refuses to inject it. This is
+    the integration test for the defensive filter inside
+    _pick_affiliate_partner_for_vendors.
+    """
+    placeholder = _partner(
+        "Atlas Live Test Partner",
+        "Atlas B2B Software Partner",
+    )
+    placeholder["affiliate_url"] = "https://example.com/atlas-live-test-partner"
+    # Pretend the post's vendor matches the placeholder's product_name.
+    out = _pick_affiliate_partner_for_vendors(
+        [placeholder],
+        ["Atlas B2B Software Partner"],
+    )
+    assert out is None
+
+
+def test_vendor_matcher_prefers_real_partner_over_placeholder():
+    """When both a placeholder AND a real partner could match, the
+    placeholder is filtered out and the real partner is returned."""
+    placeholder = _partner("Test HubSpot", "HubSpot")
+    real = _partner("HubSpot Partner", "HubSpot")
+    out = _pick_affiliate_partner_for_vendors([placeholder, real], ["HubSpot"])
+    assert out is not None
+    assert out["name"] == "HubSpot Partner"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two related follow-ups to PR #617 (merged as 7dcf9626):

## 1. Placeholder-partner guard in the generator

Adds \`_is_placeholder_partner\` helper + filter inside \`_pick_affiliate_partner_for_vendors\` that drops any partner row whose:
- \`affiliate_url\` contains \`example.com\` / \`test-partner\` / \`placeholder\`
- \`name\` or \`product_name\` contains whole-word \`test\` or \`placeholder\`

Defense-in-depth against the failure mode that triggered #617: the "Atlas Live Test Partner" row lived in the live \`affiliate_partners\` table for ~8 weeks and re-injected itself into every \`category='B2B Software'\` post until manual cleanup. The DB row was deleted, but the matcher now refuses such rows defensively. If someone recreates a placeholder row by mistake (or a test row leaks from a fixture into prod), the generator won't ship the broken state.

**9 new tests** covering:
- Placeholder URL detection (\`example.com\`, \`test-partner\`, \`placeholder\`)
- Placeholder name detection (whole-word \`test\` / \`placeholder\`)
- Real partner rows pass through (HubSpot, Pipedrive, Monday.com, Amazon, Shopify, HelpDesk)
- Substring \`test\` inside \`Attestation\` does NOT flag (word boundary)
- Integration: matcher drops placeholder even when a vendor name matches
- Real partner preferred over placeholder when both match

## 2. Strip HubSpot affiliate from \`top-complaint-every-crm-2026-04\`

The one known editorial-mismatch case. Post analyzes 8 CRM vendors (Salesforce, Copper, Zoho CRM, Close, Pipedrive, Freshsales, Insightly, Nutshell). **HubSpot is not analyzed**, but \`data_context.affiliate_url\` was set to \`https://hubspot.com/?ref=atlas\` because the prior category-fallback logic returned the first enabled CRM partner.

Surgical strip: removed \`affiliate_url\` + \`affiliate_partner\`, preserved \`booking_url\` — same pattern as the 27 placeholder posts in #617.

Future posts won't have this problem (#617's vendor-matched logic won't inject HubSpot Partner unless HubSpot is in the vendor set), and the placeholder guard above defends against the test-data class.

## Test plan

- [x] 167 tests pass across \`test_b2b_blog_post_generation.py\` + \`test_b2b_blog_post_generation_quote_gate.py\`
- [x] \`npm run build\` in atlas-churn-ui succeeds (83-URL sitemap, no TS errors)
- [x] \`extracted_content_pipeline\` synced via \`extracted/_shared/scripts/sync_extracted.sh\`
- [x] Local pre-push review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)