### PR TITLE
Add draft-writer Funnel route checker

### DIFF
--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -164,8 +164,15 @@ tailscale funnel --bg --yes \
   --set-path /invoicing-draft-writer \
   http://127.0.0.1:8066
 tailscale funnel --bg --yes \
-  --set-path /.well-known/oauth-protected-resource \
-  http://127.0.0.1:8066/.well-known/oauth-protected-resource
+  --set-path /.well-known/oauth-protected-resource/invoicing-draft-writer \
+  http://127.0.0.1:8066/.well-known/oauth-protected-resource/invoicing-draft-writer
+```
+
+Before public discovery, verify the routes are actually present and pointed at
+the draft-writer port:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_funnel_routes.py
 ```
 
 The default public route is:

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -95,8 +95,9 @@ tailscale funnel --bg --yes \
   --set-path /invoicing-draft-writer \
   http://127.0.0.1:8066
 tailscale funnel --bg --yes \
-  --set-path /.well-known/oauth-protected-resource \
-  http://127.0.0.1:8066/.well-known/oauth-protected-resource
+  --set-path /.well-known/oauth-protected-resource/invoicing-draft-writer \
+  http://127.0.0.1:8066/.well-known/oauth-protected-resource/invoicing-draft-writer
+.venv/bin/python scripts/check_invoicing_draft_writer_funnel_routes.py
 .venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp

--- a/plans/PR-Invoicing-Draft-Writer-Funnel-Route-Check.md
+++ b/plans/PR-Invoicing-Draft-Writer-Funnel-Route-Check.md
@@ -1,0 +1,90 @@
+## Why this slice exists
+
+The draft-writer OAuth connector now has correct launch guidance, but the
+operator still has to visually inspect `tailscale funnel status` before running
+public discovery/e2e. That is fragile: the current machine has read-only
+invoicing routes configured, but not the draft-writer routes.
+
+This slice adds a read-only route checker so the operator can fail fast before
+connecting ChatGPT or running public OAuth smokes.
+
+## Scope (this PR)
+
+1. Add a draft-writer Funnel route checker.
+2. Validate the primary `/invoicing-draft-writer` route proxies to the
+   configured local port.
+3. Validate the per-connector protected-resource metadata route proxies to the
+   same local port and preserves the backend metadata path.
+4. Print the exact `tailscale funnel` commands when routes are missing or
+   wrong.
+5. Add unit tests for route parsing, happy path, route drift, and CLI failure.
+
+### Files touched
+
+- `scripts/check_invoicing_draft_writer_funnel_routes.py`
+- `tests/test_check_invoicing_draft_writer_funnel_routes.py`
+- `scripts/start_invoicing_draft_writer_oauth_server.py`
+- `tests/test_start_invoicing_draft_writer_oauth_server.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-Draft-Writer-Funnel-Route-Check.md`
+
+## Mechanism
+
+The checker runs:
+
+```bash
+tailscale funnel status --json
+```
+
+It derives the public host and app path from the resource URL. For the default
+resource URL, it checks:
+
+```text
+Web["atlas-brain.tailc7bd29.ts.net:443"].Handlers["/invoicing-draft-writer"].Proxy
+Web["atlas-brain.tailc7bd29.ts.net:443"].Handlers["/.well-known/oauth-protected-resource/invoicing-draft-writer"].Proxy
+```
+
+The script does not mutate Funnel state. It only reports OK or prints the
+commands the operator should run.
+
+## Intentional
+
+- This is read-only. The operator still chooses when to expose the write
+  connector publicly.
+- The metadata route is per-connector, not the host-root metadata prefix. That
+  avoids clobbering the existing read-only invoicing connector on the same
+  Tailscale hostname.
+- The checker validates proxies exactly enough to catch wrong-port and
+  wrong-path mistakes, but it does not attempt to verify HTTPS or OAuth
+  metadata. Discovery/e2e smokes remain responsible for that.
+
+## Deferred
+
+- A write-capable route installer is deferred. Explicit operator action is
+  safer for first public exposure of write access.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile scripts/check_invoicing_draft_writer_funnel_routes.py tests/test_check_invoicing_draft_writer_funnel_routes.py
+.venv/bin/pytest tests/test_check_invoicing_draft_writer_funnel_routes.py -q
+bash scripts/local_pr_review.sh --allow-dirty
+git diff --check
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Checker script | ~190 |
+| Tests | ~160 |
+| Launcher guidance update | ~45 |
+| Docs/plan | ~165 |
+| **Total** | **~560** |
+
+This exceeds the soft cap because the route checker ships with parser and CLI
+boundary tests in the same slice, and because the launcher guidance had to be
+tightened to avoid clobbering the read-only connector's metadata route.

--- a/scripts/check_invoicing_draft_writer_funnel_routes.py
+++ b/scripts/check_invoicing_draft_writer_funnel_routes.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Verify Tailscale Funnel routes for the draft-writer invoicing OAuth connector.
+
+This check is read-only. It inspects ``tailscale funnel status --json`` and
+prints the operator commands needed to repair missing or mismatched routes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+
+DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp"
+DEFAULT_PORT = "8066"
+METADATA_PATH = "/.well-known/oauth-protected-resource"
+
+
+@dataclass(frozen=True)
+class RouteExpectation:
+    host_key: str
+    app_path: str
+    app_proxy: str
+    metadata_path: str
+    metadata_proxy: str
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that Tailscale Funnel has the two public routes required "
+            "for the draft-writer invoicing OAuth connector."
+        )
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", DEFAULT_RESOURCE_URL),
+        help=(
+            "Public Streamable HTTP MCP resource URL. Defaults to "
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL or the "
+            "standard draft-writer public URL."
+        ),
+    )
+    parser.add_argument(
+        "--port",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT", DEFAULT_PORT),
+        help=(
+            "Local draft-writer MCP port. Defaults to "
+            "ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT or 8066."
+        ),
+    )
+    parser.add_argument(
+        "--tailscale-bin",
+        default="tailscale",
+        help="Tailscale executable. Default: tailscale.",
+    )
+    return parser
+
+
+def _strip_proxy(value: Any) -> str:
+    return str(value or "").rstrip("/")
+
+
+def _host_key(resource_url: str) -> str:
+    parsed = urlparse(resource_url.strip())
+    if parsed.scheme != "https":
+        raise ValueError("--resource-url must use https for public Funnel routing")
+    if not parsed.netloc:
+        raise ValueError("--resource-url must include a host")
+    if ":" in parsed.netloc:
+        return parsed.netloc
+    return f"{parsed.netloc}:443"
+
+
+def _app_path(resource_url: str) -> str:
+    path = urlparse(resource_url.strip()).path.rstrip("/")
+    if path.endswith("/mcp"):
+        path = path[: -len("/mcp")]
+    return path or "/"
+
+
+def _validate_port(port: str) -> str:
+    try:
+        parsed = int(str(port).strip())
+    except ValueError as exc:
+        raise ValueError("--port must be an integer") from exc
+    if parsed <= 0 or parsed > 65535:
+        raise ValueError("--port must be between 1 and 65535")
+    return str(parsed)
+
+
+def _expectation(resource_url: str, port: str) -> RouteExpectation:
+    parsed_port = _validate_port(port)
+    app_path = _app_path(resource_url)
+    metadata_path = METADATA_PATH if app_path == "/" else f"{METADATA_PATH}{app_path}"
+    return RouteExpectation(
+        host_key=_host_key(resource_url),
+        app_path=app_path,
+        app_proxy=f"http://127.0.0.1:{parsed_port}",
+        metadata_path=metadata_path,
+        metadata_proxy=f"http://127.0.0.1:{parsed_port}{metadata_path}",
+    )
+
+
+def _load_funnel_status(tailscale_bin: str) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            [tailscale_bin, "funnel", "status", "--json"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"could not run {tailscale_bin}: {exc}") from exc
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"tailscale funnel status failed: {stderr}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("tailscale funnel status did not return JSON") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError("tailscale funnel status returned non-object JSON")
+    return data
+
+
+def _handlers(status: Mapping[str, Any], host_key: str) -> Mapping[str, Any]:
+    web = status.get("Web")
+    if not isinstance(web, dict):
+        return {}
+    host = web.get(host_key)
+    if not isinstance(host, dict):
+        return {}
+    handlers = host.get("Handlers")
+    if not isinstance(handlers, dict):
+        return {}
+    return handlers
+
+
+def _handler_proxy(handlers: Mapping[str, Any], path: str) -> str:
+    value = handlers.get(path)
+    if not isinstance(value, dict):
+        return ""
+    return _strip_proxy(value.get("Proxy"))
+
+
+def _route_errors(status: Mapping[str, Any], expected: RouteExpectation) -> list[str]:
+    handlers = _handlers(status, expected.host_key)
+    errors: list[str] = []
+
+    app_proxy = _handler_proxy(handlers, expected.app_path)
+    if app_proxy != expected.app_proxy:
+        errors.append(
+            f"{expected.host_key} handler {expected.app_path} proxy is "
+            f"{app_proxy or 'missing'}, expected {expected.app_proxy}"
+        )
+
+    metadata_proxy = _handler_proxy(handlers, expected.metadata_path)
+    if metadata_proxy != expected.metadata_proxy:
+        errors.append(
+            f"{expected.host_key} handler {expected.metadata_path} proxy is "
+            f"{metadata_proxy or 'missing'}, expected {expected.metadata_proxy}"
+        )
+
+    return errors
+
+
+def _repair_commands(expected: RouteExpectation) -> list[str]:
+    commands: list[str] = []
+    if expected.app_path == "/":
+        commands.append(f"tailscale funnel --bg --yes {expected.app_proxy}")
+    else:
+        commands.append(
+            "tailscale funnel --bg --yes \\\n"
+            f"  --set-path {expected.app_path} \\\n"
+            f"  {expected.app_proxy}"
+        )
+    commands.append(
+        "tailscale funnel --bg --yes \\\n"
+        f"  --set-path {expected.metadata_path} \\\n"
+        f"  {expected.metadata_proxy}"
+    )
+    return commands
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        expected = _expectation(args.resource_url, args.port)
+        status = _load_funnel_status(args.tailscale_bin)
+    except Exception as exc:
+        print(f"Draft-writer Funnel route check failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    errors = _route_errors(status, expected)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        print("Run the required route commands:", file=sys.stderr)
+        for command in _repair_commands(expected):
+            print(command, file=sys.stderr)
+        return 1
+
+    print("OK: draft-writer invoicing Funnel routes are configured")
+    print(f"- host: {expected.host_key}")
+    print(f"- connector route: {expected.app_path} -> {expected.app_proxy}")
+    print(f"- metadata route: {expected.metadata_path} -> {expected.metadata_proxy}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/start_invoicing_draft_writer_oauth_server.py
+++ b/scripts/start_invoicing_draft_writer_oauth_server.py
@@ -17,6 +17,7 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = "8066"
 DEFAULT_ISSUER_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer"
 DEFAULT_RESOURCE_URL = "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp"
+PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource"
 MIN_APPROVAL_TOKEN_LENGTH = 24
 SECRET_KEYS = {
     "ATLAS_MCP_AUTH_TOKEN",
@@ -220,10 +221,18 @@ def _funnel_app_path(resource_url: str) -> str:
     return path or "/"
 
 
+def _funnel_metadata_path(resource_url: str) -> str:
+    app_path = _funnel_app_path(resource_url)
+    if app_path == "/":
+        return PROTECTED_RESOURCE_METADATA_PATH
+    return f"{PROTECTED_RESOURCE_METADATA_PATH}{app_path}"
+
+
 def _print_operator_guidance(config: LaunchConfig) -> None:
     issuer_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL"]
     resource_url = config.env["ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL"]
     app_path = _funnel_app_path(resource_url)
+    metadata_path = _funnel_metadata_path(resource_url)
     print("Draft-writer invoicing OAuth launch configuration:")
     for line in _masked_env_report(config.env):
         print(f"- {line}")
@@ -240,8 +249,8 @@ def _print_operator_guidance(config: LaunchConfig) -> None:
     print()
     print("Required Funnel route for protected-resource metadata:")
     print("tailscale funnel --bg --yes \\")
-    print("  --set-path /.well-known/oauth-protected-resource \\")
-    print(f"  http://127.0.0.1:{config.port}/.well-known/oauth-protected-resource")
+    print(f"  --set-path {metadata_path} \\")
+    print(f"  http://127.0.0.1:{config.port}{metadata_path}")
     print()
     print("After startup, verify public discovery:")
     print(".venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \\")

--- a/tests/test_check_invoicing_draft_writer_funnel_routes.py
+++ b/tests/test_check_invoicing_draft_writer_funnel_routes.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_draft_writer_funnel_routes.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_funnel_routes",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _status(*, app_proxy: str = "http://127.0.0.1:8066", metadata_proxy: str = ""):
+    if not metadata_proxy:
+        metadata_proxy = (
+            "http://127.0.0.1:8066/.well-known/oauth-protected-resource/"
+            "invoicing-draft-writer"
+        )
+    return {
+        "Web": {
+            "atlas-brain.tailc7bd29.ts.net:443": {
+                "Handlers": {
+                    "/invoicing-draft-writer": {"Proxy": app_proxy},
+                    "/.well-known/oauth-protected-resource/invoicing-draft-writer": {
+                        "Proxy": metadata_proxy
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_expectation_derives_public_host_and_routes() -> None:
+    module = _load_script_module()
+
+    expected = module._expectation(
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+        "8066",
+    )
+
+    assert expected.host_key == "atlas-brain.tailc7bd29.ts.net:443"
+    assert expected.app_path == "/invoicing-draft-writer"
+    assert expected.app_proxy == "http://127.0.0.1:8066"
+    assert expected.metadata_path == "/.well-known/oauth-protected-resource/invoicing-draft-writer"
+    assert expected.metadata_proxy == (
+        "http://127.0.0.1:8066/.well-known/oauth-protected-resource/invoicing-draft-writer"
+    )
+
+
+def test_expectation_preserves_explicit_public_port_and_root_path() -> None:
+    module = _load_script_module()
+
+    expected = module._expectation("https://atlas.example.com:8443/mcp", "9000")
+
+    assert expected.host_key == "atlas.example.com:8443"
+    assert expected.app_path == "/"
+    assert expected.app_proxy == "http://127.0.0.1:9000"
+
+
+def test_expectation_rejects_non_https_public_resource() -> None:
+    module = _load_script_module()
+
+    try:
+        module._expectation("http://atlas.example.com/invoicing-draft-writer/mcp", "8066")
+    except ValueError as exc:
+        assert "must use https" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+
+def test_route_errors_accept_expected_status() -> None:
+    module = _load_script_module()
+    expected = module._expectation(
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+        "8066",
+    )
+
+    assert module._route_errors(_status(), expected) == []
+
+
+def test_route_errors_report_missing_and_wrong_routes() -> None:
+    module = _load_script_module()
+    expected = module._expectation(
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+        "8066",
+    )
+    status = {
+        "Web": {
+            "atlas-brain.tailc7bd29.ts.net:443": {
+                "Handlers": {
+                    "/.well-known/oauth-protected-resource/invoicing-draft-writer": {
+                        "Proxy": (
+                            "http://127.0.0.1:8065/.well-known/oauth-protected-resource/"
+                            "invoicing-draft-writer"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    errors = module._route_errors(status, expected)
+
+    assert errors == [
+        (
+            "atlas-brain.tailc7bd29.ts.net:443 handler /invoicing-draft-writer "
+            "proxy is missing, expected http://127.0.0.1:8066"
+        ),
+        (
+            "atlas-brain.tailc7bd29.ts.net:443 handler "
+            "/.well-known/oauth-protected-resource/invoicing-draft-writer "
+            "proxy is http://127.0.0.1:8065/.well-known/oauth-protected-resource/"
+            "invoicing-draft-writer, expected http://127.0.0.1:8066/"
+            ".well-known/oauth-protected-resource/invoicing-draft-writer"
+        ),
+    ]
+
+
+def test_repair_commands_include_both_required_routes() -> None:
+    module = _load_script_module()
+    expected = module._expectation(
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+        "8066",
+    )
+
+    commands = module._repair_commands(expected)
+
+    assert commands == [
+        "tailscale funnel --bg --yes \\\n"
+        "  --set-path /invoicing-draft-writer \\\n"
+        "  http://127.0.0.1:8066",
+        "tailscale funnel --bg --yes \\\n"
+        "  --set-path /.well-known/oauth-protected-resource/invoicing-draft-writer \\\n"
+        "  http://127.0.0.1:8066/.well-known/oauth-protected-resource/invoicing-draft-writer",
+    ]
+
+
+def test_load_funnel_status_rejects_invalid_json(monkeypatch) -> None:
+    module = _load_script_module()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["tailscale", "funnel", "status", "--json"],
+            returncode=0,
+            stdout="not json",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    try:
+        module._load_funnel_status("tailscale")
+    except RuntimeError as exc:
+        assert "did not return JSON" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected RuntimeError")
+
+
+def test_main_reports_success_for_expected_routes(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["tailscale", "funnel", "status", "--json"],
+            returncode=0,
+            stdout=json.dumps(_status()),
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Funnel routes are configured" in captured.out
+    assert "/invoicing-draft-writer -> http://127.0.0.1:8066" in captured.out
+
+
+def test_main_prints_repair_commands_for_route_drift(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=["tailscale", "funnel", "status", "--json"],
+            returncode=0,
+            stdout=json.dumps({"Web": {}}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "handler /invoicing-draft-writer proxy is missing" in captured.err
+    assert "Run the required route commands:" in captured.err
+    assert "--set-path /invoicing-draft-writer" in captured.err

--- a/tests/test_start_invoicing_draft_writer_oauth_server.py
+++ b/tests/test_start_invoicing_draft_writer_oauth_server.py
@@ -192,6 +192,12 @@ def test_funnel_app_path_derives_parent_path_for_mcp_resource() -> None:
         "/invoicing-draft-writer"
     )
     assert module._funnel_app_path("http://127.0.0.1:8066/mcp") == "/"
+    assert module._funnel_metadata_path("https://atlas.example.com/invoicing-draft-writer/mcp") == (
+        "/.well-known/oauth-protected-resource/invoicing-draft-writer"
+    )
+    assert module._funnel_metadata_path("http://127.0.0.1:8066/mcp") == (
+        "/.well-known/oauth-protected-resource"
+    )
 
 
 def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
@@ -214,7 +220,11 @@ def test_guidance_masks_secrets_and_uses_configured_port(capsys) -> None:
     assert "bearer-token-value-that-must-not-print" not in captured.out
     assert "--set-path /invoicing-draft-writer" in captured.out
     assert "http://127.0.0.1:9000" in captured.out
-    assert "http://127.0.0.1:9000/.well-known/oauth-protected-resource" in captured.out
+    assert "--set-path /.well-known/oauth-protected-resource/invoicing-draft-writer" in captured.out
+    assert (
+        "http://127.0.0.1:9000/.well-known/oauth-protected-resource/invoicing-draft-writer"
+        in captured.out
+    )
     assert "http://127.0.0.1:8065/.well-known/oauth-protected-resource" not in captured.out
     assert "check_invoicing_draft_writer_oauth_e2e.py" in captured.out
 


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-Funnel-Route-Check.md

The draft-writer OAuth connector needs two public Tailscale routes before ChatGPT can connect. This adds a read-only checker for `tailscale funnel status --json` so operators can verify the primary connector route and per-connector protected-resource metadata route before public discovery/e2e.

## Intentional
- The checker is read-only; operators still explicitly choose when to expose the write connector.
- Metadata routing is per-connector (`/.well-known/oauth-protected-resource/invoicing-draft-writer`) so it does not clobber the existing read-only invoicing connector on the same hostname.
- Discovery/e2e smokes remain responsible for OAuth metadata and tool-surface verification.

## Deferred
- A write-capable route installer is deferred until public write exposure is routine enough to automate.

## Verification
- `.venv/bin/python -m py_compile scripts/check_invoicing_draft_writer_funnel_routes.py scripts/start_invoicing_draft_writer_oauth_server.py tests/test_check_invoicing_draft_writer_funnel_routes.py tests/test_start_invoicing_draft_writer_oauth_server.py`
- `.venv/bin/pytest tests/test_check_invoicing_draft_writer_funnel_routes.py tests/test_start_invoicing_draft_writer_oauth_server.py -q` -> 23 passed
- Local FastMCP protected-resource metadata path check passed at `/.well-known/oauth-protected-resource/invoicing-draft-writer/mcp`
- Live current-machine route check fails closed with the two required repair commands, as expected before route installation
- `bash scripts/local_pr_review.sh` passed
- `git diff --check` passed

## Diff size
7 files, +556 / -7