### PR TITLE
Plan: PR-Content-Ops-Ingestion-Closeout

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -1,7 +1,7 @@
 # AI Content Ops Deferred Backlog
 
 Created: 2026-05-11
-Last updated: 2026-05-18
+Last updated: 2026-05-19
 
 ## Purpose
 
@@ -47,6 +47,7 @@ The following items appear in older plan docs but are no longer active backlog:
 - DB reasoning context admin visibility events.
 - Campaign operations status reasoning-provider capability check.
 - Source-adapter field alias support for common provider-style exports.
+- Atlas Intel ingestion default-fields entry for source-row imports.
 - Source-adapter cumulative audit and decision rules.
 - Source-type precedence consolidation.
 - Source-row field lookup cache for provider-style aliases.
@@ -169,3 +170,12 @@ the first urgency/date scan window. The row exporter now applies the same
 quote-grade predicate in SQL before ordering/paging, and a live TrustRadius
 run imported 1 BambooHR review source row and persisted 2 offline deterministic
 drafts. Trustpilot is blocked on data quality, not extractor code.
+
+**Support-ticket/source UI update:** PR #620 added common help desk export
+aliases such as ticket/case numbers, requester/customer contact fields,
+organization names, issue descriptions, latest comments, and ticket/case
+titles. PR #621 exposed the existing backend `default_fields` contract in
+Atlas Intel so operators can bind fallback account/contact/vendor metadata
+without editing each source row. These close the known generic source-row
+ingestion friction. Further source breadth should still wait for a real host
+export fixture.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T04:45Z by codex-2026-05-18
+Last updated: 2026-05-19T04:55Z by codex-2026-05-18
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Ingestion-Default-Fields-UI | `atlas-intel-ui/src/api/contentOps.ts`, `atlas-intel-ui/src/domain/contentOps/types.ts`, `atlas-intel-ui/src/domain/contentOps/fromWire.ts`, `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`, `docs/extraction/coordination/inflight.md`, `plans/PR-Content-Ops-Ingestion-Default-Fields-UI.md` | codex-2026-05-18 | Content Ops ingestion default fields UI |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-19T02:00Z by codex-2026-05-18
+Last updated: 2026-05-19T04:55Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #601 | — | Review-source G2, Capterra, and TrustRadius paths are live-proven through source export, source-row import, DB-backed offline draft persistence, and draft export-ready rows. Next Content Ops work should come from a real host export fixture, live provider run gap, or the separate reasoning-core productization track. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #621 | — | Source-row ingestion now covers review, CRM/call/support-style rows, common help desk export aliases, backend `default_fields`, and Atlas Intel fallback-field entry. Next Content Ops work should come from a real host export fixture, live provider run gap, or the separate reasoning-core productization track. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -46,13 +46,15 @@ source of truth for what remains.
   `--source-rows`; JSON, JSONL, and CSV source-row exports are supported, and
   `examples/campaign_source_rows.jsonl` plus
   `examples/campaign_source_bundle.json` provide packaged starter inputs.
-  Source-row CLIs and hosted ingestion APIs accept fallback `default_fields`
-  so anonymous review evidence can be bound to a real account/contact without
-  editing every exported row; row-specific values still win.
+  Source-row CLIs, hosted ingestion APIs, and the Atlas Intel New Run screen
+  accept fallback `default_fields` so anonymous review or ticket evidence can
+  be bound to a real account/contact without editing every exported row;
+  row-specific values still win.
   Ticket and conversation rows can also provide nested `messages`, `comments`,
   `thread`, `conversation`, or `entries` arrays when the source text is not
   available as one scalar field. Source-row field labels are matched leniently
-  for common CSV/export variants such as `Ticket ID`, `Account Name`,
+  for common CSV/export variants such as `Ticket ID`, `Ticket Number`,
+  `Account Name`, `Organization Name`, `Requester Email`, `Issue Description`,
   `Pain Category`, and `Open Ended Response`; source-type precedence is
   explicit and provider-style field lookups are cached per row.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content

--- a/plans/PR-Content-Ops-Ingestion-Closeout.md
+++ b/plans/PR-Content-Ops-Ingestion-Closeout.md
@@ -1,0 +1,49 @@
+# PR-Content-Ops-Ingestion-Closeout
+
+## Why this slice exists
+
+PR #620 and PR #621 closed the latest Content Ops ingestion work: common help desk source aliases and UI access to backend `default_fields`. The coordination and backlog docs still show the last ingestion PR as in flight and do not record that these operator-facing gaps are closed. This slice keeps the multi-session ledger accurate before more Content Ops work starts.
+
+## Scope (this PR)
+
+1. Remove the merged ingestion default-fields UI row from the in-flight ledger.
+2. Update the AI Content Ops backlog to record the #620/#621 closeout.
+3. Update product state/status docs so the current source-ingestion capability is discoverable.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-Ingestion-Closeout.md`
+
+## Mechanism
+
+This is documentation-only. No runtime code, schema, API, or UI behavior changes.
+
+## Intentional
+
+- No additional source aliases or UI work in this PR.
+- No change to the active rule that future source breadth needs a real host export fixture.
+- No cleanup of unrelated affiliate or invoicing state.
+
+## Deferred
+
+- End-to-end generated-asset quality tests by source type remain deferred until there is a representative host export fixture.
+- Any richer key/value editor or saved source-specific fallback presets remain future UI work.
+
+## Verification
+
+- Local PR review - passed.
+- git diff whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backlog/status/coordination docs | ~55 |
+| Plan doc | ~55 |
+| **Total** | **~110** |
+
+This is below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Closeout.md

Documentation-only closeout after #620 and #621: clears the in-flight ledger and records that help desk aliases plus Atlas Intel ingestion default fields are now shipped.

## Intentional
- Documentation-only closeout; no runtime code, API, schema, or UI behavior changes.
- Keeps future source breadth gated on real host export fixtures.
- Leaves source-type generated-asset quality tests as fixture-driven follow-up work.

## Deferred
- End-to-end generated-asset quality tests by source type.
- Richer default-fields key/value editor or saved source-specific presets.

## Verification
- bash scripts/local_pr_review.sh -> passed
- git diff --check -> passed

## Diff size
5 files, +69 / -9