### PR TITLE
Fix orphan-attribution bug: block-level blockquote stripping

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1558,12 +1558,17 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool.
 
-    A "block" is a maximal run of contiguous ``>``-prefixed lines (and the
-    blank-prefixed continuation ``>`` lines that some renderers emit
-    between paragraphs of a single blockquote). The block is kept iff
-    at least one line in the block has a quote body that matches the
-    source pool; otherwise the entire block (including any attribution
-    line like ``> -- reviewer on G2``) is removed.
+    A "block" is a maximal run of contiguous ``>``-prefixed lines. The
+    block is kept iff EVERY quote-bearing line in it matches the source
+    pool. A block with at least one ungrounded quote line is stripped
+    in its entirety (including matched quote lines and attribution
+    lines) -- the block is the unit of trust.
+
+    A line is "quote-bearing" if ``_extract_quote_body`` returns
+    non-empty text for it; attribution-only lines like ``> -- reviewer
+    on G2`` return empty and don't independently require grounding,
+    but they're stripped along with the block when any quote-bearing
+    sibling fails.
 
     Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
     are removed. The absence of a source pool is treated as "no quote
@@ -1611,21 +1616,44 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
         block_lines = lines[block_start:i]
 
         # Decide: keep the block, or strip it.
+        #
+        # Contract: no ungrounded quote text ships. A block is the unit
+        # of trust -- if any quote-bearing line in the block fails to
+        # match the source pool, the entire block is contaminated and
+        # stripped (including attribution lines, which can't stand on
+        # their own).
+        #
+        # Implementation:
+        #   1. Collect quote-bearing lines (where _extract_quote_body
+        #      returns non-empty content).
+        #   2. If there are no quote-bearing lines, the block is
+        #      orphan attribution -- strip.
+        #   3. If EVERY quote-bearing line matches the source pool,
+        #      keep the whole block (attribution included).
+        #   4. Otherwise (at least one quote-bearing line ungrounded),
+        #      strip the whole block.
         if not source_quotes:
             removed_lines += len(block_lines)
             continue
 
-        block_has_matched_quote = False
+        quote_bearing: list[str] = []
         for line in block_lines:
             m = _BLOCKQUOTE_RE.match(line)
             if not m:
                 continue
             quote = _extract_quote_body(m.group(1))
-            if quote and _quote_matches_source(quote, source_quotes):
-                block_has_matched_quote = True
-                break
+            if quote:
+                quote_bearing.append(quote)
 
-        if block_has_matched_quote:
+        if not quote_bearing:
+            # Orphan attribution / non-quote content. Nothing to ground on.
+            removed_lines += len(block_lines)
+            continue
+
+        all_quotes_grounded = all(
+            _quote_matches_source(q, source_quotes) for q in quote_bearing
+        )
+        if all_quotes_grounded:
             output.extend(block_lines)
         else:
             removed_lines += len(block_lines)

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1555,31 +1555,86 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
 
 
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
-    """Strip LLM-generated blockquote lines that do not ground in a
+    """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool.
 
-    Fails closed: when ``source_quotes`` is empty, ALL blockquote lines
-    are removed. The absence of a source pool is treated as 'no quote
-    material is grounded', not as 'everything passes' -- the latter was
+    A "block" is a maximal run of contiguous ``>``-prefixed lines (and the
+    blank-prefixed continuation ``>`` lines that some renderers emit
+    between paragraphs of a single blockquote). The block is kept iff
+    at least one line in the block has a quote body that matches the
+    source pool; otherwise the entire block (including any attribution
+    line like ``> -- reviewer on G2``) is removed.
+
+    Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
+    are removed. The absence of a source pool is treated as "no quote
+    material is grounded", not as "everything passes" -- the latter was
     the prior backdoor that allowed paraphrased LLM quotes to ship when
     the producer hadn't supplied verbatim phrases.
+
+    Why block-level (not line-level): the prior implementation iterated
+    line-by-line. A multi-line markdown blockquote like::
+
+        > "Some quote text"
+        > -- Attribution Person
+
+    would have its quote line stripped (quote body fails source match)
+    but the attribution line would be PRESERVED, because
+    ``_extract_quote_body`` returns an empty string for an attribution-
+    only line, falsifying the ``if quote and ...`` removal condition.
+    The result was orphan ``<blockquote><p>-- Attribution</p></blockquote>``
+    in the rendered HTML (44 of 79 published posts at the time of fix).
+    Block-level processing removes the entire block atomically.
+
+    The returned ``removed`` count is the number of LINES stripped (for
+    backwards compatibility with the prior contract), not the number of
+    blocks.
     """
-    removed = 0
+    text = str(markdown or "")
+    if not text:
+        return text, 0
+
+    lines = text.splitlines(keepends=False)
     output: list[str] = []
-    for line in str(markdown or "").splitlines():
-        match = _BLOCKQUOTE_RE.match(line)
-        if not match:
-            output.append(line)
+    removed_lines = 0
+    i = 0
+    n = len(lines)
+    while i < n:
+        if not _BLOCKQUOTE_RE.match(lines[i]):
+            output.append(lines[i])
+            i += 1
             continue
+
+        # Collect the contiguous blockquote block starting at i.
+        block_start = i
+        while i < n and _BLOCKQUOTE_RE.match(lines[i]):
+            i += 1
+        block_lines = lines[block_start:i]
+
+        # Decide: keep the block, or strip it.
         if not source_quotes:
-            removed += 1
+            removed_lines += len(block_lines)
             continue
-        quote = _extract_quote_body(match.group(1))
-        if quote and not _quote_matches_source(quote, source_quotes):
-            removed += 1
-            continue
-        output.append(line)
-    return "\n".join(output), removed
+
+        block_has_matched_quote = False
+        for line in block_lines:
+            m = _BLOCKQUOTE_RE.match(line)
+            if not m:
+                continue
+            quote = _extract_quote_body(m.group(1))
+            if quote and _quote_matches_source(quote, source_quotes):
+                block_has_matched_quote = True
+                break
+
+        if block_has_matched_quote:
+            output.extend(block_lines)
+        else:
+            removed_lines += len(block_lines)
+
+    # Preserve trailing newline if the original text had one.
+    result = "\n".join(output)
+    if text.endswith("\n"):
+        result += "\n"
+    return result, removed_lines
 
 
 def _sanitize_blog_markdown(markdown: str) -> tuple[str, dict[str, int]]:

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1558,12 +1558,17 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool.
 
-    A "block" is a maximal run of contiguous ``>``-prefixed lines (and the
-    blank-prefixed continuation ``>`` lines that some renderers emit
-    between paragraphs of a single blockquote). The block is kept iff
-    at least one line in the block has a quote body that matches the
-    source pool; otherwise the entire block (including any attribution
-    line like ``> -- reviewer on G2``) is removed.
+    A "block" is a maximal run of contiguous ``>``-prefixed lines. The
+    block is kept iff EVERY quote-bearing line in it matches the source
+    pool. A block with at least one ungrounded quote line is stripped
+    in its entirety (including matched quote lines and attribution
+    lines) -- the block is the unit of trust.
+
+    A line is "quote-bearing" if ``_extract_quote_body`` returns
+    non-empty text for it; attribution-only lines like ``> -- reviewer
+    on G2`` return empty and don't independently require grounding,
+    but they're stripped along with the block when any quote-bearing
+    sibling fails.
 
     Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
     are removed. The absence of a source pool is treated as "no quote
@@ -1611,21 +1616,44 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
         block_lines = lines[block_start:i]
 
         # Decide: keep the block, or strip it.
+        #
+        # Contract: no ungrounded quote text ships. A block is the unit
+        # of trust -- if any quote-bearing line in the block fails to
+        # match the source pool, the entire block is contaminated and
+        # stripped (including attribution lines, which can't stand on
+        # their own).
+        #
+        # Implementation:
+        #   1. Collect quote-bearing lines (where _extract_quote_body
+        #      returns non-empty content).
+        #   2. If there are no quote-bearing lines, the block is
+        #      orphan attribution -- strip.
+        #   3. If EVERY quote-bearing line matches the source pool,
+        #      keep the whole block (attribution included).
+        #   4. Otherwise (at least one quote-bearing line ungrounded),
+        #      strip the whole block.
         if not source_quotes:
             removed_lines += len(block_lines)
             continue
 
-        block_has_matched_quote = False
+        quote_bearing: list[str] = []
         for line in block_lines:
             m = _BLOCKQUOTE_RE.match(line)
             if not m:
                 continue
             quote = _extract_quote_body(m.group(1))
-            if quote and _quote_matches_source(quote, source_quotes):
-                block_has_matched_quote = True
-                break
+            if quote:
+                quote_bearing.append(quote)
 
-        if block_has_matched_quote:
+        if not quote_bearing:
+            # Orphan attribution / non-quote content. Nothing to ground on.
+            removed_lines += len(block_lines)
+            continue
+
+        all_quotes_grounded = all(
+            _quote_matches_source(q, source_quotes) for q in quote_bearing
+        )
+        if all_quotes_grounded:
             output.extend(block_lines)
         else:
             removed_lines += len(block_lines)

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1555,31 +1555,86 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
 
 
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
-    """Strip LLM-generated blockquote lines that do not ground in a
+    """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool.
 
-    Fails closed: when ``source_quotes`` is empty, ALL blockquote lines
-    are removed. The absence of a source pool is treated as 'no quote
-    material is grounded', not as 'everything passes' -- the latter was
+    A "block" is a maximal run of contiguous ``>``-prefixed lines (and the
+    blank-prefixed continuation ``>`` lines that some renderers emit
+    between paragraphs of a single blockquote). The block is kept iff
+    at least one line in the block has a quote body that matches the
+    source pool; otherwise the entire block (including any attribution
+    line like ``> -- reviewer on G2``) is removed.
+
+    Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
+    are removed. The absence of a source pool is treated as "no quote
+    material is grounded", not as "everything passes" -- the latter was
     the prior backdoor that allowed paraphrased LLM quotes to ship when
     the producer hadn't supplied verbatim phrases.
+
+    Why block-level (not line-level): the prior implementation iterated
+    line-by-line. A multi-line markdown blockquote like::
+
+        > "Some quote text"
+        > -- Attribution Person
+
+    would have its quote line stripped (quote body fails source match)
+    but the attribution line would be PRESERVED, because
+    ``_extract_quote_body`` returns an empty string for an attribution-
+    only line, falsifying the ``if quote and ...`` removal condition.
+    The result was orphan ``<blockquote><p>-- Attribution</p></blockquote>``
+    in the rendered HTML (44 of 79 published posts at the time of fix).
+    Block-level processing removes the entire block atomically.
+
+    The returned ``removed`` count is the number of LINES stripped (for
+    backwards compatibility with the prior contract), not the number of
+    blocks.
     """
-    removed = 0
+    text = str(markdown or "")
+    if not text:
+        return text, 0
+
+    lines = text.splitlines(keepends=False)
     output: list[str] = []
-    for line in str(markdown or "").splitlines():
-        match = _BLOCKQUOTE_RE.match(line)
-        if not match:
-            output.append(line)
+    removed_lines = 0
+    i = 0
+    n = len(lines)
+    while i < n:
+        if not _BLOCKQUOTE_RE.match(lines[i]):
+            output.append(lines[i])
+            i += 1
             continue
+
+        # Collect the contiguous blockquote block starting at i.
+        block_start = i
+        while i < n and _BLOCKQUOTE_RE.match(lines[i]):
+            i += 1
+        block_lines = lines[block_start:i]
+
+        # Decide: keep the block, or strip it.
         if not source_quotes:
-            removed += 1
+            removed_lines += len(block_lines)
             continue
-        quote = _extract_quote_body(match.group(1))
-        if quote and not _quote_matches_source(quote, source_quotes):
-            removed += 1
-            continue
-        output.append(line)
-    return "\n".join(output), removed
+
+        block_has_matched_quote = False
+        for line in block_lines:
+            m = _BLOCKQUOTE_RE.match(line)
+            if not m:
+                continue
+            quote = _extract_quote_body(m.group(1))
+            if quote and _quote_matches_source(quote, source_quotes):
+                block_has_matched_quote = True
+                break
+
+        if block_has_matched_quote:
+            output.extend(block_lines)
+        else:
+            removed_lines += len(block_lines)
+
+    # Preserve trailing newline if the original text had one.
+    result = "\n".join(output)
+    if text.endswith("\n"):
+        result += "\n"
+    return result, removed_lines
 
 
 def _sanitize_blog_markdown(markdown: str) -> tuple[str, dict[str, int]]:

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -401,6 +401,39 @@ def test_block_with_attribution_first_then_quote():
     assert "costs too much money" in out
 
 
+def test_block_with_mixed_grounded_and_ungrounded_quotes_strips_block():
+    """The block is the unit of trust. If ANY quote-bearing line is
+    ungrounded, the entire block is stripped -- even if other lines
+    in the same block are grounded.
+
+    This catches the case Codex flagged on PR #625: a grounded quote
+    followed by an LLM-added fabricated sentence in the same `>` run
+    should NOT ship either line. The contract is "no ungrounded quote
+    text ever ships", and per-line stripping inside a block would
+    reintroduce orphan-attribution bugs anyway.
+    """
+    source = ["it costs too much money for what you get"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> \"it costs too much money for what you get\"\n"
+        "> \"and the support team never responded to my emails\"\n"
+        "> -- Customer Reviewer on G2\n"
+        "\n"
+        "More prose.\n"
+    )
+    # The first quote matches the source pool; the second does not.
+    # Even though one line is grounded, the whole block ships nothing.
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 3  # all three lines of the block
+    assert "costs too much money" not in out
+    assert "support team never responded" not in out
+    assert "Customer Reviewer on G2" not in out
+    # Surrounding prose preserved.
+    assert "## Section" in out
+    assert "More prose." in out
+
+
 def test_multiple_blocks_independent_decisions():
     """Two separate blockquote blocks separated by prose. One should be
     kept (matched), one should be stripped (unmatched). The stripper

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -300,26 +300,27 @@ def test_validator_handles_markdown_without_blockquotes():
 
 
 # ---------------------------------------------------------------------------
-# Regression: multi-line blockquote orphan-attribution bug
+# Block-level blockquote stripper -- formerly the orphan-attribution bug
 #
-# These tests document the CURRENT line-by-line stripping behavior. They
-# capture the failure mode that produces empty <blockquote><p>-- attribution
-# </p></blockquote> elements in 44 of 80 published posts. When the stripper
-# is fixed to operate on contiguous blockquote BLOCKS, these tests will
-# need to be inverted (asserting full block removal + no orphan attribution).
+# These tests originally documented a regression: the line-level stripper
+# produced empty <blockquote><p>-- attribution</p></blockquote> elements in
+# 44 of 80 published posts because it removed the quote line but kept the
+# attribution line. The stripper is now block-level: it identifies a
+# contiguous run of `>` lines, decides keep-or-strip based on whether ANY
+# line in the block matches the source pool, and acts atomically on the
+# whole block.
+#
+# The tests below assert the NEW correct behavior. The third test
+# (introductory_prose) still documents a separate gap that block-level
+# stripping doesn't address -- orphan introductory prose and disclaimer
+# prose adjacent to stripped blocks. That gap is deferred to a future
+# fix that detects and removes such prose.
 # ---------------------------------------------------------------------------
 
 
-def test_regression_full_block_stripped_when_pool_empty():
-    """REGRESSION baseline: with empty source_quotes, the fail-closed
-    path correctly strips both lines of a multi-line blockquote.
-
-    This works because empty source_quotes short-circuits before
-    _extract_quote_body is called -- every line matching _BLOCKQUOTE_RE
-    is removed regardless of content. The bug only manifests when the
-    pool is populated AND a specific quote line doesn't match. See the
-    next test.
-    """
+def test_full_block_stripped_when_pool_empty():
+    """Baseline: with empty source_quotes, the fail-closed path strips
+    every blockquote block atomically."""
     markdown = (
         "## Section\n"
         "\n"
@@ -336,28 +337,14 @@ def test_regression_full_block_stripped_when_pool_empty():
     assert "Group Director" not in out
 
 
-def test_regression_orphan_attribution_left_when_pool_populated_no_match():
-    """REGRESSION: the orphan-attribution bug surfaces when
-    source_quotes is populated and the quote-line doesn't match.
+def test_full_block_stripped_when_pool_populated_no_match():
+    """The fixed behavior: with a populated source pool, if NO line in
+    the block has a quote body matching the pool, the WHOLE block is
+    stripped -- including the attribution-only line that previously
+    survived because _extract_quote_body returns empty for it.
 
-    Per b2b_blog_post_generation.py lines 1567-1582, the stripper goes
-    line-by-line:
-      * Quote line: _extract_quote_body() returns the quote text, fails
-        _quote_matches_source, line is stripped.
-      * Attribution line: _extract_quote_body() splits on '--' and takes
-        the part BEFORE, returning empty string for an attribution-only
-        line. The conditional `if quote and not _quote_matches_source(...)`
-        is FALSY because `quote` is empty -- the attribution line is
-        PRESERVED.
-
-    Result: an orphan `> -- Attribution` line in markdown, which renders
-    as `<blockquote><p>-- Attribution</p></blockquote>` in the final
-    HTML. Confirmed in 44 of 80 published posts at the time of writing.
-
-    The fix is to operate on contiguous blockquote BLOCKS instead of
-    individual lines. When that fix lands, this test should be inverted:
-    `removed == 2` and `"Group Director" not in out`.
-    """
+    This is the test that was previously the bug-documenting regression
+    (removed == 1, attribution remained). Now both lines removed."""
     source = ["something else entirely that won't match"]
     markdown = (
         "## Section\n"
@@ -368,46 +355,102 @@ def test_regression_orphan_attribution_left_when_pool_populated_no_match():
         "More prose.\n"
     )
     out, removed = _remove_unmatched_quote_lines(markdown, source)
-    # CURRENT (buggy) behavior: only the quote line is stripped.
-    # The attribution line passes through because _extract_quote_body
-    # returns empty string for it, falsifying the removal condition.
-    assert removed == 1, (
-        "Orphan-attribution bug: only the quote line is removed. "
-        "The attribution line `> -- Group Director...` is preserved "
-        "because _extract_quote_body returns an empty string for an "
-        "attribution-only line, falsifying the removal condition."
-    )
-    # The attribution line survives -- this is the visible bug:
-    assert "-- Group Director, verified reviewer on TrustRadius" in out
-    # And the made-up quote was correctly removed:
+    # Both lines of the block removed atomically.
+    assert removed == 2
     assert "made up" not in out
+    assert "-- Group Director" not in out
+    # Surrounding prose preserved.
+    assert "## Section" in out
+    assert "More prose." in out
+
+
+def test_block_kept_when_any_line_matches():
+    """If at least one quote line in the block matches the source pool,
+    the entire block is kept -- including its attribution line."""
+    source = ["it costs too much money for what you get"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> \"it costs too much money for what you get\"\n"
+        "> -- Customer Reviewer on G2\n"
+        "\n"
+        "More prose.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 0
+    assert "costs too much money" in out
+    assert "Customer Reviewer on G2" in out
+
+
+def test_block_with_attribution_first_then_quote():
+    """Some renderers emit attribution before the quote inside a single
+    block. The block-level matcher should find the quote regardless of
+    position within the block and keep the entire block."""
+    source = ["it costs too much money for what you get"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> -- Customer Reviewer on G2\n"
+        "> \"it costs too much money for what you get\"\n"
+        "\n"
+        "More prose.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 0
+    assert "Customer Reviewer on G2" in out
+    assert "costs too much money" in out
+
+
+def test_multiple_blocks_independent_decisions():
+    """Two separate blockquote blocks separated by prose. One should be
+    kept (matched), one should be stripped (unmatched). The stripper
+    treats them independently."""
+    source = ["a real quote that matches"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> \"a real quote that matches\"\n"
+        "> -- Real Reviewer on G2\n"
+        "\n"
+        "Some prose between blocks.\n"
+        "\n"
+        "> \"a fabricated quote that does not match\"\n"
+        "> -- Fabricated Person on Nowhere\n"
+        "\n"
+        "Final prose.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 2  # only the second block's two lines
+    # First block kept entirely
+    assert "real quote that matches" in out
+    assert "Real Reviewer on G2" in out
+    # Second block fully stripped
+    assert "fabricated quote that does not match" not in out
+    assert "Fabricated Person on Nowhere" not in out
+    # Prose preserved
+    assert "Some prose between blocks." in out
+    assert "Final prose." in out
 
 
 def test_regression_introductory_prose_orphaned_when_quote_stripped():
-    """REGRESSION: prose introducing a blockquote is not cleaned up
-    when the blockquote itself gets stripped.
+    """KNOWN GAP (deferred): prose introducing a blockquote is not
+    cleaned up when the blockquote itself gets stripped.
 
-    Even if the multi-line blockquote bug were fixed (full block
-    removal), this orphan would remain:
+    With block-level stripping now in place, the blockquote is removed
+    atomically, but the orphan introduction ("One reviewer noted:") and
+    any acknowledged-misattribution disclaimer ("That quote is from a
+    compensation discussion, not a CRM review") still survive because
+    they aren't blockquote-prefixed lines. They reference content that
+    no longer exists.
 
-        One reviewer on Reddit noted:
+    A complete fix would also detect and remove orphan introductory and
+    disclaimer prose adjacent to stripped blocks. The seo-geo-aeo-blog-
+    post skill v1.4.0 added regex patterns that catch the disclaimer
+    pattern in audit mode; upstream detection in the generator should
+    mirror them.
 
-        [blockquote was here, now gone]
-
-        That quote is from a compensation discussion, not a CRM review,
-        but it surfaced in the same complaint pattern analysis.
-
-    Both the introduction ("One reviewer noted:") and the disclaimer
-    ("That quote is from a...") survive stripping because they aren't
-    blockquote-prefixed lines. They reference content that no longer
-    exists, producing dangling prose readers see as broken.
-
-    This documents the gap. A complete fix needs to also detect and
-    remove orphan introductory/disclaimer prose adjacent to stripped
-    blocks. The seo-geo-aeo-blog-post skill v1.4.0 added regex patterns
-    that catch the disclaimer pattern in audit mode; upstream detection
-    in the generator should mirror them.
-    """
+    For now: this test documents the gap. When the orphan-prose work
+    lands, update the assertions."""
     source: list[str] = []  # fail-closed: all blockquotes stripped
     markdown = (
         "## Section\n"
@@ -421,10 +464,8 @@ def test_regression_introductory_prose_orphaned_when_quote_stripped():
     out, removed = _remove_unmatched_quote_lines(markdown, source)
     assert removed == 1
     assert "gets stripped" not in out
-    # CURRENT BUG: both the intro and the disclaimer prose are kept.
-    # In a fixed implementation, both should be removed (or the post
-    # should be flagged for review, since the disclaimer pattern itself
-    # signals data-pipeline trouble per the v1.4.0 skill regex).
+    # KNOWN GAP: the orphan intro and disclaimer prose survive.
+    # When the orphan-prose fix lands, change these to `not in out`.
     assert "One reviewer on Reddit noted:" in out
     assert "That quote is from a compensation discussion" in out
 


### PR DESCRIPTION
Fixes the bug producing **174 empty \`<blockquote><p>-- attribution</p></blockquote>\`** elements across **44 of 79 published posts** (baseline measured in PR #612).

## The bug

Prior \`_remove_unmatched_quote_lines\` iterated line-by-line. For a multi-line markdown blockquote like

\`\`\`
> \"Some fabricated quote\"
> -- Attribution Person
\`\`\`

the stripper would correctly remove the quote line (quote body fails source match) but PRESERVE the attribution line — \`_extract_quote_body\` returns an empty string for an attribution-only line, which falsifies the \`if quote and ...\` removal condition. The orphan attribution then rendered as \`<blockquote><p>-- Attribution</p></blockquote>\` in the final HTML.

## The fix

\`_remove_unmatched_quote_lines\` now operates on contiguous blockquote BLOCKS:

1. Identify a maximal run of \`>\`-prefixed lines.
2. Check whether ANY line in the block has a quote body matching the source pool.
3. If yes, keep the entire block. If no, strip the entire block atomically.

Fail-closed contract preserved: empty \`source_quotes\` → all blocks stripped. \`removed\` count stays line-count (not block-count) for backward compat.

## Tests

| Test | Before | After |
|---|---|---|
| \`test_full_block_stripped_when_pool_empty\` | passed (baseline) | passes (renamed) |
| \`test_full_block_stripped_when_pool_populated_no_match\` | passed (asserting bug: \`removed==1\`, attribution remained) | **asserts the fix: \`removed==2\`, both lines gone** |
| \`test_regression_introductory_prose_orphaned\` | passed (asserting bug AND gap) | passes (documenting remaining gap) |
| \`test_block_kept_when_any_line_matches\` | (new) | passes |
| \`test_block_with_attribution_first_then_quote\` | (new) | passes |
| \`test_multiple_blocks_independent_decisions\` | (new) | passes |

**170 tests pass** across \`test_b2b_blog_post_generation.py\` + \`test_b2b_blog_post_generation_quote_gate.py\`.

## Known remaining gap (deferred)

When a block is stripped, **orphan introductory prose and disclaimer prose adjacent to the stripped block survive**:

\`\`\`
One reviewer on Reddit noted:

[block was here, now stripped]

That quote is from a compensation discussion, not a CRM review, but it surfaced...
\`\`\`

The intro (\"One reviewer on Reddit noted:\") and the v1.4.0-pattern disclaimer (\"That quote is from a ... discussion, not a ... review\") aren't blockquote-prefixed lines, so they aren't touched by this fix. The \`test_regression_introductory_prose_orphaned\` test documents this with KNOWN GAP comments.

A complete fix would detect orphan adjacent prose and remove it, OR flag posts containing the disclaimer pattern for human review. Deferred to a follow-up.

## Effect on existing posts

Generator change only. **The 44 already-published posts with 174 empty blockquotes still ship the bad state.** Separate cleanup task — either (a) regenerate those posts through the fixed pipeline, or (b) write a one-off strip script targeted at the empty-blockquote pattern.

## Test plan

- [x] 170 tests pass
- [x] \`npm run build\` in atlas-churn-ui succeeds (83-URL sitemap, no TS errors)
- [x] \`extracted_content_pipeline\` synced via \`extracted/_shared/scripts/sync_extracted.sh\`
- [x] Local pre-push review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)