### PR TITLE
Allow public host for draft-writer OAuth MCP transport

### DIFF
--- a/atlas_brain/mcp/invoicing_draft_writer_server.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_server.py
@@ -23,6 +23,7 @@ from contextlib import asynccontextmanager
 from datetime import date, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from mcp.server.fastmcp import FastMCP
 
@@ -369,9 +370,6 @@ def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
     """Configure FastMCP's built-in OAuth auth for ChatGPT connectors."""
     global _oauth_provider
 
-    if _oauth_provider is not None:
-        return _oauth_provider
-
     from mcp.server.auth.provider import ProviderTokenVerifier
     from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
 
@@ -383,6 +381,13 @@ def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
         resource_server_url=resource_url,
         approval_token=approval_token,
     )
+    mcp.settings.transport_security = _oauth_transport_security_settings(
+        issuer_url=issuer_url,
+        resource_url=resource_url,
+    )
+
+    if _oauth_provider is not None:
+        return _oauth_provider
 
     provider = InvoicingDraftWriterOAuthProvider(
         issuer_url=issuer_url,
@@ -403,6 +408,37 @@ def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
     mcp._token_verifier = ProviderTokenVerifier(provider)
     _oauth_provider = provider
     return provider
+
+
+def _oauth_transport_security_settings(*, issuer_url: str, resource_url: str):
+    """Allow public OAuth hosts while keeping MCP DNS-rebinding protection on."""
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    allowed_hosts = {
+        "127.0.0.1:*",
+        "localhost:*",
+        "[::1]:*",
+    }
+    for url in (issuer_url, resource_url):
+        allowed_hosts.update(_host_header_variants(url))
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(allowed_hosts),
+    )
+
+
+def _host_header_variants(url: str) -> set[str]:
+    parsed = urlparse(url.strip())
+    if not parsed.hostname:
+        return set()
+    variants = {parsed.netloc}
+    if parsed.port is None:
+        variants.add(parsed.hostname)
+        if parsed.scheme == "https":
+            variants.add(f"{parsed.hostname}:443")
+        elif parsed.scheme == "http":
+            variants.add(f"{parsed.hostname}:80")
+    return {variant for variant in variants if variant}
 
 
 if __name__ == "__main__":

--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -200,6 +200,13 @@ Then verify OAuth token exchange and the exact four-tool surface:
 
 The e2e smoke lists tools only. It must not create or update invoices.
 
+If discovery passes but e2e fails with `421 Misdirected Request` or
+`Invalid Host header`, the MCP transport host allowlist is stale. OAuth mode
+must allow the public host from
+`ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL` /
+`ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL` while keeping
+DNS-rebinding protection enabled.
+
 ## Required implementation tests
 
 The server PR must include tests that prove:

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -107,6 +107,11 @@ tailscale funnel --bg --yes \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 ```
 
+If the e2e smoke reaches token exchange but the MCP session fails with
+`421 Misdirected Request` / `Invalid Host header`, the OAuth server's transport
+host allowlist does not include the public Tailscale host. Keep DNS-rebinding
+protection enabled and add the configured issuer/resource host to the allowlist.
+
 ## Step 2: add OAuth mode
 
 Use `atlas_brain/mcp/invoicing_readonly_oauth.py` as the template. The minimum

--- a/plans/PR-Invoicing-Draft-Writer-OAuth-Public-Host.md
+++ b/plans/PR-Invoicing-Draft-Writer-OAuth-Public-Host.md
@@ -1,0 +1,92 @@
+## Why this slice exists
+
+The public draft-writer route and OAuth discovery now work, but the e2e smoke
+fails when it opens an authenticated MCP session through Tailscale. Server logs
+show:
+
+```text
+421 Misdirected Request
+Invalid Host header: atlas-brain.tailc7bd29.ts.net
+```
+
+FastMCP auto-enables DNS-rebinding protection for localhost-backed servers. The
+draft-writer process is bound to `127.0.0.1`, but public clients reach it with
+the Tailscale hostname. The MCP transport path therefore needs an explicit
+allowlist for the configured public issuer/resource host.
+
+## Scope (this PR)
+
+1. Add a draft-writer transport-security helper for OAuth HTTP mode.
+2. Allow localhost plus the configured public issuer/resource hosts.
+3. Keep DNS-rebinding protection enabled instead of disabling it broadly.
+4. Add tests proving public hosts are allowlisted and unrelated hosts are not.
+5. Update operator docs to identify a `421 Invalid Host header` as this exact
+   guardrail.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_draft_writer_server.py`
+- `tests/test_invoicing_draft_writer_oauth.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-Draft-Writer-OAuth-Public-Host.md`
+
+## Mechanism
+
+The server derives allowed `Host` values from:
+
+- `ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL`
+- `ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL`
+- localhost defaults used by local smoke tests
+
+Then it assigns `mcp.settings.transport_security` before creating the
+Streamable HTTP app:
+
+```python
+TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=[...],
+)
+```
+
+## Intentional
+
+- This does not disable DNS-rebinding protection. The public hostname is
+  allowed explicitly.
+- This is scoped to the draft-writer server because this is the connector we
+  are actively rolling out. Read-only can get the same tightening in a separate
+  compatibility slice if needed.
+
+## Deferred
+
+- Dedicated hostname support remains deferred. The allowlist is derived from
+  the configured public URLs, so it will work for either path-prefixed or
+  dedicated-host deployments.
+
+## Verification
+
+Planned commands:
+
+```bash
+.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_server.py tests/test_invoicing_draft_writer_oauth.py
+.venv/bin/pytest tests/test_invoicing_draft_writer_oauth.py tests/test_check_invoicing_draft_writer_oauth_e2e.py -q
+bash scripts/local_pr_review.sh --allow-dirty
+git diff --check
+```
+
+Manual rollout verification after merge:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_funnel_routes.py
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py --approval-token-file .secrets/invoicing-draft-writer-approval-token --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+## Estimated diff size
+
+| Area | LOC churn (approx) |
+|---|---:|
+| Server | ~45 |
+| Tests | ~55 |
+| Docs/plan | ~105 |
+| **Total** | **~205** |

--- a/tests/test_invoicing_draft_writer_oauth.py
+++ b/tests/test_invoicing_draft_writer_oauth.py
@@ -64,6 +64,7 @@ def _reset_draft_writer_auth_state() -> None:
     draft_writer.mcp._auth_server_provider = None
     draft_writer.mcp._token_verifier = None
     draft_writer.mcp._session_manager = None
+    draft_writer.mcp.settings.transport_security = None
 
 
 @pytest.fixture(autouse=True)
@@ -234,6 +235,43 @@ def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(mo
         response = client.get("/mcp")
         assert response.status_code == 401
         assert "resource_metadata=" in response.headers["www-authenticate"]
+
+
+def test_oauth_transport_security_allows_configured_public_host():
+    settings = draft_writer._oauth_transport_security_settings(
+        issuer_url="https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer",
+        resource_url="https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+    )
+
+    assert settings.enable_dns_rebinding_protection is True
+    assert "atlas-brain.tailc7bd29.ts.net" in settings.allowed_hosts
+    assert "atlas-brain.tailc7bd29.ts.net:443" in settings.allowed_hosts
+    assert "127.0.0.1:*" in settings.allowed_hosts
+    assert "localhost:*" in settings.allowed_hosts
+    assert "evil.example.com" not in settings.allowed_hosts
+
+
+def test_configure_oauth_auth_installs_public_host_transport_security(monkeypatch):
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "oauth")
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL",
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL",
+        "https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp",
+    )
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
+        "approval-token-with-enough-entropy",
+    )
+
+    draft_writer._configure_oauth_auth()
+
+    settings = draft_writer.mcp.settings.transport_security
+    assert settings is not None
+    assert settings.enable_dns_rebinding_protection is True
+    assert "atlas-brain.tailc7bd29.ts.net" in settings.allowed_hosts
 
 
 def test_approval_page_omits_absolute_form_action_for_prefixed_mount(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-OAuth-Public-Host.md

Public route/discovery passed for the draft-writer connector, but authenticated MCP e2e initially failed with `421 Misdirected Request` because FastMCP transport security rejected the Tailscale public Host header. This keeps DNS-rebinding protection enabled and explicitly allowlists the configured OAuth issuer/resource host for the draft-writer MCP transport.

## Intentional
- DNS-rebinding protection remains enabled; the configured public OAuth host is allowlisted explicitly.
- Scope stays on the draft-writer server because that is the connector being publicly rolled out.
- Read-only can receive the same tightening in a separate compatibility slice if needed.

## Deferred
- Dedicated hostname support remains deferred; host allowlisting derives from configured issuer/resource URLs.

## Verification
- `.venv/bin/python -m py_compile atlas_brain/mcp/invoicing_draft_writer_server.py tests/test_invoicing_draft_writer_oauth.py`
- `.venv/bin/pytest tests/test_invoicing_draft_writer_oauth.py tests/test_check_invoicing_draft_writer_oauth_e2e.py -q` -> 24 passed
- Public `check_invoicing_draft_writer_funnel_routes.py` passed
- Public `check_invoicing_draft_writer_oauth_discovery.py` passed
- Public `check_invoicing_draft_writer_oauth_e2e.py` passed and listed exactly 4 draft-writer tools
- `bash scripts/local_pr_review.sh` passed
- `git diff --check` passed

## Diff size
5 files, +181 / -3