### PR TITLE
Tighten BlogPost.topic_type to a 10-value string-literal union

### DIFF
--- a/atlas-churn-ui/src/content/blog/index.ts
+++ b/atlas-churn-ui/src/content/blog/index.ts
@@ -37,6 +37,61 @@ export interface FaqItem {
   answer: string
 }
 
+/**
+ * Canonical topic_type values. One per blueprint function in
+ * atlas_brain/autonomous/tasks/b2b_blog_post_generation.py. New
+ * blueprint functions must add their topic_type value here too --
+ * adding a new producer without updating this union surfaces as a
+ * compile error in any post file using the new type, which is the
+ * intended forcing function.
+ *
+ * Mapping (blueprint function -> topic_type):
+ *   _blueprint_vendor_alternative      -> 'vendor_alternative'
+ *   _blueprint_vendor_showdown         -> 'vendor_showdown'
+ *   _blueprint_churn_report            -> 'churn_report'
+ *   _blueprint_migration_guide         -> 'migration_guide'
+ *   _blueprint_vendor_deep_dive        -> 'vendor_deep_dive'
+ *   _blueprint_market_landscape        -> 'market_landscape'
+ *   _blueprint_pricing_reality_check   -> 'pricing_reality_check'
+ *   _blueprint_switching_story         -> 'switching_story'
+ *   _blueprint_pain_point_roundup      -> 'pain_point_roundup'
+ *   _blueprint_best_fit_guide          -> 'best_fit_guide'
+ */
+export type BlogTopicType =
+  | 'vendor_alternative'
+  | 'vendor_showdown'
+  | 'churn_report'
+  | 'migration_guide'
+  | 'vendor_deep_dive'
+  | 'market_landscape'
+  | 'pricing_reality_check'
+  | 'switching_story'
+  | 'pain_point_roundup'
+  | 'best_fit_guide'
+
+const VALID_TOPIC_TYPES: ReadonlySet<string> = new Set<BlogTopicType>([
+  'vendor_alternative',
+  'vendor_showdown',
+  'churn_report',
+  'migration_guide',
+  'vendor_deep_dive',
+  'market_landscape',
+  'pricing_reality_check',
+  'switching_story',
+  'pain_point_roundup',
+  'best_fit_guide',
+])
+
+/**
+ * Coerce arbitrary input (typically from a draft API or a JSON parse)
+ * to a BlogTopicType, returning undefined for anything else. Use this at
+ * boundaries where untyped data crosses into the strict BlogPost type.
+ */
+export function coerceTopicType(value: unknown): BlogTopicType | undefined {
+  if (typeof value !== 'string') return undefined
+  return VALID_TOPIC_TYPES.has(value) ? (value as BlogTopicType) : undefined
+}
+
 export interface BlogPost {
   slug: string
   title: string
@@ -46,7 +101,7 @@ export interface BlogPost {
   tags: string[]
   content: string
   charts?: ChartSpec[]
-  topic_type?: string
+  topic_type?: BlogTopicType
   data_context?: BlogDataContext
   seo_title?: string
   seo_description?: string

--- a/atlas-churn-ui/src/pages/BlogReview.tsx
+++ b/atlas-churn-ui/src/pages/BlogReview.tsx
@@ -20,7 +20,7 @@ import { resolveBlogArticleCta } from '../lib/blogCta'
 import BlogFailureExplanation from '../components/BlogFailureExplanation'
 import type { Column } from '../components/DataTable'
 import type { BlogDraftSummary, BlogDraft, BlogEvidence } from '../types'
-import { loadPostsBySlugs } from '../content/blog'
+import { coerceTopicType, loadPostsBySlugs } from '../content/blog'
 import type { BlogPost as BlogPostType } from '../content/blog'
 import {
   fetchBlogDrafts,
@@ -132,7 +132,7 @@ function derivePreviewPost(draft: BlogDraft): BlogPostType {
     tags: draft.tags || [],
     content: draft.content || '',
     charts: Array.isArray(draft.charts) ? draft.charts as BlogPostType['charts'] : [],
-    topic_type: draft.topic_type,
+    topic_type: coerceTopicType(draft.topic_type),
     data_context: draft.data_context || {},
     seo_title: draft.seo_title || draft.title,
     seo_description: draft.seo_description || draft.description || '',


### PR DESCRIPTION
Replaces \`topic_type?: string\` with \`BlogTopicType\` — a strict union of the 10 canonical values, one per blueprint producer function in \`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py\`.

## Why

The seo-geo-aeo-blog-post skill and PR #612's analyzer both treated \`topic_type\` as a 5-value enum (vendor_deep_dive, migration_guide, landscape, comparison, complaint_analysis), based on the strongest existing posts. But the generator actually has **10 distinct blueprint producers**, each semantically distinct:

- \`best_fit_guide\` is "which X for [segment]" buyer-fit roundups
- \`pricing_reality_check\` is real-cost analysis
- \`switching_story\` is narrative-shaped while \`migration_guide\` is how-to
- etc.

Collapsing producers into the narrow 5-value enum would be lossy. Expanding the enum to match producers preserves the distinctions, requires zero post backfills (the existing data already uses these values), and makes the TypeScript union double as schema documentation enforced at compile time.

## Effects

- \`npm run build\` in \`atlas-churn-ui\`: **clean** — 83-URL sitemap, all 80 posts satisfy the strict union, no TS errors
- Skill analyzer \"Invalid topic_type\" detector: **38 posts → 0**
- One callsite needed updating: \`BlogReview.tsx:135\` previously assigned \`draft.topic_type\` (typed as \`string\`) directly. Now uses a new \`coerceTopicType(value: unknown)\` helper that validates at the trust boundary.

## Skill + analyzer updates (out-of-tree, in \`~/.claude/skills/\`)

- SKILL.md v1.4.0 → v1.5.0
- Pillar table expanded to 10 rows
- Step 7/8 valid-enum lists updated
- bad-post example's "invalid topic_type" failure updated
- Analyzer detector updated

## Anti-recurrence

The strict union means any future \`BlogPost\` file with an invalid \`topic_type\` fails at TS build time. Adding a new blueprint producer **must** be paired with adding the new value to \`BlogTopicType\` — the type system enforces the coupling.

## Test plan

- [x] \`npm run build\` succeeds with 83 URLs and no TS errors
- [x] All 80 published posts conform to the strict union (build catches drift)
- [x] Analyzer detector goes from 38 invalid posts to 0
- [x] \`BlogReview.tsx\` draft preview still compiles via \`coerceTopicType\` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)