### PR TITLE
Plan: PR-Content-Ops-Review-Source-Live-Provider-Smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,5 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Ops-Review-Source-Live-Provider-Smoke | `scripts/content_ops_source_postgres_smoke_helpers.py`, `scripts/smoke_content_ops_review_source_postgres.py`, review-source smoke tests/docs | codex-2026-05-18 | Invoicing route-check PRs; unrelated extraction slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -202,8 +202,10 @@ python scripts/smoke_content_ops_review_source_generation.py \
 To prove the same source can run through the Postgres-backed path, use the
 database smoke. It imports source rows into `campaign_opportunities` under the
 provided account id, replaces matching imported opportunities by default, and
-persists offline generated drafts. If the required Content Ops tables are not
-present, the smoke fails before import and points at the migration runner:
+persists generated drafts. The default uses deterministic offline generation;
+pass `--llm pipeline` to exercise the product `PipelineLLMClient`. If the
+required Content Ops tables are not present, the smoke fails before import and
+points at the migration runner:
 
 ```bash
 python scripts/smoke_content_ops_review_source_postgres.py \
@@ -213,6 +215,7 @@ python scripts/smoke_content_ops_review_source_postgres.py \
   --account-id acct_123 \
   --default-field company_name="Acme Logistics" \
   --default-field contact_email=ops@example.com \
+  --llm pipeline \
   --json
 ```
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -497,11 +497,13 @@ importing.
 
 For a DB-backed smoke, use the Postgres variant. It imports the exported
 source rows into `campaign_opportunities`, replaces matching imported
-opportunities by default, runs offline draft generation through the product
-Postgres runner, and reports persisted campaign ids. The smoke checks for the
-required `campaign_opportunities` and `b2b_campaigns` tables before import; if
-either is missing, run `scripts/run_extracted_content_pipeline_migrations.py`
-against the same database first:
+opportunities by default, runs draft generation through the product Postgres
+runner, and reports persisted campaign ids. It defaults to deterministic
+offline generation; pass `--llm pipeline` to use the configured product
+`PipelineLLMClient`. The smoke checks for the required
+`campaign_opportunities` and `b2b_campaigns` tables before import; if either is
+missing, run `scripts/run_extracted_content_pipeline_migrations.py` against the
+same database first:
 
 ```bash
 python scripts/smoke_content_ops_review_source_postgres.py \
@@ -511,6 +513,7 @@ python scripts/smoke_content_ops_review_source_postgres.py \
   --account-id acct_123 \
   --default-field company_name="Acme Logistics" \
   --default-field contact_email=ops@example.com \
+  --llm pipeline \
   --json
 ```
 

--- a/plans/PR-Content-Ops-Review-Source-Live-Provider-Smoke.md
+++ b/plans/PR-Content-Ops-Review-Source-Live-Provider-Smoke.md
@@ -1,0 +1,78 @@
+# PR-Content-Ops-Review-Source-Live-Provider-Smoke
+
+## Why this slice exists
+
+The review-source Postgres smoke currently proves G2 review rows can be
+exported, inspected, imported into `campaign_opportunities`, and persisted as
+offline deterministic drafts. The deferred gap is live provider generation over
+those imported review-source rows. This slice adds that operator path without
+changing the default offline smoke.
+
+## Scope (this PR)
+
+1. Add an opt-in provider mode to the review-source Postgres smoke.
+2. Let the shared source-row Postgres smoke helper accept injected LLM and skill
+   ports while preserving the existing offline defaults.
+3. Document the live-provider flag at the existing review-source smoke command
+   sites.
+4. Add focused tests for default offline behavior and live-provider wiring.
+
+### Files touched
+
+- `scripts/content_ops_source_postgres_smoke_helpers.py`
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `tests/test_content_ops_source_postgres_smoke_helpers.py`
+- `tests/test_smoke_content_ops_review_source_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Review-Source-Live-Provider-Smoke.md`
+
+## Mechanism
+
+`generate_imported_target_drafts` keeps constructing
+`DeterministicCampaignLLM` and `StaticCampaignSkillStore` when no ports are
+supplied. The review-source smoke adds `--llm offline|pipeline`; `offline` is
+the default, and `pipeline` passes the product LLM client plus skill registry
+through the same helper into
+`generate_campaign_drafts_from_postgres`.
+
+## Intentional
+
+- The default remains offline so CI and host readiness checks do not require
+  provider credentials.
+- The CFPB Postgres smoke keeps using the shared helper defaults and does not
+  need a CLI change in this slice.
+- Tests monkeypatch the provider factory and skill registry; they do not make a
+  live provider call.
+
+## Deferred
+
+- A real operator run against a host database with provider credentials remains
+  a manual smoke after merge.
+- Broader `--llm pipeline` parity for the CFPB smoke can land separately if the
+  support-ticket path needs live-provider proof.
+
+## Verification
+
+- Focused smoke/helper tests -> `16 passed`.
+- Python compile check for edited scripts/tests -> passed.
+- ASCII check on edited Python/test files -> passed.
+- `git diff --check` -> passed.
+- `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` -> passed.
+- `scripts/audit_extracted_standalone.py` -> passed.
+- `scripts/check_ascii_python.sh` -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke helper and CLI | ~45 |
+| Tests | ~65 |
+| Docs and coordination | ~35 |
+| Plan | ~55 |
+| **Total** | **~200** |
+
+This is below the 400 LOC review budget.

--- a/scripts/content_ops_source_postgres_smoke_helpers.py
+++ b/scripts/content_ops_source_postgres_smoke_helpers.py
@@ -24,7 +24,11 @@ async def generate_imported_target_drafts(
     channels: Sequence[str],
     target_ids: Sequence[str],
     opportunity_table: str,
+    llm: Any | None = None,
+    skills: Any | None = None,
 ) -> dict[str, Any]:
+    resolved_llm = llm or DeterministicCampaignLLM()
+    resolved_skills = skills or StaticCampaignSkillStore()
     saved_ids: list[str] = []
     errors: list[Mapping[str, Any]] = []
     requested = 0
@@ -40,8 +44,8 @@ async def generate_imported_target_drafts(
             channels=tuple(channels),
             limit=1,
             filters={"target_id": target_id},
-            llm=DeterministicCampaignLLM(),
-            skills=StaticCampaignSkillStore(),
+            llm=resolved_llm,
+            skills=resolved_skills,
             config=CampaignGenerationConfig(channels=tuple(channels), limit=1),
             opportunity_table=opportunity_table,
         )

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -18,6 +18,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_llm_client import (  # noqa: E402
+    create_pipeline_llm_client,
+)
 from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
     import_campaign_opportunities,
 )
@@ -28,6 +31,8 @@ from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
 from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
 )
+from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
+
 
 def _load_script_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, path)
@@ -72,7 +77,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Smoke-test Atlas review-source rows through Content Ops source "
-            "export, Postgres import, and DB-backed offline draft generation."
+            "export, Postgres import, and DB-backed draft generation."
         )
     )
     parser.add_argument("--source", default="g2")
@@ -80,6 +85,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--limit", type=int, default=1)
     parser.add_argument("--target-mode", default="vendor_retention")
     parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument(
+        "--llm",
+        choices=("offline", "pipeline"),
+        default="offline",
+        help="Use deterministic offline generation or the product PipelineLLMClient.",
+    )
     parser.add_argument("--min-drafts", type=int, default=None)
     parser.add_argument("--min-quote-grade-rows", type=int, default=1)
     parser.add_argument("--min-review-text-chars", type=int, default=80)
@@ -177,6 +188,15 @@ async def _fetch_review_inputs(
         require_review_url=not bool(args.allow_missing_source_url),
     )
     return source_summary, source_rows
+
+
+def _generation_ports_for_args(args: argparse.Namespace) -> dict[str, Any]:
+    if args.llm == "offline":
+        return {}
+    return {
+        "llm": create_pipeline_llm_client(),
+        "skills": get_skill_registry(),
+    }
 
 
 async def run_review_source_postgres_smoke(
@@ -279,6 +299,7 @@ async def run_review_source_postgres_smoke(
                     channels=channels,
                     target_ids=imported_target_ids,
                     opportunity_table=str(args.opportunity_table),
+                    **_generation_ports_for_args(args),
                 )
                 saved_drafts = await fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
                 errors.extend(generation_errors(drafts_result))

--- a/tests/test_content_ops_source_postgres_smoke_helpers.py
+++ b/tests/test_content_ops_source_postgres_smoke_helpers.py
@@ -160,3 +160,41 @@ async def test_generate_imported_target_drafts_aggregates_multiple_targets(monke
     assert result["errors"] == [{"target_id": "source-2", "reason": "bad"}]
     assert calls[0]["filters"] == {"target_id": "source-1"}
     assert calls[0]["channels"] == ("email_cold", "email_followup")
+    assert isinstance(calls[0]["llm"], helpers.DeterministicCampaignLLM)
+    assert isinstance(calls[0]["skills"], helpers.StaticCampaignSkillStore)
+
+
+@pytest.mark.asyncio
+async def test_generate_imported_target_drafts_uses_injected_llm_and_skills(monkeypatch):
+    calls = []
+    llm = object()
+    skills = object()
+
+    async def fake_generate(*_args, **kwargs):
+        calls.append(kwargs)
+        return _GenerationResult({
+            "requested": 1,
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-1"],
+            "errors": [],
+        })
+
+    monkeypatch.setattr(helpers, "generate_campaign_drafts_from_postgres", fake_generate)
+
+    result = await helpers.generate_imported_target_drafts(
+        pool=object(),
+        account_id="acct",
+        user_id="user",
+        target_mode="vendor_retention",
+        channels=("email_cold",),
+        target_ids=("source-1",),
+        opportunity_table="campaign_opportunities",
+        llm=llm,
+        skills=skills,
+    )
+
+    assert result["generated"] == 1
+    assert calls[0]["llm"] is llm
+    assert calls[0]["skills"] is skills

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -162,6 +162,7 @@ def _args(**overrides):
         "limit": 1,
         "target_mode": "vendor_retention",
         "channels": "email_cold",
+        "llm": "offline",
         "min_drafts": None,
         "min_quote_grade_rows": 1,
         "min_review_text_chars": 80,
@@ -188,6 +189,17 @@ def _args(**overrides):
     }
     values.update(overrides)
     return argparse.Namespace(**values)
+
+
+def test_parse_args_defaults_to_offline_llm():
+    args = smoke._parse_args([
+        "--account-id",
+        "acct-smoke",
+        "--database-url",
+        "postgres://example",
+    ])
+
+    assert args.llm == "offline"
 
 
 @pytest.mark.asyncio
@@ -226,6 +238,47 @@ async def test_review_source_postgres_smoke_imports_and_persists(monkeypatch, tm
     assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
     assert "FROM b2b_campaigns" in pool.fetch_calls[-1]["query"]
     assert pool.fetch_calls[2]["args"] == ("vendor_retention", "acct-smoke", "review-1", 1)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_pipeline_llm_wires_provider_ports(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_saved_draft_row()],
+    )
+    llm = object()
+    skills = object()
+    calls = []
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "create_pipeline_llm_client", lambda: llm)
+    monkeypatch.setattr(smoke, "get_skill_registry", lambda: skills)
+
+    async def generate_with_ports(**kwargs):
+        calls.append(kwargs)
+        return {
+            "requested": 1,
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-1"],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(smoke, "generate_imported_target_drafts", generate_with_ports)
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(llm="pipeline"),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert calls[0]["llm"] is llm
+    assert calls[0]["skills"] is skills
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Source-Live-Provider-Smoke.md

Adds an opt-in live-provider mode to the review-source Postgres smoke so imported G2 review-source rows can be generated through the product PipelineLLMClient seam. Offline deterministic generation remains the default for CI and host readiness checks.

## Intentional
- Offline remains the default so CI and host readiness checks do not require provider credentials.
- The shared helper keeps deterministic defaults for the CFPB smoke and any existing callers.
- Tests monkeypatch provider factories; they do not make live provider calls.

## Deferred
- A real operator run against a host database with provider credentials remains a manual smoke after merge.
- Broader `--llm pipeline` parity for the CFPB smoke can land separately if the support-ticket path needs live-provider proof.

## Verification
- `pytest tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py -q` -> 16 passed
- `python -m py_compile scripts/content_ops_source_postgres_smoke_helpers.py scripts/smoke_content_ops_review_source_postgres.py tests/test_content_ops_source_postgres_smoke_helpers.py tests/test_smoke_content_ops_review_source_postgres.py` -> passed
- ASCII check on edited Python/test files -> passed
- `git diff --check` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
8 files, +211 / -10
