### PR TITLE
Make invoice-number lookup case-insensitive

### DIFF
--- a/atlas_brain/storage/repositories/invoice.py
+++ b/atlas_brain/storage/repositories/invoice.py
@@ -170,8 +170,8 @@ class InvoiceRepository:
 
         try:
             row = await pool.fetchrow(
-                "SELECT * FROM invoices WHERE invoice_number = $1",
-                invoice_number.upper(),
+                "SELECT * FROM invoices WHERE lower(invoice_number) = lower($1)",
+                invoice_number.strip(),
             )
             return self._row_to_dict(row) if row else None
         except DatabaseUnavailableError:

--- a/plans/PR-Invoicing-Number-Case-Insensitive-Lookup.md
+++ b/plans/PR-Invoicing-Number-Case-Insensitive-Lookup.md
@@ -1,0 +1,75 @@
+# Invoicing Number Case-Insensitive Lookup
+
+## Why this slice exists
+
+The live draft-writer connector smoke created a draft invoice and returned the
+invoice number `INV-2026-May-0185`, but the exposed `get_invoice` tool could
+not find that invoice by number. The repository generates invoice numbers with
+`to_char(..., 'YYYY-Mon')`, preserving mixed-case month names, while
+`InvoiceRepository.get_by_number()` uppercases the caller input before an exact
+SQL comparison. That turns `INV-2026-May-0185` into `INV-2026-MAY-0185` and
+misses the row.
+
+This breaks the connector contract: a host-facing tool can create a draft and
+return an invoice number that the same tool surface cannot read back.
+
+## Scope
+
+1. Make invoice-number lookup tolerant of caller casing while preserving exact
+   invoice-number storage.
+2. Add a focused repository regression proving mixed-case generated invoice
+   numbers remain retrievable.
+3. Keep the draft-writer MCP surface unchanged.
+
+### Files touched
+
+- `atlas_brain/storage/repositories/invoice.py`
+- `tests/test_invoice_repository.py`
+- `plans/PR-Invoicing-Number-Case-Insensitive-Lookup.md`
+
+## Mechanism
+
+`InvoiceRepository.get_by_number()` will stop mutating the lookup argument to
+uppercase. It will compare `lower(invoice_number) = lower($1)` in SQL and pass
+the caller-provided invoice number after trimming surrounding whitespace.
+
+The regression uses a fake asyncpg-shaped pool against the real repository
+method, captures the SQL and bind argument, and returns a row only if the query
+uses a case-insensitive comparison. That locks the behavior without requiring a
+live database.
+
+## Intentional
+
+- No migration: invoice numbers already exist in mixed case and do not need to
+  be rewritten.
+- No change to invoice generation: existing `YYYY-Mon` numbers stay stable for
+  customer-facing invoices and previously sent PDFs/emails.
+- No MCP tool change: the bug is below both read-only and draft-writer MCP
+  servers, so fixing the repository closes both surfaces.
+- No cleanup of the live smoke draft: it is blocked from sending by missing
+  email and zero subtotal and remains useful as an audit artifact.
+
+## Deferred
+
+- A reusable live write smoke script for the draft-writer connector can be a
+  follow-up if we want repeatable operator verification after future MCP server
+  changes.
+- Any invoice-number format simplification is out of scope because it would
+  affect historical customer-facing identifiers.
+
+## Verification
+
+- Focused pytest: `.venv/bin/python -m pytest` against the repository
+  regression and draft-writer MCP suite; result: 14 passed.
+- Python compile check for the repository and regression test; result: passed.
+- Git whitespace check; result: passed.
+- Local PR review bundle in advisory dirty mode; result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Repository lookup patch | ~5 |
+| Regression test | ~60 |
+| Plan doc | ~70 |
+| **Total** | ~135 |

--- a/tests/test_invoice_repository.py
+++ b/tests/test_invoice_repository.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain.storage.repositories import invoice as invoice_repo_mod
+
+
+class _InvoiceLookupPool:
+    is_initialized = True
+
+    def __init__(self) -> None:
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+        self.fetchrow_calls.append((query, args))
+        invoice_number = args[0]
+        if (
+            "lower(invoice_number) = lower($1)" in query
+            and invoice_number == "INV-2026-May-0185"
+        ):
+            return {
+                "id": "invoice-1",
+                "invoice_number": "INV-2026-May-0185",
+                "line_items": [],
+                "metadata": {},
+            }
+        return None
+
+
+@pytest.mark.asyncio
+async def test_get_by_number_finds_mixed_case_generated_invoice_numbers(monkeypatch):
+    pool = _InvoiceLookupPool()
+    monkeypatch.setattr(invoice_repo_mod, "get_db_pool", lambda: pool)
+
+    invoice = await invoice_repo_mod.InvoiceRepository().get_by_number(
+        " INV-2026-May-0185 "
+    )
+
+    assert invoice is not None
+    assert invoice["invoice_number"] == "INV-2026-May-0185"
+    assert len(pool.fetchrow_calls) == 1
+    query, args = pool.fetchrow_calls[0]
+    assert "lower(invoice_number) = lower($1)" in query
+    assert args == ("INV-2026-May-0185",)


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Number-Case-Insensitive-Lookup.md

Fixes the live draft-writer connector read-after-create miss where generated invoice numbers use mixed-case month names (`INV-2026-May-0185`) but repository lookup uppercased the input before an exact comparison.

## Intentional
- Preserve existing `YYYY-Mon` invoice-number generation and storage.
- Fix the repository layer so both read-only and draft-writer MCP invoice readers inherit the behavior.
- No live smoke-draft cleanup in this slice; the test draft is blocked from sending by missing email and zero subtotal.

## Deferred
- Reusable live draft-writer write smoke script remains a follow-up.
- Invoice-number format simplification is out of scope because historical customer-facing IDs should remain stable.

## Verification
- `.venv/bin/python -m pytest tests/test_invoice_repository.py tests/test_invoicing_draft_writer_mcp.py` -> 14 passed.
- `python -m py_compile atlas_brain/storage/repositories/invoice.py tests/test_invoice_repository.py` -> passed.
- `git diff --check` -> passed.
- `bash scripts/local_pr_review.sh` -> passed.

## Diff size
3 files, +121 / -2.
