### PR TITLE
Plan: PR-Content-Ops-CFPB-Live-Provider-Smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Review-Source-Live-Provider-Smoke | `scripts/content_ops_source_postgres_smoke_helpers.py`, `scripts/smoke_content_ops_review_source_postgres.py`, review-source smoke tests/docs | codex-2026-05-18 | Invoicing route-check PRs; unrelated extraction slices |
+| TBD | PR-Content-Ops-CFPB-Live-Provider-Smoke | `scripts/smoke_content_ops_cfpb_source_postgres.py`, CFPB smoke tests/docs | codex-2026-05-18 | Invoicing route-check PRs; unrelated extraction slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -223,7 +223,9 @@ Public CFPB complaint narratives can also seed the same source-row path when
 you want support-ticket-like evidence without using seller or review-site data.
 The exporter reads CFPB's public CSV endpoint, keeps narrative-bearing
 complaints, and emits `source_type="support_ticket"` rows. Account and contact
-binding still comes from host defaults:
+binding still comes from host defaults. The Postgres smoke defaults to offline
+generation; pass `--llm pipeline` to use the configured product
+`PipelineLLMClient`:
 
 ```bash
 python scripts/export_content_ops_cfpb_sources.py \
@@ -241,6 +243,7 @@ python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --account-id acct_123 \
   --default-field company_name="Acme Logistics" \
   --default-field contact_email=ops@example.com \
+  --llm pipeline \
   --json
 ```
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -531,8 +531,9 @@ python scripts/export_content_ops_cfpb_sources.py \
 ```
 
 The DB smoke fetches CFPB rows, inspects source-row ingestion, imports them
-under the provided account id, and persists offline generated drafts through
-the Postgres runner:
+under the provided account id, and persists generated drafts through the
+Postgres runner. It defaults to offline generation; pass `--llm pipeline` to
+use the configured product `PipelineLLMClient`:
 
 ```bash
 python scripts/smoke_content_ops_cfpb_source_postgres.py \
@@ -542,6 +543,7 @@ python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --account-id acct_123 \
   --default-field company_name="Acme Logistics" \
   --default-field contact_email=ops@example.com \
+  --llm pipeline \
   --json
 ```
 

--- a/plans/PR-Content-Ops-CFPB-Live-Provider-Smoke.md
+++ b/plans/PR-Content-Ops-CFPB-Live-Provider-Smoke.md
@@ -1,0 +1,70 @@
+# PR-Content-Ops-CFPB-Live-Provider-Smoke
+
+## Why this slice exists
+
+PR #628 added live-provider mode to the G2 review-source Postgres smoke and
+left CFPB/support-ticket-like parity as the next narrow follow-up. CFPB is the
+public support-ticket-like source path, so it should be able to prove the same
+imported source rows can run through the product `PipelineLLMClient` seam
+without changing the default offline smoke.
+
+## Scope (this PR)
+
+1. Add `--llm offline|pipeline` to the CFPB Postgres smoke.
+2. Wire `--llm pipeline` through the existing shared Postgres smoke helper.
+3. Document the live-provider option at the CFPB smoke command sites.
+4. Add focused tests for default offline behavior and provider-port wiring.
+5. Replace the stale merged #628 in-flight row with this slice's claim.
+
+### Files touched
+
+- `scripts/smoke_content_ops_cfpb_source_postgres.py`
+- `tests/test_smoke_content_ops_cfpb_source_postgres.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-CFPB-Live-Provider-Smoke.md`
+
+## Mechanism
+
+The CFPB smoke keeps `offline` as the default. When `--llm pipeline` is passed,
+it constructs the product LLM client and skill registry, then passes them into
+`generate_imported_target_drafts`. That helper already defaults to
+deterministic offline ports, so existing CFPB smoke behavior remains unchanged.
+
+## Intentional
+
+- No new generator, importer, or source adapter.
+- Tests monkeypatch provider factories; they do not call a real LLM provider.
+- This does not run the manual live smoke because this environment does not
+  have `EXTRACTED_DATABASE_URL` or provider credentials loaded.
+
+## Deferred
+
+- A real CFPB live-provider run remains an operator smoke after merge.
+- Hosted UI/source-run controls for choosing live vs offline generation remain
+  separate product work.
+
+## Verification
+
+- Focused CFPB smoke tests -> `9 passed`.
+- Python compile check for edited script/test -> passed.
+- `git diff --check` -> passed.
+- ASCII check on edited script/test -> passed.
+- `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` -> passed.
+- `scripts/audit_extracted_standalone.py` -> passed.
+- `scripts/check_ascii_python.sh` -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| CFPB smoke CLI | ~25 |
+| Tests | ~50 |
+| Docs and coordination | ~20 |
+| Plan | ~55 |
+| **Total** | **~150** |
+
+This is below the 400 LOC review budget.

--- a/scripts/smoke_content_ops_cfpb_source_postgres.py
+++ b/scripts/smoke_content_ops_cfpb_source_postgres.py
@@ -19,6 +19,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_llm_client import (  # noqa: E402
+    create_pipeline_llm_client,
+)
 from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
     import_campaign_opportunities,
 )
@@ -29,6 +32,8 @@ from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
 from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
 )
+from extracted_content_pipeline.skills.registry import get_skill_registry  # noqa: E402
+
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - host dependency
@@ -113,7 +118,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Smoke-test CFPB complaint rows through Content Ops source export, "
-            "Postgres import, and DB-backed offline draft generation."
+            "Postgres import, and DB-backed draft generation."
         )
     )
     parser.add_argument("--company", default=None)
@@ -130,6 +135,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--source-type", default=DEFAULT_SOURCE_TYPE)
     parser.add_argument("--target-mode", default="vendor_retention")
     parser.add_argument("--channels", default=",".join(DEFAULT_CHANNELS))
+    parser.add_argument(
+        "--llm",
+        choices=("offline", "pipeline"),
+        default="offline",
+        help="Use deterministic offline generation or the product PipelineLLMClient.",
+    )
     parser.add_argument("--min-drafts", type=int, default=None)
     parser.add_argument("--allow-ingestion-warnings", action="store_true")
     parser.add_argument(
@@ -173,6 +184,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--account-id is required")
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+def _generation_ports_for_args(args: argparse.Namespace) -> dict[str, Any]:
+    if args.llm == "offline":
+        return {}
+    return {
+        "llm": create_pipeline_llm_client(),
+        "skills": get_skill_registry(),
+    }
 
 
 async def run_cfpb_source_postgres_smoke(
@@ -270,6 +290,7 @@ async def run_cfpb_source_postgres_smoke(
                     channels=channels,
                     target_ids=imported_target_ids,
                     opportunity_table=str(args.opportunity_table),
+                    **_generation_ports_for_args(args),
                 )
                 saved_drafts = await fetch_saved_drafts(pool, drafts_result.get("saved_ids") or [])
                 errors.extend(generation_errors(drafts_result))

--- a/tests/test_smoke_content_ops_cfpb_source_postgres.py
+++ b/tests/test_smoke_content_ops_cfpb_source_postgres.py
@@ -136,6 +136,7 @@ def _args(**overrides):
         "source_type": "support_ticket",
         "target_mode": "vendor_retention",
         "channels": "email_cold",
+        "llm": "offline",
         "min_drafts": None,
         "allow_ingestion_warnings": False,
         "default_field": [
@@ -155,6 +156,17 @@ def _args(**overrides):
     }
     values.update(overrides)
     return argparse.Namespace(**values)
+
+
+def test_parse_args_defaults_to_offline_llm():
+    args = smoke._parse_args([
+        "--account-id",
+        "acct-smoke",
+        "--database-url",
+        "postgres://example",
+    ])
+
+    assert args.llm == "offline"
 
 
 @pytest.mark.asyncio
@@ -192,6 +204,44 @@ async def test_cfpb_source_postgres_smoke_imports_and_persists(monkeypatch, tmp_
     assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]
     assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
     assert pool.fetch_calls[0]["args"] == ("vendor_retention", "acct-smoke", "cfpb:1", 1)
+
+
+@pytest.mark.asyncio
+async def test_cfpb_source_postgres_smoke_pipeline_llm_wires_provider_ports(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(opportunity_rows=[_saved_draft_row()])
+    llm = object()
+    skills = object()
+    calls = []
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_source_row()])
+    monkeypatch.setattr(smoke, "create_pipeline_llm_client", lambda: llm)
+    monkeypatch.setattr(smoke, "get_skill_registry", lambda: skills)
+
+    async def generate_with_ports(**kwargs):
+        calls.append(kwargs)
+        return {
+            "requested": 1,
+            "generated": 1,
+            "skipped": 0,
+            "reasoning_contexts_used": 0,
+            "saved_ids": ["campaign-1"],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(smoke, "generate_imported_target_drafts", generate_with_ports)
+
+    code, payload = await smoke.run_cfpb_source_postgres_smoke(
+        _args(llm="pipeline"),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert calls[0]["llm"] is llm
+    assert calls[0]["skills"] is skills
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-CFPB-Live-Provider-Smoke.md

Adds opt-in live-provider mode to the CFPB/support-ticket-like Postgres smoke so imported CFPB source rows can run through the product PipelineLLMClient seam. Offline deterministic generation remains the default.

## Intentional
- Offline remains the default so CI and host readiness checks do not require provider credentials.
- Tests monkeypatch provider factories and do not call a real LLM provider.
- This does not add a new generator, importer, or source adapter.

## Deferred
- A real CFPB live-provider run remains an operator smoke after merge.
- Hosted UI/source-run controls for choosing live vs offline generation remain separate product work.

## Verification
- `pytest tests/test_smoke_content_ops_cfpb_source_postgres.py -q` -> 9 passed
- `python -m py_compile scripts/smoke_content_ops_cfpb_source_postgres.py tests/test_smoke_content_ops_cfpb_source_postgres.py` -> passed
- `git diff --check` -> passed
- ASCII check on edited script/test -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
6 files, +151 / -5
