### PR TITLE
Plan: PR-Content-Ops-Live-Provider-Smoke-Closeout

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -132,6 +132,14 @@ row imported, 2 offline deterministic campaign drafts persisted
 (`email_cold`, `email_followup`), and the draft export CLI returned both rows
 under `account_id=content_ops_smoke`.
 
+**Live-provider smoke update:** PR #628 added optional `--llm pipeline` mode to
+the review-source Postgres smoke, and PR #630 added the same mode to the CFPB
+support-ticket-like Postgres smoke. Both paths still default to deterministic
+offline generation for CI and host readiness, but operators can now run the
+same imported source rows through the product `PipelineLLMClient` seam when
+database and provider credentials are available. A live operator run remains
+manual because this session did not have those credentials loaded.
+
 ## Current Pick Recommendation
 
 The host-facing AI Content Ops reasoning-policy arc is complete for the current
@@ -162,7 +170,8 @@ the list above in its plan doc.
 
 The review-source readiness and Postgres smoke closeouts do not create a new
 active Content Ops implementation backlog. G2 can use the existing exporter,
-source-row import, DB-backed draft persistence, and draft export path.
+source-row import, DB-backed draft persistence, optional live-provider
+generation mode, and draft export path.
 Capterra and TrustRadius now also pass the Postgres smoke. The TrustRadius run
 surfaced and closed a row-export gap: summary counts found 31 quote-grade rows
 while the row exporter returned 0 because quote-grade filtering happened after
@@ -177,5 +186,6 @@ organization names, issue descriptions, latest comments, and ticket/case
 titles. PR #621 exposed the existing backend `default_fields` contract in
 Atlas Intel so operators can bind fallback account/contact/vendor metadata
 without editing each source row. These close the known generic source-row
-ingestion friction. Further source breadth should still wait for a real host
-export fixture.
+ingestion friction. PR #630 added optional live-provider mode to the CFPB
+support-ticket-like Postgres smoke, matching the review-source path. Further
+source breadth should still wait for a real host export fixture.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,5 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-CFPB-Live-Provider-Smoke | `scripts/smoke_content_ops_cfpb_source_postgres.py`, CFPB smoke tests/docs | codex-2026-05-18 | Invoicing route-check PRs; unrelated extraction slices |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-19T04:55Z by codex-2026-05-18
+Last updated: 2026-05-19T05:30Z by codex-2026-05-18
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #621 | — | Source-row ingestion now covers review, CRM/call/support-style rows, common help desk export aliases, backend `default_fields`, and Atlas Intel fallback-field entry. Next Content Ops work should come from a real host export fixture, live provider run gap, or the separate reasoning-core productization track. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #630 | — | Source-row ingestion now covers review, CRM/call/support-style rows, common help desk export aliases, backend `default_fields`, Atlas Intel fallback-field entry, and optional live-provider Postgres smokes for review-source and CFPB support-ticket-like rows. Next Content Ops work should come from a real host export fixture or the separate reasoning-core productization track. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -104,13 +104,19 @@ source of truth for what remains.
   and offline campaign draft generation, so operators can prove a source such
   as G2 produces usable drafts before import or live provider generation.
 - `scripts/smoke_content_ops_review_source_postgres.py` extends that same
-  review-source path through scoped source-row import and DB-backed offline
-  campaign draft persistence. It replaces matching imported opportunities by
-  default so repeated smoke runs do not duplicate `campaign_opportunities`,
-  and it preflights required Content Ops tables before import so hosts get a
-  migration-runner instruction instead of a late `UndefinedTableError`. A live
-  local Atlas G2/Slack run has passed through source export, import,
-  DB-backed offline draft persistence, and draft export.
+  review-source path through scoped source-row import and DB-backed campaign
+  draft persistence. It defaults to deterministic offline generation and also
+  accepts `--llm pipeline` for product `PipelineLLMClient` runs. It replaces
+  matching imported opportunities by default so repeated smoke runs do not
+  duplicate `campaign_opportunities`, and it preflights required Content Ops
+  tables before import so hosts get a migration-runner instruction instead of a
+  late `UndefinedTableError`. A live local Atlas G2/Slack run has passed
+  through source export, import, DB-backed offline draft persistence, and draft
+  export.
+- `scripts/smoke_content_ops_cfpb_source_postgres.py` gives the public CFPB
+  support-ticket-like source path the same Postgres import and draft
+  persistence smoke, with offline default mode and optional `--llm pipeline`
+  provider mode.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/plans/PR-Content-Ops-Live-Provider-Smoke-Closeout.md
+++ b/plans/PR-Content-Ops-Live-Provider-Smoke-Closeout.md
@@ -1,0 +1,62 @@
+# PR-Content-Ops-Live-Provider-Smoke-Closeout
+
+## Why this slice exists
+
+PR #628 and PR #630 closed the live-provider smoke gap for the two public
+source-row Postgres paths: scraped review sources and CFPB support-ticket-like
+sources. The coordination and backlog docs still show the CFPB slice as in
+flight and still describe the live-provider run gap as open. This slice keeps
+the multi-session ledger accurate before the next Content Ops or reasoning-core
+work starts.
+
+## Scope (this PR)
+
+1. Remove the merged CFPB live-provider smoke row from the in-flight ledger.
+2. Advance `extracted_content_pipeline` state to PR #630.
+3. Record the review-source and CFPB live-provider smoke closeout in the active
+   Content Ops backlog.
+4. Refresh product status wording so the available smoke modes are clear.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `docs/extraction/coordination/state.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-Live-Provider-Smoke-Closeout.md`
+
+## Mechanism
+
+Documentation-only closeout. No runtime code, tests, APIs, or schemas change.
+
+## Intentional
+
+- This does not claim that a live operator run was executed in this environment;
+  provider and database credentials were not loaded here.
+- This keeps the source-breadth backlog waiting on a real host export fixture
+  rather than inventing more hypothetical adapters.
+- This keeps reasoning product depth as a separate `extracted_reasoning_core`
+  decision path.
+
+## Deferred
+
+- Manual live-provider smoke runs with host credentials.
+- Any new source adapters or aliases driven by a real host export fixture.
+- Further reasoning-core productization if a concrete runtime need appears.
+
+## Verification
+
+- `git diff --check` -> passed.
+- Plan/docs presence check -> passed.
+- Grep spot-check for #630/live-provider status wording -> passed.
+- `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Coordination/state/backlog/status docs | ~45 |
+| Plan doc | ~55 |
+| **Total** | **~100** |
+
+This is below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Live-Provider-Smoke-Closeout.md

Closes out the Content Ops live-provider smoke documentation after #628 and #630: removes the merged in-flight row, advances Content Ops state to #630, and records that review-source plus CFPB Postgres smokes now support optional `--llm pipeline` provider mode.

## Intentional
- Documentation-only; no runtime code, schemas, or APIs change.
- This does not claim a live operator run was executed in this environment because DB/provider credentials were not loaded.
- Source breadth still waits on a real host export fixture.

## Deferred
- Manual live-provider smoke runs with host credentials.
- New source adapters or aliases driven by a real host export fixture.
- Further reasoning-core productization if a concrete runtime need appears.

## Verification
- `git diff --check` -> passed
- Plan/docs presence check -> passed
- Grep spot-check for #630/live-provider status wording -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
5 files, +90 / -13
