### PR TITLE
Add draft-writer live write smoke

### DIFF
--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -200,6 +200,22 @@ Then verify OAuth token exchange and the exact four-tool surface:
 
 The e2e smoke lists tools only. It must not create or update invoices.
 
+After discovery and no-mutation e2e pass, operators can run the explicit live
+write smoke:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_live_write.py \
+  --create-blocked-draft \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+That command creates or reuses one idempotent test draft with no customer email
+and a zero subtotal, then verifies `get_invoice` by invoice number and
+`list_pending_drafts`. The expected result is a blocked draft with `no_email`
+and `subtotal_zero`, not a sendable invoice.
+
 If discovery passes but e2e fails with `421 Misdirected Request` or
 `Invalid Host header`, the MCP transport host allowlist is stale. OAuth mode
 must allow the public host from
@@ -224,6 +240,8 @@ The public smoke scripts must mirror the read-only connector pattern:
 
 - Discovery smoke checks metadata and unauthenticated `401`.
 - OAuth e2e smoke completes the flow and calls only `list_tools`.
+- Live write smoke requires explicit acknowledgement and creates only a blocked
+  idempotent smoke draft.
 - Tool-surface check rejects denied tools by name.
 
 ## Required audit metadata

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -105,7 +105,16 @@ tailscale funnel --bg --yes \
   --approval-token-file .secrets/invoicing-draft-writer-approval-token \
   --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
   --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+.venv/bin/python scripts/check_invoicing_draft_writer_live_write.py \
+  --create-blocked-draft \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 ```
+
+Run the live write smoke only after the no-mutation e2e smoke passes. It creates
+or reuses one idempotent blocked test draft and verifies invoice-number readback
+plus pending-draft blockers.
 
 If the e2e smoke reaches token exchange but the MCP session fails with
 `421 Misdirected Request` / `Invalid Host header`, the OAuth server's transport

--- a/plans/PR-Invoicing-Draft-Writer-Live-Write-Smoke.md
+++ b/plans/PR-Invoicing-Draft-Writer-Live-Write-Smoke.md
@@ -1,0 +1,89 @@
+# Invoicing Draft Writer Live Write Smoke
+
+## Why this slice exists
+
+The draft-writer connector now works through ChatGPT and #629 fixed the
+read-after-create invoice-number lookup bug. The remaining verification gap is
+operational: we have a no-mutation OAuth e2e check that lists tools, but no
+repeatable host-facing smoke that proves the public connector can create a
+safe draft and then read it back.
+
+The live test we ran manually created an intentionally blocked draft invoice
+(no email, zero subtotal) and verified that the connector did not expose send
+or payment tools. This slice turns that manual write check into an explicit
+operator command.
+
+This slice exceeds the soft 400 LOC budget because the safe live-write command
+needs its own validation contract: explicit write acknowledgement, idempotent
+draft creation, invoice-number readback, pending-draft blocker checks, tests,
+and operator docs. Splitting those apart would ship a write-capable script
+without the reviewable safety harness in the same PR.
+
+## Scope
+
+1. Add a live write smoke script for the draft-writer OAuth connector.
+2. Require an explicit acknowledgement flag before any draft is created.
+3. Create or reuse one idempotent blocked test draft.
+4. Verify readback by invoice number and visibility in `list_pending_drafts`.
+5. Document where the live write smoke fits after the no-mutation e2e smoke.
+6. Add unit tests for the smoke script's safety and validation behavior.
+
+### Files touched
+
+- `scripts/check_invoicing_draft_writer_live_write.py`
+- `tests/test_check_invoicing_draft_writer_live_write.py`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `plans/PR-Invoicing-Draft-Writer-Live-Write-Smoke.md`
+
+## Mechanism
+
+The new script reuses the existing OAuth helper functions from
+`scripts/check_invoicing_draft_writer_oauth_e2e.py` for client registration,
+operator approval, token exchange, and public MCP transport setup. After the
+operator passes `--create-blocked-draft`, the script calls
+`create_draft_invoice` with a default idempotency key, test customer name, no
+email address, and a zero-dollar line item. That shape is intentionally blocked
+from sending by `no_email` and warned by `subtotal_zero`.
+
+The script then calls `get_invoice` with the returned invoice number and calls
+`list_pending_drafts` with the smoke business context. The command exits nonzero
+if create/read/list disagree, if the draft is not blocked, or if the metadata
+marker is missing.
+
+## Intentional
+
+- This is a live write smoke, not part of the default no-mutation e2e check.
+  The explicit `--create-blocked-draft` flag prevents accidental writes.
+- The smoke is idempotent by default, so repeated runs reuse the same daily test
+  draft instead of creating unbounded duplicates.
+- The script does not void or delete the test draft. The draft remains blocked
+  and visible for operator audit.
+- No connector tool-surface change. This validates the deployed surface only.
+
+## Deferred
+
+- A separate cleanup/void operator command can be added later if blocked smoke
+  drafts become noisy.
+- Extending the same live-write pattern to other MCP write connectors remains a
+  separate connector-by-connector rollout.
+
+## Verification
+
+- Focused pytest for the new smoke script and OAuth helper: 22 passed.
+- Python compile check for the new script and tests: passed.
+- Git whitespace check: passed.
+- Live public smoke against the draft-writer connector: reused
+  `INV-2026-May-0185`, confirmed `no_email` blocker and `subtotal_zero`
+  warning.
+- Local PR review bundle in advisory dirty mode: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Live write smoke script | ~365 |
+| Unit tests | ~210 |
+| Operator docs | ~30 |
+| Plan doc | ~90 |
+| **Total** | ~695 |

--- a/scripts/check_invoicing_draft_writer_live_write.py
+++ b/scripts/check_invoicing_draft_writer_live_write.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Run a live write smoke for the draft-writer invoicing OAuth connector."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_invoicing_draft_writer_oauth_e2e import (  # noqa: E402
+    DEFAULT_REDIRECT_URI,
+    DEFAULT_SCOPE,
+    OAuthE2EConfig,
+    _approve_authorization,
+    _config_from_args,
+    _exchange_token,
+    _register_client,
+    _start_authorization,
+)
+
+
+DEFAULT_CUSTOMER_NAME = "ATLAS TEST - DO NOT SEND - Draft Writer Connector"
+DEFAULT_BUSINESS_CONTEXT_ID = "atlas-mcp-live-smoke"
+DEFAULT_LINE_DESCRIPTION = "Live connector smoke - blocked draft, do not send"
+EXPECTED_METADATA = {
+    "mcp_connector": "invoicing_draft_writer",
+    "operator_review_required": True,
+    "created_by_remote_connector": True,
+}
+
+
+@dataclass(frozen=True)
+class LiveWriteConfig:
+    idempotency_key: str
+    customer_name: str
+    business_context_id: str
+
+
+@dataclass(frozen=True)
+class LiveWriteResult:
+    created: bool
+    invoice_number: str
+    invoice_id: str | None
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _default_idempotency_key(today: date | None = None) -> str:
+    day = today or date.today()
+    return f"atlas-draft-writer-live-smoke-{day.isoformat()}-v1"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create or reuse one intentionally blocked draft invoice through "
+            "the public draft-writer OAuth MCP connector, then verify readback."
+        )
+    )
+    parser.add_argument(
+        "--issuer-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", ""),
+        help="Public OAuth issuer URL.",
+    )
+    parser.add_argument(
+        "--resource-url",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", ""),
+        help="Public Streamable HTTP MCP resource URL.",
+    )
+    parser.add_argument(
+        "--approval-token",
+        default=os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", ""),
+        help="Operator approval token.",
+    )
+    parser.add_argument(
+        "--approval-token-file",
+        default="",
+        help="Read the operator approval token from this local file.",
+    )
+    parser.add_argument(
+        "--redirect-uri",
+        default=DEFAULT_REDIRECT_URI,
+        help=f"OAuth redirect URI to register. Default: {DEFAULT_REDIRECT_URI}.",
+    )
+    parser.add_argument(
+        "--scope",
+        default=DEFAULT_SCOPE,
+        help=f"Required OAuth scope. Default: {DEFAULT_SCOPE}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds. Default: 10.",
+    )
+    parser.add_argument(
+        "--idempotency-key",
+        default="",
+        help="Idempotency key for the smoke draft. Defaults to one key per day.",
+    )
+    parser.add_argument(
+        "--customer-name",
+        default=DEFAULT_CUSTOMER_NAME,
+        help=f"Smoke draft customer name. Default: {DEFAULT_CUSTOMER_NAME}.",
+    )
+    parser.add_argument(
+        "--business-context-id",
+        default=DEFAULT_BUSINESS_CONTEXT_ID,
+        help=f"Smoke draft business context. Default: {DEFAULT_BUSINESS_CONTEXT_ID}.",
+    )
+    parser.add_argument(
+        "--create-blocked-draft",
+        action="store_true",
+        help=(
+            "Required safety acknowledgement. The smoke creates or reuses a "
+            "draft invoice with no email and zero subtotal so it cannot be sent."
+        ),
+    )
+    return parser
+
+
+def _live_config_from_args(args: argparse.Namespace) -> LiveWriteConfig:
+    key = (args.idempotency_key or _default_idempotency_key()).strip()
+    customer = args.customer_name.strip()
+    context = args.business_context_id.strip()
+    missing: list[str] = []
+    if not key:
+        missing.append("--idempotency-key")
+    if not customer:
+        missing.append("--customer-name")
+    if not context:
+        missing.append("--business-context-id")
+    if missing:
+        raise ValueError("missing required values: " + ", ".join(missing))
+    return LiveWriteConfig(
+        idempotency_key=key,
+        customer_name=customer,
+        business_context_id=context,
+    )
+
+
+def _create_arguments(config: LiveWriteConfig) -> dict[str, Any]:
+    return {
+        "customer_name": config.customer_name,
+        "line_items": json.dumps(
+            [
+                {
+                    "description": DEFAULT_LINE_DESCRIPTION,
+                    "quantity": 1,
+                    "unit_price": 0,
+                }
+            ]
+        ),
+        "idempotency_key": config.idempotency_key,
+        "due_days": 30,
+        "invoice_for": "Draft-writer connector live smoke",
+        "business_context_id": config.business_context_id,
+        "notes": "Blocked live smoke draft. Do not send.",
+    }
+
+
+def _pending_drafts_arguments(config: LiveWriteConfig) -> dict[str, Any]:
+    return {
+        "business_context_id": config.business_context_id,
+        "only_blocked": True,
+        "limit": 200,
+    }
+
+
+def _tool_text(result: Any) -> str:
+    return "".join(getattr(item, "text", "") for item in getattr(result, "content", []))
+
+
+async def _call_json_tool(
+    session: Any,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    result = await session.call_tool(tool_name, arguments)
+    text = _tool_text(result)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{tool_name} returned non-JSON output") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{tool_name} returned non-object JSON")
+    return payload
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_pending_draft(
+    pending_payload: dict[str, Any],
+    invoice_number: str,
+) -> dict[str, Any] | None:
+    drafts = pending_payload.get("drafts")
+    if not isinstance(drafts, list):
+        return None
+    for draft in drafts:
+        if isinstance(draft, dict) and draft.get("invoice_number") == invoice_number:
+            return draft
+    return None
+
+
+def _validate_smoke_result(
+    create_payload: dict[str, Any],
+    get_payload: dict[str, Any],
+    pending_payload: dict[str, Any],
+    config: LiveWriteConfig,
+) -> list[str]:
+    errors: list[str] = []
+    if create_payload.get("success") is not True:
+        errors.append("create_draft_invoice did not return success=true")
+
+    invoice = create_payload.get("invoice")
+    if not isinstance(invoice, dict):
+        return errors + ["create_draft_invoice response missing invoice object"]
+
+    invoice_number = str(invoice.get("invoice_number") or "")
+    if not invoice_number:
+        errors.append("created invoice missing invoice_number")
+    if invoice.get("status") != "draft":
+        errors.append("created invoice is not draft")
+    if invoice.get("customer_name") != config.customer_name:
+        errors.append("created invoice customer_name does not match smoke config")
+    if invoice.get("business_context_id") != config.business_context_id:
+        errors.append("created invoice business_context_id does not match smoke config")
+    if invoice.get("customer_email") not in {None, ""}:
+        errors.append("smoke invoice unexpectedly has customer_email")
+    if _as_float(invoice.get("total_amount")) != 0.0:
+        errors.append("smoke invoice total_amount is not zero")
+
+    metadata = invoice.get("metadata")
+    if not isinstance(metadata, dict):
+        errors.append("created invoice metadata is missing")
+    else:
+        for key, expected in EXPECTED_METADATA.items():
+            if metadata.get(key) != expected:
+                errors.append(f"created invoice metadata.{key} mismatch")
+        if metadata.get("idempotency_key") != config.idempotency_key:
+            errors.append("created invoice metadata.idempotency_key mismatch")
+
+    if get_payload.get("found") is not True:
+        errors.append("get_invoice did not find created invoice by invoice number")
+    read_invoice = get_payload.get("invoice")
+    if not isinstance(read_invoice, dict):
+        errors.append("get_invoice response missing invoice object")
+    elif invoice_number and read_invoice.get("invoice_number") != invoice_number:
+        errors.append("get_invoice returned a different invoice_number")
+
+    pending = _find_pending_draft(pending_payload, invoice_number)
+    if pending is None:
+        errors.append("list_pending_drafts did not include the smoke invoice")
+    else:
+        blockers = pending.get("blockers")
+        warnings = pending.get("warnings")
+        if not isinstance(blockers, list) or "no_email" not in blockers:
+            errors.append("pending smoke invoice is missing no_email blocker")
+        if pending.get("send_safe") is not False:
+            errors.append("pending smoke invoice is not blocked from sending")
+        if not isinstance(warnings, list) or "subtotal_zero" not in warnings:
+            errors.append("pending smoke invoice is missing subtotal_zero warning")
+
+    return errors
+
+
+async def _run_live_write_smoke(
+    oauth_config: OAuthE2EConfig,
+    live_config: LiveWriteConfig,
+) -> LiveWriteResult:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    client = _register_client(oauth_config)
+    auth = _start_authorization(oauth_config, client)
+    code = _approve_authorization(oauth_config, auth)
+    token = _exchange_token(oauth_config, client, auth, code)
+
+    async with streamablehttp_client(
+        oauth_config.resource_url,
+        headers={"Authorization": f"Bearer {token.access_token}"},
+        timeout=oauth_config.timeout,
+        sse_read_timeout=oauth_config.timeout,
+    ) as (read_stream, write_stream, _get_session_id):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            create_payload = await _call_json_tool(
+                session,
+                "create_draft_invoice",
+                _create_arguments(live_config),
+            )
+            invoice = create_payload.get("invoice") if isinstance(create_payload, dict) else None
+            if not isinstance(invoice, dict):
+                raise RuntimeError("create_draft_invoice response missing invoice object")
+            invoice_number = str(invoice.get("invoice_number") or "")
+            if not invoice_number:
+                raise RuntimeError("create_draft_invoice response missing invoice_number")
+
+            get_payload = await _call_json_tool(
+                session,
+                "get_invoice",
+                {"invoice_id": invoice_number},
+            )
+            pending_payload = await _call_json_tool(
+                session,
+                "list_pending_drafts",
+                _pending_drafts_arguments(live_config),
+            )
+
+    errors = _validate_smoke_result(create_payload, get_payload, pending_payload, live_config)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+
+    pending = _find_pending_draft(pending_payload, invoice_number) or {}
+    return LiveWriteResult(
+        created=create_payload.get("created") is True,
+        invoice_number=invoice_number,
+        invoice_id=str(invoice.get("id")) if invoice.get("id") else None,
+        blockers=tuple(pending.get("blockers") or ()),
+        warnings=tuple(pending.get("warnings") or ()),
+    )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if not args.create_blocked_draft:
+        print(
+            "refusing to create a live draft without --create-blocked-draft",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        oauth_config = _config_from_args(args)
+        live_config = _live_config_from_args(args)
+        result = asyncio.run(_run_live_write_smoke(oauth_config, live_config))
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    action = "created" if result.created else "reused"
+    print("Draft-writer live write smoke completed")
+    print(f"- action: {action}")
+    print(f"- invoice_number: {result.invoice_number}")
+    if result.invoice_id:
+        print(f"- invoice_id: {result.invoice_id}")
+    print(f"- blockers: {', '.join(result.blockers) or 'none'}")
+    print(f"- warnings: {', '.join(result.warnings) or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_check_invoicing_draft_writer_live_write.py
+++ b/tests/test_check_invoicing_draft_writer_live_write.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_invoicing_draft_writer_live_write.py"
+
+
+def _load_script_module():
+    scripts_dir = str(ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(
+        "check_invoicing_draft_writer_live_write",
+        SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "idempotency_key": "atlas-draft-writer-live-smoke-test-v1",
+        "customer_name": "ATLAS TEST - DO NOT SEND - Draft Writer Connector",
+        "business_context_id": "atlas-mcp-live-smoke",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _create_payload(module):
+    return {
+        "success": True,
+        "created": True,
+        "invoice": {
+            "id": "invoice-1",
+            "invoice_number": "INV-2026-May-0185",
+            "status": "draft",
+            "customer_name": module.DEFAULT_CUSTOMER_NAME,
+            "customer_email": None,
+            "business_context_id": module.DEFAULT_BUSINESS_CONTEXT_ID,
+            "total_amount": 0.0,
+            "metadata": {
+                **module.EXPECTED_METADATA,
+                "idempotency_key": "atlas-draft-writer-live-smoke-test-v1",
+            },
+        },
+    }
+
+
+def _get_payload():
+    return {
+        "found": True,
+        "invoice": {
+            "invoice_number": "INV-2026-May-0185",
+            "status": "draft",
+        },
+    }
+
+
+def _pending_payload():
+    return {
+        "drafts": [
+            {
+                "invoice_number": "INV-2026-May-0185",
+                "blockers": ["no_email"],
+                "warnings": ["subtotal_zero", "no_contact_id"],
+                "send_safe": False,
+            }
+        ],
+        "summary": {"blocked": 1},
+    }
+
+
+def test_default_idempotency_key_is_daily_and_stable() -> None:
+    module = _load_script_module()
+
+    assert module._default_idempotency_key(module.date(2026, 5, 19)) == (
+        "atlas-draft-writer-live-smoke-2026-05-19-v1"
+    )
+
+
+def test_main_refuses_to_create_without_explicit_ack_before_config(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    def fail_config(_args):
+        raise AssertionError("config touched")
+
+    monkeypatch.setattr(module, "_config_from_args", fail_config)
+
+    result = module._main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "--create-blocked-draft" in captured.err
+
+
+def test_live_config_from_args_requires_smoke_identifiers() -> None:
+    module = _load_script_module()
+
+    try:
+        module._live_config_from_args(
+            _args(idempotency_key=" ", customer_name="", business_context_id=" ")
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")
+
+    assert "--idempotency-key" in message
+    assert "--customer-name" in message
+    assert "--business-context-id" in message
+
+
+def test_create_arguments_build_blocked_zero_dollar_draft() -> None:
+    module = _load_script_module()
+    config = module.LiveWriteConfig(
+        idempotency_key="key-1",
+        customer_name="ATLAS TEST",
+        business_context_id="ctx-1",
+    )
+
+    args = module._create_arguments(config)
+
+    assert args["customer_name"] == "ATLAS TEST"
+    assert args["idempotency_key"] == "key-1"
+    assert args["business_context_id"] == "ctx-1"
+    assert "customer_email" not in args
+    assert '"unit_price": 0' in args["line_items"]
+
+
+def test_pending_drafts_arguments_uses_tool_cap_for_busy_accounts() -> None:
+    module = _load_script_module()
+    config = module.LiveWriteConfig(
+        idempotency_key="key-1",
+        customer_name="ATLAS TEST",
+        business_context_id="ctx-1",
+    )
+
+    args = module._pending_drafts_arguments(config)
+
+    assert args == {
+        "business_context_id": "ctx-1",
+        "only_blocked": True,
+        "limit": 200,
+    }
+
+
+def test_validate_smoke_result_accepts_blocked_draft_contract() -> None:
+    module = _load_script_module()
+    config = module._live_config_from_args(_args())
+
+    errors = module._validate_smoke_result(
+        _create_payload(module),
+        _get_payload(),
+        _pending_payload(),
+        config,
+    )
+
+    assert errors == []
+
+
+def test_validate_smoke_result_rejects_send_safe_or_missing_metadata() -> None:
+    module = _load_script_module()
+    config = module._live_config_from_args(_args())
+    create_payload = _create_payload(module)
+    create_payload["invoice"]["metadata"] = {}
+    pending_payload = _pending_payload()
+    pending_payload["drafts"][0]["blockers"] = []
+    pending_payload["drafts"][0]["send_safe"] = True
+
+    errors = module._validate_smoke_result(
+        create_payload,
+        _get_payload(),
+        pending_payload,
+        config,
+    )
+
+    assert "created invoice metadata.mcp_connector mismatch" in errors
+    assert "created invoice metadata.idempotency_key mismatch" in errors
+    assert "pending smoke invoice is missing no_email blocker" in errors
+    assert "pending smoke invoice is not blocked from sending" in errors
+
+
+def test_main_reports_success_without_printing_approval_token(monkeypatch, capsys) -> None:
+    module = _load_script_module()
+
+    async def fake_run(_oauth_config, _live_config):
+        return module.LiveWriteResult(
+            created=False,
+            invoice_number="INV-2026-May-0185",
+            invoice_id="invoice-1",
+            blockers=("no_email",),
+            warnings=("subtotal_zero",),
+        )
+
+    monkeypatch.setattr(module, "_run_live_write_smoke", fake_run)
+
+    result = module._main(
+        [
+            "--create-blocked-draft",
+            "--issuer-url",
+            "https://atlas.example.com/invoicing-draft-writer",
+            "--resource-url",
+            "https://atlas.example.com/invoicing-draft-writer/mcp",
+            "--approval-token",
+            "secret-approval-token-value",
+            "--idempotency-key",
+            "atlas-draft-writer-live-smoke-test-v1",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Draft-writer live write smoke completed" in captured.out
+    assert "action: reused" in captured.out
+    assert "INV-2026-May-0185" in captured.out
+    assert "secret-approval-token-value" not in captured.out


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Draft-Writer-Live-Write-Smoke.md

Adds an explicit operator live-write smoke for the public invoicing draft-writer OAuth connector. The command creates or reuses one idempotent blocked test draft, verifies readback by invoice number, and confirms the draft remains blocked in `list_pending_drafts`.

## Intentional
- Requires `--create-blocked-draft` before any live mutation.
- Uses no customer email and a zero-dollar line item so the smoke draft is blocked from sending.
- Reuses a daily idempotency key by default to avoid unbounded duplicate smoke drafts.
- Uses the `list_pending_drafts` tool cap so reused smoke drafts are not dropped in busy accounts.
- Does not clean up or void the smoke draft; it remains blocked and auditable.

## Deferred
- Cleanup/void tooling for smoke drafts remains a separate operator slice.
- Extending this live-write pattern to other MCP write connectors is connector-specific follow-up work.

## Verification
- `.venv/bin/python -m pytest tests/test_check_invoicing_draft_writer_live_write.py tests/test_check_invoicing_draft_writer_oauth_e2e.py` -> 22 passed.
- `python -m py_compile scripts/check_invoicing_draft_writer_live_write.py tests/test_check_invoicing_draft_writer_live_write.py` -> passed.
- `git diff --check` -> passed.
- Live public smoke reused `INV-2026-May-0185`, with `no_email` blocker and `subtotal_zero` warning.
- `bash scripts/local_pr_review.sh` -> passed.

## Diff size
5 files, +710 / -0. Over soft budget; plan explains why the write-capable command, safety validation, tests, and operator docs ship together.
