### PR TITLE
Persist invoicing OAuth clients and refresh tokens

### DIFF
--- a/atlas_brain/mcp/invoicing_draft_writer_oauth.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_oauth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from html import escape
+from pathlib import Path
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
@@ -30,6 +31,7 @@ class InvoicingDraftWriterOAuthProvider(InvoicingReadonlyOAuthProvider):
         scopes: list[str] | None = None,
         authorization_ttl_seconds: int = 300,
         access_token_ttl_seconds: int = 3600,
+        state_file: str | Path | None = None,
     ) -> None:
         super().__init__(
             issuer_url=issuer_url,
@@ -37,6 +39,7 @@ class InvoicingDraftWriterOAuthProvider(InvoicingReadonlyOAuthProvider):
             scopes=scopes or [DEFAULT_DRAFT_WRITE_SCOPE],
             authorization_ttl_seconds=authorization_ttl_seconds,
             access_token_ttl_seconds=access_token_ttl_seconds,
+            state_file=state_file,
         )
 
 

--- a/atlas_brain/mcp/invoicing_draft_writer_server.py
+++ b/atlas_brain/mcp/invoicing_draft_writer_server.py
@@ -376,6 +376,10 @@ def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
     issuer_url = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL", "").strip()
     resource_url = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL", "").strip()
     approval_token = os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN", "").strip()
+    state_file = (
+        os.environ.get("ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE", "").strip()
+        or None
+    )
     validate_oauth_settings(
         issuer_url=issuer_url,
         resource_server_url=resource_url,
@@ -393,6 +397,7 @@ def _configure_oauth_auth() -> InvoicingDraftWriterOAuthProvider:
         issuer_url=issuer_url,
         approval_token=approval_token,
         scopes=[DEFAULT_DRAFT_WRITE_SCOPE],
+        state_file=state_file,
     )
     mcp.settings.auth = AuthSettings(
         issuer_url=as_any_http_url(issuer_url),

--- a/atlas_brain/mcp/invoicing_readonly_oauth.py
+++ b/atlas_brain/mcp/invoicing_readonly_oauth.py
@@ -7,10 +7,13 @@ flow without exposing mutating invoice tools or accepting anonymous access.
 
 from __future__ import annotations
 
+import json
+import os
 import secrets
 import time
 from dataclasses import dataclass
 from html import escape
+from pathlib import Path
 from typing import Any
 
 from mcp.server.auth.provider import (
@@ -31,6 +34,8 @@ from starlette.responses import HTMLResponse, RedirectResponse, Response
 
 
 DEFAULT_READONLY_SCOPE = "invoices.read"
+DEFAULT_MAX_PERSISTED_CLIENTS = 25
+DEFAULT_MAX_PERSISTED_REFRESH_TOKENS = 100
 
 
 @dataclass(frozen=True)
@@ -55,18 +60,25 @@ class InvoicingReadonlyOAuthProvider(
         scopes: list[str] | None = None,
         authorization_ttl_seconds: int = 300,
         access_token_ttl_seconds: int = 3600,
+        state_file: str | Path | None = None,
+        max_persisted_clients: int = DEFAULT_MAX_PERSISTED_CLIENTS,
+        max_persisted_refresh_tokens: int = DEFAULT_MAX_PERSISTED_REFRESH_TOKENS,
     ) -> None:
         self.issuer_url = issuer_url.rstrip("/")
         self.approval_token = approval_token
         self.scopes = scopes or [DEFAULT_READONLY_SCOPE]
         self.authorization_ttl_seconds = authorization_ttl_seconds
         self.access_token_ttl_seconds = access_token_ttl_seconds
+        self.state_file = Path(state_file) if state_file else None
+        self.max_persisted_clients = max_persisted_clients
+        self.max_persisted_refresh_tokens = max_persisted_refresh_tokens
 
         self._clients: dict[str, OAuthClientInformationFull] = {}
         self._pending: dict[str, PendingAuthorization] = {}
         self._authorization_codes: dict[str, AuthorizationCode] = {}
         self._refresh_tokens: dict[str, RefreshToken] = {}
         self._access_tokens: dict[str, AccessToken] = {}
+        self._load_state()
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
         return self._clients.get(client_id)
@@ -74,7 +86,13 @@ class InvoicingReadonlyOAuthProvider(
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         if not client_info.client_id:  # pragma: no cover - registration handler sets this
             client_info.client_id = secrets.token_urlsafe(24)
+        if (
+            client_info.client_id not in self._clients
+            and len(self._clients) >= self.max_persisted_clients
+        ):
+            raise RuntimeError("OAuth client registration limit reached")
         self._clients[client_info.client_id] = client_info
+        self._save_state()
 
     async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
         if not client.client_id:
@@ -130,6 +148,8 @@ class InvoicingReadonlyOAuthProvider(
             client_id=client.client_id,
             scopes=authorization_code.scopes,
         )
+        self._trim_refresh_tokens()
+        self._save_state()
         return OAuthToken(
             access_token=access_token,
             refresh_token=refresh_token,
@@ -183,6 +203,7 @@ class InvoicingReadonlyOAuthProvider(
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         self._access_tokens.pop(token.token, None)
         self._refresh_tokens.pop(token.token, None)
+        self._save_state()
 
     def approve_pending_authorization(self, *, request_id: str, approval_token: str) -> str:
         """Approve a pending authorization request and return the redirect URI."""
@@ -210,6 +231,72 @@ class InvoicingReadonlyOAuthProvider(
 
     def pending_authorization(self, request_id: str) -> PendingAuthorization | None:
         return self._pending.get(request_id)
+
+    def _load_state(self) -> None:
+        if self.state_file is None or not self.state_file.exists():
+            return
+        try:
+            data = json.loads(self.state_file.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"could not load OAuth state file {self.state_file}") from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(f"OAuth state file {self.state_file} must contain a JSON object")
+
+        clients = data.get("clients", {})
+        if not isinstance(clients, dict):
+            raise RuntimeError("OAuth state clients must be a JSON object")
+        for client_id, payload in clients.items():
+            if not isinstance(client_id, str) or not isinstance(payload, dict):
+                raise RuntimeError("OAuth state clients must map IDs to JSON objects")
+            client = OAuthClientInformationFull(**payload)
+            if client.client_id != client_id:
+                raise RuntimeError("OAuth state client_id mismatch")
+            self._clients[client_id] = client
+
+        refresh_tokens = data.get("refresh_tokens", {})
+        if not isinstance(refresh_tokens, dict):
+            raise RuntimeError("OAuth state refresh_tokens must be a JSON object")
+        for token, payload in refresh_tokens.items():
+            if not isinstance(token, str) or not isinstance(payload, dict):
+                raise RuntimeError("OAuth state refresh_tokens must map tokens to JSON objects")
+            refresh = RefreshToken(**payload)
+            if refresh.token != token:
+                raise RuntimeError("OAuth state refresh token mismatch")
+            self._refresh_tokens[token] = refresh
+
+    def _save_state(self) -> None:
+        if self.state_file is None:
+            return
+        self.state_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        data = {
+            "clients": {
+                client_id: client.model_dump(mode="json")
+                for client_id, client in sorted(self._clients.items())
+            },
+            "refresh_tokens": {
+                token: refresh.model_dump(mode="json")
+                for token, refresh in sorted(self._refresh_tokens.items())
+            },
+        }
+        tmp_path = self.state_file.with_name(f"{self.state_file.name}.tmp")
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+        os.replace(tmp_path, self.state_file)
+        os.chmod(self.state_file, 0o600)
+
+    def _trim_refresh_tokens(self) -> None:
+        while len(self._refresh_tokens) > self.max_persisted_refresh_tokens:
+            oldest = next(iter(self._refresh_tokens))
+            self._refresh_tokens.pop(oldest, None)
 
 
 def approval_page(

--- a/atlas_brain/mcp/invoicing_readonly_server.py
+++ b/atlas_brain/mcp/invoicing_readonly_server.py
@@ -229,6 +229,7 @@ def _configure_oauth_auth() -> InvoicingReadonlyOAuthProvider:
     issuer_url = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL", "").strip()
     resource_url = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_RESOURCE_URL", "").strip()
     approval_token = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN", "").strip()
+    state_file = os.environ.get("ATLAS_MCP_INVOICING_READONLY_OAUTH_STATE_FILE", "").strip() or None
     validate_oauth_settings(
         issuer_url=issuer_url,
         resource_server_url=resource_url,
@@ -239,6 +240,7 @@ def _configure_oauth_auth() -> InvoicingReadonlyOAuthProvider:
         issuer_url=issuer_url,
         approval_token=approval_token,
         scopes=[DEFAULT_READONLY_SCOPE],
+        state_file=state_file,
     )
     mcp.settings.auth = AuthSettings(
         issuer_url=as_any_http_url(issuer_url),

--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -123,6 +123,7 @@ ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE=oauth
 ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer
 ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_RESOURCE_URL=https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
 ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN=<long-random-token>
+ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE=.secrets/invoicing-draft-writer-oauth-state.json
 ATLAS_MCP_INVOICING_DRAFT_WRITER_PORT=<dedicated-port>
 ```
 
@@ -139,6 +140,11 @@ print(secrets.token_urlsafe(32))
 PY
 chmod 600 .secrets/invoicing-draft-writer-approval-token
 ```
+
+The optional OAuth state file stores ChatGPT client registrations and refresh
+tokens so the connector survives local MCP server restarts. Keep it under
+`.secrets/`; the provider writes it with owner-only permissions. It does not
+store pending approval requests, one-time authorization codes, or access tokens.
 
 The approval page copy must say draft-write access, not read-only access.
 

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -371,8 +371,17 @@ Run with the repo virtualenv:
 
 ### ChatGPT works until restart, then fails
 
-The current OAuth provider is in-memory. If this becomes a real operational
-problem, the next slice is durable OAuth client/token persistence.
+Set the server-specific OAuth state file env var before startup:
+
+```bash
+ATLAS_MCP_INVOICING_READONLY_OAUTH_STATE_FILE=.secrets/invoicing-readonly-oauth-state.json
+ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE=.secrets/invoicing-draft-writer-oauth-state.json
+```
+
+The state file persists registered OAuth clients and refresh tokens only. It is
+local operator secret material and should stay under `.secrets/`. Pending
+approval requests, one-time authorization codes, and access tokens remain
+process-local.
 
 ## What to defer until after read-only works
 

--- a/plans/PR-Invoicing-OAuth-State-File.md
+++ b/plans/PR-Invoicing-OAuth-State-File.md
@@ -1,0 +1,91 @@
+# Invoicing OAuth State File
+
+## Why this slice exists
+
+The ChatGPT invoicing MCP connectors now work through OAuth, but the OAuth
+provider is process-local. After a server restart, ChatGPT can still hold its
+registered client credentials and refresh token while the server forgets both.
+That creates a predictable operator failure mode: the connector works until the
+local MCP server or PC restarts, then token refresh fails and the operator has
+to reconnect.
+
+This slice adds optional local state-file persistence for invoicing OAuth client
+registrations and refresh tokens. It closes the restart gap without changing the
+MCP tool surface or making OAuth approval automatic.
+
+## Scope
+
+1. Add optional state-file persistence to the shared invoicing OAuth provider.
+2. Persist registered OAuth clients and refresh tokens only.
+3. Wire separate state-file env vars for read-only and draft-writer connectors.
+4. Document the env vars and the restart behavior.
+5. Cap persisted dynamic client registrations to avoid durable state-file growth
+   from unauthenticated `/register` traffic.
+6. Add tests proving client/refresh-token state survives provider recreation.
+
+### Files touched
+
+- `atlas_brain/mcp/invoicing_readonly_oauth.py`
+- `atlas_brain/mcp/invoicing_readonly_server.py`
+- `atlas_brain/mcp/invoicing_draft_writer_oauth.py`
+- `atlas_brain/mcp/invoicing_draft_writer_server.py`
+- `tests/test_invoicing_readonly_oauth.py`
+- `tests/test_invoicing_draft_writer_oauth.py`
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `plans/PR-Invoicing-OAuth-State-File.md`
+
+## Mechanism
+
+`InvoicingReadonlyOAuthProvider` will accept an optional `state_file` path. When
+present, the provider loads JSON state at startup and writes it after client
+registration, authorization-code exchange, and token revocation. The persisted
+state includes OAuth client registrations and refresh tokens. Pending approval
+requests, one-time authorization codes, and access tokens remain process-local.
+
+The read-only server reads
+`ATLAS_MCP_INVOICING_READONLY_OAUTH_STATE_FILE`. The draft-writer server reads
+`ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE`. Both env vars are optional;
+without them, behavior stays in-memory.
+
+Persisted dynamic client registrations are capped because OAuth dynamic client
+registration is intentionally public. The cap keeps bogus registrations from
+growing durable local state unboundedly.
+
+## Intentional
+
+- Access tokens are not persisted. A restarted connector should refresh using a
+  persisted refresh token rather than keep using an old bearer token.
+- Pending authorizations and authorization codes are not persisted because they
+  are short-lived one-time values.
+- The state file is local operator secret material. The provider writes it with
+  owner-only permissions and docs place it under `.secrets/`.
+- No DB migration. These OAuth connectors are local operator MCP surfaces, not a
+  multi-tenant web auth system.
+- Dynamic client registration is still public OAuth behavior, but persisted
+  client state is capped so abuse cannot grow the state file indefinitely.
+
+## Deferred
+
+- Encrypting the state file at rest can be considered later if these connectors
+  move off a local operator machine.
+- Applying the same state-file pattern to non-invoicing MCP servers is a future
+  per-server rollout.
+
+## Verification
+
+- Focused OAuth tests: 21 passed.
+- Python compile check for touched OAuth modules/tests: passed.
+- Git whitespace check: passed.
+- Local PR review bundle in advisory dirty mode: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Provider persistence | ~90 |
+| Server env wiring | ~15 |
+| Tests | ~130 |
+| Docs | ~25 |
+| Plan doc | ~95 |
+| **Total** | ~355 |

--- a/tests/test_invoicing_draft_writer_oauth.py
+++ b/tests/test_invoicing_draft_writer_oauth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import stat
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -162,6 +163,48 @@ async def test_oauth_provider_refresh_token_issues_new_access_token():
 
 
 @pytest.mark.asyncio
+async def test_draft_writer_oauth_provider_state_file_survives_restart(tmp_path):
+    state_file = tmp_path / "draft-writer-oauth-state.json"
+    provider = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+        state_file=state_file,
+    )
+    client = _client()
+    await provider.register_client(client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    first_token = await provider.exchange_authorization_code(client, auth_code)
+    assert first_token.refresh_token is not None
+
+    restarted = InvoicingDraftWriterOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-draft-writer",
+        approval_token="approval-token-with-enough-entropy",
+        state_file=state_file,
+    )
+    loaded_client = await restarted.get_client(client.client_id)
+    assert loaded_client is not None
+    refresh = await restarted.load_refresh_token(loaded_client, first_token.refresh_token)
+    assert refresh is not None
+
+    second_token = await restarted.exchange_refresh_token(
+        loaded_client,
+        refresh,
+        [DEFAULT_DRAFT_WRITE_SCOPE],
+    )
+
+    assert second_token.refresh_token == first_token.refresh_token
+    assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
 async def test_oauth_provider_binds_refresh_tokens_to_client():
     provider = InvoicingDraftWriterOAuthProvider(
         issuer_url="https://atlas.example.com/invoicing-draft-writer",
@@ -200,7 +243,10 @@ def test_validate_oauth_settings_requires_approval_token():
         )
 
 
-def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(monkeypatch):
+def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(
+    monkeypatch,
+    tmp_path,
+):
     monkeypatch.setenv("ATLAS_MCP_INVOICING_DRAFT_WRITER_AUTH_MODE", "oauth")
     monkeypatch.setenv(
         "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_ISSUER_URL",
@@ -214,8 +260,15 @@ def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(mo
         "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_APPROVAL_TOKEN",
         "approval-token-with-enough-entropy",
     )
+    state_file = tmp_path / "draft-writer-state.json"
+    monkeypatch.setenv(
+        "ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE",
+        str(state_file),
+    )
 
     app = draft_writer._streamable_http_app()
+    assert draft_writer._oauth_provider is not None
+    assert draft_writer._oauth_provider.state_file == state_file
 
     with TestClient(app) as client:
         auth_metadata = client.get("/.well-known/oauth-authorization-server")

--- a/tests/test_invoicing_readonly_oauth.py
+++ b/tests/test_invoicing_readonly_oauth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import stat
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -161,6 +162,67 @@ async def test_oauth_provider_refresh_token_issues_new_access_token():
 
 
 @pytest.mark.asyncio
+async def test_oauth_provider_state_file_survives_restart(tmp_path):
+    state_file = tmp_path / "readonly-oauth-state.json"
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+        state_file=state_file,
+    )
+    client = _client()
+    await provider.register_client(client)
+    approval_url = await provider.authorize(client, _params())
+    request_id = parse_qs(urlparse(approval_url).query)["request_id"][0]
+    redirect_uri = provider.approve_pending_authorization(
+        request_id=request_id,
+        approval_token="approval-token-with-enough-entropy",
+    )
+    code = parse_qs(urlparse(redirect_uri).query)["code"][0]
+    auth_code = await provider.load_authorization_code(client, code)
+    assert auth_code is not None
+    first_token = await provider.exchange_authorization_code(client, auth_code)
+    assert first_token.refresh_token is not None
+
+    restarted = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+        state_file=state_file,
+    )
+    loaded_client = await restarted.get_client(client.client_id)
+    assert loaded_client is not None
+    assert loaded_client.client_secret == "secret-1"
+    refresh = await restarted.load_refresh_token(loaded_client, first_token.refresh_token)
+    assert refresh is not None
+
+    second_token = await restarted.exchange_refresh_token(
+        loaded_client,
+        refresh,
+        [DEFAULT_READONLY_SCOPE],
+    )
+
+    assert second_token.refresh_token == first_token.refresh_token
+    assert second_token.access_token != first_token.access_token
+    assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_state_file_caps_persisted_client_registrations(tmp_path):
+    provider = InvoicingReadonlyOAuthProvider(
+        issuer_url="https://atlas.example.com/invoicing-readonly",
+        approval_token="approval-token-with-enough-entropy",
+        state_file=tmp_path / "readonly-oauth-state.json",
+        max_persisted_clients=1,
+    )
+    await provider.register_client(_client())
+
+    with pytest.raises(RuntimeError, match="registration limit"):
+        await provider.register_client(_other_client())
+
+    assert await provider.get_client("client-1") is not None
+    assert await provider.get_client("client-2") is None
+
+
+@pytest.mark.asyncio
 async def test_oauth_provider_binds_refresh_tokens_to_client():
     provider = InvoicingReadonlyOAuthProvider(
         issuer_url="https://atlas.example.com/invoicing-readonly",
@@ -199,7 +261,10 @@ def test_validate_oauth_settings_requires_approval_token():
         )
 
 
-def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(monkeypatch):
+def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(
+    monkeypatch,
+    tmp_path,
+):
     monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_AUTH_MODE", "oauth")
     monkeypatch.setenv(
         "ATLAS_MCP_INVOICING_READONLY_OAUTH_ISSUER_URL",
@@ -213,8 +278,12 @@ def test_streamable_http_app_in_oauth_mode_exposes_metadata_and_requires_auth(mo
         "ATLAS_MCP_INVOICING_READONLY_OAUTH_APPROVAL_TOKEN",
         "approval-token-with-enough-entropy",
     )
+    state_file = tmp_path / "readonly-state.json"
+    monkeypatch.setenv("ATLAS_MCP_INVOICING_READONLY_OAUTH_STATE_FILE", str(state_file))
 
     app = readonly._streamable_http_app()
+    assert readonly._oauth_provider is not None
+    assert readonly._oauth_provider.state_file == state_file
 
     with TestClient(app) as client:
         auth_metadata = client.get("/.well-known/oauth-authorization-server")


### PR DESCRIPTION
Plan: plans/PR-Invoicing-OAuth-State-File.md

Adds optional local OAuth state-file persistence for the invoicing MCP connectors so ChatGPT client registration and refresh-token state can survive local server restarts.

## Intentional
- Persists registered OAuth clients and refresh tokens only.
- Keeps pending approval requests, one-time authorization codes, and access tokens process-local.
- Uses server-specific env vars for read-only and draft-writer connectors.
- Caps persisted dynamic client registrations so unauthenticated `/register` traffic cannot grow the state file indefinitely.
- Writes the state file with owner-only permissions and documents `.secrets/` placement.

## Deferred
- Encrypting the local state file at rest remains a future hardening item if these connectors move off the operator machine.
- Applying the same state-file pattern to non-invoicing MCP servers is a future per-server rollout.

## Verification
- `.venv/bin/python -m pytest tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_oauth.py` -> 21 passed.
- `python -m py_compile atlas_brain/mcp/invoicing_readonly_oauth.py atlas_brain/mcp/invoicing_draft_writer_oauth.py atlas_brain/mcp/invoicing_readonly_server.py atlas_brain/mcp/invoicing_draft_writer_server.py tests/test_invoicing_readonly_oauth.py tests/test_invoicing_draft_writer_oauth.py` -> passed.
- `git diff --check` -> passed.
- `bash scripts/local_pr_review.sh` -> passed.

## Diff size
9 files, +329 / -4.
