### PR TITLE
Disable Evidence-anchor auto-injection (cleanup-only repair)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -2145,117 +2145,6 @@ def _needs_timing_or_numeric_anchor(report: dict[str, Any]) -> bool:
     )
 
 
-def _select_specificity_anchor_terms(
-    blueprint: PostBlueprint,
-    report: dict[str, Any],
-) -> dict[str, str]:
-    specificity = _blog_specificity_context(blueprint)
-    rows = _specificity_rows(blueprint)
-    if not rows:
-        return {}
-
-    needs_timing_numeric = _needs_timing_or_numeric_anchor(report)
-    timing_anchor = _first_term_from_rows(rows, lambda row: row.get("time_anchor"))
-    numeric_anchor = _first_term_from_rows(rows, _first_numeric_literal)
-    competitor = _first_term_from_rows(rows, lambda row: row.get("competitor"))
-    pain = _first_term_from_rows(rows, _meaningful_pain_label)
-    workflow = _first_term_from_rows(rows, _meaningful_workflow_label)
-
-    signal_terms = specificity_signal_terms(
-        anchor_examples=specificity.get("anchor_examples"),
-        witness_highlights=specificity.get("witness_highlights"),
-        allow_company_names=False,
-    )
-    if not timing_anchor:
-        timing_anchor = _preferred_signal_term(signal_terms.get("timing_terms"))
-    if not numeric_anchor:
-        numeric_anchor = _preferred_signal_term(
-            signal_terms.get("numeric_terms"),
-            predicate=_is_meaningful_numeric_anchor,
-        )
-    if not competitor:
-        competitor = _preferred_signal_term(signal_terms.get("competitor_terms"))
-    if not pain:
-        pain = _preferred_signal_term(
-            signal_terms.get("pain_terms"),
-            skip={
-                "recommendation",
-                "unknown",
-                "none",
-                *(_blog_low_signal_anchor_labels()),
-            },
-        )
-        if pain and not _is_meaningful_blog_anchor_label(pain):
-            pain = ""
-        else:
-            pain = _humanize_blog_anchor_label(pain)
-    if not workflow:
-        workflow = _preferred_signal_term(
-            signal_terms.get("workflow_terms"),
-            skip={"unknown", "none"},
-        )
-        if workflow and not _is_meaningful_blog_anchor_label(workflow):
-            workflow = ""
-        else:
-            workflow = _humanize_blog_anchor_label(workflow)
-
-    if needs_timing_numeric and not (timing_anchor or numeric_anchor):
-        return {}
-
-    return {
-        "time_anchor": timing_anchor,
-        "numeric_anchor": numeric_anchor,
-        "competitor": competitor,
-        "pain": pain,
-        "workflow": workflow,
-    }
-
-
-def _build_specificity_anchor_note(
-    blueprint: PostBlueprint,
-    report: dict[str, Any],
-) -> str:
-    terms = _select_specificity_anchor_terms(blueprint, report)
-    if not terms:
-        return ""
-
-    detail_bits: list[str] = []
-    time_anchor = terms["time_anchor"]
-    numeric_anchor = terms["numeric_anchor"]
-    competitor = terms["competitor"]
-    pain = terms["pain"]
-    workflow = terms["workflow"]
-
-    if time_anchor:
-        detail_bits.append(f"{time_anchor} is the live timing trigger")
-    if numeric_anchor:
-        detail_bits.append(f"{numeric_anchor} is the concrete spend anchor")
-    if competitor:
-        detail_bits.append(f"{competitor} is the competitive alternative in the witness-backed record")
-    if pain:
-        detail_bits.append(f"the core pressure showing up in the evidence is {pain}")
-    if workflow:
-        detail_bits.append(f"the workflow shift in play is {workflow}")
-
-    if not detail_bits:
-        return ""
-
-    note = "Evidence anchor: " + ", ".join(detail_bits[:-1])
-    if len(detail_bits) > 1:
-        note += f", and {detail_bits[-1]}."
-    else:
-        note += f"{detail_bits[-1]}."
-    if len(detail_bits) == 1:
-        note = "Evidence anchor: " + detail_bits[0] + "."
-    return note
-
-
-def _has_specificity_issues(report: dict[str, Any]) -> bool:
-    blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
-    warnings = [str(warning) for warning in (report.get("warnings") or [])]
-    return any(issue.startswith("witness_specificity:") for issue in blockers + warnings)
-
-
 def _apply_specificity_anchor_repair(
     blueprint: PostBlueprint,
     content: dict[str, Any],
@@ -2279,8 +2168,6 @@ def _apply_specificity_anchor_repair(
     a prior generation, or copy-pasted from a stale template), it's
     stripped so subsequent passes don't ship the stale prose.
 
-    ``_build_specificity_anchor_note`` is no longer called from this
-    module and exists only as dead code; future cleanup can delete it.
     """
     updated = dict(content or {})
     body = str(updated.get("content") or "")

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -2261,36 +2261,49 @@ def _apply_specificity_anchor_repair(
     content: dict[str, Any],
     report: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    """Cleanup-only repair for the legacy "Evidence anchor:" injection.
+
+    HISTORY: This function previously INJECTED an ``Evidence anchor:``
+    prose line into the post body whenever a ``witness_specificity``
+    quality check failed. The injected text used internal-pipeline
+    jargon ("Evidence anchor:", "live timing trigger", "concrete spend
+    anchor", "core pressure", "workflow shift in play"). Readers saw
+    this as broken/draft content -- 19 of 79 published posts shipped
+    with the jargon visible (measured in PR #612's baseline analyzer).
+
+    CURRENT BEHAVIOR (PR #632+): the injection path is disabled.
+    Specificity failures stay in the report so the quality gate
+    surfaces them as quality issues, holding the post for human review
+    instead of papering over with jargon. The REMOVAL path is preserved:
+    if a post body already contains an ``Evidence anchor:`` line (from
+    a prior generation, or copy-pasted from a stale template), it's
+    stripped so subsequent passes don't ship the stale prose.
+
+    ``_build_specificity_anchor_note`` is no longer called from this
+    module and exists only as dead code; future cleanup can delete it.
+    """
     updated = dict(content or {})
     body = str(updated.get("content") or "")
     has_existing_note = _has_blog_note(body, marker="Evidence anchor:")
-    if not _has_specificity_issues(report) and not has_existing_note:
+
+    if not has_existing_note:
+        # Nothing to clean up. Specificity issues (if any) remain in
+        # the report so the quality gate fails the post for human
+        # review rather than silently auto-papering over the issue.
         return updated, report, False
 
-    note = _build_specificity_anchor_note(blueprint, report)
-    if not note:
-        if not has_existing_note:
-            return updated, report, False
-        repaired_body = _remove_blog_note(body, marker="Evidence anchor:")
-        if repaired_body == body:
-            return updated, report, False
-        updated["content"] = repaired_body
-        updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
-        repaired_report = dict(repaired_report)
-        fixes = list(repaired_report.get("fixes_applied", []) or [])
-        fixes.append("removed_low_signal_witness_anchor_note")
-        repaired_report["fixes_applied"] = fixes
-        return updated, repaired_report, True
-
-    repaired_body = _insert_blog_note(body, note, marker="Evidence anchor:")
+    # Existing "Evidence anchor:" line present. Strip it. Anchor
+    # injection produced reader-hostile prose; legacy anchors should
+    # be removed on every quality pass so a refreshed post doesn't
+    # carry over jargon from the prior generation.
+    repaired_body = _remove_blog_note(body, marker="Evidence anchor:")
     if repaired_body == body:
         return updated, report, False
-
     updated["content"] = repaired_body
     updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
     repaired_report = dict(repaired_report)
     fixes = list(repaired_report.get("fixes_applied", []) or [])
-    fixes.append("added_witness_anchor_note")
+    fixes.append("removed_disabled_witness_anchor_note")
     repaired_report["fixes_applied"] = fixes
     return updated, repaired_report, True
 

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -2145,117 +2145,6 @@ def _needs_timing_or_numeric_anchor(report: dict[str, Any]) -> bool:
     )
 
 
-def _select_specificity_anchor_terms(
-    blueprint: PostBlueprint,
-    report: dict[str, Any],
-) -> dict[str, str]:
-    specificity = _blog_specificity_context(blueprint)
-    rows = _specificity_rows(blueprint)
-    if not rows:
-        return {}
-
-    needs_timing_numeric = _needs_timing_or_numeric_anchor(report)
-    timing_anchor = _first_term_from_rows(rows, lambda row: row.get("time_anchor"))
-    numeric_anchor = _first_term_from_rows(rows, _first_numeric_literal)
-    competitor = _first_term_from_rows(rows, lambda row: row.get("competitor"))
-    pain = _first_term_from_rows(rows, _meaningful_pain_label)
-    workflow = _first_term_from_rows(rows, _meaningful_workflow_label)
-
-    signal_terms = specificity_signal_terms(
-        anchor_examples=specificity.get("anchor_examples"),
-        witness_highlights=specificity.get("witness_highlights"),
-        allow_company_names=False,
-    )
-    if not timing_anchor:
-        timing_anchor = _preferred_signal_term(signal_terms.get("timing_terms"))
-    if not numeric_anchor:
-        numeric_anchor = _preferred_signal_term(
-            signal_terms.get("numeric_terms"),
-            predicate=_is_meaningful_numeric_anchor,
-        )
-    if not competitor:
-        competitor = _preferred_signal_term(signal_terms.get("competitor_terms"))
-    if not pain:
-        pain = _preferred_signal_term(
-            signal_terms.get("pain_terms"),
-            skip={
-                "recommendation",
-                "unknown",
-                "none",
-                *(_blog_low_signal_anchor_labels()),
-            },
-        )
-        if pain and not _is_meaningful_blog_anchor_label(pain):
-            pain = ""
-        else:
-            pain = _humanize_blog_anchor_label(pain)
-    if not workflow:
-        workflow = _preferred_signal_term(
-            signal_terms.get("workflow_terms"),
-            skip={"unknown", "none"},
-        )
-        if workflow and not _is_meaningful_blog_anchor_label(workflow):
-            workflow = ""
-        else:
-            workflow = _humanize_blog_anchor_label(workflow)
-
-    if needs_timing_numeric and not (timing_anchor or numeric_anchor):
-        return {}
-
-    return {
-        "time_anchor": timing_anchor,
-        "numeric_anchor": numeric_anchor,
-        "competitor": competitor,
-        "pain": pain,
-        "workflow": workflow,
-    }
-
-
-def _build_specificity_anchor_note(
-    blueprint: PostBlueprint,
-    report: dict[str, Any],
-) -> str:
-    terms = _select_specificity_anchor_terms(blueprint, report)
-    if not terms:
-        return ""
-
-    detail_bits: list[str] = []
-    time_anchor = terms["time_anchor"]
-    numeric_anchor = terms["numeric_anchor"]
-    competitor = terms["competitor"]
-    pain = terms["pain"]
-    workflow = terms["workflow"]
-
-    if time_anchor:
-        detail_bits.append(f"{time_anchor} is the live timing trigger")
-    if numeric_anchor:
-        detail_bits.append(f"{numeric_anchor} is the concrete spend anchor")
-    if competitor:
-        detail_bits.append(f"{competitor} is the competitive alternative in the witness-backed record")
-    if pain:
-        detail_bits.append(f"the core pressure showing up in the evidence is {pain}")
-    if workflow:
-        detail_bits.append(f"the workflow shift in play is {workflow}")
-
-    if not detail_bits:
-        return ""
-
-    note = "Evidence anchor: " + ", ".join(detail_bits[:-1])
-    if len(detail_bits) > 1:
-        note += f", and {detail_bits[-1]}."
-    else:
-        note += f"{detail_bits[-1]}."
-    if len(detail_bits) == 1:
-        note = "Evidence anchor: " + detail_bits[0] + "."
-    return note
-
-
-def _has_specificity_issues(report: dict[str, Any]) -> bool:
-    blockers = [str(issue) for issue in (report.get("blocking_issues") or [])]
-    warnings = [str(warning) for warning in (report.get("warnings") or [])]
-    return any(issue.startswith("witness_specificity:") for issue in blockers + warnings)
-
-
 def _apply_specificity_anchor_repair(
     blueprint: PostBlueprint,
     content: dict[str, Any],
@@ -2279,8 +2168,6 @@ def _apply_specificity_anchor_repair(
     a prior generation, or copy-pasted from a stale template), it's
     stripped so subsequent passes don't ship the stale prose.
 
-    ``_build_specificity_anchor_note`` is no longer called from this
-    module and exists only as dead code; future cleanup can delete it.
     """
     updated = dict(content or {})
     body = str(updated.get("content") or "")

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -2261,36 +2261,49 @@ def _apply_specificity_anchor_repair(
     content: dict[str, Any],
     report: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any], bool]:
+    """Cleanup-only repair for the legacy "Evidence anchor:" injection.
+
+    HISTORY: This function previously INJECTED an ``Evidence anchor:``
+    prose line into the post body whenever a ``witness_specificity``
+    quality check failed. The injected text used internal-pipeline
+    jargon ("Evidence anchor:", "live timing trigger", "concrete spend
+    anchor", "core pressure", "workflow shift in play"). Readers saw
+    this as broken/draft content -- 19 of 79 published posts shipped
+    with the jargon visible (measured in PR #612's baseline analyzer).
+
+    CURRENT BEHAVIOR (PR #632+): the injection path is disabled.
+    Specificity failures stay in the report so the quality gate
+    surfaces them as quality issues, holding the post for human review
+    instead of papering over with jargon. The REMOVAL path is preserved:
+    if a post body already contains an ``Evidence anchor:`` line (from
+    a prior generation, or copy-pasted from a stale template), it's
+    stripped so subsequent passes don't ship the stale prose.
+
+    ``_build_specificity_anchor_note`` is no longer called from this
+    module and exists only as dead code; future cleanup can delete it.
+    """
     updated = dict(content or {})
     body = str(updated.get("content") or "")
     has_existing_note = _has_blog_note(body, marker="Evidence anchor:")
-    if not _has_specificity_issues(report) and not has_existing_note:
+
+    if not has_existing_note:
+        # Nothing to clean up. Specificity issues (if any) remain in
+        # the report so the quality gate fails the post for human
+        # review rather than silently auto-papering over the issue.
         return updated, report, False
 
-    note = _build_specificity_anchor_note(blueprint, report)
-    if not note:
-        if not has_existing_note:
-            return updated, report, False
-        repaired_body = _remove_blog_note(body, marker="Evidence anchor:")
-        if repaired_body == body:
-            return updated, report, False
-        updated["content"] = repaired_body
-        updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
-        repaired_report = dict(repaired_report)
-        fixes = list(repaired_report.get("fixes_applied", []) or [])
-        fixes.append("removed_low_signal_witness_anchor_note")
-        repaired_report["fixes_applied"] = fixes
-        return updated, repaired_report, True
-
-    repaired_body = _insert_blog_note(body, note, marker="Evidence anchor:")
+    # Existing "Evidence anchor:" line present. Strip it. Anchor
+    # injection produced reader-hostile prose; legacy anchors should
+    # be removed on every quality pass so a refreshed post doesn't
+    # carry over jargon from the prior generation.
+    repaired_body = _remove_blog_note(body, marker="Evidence anchor:")
     if repaired_body == body:
         return updated, report, False
-
     updated["content"] = repaired_body
     updated, repaired_report = _apply_blog_quality_gate(blueprint, updated)
     repaired_report = dict(repaired_report)
     fixes = list(repaired_report.get("fixes_applied", []) or [])
-    fixes.append("added_witness_anchor_note")
+    fixes.append("removed_disabled_witness_anchor_note")
     repaired_report["fixes_applied"] = fixes
     return updated, repaired_report, True
 

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -1577,7 +1577,7 @@ async def test_fetch_category_topic_stats_reads_vendor_mentions():
     assert "COUNT(DISTINCT vm.vendor_name)" in sql
 
 
-def test_apply_blog_deterministic_repairs_adds_witness_anchor_note():
+def test_apply_blog_deterministic_repairs_does_not_inject_witness_anchor_note():
     blueprint = blog_mod.PostBlueprint(
         topic_type="vendor_alternative",
         slug="zendesk-alternatives-2026-03",
@@ -1605,18 +1605,19 @@ def test_apply_blog_deterministic_repairs_adds_witness_anchor_note():
         report,
     )
 
-    assert "Evidence anchor:" in repaired["content"]
-    assert "Q2 renewal" in repaired["content"]
-    assert "$200k/year" in repaired["content"]
-    assert "Freshdesk" in repaired["content"]
-    assert "added_witness_anchor_note" in repaired_report["fixes_applied"]
-    assert not any(
+    # Auto-injection of "Evidence anchor: ..." prose is disabled
+    # (see _apply_specificity_anchor_repair). Specificity failures stay
+    # in the report so the quality gate fails the post for human review
+    # instead of papering over with internal-pipeline jargon.
+    assert "Evidence anchor:" not in repaired["content"]
+    assert "added_witness_anchor_note" not in repaired_report.get("fixes_applied", [])
+    assert any(
         issue.startswith("witness_specificity:")
         for issue in repaired_report["blocking_issues"]
     )
 
 
-def test_apply_blog_deterministic_repairs_prefers_timing_or_numeric_anchor_when_required():
+def test_apply_blog_deterministic_repairs_specificity_failure_persists_when_anchor_terms_available():
     blueprint = blog_mod.PostBlueprint(
         topic_type="vendor_deep_dive",
         slug="metabase-deep-dive-2026-04",
@@ -1672,17 +1673,22 @@ def test_apply_blog_deterministic_repairs_prefers_timing_or_numeric_anchor_when_
         report,
     )
 
-    assert "after one year" in repaired["content"]
-    assert "$10k" in repaired["content"]
-    assert "Looker" in repaired["content"]
-    assert "added_witness_anchor_note" in repaired_report["fixes_applied"]
-    assert not any(
+    # Even when rich anchor terms (time, numeric, competitor) are
+    # available in data_context, the disabled injection does NOT add
+    # them to the content. The specificity failure surfaces in the
+    # report so a human reviewer can write the anchor terms in
+    # naturally instead of receiving auto-generated jargon prose.
+    assert "after one year" not in repaired["content"]
+    assert "$10k" not in repaired["content"]
+    assert "Looker" not in repaired["content"]
+    assert "added_witness_anchor_note" not in repaired_report.get("fixes_applied", [])
+    assert any(
         issue.startswith("witness_specificity:")
         for issue in repaired_report["blocking_issues"]
     )
 
 
-def test_apply_blog_deterministic_repairs_replaces_stale_evidence_anchor_note():
+def test_apply_blog_deterministic_repairs_removes_stale_evidence_anchor_note():
     blueprint = blog_mod.PostBlueprint(
         topic_type="vendor_deep_dive",
         slug="metabase-deep-dive-2026-04",
@@ -1731,16 +1737,20 @@ def test_apply_blog_deterministic_repairs_replaces_stale_evidence_anchor_note():
         report,
     )
 
-    assert repaired["content"].count("Evidence anchor:") == 1
-    assert "after one year" in repaired["content"]
-    assert "$10k" in repaired["content"]
-    assert not any(
+    # With auto-injection disabled, a stale "Evidence anchor:" line in
+    # an existing body is REMOVED (cleanup branch of the repair). No
+    # new anchor is injected to replace it. The specificity failure
+    # remains in the report so the post is held for human review.
+    assert "Evidence anchor:" not in repaired["content"]
+    assert "removed_disabled_witness_anchor_note" in repaired_report["fixes_applied"]
+    assert "added_witness_anchor_note" not in repaired_report["fixes_applied"]
+    assert any(
         issue.startswith("witness_specificity:")
         for issue in repaired_report["blocking_issues"]
     )
 
 
-def test_apply_blog_deterministic_repairs_refreshes_legacy_evidence_note_without_active_specificity_issue():
+def test_apply_blog_deterministic_repairs_removes_legacy_evidence_note_when_specificity_passes():
     blueprint = blog_mod.PostBlueprint(
         topic_type="vendor_deep_dive",
         slug="metabase-deep-dive-2026-04",
@@ -1788,14 +1798,21 @@ def test_apply_blog_deterministic_repairs_refreshes_legacy_evidence_note_without
         report,
     )
 
-    assert repaired["content"].count("Evidence anchor:") == 1
+    # Legacy "Evidence anchor:" line is removed (cleanup branch). No
+    # new injection happens, even when richer anchor terms are available
+    # in data_context -- the cleanup-only behavior is consistent across
+    # specificity-passing and specificity-failing cases.
+    #
+    # Note: "$10k", "Looker", etc. legitimately appear in the prose
+    # body of this fixture, so we only assert that the "Evidence anchor:"
+    # prose line itself is gone, not that the underlying terms are.
+    assert "Evidence anchor:" not in repaired["content"]
     assert "8.3 is the concrete spend anchor" not in repaired["content"]
-    assert "$10k" in repaired["content"]
-    assert "Looker" in repaired["content"]
-    assert "added_witness_anchor_note" in repaired_report["fixes_applied"]
+    assert "removed_disabled_witness_anchor_note" in repaired_report["fixes_applied"]
+    assert "added_witness_anchor_note" not in repaired_report["fixes_applied"]
 
 
-def test_apply_blog_deterministic_repairs_uses_excerpt_derived_numeric_anchor():
+def test_apply_blog_deterministic_repairs_does_not_inject_excerpt_derived_numeric_anchor():
     blueprint = blog_mod.PostBlueprint(
         topic_type="vendor_deep_dive",
         slug="palo-alto-networks-deep-dive-2026-04",
@@ -1833,10 +1850,14 @@ def test_apply_blog_deterministic_repairs_uses_excerpt_derived_numeric_anchor():
         report,
     )
 
-    assert "10 b" in repaired["content"].lower()
-    assert "pricing" in repaired["content"].lower()
-    assert "bundled suite consolidation" in repaired["content"]
-    assert not any(
+    # Auto-injection is disabled. Even when excerpt_text contains a
+    # numeric anchor that the old behavior would have extracted and
+    # injected, the disabled repair does NOT add it. Specificity
+    # failure persists for human review.
+    assert "Evidence anchor:" not in repaired["content"]
+    assert "10 b" not in repaired["content"].lower()
+    assert "bundled suite consolidation" not in repaired["content"]
+    assert any(
         issue.startswith("witness_specificity:")
         for issue in repaired_report["blocking_issues"]
     )
@@ -1933,7 +1954,9 @@ def test_apply_blog_deterministic_repairs_removes_low_signal_existing_evidence_n
     )
 
     assert "Evidence anchor:" not in repaired["content"]
-    assert "removed_low_signal_witness_anchor_note" in repaired_report["fixes_applied"]
+    # Cleanup fix label was renamed when auto-injection was disabled;
+    # both removal cases (low-signal, disabled) now share the same label.
+    assert "removed_disabled_witness_anchor_note" in repaired_report["fixes_applied"]
     assert any(
         issue.startswith("witness_specificity:")
         for issue in repaired_report["blocking_issues"]

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -1277,8 +1277,9 @@ def test_best_fit_guide_blueprint_routes_quotes_through_contract_gate():
 
 
 def test_specificity_anchor_repair_does_not_inject_when_specificity_fails():
-    """Even with a clear specificity_anchor in the report, the disabled
-    repair does NOT inject "Evidence anchor:" prose into the body."""
+    """Even with ``witness_specificity`` entries in the report's
+    ``blocking_issues``, the disabled repair does NOT inject an
+    "Evidence anchor:" prose line into the body."""
     from atlas_brain.autonomous.tasks.b2b_blog_post_generation import PostBlueprint
     blueprint = PostBlueprint(
         topic_type="vendor_deep_dive",

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -28,6 +28,7 @@ sys.modules.setdefault("asyncpg", _asyncpg_mock)
 sys.modules.setdefault("asyncpg.exceptions", _asyncpg_exceptions)
 
 from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (  # noqa: E402
+    _apply_specificity_anchor_repair,
     _blog_quote_highlights,
     _blueprint_best_fit_guide,
     _blueprint_market_landscape,
@@ -1258,3 +1259,105 @@ def test_best_fit_guide_blueprint_routes_quotes_through_contract_gate():
     assert quote["review_id"] == "bf-review-1"
     assert quote["source"] == "g2"
     assert quote["field"] == "specific_complaints"
+
+
+# ---------------------------------------------------------------------------
+# Evidence-anchor auto-injection disable
+#
+# Auto-injection of "Evidence anchor: ..." prose was disabled (see
+# _apply_specificity_anchor_repair). The function is now cleanup-only:
+# it removes any existing "Evidence anchor:" line from the body so a
+# refreshed post doesn't carry over the legacy jargon, but it does NOT
+# inject a new line on specificity failures. The specificity issues
+# stay in the report so the post is held for human review.
+#
+# These tests cover the disable directly, independent of the broader
+# deterministic-repairs flow that's tested in test_b2b_blog_post_generation.
+# ---------------------------------------------------------------------------
+
+
+def test_specificity_anchor_repair_does_not_inject_when_specificity_fails():
+    """Even with a clear specificity_anchor in the report, the disabled
+    repair does NOT inject "Evidence anchor:" prose into the body."""
+    from atlas_brain.autonomous.tasks.b2b_blog_post_generation import PostBlueprint
+    blueprint = PostBlueprint(
+        topic_type="vendor_deep_dive",
+        slug="x-deep-dive-2026-04",
+        suggested_title="X Deep Dive",
+        tags=["test"],
+        data_context={"vendor": "X", "review_period": "2025-06 to 2026-03"},
+        sections=[],
+        charts=[],
+    )
+    content = {"content": "# X\n\nGeneric prose with no specific anchor.\n"}
+    report = {
+        "blocking_issues": ["witness_specificity:missing_timing_or_numeric"],
+        "warnings": [],
+        "fixes_applied": [],
+    }
+    repaired, repaired_report, did_repair = _apply_specificity_anchor_repair(
+        blueprint, content, report,
+    )
+    assert "Evidence anchor:" not in repaired["content"]
+    assert did_repair is False
+    # The specificity issue remains in the report so the gate fails the post.
+    assert any(
+        issue.startswith("witness_specificity:")
+        for issue in repaired_report["blocking_issues"]
+    )
+
+
+def test_specificity_anchor_repair_removes_existing_legacy_anchor():
+    """When a post body has a legacy 'Evidence anchor:' line from a prior
+    generation, the cleanup branch strips it so subsequent passes don't
+    ship stale jargon."""
+    from atlas_brain.autonomous.tasks.b2b_blog_post_generation import PostBlueprint
+    blueprint = PostBlueprint(
+        topic_type="vendor_deep_dive",
+        slug="x-deep-dive-2026-04",
+        suggested_title="X Deep Dive",
+        tags=["test"],
+        data_context={"vendor": "X", "review_period": "2025-06 to 2026-03"},
+        sections=[],
+        charts=[],
+    )
+    content = {
+        "content": (
+            "# X Deep Dive\n\n"
+            "Evidence anchor: month-end is the live timing trigger, "
+            "$200k is the concrete spend anchor.\n\n"
+            "More prose continues.\n"
+        ),
+    }
+    report = {
+        "blocking_issues": [],
+        "warnings": [],
+        "fixes_applied": [],
+    }
+    repaired, repaired_report, did_repair = _apply_specificity_anchor_repair(
+        blueprint, content, report,
+    )
+    assert "Evidence anchor:" not in repaired["content"]
+    assert did_repair is True
+    assert "removed_disabled_witness_anchor_note" in repaired_report["fixes_applied"]
+
+
+def test_specificity_anchor_repair_no_op_when_no_anchor_and_no_issues():
+    """No existing anchor + no specificity issues = nothing to do."""
+    from atlas_brain.autonomous.tasks.b2b_blog_post_generation import PostBlueprint
+    blueprint = PostBlueprint(
+        topic_type="vendor_deep_dive",
+        slug="x-deep-dive-2026-04",
+        suggested_title="X Deep Dive",
+        tags=["test"],
+        data_context={"vendor": "X", "review_period": "2025-06 to 2026-03"},
+        sections=[],
+        charts=[],
+    )
+    content = {"content": "# X Deep Dive\n\nClean prose, no anchor line.\n"}
+    report = {"blocking_issues": [], "warnings": [], "fixes_applied": []}
+    repaired, repaired_report, did_repair = _apply_specificity_anchor_repair(
+        blueprint, content, report,
+    )
+    assert did_repair is False
+    assert repaired["content"] == content["content"]

--- a/tests/test_blog_quality_backfill.py
+++ b/tests/test_blog_quality_backfill.py
@@ -13,10 +13,18 @@ from atlas_brain.services.blog_quality_backfill import (
 
 
 def test_derive_blog_quality_patch_backfills_latest_audit():
+    # Content includes the specific anchor terms ($200k/year, Q2 renewal,
+    # BigCommerce) naturally in the prose so the witness_specificity
+    # quality check passes on its own. Auto-injection of an "Evidence
+    # anchor:" prose line is disabled (see _apply_specificity_anchor_repair
+    # in atlas_brain.autonomous.tasks.b2b_blog_post_generation), so the
+    # post must satisfy specificity on the content itself, not via
+    # generator-side prose injection.
     filler = (
         "This analysis reflects self-selected feedback from public software reviews. "
-        "Shopify migration signals show broad urgency, pricing pressure, and evaluation activity "
-        "across public review sources. "
+        "Shopify migration signals show broad urgency, $200k/year pricing pressure at the "
+        "Q2 renewal window, and evaluation activity that flags BigCommerce as the "
+        "competitive alternative across public review sources. "
     ) * 140
     patch = derive_blog_quality_patch(
         {
@@ -61,8 +69,13 @@ def test_derive_blog_quality_patch_backfills_latest_audit():
     assert audit["status"] == "pass"
     assert audit["min_words_required"] == 1500
     assert audit["target_words"] == 2100
-    assert "Evidence anchor:" in patch["resolved_content"]["content"]
-    assert "added_witness_anchor_note" in audit["fixes_applied"]
+    # Auto-injection of "Evidence anchor:" is disabled -- the post passes
+    # specificity because the prose itself contains the anchor terms.
+    # Since content is unchanged by the audit pass, `resolved_content`
+    # may not be present on `patch` (the patch only contains delta keys).
+    if "resolved_content" in patch:
+        assert "Evidence anchor:" not in patch["resolved_content"]["content"]
+    assert "added_witness_anchor_note" not in audit["fixes_applied"]
     assert patch["failure_step"] is None
 
 
@@ -299,7 +312,24 @@ async def test_apply_blog_quality_backfill_updates_recent_rows():
                 "description": "desc",
                 "topic_type": "migration_guide",
                 "tags": ["shopify", "migration"],
-                "content": "<p>" + ("Generic market pressure is rising. " * 120) + "</p>",
+                # Content includes the specific anchor terms in prose so the
+                # post passes specificity without needing the (disabled)
+                # auto-injection. Methodology disclaimer is also included
+                # so the post passes ALL quality checks naturally.
+                # See _apply_specificity_anchor_repair.
+                "content": (
+                    "<p><em>Methodology note: This analysis reflects self-selected "
+                    "feedback from public software reviews collected between 2025-06 "
+                    "and 2026-03. It captures reviewer perception, not a census of "
+                    "all users.</em></p>"
+                    "<p>"
+                    + (
+                        "Shopify migration signals show $200k/year pricing pressure at "
+                        "the Q2 renewal window while BigCommerce keeps surfacing as the "
+                        "competitive alternative. "
+                    ) * 120
+                    + "</p>"
+                ),
                 "charts": [],
                 "data_context": {
                     "reasoning_anchor_examples": {
@@ -366,7 +396,12 @@ async def test_apply_blog_quality_backfill_updates_recent_rows():
     assert result["changed"] == 1
     assert result["applied"] == 1
     assert len(pool.executed) == 1
-    updated_context = json.loads(pool.executed[0][1][10])
+    # The SQL update places data_context at $2 (i.e. args[1]). The
+    # earlier hardcoded args[10] read happened to work when the post
+    # failed in a specific way during the auto-injection era; with
+    # injection disabled the post passes on its own and args[10] is
+    # the rejection_reason slot (None). Read the canonical position.
+    updated_context = json.loads(pool.executed[0][1][1])
     assert updated_context["latest_quality_audit"]["boundary"] == "backfill"
 
 


### PR DESCRIPTION
\`_apply_specificity_anchor_repair\` was injecting an "Evidence anchor: ..." prose line into the post body whenever a \`witness_specificity\` quality check failed. The injected text used internal-pipeline jargon ("Evidence anchor:", "live timing trigger", "concrete spend anchor", "core pressure", "workflow shift in play") — readers saw it as broken/draft content. **19 of 79 published posts** shipped with the jargon visible (measured in PR #612's baseline analyzer).

## Behavior change

| Case | Old | New |
|---|---|---|
| No anchor + no specificity issues | no-op | no-op |
| No anchor + specificity issues | inject anchor prose → post passes | **no injection; issues persist in report → gate fails post for human review** |
| Existing anchor (any case) | refresh / replace / remove | **strip (cleanup-only)** |

Fix labels: \`added_witness_anchor_note\` and \`removed_low_signal_witness_anchor_note\` no longer fire. Replaced with \`removed_disabled_witness_anchor_note\` for the cleanup branch.

## Why

Per the seo-geo-aeo-blog-post skill's non-negotiable principle #5 ("Human in the loop"), the pipeline should never write reader-facing prose. It should refuse to publish content that fails the quality bar. Auto-papering-over specificity failures with jargon was the antipattern.

## Tests

- **8 existing deterministic-repair tests** updated to assert no injection. Names and docstrings updated to reflect cleanup-only semantics. None lost coverage; they now regression-test that injection STAYS disabled.
- **2 backfill tests** updated: content now contains the anchor terms inline so the post passes specificity naturally. One test had its SQL-args index corrected (1, not 10).
- **3 new direct tests** in \`test_b2b_blog_post_generation_quote_gate.py\` cover the function's three branches.

**182 tests pass** across the three generator/backfill test files (was 179).

## Effect on existing posts

Generator change only. The 19 already-published posts with "Evidence anchor:" jargon are NOT automatically rewritten. They'll self-heal when refreshed through the quality pipeline (the cleanup branch strips the legacy anchor on next pass).

Alternative for immediate cleanup: a one-off strip script analogous to the placeholder-affiliate strip in PR #617. Not in scope for this PR.

## Test plan

- [x] 182 tests pass
- [x] \`npm run build\` in atlas-churn-ui: clean
- [x] \`extracted_content_pipeline\` synced via \`extracted/_shared/scripts/sync_extracted.sh\`
- [x] Local pre-push review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)