### PR TITLE
Document current MCP connector rollout handoff

### DIFF
--- a/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
+++ b/docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md
@@ -25,6 +25,50 @@ It should expose the smallest useful surface:
 
 It must not expose the full `atlas_brain.mcp.invoicing_server` tool surface.
 
+## Current operational state: 2026-05-19
+
+The draft-writer connector is live and proven through the public ChatGPT-style
+OAuth path:
+
+```text
+https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Merged implementation slices:
+
+- `#623`: Funnel route checker for draft-writer app and protected-resource
+  metadata routes.
+- `#626`: public-host transport security allowlist with DNS-rebinding
+  protection still enabled.
+- `#629`: case-insensitive invoice-number lookup so created mixed-case invoice
+  numbers can be read back.
+- `#632`: explicit blocked-draft live write smoke.
+- `#633`: OAuth state-file persistence for clients and refresh tokens.
+
+Current local runtime expectations:
+
+- Server listens on port `8066`.
+- Approval token lives at
+  `.secrets/invoicing-draft-writer-approval-token`.
+- OAuth state lives at
+  `.secrets/invoicing-draft-writer-oauth-state.json`.
+- Start/restart with
+  `ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE=.secrets/invoicing-draft-writer-oauth-state.json`.
+- Run discovery, no-mutation OAuth e2e, then live write smoke after restart.
+
+The live smoke draft is:
+
+- Invoice number: `INV-2026-May-0185`
+- Invoice id: `fa473ad7-435d-442d-9ab8-9f8fb7ec6954`
+- Customer: `ATLAS TEST - DO NOT SEND - Draft Writer Connector`
+- Business context: `atlas-mcp-live-smoke`
+- Send blocker: `no_email`
+- Warnings: `subtotal_zero`, `no_contact_id`
+
+Do not send, approve, or clean up that smoke draft unless the operator
+explicitly asks for cleanup. It is useful as a persistent audit artifact proving
+the connector creates blocked review-only drafts.
+
 ## Why separate server
 
 The existing full server is designed for trusted local operators. It contains

--- a/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
+++ b/docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md
@@ -25,6 +25,86 @@ The working implementation landed through:
 
 Use those PRs as concrete references.
 
+## Current handoff: 2026-05-19
+
+The invoicing connector rollout now has two proven ChatGPT-facing surfaces:
+
+| Surface | Public MCP URL | Port | Status |
+|---|---|---:|---|
+| Read-only invoicing | `https://atlas-brain.tailc7bd29.ts.net/invoicing-readonly/mcp` | 8065 | Proven earlier; read-only pattern source |
+| Draft-writer invoicing | `https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp` | 8066 | Proven live with blocked-draft write smoke |
+
+Recent MCP connector PRs that matter for the next session:
+
+- `#623` added the read-only Tailscale Funnel route checker for the
+  draft-writer path and connector-specific protected-resource metadata route.
+- `#626` allowed the configured public Tailscale host in draft-writer OAuth
+  transport security while keeping DNS-rebinding protection enabled.
+- `#629` fixed invoice-number readback by making repository invoice-number
+  lookup case-insensitive. This closed the live bug where
+  `INV-2026-May-0185` could be created but not fetched by number.
+- `#632` added `scripts/check_invoicing_draft_writer_live_write.py`, the
+  explicit blocked-draft write smoke.
+- `#633` added optional OAuth state-file persistence for invoicing MCP clients
+  and refresh tokens.
+
+Current local draft-writer runtime state after restart:
+
+- Server command: `.venv/bin/python scripts/start_invoicing_draft_writer_oauth_server.py --approval-token-file .secrets/invoicing-draft-writer-approval-token`
+- Required env for restart durability:
+  `ATLAS_MCP_INVOICING_DRAFT_WRITER_OAUTH_STATE_FILE=.secrets/invoicing-draft-writer-oauth-state.json`
+- Public URL: `https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp`
+- Listening port: `8066`
+- State file: `.secrets/invoicing-draft-writer-oauth-state.json`
+- Approval token file: `.secrets/invoicing-draft-writer-approval-token`
+- The state file stores registered OAuth clients and refresh tokens only. It
+  does not store pending approvals, authorization codes, or access tokens.
+
+Post-restart verification that passed on 2026-05-19:
+
+```bash
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_discovery.py \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+
+.venv/bin/python scripts/check_invoicing_draft_writer_oauth_e2e.py \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+
+.venv/bin/python scripts/check_invoicing_draft_writer_live_write.py \
+  --create-blocked-draft \
+  --approval-token-file .secrets/invoicing-draft-writer-approval-token \
+  --issuer-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer \
+  --resource-url https://atlas-brain.tailc7bd29.ts.net/invoicing-draft-writer/mcp
+```
+
+Expected live-write result: action `reused`, invoice
+`INV-2026-May-0185`, blocker `no_email`, warnings `subtotal_zero` and
+`no_contact_id`. That draft is intentionally blocked and should not be sent.
+
+Known limits to carry forward:
+
+- The server is not daemonized. It runs in a foreground/persistent session; a
+  systemd user-service or other process manager is a future operational slice.
+- ChatGPT may need one reconnect after enabling a new state file so the file can
+  be seeded with its client and refresh token.
+- Dynamic OAuth registration is public by design, but persisted client state is
+  capped. Do not remove that cap without replacing it with a better abuse
+  boundary.
+- Copilot errored on recent PR reviews and Codex review hit usage limits, so
+  local `scripts/local_pr_review.sh` plus focused tests were the real review
+  gate for `#633`.
+
+Recommended next MCP connector slices:
+
+1. Add a process-manager/operator service for draft-writer OAuth if the server
+   needs to survive terminal/session closure.
+2. Repeat the same read-only-first OAuth pattern for the next MCP domain
+   instead of exposing a full write server.
+3. Only add more invoicing write tools after a separate guardrail document and
+   allowlist smoke exist for that exact tool surface.
+
 ## Fast path for the next server
 
 Do not start by debugging ChatGPT. Build and verify the server in this order:

--- a/plans/PR-MCP-Connector-Session-Handoff.md
+++ b/plans/PR-MCP-Connector-Session-Handoff.md
@@ -10,7 +10,7 @@ which server is running, which smokes are authoritative, or which risks remain.
 This docs-only slice records the current operational state and the next-step
 queue for MCP connector work.
 
-## Scope
+## Scope (this PR)
 
 1. Add a current-state handoff section to the ChatGPT OAuth rollout runbook.
 2. Add a concrete draft-writer operational-state section to the invoicing write
@@ -47,8 +47,10 @@ section focused on the live draft-writer connector and its local state files.
 
 ## Verification
 
-- Git whitespace check: passed.
-- Local PR review bundle in advisory dirty mode: passed.
+Commands run:
+
+    git diff --check
+    bash scripts/local_pr_review.sh
 
 ## Estimated diff size
 

--- a/plans/PR-MCP-Connector-Session-Handoff.md
+++ b/plans/PR-MCP-Connector-Session-Handoff.md
@@ -1,0 +1,60 @@
+# MCP Connector Session Handoff
+
+## Why this slice exists
+
+The invoicing MCP connector rollout advanced from read-only OAuth to a working
+ChatGPT draft-writer connector with live write smoke and OAuth state-file
+persistence. The next session should not have to reconstruct which PRs landed,
+which server is running, which smokes are authoritative, or which risks remain.
+
+This docs-only slice records the current operational state and the next-step
+queue for MCP connector work.
+
+## Scope
+
+1. Add a current-state handoff section to the ChatGPT OAuth rollout runbook.
+2. Add a concrete draft-writer operational-state section to the invoicing write
+   guardrails.
+3. Capture the restart/state-file requirement, smoke commands, and known limits.
+
+### Files touched
+
+- `docs/MCP_CHATGPT_OAUTH_ROLLOUT_RUNBOOK.md`
+- `docs/INVOICING_MCP_WRITE_ACCESS_GUARDRAILS.md`
+- `plans/PR-MCP-Connector-Session-Handoff.md`
+
+## Mechanism
+
+The runbook gets a dated handoff section immediately after the proven outcome,
+covering merged PRs, current public URL, runtime state, required smokes, and the
+recommended next MCP connector slices. The invoicing guardrails get a narrower
+section focused on the live draft-writer connector and its local state files.
+
+## Intentional
+
+- Docs only. No server, tool, OAuth, or route behavior changes.
+- The handoff records current local operation but does not claim the server is
+  daemonized; it is still foreground/persistent-session operation.
+- The handoff names Copilot/Codex review limitations from the session so future
+  agents know why local review mattered.
+
+## Deferred
+
+- A durable process manager/systemd user service remains a future operational
+  slice if we want the MCP connector to survive terminal/session closure.
+- Applying the same OAuth pattern to CRM/email/calendar/etc. remains per-server
+  rollout work.
+
+## Verification
+
+- Git whitespace check: passed.
+- Local PR review bundle in advisory dirty mode: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Rollout runbook handoff | ~80 |
+| Invoicing guardrails handoff | ~40 |
+| Plan doc | ~60 |
+| **Total** | ~180 |


### PR DESCRIPTION
Plan: plans/PR-MCP-Connector-Session-Handoff.md

Documents the current invoicing MCP connector rollout state so the next session can resume without reconstructing recent OAuth, Tailscale, write-access, and persistence decisions from PR history.

## Intentional
- Docs-only handoff. No server behavior or connector policy changes.
- Keeps the smoke draft details visible while preserving secret/token boundaries.

## Deferred
- Process manager/user-service setup for connector survivability.
- Repeating the read-only-first OAuth pattern for the next MCP domain.
- Any broader write-access expansion beyond guarded draft invoice tools.

## Verification
- bash scripts/local_pr_review.sh
- git diff --check

## Diff size
3 files, +184 / -0
