### PR TITLE
Strip "Evidence anchor:" jargon from 19 published blog posts

### DIFF
--- a/atlas-churn-ui/src/content/blog/best-crm-for-51-200-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/best-crm-for-51-200-2026-04.ts
@@ -161,8 +161,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "CRM"
 },
-  content: `<p>Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing up in the evidence is pricing.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Choosing a CRM for a team of 51-200 employees means balancing simplicity with scalability. You need something that works today without locking you into a platform that collapses under growth or bleeds budget through hidden fees.</p>
 <p>We analyzed 1163 real user reviews across 8 CRM tools to find who's actually best for what. The data comes from verified platforms like G2, Gartner, and PeerSpot (172 reviews), plus community sources like Reddit (3115 reviews), covering the period from February 25 to April 7, 2026.</p>

--- a/atlas-churn-ui/src/content/blog/best-project-management-for-201-1000-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/best-project-management-for-201-1000-2026-04.ts
@@ -166,8 +166,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Project Management"
 },
-  content: `<p>Evidence anchor: year is the live timing trigger, $10.99 is the concrete spend anchor, the core pressure showing up in the evidence is pricing, and the workflow shift in play is workflow substitution.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Most project management software comparisons rank vendors by rating or feature count. This one doesn't.</p>
 <p>We analyzed <strong>1464 real user reviews</strong> across <strong>10 project management tools</strong> to find who's actually best for <strong>201-1000 employee teams</strong>. The data comes from verified platforms like G2, Gartner Peer Insights, and PeerSpot, plus community feedback from Reddit and other forums, covering reviews from February 28 to April 7, 2026.</p>

--- a/atlas-churn-ui/src/content/blog/close-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/close-deep-dive-2026-04.ts
@@ -154,8 +154,7 @@ const post: BlogPost = {
   "vendor_filter": "Close",
   "category_filter": "CRM"
 },
-  content: `<p>Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing up in the evidence is pricing.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Close CRM serves small to mid-sized sales teams looking for a focused, sales-first platform. But how does it actually perform in the field?</p>
 <p>This deep dive analyzes 1042 Close reviews collected between March 3 and April 7, 2026. We enriched 610 of those reviews with structured sentiment analysis, pain categorization, and buyer role identification. The analysis draws from G2 verified reviews and Reddit community discussions to surface patterns that self-reported review data can reveal.</p>

--- a/atlas-churn-ui/src/content/blog/communication-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/communication-landscape-2026-04.ts
@@ -136,8 +136,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Communication"
 },
-  content: `<p>Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>The Communication software market in 2026 is defined by consolidation pressure, bundled suite economics, and a Windows 11 upgrade cycle that exposed cost trade-offs for small and mid-sized buyers. This analysis examines 159 churn signals collected from March 3 to April 8, 2026, spanning Microsoft Teams, Slack, Zoom, and RingCentral.</p>
 <p>The data comes from 1,512 enriched reviews across verified platforms (G2, Gartner Peer Insights, PeerSpot) and community sources (Reddit, Hacker News). Of those, 151 reviews came from verified platforms and 1,361 from community discussions. This is a self-selected sample reflecting reviewer perception, not universal product truth.</p>

--- a/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
@@ -154,8 +154,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "CRM"
 },
-  content: `<p>Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing up in the evidence is pricing.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>The CRM market in 2026 is crowded, competitive, and under pricing pressure. Between February 25 and April 7, 2026, we analyzed 3,287 enriched reviews across 8 major vendors to map the current landscape. The sample includes 172 verified reviews from platforms like G2, Gartner, and PeerSpot, plus 3,115 community reviews from Reddit and similar forums.</p>
 <p>This analysis covers 1,163 total churn signals with an average urgency score of 2.1 across the category. The goal is not to crown a winner, but to show which vendors face the highest churn risk, which pain points recur across platforms, and where each product holds strength or shows weakness.</p>

--- a/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
@@ -146,8 +146,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Helpdesk"
 },
-  content: `<p>Evidence anchor: two months is the live timing trigger, $500,000 is the concrete spend anchor, HubSpot is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is competitor switch.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>The helpdesk software market in 2026 is shaped by intense price competition and high churn velocity. Five major vendors—Freshdesk, Zendesk, Help Scout, HappyFox, and Zoho Desk—dominate the landscape, collectively generating 41 churn signals across 1501 enriched reviews analyzed between February 28 and April 7, 2026.</p>
 <p>This analysis draws from verified platforms (G2, Gartner Peer Insights, PeerSpot, Software Advice) and community sources (Reddit, Twitter, forums) to map vendor strengths, weaknesses, and the recurring pain patterns that drive switching behavior. Rather than treating each vendor in isolation, we've identified the category-wide challenges that affect all five platforms and the specific friction points that make customers vulnerable to competitive displacement.</p>

--- a/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
@@ -142,7 +142,6 @@ const post: BlogPost = {
 },
   content: `<h1 id="marketing-automation-landscape-2026-5-vendors-compared-by-real-user-data">Marketing Automation Landscape 2026: 5 Vendors Compared by Real User Data</h1>
 <p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-06. It captures reviewer perception, not a census of all users.</em></p>
-<p>Evidence anchor: 24/7 is the live timing trigger, $800 m is the concrete spend anchor, unknown is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
 <h2 id="introduction">Introduction</h2>
 <p>The marketing automation category has become a crowded, price-sensitive market where feature parity is high and cost differentiation drives switching behavior. This analysis examines 1,568 enriched reviews of five major vendors—ActiveCampaign, Brevo, GetResponse, Klaviyo, and Mailchimp—collected between February 28 and April 6, 2026.</p>
 <p>Our data comes from verified review platforms (G2, Gartner Peer Insights, PeerSpot) and community platforms (Reddit, Software Advice, TrustPilot), giving us both structured ratings and unfiltered switching intent signals. The goal is not to declare a winner, but to show you where the churn pressure lies, which vendors face the highest replacement risk, and what patterns repeat across the category.</p>

--- a/atlas-churn-ui/src/content/blog/microsoft-teams-vs-notion-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/microsoft-teams-vs-notion-2026-04.ts
@@ -128,8 +128,7 @@ const post: BlogPost = {
   "vendor_filter": "Microsoft Teams",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Microsoft Teams and Notion occupy different corners of the collaboration software market, but both face rising reviewer frustration in early 2026. Between March 3 and April 8, 2026, we analyzed 198 reviewer signals: 36 for Microsoft Teams and 162 for Notion. The data reveals a stark urgency gap. Notion's average urgency score sits at 2.7, while Microsoft Teams registers 1.8—a 0.9-point difference that reflects distinct pain points and market pressures.</p>
 <p>This analysis draws from 2,568 total reviews, with 1,509 enriched for deeper context and 152 flagged for churn intent. Sources include verified platforms like G2, Gartner Peer Insights, and PeerSpot (111 reviews), alongside community feedback from Reddit and other forums (1,398 reviews). The sample is self-selected, so results reflect reviewer perception rather than universal product truth.</p>

--- a/atlas-churn-ui/src/content/blog/microsoft-teams-vs-salesforce-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/microsoft-teams-vs-salesforce-2026-04.ts
@@ -128,8 +128,7 @@ const post: BlogPost = {
   "vendor_filter": "Microsoft Teams",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Microsoft Teams and Salesforce serve different primary functions—collaboration versus CRM—but both face pricing and integration pressure in the March-April 2026 review window. Across 108 signals (34 for Microsoft Teams, 74 for Salesforce), the urgency gap is stark: Salesforce registers 3.2 compared to Microsoft Teams' 1.9, a 1.3-point difference.</p>
 <p>This analysis draws from 2,878 reviews analyzed between February 25 and April 7, 2026, with 1,697 enriched for churn intent and 90 showing active switching signals. Sources include verified platforms (G2, Gartner, PeerSpot) and community platforms (Reddit, GitHub). The sample reflects self-selected reviewer feedback, not universal product performance.</p>

--- a/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
@@ -154,8 +154,7 @@ const post: BlogPost = {
   "vendor_filter": "Pipedrive",
   "category_filter": "CRM"
 },
-  content: `<p>Evidence anchor: 2 months is the live timing trigger, $15/user is the concrete spend anchor, Nutshell is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is competitor switch.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-06. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-06. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Pipedrive positions itself as a sales-focused CRM built for pipeline visibility and deal management. But what happens when reviewer experience diverges from vendor positioning?</p>
 <p>This analysis examines 262 Pipedrive reviews collected between March 3 and April 6, 2026, drawing from verified platforms including G2, Gartner Peer Insights, and PeerSpot, alongside community discussions on Reddit. Of the 262 reviews analyzed, 143 contained enriched context including role, company size, or specific pain points. 10 reviews showed explicit churn intent.</p>

--- a/atlas-churn-ui/src/content/blog/power-bi-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/power-bi-deep-dive-2026-04.ts
@@ -148,8 +148,7 @@ const post: BlogPost = {
   "vendor_filter": "Power BI",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: today is the live timing trigger, $5/month is the concrete spend anchor, Tableau is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is competitor switch.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Power BI sits at the center of Microsoft's analytics strategy, but 1374 reviews analyzed between March 3 and April 8, 2026 reveal a product under pressure from its own vendor's bundling ambitions. This analysis draws from 796 enriched reviews across G2, Gartner Peer Insights, PeerSpot, and Reddit to map where Power BI delivers value and where friction is pushing teams toward Tableau, Looker, and cloud-native alternatives.</p>
 <p>The core tension: Microsoft's Fabric licensing push is creating immediate pricing decisions for teams that adopted Power BI for Excel integration and Microsoft 365 workflow continuity. Reviewers report evaluating €400/mo Pro-only licenses against €1k/mo Pro+Fabric bundles while navigating April 2026 scorecard hierarchy deprecation and May 2026 legacy import sunset deadlines. That compressed timeline is turning latent dissatisfaction into active evaluation pressure.</p>

--- a/atlas-churn-ui/src/content/blog/project-management-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/project-management-landscape-2026-04.ts
@@ -154,8 +154,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Project Management"
 },
-  content: `<p>Evidence anchor: year is the live timing trigger, $10.99 is the concrete spend anchor, the core pressure showing up in the evidence is pricing, and the workflow shift in play is workflow substitution.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>The project management software market remains one of the most contested categories in B2B SaaS. As of April 2026, 10 major vendors compete for mindshare across teams of every size, from five-person startups to 30,000-employee enterprises.</p>
 <p>This landscape analysis draws from <strong>1,464 churn signals</strong> collected between February 28 and April 7, 2026. The dataset includes 345 reviews from verified platforms (G2, Gartner Peer Insights, PeerSpot) and 2,674 mentions from community sources (Reddit, forums). The average churn urgency score across the category sits at 2.8, indicating moderate but persistent dissatisfaction.</p>

--- a/atlas-churn-ui/src/content/blog/real-cost-of-copper-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/real-cost-of-copper-2026-04.ts
@@ -72,8 +72,7 @@ const post: BlogPost = {
   "vendor_filter": "Copper",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: $12 is the concrete spend anchor, Aluminum is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is workflow substitution.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>When you're evaluating Copper CRM, pricing is not the loudest complaint—but it's persistent enough to matter. Out of 738 total Copper reviews analyzed between February 28 and April 7, 2026, 90 reviewers flagged pricing as a pain point. That's roughly 12% of the review corpus, with an average urgency score of 1.8 out of 10.</p>
 <p>This analysis draws from 1,085 enriched reviews across verified platforms like G2, Gartner Peer Insights, and Software Advice, plus community discussions on Reddit and Hacker News. The majority of reviews (1,071) come from community platforms, with only 14 from verified review sites. That distribution matters: community reviews tend to surface raw frustration and switching intent more openly than structured platform reviews.</p>

--- a/atlas-churn-ui/src/content/blog/real-cost-of-woocommerce-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/real-cost-of-woocommerce-2026-04.ts
@@ -68,8 +68,7 @@ const post: BlogPost = {
   "vendor_filter": "WooCommerce",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: this week is the live timing trigger, $29/mo is the concrete spend anchor, Shopify is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is workflow substitution.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-04. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-04. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>WooCommerce markets itself as a free eCommerce plugin for WordPress. But 93 out of 435 reviews analyzed between March 3 and April 4, 2026 tell a different story about what store owners actually pay.</p>
 <p>The pricing complaints carry an average urgency of 2.3 out of 10—not catastrophic, but persistent enough to appear in 21% of the review sample. This analysis draws from 692 enriched reviews across verified platforms like G2 and Capterra, plus community feedback from Reddit and Twitter. 11 reviews came from verified platforms, while 681 came from community discussions where store owners candidly discuss real costs.</p>

--- a/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-04.ts
@@ -128,8 +128,7 @@ const post: BlogPost = {
   "vendor_filter": "ClickUp",
   "category_filter": "B2B Software"
 },
-  content: `<p>Evidence anchor: month is the live timing trigger, $29 is the concrete spend anchor, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>ClickUp attracts inbound migrations from 6 documented competitor platforms, according to analysis of 1058 total reviews collected between February 28, 2026 and April 8, 2026. The dataset includes 437 enriched reviews from verified platforms like G2 (37 reviews), Gartner Peer Insights (10 reviews), and PeerSpot (9 reviews), alongside 381 community platform signals from Reddit.</p>
 <p>Teams switching to ClickUp typically come from Trello, Notion, Jira, Asana, Airtable, and Todoist. The migration pattern centers on bundled suite consolidation—teams seeking to replace multiple point solutions with a single platform. However, the evidence also shows that ClickUp's consolidation strategy introduces its own complexity trade-offs, particularly around navigation hierarchy and notification management.</p>

--- a/atlas-churn-ui/src/content/blog/top-complaint-every-communication-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-communication-2026-04.ts
@@ -88,8 +88,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Communication"
 },
-  content: `<p>Evidence anchor: 3 m is the concrete spend anchor, Linux is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-03-03 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Every Communication tool has a fatal flaw. We analyzed 756 reviews across Slack, Zoom, Microsoft Teams, and RingCentral between March 3 and April 8, 2026 to find out what breaks first.</p>
 <p>This is not a hit piece. It is also not a puff piece. The data comes from 1,512 enriched reviews pulled from G2, Gartner, Reddit, and other verified and community platforms. The goal is simple: show you the single biggest complaint for each vendor, backed by reviewer evidence, so you can pick the trade-off you can live with.</p>

--- a/atlas-churn-ui/src/content/blog/top-complaint-every-crm-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-crm-2026-04.ts
@@ -108,8 +108,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "CRM"
 },
-  content: `<p>Evidence anchor: month end is the live timing trigger, $170k is the concrete spend anchor, and the core pressure showing up in the evidence is pricing.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Every CRM has a flaw. Some charge too much. Some ship half-baked features. Some frustrate users so thoroughly that reviewers stop recommending them altogether.</p>
 <p>We analyzed <strong>1202 complaints</strong> across <strong>8 major CRM vendors</strong> between February 25 and April 7, 2026. The data comes from verified review platforms (G2, Gartner Peer Insights, PeerSpot) and community discussions (Reddit, Hacker News). We enriched 3326 reviews from a total pool of 4989, isolating 176 churn-intent signals and tracking complaint patterns by category, urgency, and timing.</p>

--- a/atlas-churn-ui/src/content/blog/top-complaint-every-helpdesk-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-helpdesk-2026-04.ts
@@ -109,8 +109,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Helpdesk"
 },
-  content: `<p>Evidence anchor: two months is the live timing trigger, $500,000 is the concrete spend anchor, HubSpot is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is competitor switch.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Every helpdesk tool has a flaw. Not a minor quirk—a recurring complaint that shows up in review after review.</p>
 <p>We analyzed 424 helpdesk software reviews across 7 major vendors from February 28 to April 8, 2026. The sample includes 196 verified reviews from G2, Gartner, and PeerSpot, plus 1,332 community mentions from Reddit and other platforms. The goal: identify the #1 complaint for each tool based on what reviewers actually say.</p>

--- a/atlas-churn-ui/src/content/blog/top-complaint-every-marketing-automation-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-marketing-automation-2026-04.ts
@@ -98,8 +98,7 @@ const post: BlogPost = {
   "vendor_filter": null,
   "category_filter": "Marketing Automation"
 },
-  content: `<p>Evidence anchor: 24/7 is the live timing trigger, $800 m is the concrete spend anchor, unknown is the competitive alternative in the witness-backed record, the core pressure showing up in the evidence is pricing, and the workflow shift in play is bundled suite consolidation.</p>
-<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
+  content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-08. It captures reviewer perception, not a census of all users.</em></p>
 <h2 id="introduction">Introduction</h2>
 <p>Every marketing automation platform has a weakness. The question is whether you can live with it.</p>
 <p>We analyzed 743 reviews across 6 marketing automation vendors between February 28 and April 8, 2026. The sample includes 156 verified reviews from G2, Gartner, PeerSpot, and Software Advice, plus 1,432 community discussions from Reddit and other forums. We enriched 1,588 of the 2,534 total reviews collected.</p>


### PR DESCRIPTION
Companion to PR #634 (generator-side auto-injection disable). #634 self-heals these posts on next refresh, but this PR strips the jargon immediately so live posts stop rendering it.

## What

Every affected post had a \`<p>Evidence anchor: ...</p>\` as the FIRST paragraph of \`content\`, immediately before the methodology note. Internal-pipeline language ("Evidence anchor:", "live timing trigger", "concrete spend anchor", "core pressure showing up in the evidence", "workflow shift in play") rendered as broken/draft content to readers.

**Example** (\`switch-to-clickup-2026-04\`):

Before:
\`\`\`html
<p>Evidence anchor: month is the live timing trigger, $29 is the concrete
spend anchor, the core pressure showing up in the evidence is pricing,
and the workflow shift in play is bundled suite consolidation.</p>
<p><em>Methodology note: ...</em></p>
\`\`\`

After:
\`\`\`html
<p><em>Methodology note: ...</em></p>
\`\`\`

## Affected slugs (19 total)

best-crm-for-51-200, best-project-management-for-201-1000, close-deep-dive, communication-landscape, crm-landscape, helpdesk-landscape, marketing-automation-landscape, microsoft-teams-vs-notion, microsoft-teams-vs-salesforce, pipedrive-deep-dive, power-bi-deep-dive, project-management-landscape, real-cost-of-copper, real-cost-of-woocommerce, switch-to-clickup, top-complaint-every-communication, top-complaint-every-crm, top-complaint-every-helpdesk, top-complaint-every-marketing-automation (all 2026-04).

## Verification

- Analyzer Evidence-anchor count: **19 → 0** (\`~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js\`)
- \`npm run build\` in atlas-churn-ui: **clean** (83-URL sitemap, no TS errors)
- Per-post diff shape: 1 line removed, 0 added. Methodology note becomes the new opening paragraph (which was always the design intent).

## Relationship to other PRs

- PR #634 (open): disables the generator-side injection so this jargon never enters new posts.
- This PR: strips the jargon from the 19 already-published artifacts.

Both can merge in any order. Together they close the Evidence-anchor bug category entirely (generator + data both clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)