### PR TITLE
Fix live provider circular import

### DIFF
--- a/atlas_brain/auth/__init__.py
+++ b/atlas_brain/auth/__init__.py
@@ -1,8 +1,21 @@
 """SaaS authentication and authorization for Atlas consumer intelligence."""
 
-from .dependencies import AuthUser, require_auth, optional_auth, require_plan
-from .jwt import create_access_token, create_refresh_token, decode_token
-from .passwords import hash_password, verify_password
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_EXPORT_MODULES = {
+    "AuthUser": ".dependencies",
+    "require_auth": ".dependencies",
+    "optional_auth": ".dependencies",
+    "require_plan": ".dependencies",
+    "create_access_token": ".jwt",
+    "create_refresh_token": ".jwt",
+    "decode_token": ".jwt",
+    "hash_password": ".passwords",
+    "verify_password": ".passwords",
+}
 
 __all__ = [
     "AuthUser",
@@ -15,3 +28,22 @@ __all__ = [
     "hash_password",
     "verify_password",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve package-level auth exports.
+
+    Config validation imports ``atlas_brain.auth.encryption`` while
+    ``settings`` is still being constructed. Eagerly importing auth
+    dependencies here re-enters ``atlas_brain.config`` before that module has
+    finished initialization, so keep settings-dependent modules behind this
+    lazy boundary.
+    """
+
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_name, __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T04:55Z by codex-2026-05-18
+Last updated: 2026-05-19T17:34Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Live-Provider-Circular-Import | `atlas_brain/auth/__init__.py`, `tests/test_live_provider_circular_import.py`, `plans/PR-Live-Provider-Circular-Import.md` | codex-2026-05-19 | Auth package init, live provider smoke/import-boundary work |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Live-Provider-Circular-Import.md
+++ b/plans/PR-Live-Provider-Circular-Import.md
@@ -1,0 +1,99 @@
+# PR-Live-Provider-Circular-Import
+
+## Why this slice exists
+
+The live provider smoke for AI Content Ops works only when
+`EXTRACTED_LLM_INFRA_STANDALONE=1` is set. In the normal Atlas bridge mode,
+`PipelineLLMClient` imports the extracted LLM infrastructure registry, which
+imports `atlas_brain.services.registry`. That path initializes Atlas config.
+During config validation, `atlas_brain.config` late-imports
+`atlas_brain.auth.encryption`, but `atlas_brain.auth.__init__` eagerly imports
+auth dependencies that import `settings` from the still-initializing config
+module. The result is a circular import before a live provider can resolve.
+
+This is not a smoke-script problem. The source issue is auth package
+initialization doing settings-dependent work before config has finished
+constructing `settings`.
+
+## Scope (this PR)
+
+1. Make package-level `atlas_brain.auth` exports lazy so importing
+   `atlas_brain.auth.encryption` during config validation does not import
+   `atlas_brain.auth.dependencies` or `atlas_brain.auth.jwt`.
+2. Preserve the existing package-level auth API for callers that import
+   `AuthUser`, `require_auth`, token helpers, or password helpers from
+   `atlas_brain.auth`.
+3. Add a subprocess regression test for the real `PipelineLLMClient` default
+   resolver in Atlas bridge mode with `EXTRACTED_LLM_INFRA_STANDALONE` unset.
+4. Register this slice in the coordination ledger.
+
+### Files touched
+
+- `atlas_brain/auth/__init__.py`
+- `tests/test_live_provider_circular_import.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Live-Provider-Circular-Import.md`
+
+## Mechanism
+
+`atlas_brain.auth.__init__` keeps the same `__all__` but resolves exported
+symbols through `__getattr__`. Imports that need `settings` stay behind the
+lazy boundary until a caller asks for them. Password helpers remain safe to
+load lazily as well for one consistent package pattern.
+
+The regression test runs a fresh Python subprocess, unsets
+`EXTRACTED_LLM_INFRA_STANDALONE`, sets a fake OpenRouter key, creates the
+product `PipelineLLMClient`, and calls its default resolver. The resolver
+constructs the provider adapter but does not call the network.
+
+## Intentional
+
+- No changes to `extracted_llm_infrastructure.services.registry`: bridge mode
+  is still allowed to re-export the Atlas registry. The failing import was
+  caused by auth package initialization during config validation, not by the
+  provider resolver needing standalone mode.
+- No environment-variable workaround in the smoke scripts: the default bridge
+  mode should import cleanly.
+- The test uses a subprocess instead of in-process monkeypatching so already
+  imported modules cannot mask the circular import.
+
+## Deferred
+
+- Broader `atlas_brain.services.__init__` import slimming is deferred. It may
+  still be valuable, but it is a wider API cleanup than needed to fix this
+  provider-resolution failure.
+
+## Verification
+
+Local checks:
+
+```bash
+pytest tests/test_live_provider_circular_import.py
+# 1 passed
+
+python -m py_compile atlas_brain/auth/__init__.py tests/test_live_provider_circular_import.py
+# passed
+
+pytest tests/test_auth_dependencies.py tests/test_extracted_campaign_llm_client.py tests/test_live_provider_circular_import.py
+# 21 passed
+
+python - <<'PY'
+# Default resolver smoke with EXTRACTED_LLM_INFRA_STANDALONE unset
+PY
+# OpenRouterLLM openrouter anthropic/claude-sonnet-4-5
+
+bash scripts/local_pr_review.sh --allow-dirty
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `atlas_brain/auth/__init__.py` | 22 |
+| `tests/test_live_provider_circular_import.py` | 51 |
+| `docs/extraction/coordination/inflight.md` | 1 |
+| `plans/PR-Live-Provider-Circular-Import.md` | 110 |
+| **Total** | **184** |
+
+Below the 400 LOC review budget.

--- a/tests/test_live_provider_circular_import.py
+++ b/tests/test_live_provider_circular_import.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pipeline_llm_default_resolver_imports_with_saas_auth_enabled() -> None:
+    """Bridge-mode live provider resolution must not require standalone mode."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.pop("EXTRACTED_LLM_INFRA_STANDALONE", None)
+    env.update({
+        "ATLAS_SAAS_ENABLED": "true",
+        "ATLAS_SAAS_JWT_SECRET": "test-jwt-secret-not-for-prod",
+        "ATLAS_SAAS_API_KEY_PEPPER": "test-api-key-pepper-not-for-prod",
+        # Synthetic test KEK, not a live secret.
+        "ATLAS_SAAS_BYOK_ENCRYPTION_KEK": (
+            "v1:fmrbL_ZK1IndEFcRceIBy63lLHnlk-CHeY6kmnn6QgI="
+        ),
+        "EXTRACTED_CAMPAIGN_LLM_WORKLOAD": "openrouter",
+        "EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL": (
+            "anthropic/claude-sonnet-4-5"
+        ),
+        "OPENROUTER_API_KEY": "test-openrouter-key",
+    })
+
+    code = """
+from extracted_content_pipeline.campaign_llm_client import create_pipeline_llm_client
+
+client = create_pipeline_llm_client()
+llm = client.resolver(
+    workload=client.workload,
+    prefer_cloud=client.prefer_cloud,
+    try_openrouter=client.try_openrouter,
+    auto_activate_ollama=client.auto_activate_ollama,
+    openrouter_model=client.openrouter_model,
+)
+assert llm is not None
+assert getattr(llm, "name", "") == "openrouter"
+assert getattr(llm, "model", "") == "anthropic/claude-sonnet-4-5"
+print("resolved", llm.name, llm.model)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "resolved openrouter anthropic/claude-sonnet-4-5" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-Live-Provider-Circular-Import.md

Fixes the AI Content Ops live-provider bridge-mode import failure by making package-level `atlas_brain.auth` exports lazy. Config validation can now import `atlas_brain.auth.encryption` while `settings` is still initializing without accidentally importing auth dependencies that re-enter config.

## Intentional
- Leave extracted LLM infrastructure bridge mode intact; the source failure was auth package initialization, not the provider resolver.
- Use a subprocess regression so module cache state cannot hide the circular import.

## Deferred
- Broader `atlas_brain.services` package import slimming remains a separate cleanup.

## Verification
- `pytest tests/test_live_provider_circular_import.py` -> 1 passed
- `python -m py_compile atlas_brain/auth/__init__.py tests/test_live_provider_circular_import.py` -> passed
- `pytest tests/test_auth_dependencies.py tests/test_extracted_campaign_llm_client.py tests/test_live_provider_circular_import.py` -> 21 passed
- Default resolver smoke with `EXTRACTED_LLM_INFRA_STANDALONE` unset -> `OpenRouterLLM openrouter anthropic/claude-sonnet-4-5`
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
4 files, +192 / -4