### PR TITLE
Strip orphan intro + disclaimer prose alongside stripped blockquotes

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1599,8 +1599,26 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
     """True if ``line`` matches one of the acknowledged-misattribution
     disclaimer patterns. When a stripped blockquote is followed by a
     disclaimer apologising for it, the disclaimer is also orphaned and
-    should be removed."""
+    should be removed.
+
+    Guards against markdown structural lines: a fresh blockquote
+    starting with ``> "That quote is from a ..."``, a heading like
+    ``# That review was on a forum``, or a list item like
+    ``- That reviewer is on a different platform`` would technically
+    match the regex set but represent legitimate document structure
+    (and may be grounded content the caller intends to keep). Codex
+    flagged this on #638: adjacent blockquotes where the second
+    block's first line itself looks like a disclaimer could have the
+    forward span widen INTO the second block, deleting grounded
+    content. Skip any line whose stripped form starts with the
+    blockquote, heading, or list-marker tokens.
+    """
     if not line or not line.strip():
+        return False
+    stripped = line.lstrip()
+    if stripped.startswith((">", "#", "-", "*", "+")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
         return False
     return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
 

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1554,15 +1554,84 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
     return False
 
 
+# Disclaimer-prose patterns. When a blockquote block is stripped, an
+# adjacent paragraph matching one of these patterns is itself orphaned
+# (it references content that no longer exists) and stripped along
+# with the block. These match the seo-geo-aeo-blog-post skill's v1.4.0
+# detection patterns -- the audit catches the same shapes post-publish,
+# and this stripper catches them upstream during generation.
+_ORPHAN_DISCLAIMER_RES = (
+    re.compile(r"that quote is from a .{0,60}? discussion, not a", re.IGNORECASE),
+    re.compile(r"misattributed in the source data", re.IGNORECASE),
+    re.compile(
+        r"(?:quote|review|reviewer) (?:is|was) (?:from|on) a .{0,60}? "
+        r"(?:discussion|review|forum|context)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?:quote|review) is misattributed", re.IGNORECASE),
+)
+
+
+def _looks_like_intro_paragraph(line: str) -> bool:
+    """True if ``line`` looks like a single-line paragraph introducing a
+    blockquote that immediately follows. Used by the orphan-prose cleanup
+    in ``_remove_unmatched_quote_lines``.
+
+    A line qualifies as an intro when it:
+      * has non-empty content;
+      * ends with a colon (the canonical lead-in to a quote);
+      * is not itself a blockquote, heading, or list marker;
+      * is not absurdly long (>180 chars) -- introductions are short.
+    """
+    stripped = (line or "").strip()
+    if len(stripped) < 3 or len(stripped) > 180:
+        return False
+    if not stripped.endswith(":"):
+        return False
+    if stripped.startswith((">", "#", "-", "*")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
+        return False
+    return True
+
+
+def _looks_like_orphan_disclaimer(line: str) -> bool:
+    """True if ``line`` matches one of the acknowledged-misattribution
+    disclaimer patterns. When a stripped blockquote is followed by a
+    disclaimer apologising for it, the disclaimer is also orphaned and
+    should be removed."""
+    if not line or not line.strip():
+        return False
+    return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
+
+
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
-    quote-grade source pool.
+    quote-grade source pool, AND the orphan prose adjacent to them.
 
     A "block" is a maximal run of contiguous ``>``-prefixed lines. The
     block is kept iff EVERY quote-bearing line in it matches the source
     pool. A block with at least one ungrounded quote line is stripped
-    in its entirety (including matched quote lines and attribution
-    lines) -- the block is the unit of trust.
+    in its entirety (matched quote lines and attribution lines alike) --
+    the block is the unit of trust.
+
+    When a block is stripped, the cleanup also widens the strip span to
+    include:
+
+      * **Orphan introductory prose**: a single-line paragraph ending
+        with ``:`` immediately preceding the block (e.g.
+        ``One reviewer on Reddit noted:``). Without removal it dangles
+        with no quote to introduce.
+      * **Orphan disclaimer prose**: a single-line paragraph matching
+        one of the acknowledged-misattribution patterns (e.g.
+        ``That quote is from a compensation discussion, not a CRM
+        review``) immediately following the block. These shipped in
+        production posts when the upstream LLM hedged on ungrounded
+        quotes; the v1.4.0 audit catches them post-publish and this
+        stripper catches them upstream during generation.
+
+    Blank-line separators between the prose and the block are also
+    removed so the post body doesn't accumulate dead vertical space.
 
     A line is "quote-bearing" if ``_extract_quote_body`` returns
     non-empty text for it; attribution-only lines like ``> -- reviewer
@@ -1571,94 +1640,99 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
     sibling fails.
 
     Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
-    are removed. The absence of a source pool is treated as "no quote
-    material is grounded", not as "everything passes" -- the latter was
-    the prior backdoor that allowed paraphrased LLM quotes to ship when
-    the producer hadn't supplied verbatim phrases.
+    are removed (along with their adjacent intro/disclaimer prose).
 
-    Why block-level (not line-level): the prior implementation iterated
-    line-by-line. A multi-line markdown blockquote like::
-
-        > "Some quote text"
-        > -- Attribution Person
-
-    would have its quote line stripped (quote body fails source match)
-    but the attribution line would be PRESERVED, because
-    ``_extract_quote_body`` returns an empty string for an attribution-
-    only line, falsifying the ``if quote and ...`` removal condition.
-    The result was orphan ``<blockquote><p>-- Attribution</p></blockquote>``
-    in the rendered HTML (44 of 79 published posts at the time of fix).
-    Block-level processing removes the entire block atomically.
-
-    The returned ``removed`` count is the number of LINES stripped (for
-    backwards compatibility with the prior contract), not the number of
-    blocks.
+    The returned ``removed`` count is the total number of LINES
+    stripped (block + intro + disclaimer + intervening blank lines).
     """
     text = str(markdown or "")
     if not text:
         return text, 0
 
     lines = text.splitlines(keepends=False)
-    output: list[str] = []
-    removed_lines = 0
-    i = 0
     n = len(lines)
+
+    # ---- Pass 1: identify strip spans ------------------------------------
+    # Each span is a (start, end_exclusive) range of line indices to
+    # remove. Spans may include adjacent intro / blank-separator /
+    # disclaimer lines around a stripped block.
+    strip_spans: list[tuple[int, int]] = []
+    i = 0
     while i < n:
         if not _BLOCKQUOTE_RE.match(lines[i]):
-            output.append(lines[i])
             i += 1
             continue
 
-        # Collect the contiguous blockquote block starting at i.
         block_start = i
         while i < n and _BLOCKQUOTE_RE.match(lines[i]):
             i += 1
-        block_lines = lines[block_start:i]
+        block_end = i  # exclusive
 
-        # Decide: keep the block, or strip it.
-        #
-        # Contract: no ungrounded quote text ships. A block is the unit
-        # of trust -- if any quote-bearing line in the block fails to
-        # match the source pool, the entire block is contaminated and
-        # stripped (including attribution lines, which can't stand on
-        # their own).
-        #
-        # Implementation:
-        #   1. Collect quote-bearing lines (where _extract_quote_body
-        #      returns non-empty content).
-        #   2. If there are no quote-bearing lines, the block is
-        #      orphan attribution -- strip.
-        #   3. If EVERY quote-bearing line matches the source pool,
-        #      keep the whole block (attribution included).
-        #   4. Otherwise (at least one quote-bearing line ungrounded),
-        #      strip the whole block.
+        # Decide keep-vs-strip for this block.
         if not source_quotes:
-            removed_lines += len(block_lines)
-            continue
-
-        quote_bearing: list[str] = []
-        for line in block_lines:
-            m = _BLOCKQUOTE_RE.match(line)
-            if not m:
-                continue
-            quote = _extract_quote_body(m.group(1))
-            if quote:
-                quote_bearing.append(quote)
-
-        if not quote_bearing:
-            # Orphan attribution / non-quote content. Nothing to ground on.
-            removed_lines += len(block_lines)
-            continue
-
-        all_quotes_grounded = all(
-            _quote_matches_source(q, source_quotes) for q in quote_bearing
-        )
-        if all_quotes_grounded:
-            output.extend(block_lines)
+            should_strip = True
         else:
-            removed_lines += len(block_lines)
+            quote_bearing: list[str] = []
+            for line in lines[block_start:block_end]:
+                m = _BLOCKQUOTE_RE.match(line)
+                if not m:
+                    continue
+                quote = _extract_quote_body(m.group(1))
+                if quote:
+                    quote_bearing.append(quote)
 
-    # Preserve trailing newline if the original text had one.
+            if not quote_bearing:
+                # Orphan attribution / non-quote content. Nothing to
+                # ground on; strip the whole block.
+                should_strip = True
+            else:
+                should_strip = not all(
+                    _quote_matches_source(q, source_quotes) for q in quote_bearing
+                )
+
+        if not should_strip:
+            continue
+
+        # Widen the span backward to swallow blank separators + an
+        # orphan intro paragraph ending with ':'.
+        span_start = block_start
+        cursor = block_start - 1
+        while cursor >= 0 and not lines[cursor].strip():
+            cursor -= 1
+        if cursor >= 0 and _looks_like_intro_paragraph(lines[cursor]):
+            # Don't pull intro across a prior strip-span boundary.
+            prior_end = strip_spans[-1][1] if strip_spans else 0
+            if cursor >= prior_end:
+                # Include the intro line + all blanks between it and
+                # the block.
+                span_start = cursor
+
+        # Widen the span forward to swallow blank separators + an
+        # orphan disclaimer paragraph.
+        span_end = block_end
+        cursor = block_end
+        while cursor < n and not lines[cursor].strip():
+            cursor += 1
+        if cursor < n and _looks_like_orphan_disclaimer(lines[cursor]):
+            span_end = cursor + 1
+
+        strip_spans.append((span_start, span_end))
+
+    # ---- Pass 2: build output --------------------------------------------
+    output: list[str] = []
+    removed_lines = 0
+    span_idx = 0
+    for idx in range(n):
+        while span_idx < len(strip_spans) and idx >= strip_spans[span_idx][1]:
+            span_idx += 1
+        if (
+            span_idx < len(strip_spans)
+            and strip_spans[span_idx][0] <= idx < strip_spans[span_idx][1]
+        ):
+            removed_lines += 1
+        else:
+            output.append(lines[idx])
+
     result = "\n".join(output)
     if text.endswith("\n"):
         result += "\n"

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1599,8 +1599,26 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
     """True if ``line`` matches one of the acknowledged-misattribution
     disclaimer patterns. When a stripped blockquote is followed by a
     disclaimer apologising for it, the disclaimer is also orphaned and
-    should be removed."""
+    should be removed.
+
+    Guards against markdown structural lines: a fresh blockquote
+    starting with ``> "That quote is from a ..."``, a heading like
+    ``# That review was on a forum``, or a list item like
+    ``- That reviewer is on a different platform`` would technically
+    match the regex set but represent legitimate document structure
+    (and may be grounded content the caller intends to keep). Codex
+    flagged this on #638: adjacent blockquotes where the second
+    block's first line itself looks like a disclaimer could have the
+    forward span widen INTO the second block, deleting grounded
+    content. Skip any line whose stripped form starts with the
+    blockquote, heading, or list-marker tokens.
+    """
     if not line or not line.strip():
+        return False
+    stripped = line.lstrip()
+    if stripped.startswith((">", "#", "-", "*", "+")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
         return False
     return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
 

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1554,15 +1554,84 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
     return False
 
 
+# Disclaimer-prose patterns. When a blockquote block is stripped, an
+# adjacent paragraph matching one of these patterns is itself orphaned
+# (it references content that no longer exists) and stripped along
+# with the block. These match the seo-geo-aeo-blog-post skill's v1.4.0
+# detection patterns -- the audit catches the same shapes post-publish,
+# and this stripper catches them upstream during generation.
+_ORPHAN_DISCLAIMER_RES = (
+    re.compile(r"that quote is from a .{0,60}? discussion, not a", re.IGNORECASE),
+    re.compile(r"misattributed in the source data", re.IGNORECASE),
+    re.compile(
+        r"(?:quote|review|reviewer) (?:is|was) (?:from|on) a .{0,60}? "
+        r"(?:discussion|review|forum|context)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?:quote|review) is misattributed", re.IGNORECASE),
+)
+
+
+def _looks_like_intro_paragraph(line: str) -> bool:
+    """True if ``line`` looks like a single-line paragraph introducing a
+    blockquote that immediately follows. Used by the orphan-prose cleanup
+    in ``_remove_unmatched_quote_lines``.
+
+    A line qualifies as an intro when it:
+      * has non-empty content;
+      * ends with a colon (the canonical lead-in to a quote);
+      * is not itself a blockquote, heading, or list marker;
+      * is not absurdly long (>180 chars) -- introductions are short.
+    """
+    stripped = (line or "").strip()
+    if len(stripped) < 3 or len(stripped) > 180:
+        return False
+    if not stripped.endswith(":"):
+        return False
+    if stripped.startswith((">", "#", "-", "*")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
+        return False
+    return True
+
+
+def _looks_like_orphan_disclaimer(line: str) -> bool:
+    """True if ``line`` matches one of the acknowledged-misattribution
+    disclaimer patterns. When a stripped blockquote is followed by a
+    disclaimer apologising for it, the disclaimer is also orphaned and
+    should be removed."""
+    if not line or not line.strip():
+        return False
+    return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
+
+
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
-    quote-grade source pool.
+    quote-grade source pool, AND the orphan prose adjacent to them.
 
     A "block" is a maximal run of contiguous ``>``-prefixed lines. The
     block is kept iff EVERY quote-bearing line in it matches the source
     pool. A block with at least one ungrounded quote line is stripped
-    in its entirety (including matched quote lines and attribution
-    lines) -- the block is the unit of trust.
+    in its entirety (matched quote lines and attribution lines alike) --
+    the block is the unit of trust.
+
+    When a block is stripped, the cleanup also widens the strip span to
+    include:
+
+      * **Orphan introductory prose**: a single-line paragraph ending
+        with ``:`` immediately preceding the block (e.g.
+        ``One reviewer on Reddit noted:``). Without removal it dangles
+        with no quote to introduce.
+      * **Orphan disclaimer prose**: a single-line paragraph matching
+        one of the acknowledged-misattribution patterns (e.g.
+        ``That quote is from a compensation discussion, not a CRM
+        review``) immediately following the block. These shipped in
+        production posts when the upstream LLM hedged on ungrounded
+        quotes; the v1.4.0 audit catches them post-publish and this
+        stripper catches them upstream during generation.
+
+    Blank-line separators between the prose and the block are also
+    removed so the post body doesn't accumulate dead vertical space.
 
     A line is "quote-bearing" if ``_extract_quote_body`` returns
     non-empty text for it; attribution-only lines like ``> -- reviewer
@@ -1571,94 +1640,99 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
     sibling fails.
 
     Fails closed: when ``source_quotes`` is empty, ALL blockquote blocks
-    are removed. The absence of a source pool is treated as "no quote
-    material is grounded", not as "everything passes" -- the latter was
-    the prior backdoor that allowed paraphrased LLM quotes to ship when
-    the producer hadn't supplied verbatim phrases.
+    are removed (along with their adjacent intro/disclaimer prose).
 
-    Why block-level (not line-level): the prior implementation iterated
-    line-by-line. A multi-line markdown blockquote like::
-
-        > "Some quote text"
-        > -- Attribution Person
-
-    would have its quote line stripped (quote body fails source match)
-    but the attribution line would be PRESERVED, because
-    ``_extract_quote_body`` returns an empty string for an attribution-
-    only line, falsifying the ``if quote and ...`` removal condition.
-    The result was orphan ``<blockquote><p>-- Attribution</p></blockquote>``
-    in the rendered HTML (44 of 79 published posts at the time of fix).
-    Block-level processing removes the entire block atomically.
-
-    The returned ``removed`` count is the number of LINES stripped (for
-    backwards compatibility with the prior contract), not the number of
-    blocks.
+    The returned ``removed`` count is the total number of LINES
+    stripped (block + intro + disclaimer + intervening blank lines).
     """
     text = str(markdown or "")
     if not text:
         return text, 0
 
     lines = text.splitlines(keepends=False)
-    output: list[str] = []
-    removed_lines = 0
-    i = 0
     n = len(lines)
+
+    # ---- Pass 1: identify strip spans ------------------------------------
+    # Each span is a (start, end_exclusive) range of line indices to
+    # remove. Spans may include adjacent intro / blank-separator /
+    # disclaimer lines around a stripped block.
+    strip_spans: list[tuple[int, int]] = []
+    i = 0
     while i < n:
         if not _BLOCKQUOTE_RE.match(lines[i]):
-            output.append(lines[i])
             i += 1
             continue
 
-        # Collect the contiguous blockquote block starting at i.
         block_start = i
         while i < n and _BLOCKQUOTE_RE.match(lines[i]):
             i += 1
-        block_lines = lines[block_start:i]
+        block_end = i  # exclusive
 
-        # Decide: keep the block, or strip it.
-        #
-        # Contract: no ungrounded quote text ships. A block is the unit
-        # of trust -- if any quote-bearing line in the block fails to
-        # match the source pool, the entire block is contaminated and
-        # stripped (including attribution lines, which can't stand on
-        # their own).
-        #
-        # Implementation:
-        #   1. Collect quote-bearing lines (where _extract_quote_body
-        #      returns non-empty content).
-        #   2. If there are no quote-bearing lines, the block is
-        #      orphan attribution -- strip.
-        #   3. If EVERY quote-bearing line matches the source pool,
-        #      keep the whole block (attribution included).
-        #   4. Otherwise (at least one quote-bearing line ungrounded),
-        #      strip the whole block.
+        # Decide keep-vs-strip for this block.
         if not source_quotes:
-            removed_lines += len(block_lines)
-            continue
-
-        quote_bearing: list[str] = []
-        for line in block_lines:
-            m = _BLOCKQUOTE_RE.match(line)
-            if not m:
-                continue
-            quote = _extract_quote_body(m.group(1))
-            if quote:
-                quote_bearing.append(quote)
-
-        if not quote_bearing:
-            # Orphan attribution / non-quote content. Nothing to ground on.
-            removed_lines += len(block_lines)
-            continue
-
-        all_quotes_grounded = all(
-            _quote_matches_source(q, source_quotes) for q in quote_bearing
-        )
-        if all_quotes_grounded:
-            output.extend(block_lines)
+            should_strip = True
         else:
-            removed_lines += len(block_lines)
+            quote_bearing: list[str] = []
+            for line in lines[block_start:block_end]:
+                m = _BLOCKQUOTE_RE.match(line)
+                if not m:
+                    continue
+                quote = _extract_quote_body(m.group(1))
+                if quote:
+                    quote_bearing.append(quote)
 
-    # Preserve trailing newline if the original text had one.
+            if not quote_bearing:
+                # Orphan attribution / non-quote content. Nothing to
+                # ground on; strip the whole block.
+                should_strip = True
+            else:
+                should_strip = not all(
+                    _quote_matches_source(q, source_quotes) for q in quote_bearing
+                )
+
+        if not should_strip:
+            continue
+
+        # Widen the span backward to swallow blank separators + an
+        # orphan intro paragraph ending with ':'.
+        span_start = block_start
+        cursor = block_start - 1
+        while cursor >= 0 and not lines[cursor].strip():
+            cursor -= 1
+        if cursor >= 0 and _looks_like_intro_paragraph(lines[cursor]):
+            # Don't pull intro across a prior strip-span boundary.
+            prior_end = strip_spans[-1][1] if strip_spans else 0
+            if cursor >= prior_end:
+                # Include the intro line + all blanks between it and
+                # the block.
+                span_start = cursor
+
+        # Widen the span forward to swallow blank separators + an
+        # orphan disclaimer paragraph.
+        span_end = block_end
+        cursor = block_end
+        while cursor < n and not lines[cursor].strip():
+            cursor += 1
+        if cursor < n and _looks_like_orphan_disclaimer(lines[cursor]):
+            span_end = cursor + 1
+
+        strip_spans.append((span_start, span_end))
+
+    # ---- Pass 2: build output --------------------------------------------
+    output: list[str] = []
+    removed_lines = 0
+    span_idx = 0
+    for idx in range(n):
+        while span_idx < len(strip_spans) and idx >= strip_spans[span_idx][1]:
+            span_idx += 1
+        if (
+            span_idx < len(strip_spans)
+            and strip_spans[span_idx][0] <= idx < strip_spans[span_idx][1]
+        ):
+            removed_lines += 1
+        else:
+            output.append(lines[idx])
+
     result = "\n".join(output)
     if text.endswith("\n"):
         result += "\n"

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -544,7 +544,11 @@ def test_orphan_disclaimer_alone_stripped_when_no_intro():
         "That quote is from a payment platform discussion, not a CRM review.\n"
     )
     out, removed = _remove_unmatched_quote_lines(markdown, source)
-    assert "a quote" not in out or ">" not in out  # blockquote line gone
+    # The blockquote line `> a quote` is gone (assertion was previously
+    # `"a quote" not in out OR ">" not in out` which would pass even when
+    # the blockquote remained as long as "a quote" appeared elsewhere --
+    # tightened per Copilot review on PR #638).
+    assert "> a quote" not in out
     assert "That quote is from a payment platform discussion" not in out
     # The 'normal prose' line doesn't end with ':' so it's preserved.
     assert "Some normal prose without a colon ending." in out
@@ -597,6 +601,39 @@ def test_orphan_intro_not_stripped_when_too_long():
     # The block (1 line) is stripped; the long intro is preserved.
     assert "some fabricated quote" not in out
     assert long_intro in out
+
+
+def test_adjacent_blocks_disclaimer_shaped_second_block_not_absorbed():
+    """Codex P1 on PR #638: with two adjacent blockquotes, if the
+    second block starts with text matching the disclaimer regex
+    (e.g. `> "That quote is from a different review..."`), the first
+    stripped block's forward span must NOT widen into the second
+    block. Otherwise a grounded second block can be silently deleted.
+
+    The fix lives in ``_looks_like_orphan_disclaimer``: it now refuses
+    to classify blockquote-, heading-, or list-prefixed lines as
+    orphan disclaimer prose, so the forward-span widening stops at
+    structural boundaries.
+    """
+    source = ["that quote is from a real source about pricing pressure"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "> a fabricated quote\n"
+        "\n"
+        "> that quote is from a real source about pricing pressure\n"
+        "\n"
+        "Final prose.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    # First block (fabricated) -- stripped.
+    assert "a fabricated quote" not in out
+    # Second block matches the source pool AND happens to start with
+    # disclaimer-shaped text -- must be preserved, NOT absorbed into
+    # the first block's strip span.
+    assert "that quote is from a real source about pricing pressure" in out
+    # Final prose unaffected.
+    assert "Final prose." in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -320,7 +320,12 @@ def test_validator_handles_markdown_without_blockquotes():
 
 def test_full_block_stripped_when_pool_empty():
     """Baseline: with empty source_quotes, the fail-closed path strips
-    every blockquote block atomically."""
+    every blockquote block atomically.
+
+    The stripper also sweeps the orphan introductory paragraph
+    immediately preceding the block (``One reviewer noted:`` -- a
+    single-line paragraph ending with ``:``) so the resulting body
+    doesn't dangle the lead-in with no quote to follow."""
     markdown = (
         "## Section\n"
         "\n"
@@ -332,9 +337,15 @@ def test_full_block_stripped_when_pool_empty():
         "More prose continues here.\n"
     )
     out, removed = _remove_unmatched_quote_lines(markdown, [])
-    assert removed == 2
+    # Block (2 lines) + blank separator + intro line = 4 lines removed.
+    assert removed == 4
     assert "fabricated quote" not in out
     assert "Group Director" not in out
+    # Orphan intro prose is also gone.
+    assert "One reviewer noted:" not in out
+    # Surrounding content preserved.
+    assert "## Section" in out
+    assert "More prose continues here." in out
 
 
 def test_full_block_stripped_when_pool_populated_no_match():
@@ -465,25 +476,20 @@ def test_multiple_blocks_independent_decisions():
     assert "Final prose." in out
 
 
-def test_regression_introductory_prose_orphaned_when_quote_stripped():
-    """KNOWN GAP (deferred): prose introducing a blockquote is not
-    cleaned up when the blockquote itself gets stripped.
+def test_orphan_intro_and_disclaimer_prose_stripped_with_block():
+    """When a blockquote is stripped, the stripper also sweeps the
+    orphan introductory paragraph immediately before it AND any
+    acknowledged-misattribution disclaimer paragraph immediately
+    after it. Both reference content that no longer exists, so leaving
+    them in the body produces dangling prose.
 
-    With block-level stripping now in place, the blockquote is removed
-    atomically, but the orphan introduction ("One reviewer noted:") and
-    any acknowledged-misattribution disclaimer ("That quote is from a
-    compensation discussion, not a CRM review") still survive because
-    they aren't blockquote-prefixed lines. They reference content that
-    no longer exists.
+    The disclaimer detection mirrors the seo-geo-aeo-blog-post skill's
+    v1.4.0 audit patterns -- the audit catches these post-publish, and
+    the generator now catches them upstream.
 
-    A complete fix would also detect and remove orphan introductory and
-    disclaimer prose adjacent to stripped blocks. The seo-geo-aeo-blog-
-    post skill v1.4.0 added regex patterns that catch the disclaimer
-    pattern in audit mode; upstream detection in the generator should
-    mirror them.
-
-    For now: this test documents the gap. When the orphan-prose work
-    lands, update the assertions."""
+    Previously this test documented the gap (intro and disclaimer
+    survived stripping). The orphan-prose extension to the stripper
+    closes the gap; the assertions are inverted accordingly."""
     source: list[str] = []  # fail-closed: all blockquotes stripped
     markdown = (
         "## Section\n"
@@ -495,12 +501,102 @@ def test_regression_introductory_prose_orphaned_when_quote_stripped():
         "That quote is from a compensation discussion, not a CRM review, but it surfaced in the same complaint pattern analysis.\n"
     )
     out, removed = _remove_unmatched_quote_lines(markdown, source)
-    assert removed == 1
+    # Block (1 line) + 2 blanks + intro line + disclaimer line = 5 lines.
+    assert removed == 5
     assert "gets stripped" not in out
-    # KNOWN GAP: the orphan intro and disclaimer prose survive.
-    # When the orphan-prose fix lands, change these to `not in out`.
-    assert "One reviewer on Reddit noted:" in out
-    assert "That quote is from a compensation discussion" in out
+    assert "One reviewer on Reddit noted:" not in out
+    assert "That quote is from a compensation discussion" not in out
+    # Surrounding content (the H2) is preserved.
+    assert "## Section" in out
+
+
+def test_orphan_intro_alone_stripped_when_no_disclaimer():
+    """Intro-only case: block has an intro paragraph before it but no
+    disclaimer after. Only the intro is swept along with the block."""
+    source: list[str] = []
+    markdown = (
+        "## Section\n"
+        "\n"
+        "A reviewer on G2 said:\n"
+        "\n"
+        "> some fabricated quote\n"
+        "\n"
+        "Body prose continues here.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert "some fabricated quote" not in out
+    assert "A reviewer on G2 said:" not in out
+    assert "Body prose continues here." in out
+
+
+def test_orphan_disclaimer_alone_stripped_when_no_intro():
+    """Disclaimer-only case: block has a disclaimer after but no
+    introductory ':' paragraph before. Only the disclaimer is swept
+    along with the block."""
+    source: list[str] = []
+    markdown = (
+        "## Section\n"
+        "\n"
+        "Some normal prose without a colon ending.\n"
+        "\n"
+        "> a quote\n"
+        "\n"
+        "That quote is from a payment platform discussion, not a CRM review.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert "a quote" not in out or ">" not in out  # blockquote line gone
+    assert "That quote is from a payment platform discussion" not in out
+    # The 'normal prose' line doesn't end with ':' so it's preserved.
+    assert "Some normal prose without a colon ending." in out
+
+
+def test_orphan_prose_preserved_for_kept_blocks():
+    """When a block is KEPT (its quotes ground), the surrounding intro
+    and prose are also preserved. The orphan-prose cleanup only fires
+    on stripped blocks."""
+    source = ["it costs too much money for what you get"]
+    markdown = (
+        "## Section\n"
+        "\n"
+        "A verified reviewer noted:\n"
+        "\n"
+        "> \"it costs too much money for what you get\"\n"
+        "> -- Customer Reviewer on G2\n"
+        "\n"
+        "Body prose continues here.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 0
+    assert "A verified reviewer noted:" in out
+    assert "costs too much money" in out
+    assert "Customer Reviewer on G2" in out
+    assert "Body prose continues here." in out
+
+
+def test_orphan_intro_not_stripped_when_too_long():
+    """An 'intro paragraph' must be reasonably short. A long paragraph
+    that happens to end with ':' is NOT swept along with a stripped
+    block -- it's substantive content, not a lead-in."""
+    source: list[str] = []
+    long_intro = (
+        "This is a long paragraph that contains substantive analysis "
+        "and discussion of the methodology, the data sources, the "
+        "limitations of self-selected reviewer feedback, and the way "
+        "patterns emerge from cross-vendor analysis across the corpus:"
+    )
+    markdown = (
+        "## Section\n"
+        "\n"
+        f"{long_intro}\n"
+        "\n"
+        "> some fabricated quote\n"
+        "\n"
+        "Body prose continues here.\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    # The block (1 line) is stripped; the long intro is preserved.
+    assert "some fabricated quote" not in out
+    assert long_intro in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the **KNOWN GAP** that PR #625's \`test_regression_introductory_prose_orphaned_when_quote_stripped\` documented.

## The gap

#625's block-level stripper atomically removed contaminated blockquote blocks, but adjacent prose dangled:

\`\`\`
One reviewer on Reddit noted:

[block was here, now removed]

That quote is from a compensation discussion, not a CRM review.
\`\`\`

The intro (\`One reviewer on Reddit noted:\`) and the disclaimer (\`That quote is from a compensation discussion...\`) aren't blockquote-prefixed lines, so the prior stripper left them in place. They reference content that no longer exists — readers see broken prose.

## The fix

\`_remove_unmatched_quote_lines\` now widens each strip span to include:

1. **Orphan intro paragraph** — single-line paragraph ending with \`:\` immediately preceding the stripped block (with optional blank-line separator). Length-bounded (3-180 chars) so long substantive paragraphs that happen to end with \`:\` are preserved.
2. **Orphan disclaimer paragraph** — single-line paragraph immediately after the stripped block matching the acknowledged-misattribution patterns from the seo-geo-aeo-blog-post skill's v1.4.0 audit:
   - \`/that quote is from a .{0,60}? discussion, not a/i\`
   - \`/misattributed in the source data/i\`
   - \`/(quote\\|review\\|reviewer) (is\\|was) (from\\|on) a .{0,60}? (discussion\\|review\\|forum\\|context)/i\`
   - \`/(quote\\|review) is misattributed/i\`
3. **Blank separators** between the prose and the block.

Implementation uses a span-collection pass followed by a filter pass. Cleaner than single-pass-with-lookback and correctly handles edge cases where adjacent blocks could otherwise have overlapping spans.

## Tests

- \`test_full_block_stripped_when_pool_empty\` updated: removed count reflects intro+block (4 lines vs prior 2).
- \`test_regression_introductory_prose_orphaned_when_quote_stripped\` renamed and inverted (no longer documents a gap; asserts orphan-prose IS stripped).
- 4 new tests:
  - \`test_orphan_intro_alone_stripped_when_no_disclaimer\`
  - \`test_orphan_disclaimer_alone_stripped_when_no_intro\`
  - \`test_orphan_prose_preserved_for_kept_blocks\` (no cleanup when block kept)
  - \`test_orphan_intro_not_stripped_when_too_long\` (length heuristic)

**183 tests pass** across the three generator/backfill test files (was 179).

## Effect on existing posts

Generator change only. Existing published posts with orphan intro/disclaimer prose around old stripped quotes won't be auto-fixed by this PR. They'd be cleaned up if regenerated through the quality pipeline, or addressed by a one-off cleanup script.

## Test plan

- [x] 183 tests pass with \`ATLAS_SAAS_ENABLED=false ATLAS_DB_ENABLED=false\`
- [x] \`npm run build\` in atlas-churn-ui: clean
- [x] \`extracted_content_pipeline\` synced via \`extracted/_shared/scripts/sync_extracted.sh\`
- [x] Local pre-push review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)