### PR TITLE
Convert markdown bullet syntax inside <p> tags to semantic <ul><li>

### DIFF
--- a/atlas-churn-ui/src/content/blog/best-hr-hcm-for-51-200-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/best-hr-hcm-for-51-200-2026-04.ts
@@ -165,15 +165,19 @@ const post: BlogPost = {
 <h2 id="bamboohr-best-for-51200-2011000-teams">BambooHR: Best For 51–200, 201–1000 Teams</h2>
 <p><strong>Rating:</strong> 4.3 | <strong>Reviews analyzed:</strong> 42</p>
 <p><strong>Best for:</strong> Single-country, stable-headcount teams that prioritize simplicity and onboarding ease.</p>
-<p><strong>Strengths:</strong>
-- Integration capabilities
-- Onboarding experience (for most users)
-- Feature set for core HR workflows</p>
-<p><strong>Weaknesses:</strong>
-- Pricing and add-on costs
-- UX and interface design
-- Payroll and international tax limitations
-- Contract lock-in</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Integration capabilities</li>
+<li>Onboarding experience (for most users)</li>
+<li>Feature set for core HR workflows</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing and add-on costs</li>
+<li>UX and interface design</li>
+<li>Payroll and international tax limitations</li>
+<li>Contract lock-in</li>
+</ul>
 <h3 id="the-bamboohr-story">The BambooHR Story</h3>
 <p>BambooHR works well until it doesn't. Reviewers praise the initial onboarding and straightforward HR core features. But when teams scale, expand internationally, or need payroll depth, the cracks show.</p>
 <p>The most consistent complaint is <strong>pricing.</strong> Reviewers report that BambooHR's base cost is expensive, and critical features require add-ons:</p>
@@ -188,29 +192,37 @@ const post: BlogPost = {
 </blockquote>
 <p>These aren't catastrophic failures, but they create friction during high-volume hiring periods.</p>
 <h3 id="should-you-choose-bamboohr">Should You Choose BambooHR?</h3>
-<p>Yes, if:
-- You're a US-only company with stable headcount (under 300)
-- You want straightforward HR workflows without payroll complexity
-- You value integration and feature breadth over lowest cost
-- You have a dedicated HR person who can manage the platform</p>
-<p>No, if:
-- You're planning international expansion
-- You need advanced payroll, tax, or benefits administration
-- You want to consolidate payroll and HR in one tool
-- You're cost-sensitive and want to avoid add-on fees</p>
+<p>Yes, if:</p>
+<ul>
+<li>You're a US-only company with stable headcount (under 300)</li>
+<li>You want straightforward HR workflows without payroll complexity</li>
+<li>You value integration and feature breadth over lowest cost</li>
+<li>You have a dedicated HR person who can manage the platform</li>
+</ul>
+<p>No, if:</p>
+<ul>
+<li>You're planning international expansion</li>
+<li>You need advanced payroll, tax, or benefits administration</li>
+<li>You want to consolidate payroll and HR in one tool</li>
+<li>You're cost-sensitive and want to avoid add-on fees</li>
+</ul>
 <hr />
 <h2 id="gusto-best-for-51200-2011000-teams">Gusto: Best For 51–200, 201–1000 Teams</h2>
 <p><strong>Rating:</strong> 4.6 | <strong>Reviews analyzed:</strong> 61</p>
 <p><strong>Best for:</strong> Teams that prioritize payroll accuracy, compliance, and ease of use over deep integrations.</p>
-<p><strong>Strengths:</strong>
-- Security and data protection
-- Performance and system reliability
-- Integration with payroll and tax compliance</p>
-<p><strong>Weaknesses:</strong>
-- UX and interface design
-- Contract lock-in and switching costs
-- Support responsiveness
-- Data migration complexity</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Security and data protection</li>
+<li>Performance and system reliability</li>
+<li>Integration with payroll and tax compliance</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>UX and interface design</li>
+<li>Contract lock-in and switching costs</li>
+<li>Support responsiveness</li>
+<li>Data migration complexity</li>
+</ul>
 <h3 id="the-gusto-story">The Gusto Story</h3>
 <p>Gusto has the highest review volume in this comparison (61 reviews), and the 4.6 rating reflects broad satisfaction. Reviewers consistently praise the payroll and compliance side—Gusto handles tax filings, benefits, and multi-state compliance better than BambooHR.</p>
 <p>But Gusto is not without friction. The most vocal complaints center on <strong>UX and contract lock-in:</strong></p>
@@ -221,29 +233,37 @@ const post: BlogPost = {
 <p>This quote, paired with the high rating, suggests that Gusto's payroll strength outweighs UX frustration for many teams. They tolerate the interface because the payroll side works.</p>
 <p>The <strong>contract lock-in</strong> complaint is significant. Once you commit to Gusto, migrating away (especially if you've used their payroll for years) is expensive and risky.</p>
 <h3 id="should-you-choose-gusto">Should You Choose Gusto?</h3>
-<p>Yes, if:
-- Payroll accuracy and tax compliance are your top priority
-- You want a single platform for HR, payroll, and benefits
-- You're willing to tolerate a less polished interface for payroll reliability
-- You plan to stay with one vendor for 3+ years</p>
-<p>No, if:
-- You need a highly customizable, modern interface
-- You want to keep payroll and HR separate
-- You're evaluating multiple vendors and want flexibility to switch
-- You need deep integrations with specialized tools</p>
+<p>Yes, if:</p>
+<ul>
+<li>Payroll accuracy and tax compliance are your top priority</li>
+<li>You want a single platform for HR, payroll, and benefits</li>
+<li>You're willing to tolerate a less polished interface for payroll reliability</li>
+<li>You plan to stay with one vendor for 3+ years</li>
+</ul>
+<p>No, if:</p>
+<ul>
+<li>You need a highly customizable, modern interface</li>
+<li>You want to keep payroll and HR separate</li>
+<li>You're evaluating multiple vendors and want flexibility to switch</li>
+<li>You need deep integrations with specialized tools</li>
+</ul>
 <hr />
 <h2 id="rippling-best-for-51200-2011000-teams">Rippling: Best For 51–200, 201–1000 Teams</h2>
 <p><strong>Rating:</strong> 4.6 | <strong>Reviews analyzed:</strong> 44</p>
 <p><strong>Best for:</strong> Growing teams that want a unified platform for HR, IT, and payroll with strong integrations.</p>
-<p><strong>Strengths:</strong>
-- Integration ecosystem
-- Feature breadth and innovation
-- Overall satisfaction (for many segments)</p>
-<p><strong>Weaknesses:</strong>
-- UX and interface complexity
-- Support quality and responsiveness
-- Onboarding friction
-- Performance issues under load</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Integration ecosystem</li>
+<li>Feature breadth and innovation</li>
+<li>Overall satisfaction (for many segments)</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>UX and interface complexity</li>
+<li>Support quality and responsiveness</li>
+<li>Onboarding friction</li>
+<li>Performance issues under load</li>
+</ul>
 <h3 id="the-rippling-story">The Rippling Story</h3>
 <p>Rippling is the modern, feature-rich alternative. Reviewers praise the integration capabilities and breadth of features—you can manage HR, IT, payroll, and benefits in one platform. The 4.6 rating matches Gusto's, but for different reasons.</p>
 <p>Where Rippling stumbles is <strong>UX and support.</strong> Reviewers report that the interface is powerful but overwhelming, and support doesn't always keep up:</p>
@@ -253,29 +273,37 @@ const post: BlogPost = {
 </blockquote>
 <p>This positive note is tempered by the reality that many reviewers struggle with onboarding and ongoing support. The platform does a lot, but learning curve is steep.</p>
 <h3 id="should-you-choose-rippling">Should You Choose Rippling?</h3>
-<p>Yes, if:
-- You want a single platform for HR, payroll, and IT management
-- Your team has strong technical skills or dedicated admin resources
-- You value feature breadth and integration depth
-- You're willing to invest in onboarding and training</p>
-<p>No, if:
-- You want a simple, easy-to-use interface
-- You need immediate, responsive support
-- You're a small team without dedicated HR admin
-- You prioritize ease of use over feature completeness</p>
+<p>Yes, if:</p>
+<ul>
+<li>You want a single platform for HR, payroll, and IT management</li>
+<li>Your team has strong technical skills or dedicated admin resources</li>
+<li>You value feature breadth and integration depth</li>
+<li>You're willing to invest in onboarding and training</li>
+</ul>
+<p>No, if:</p>
+<ul>
+<li>You want a simple, easy-to-use interface</li>
+<li>You need immediate, responsive support</li>
+<li>You're a small team without dedicated HR admin</li>
+<li>You prioritize ease of use over feature completeness</li>
+</ul>
 <hr />
 <h2 id="workday-best-for-1000-2011000-teams">Workday: Best For 1000+, 201–1000 Teams</h2>
 <p><strong>Rating:</strong> 4.2 | <strong>Reviews analyzed:</strong> 37</p>
 <p><strong>Best for:</strong> Large enterprises with complex global operations, multiple business units, and dedicated HCM teams.</p>
-<p><strong>Strengths:</strong>
-- Integration and extensibility
-- Feature depth for enterprise workflows
-- Compliance and audit capabilities</p>
-<p><strong>Weaknesses:</strong>
-- Support and implementation complexity
-- Overall user satisfaction (for smaller teams)
-- UX and system performance
-- Contract lock-in and switching costs</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Integration and extensibility</li>
+<li>Feature depth for enterprise workflows</li>
+<li>Compliance and audit capabilities</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Support and implementation complexity</li>
+<li>Overall user satisfaction (for smaller teams)</li>
+<li>UX and system performance</li>
+<li>Contract lock-in and switching costs</li>
+</ul>
 <h3 id="the-workday-story">The Workday Story</h3>
 <p>Workday is built for large enterprises, and the 4.2 rating reflects that. Teams with 1000+ employees and dedicated HCM staff rate it higher than smaller teams. The platform is powerful but complex.</p>
 <p>Reviewers note challenges with support and user experience:</p>
@@ -285,16 +313,20 @@ const post: BlogPost = {
 </blockquote>
 <p>This fragmented feedback suggests that Workday experiences vary widely by implementation and team expertise.</p>
 <h3 id="should-you-choose-workday">Should You Choose Workday?</h3>
-<p>Yes, if:
-- You have 1000+ employees across multiple countries
-- You need advanced reporting, analytics, and compliance features
-- You have a dedicated HCM and IT team
-- You're willing to invest in a multi-year implementation</p>
-<p>No, if:
-- You're a 51–200 person team
-- You want quick time-to-value
-- You need responsive, hands-on support
-- You're cost-conscious (Workday is the most expensive option)</p>
+<p>Yes, if:</p>
+<ul>
+<li>You have 1000+ employees across multiple countries</li>
+<li>You need advanced reporting, analytics, and compliance features</li>
+<li>You have a dedicated HCM and IT team</li>
+<li>You're willing to invest in a multi-year implementation</li>
+</ul>
+<p>No, if:</p>
+<ul>
+<li>You're a 51–200 person team</li>
+<li>You want quick time-to-value</li>
+<li>You need responsive, hands-on support</li>
+<li>You're cost-conscious (Workday is the most expensive option)</li>
+</ul>
 <hr />
 <h2 id="how-to-actually-choose">How to Actually Choose</h2>
 <p>Ratings and feature lists won't make this decision for you. Here's a framework:</p>
@@ -344,15 +376,19 @@ const post: BlogPost = {
 <li><strong>Workday:</strong> Highest cost, but justified for large enterprises</li>
 </ul>
 <h3 id="4-assess-support-capacity">4. Assess Support Capacity</h3>
-<p>Both Gusto and Rippling face support complaints. If you need responsive support:
-- Budget for a dedicated HR admin or choose a simpler tool
-- Ask for SLA guarantees during the sales process
-- Check support availability in your time zone</p>
+<p>Both Gusto and Rippling face support complaints. If you need responsive support:</p>
+<ul>
+<li>Budget for a dedicated HR admin or choose a simpler tool</li>
+<li>Ask for SLA guarantees during the sales process</li>
+<li>Check support availability in your time zone</li>
+</ul>
 <h3 id="5-plan-for-switching-costs">5. Plan for Switching Costs</h3>
-<p>All four vendors have contract lock-in. Before you sign:
-- Understand data export and migration capabilities
-- Negotiate an exit clause or month-to-month option if possible
-- Plan for at least 2–3 months of dual-system overlap</p>
+<p>All four vendors have contract lock-in. Before you sign:</p>
+<ul>
+<li>Understand data export and migration capabilities</li>
+<li>Negotiate an exit clause or month-to-month option if possible</li>
+<li>Plan for at least 2–3 months of dual-system overlap</li>
+</ul>
 <hr />
 <h2 id="what-reviewers-actually-say-in-hr-hcm">What Reviewers Actually Say in HR / HCM</h2>
 <p>Beyond ratings, here's what real users are experiencing:</p>

--- a/atlas-churn-ui/src/content/blog/best-project-management-for-201-1000-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/best-project-management-for-201-1000-2026-04.ts
@@ -223,14 +223,18 @@ const post: BlogPost = {
 <p>That's a displacement signal tied to feature gaps and UX friction. The migration itself became a pain point, suggesting data export and import complexity.</p>
 <p>Pricing complaints appear across the review set. One reviewer mentioned unexpected annual renewal charges. Another noted per-seat pricing at $10.99 scales quickly for mid-market teams.</p>
 <p>Security and reliability weaknesses show up in the data, though with lower mention counts than UX and pricing. Data migration pain is real—reviewers cite export limitations and formatting loss when moving to or from Asana.</p>
-<p><strong>Who should use Asana:</strong>
-- 51-200 or 201-1000 employee teams with straightforward project workflows
-- Teams that prioritize onboarding speed and clean UX over deep customization
-- Organizations willing to accept limited automation and reporting in exchange for simplicity</p>
-<p><strong>Who should avoid Asana:</strong>
-- Teams with complex, multi-layered workflows requiring extensive automation
-- Organizations with strict data migration or export requirements
-- Budget-conscious teams scaling beyond 100 seats where per-seat pricing becomes prohibitive</p>
+<p><strong>Who should use Asana:</strong></p>
+<ul>
+<li>51-200 or 201-1000 employee teams with straightforward project workflows</li>
+<li>Teams that prioritize onboarding speed and clean UX over deep customization</li>
+<li>Organizations willing to accept limited automation and reporting in exchange for simplicity</li>
+</ul>
+<p><strong>Who should avoid Asana:</strong></p>
+<ul>
+<li>Teams with complex, multi-layered workflows requiring extensive automation</li>
+<li>Organizations with strict data migration or export requirements</li>
+<li>Budget-conscious teams scaling beyond 100 seats where per-seat pricing becomes prohibitive</li>
+</ul>
 <h2 id="basecamp-best-for-201-1000-1000-teams">Basecamp: Best For 201-1000, 1000+ Teams</h2>
 <p><strong>Average rating:</strong> 4.4<br />
 <strong>Review count:</strong> 19<br />
@@ -241,14 +245,18 @@ const post: BlogPost = {
 <p>Reviewers cite flat-rate pricing as a strength—no per-seat surprises. Data migration is easier than competitors, and the feature set covers core project management needs without bloat.</p>
 <p>But UX friction appears in the pain data. Reviewers report a dated interface, limited customization, and navigation patterns that feel rigid compared to newer tools. Integration weaknesses show up too—Basecamp doesn't connect as deeply to third-party tools as Asana, Monday.com, or Jira.</p>
 <p>Support is the primary weakness. Reviewers report slow response times and limited help documentation for edge cases.</p>
-<p><strong>Who should use Basecamp:</strong>
-- 201-1000 or 1000+ employee teams that want predictable, flat-rate pricing
-- Organizations with straightforward workflows that don't require deep third-party integrations
-- Teams willing to accept a simpler, less customizable interface in exchange for cost stability</p>
-<p><strong>Who should avoid Basecamp:</strong>
-- Teams that rely heavily on integrations with CRM, analytics, or development tools
-- Organizations that need responsive, high-touch support
-- Teams that prioritize modern UX and extensive customization options</p>
+<p><strong>Who should use Basecamp:</strong></p>
+<ul>
+<li>201-1000 or 1000+ employee teams that want predictable, flat-rate pricing</li>
+<li>Organizations with straightforward workflows that don't require deep third-party integrations</li>
+<li>Teams willing to accept a simpler, less customizable interface in exchange for cost stability</li>
+</ul>
+<p><strong>Who should avoid Basecamp:</strong></p>
+<ul>
+<li>Teams that rely heavily on integrations with CRM, analytics, or development tools</li>
+<li>Organizations that need responsive, high-touch support</li>
+<li>Teams that prioritize modern UX and extensive customization options</li>
+</ul>
 <h2 id="jira-best-for-201-1000-1000-teams">Jira: Best For 201-1000, 1000+ Teams</h2>
 <p><strong>Average rating:</strong> 4.3<br />
 <strong>Review count:</strong> 60<br />
@@ -271,14 +279,18 @@ const post: BlogPost = {
 <p>-- Customer Support Specialist, verified reviewer on G2</p>
 </blockquote>
 <p>That's a positive sentiment signal from a mid-market user in computer software. The review suggests Jira still works for technical teams that can absorb the complexity, but the overall dissatisfaction pattern indicates fragile retention.</p>
-<p><strong>Who should use Jira:</strong>
-- 201-1000 or 1000+ employee engineering or product teams with technical users
-- Organizations that need deep customization, automation, and reporting
-- Teams willing to invest in onboarding and configuration to unlock Jira's full feature set</p>
-<p><strong>Who should avoid Jira:</strong>
-- Non-technical teams or cross-functional organizations with mixed user types
-- Budget-conscious teams facing Jira Cloud pricing increases
-- Organizations that need simple, fast data migration or flexible contract terms</p>
+<p><strong>Who should use Jira:</strong></p>
+<ul>
+<li>201-1000 or 1000+ employee engineering or product teams with technical users</li>
+<li>Organizations that need deep customization, automation, and reporting</li>
+<li>Teams willing to invest in onboarding and configuration to unlock Jira's full feature set</li>
+</ul>
+<p><strong>Who should avoid Jira:</strong></p>
+<ul>
+<li>Non-technical teams or cross-functional organizations with mixed user types</li>
+<li>Budget-conscious teams facing Jira Cloud pricing increases</li>
+<li>Organizations that need simple, fast data migration or flexible contract terms</li>
+</ul>
 <h2 id="mondaycom-best-for-51-200-1000-teams">Monday.com: Best For 51-200, 1000+ Teams</h2>
 <p><strong>Average rating:</strong> 4.5<br />
 <strong>Review count:</strong> 62<br />
@@ -291,14 +303,18 @@ const post: BlogPost = {
 <p>UX friction appears in the review data too. Reviewers report feature bloat, navigation complexity, and a learning curve that grows steeper as teams add more boards and automations.</p>
 <p>Support gaps show up consistently. Reviewers cite slow response times, limited help documentation, and difficulty getting answers for complex configuration issues.</p>
 <p>Security and reliability are the primary weaknesses. Reviewers report occasional downtime, slow load times for large boards, and concerns about data access controls.</p>
-<p><strong>Who should use Monday.com:</strong>
-- 51-200 or 1000+ employee teams with non-technical users who need visual, board-based workflows
-- Organizations that prioritize low admin burden and fast onboarding
-- Teams willing to accept pricing risk and support gaps in exchange for a flexible, customizable interface</p>
-<p><strong>Who should avoid Monday.com:</strong>
-- Budget-conscious teams scaling beyond 100 seats where per-seat pricing becomes prohibitive
-- Organizations with strict security or uptime requirements
-- Teams that need responsive, high-touch support for complex configurations</p>
+<p><strong>Who should use Monday.com:</strong></p>
+<ul>
+<li>51-200 or 1000+ employee teams with non-technical users who need visual, board-based workflows</li>
+<li>Organizations that prioritize low admin burden and fast onboarding</li>
+<li>Teams willing to accept pricing risk and support gaps in exchange for a flexible, customizable interface</li>
+</ul>
+<p><strong>Who should avoid Monday.com:</strong></p>
+<ul>
+<li>Budget-conscious teams scaling beyond 100 seats where per-seat pricing becomes prohibitive</li>
+<li>Organizations with strict security or uptime requirements</li>
+<li>Teams that need responsive, high-touch support for complex configurations</li>
+</ul>
 <p><a href="https://try.monday.com/1p7bntdd5bui">Try Monday.com</a></p>
 <h2 id="smartsheet-best-for-201-1000-51-200-teams">Smartsheet: Best For 201-1000, 51-200 Teams</h2>
 <p><strong>Average rating:</strong> 4.0<br />
@@ -311,14 +327,18 @@ const post: BlogPost = {
 <p>But pricing complaints lead the pain map, followed by support gaps and overall dissatisfaction. Reviewers report unexpected cost increases, per-seat pricing that scales unpredictably, and annual contracts with no prorated refunds.</p>
 <p>Support is a consistent weakness. Reviewers cite slow response times, limited help documentation, and difficulty getting answers for complex formula or automation issues.</p>
 <p>Data migration and contract lock-in are the primary weaknesses. Reviewers report difficulty exporting data in usable formats, and annual contracts create friction when teams want to leave.</p>
-<p><strong>Who should use Smartsheet:</strong>
-- 51-200 or 201-1000 employee teams with spreadsheet-heavy workflows
-- Organizations that prioritize reliability and low technical debt
-- Teams willing to accept pricing risk and support gaps in exchange for a familiar, spreadsheet-like interface</p>
-<p><strong>Who should avoid Smartsheet:</strong>
-- Budget-conscious teams facing pricing increases or per-seat scaling issues
-- Organizations that need responsive, high-touch support
-- Teams that require simple, fast data migration or flexible contract terms</p>
+<p><strong>Who should use Smartsheet:</strong></p>
+<ul>
+<li>51-200 or 201-1000 employee teams with spreadsheet-heavy workflows</li>
+<li>Organizations that prioritize reliability and low technical debt</li>
+<li>Teams willing to accept pricing risk and support gaps in exchange for a familiar, spreadsheet-like interface</li>
+</ul>
+<p><strong>Who should avoid Smartsheet:</strong></p>
+<ul>
+<li>Budget-conscious teams facing pricing increases or per-seat scaling issues</li>
+<li>Organizations that need responsive, high-touch support</li>
+<li>Teams that require simple, fast data migration or flexible contract terms</li>
+</ul>
 <h2 id="teamwork-best-for-51-200-201-1000-teams">Teamwork: Best For 51-200, 201-1000 Teams</h2>
 <p><strong>Average rating:</strong> 4.5<br />
 <strong>Review count:</strong> 32<br />
@@ -329,14 +349,18 @@ const post: BlogPost = {
 <p>Reviewers cite strong UX, solid integration depth, and reliable performance. The interface is clean, and the feature set covers most project management workflows without the bloat that shows up in Monday.com or Jira.</p>
 <p>But overall dissatisfaction appears in the pain data, followed by UX friction. The review sample is smaller (32 reviews), so confidence is lower, but the pattern suggests retention is fragile.</p>
 <p>Support, reliability, and pricing are the primary weaknesses. Reviewers report slow response times, occasional downtime, and pricing that scales unpredictably as teams grow.</p>
-<p><strong>Who should use Teamwork:</strong>
-- 51-200 or 201-1000 employee teams that prioritize clean UX and integration depth
-- Organizations willing to accept support and reliability gaps in exchange for a simpler, less bloated interface
-- Teams that need solid performance without the complexity of Jira or the feature bloat of Monday.com</p>
-<p><strong>Who should avoid Teamwork:</strong>
-- Organizations with strict uptime or support requirements
-- Budget-conscious teams facing pricing increases or per-seat scaling issues
-- Teams that need a larger review sample and higher confidence before committing</p>
+<p><strong>Who should use Teamwork:</strong></p>
+<ul>
+<li>51-200 or 201-1000 employee teams that prioritize clean UX and integration depth</li>
+<li>Organizations willing to accept support and reliability gaps in exchange for a simpler, less bloated interface</li>
+<li>Teams that need solid performance without the complexity of Jira or the feature bloat of Monday.com</li>
+</ul>
+<p><strong>Who should avoid Teamwork:</strong></p>
+<ul>
+<li>Organizations with strict uptime or support requirements</li>
+<li>Budget-conscious teams facing pricing increases or per-seat scaling issues</li>
+<li>Teams that need a larger review sample and higher confidence before committing</li>
+</ul>
 <h2 id="how-to-actually-choose">How to Actually Choose</h2>
 <p>Ratings and feature lists won't tell you which tool fits your team. Here's a decision framework based on the evidence.</p>
 <h3 id="start-with-team-size-and-user-type">Start with team size and user type</h3>
@@ -347,19 +371,23 @@ const post: BlogPost = {
 <li><strong>1000+ employees, flat-rate pricing preference:</strong> Basecamp. Limited integrations and dated UX, but predictable costs.</li>
 </ul>
 <h3 id="then-layer-in-budget-and-contract-risk">Then layer in budget and contract risk</h3>
-<p>Per-seat pricing scales unpredictably. One Reddit reviewer compared vendors and found:
-- Jira: 92× multiplier at $9.05/seat
-- Monday.com: 78× multiplier at $9/seat
-- Asana: 62× multiplier at $10.99/seat</p>
+<p>Per-seat pricing scales unpredictably. One Reddit reviewer compared vendors and found:</p>
+<ul>
+<li>Jira: 92× multiplier at $9.05/seat</li>
+<li>Monday.com: 78× multiplier at $9/seat</li>
+<li>Asana: 62× multiplier at $10.99/seat</li>
+</ul>
 <p>For a 200-person team, that's $1810/month (Jira), $1800/month (Monday), or $2198/month (Asana). Annual contracts lock you in with no prorated refunds.</p>
 <p>One Software Advice reviewer was charged $265 for an annual renewal on a barely-used service. No refund. No flexibility.</p>
 <p>If budget predictability matters, Basecamp's flat-rate pricing is the only option in this set that eliminates per-seat risk.</p>
 <h3 id="finally-test-for-your-must-have-features">Finally, test for your must-have features</h3>
-<p>Don't assume every tool covers your workflow. The pain data shows:
-- <strong>Automation and reporting:</strong> Jira is strongest, but complex. Asana and Monday.com cover basics but hit limits quickly.
-- <strong>Integrations:</strong> Teamwork and Monday.com are strongest. Basecamp is weakest.
-- <strong>Data migration:</strong> Basecamp is easiest. Jira and Smartsheet are hardest.
-- <strong>Support:</strong> All vendors show support gaps. Jira and Smartsheet are worst.</p>
+<p>Don't assume every tool covers your workflow. The pain data shows:</p>
+<ul>
+<li><strong>Automation and reporting:</strong> Jira is strongest, but complex. Asana and Monday.com cover basics but hit limits quickly.</li>
+<li><strong>Integrations:</strong> Teamwork and Monday.com are strongest. Basecamp is weakest.</li>
+<li><strong>Data migration:</strong> Basecamp is easiest. Jira and Smartsheet are hardest.</li>
+<li><strong>Support:</strong> All vendors show support gaps. Jira and Smartsheet are worst.</li>
+</ul>
 <h3 id="the-category-conclusion">The category conclusion</h3>
 <p>The project management category exhibits moderate displacement intensity with a stable market structure. ClickUp is experiencing significant outbound displacement (10 mentions to Asana, 2 to Monday.com) with UX cited as the primary driver. Jira shows end-user dissatisfaction with UX and faces displacement pressure toward both Asana (5 mentions) and ClickUp (3 mentions).</p>
 <p>Pricing backlash is the immediate trigger. Unexpected annual renewal charges combined with inflexible cancellation policies create acute dissatisfaction when users attempt to cancel after discovering charges. This happens immediately following annual renewal charges, particularly when users discover unexpected billing after reduced usage periods.</p>

--- a/atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts
@@ -193,23 +193,29 @@ const post: BlogPost = {
 <p>{{chart:pain-radar}}</p>
 <p>Pain signals cluster around six key areas:</p>
 <h3 id="pricing-primary-pain-point">Pricing (Primary Pain Point)</h3>
-<p>Pricing complaints dominate the recent review window. Reviewers report:
-- Escalating costs as contact volume grows past 25,000
-- Professional plan pricing ($449/month) perceived as unjustified relative to feature set
-- Bundled pricing structures that force upgrades for single-feature needs
-- Competitor consolidation strategies (e.g., moving to HubSpot or ActiveCampaign for bundled CRM + email)</p>
+<p>Pricing complaints dominate the recent review window. Reviewers report:</p>
+<ul>
+<li>Escalating costs as contact volume grows past 25,000</li>
+<li>Professional plan pricing ($449/month) perceived as unjustified relative to feature set</li>
+<li>Bundled pricing structures that force upgrades for single-feature needs</li>
+<li>Competitor consolidation strategies (e.g., moving to HubSpot or ActiveCampaign for bundled CRM + email)</li>
+</ul>
 <p>The pricing pain is not about absolute cost but perceived value loss. Reviewers who stay under 10,000 contacts report satisfaction; those scaling report frustration.</p>
 <h3 id="competitive-inferiority">Competitive Inferiority</h3>
-<p>Reviewers frequently position Brevo as a "good starter tool" that loses ground to specialized platforms:
-- <strong>SMS &amp; messaging:</strong> Klaviyo and Twilio offer deeper SMS automation
-- <strong>CRM integration:</strong> ActiveCampaign and HubSpot provide tighter native CRM workflows
-- <strong>Advanced segmentation:</strong> MailerLite and Klaviyo offer more granular behavioral segmentation</p>
+<p>Reviewers frequently position Brevo as a "good starter tool" that loses ground to specialized platforms:</p>
+<ul>
+<li><strong>SMS &amp; messaging:</strong> Klaviyo and Twilio offer deeper SMS automation</li>
+<li><strong>CRM integration:</strong> ActiveCampaign and HubSpot provide tighter native CRM workflows</li>
+<li><strong>Advanced segmentation:</strong> MailerLite and Klaviyo offer more granular behavioral segmentation</li>
+</ul>
 <p>Brevo is perceived as a "jack of all trades, master of none" in the mid-market segment.</p>
 <h3 id="contract-lock-in-and-feature-restrictions">Contract Lock-In and Feature Restrictions</h3>
-<p>Reviewers report friction around:
-- Difficulty downgrading plans mid-cycle
-- Feature availability tied to plan tier rather than usage
-- Limited transparency on what triggers tier escalation</p>
+<p>Reviewers report friction around:</p>
+<ul>
+<li>Difficulty downgrading plans mid-cycle</li>
+<li>Feature availability tied to plan tier rather than usage</li>
+<li>Limited transparency on what triggers tier escalation</li>
+</ul>
 <h3 id="performance-and-reliability">Performance and Reliability</h3>
 <p>While not the loudest complaint, delivery speed and uptime concerns surface in a minority of reviews, particularly around bulk send performance and API rate limits.</p>
 <h3 id="security-and-data-privacy">Security and Data Privacy</h3>
@@ -218,15 +224,17 @@ const post: BlogPost = {
 <h2 id="the-brevo-ecosystem-integrations-use-cases">The Brevo Ecosystem: Integrations &amp; Use Cases</h2>
 <p>Brevo's deployment footprint spans email-first and CRM-adjacent workflows:</p>
 <h3 id="primary-integrations">Primary Integrations</h3>
-<p>Reviewers mention 8 core integrations:
-- <strong>ClickUp</strong> (project management)
-- <strong>Canva</strong> (design templates)
-- <strong>Elastic</strong> (analytics)
-- <strong>Evernote</strong> (note-taking)
-- <strong>ADN Email</strong> (legacy email systems)
-- <strong>Doppler Email Marketing</strong> (email ops)
-- <strong>Agency AutomationTEAM</strong> (agency workflows)
-- <strong>API</strong> (custom workflows)</p>
+<p>Reviewers mention 8 core integrations:</p>
+<ul>
+<li><strong>ClickUp</strong> (project management)</li>
+<li><strong>Canva</strong> (design templates)</li>
+<li><strong>Elastic</strong> (analytics)</li>
+<li><strong>Evernote</strong> (note-taking)</li>
+<li><strong>ADN Email</strong> (legacy email systems)</li>
+<li><strong>Doppler Email Marketing</strong> (email ops)</li>
+<li><strong>Agency AutomationTEAM</strong> (agency workflows)</li>
+<li><strong>API</strong> (custom workflows)</li>
+</ul>
 <p>The integration list skews toward productivity and design tools rather than deep CRM or data warehouse connections. This reflects Brevo's positioning as an email-first platform with extension capabilities.</p>
 <h3 id="primary-use-cases">Primary Use Cases</h3>
 <p>Reviewers deploy Brevo for:
@@ -304,24 +312,30 @@ const post: BlogPost = {
 <h3 id="contact-volume-scaling-pain">Contact Volume Scaling Pain</h3>
 <p>Reviewers report that Professional plan pricing doesn't scale linearly with contact growth. A team with 50,000 contacts pays the same as a team with 500,000 contacts. This inverts the typical SaaS model and creates buyer resentment when contact growth outpaces revenue growth.</p>
 <h3 id="missing-mid-market-tier">Missing Mid-Market Tier</h3>
-<p>Reviewers explicitly ask for a $100–200/month tier with:
-- 25,000–50,000 contact limits
-- Basic automation (not full suite)
-- Standard support (not premium)</p>
+<p>Reviewers explicitly ask for a $100–200/month tier with:</p>
+<ul>
+<li>25,000–50,000 contact limits</li>
+<li>Basic automation (not full suite)</li>
+<li>Standard support (not premium)</li>
+</ul>
 <p>This gap drives evaluators toward MailerLite, which offers graduated pricing, or Mailchimp, which has stronger feature parity at mid-market price points.</p>
 <hr />
 <h2 id="churn-signals-and-switching-intent">Churn Signals and Switching Intent</h2>
 <p>Analysis identified <strong>5 explicit switching signals</strong> across the 38 reviews:</p>
 <h3 id="active-evaluation-window">Active Evaluation Window</h3>
-<p>Reviewers posted switching questions and alternative requests <strong>within the past few weeks</strong> (March 2026). Timing anchors include:
-- "Help Needed: Switching from Brevo (SendinBlue) for Newsletter Emails – Need Suggestions for a Cheaper Alternative" (Reddit)
-- "Has anyone switched away from Brevo?" (Reddit)
-- "Just starting out with email marketing [looking at alternatives]" (Reddit)</p>
+<p>Reviewers posted switching questions and alternative requests <strong>within the past few weeks</strong> (March 2026). Timing anchors include:</p>
+<ul>
+<li>"Help Needed: Switching from Brevo (SendinBlue) for Newsletter Emails – Need Suggestions for a Cheaper Alternative" (Reddit)</li>
+<li>"Has anyone switched away from Brevo?" (Reddit)</li>
+<li>"Just starting out with email marketing [looking at alternatives]" (Reddit)</li>
+</ul>
 <p>These are active, not dormant, evaluation signals. Reviewers are in the consideration phase and soliciting peer input.</p>
 <h3 id="budget-driven-switching">Budget-Driven Switching</h3>
-<p>Reviewers cite explicit dollar thresholds:
-- "Budget is flexible but ideally staying under $300/month to start"
-- "Looking for something cheaper than Brevo's Professional plan"</p>
+<p>Reviewers cite explicit dollar thresholds:</p>
+<ul>
+<li>"Budget is flexible but ideally staying under $300/month to start"</li>
+<li>"Looking for something cheaper than Brevo's Professional plan"</li>
+</ul>
 <p>This signals price-elastic demand. At $450+/month, Brevo loses buyers to MailerLite ($50–300/month), Mailchimp ($20–350/month), and open-source alternatives.</p>
 <h3 id="bundled-suite-consolidation">Bundled Suite Consolidation</h3>
 <p>One reviewer noted the appeal of consolidating email + CRM into a single vendor (e.g., HubSpot) to reduce contract management and integration overhead. This is a strategic churn vector: Brevo loses not because of product failure but because of buyer simplification.</p>
@@ -340,18 +354,22 @@ const post: BlogPost = {
 <hr />
 <h2 id="the-bottom-line-on-brevo">The Bottom Line on Brevo</h2>
 <h3 id="who-should-consider-brevo">Who Should Consider Brevo</h3>
-<p><strong>Best fit:</strong>
-- Startups and small teams (under 10,000 contacts) with email-first workflows
-- Agencies managing multiple client campaigns with minimal customization
-- Non-technical marketers who prioritize ease of use over advanced automation
-- Teams with tight budgets ($8–100/month) seeking a low-risk entry point</p>
+<p><strong>Best fit:</strong></p>
+<ul>
+<li>Startups and small teams (under 10,000 contacts) with email-first workflows</li>
+<li>Agencies managing multiple client campaigns with minimal customization</li>
+<li>Non-technical marketers who prioritize ease of use over advanced automation</li>
+<li>Teams with tight budgets ($8–100/month) seeking a low-risk entry point</li>
+</ul>
 <p><strong>Why:</strong> Brevo's Starter plan offers exceptional value for early-stage teams. The interface is intuitive, integrations are adequate, and support is responsive for basic use cases.</p>
 <h3 id="who-should-look-elsewhere">Who Should Look Elsewhere</h3>
-<p><strong>Poor fit:</strong>
-- Mid-market teams (25,000+ contacts) facing Professional plan pricing shock
-- Buyers needing advanced SMS, segmentation, or CRM-native automation
-- Teams seeking vendor consolidation (HubSpot, Salesforce bundles offer better ROI)
-- Enterprises requiring guaranteed SLAs and dedicated support</p>
+<p><strong>Poor fit:</strong></p>
+<ul>
+<li>Mid-market teams (25,000+ contacts) facing Professional plan pricing shock</li>
+<li>Buyers needing advanced SMS, segmentation, or CRM-native automation</li>
+<li>Teams seeking vendor consolidation (HubSpot, Salesforce bundles offer better ROI)</li>
+<li>Enterprises requiring guaranteed SLAs and dedicated support</li>
+</ul>
 <p><strong>Why:</strong> Brevo's pricing model punishes scale. Its feature set plateaus at mid-market complexity. Competitors offer better value at $300–500/month spend levels.</p>
 <h3 id="active-evaluation-signals">Active Evaluation Signals</h3>
 <p>As of March 2026, <strong>evaluators are actively shopping alternatives.</strong> Pricing complaints surfaced within the past few weeks. Budget thresholds ($300/month) and competitor mentions (ActiveCampaign, Klaviyo, MailerLite) indicate real switching momentum.</p>
@@ -386,11 +404,13 @@ const post: BlogPost = {
 <p><strong>Sources:</strong> G2 (3 reviews), Gartner Peer Insights (4 reviews), TrustRadius (1 review), Reddit (30 reviews).</p>
 <p><strong>Time window:</strong> March 3–28, 2026.</p>
 <p><strong>Confidence level:</strong> Moderate. Sample size is sufficient for pattern identification but limited for statistical generalization. Community reviews (Reddit) are self-selected and may skew toward pain-point venting.</p>
-<p><strong>Limitations:</strong>
-- No account-level intent data available; unable to validate switching momentum at portfolio scale.
-- Support quality assessment relies on anecdotal reports; no systematic SLA or response-time data.
-- Pricing analysis reflects reviewer perception, not official Brevo pricing documentation.
-- Results reflect reviewer perception, not product capability.</p>
+<p><strong>Limitations:</strong></p>
+<ul>
+<li>No account-level intent data available; unable to validate switching momentum at portfolio scale.</li>
+<li>Support quality assessment relies on anecdotal reports; no systematic SLA or response-time data.</li>
+<li>Pricing analysis reflects reviewer perception, not official Brevo pricing documentation.</li>
+<li>Results reflect reviewer perception, not product capability.</li>
+</ul>
 <p><strong>Data source:</strong> Public B2B software review platforms and community forums. Analysis conducted April 7, 2026.</p>`,
 }
 

--- a/atlas-churn-ui/src/content/blog/close-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/close-deep-dive-2026-04.ts
@@ -160,11 +160,13 @@ const post: BlogPost = {
 <p>Close CRM serves small to mid-sized sales teams looking for a focused, sales-first platform. But how does it actually perform in the field?</p>
 <p>This deep dive analyzes 1042 Close reviews collected between March 3 and April 7, 2026. We enriched 610 of those reviews with structured sentiment analysis, pain categorization, and buyer role identification. The analysis draws from G2 verified reviews and Reddit community discussions to surface patterns that self-reported review data can reveal.</p>
 <p>The sample includes 11 verified platform reviews and 599 community posts. While this is a self-selected sample—reviewers choose when and why to share feedback—it offers concrete insight into where Close creates friction and where it delivers value.</p>
-<p>Key findings:
-- 34 reviews showed churn or switching intent
-- Economic buyers surfaced the strongest pressure signals
-- Pricing complaints cluster around month-end compensation review windows
-- 3 active evaluation signals were visible during the analysis period</p>
+<p>Key findings:</p>
+<ul>
+<li>34 reviews showed churn or switching intent</li>
+<li>Economic buyers surfaced the strongest pressure signals</li>
+<li>Pricing complaints cluster around month-end compensation review windows</li>
+<li>3 active evaluation signals were visible during the analysis period</li>
+</ul>
 <p>This is not a universal product assessment. It is an evidence-backed look at what reviewers report when they choose to speak up.</p>
 <h2 id="what-close-does-well-and-where-it-falls-short">What Close Does Well -- and Where It Falls Short</h2>
 <p>Close CRM's strengths and weaknesses emerge clearly when you map reviewer feedback across 610 enriched reviews.</p>

--- a/atlas-churn-ui/src/content/blog/help-scout-vs-zendesk-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/help-scout-vs-zendesk-2026-04.ts
@@ -183,36 +183,46 @@ const post: BlogPost = {
 <h2 id="who-is-churning-buyer-profile-breakdown">Who Is Churning? Buyer Profile Breakdown</h2>
 <p>Buyer role distribution reveals who is experiencing friction and who is making switching decisions.</p>
 <h3 id="help-scout-buyer-roles">Help Scout Buyer Roles</h3>
-<p>Help Scout signals include:
-- 1 economic buyer
-- 1 champion
-- 1 evaluator</p>
+<p>Help Scout signals include:</p>
+<ul>
+<li>1 economic buyer</li>
+<li>1 champion</li>
+<li>1 evaluator</li>
+</ul>
 <p>The decision-maker churn rate is 1.0, meaning 100% of decision-makers in the sample expressed churn intent or active dissatisfaction. That is a small sample (3 total roles), but it is a red flag: the people who control budget and vendor decisions are the ones expressing friction.</p>
 <p>The Customer Success Manager who cited CRM integration gaps is an evaluator role. That is a workflow owner, not a budget owner, but evaluators influence champion and economic buyer decisions. When an evaluator publicly states a dislike on G2, it is a signal that the pain point has already been escalated internally.</p>
 <h3 id="zendesk-buyer-roles">Zendesk Buyer Roles</h3>
-<p>Zendesk signals include:
-- 2 economic buyers
-- 2 champions
-- 2 end users</p>
+<p>Zendesk signals include:</p>
+<ul>
+<li>2 economic buyers</li>
+<li>2 champions</li>
+<li>2 end users</li>
+</ul>
 <p>The decision-maker churn rate is 0.0, meaning no economic buyers or champions in the sample expressed explicit churn intent. That is surprising given the higher urgency score (3.3), but it aligns with the nature of Zendesk complaints: billing disputes and support delays are frustrating, but they do not always trigger immediate switching decisions.</p>
 <p>The two end users in the sample are likely experiencing operational friction—email delivery failures, support delays, or workflow complexity—but are not in a position to make vendor decisions. That creates a lag: end-user dissatisfaction accumulates, but switching decisions wait for contract renewal or budget cycle windows.</p>
 <p>The November 13, 2024 billing dispute and the May 14, 2025 cancellation dispute are both outlier signals, meaning they represent edge cases rather than common patterns. However, outlier signals often predict future common patterns when the underlying cause (billing opacity, cancellation friction) is systemic rather than account-specific.</p>
 <h3 id="segment-and-size-signals">Segment and Size Signals</h3>
-<p>The data does not include explicit company size or industry breakdowns, but the quotable phrases and witness highlights offer clues:
-- A Zendesk reviewer on Reddit described a "small business (four employees)" using Zendesk Sell
-- A Gartner reviewer described Zendesk as handling "emails, chat and socials in one view," suggesting a mid-market or enterprise use case
-- A Software Advice reviewer noted Zendesk is "pricey and complex for small teams"</p>
+<p>The data does not include explicit company size or industry breakdowns, but the quotable phrases and witness highlights offer clues:</p>
+<ul>
+<li>A Zendesk reviewer on Reddit described a "small business (four employees)" using Zendesk Sell</li>
+<li>A Gartner reviewer described Zendesk as handling "emails, chat and socials in one view," suggesting a mid-market or enterprise use case</li>
+<li>A Software Advice reviewer noted Zendesk is "pricey and complex for small teams"</li>
+</ul>
 <p>That suggests Zendesk's friction points are most acute for small teams (under 10 employees) who lack the operational capacity to navigate billing disputes or support delays. Help Scout's friction points, by contrast, are most acute for teams that rely on deep CRM integration or advanced workflow automation—likely mid-market teams (50-200 employees) with dedicated Customer Success or Support Operations roles.</p>
 <h2 id="the-verdict">The Verdict</h2>
 <p>Zendesk faces higher urgency pressure (3.3 vs 2.2), more acute operational friction, and active displacement to Freshdesk and Intercom. Help Scout faces lower urgency but structural friction around integration gaps and customization depth.</p>
 <p>The decisive factor is not feature parity. It is market regime and switching cost trajectory. The helpdesk category is in an entrenchment regime with negative churn velocity, meaning buyers who delay switching face rising lock-in costs over time. Zendesk's higher urgency score suggests accounts are already experiencing that lock-in pressure and are actively evaluating alternatives. Help Scout's lower urgency score suggests accounts are tolerating friction for now, but the integration gaps create a natural opening for competitors.</p>
-<p>For buyers evaluating between Help Scout and Zendesk:
-- If your team is under 20 employees and does not require deep CRM integration, Help Scout's simplicity and support experience are defensible strengths
-- If your team is over 50 employees and relies on multi-channel orchestration, Zendesk's feature depth is defensible—but only if you can navigate billing disputes and support delays without operational disruption
-- If your team is in the 20-50 employee range and requires CRM connectivity, neither vendor is a clean fit. Freshdesk and Intercom are capturing displacement flow from Zendesk for a reason: they offer better pricing transparency and workflow flexibility at that segment.</p>
-<p>For vendors targeting Help Scout or Zendesk accounts:
-- Help Scout accounts are vulnerable on integration depth and workflow automation. A Customer Success Manager explicitly cited CRM connectivity as a dislike, and support weakness mentions are ticking up. The timing window is immediate: the category is hardening into entrenchment, and buyers who delay switching face rising lock-in costs.
-- Zendesk accounts are vulnerable on pricing disputes, billing transparency, and support responsiveness. The November 13, 2024 and May 14, 2025 billing disputes are outlier signals, but they point to systemic friction. The timing window is also immediate: accounts experiencing operational disruption (email delivery failures, billing disputes) are already in active evaluation mode.</p>
+<p>For buyers evaluating between Help Scout and Zendesk:</p>
+<ul>
+<li>If your team is under 20 employees and does not require deep CRM integration, Help Scout's simplicity and support experience are defensible strengths</li>
+<li>If your team is over 50 employees and relies on multi-channel orchestration, Zendesk's feature depth is defensible—but only if you can navigate billing disputes and support delays without operational disruption</li>
+<li>If your team is in the 20-50 employee range and requires CRM connectivity, neither vendor is a clean fit. Freshdesk and Intercom are capturing displacement flow from Zendesk for a reason: they offer better pricing transparency and workflow flexibility at that segment.</li>
+</ul>
+<p>For vendors targeting Help Scout or Zendesk accounts:</p>
+<ul>
+<li>Help Scout accounts are vulnerable on integration depth and workflow automation. A Customer Success Manager explicitly cited CRM connectivity as a dislike, and support weakness mentions are ticking up. The timing window is immediate: the category is hardening into entrenchment, and buyers who delay switching face rising lock-in costs.</li>
+<li>Zendesk accounts are vulnerable on pricing disputes, billing transparency, and support responsiveness. The November 13, 2024 and May 14, 2025 billing disputes are outlier signals, but they point to systemic friction. The timing window is also immediate: accounts experiencing operational disruption (email delivery failures, billing disputes) are already in active evaluation mode.</li>
+</ul>
 <h3 id="help-scout-reviewer-voices">Help Scout Reviewer Voices</h3>
 <p>A Customer Success Manager on G2 described the CRM integration gap:</p>
 <blockquote>

--- a/atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts
@@ -200,10 +200,12 @@ const post: BlogPost = {
 <p>The one-year pattern surfaces most clearly in support complaint timing. One reviewer explicitly referenced "after one year" when describing help function inadequacy and video library frustration. This timing correlation suggests that Insightly's onboarding resources successfully address initial deployment questions but fail to scale with implementation complexity. Teams moving beyond basic contact entry into project management, opportunity tracking, or multi-user coordination encounter support gaps that trigger evaluation cycles.</p>
 <p>Contract renewal windows create natural evaluation pressure. One contract end signal appears in the sample, indicating a team approaching renewal decision with active dissatisfaction. The absence of budget cycle signals (0 mentions) and renewal signals (0 mentions) suggests that timing pressure comes more from accumulated operational friction than from formal procurement processes.</p>
 <p>Sentiment trajectory data shows neutral movement, with 0% declining and 0% improving sentiment in the temporal analysis window. This stability indicates that Insightly maintains baseline satisfaction among retained users but struggles to generate momentum or enthusiasm. The absence of improving sentiment signals limits viral adoption and champion development, while stable dissatisfaction creates persistent churn risk.</p>
-<p>Priority timing triggers include:
-- One-year contract renewal approaching
-- Just over one year tenure
-- 2.1-2 years tenure</p>
+<p>Priority timing triggers include:</p>
+<ul>
+<li>One-year contract renewal approaching</li>
+<li>Just over one year tenure</li>
+<li>2.1-2 years tenure</li>
+</ul>
 <p>These windows represent natural evaluation points when teams reassess CRM platform fit, support adequacy, and feature maturity. The concentration around one-year tenure suggests that Insightly's retention challenge centers on the transition from initial deployment to mature usage rather than on early-stage onboarding failure.</p>
 <p>Storage limit friction creates immediate timing pressure outside of contract cycles. At least one account discontinued usage after exceeding free-tier capacity, demonstrating that capacity-based pricing can trigger abrupt churn when usage growth outpaces plan limits. This pattern disproportionately affects small businesses experiencing rapid contact database expansion or document attachment growth.</p>
 <h2 id="where-insightly-pressure-shows-up-in-accounts">Where Insightly Pressure Shows Up in Accounts</h2>

--- a/atlas-churn-ui/src/content/blog/linode-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/linode-deep-dive-2026-04.ts
@@ -192,10 +192,12 @@ const post: BlogPost = {
 <p>This integration profile suggests a technical user base comfortable with API-driven workflows and infrastructure-as-code patterns. The presence of nginx and pm2 indicates web application hosting. Wireguard suggests VPN and secure networking use cases. S3 integration points to object storage requirements, likely for backup or static asset delivery.</p>
 <p>Use case distribution shows Linode core platform leading with 5 mentions and an average urgency score of 3.8 out of 10. VPS use cases register 2 mentions but with notably higher urgency (4.5), suggesting users deploying virtual private servers experience more acute operational pressure.</p>
 <p>Certificate manager appears twice with low urgency (1.8), indicating SSL/TLS management is table stakes rather than a pain point. Database as a service, Linode VM, and LKE (Linode Kubernetes Engine) each register single mentions with varying urgency levels.</p>
-<p>The relatively low mention frequency across use cases suggests either:
-- Review data doesn't capture the full breadth of Linode deployments
-- Users focus feedback on pain points rather than routine operational use
-- The platform serves a long-tail of diverse use cases without clear modal deployment patterns</p>
+<p>The relatively low mention frequency across use cases suggests either:</p>
+<ul>
+<li>Review data doesn't capture the full breadth of Linode deployments</li>
+<li>Users focus feedback on pain points rather than routine operational use</li>
+<li>The platform serves a long-tail of diverse use cases without clear modal deployment patterns</li>
+</ul>
 <p>One reviewer anchored their context explicitly:</p>
 <blockquote>
 <p>"Background: I host game servers for a small amount of money"</p>
@@ -215,20 +217,24 @@ const post: BlogPost = {
 <p>This timing-segment intersection is critical. Evaluators are already in active comparison mode, making them vulnerable to competitive displacement. When that evaluation coincides with acquisition integration uncertainty, the risk of churn intensifies. Economic buyers, who control budget and vendor selection, become particularly sensitive to stability signals during M&amp;A transitions.</p>
 <p>The witness evidence supports this pattern. One reviewer considering Amazon SES represents the evaluator cohort actively weighing alternatives. The explicit mention of "considerable work managing email deliverability" suggests they're conducting detailed operational assessment, not casual browsing.</p>
 <p>The named account evidence—though limited to a single mention of Verkada with security management concerns—indicates enterprise-scale deployments are experiencing specific pain. When a named organization surfaces in review data with a concrete pain category, it signals that account-level pressure exists beyond individual user frustration.</p>
-<p>However, account-level intent data shows a significant gap. The account packet reports zero accounts across all metrics (total accounts, high intent count, active eval count), creating a disconnect between witness evidence and quantified account pressure. This data gap prevents reliable account-level vulnerability assessment and suggests either:
-- Account tracking is incomplete
-- Named mentions are too sparse to generate aggregate metrics
-- Privacy filtering is removing identifiable account data</p>
+<p>However, account-level intent data shows a significant gap. The account packet reports zero accounts across all metrics (total accounts, high intent count, active eval count), creating a disconnect between witness evidence and quantified account pressure. This data gap prevents reliable account-level vulnerability assessment and suggests either:</p>
+<ul>
+<li>Account tracking is incomplete</li>
+<li>Named mentions are too sparse to generate aggregate metrics</li>
+<li>Privacy filtering is removing identifiable account data</li>
+</ul>
 <p>The segment targeting summary explicitly states evaluators and economic buyers face the strongest pressure, but without robust account-level metrics, it's difficult to translate that pressure into specific named opportunities or quantified pipeline risk.</p>
 <p>For vendors competing against Linode, this suggests targeting active evaluators during the post-acquisition integration window when service continuity concerns create openness to alternatives. For Linode, it indicates the need to provide explicit stability signals and integration roadmaps to reassure economic buyers and prevent evaluator defection.</p>
 <h2 id="when-linode-friction-turns-into-action">When Linode Friction Turns Into Action</h2>
 <p>Timing intelligence reveals when dissatisfaction becomes operational. The data shows 31 active evaluation signals visible right now, indicating users are currently assessing alternatives. These aren't historical complaints—they're real-time decision processes in motion.</p>
 <p>The timing summary explicitly identifies the post-acquisition integration period as the critical window when service continuity concerns peak and buyers evaluate alternatives before committing to renewed contracts. This isn't speculative—it's grounded in the temporal clustering of evaluation signals during Akamai's integration of Linode.</p>
 <p>Two immediate trigger events appear in the data: Akamai takeover integration milestones and account cancellation events. These triggers represent discrete moments when users must make active decisions—renew or leave, expand or contract, stay or switch.</p>
-<p>However, the temporal signal data shows significant gaps. Evaluation deadline signals, contract end signals, renewal signals, and budget cycle signals all register zero. This absence suggests either:
-- Reviewers don't disclose contract timing publicly
-- The data collection window missed these signals
-- Linode's customer base operates on less formalized contract cycles</p>
+<p>However, the temporal signal data shows significant gaps. Evaluation deadline signals, contract end signals, renewal signals, and budget cycle signals all register zero. This absence suggests either:</p>
+<ul>
+<li>Reviewers don't disclose contract timing publicly</li>
+<li>The data collection window missed these signals</li>
+<li>Linode's customer base operates on less formalized contract cycles</li>
+</ul>
 <p>Sentiment direction data is insufficient for trend analysis. Declining percentage and improving percentage both register 0.0%, preventing any confident statement about whether Linode sentiment is deteriorating, stabilizing, or improving over time.</p>
 <p>Despite these data limitations, the 31 active evaluation signals represent concrete evidence of in-flight decision processes. When users publicly state they're evaluating alternatives, they've already crossed a mental threshold from passive dissatisfaction to active search.</p>
 <p>The best timing window—post-acquisition integration period—creates a natural opportunity for competitive engagement. Buyers facing vendor M&amp;A transitions experience heightened uncertainty and become more receptive to outreach from stable alternatives. This window typically lasts 6-18 months as the acquiring company integrates operations, migrates infrastructure, and consolidates support teams.</p>
@@ -236,16 +242,20 @@ const post: BlogPost = {
 <h2 id="where-linode-pressure-shows-up-in-accounts">Where Linode Pressure Shows Up in Accounts</h2>
 <p>Account-level pressure analysis reveals a significant data gap. The account packet reports zero accounts across all metrics: total accounts, high intent count, and active evaluation count. This creates a disconnect between witness evidence showing named account pressure and quantified account-level metrics.</p>
 <p>The witness data includes at least one named account—Verkada—with explicit security management concerns. The presence of a named organization in review data typically indicates enterprise-scale deployment and suggests the pain is severe enough for employees to publicly discuss it. However, without supporting account packet data, it's impossible to assess whether this represents isolated friction or broader account-level vulnerability.</p>
-<p>This data gap has several possible explanations:
-- Privacy filtering may be removing identifiable account information to protect reviewer anonymity
-- Account tracking may require more explicit company mentions than appear in the review corpus
-- The sample size (188 enriched reviews) may be too small to generate statistically significant account clusters
-- Linode's customer base may skew toward individual developers and small teams rather than named enterprise accounts</p>
-<p>The absence of account-level metrics prevents answering critical questions:
-- Which named accounts are showing churn risk?
-- How many accounts have multiple employees expressing dissatisfaction?
-- Which accounts are in active evaluation with budget allocated?
-- What's the total contract value at risk from accounts showing high intent to switch?</p>
+<p>This data gap has several possible explanations:</p>
+<ul>
+<li>Privacy filtering may be removing identifiable account information to protect reviewer anonymity</li>
+<li>Account tracking may require more explicit company mentions than appear in the review corpus</li>
+<li>The sample size (188 enriched reviews) may be too small to generate statistically significant account clusters</li>
+<li>Linode's customer base may skew toward individual developers and small teams rather than named enterprise accounts</li>
+</ul>
+<p>The absence of account-level metrics prevents answering critical questions:</p>
+<ul>
+<li>Which named accounts are showing churn risk?</li>
+<li>How many accounts have multiple employees expressing dissatisfaction?</li>
+<li>Which accounts are in active evaluation with budget allocated?</li>
+<li>What's the total contract value at risk from accounts showing high intent to switch?</li>
+</ul>
 <p>For competitive intelligence purposes, this gap limits the ability to build named account target lists or prioritize outreach based on demonstrated account-level pressure. For Linode customer success teams, it prevents proactive intervention with at-risk accounts before they reach cancellation.</p>
 <p>The single Verkada mention with security management concerns represents a proof point that named account pressure exists, but without broader account packet data, it's impossible to assess scale, concentration, or trend direction. The witness evidence shows at least one enterprise experiencing pain; the account data can't confirm whether that's an outlier or part of a broader pattern.</p>
 <h2 id="how-linode-stacks-up-against-competitors">How Linode Stacks Up Against Competitors</h2>
@@ -259,11 +269,13 @@ const post: BlogPost = {
 <p>-- reviewer on Twitter</p>
 </blockquote>
 <p>This truncated quote reveals the cognitive trade-off buyers face: AWS may offer superior capability, but migration and operational complexity create friction. DigitalOcean and Linode appear grouped together as simpler alternatives, suggesting they compete in the same "easy VPS hosting" category rather than against AWS's full platform.</p>
-<p>For vendors competing against Linode, the competitive landscape suggests positioning around:
-- Feature breadth (if you're DigitalOcean)
-- Enterprise stability (if you're targeting post-acquisition uncertainty)
-- Migration simplicity (given the "considerable work" concern around AWS)
-- Performance consistency (given Linode's performance weakness mentions)</p>
+<p>For vendors competing against Linode, the competitive landscape suggests positioning around:</p>
+<ul>
+<li>Feature breadth (if you're DigitalOcean)</li>
+<li>Enterprise stability (if you're targeting post-acquisition uncertainty)</li>
+<li>Migration simplicity (given the "considerable work" concern around AWS)</li>
+<li>Performance consistency (given Linode's performance weakness mentions)</li>
+</ul>
 <p>For Linode, the competitive challenge is defending against DigitalOcean on features and performance while preventing AWS from capturing users who need specific managed services that Linode doesn't offer.</p>
 <h2 id="where-linode-sits-in-the-cloud-infrastructure-market">Where Linode Sits in the Cloud Infrastructure Market</h2>
 <p>Market regime analysis characterizes the VPS hosting category as stable, with low churn velocity (0.033) and moderate price pressure (0.23). However, the confidence score is low (0.5), and the analysis explicitly notes that single-vendor evidence prevents definitive category-wide conclusions.</p>
@@ -308,10 +320,12 @@ const post: BlogPost = {
 <p>The post-acquisition integration period creates the most significant near-term risk. With 31 active evaluation signals visible and explicit reviewer mentions of long-tenured users migrating away, the Akamai acquisition is functioning as a trigger event that elevates churn risk. Evaluators and economic buyers—the highest-intent segments—are feeling the strongest pressure during this integration window.</p>
 <p>Account-level data gaps prevent quantifying the scale of at-risk revenue, but the witness evidence shows at least one named account (Verkada) with security management concerns. The absence of broader account metrics limits the ability to assess whether this represents isolated friction or systemic vulnerability.</p>
 <p>Competitively, Linode faces pressure from DigitalOcean on features and performance, while AWS captures users who need specific managed services. The VPS hosting category appears stable with low churn velocity, but acquisition activity suggests potential consolidation pressure that could shift market dynamics.</p>
-<p>For buyers evaluating Linode:
-- <strong>Choose Linode if</strong> pricing is your primary decision factor and you have technical capacity to manage infrastructure gaps
-- <strong>Look elsewhere if</strong> you need enterprise-grade support, comprehensive security tooling, or stability guarantees during the post-acquisition period
-- <strong>Evaluate carefully if</strong> you're an economic buyer concerned about vendor continuity or an evaluator comparing feature breadth against DigitalOcean</p>
+<p>For buyers evaluating Linode:</p>
+<ul>
+<li><strong>Choose Linode if</strong> pricing is your primary decision factor and you have technical capacity to manage infrastructure gaps</li>
+<li><strong>Look elsewhere if</strong> you need enterprise-grade support, comprehensive security tooling, or stability guarantees during the post-acquisition period</li>
+<li><strong>Evaluate carefully if</strong> you're an economic buyer concerned about vendor continuity or an evaluator comparing feature breadth against DigitalOcean</li>
+</ul>
 <p>For vendors competing against Linode, the opportunity window is now: engage active evaluators during the integration period with stability positioning, migration support, and feature breadth messaging. The 31 active evaluation signals represent concrete pipeline opportunities.</p>
 <p>For Linode, the retention challenge is clear: provide explicit integration roadmaps, demonstrate service continuity, and prevent evaluation signals from converting to cancellations. The pricing anchor is strong, but it won't hold indefinitely if operational gaps widen or acquisition uncertainty persists.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/power-bi-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/power-bi-deep-dive-2026-04.ts
@@ -281,25 +281,31 @@ const post: BlogPost = {
 <p>Power BI in early 2026 is a product under pressure from its own vendor's bundling strategy. Microsoft's Fabric tier push is creating pricing complexity and forced migration deadlines that are converting latent dissatisfaction into active evaluation pressure. The March-May 2026 window—April 15 scorecard hierarchy deprecation, May 31 legacy import sunset—is the critical decision period when teams will choose between migrating to Fabric-bundled tiers or switching to Tableau, Looker, or cloud-native alternatives.</p>
 <p>The review evidence shows Power BI's retention is driven by Microsoft 365 workflow lock-in rather than product enthusiasm. Teams stay because Excel integration, Teams embedding, and SharePoint connectivity create switching costs, not because Power BI outperforms Tableau on UX or Looker on performance. That lock-in advantage is real, but it is under pressure from cloud-native consolidation trends and Microsoft's own Fabric complexity.</p>
 <h3 id="who-should-buy-power-bi">Who should buy Power BI</h3>
-<p>Power BI makes sense for teams that:
-- Are already embedded in Microsoft 365 and value Excel, Teams, and SharePoint integration
-- Have end users who prefer familiar Microsoft UI patterns over best-of-breed BI tools
-- Can absorb Fabric tier complexity and are willing to navigate Microsoft's licensing roadmap
-- Do not need cutting-edge performance or cloud-native data platform integration</p>
-<p>Power BI does not make sense for teams that:
-- Are consolidating on Google Cloud Platform or AWS and want cloud-native BI tools
-- Prioritize performance, UX, and simplicity over Microsoft ecosystem lock-in
-- Are cost-sensitive and want predictable pricing without tier bundling complexity
-- Are facing April-May 2026 deprecation deadlines and prefer switching over migration</p>
+<p>Power BI makes sense for teams that:</p>
+<ul>
+<li>Are already embedded in Microsoft 365 and value Excel, Teams, and SharePoint integration</li>
+<li>Have end users who prefer familiar Microsoft UI patterns over best-of-breed BI tools</li>
+<li>Can absorb Fabric tier complexity and are willing to navigate Microsoft's licensing roadmap</li>
+<li>Do not need cutting-edge performance or cloud-native data platform integration</li>
+</ul>
+<p>Power BI does not make sense for teams that:</p>
+<ul>
+<li>Are consolidating on Google Cloud Platform or AWS and want cloud-native BI tools</li>
+<li>Prioritize performance, UX, and simplicity over Microsoft ecosystem lock-in</li>
+<li>Are cost-sensitive and want predictable pricing without tier bundling complexity</li>
+<li>Are facing April-May 2026 deprecation deadlines and prefer switching over migration</li>
+</ul>
 <h3 id="competitive-alternatives-to-consider">Competitive alternatives to consider</h3>
 <p>Tableau remains the primary alternative for teams prioritizing UX and performance. It wins on dashboard flexibility and data visualization but loses on Microsoft integration. Teams evaluating Tableau should assess whether the UX advantage is worth the loss of Excel and Teams continuity.</p>
 <p>Looker is the cloud-native alternative for GCP-committed teams. It fits cleanly into GCP's data platform strategy and offers simpler pricing than Power BI's Fabric tiers. Teams consolidating on Google Cloud should evaluate Looker as a platform-native option.</p>
 <p>Databricks and Metabase serve niche use cases: Databricks for data platform-native BI, Metabase for cost-sensitive teams that prefer open-source simplicity. Neither is a direct Power BI replacement, but both appeal to teams that want to avoid vendor lock-in.</p>
 <h3 id="timing-guidance-march-may-2026-is-the-decision-window">Timing guidance: March-May 2026 is the decision window</h3>
-<p>The March-May 2026 window is the most critical decision period for Power BI customers. April 15 scorecard hierarchy deprecation and May 31 legacy import sunset force technical debt resolution during the same period when Fabric pricing evaluation is most active. Teams facing these deadlines should:
-- Assess migration cost vs. switching cost before committing to Fabric tier upgrades
-- Evaluate Tableau, Looker, and cloud-native alternatives during the deprecation window
-- Use the forced migration moment as a natural switching trigger if Power BI no longer fits</p>
+<p>The March-May 2026 window is the most critical decision period for Power BI customers. April 15 scorecard hierarchy deprecation and May 31 legacy import sunset force technical debt resolution during the same period when Fabric pricing evaluation is most active. Teams facing these deadlines should:</p>
+<ul>
+<li>Assess migration cost vs. switching cost before committing to Fabric tier upgrades</li>
+<li>Evaluate Tableau, Looker, and cloud-native alternatives during the deprecation window</li>
+<li>Use the forced migration moment as a natural switching trigger if Power BI no longer fits</li>
+</ul>
 <p>The 4 active evaluation signals visible in early April 2026 suggest some teams are already in this decision cycle. The stable category regime may shift to unstable if deprecation deadlines convert latent dissatisfaction into explicit switching.</p>
 <p>For more context on how Power BI fits into broader Microsoft ecosystem dynamics, see <a href="/blog/microsoft-teams-vs-notion-2026-04">Microsoft Teams vs Notion</a> and <a href="/blog/azure-deep-dive-2026-04">Azure Deep Dive</a>.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/sentinelone-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/sentinelone-deep-dive-2026-04.ts
@@ -177,23 +177,27 @@ const post: BlogPost = {
 <p>The pain distribution aligns with the pricing-driven thesis: reviewers feel cost pressure first, followed by operational friction in management workflows. The security functionality itself generates fewer complaints, supporting the claim that customers stay for the EDR capabilities despite other friction.</p>
 <h2 id="the-sentinelone-ecosystem-integrations-use-cases">The SentinelOne Ecosystem: Integrations &amp; Use Cases</h2>
 <p>SentinelOne reviewers mention 8 integrations and 6 primary use cases. The integration profile reveals a cloud-native and endpoint-focused deployment pattern.</p>
-<p>Top integrations by mention count:
-- SentinelOne (6 mentions)
-- Huntress (5 mentions)
-- AWS (4 mentions)
-- Intune (4 mentions)
-- M365 (4 mentions)
-- Azure (3 mentions)
-- NinjaOne (3 mentions)
-- O365 (3 mentions)</p>
+<p>Top integrations by mention count:</p>
+<ul>
+<li>SentinelOne (6 mentions)</li>
+<li>Huntress (5 mentions)</li>
+<li>AWS (4 mentions)</li>
+<li>Intune (4 mentions)</li>
+<li>M365 (4 mentions)</li>
+<li>Azure (3 mentions)</li>
+<li>NinjaOne (3 mentions)</li>
+<li>O365 (3 mentions)</li>
+</ul>
 <p>The integration mentions cluster around Microsoft 365 ecosystems and cloud infrastructure, suggesting SentinelOne deployments often sit within broader Microsoft and AWS environments. The Huntress mentions indicate co-deployment scenarios where SentinelOne handles EDR while Huntress provides managed detection and response.</p>
-<p>Top use cases by mention count and urgency:
-- SentinelOne Singularity Endpoint (6 mentions, 1.2 urgency)
-- SentinelOne Singularity (5 mentions, 4.5 urgency)
-- EDR (4 mentions, 5.6 urgency)
-- SentinelOne Singularity Complete (3 mentions, 5.0 urgency)
-- Defender (3 mentions, 4.0 urgency)
-- Huntress (3 mentions, 3.2 urgency)</p>
+<p>Top use cases by mention count and urgency:</p>
+<ul>
+<li>SentinelOne Singularity Endpoint (6 mentions, 1.2 urgency)</li>
+<li>SentinelOne Singularity (5 mentions, 4.5 urgency)</li>
+<li>EDR (4 mentions, 5.6 urgency)</li>
+<li>SentinelOne Singularity Complete (3 mentions, 5.0 urgency)</li>
+<li>Defender (3 mentions, 4.0 urgency)</li>
+<li>Huntress (3 mentions, 3.2 urgency)</li>
+</ul>
 <p>The urgency scores suggest active evaluation pressure around EDR category decisions, with reviewers comparing SentinelOne Singularity Complete against Microsoft Defender and Huntress. One reviewer explicitly stated:</p>
 <blockquote>
 <p>I currently run Sophos Intercept X XDR and Arctic Wolf. We are handling a migration from legacy stack and finding the right fit with CS and S1.</p>
@@ -202,12 +206,14 @@ const post: BlogPost = {
 <p>This migration language indicates active switching behavior, consistent with the high churn velocity observed in the EDR category.</p>
 <h2 id="who-reviews-sentinelone-buyer-personas">Who Reviews SentinelOne: Buyer Personas</h2>
 <p>The buyer role distribution reveals who engages with SentinelOne during evaluation and post-purchase stages.</p>
-<p>Top buyer roles by review count:
-- Evaluator, evaluation stage: 57 reviews
-- Economic buyer, post-purchase: 5 reviews
-- Unknown, post-purchase: 3 reviews
-- Evaluator, post-purchase: 2 reviews
-- End user, post-purchase: 2 reviews</p>
+<p>Top buyer roles by review count:</p>
+<ul>
+<li>Evaluator, evaluation stage: 57 reviews</li>
+<li>Economic buyer, post-purchase: 5 reviews</li>
+<li>Unknown, post-purchase: 3 reviews</li>
+<li>Evaluator, post-purchase: 2 reviews</li>
+<li>End user, post-purchase: 2 reviews</li>
+</ul>
 <p>Evaluators dominate the sample, with 57 reviews coming from individuals in active evaluation. This aligns with the active evaluation signals and timing urgency observed in the data. Economic buyers appear in smaller numbers but at the post-purchase stage, suggesting they engage after the initial evaluation phase.</p>
 <p>The role distribution supports the thesis that SentinelOne generates evaluation interest but faces conversion friction. The high evaluator count relative to post-purchase economic buyers suggests a gap between interest and purchase commitment, potentially driven by the pricing friction documented in the pain analysis.</p>
 <h2 id="which-teams-feel-sentinelone-pain-first">Which Teams Feel SentinelOne Pain First</h2>
@@ -216,14 +222,16 @@ const post: BlogPost = {
 <p>The enterprise high contract signal indicates that SentinelOne's customer base skews toward larger deployments, consistent with reviewer statements that enterprises accept the cost while SMBs find it prohibitive. The segment targeting summary confirms this: pressure concentrates where budget authority meets deployment scale.</p>
 <h2 id="when-sentinelone-friction-turns-into-action">When SentinelOne Friction Turns Into Action</h2>
 <p>Timing signals reveal when dissatisfaction becomes operational. The current window shows immediate engagement opportunity.</p>
-<p>Key timing metrics:
-- 2 active evaluation signals visible now
-- 2 evaluation deadline signals present
-- 0 contract end signals
-- 0 renewal signals
-- 0 budget cycle signals
-- 0% declining sentiment
-- 0% improving sentiment</p>
+<p>Key timing metrics:</p>
+<ul>
+<li>2 active evaluation signals visible now</li>
+<li>2 evaluation deadline signals present</li>
+<li>0 contract end signals</li>
+<li>0 renewal signals</li>
+<li>0 budget cycle signals</li>
+<li>0% declining sentiment</li>
+<li>0% improving sentiment</li>
+</ul>
 <p>The absence of sentiment trend data suggests stable perception, with neither widespread deterioration nor improvement. The active evaluation signals indicate current decision-making activity, with pricing friction creating urgency for cost-comparison conversations.</p>
 <p>One priority timing trigger emerged: "SentinelOne WatchTower merged into another solution." This consolidation signal suggests product portfolio changes that may create evaluation pressure for customers using WatchTower.</p>
 <p>The best timing window for engagement is immediate. Active evaluation signals are present, and pricing friction creates natural entry points for cost-competitive alternatives. The lack of renewal or contract end signals means this pressure is evaluation-driven, not contract-driven.</p>
@@ -233,11 +241,13 @@ const post: BlogPost = {
 <p>The minimal account pressure data contrasts with the broader evaluation signals, suggesting that while category-level evaluation activity is present, specific named-account intent is harder to detect in this sample. This may reflect data collection limitations rather than actual account behavior.</p>
 <h2 id="how-sentinelone-stacks-up-against-competitors">How SentinelOne Stacks Up Against Competitors</h2>
 <p>SentinelOne reviewers most frequently compare the platform to CrowdStrike, Sophos, Huntress, and Webroot. The competitive landscape reveals a crowded EDR category with active displacement patterns.</p>
-<p>CrowdStrike appears as the primary comparison point, mentioned in multiple reviewer contexts. The competitive positioning shows similar strength profiles:
-- CrowdStrike strengths: integration, features
-- CrowdStrike weaknesses: contract lock-in, technical debt
-- SentinelOne strengths: API capabilities, features
-- SentinelOne weaknesses: reliability, contract lock-in</p>
+<p>CrowdStrike appears as the primary comparison point, mentioned in multiple reviewer contexts. The competitive positioning shows similar strength profiles:</p>
+<ul>
+<li>CrowdStrike strengths: integration, features</li>
+<li>CrowdStrike weaknesses: contract lock-in, technical debt</li>
+<li>SentinelOne strengths: API capabilities, features</li>
+<li>SentinelOne weaknesses: reliability, contract lock-in</li>
+</ul>
 <p>Both vendors face contract lock-in concerns, suggesting that EDR category switching friction is a common pattern, not a SentinelOne-specific issue. The technical debt mentions for CrowdStrike and reliability mentions for SentinelOne suggest different operational pain points despite similar feature strength.</p>
 <p>One reviewer directly addressed the comparison:</p>
 <blockquote>
@@ -281,10 +291,12 @@ const post: BlogPost = {
 </li>
 </ol>
 <p>The EDR category's high churn velocity (0.16 average) means that even satisfied customers may evaluate alternatives as part of routine assessment. SentinelOne's position within this regime requires ongoing competitive vigilance, particularly as CrowdStrike, Sophos, and Huntress appear as frequent comparison points.</p>
-<p>For buyers evaluating SentinelOne:
-- <strong>If you are an enterprise buyer prioritizing EDR functionality</strong>, reviewer evidence suggests SentinelOne delivers on security capabilities and integration with Microsoft 365 ecosystems. The pricing at $7 to $10 per agent per month is viewed as competitive when functionality is factored in.
-- <strong>If you are an SMB buyer with budget constraints</strong>, reviewer evidence suggests pricing friction may create affordability barriers. Consider whether the EDR functionality justifies the cost relative to alternatives.
-- <strong>If you are evaluating SentinelOne against CrowdStrike</strong>, both vendors show similar strength profiles in features and integration, with different operational pain points. CrowdStrike reviewers cite technical debt concerns, while SentinelOne reviewers mention reliability friction.</p>
+<p>For buyers evaluating SentinelOne:</p>
+<ul>
+<li><strong>If you are an enterprise buyer prioritizing EDR functionality</strong>, reviewer evidence suggests SentinelOne delivers on security capabilities and integration with Microsoft 365 ecosystems. The pricing at $7 to $10 per agent per month is viewed as competitive when functionality is factored in.</li>
+<li><strong>If you are an SMB buyer with budget constraints</strong>, reviewer evidence suggests pricing friction may create affordability barriers. Consider whether the EDR functionality justifies the cost relative to alternatives.</li>
+<li><strong>If you are evaluating SentinelOne against CrowdStrike</strong>, both vendors show similar strength profiles in features and integration, with different operational pain points. CrowdStrike reviewers cite technical debt concerns, while SentinelOne reviewers mention reliability friction.</li>
+</ul>
 <p>The minimal account-level intent data (2 accounts at 0.7 intent score) limits confidence in named-account targeting. The broader evaluation signals and category churn velocity suggest that engagement opportunities exist, but specific account pressure is harder to detect in this sample.</p>
 <p>This analysis is based on self-selected reviewer feedback collected between March 3 and April 6, 2026. Results reflect reviewer perception, not product capability. The high confidence rating is based on 323 enriched reviews, but the sample remains a subset of SentinelOne's total customer base.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-04.ts
@@ -152,10 +152,12 @@ const post: BlogPost = {
 <p>The migration sources suggest ClickUp occupies a middle ground: more capable than lightweight task tools, more flexible than rigid enterprise systems, but also more complex than either.</p>
 <h3 id="migration-patterns-by-replacement-mode">Migration Patterns by Replacement Mode</h3>
 <p>The dataset includes signals tagged with <code>bundled_suite_consolidation</code> as the replacement mode. This indicates teams are not just switching from one tool to another—they are collapsing multiple tools into ClickUp.</p>
-<p>For example, a team might migrate from:
-- Trello for task management
-- Notion for documentation
-- Zapier for workflow automation</p>
+<p>For example, a team might migrate from:</p>
+<ul>
+<li>Trello for task management</li>
+<li>Notion for documentation</li>
+<li>Zapier for workflow automation</li>
+</ul>
 <p>...into ClickUp's unified environment. The consolidation creates efficiency gains but also introduces coordination complexity. One common pattern witness noted:</p>
 <blockquote>
 <p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>
@@ -169,10 +171,12 @@ const post: BlogPost = {
 <p>{{chart:pain-bar}}</p>
 <p>UX complaints are the most common trigger, followed by pricing friction, feature gaps, performance issues, overall dissatisfaction, and onboarding challenges. However, these categories reflect dissatisfaction with <em>previous</em> tools, not necessarily ClickUp's strengths.</p>
 <h3 id="ux-regression-in-legacy-tools">UX Regression in Legacy Tools</h3>
-<p>Reviewers leaving Trello, Asana, and Jira frequently cite UX regression. The complaints cluster around:
-- Navigation complexity as project count grows
-- View limitations (lack of Gantt, Calendar, or Timeline views)
-- Inflexible hierarchy structures</p>
+<p>Reviewers leaving Trello, Asana, and Jira frequently cite UX regression. The complaints cluster around:</p>
+<ul>
+<li>Navigation complexity as project count grows</li>
+<li>View limitations (lack of Gantt, Calendar, or Timeline views)</li>
+<li>Inflexible hierarchy structures</li>
+</ul>
 <p>ClickUp addresses these gaps with multiple view modes and customizable hierarchies. But the data also shows that ClickUp's flexibility introduces its own UX complexity. One counterevidence witness from TrustRadius noted:</p>
 <blockquote>
 <p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>
@@ -186,28 +190,36 @@ const post: BlogPost = {
 <p>This 222% increase triggered explicit pricing backlash. While this is an outlier case, it highlights pricing volatility as a migration risk. Teams switching to ClickUp should validate current pricing and lock in contract terms before committing.</p>
 <p>The data does not support a claim that ClickUp is universally cheaper than competitors. Pricing complaints appear in 437 enriched reviews, but the rate is not quantified in the blueprint.</p>
 <h3 id="feature-gaps-and-integration-needs">Feature Gaps and Integration Needs</h3>
-<p>Teams leaving Notion and Airtable cite feature gaps around:
-- Advanced automation
-- Native time tracking
-- Resource capacity planning</p>
-<p>ClickUp addresses some of these gaps with built-in features. However, integration depth varies. The most frequently mentioned integrations in the dataset are:
-- Zapier (15 mentions)
-- GitHub (7 mentions)
-- Jira (5 mentions)
-- Notion (5 mentions)
-- HubSpot (4 mentions)</p>
+<p>Teams leaving Notion and Airtable cite feature gaps around:</p>
+<ul>
+<li>Advanced automation</li>
+<li>Native time tracking</li>
+<li>Resource capacity planning</li>
+</ul>
+<p>ClickUp addresses some of these gaps with built-in features. However, integration depth varies. The most frequently mentioned integrations in the dataset are:</p>
+<ul>
+<li>Zapier (15 mentions)</li>
+<li>GitHub (7 mentions)</li>
+<li>Jira (5 mentions)</li>
+<li>Notion (5 mentions)</li>
+<li>HubSpot (4 mentions)</li>
+</ul>
 <p>These integration signals suggest teams rely on connectors to bridge ClickUp with existing toolchains. Native integration quality is not quantified in the data.</p>
 <h3 id="performance-and-reliability">Performance and Reliability</h3>
-<p>Performance issues rank fourth among migration triggers. Reviewers leaving Notion and Airtable report:
-- Slow load times as database size grows
-- Sync delays in collaborative editing
-- Mobile app performance degradation</p>
+<p>Performance issues rank fourth among migration triggers. Reviewers leaving Notion and Airtable report:</p>
+<ul>
+<li>Slow load times as database size grows</li>
+<li>Sync delays in collaborative editing</li>
+<li>Mobile app performance degradation</li>
+</ul>
 <p>ClickUp reviewers do not report widespread performance complaints in the dataset. However, the sample size for performance-specific signals is limited, so this should be treated as absence of evidence rather than evidence of absence.</p>
 <h3 id="onboarding-challenges">Onboarding Challenges</h3>
-<p>Onboarding friction appears in both outbound signals (teams leaving rigid tools like Jira) and inbound caution (teams learning ClickUp's hierarchy). The data does not include quantified onboarding timelines, but qualitative signals suggest:
-- Admin setup takes longer than simpler tools like Trello
-- End-user adoption requires training on folder/list/task structure
-- Notification defaults may need tuning to avoid overload</p>
+<p>Onboarding friction appears in both outbound signals (teams leaving rigid tools like Jira) and inbound caution (teams learning ClickUp's hierarchy). The data does not include quantified onboarding timelines, but qualitative signals suggest:</p>
+<ul>
+<li>Admin setup takes longer than simpler tools like Trello</li>
+<li>End-user adoption requires training on folder/list/task structure</li>
+<li>Notification defaults may need tuning to avoid overload</li>
+</ul>
 <p>One Reddit reviewer noted:</p>
 <blockquote>
 <p>"I run a screen printing shop"<br />
@@ -221,10 +233,12 @@ const post: BlogPost = {
 <h2 id="making-the-switch-what-to-expect">Making the Switch: What to Expect</h2>
 <p>Migrating to ClickUp involves three practical phases: data migration, workflow reconfiguration, and team adoption. The dataset does not include quantified migration timelines, but reviewer signals suggest each phase has distinct friction points.</p>
 <h3 id="data-migration-and-integration-setup">Data Migration and Integration Setup</h3>
-<p>ClickUp supports CSV imports and native connectors for Trello, Asana, Jira, and other platforms. However, reviewers report:
-- Custom field mappings require manual configuration
-- Attachment migration is incomplete for some platforms
-- Historical comments may not transfer cleanly</p>
+<p>ClickUp supports CSV imports and native connectors for Trello, Asana, Jira, and other platforms. However, reviewers report:</p>
+<ul>
+<li>Custom field mappings require manual configuration</li>
+<li>Attachment migration is incomplete for some platforms</li>
+<li>Historical comments may not transfer cleanly</li>
+</ul>
 <p>One verified reviewer on G2 noted:</p>
 <blockquote>
 <p>"What do you like best about ClickUp"<br />
@@ -237,10 +251,12 @@ const post: BlogPost = {
 <blockquote>
 <p>-- Group Director, Client Operations, verified reviewer on TrustRadius</p>
 </blockquote>
-<p>This suggests teams should invest time in hierarchy planning before migration. Common patterns include:
-- Folders for departments or clients
-- Lists for projects or workflows
-- Tasks for individual deliverables</p>
+<p>This suggests teams should invest time in hierarchy planning before migration. Common patterns include:</p>
+<ul>
+<li>Folders for departments or clients</li>
+<li>Lists for projects or workflows</li>
+<li>Tasks for individual deliverables</li>
+</ul>
 <p>However, ClickUp also supports spaces, goals, and docs, which add additional hierarchy layers. Teams consolidating multiple tools should map workflows to ClickUp's structure before migrating data.</p>
 <h3 id="team-adoption-and-notification-management">Team Adoption and Notification Management</h3>
 <p>End-user adoption is the third migration phase. Reviewers report notification overload as a common friction point, particularly for teams consolidating workflows from multiple tools.</p>
@@ -257,10 +273,12 @@ const post: BlogPost = {
 <h3 id="learning-curve-and-productivity-delta">Learning Curve and Productivity Delta</h3>
 <p>The reasoning context includes a <code>productivity_delta_claim</code> of "more_productive" for bundled suite consolidation cases. However, this claim is based on reviewer self-report, not measured productivity data.</p>
 <p>The counterevidence section notes that "customers remain anchored by overall satisfaction (252 mentions), UX strengths (89 mentions), and feature breadth (64 mentions)." This suggests retained users find value despite complexity trade-offs.</p>
-<p>Teams should expect:
-- Initial productivity dip during the learning phase
-- Gradual productivity recovery as workflows stabilize
-- Long-term efficiency gains from consolidation, if workflows are well-configured</p>
+<p>Teams should expect:</p>
+<ul>
+<li>Initial productivity dip during the learning phase</li>
+<li>Gradual productivity recovery as workflows stabilize</li>
+<li>Long-term efficiency gains from consolidation, if workflows are well-configured</li>
+</ul>
 <p>The data does not support a universal claim that ClickUp makes teams more productive. The productivity delta depends on how well the team configures workflows and manages the learning curve.</p>
 <h3 id="migration-checklist">Migration Checklist</h3>
 <p>Based on reviewer signals, teams should:
@@ -283,26 +301,32 @@ const post: BlogPost = {
 </ul>
 <p>Despite these friction points, the counterevidence shows that customers remain anchored by overall satisfaction (252 mentions), UX strengths (89 mentions), and feature breadth (64 mentions). This suggests ClickUp delivers value that outweighs navigation frustration for retained users.</p>
 <h3 id="who-should-migrate-to-clickup">Who Should Migrate to ClickUp?</h3>
-<p>The data supports migration for:
-- Teams outgrowing simpler tools like Trello or Todoist
-- Teams consolidating multiple point solutions into a unified platform
-- Teams needing flexible view modes (Gantt, Timeline, Calendar)
-- Teams willing to invest time learning hierarchy and notification configuration</p>
+<p>The data supports migration for:</p>
+<ul>
+<li>Teams outgrowing simpler tools like Trello or Todoist</li>
+<li>Teams consolidating multiple point solutions into a unified platform</li>
+<li>Teams needing flexible view modes (Gantt, Timeline, Calendar)</li>
+<li>Teams willing to invest time learning hierarchy and notification configuration</li>
+</ul>
 <h3 id="who-should-proceed-with-caution">Who Should Proceed with Caution?</h3>
-<p>The data flags caution for:
-- Teams expecting plug-and-play simplicity
-- Teams with limited admin capacity for workflow configuration
-- Teams sensitive to pricing volatility
-- Teams requiring built-in resource capacity planning without manual configuration</p>
+<p>The data flags caution for:</p>
+<ul>
+<li>Teams expecting plug-and-play simplicity</li>
+<li>Teams with limited admin capacity for workflow configuration</li>
+<li>Teams sensitive to pricing volatility</li>
+<li>Teams requiring built-in resource capacity planning without manual configuration</li>
+</ul>
 <h3 id="market-context">Market Context</h3>
 <p>The reasoning context flags a stable market regime with no widespread vendor displacement wave. This suggests ClickUp's growth is driven by incremental dissatisfaction with existing tools rather than systemic category failure.</p>
 <p>Teams evaluating ClickUp should compare it to <a href="/blog/microsoft-teams-vs-notion-2026-04">Microsoft Teams</a>, Notion, Asana, and other collaboration platforms based on their specific workflow needs, not on generic claims about productivity or cost savings.</p>
 <h3 id="confidence-and-limitations">Confidence and Limitations</h3>
 <p>This analysis is based on 437 enriched reviews from verified platforms (G2, Gartner Peer Insights, PeerSpot, TrustRadius) and 381 community platform signals (Reddit). The sample is self-selected and reflects reviewer perception, not universal product capability.</p>
-<p>The reasoning context flags low confidence for timing intelligence, migration proof, and category reasoning. This means:
-- Timing signals are based on limited evidence
-- Migration success rates are not quantified
-- Category-wide trends are not conclusively established</p>
+<p>The reasoning context flags low confidence for timing intelligence, migration proof, and category reasoning. This means:</p>
+<ul>
+<li>Timing signals are based on limited evidence</li>
+<li>Migration success rates are not quantified</li>
+<li>Category-wide trends are not conclusively established</li>
+</ul>
 <p>Teams should treat this guide as directional insight, not as definitive proof of migration outcomes.</p>
 <h3 id="next-steps">Next Steps</h3>
 <p>For teams considering migration, the practical next steps are:

--- a/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts
@@ -157,24 +157,30 @@ const post: BlogPost = {
 <p>Reviewers report that non-technical team members adapt to Shopify faster than to WooCommerce or custom-built solutions. The admin interface is consistently described as intuitive for basic tasks (product uploads, order management, basic theme customization). However, reviewers with technical backgrounds report frustration with Shopify's "walled garden" approach—less access to underlying code means less ability to customize beyond what themes and apps offer.</p>
 <p>One reviewer describes switching after "10 years using Shopify," suggesting that while onboarding is smooth, long-term users eventually encounter limitations that prompt re-evaluation. The data does not reveal what specific limitations triggered this reviewer's exit, but the pattern of long tenure followed by switching intent appears multiple times in the dataset.</p>
 <h3 id="what-reviewers-miss-after-switching">What Reviewers Miss After Switching</h3>
-<p>Reviewers who switched from WooCommerce mention missing:
-- <strong>Technical SEO control</strong>: Open-source platforms allow direct manipulation of site structure, URL patterns, and meta tags. Shopify offers less granular control, which some reviewers cite as a limitation for SEO-focused brands.
-- <strong>Open-source flexibility</strong>: The ability to modify core code or build custom functionality without relying on third-party apps. Reviewers describe this as a trade-off—less flexibility, but also less maintenance burden.</p>
+<p>Reviewers who switched from WooCommerce mention missing:</p>
+<ul>
+<li><strong>Technical SEO control</strong>: Open-source platforms allow direct manipulation of site structure, URL patterns, and meta tags. Shopify offers less granular control, which some reviewers cite as a limitation for SEO-focused brands.</li>
+<li><strong>Open-source flexibility</strong>: The ability to modify core code or build custom functionality without relying on third-party apps. Reviewers describe this as a trade-off—less flexibility, but also less maintenance burden.</li>
+</ul>
 <p>Reviewers who switched from simpler platforms (like commentsold) report no major losses—Shopify offers more features across the board. The pain points in this segment cluster around cost rather than capability.</p>
 <h3 id="what-reviewers-gain">What Reviewers Gain</h3>
 <blockquote>
 <p>"Shopify helps brands create high converting ecommerce websites" -- software reviewer</p>
 </blockquote>
-<p>Reviewers consistently cite:
-- <strong>Operational simplicity</strong>: Less time spent on maintenance, updates, and troubleshooting. One reviewer describes relief at no longer needing developer resources for routine tasks.
-- <strong>App ecosystem breadth</strong>: While app costs are a complaint, reviewers acknowledge that the ecosystem solves problems faster than custom development.
-- <strong>Brand-building tools</strong>: Reviewers praise Shopify's theme quality, checkout customization, and marketing integrations (especially Klaviyo and Meta).</p>
+<p>Reviewers consistently cite:</p>
+<ul>
+<li><strong>Operational simplicity</strong>: Less time spent on maintenance, updates, and troubleshooting. One reviewer describes relief at no longer needing developer resources for routine tasks.</li>
+<li><strong>App ecosystem breadth</strong>: While app costs are a complaint, reviewers acknowledge that the ecosystem solves problems faster than custom development.</li>
+<li><strong>Brand-building tools</strong>: Reviewers praise Shopify's theme quality, checkout customization, and marketing integrations (especially Klaviyo and Meta).</li>
+</ul>
 <p>For teams considering migration from other platforms, our guide on <a href="https://churnsignals.co/blog/switch-to-clickup-2026-03">switching to ClickUp</a> offers a parallel case study in migration decision-making, though in a different software category.</p>
 <h3 id="migration-timeline">Migration Timeline</h3>
-<p>Reviewers report varying timelines:
-- <strong>Simple stores (under 100 products, no custom code)</strong>: 1-2 weeks from start to launch, including theme setup and product import.
-- <strong>Mid-complexity stores (100-1000 products, multiple integrations)</strong>: 4-6 weeks, with the bulk of time spent on data migration, app configuration, and team training.
-- <strong>Complex stores (custom functionality, multi-location, high SKU count)</strong>: 2-3 months, often with phased rollout (e.g., online first, then POS integration).</p>
+<p>Reviewers report varying timelines:</p>
+<ul>
+<li><strong>Simple stores (under 100 products, no custom code)</strong>: 1-2 weeks from start to launch, including theme setup and product import.</li>
+<li><strong>Mid-complexity stores (100-1000 products, multiple integrations)</strong>: 4-6 weeks, with the bulk of time spent on data migration, app configuration, and team training.</li>
+<li><strong>Complex stores (custom functionality, multi-location, high SKU count)</strong>: 2-3 months, often with phased rollout (e.g., online first, then POS integration).</li>
+</ul>
 <p>Reviewers recommend running a pilot phase—importing a subset of products, testing checkout flow, and verifying integrations before full cutover. Multiple reviewers cite parallel usage (old platform + Shopify) as the most effective transition approach, particularly for retailers who cannot afford downtime.</p>
 <h2 id="key-takeaways">Key Takeaways</h2>
 <p>Based on 1,503 enriched reviews and 93 switching signals, the migration pattern to Shopify reflects deliberate platform re-evaluation rather than sudden dissatisfaction. The data suggests the following:</p>
@@ -185,11 +191,13 @@ const post: BlogPost = {
 <p><strong>Decision-maker churn rate is modest but real.</strong> At 8%, one in twelve decision-makers who review Shopify express switching intent. This is not a crisis-level churn signal, but it indicates that the platform is not universally loved. The market regime classification of "stable" suggests this is normal category churn, not a Shopify-specific problem.</p>
 <p><strong>Integration ecosystem is a double-edged sword.</strong> Reviewers praise the breadth of available apps (Klaviyo, Stripe, Meta, Instagram are most mentioned), but app costs accumulate quickly. Teams switching from open-source platforms report sticker shock at monthly recurring app fees compared to one-time plugin costs.</p>
 <p><strong>The right fit depends on buyer priorities.</strong> Reviewers who prioritize operational simplicity, brand-building tools, and ease of use report high satisfaction. Reviewers who prioritize technical control, SEO flexibility, and cost predictability report frustration. The data does not suggest Shopify is "better" or "worse" than alternatives—it suggests different platforms serve different priorities.</p>
-<p>For teams evaluating Shopify, the data suggests asking:
-- How much technical control do we need versus operational simplicity?
-- What is our total cost of ownership, including apps and transaction fees?
-- Do we have the internal capacity to manage a more technical platform, or do we need a managed solution?
-- Are we in a growth phase where ease of scaling matters more than cost optimization?</p>
+<p>For teams evaluating Shopify, the data suggests asking:</p>
+<ul>
+<li>How much technical control do we need versus operational simplicity?</li>
+<li>What is our total cost of ownership, including apps and transaction fees?</li>
+<li>Do we have the internal capacity to manage a more technical platform, or do we need a managed solution?</li>
+<li>Are we in a growth phase where ease of scaling matters more than cost optimization?</li>
+</ul>
 <p>The migration pattern is real, but it is not one-way. Shopify attracts users frustrated with complexity and scalability limits elsewhere, but it also loses users who outgrow its constraints or find the cost structure unsustainable. The data suggests that the "right" platform depends on where a team is in their growth trajectory and what trade-offs they are willing to accept.</p>
 <p>For authoritative guidance on e-commerce platform capabilities, see <a href="https://www.shopify.com/">Shopify's official product page</a>.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts
@@ -205,11 +205,13 @@ const post: BlogPost = {
 <p>If your team relies heavily on complex contact segmentation or account-based filtering, allocate extra time to configure workarounds or evaluate whether Zoho CRM's filtering capabilities match your needs.</p>
 <h3 id="data-migration-complexity">Data migration complexity</h3>
 <p>Data migration appears as a pain category in the review data, though with lower frequency than pricing and UX concerns. This suggests most teams successfully migrate data, but some encounter friction.</p>
-<p>Common data migration challenges include:
-- Field mapping between your current CRM and Zoho CRM's schema
-- Custom field recreation and validation
-- Historical activity data preservation
-- Attachment and document migration</p>
+<p>Common data migration challenges include:</p>
+<ul>
+<li>Field mapping between your current CRM and Zoho CRM's schema</li>
+<li>Custom field recreation and validation</li>
+<li>Historical activity data preservation</li>
+<li>Attachment and document migration</li>
+</ul>
 <p>If you're migrating from Salesforce, expect to map custom objects and fields manually. Salesforce's flexibility creates migration complexity when moving to any platform, including Zoho CRM.</p>
 <p>For teams migrating from Slack or other non-CRM tools, the data migration burden is lighter but requires careful mapping of conversation history and customer context into CRM records.</p>
 <h3 id="support-expectations-during-migration">Support expectations during migration</h3>
@@ -226,12 +228,14 @@ const post: BlogPost = {
 <li><strong>Week 9+</strong>: Full cutover, old CRM decommissioning</li>
 </ol>
 <p>This timeline assumes a small-to-midsize team (under 50 users) with standard integrations. Larger teams or complex custom workflows may require 12-16 weeks.</p>
-<p>For teams considering whether to migrate, the review data suggests Zoho CRM works best when:
-- You're consolidating multiple tools into one platform
-- Your team is small-to-midsize (under 50 users)
-- You can test workflows on the free tier before upgrading
-- You don't require complex contact segmentation or account-based filtering
-- You have internal resources to configure Zapier workflows if needed</p>
+<p>For teams considering whether to migrate, the review data suggests Zoho CRM works best when:</p>
+<ul>
+<li>You're consolidating multiple tools into one platform</li>
+<li>Your team is small-to-midsize (under 50 users)</li>
+<li>You can test workflows on the free tier before upgrading</li>
+<li>You don't require complex contact segmentation or account-based filtering</li>
+<li>You have internal resources to configure Zapier workflows if needed</li>
+</ul>
 <p>If you're evaluating <a href="/blog/pipedrive-deep-dive-2026-04">Pipedrive</a>, <a href="/blog/insightly-deep-dive-2026-04">Insightly</a>, or <a href="/blog/freshsales-deep-dive-2026-04">Freshsales</a> as alternatives, compare integration ecosystems and support models against the patterns documented here.</p>
 <h2 id="key-takeaways">Key Takeaways</h2>
 <p>Zoho CRM attracts users from 4 documented competitor platforms, with pricing and UX concerns driving most migration decisions. The review data, spanning 963 total reviews and 271 enriched signals, reveals specific patterns that matter for teams evaluating a switch.</p>
@@ -247,25 +251,31 @@ const post: BlogPost = {
 <p>If your current CRM integrates with tools that Zoho CRM doesn't support natively, evaluate whether Zapier bridges the gap or whether you need a platform with direct integrations.</p>
 <h3 id="consolidation-opportunity-for-small-teams">Consolidation opportunity for small teams</h3>
 <p>One documented case shows a team reducing monthly spend from $540 to a lower consolidated cost by switching to Zoho CRM. This pattern aligns with small business use cases where teams consolidate lead tracking, customer follow-up, and communication tools into one platform.</p>
-<p>The consolidation opportunity is strongest when:
-- You're currently paying for multiple tools that Zoho CRM can replace
-- Your team is under 50 users
-- You don't require enterprise-grade support SLAs</p>
+<p>The consolidation opportunity is strongest when:</p>
+<ul>
+<li>You're currently paying for multiple tools that Zoho CRM can replace</li>
+<li>Your team is under 50 users</li>
+<li>You don't require enterprise-grade support SLAs</li>
+</ul>
 <h3 id="data-limitations-and-confidence">Data limitations and confidence</h3>
 <p>The sample includes 4 explicit switching mentions, which is a small base for ranking competitor migration volume. The pain category data (pricing, UX, overall dissatisfaction, contract lock-in, data migration, performance) provides stronger confidence because it draws from a larger review set.</p>
 <p>The support experience pattern is based on multiple reviews but still reflects a self-selected sample. Not all paying customers experience bot-mediated support friction, and the free tier remains functional for teams with minimal support needs.</p>
 <h3 id="when-zoho-crm-fits">When Zoho CRM fits</h3>
-<p>Reviewer experience suggests Zoho CRM works best for:
-- Small-to-midsize teams (under 50 users)
-- Teams consolidating multiple tools
-- Workflows centered on lead tracking and customer follow-up
-- Teams comfortable with Zapier for integration gaps
-- Teams that can validate workflows on the free tier before upgrading</p>
-<p>Zoho CRM may not fit if:
-- You require complex contact segmentation or account-based filtering
-- You need enterprise-grade support SLAs
-- Your current CRM has integrations that Zoho CRM doesn't support (and Zapier can't bridge)
-- You're migrating from Salesforce with heavy custom object dependencies</p>
+<p>Reviewer experience suggests Zoho CRM works best for:</p>
+<ul>
+<li>Small-to-midsize teams (under 50 users)</li>
+<li>Teams consolidating multiple tools</li>
+<li>Workflows centered on lead tracking and customer follow-up</li>
+<li>Teams comfortable with Zapier for integration gaps</li>
+<li>Teams that can validate workflows on the free tier before upgrading</li>
+</ul>
+<p>Zoho CRM may not fit if:</p>
+<ul>
+<li>You require complex contact segmentation or account-based filtering</li>
+<li>You need enterprise-grade support SLAs</li>
+<li>Your current CRM has integrations that Zoho CRM doesn't support (and Zapier can't bridge)</li>
+<li>You're migrating from Salesforce with heavy custom object dependencies</li>
+</ul>
 <h3 id="next-steps">Next steps</h3>
 <p>If you're evaluating Zoho CRM as a migration target:</p>
 <ol>

--- a/atlas-churn-ui/src/content/blog/why-teams-leave-slack-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/why-teams-leave-slack-2026-04.ts
@@ -139,18 +139,24 @@ const post: BlogPost = {
 <p>If infrastructure ownership is the driver, open-source alternatives like Mattermost and Rocket.Chat are viable. But self-hosting has real costs: server management, security patches, backup management, and uptime responsibility. Only switch to self-hosted if you have the internal capacity to run infrastructure.</p>
 <p>If you are on Slack's free tier and hitting history retention limits, you have three options: upgrade to paid, switch to a platform with better free-tier history, or accept the limitation and treat Slack as ephemeral communication only.</p>
 <p>The verdict: most teams should not do a full Slack replacement. Most teams should migrate specific workflows to async tools while keeping Slack for real-time coordination.</p>
-<p>Full replacement makes sense when:
-- Cost pressure is severe and Microsoft 365 is already deployed
-- Infrastructure ownership is a strategic priority and internal capacity exists
-- The entire team culture has shifted to async-first and real-time chat is now the exception</p>
-<p>Workflow migration makes sense when:
-- Specific workflows (design reviews, project documentation, decision records) are suffering from real-time chat culture
-- The team wants to preserve async communication without losing real-time coordination capability
-- Integration and onboarding benefits of Slack still matter for other use cases</p>
-<p>Stay on Slack when:
-- Real-time coordination is genuinely critical to your workflows
-- Integration ecosystem is deeply embedded in your operations
-- Cost is not a constraint and workflow culture is healthy</p>
+<p>Full replacement makes sense when:</p>
+<ul>
+<li>Cost pressure is severe and Microsoft 365 is already deployed</li>
+<li>Infrastructure ownership is a strategic priority and internal capacity exists</li>
+<li>The entire team culture has shifted to async-first and real-time chat is now the exception</li>
+</ul>
+<p>Workflow migration makes sense when:</p>
+<ul>
+<li>Specific workflows (design reviews, project documentation, decision records) are suffering from real-time chat culture</li>
+<li>The team wants to preserve async communication without losing real-time coordination capability</li>
+<li>Integration and onboarding benefits of Slack still matter for other use cases</li>
+</ul>
+<p>Stay on Slack when:</p>
+<ul>
+<li>Real-time coordination is genuinely critical to your workflows</li>
+<li>Integration ecosystem is deeply embedded in your operations</li>
+<li>Cost is not a constraint and workflow culture is healthy</li>
+</ul>
 <p>The data shows teams are actively evaluating alternatives now. Two accounts show active evaluation signals during the March-April 2026 window. If you are considering a switch, you are not alone. But most switching stories describe workflow migration, not platform abandonment. That is probably the right pattern for most teams.</p>`,
 }
 

--- a/atlas-churn-ui/src/content/blog/woocommerce-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/woocommerce-deep-dive-2026-04.ts
@@ -231,11 +231,13 @@ const post: BlogPost = {
 <p><strong>Confidence note:</strong> Timing intelligence is based on limited evidence. The patterns described reflect observable signals, not comprehensive coverage of the WooCommerce user base.</p>
 <h2 id="where-woocommerce-pressure-shows-up-in-accounts">Where WooCommerce Pressure Shows Up in Accounts</h2>
 <p>No account-level intent data is available in this analysis. The review sample does not include named-account tracking, ABM signals, or enterprise buying committee visibility.</p>
-<p>This means the analysis cannot assess:
-- Which specific companies are evaluating WooCommerce alternatives
-- Whether pressure is concentrated in specific industries or company sizes
-- How many active evaluations are in progress at the market level
-- Whether churn risk is accelerating in any measurable segment</p>
+<p>This means the analysis cannot assess:</p>
+<ul>
+<li>Which specific companies are evaluating WooCommerce alternatives</li>
+<li>Whether pressure is concentrated in specific industries or company sizes</li>
+<li>How many active evaluations are in progress at the market level</li>
+<li>Whether churn risk is accelerating in any measurable segment</li>
+</ul>
 <p>One reviewer mentioned working at Webhouse, a 9-employee information technology and services company in Australia, with 3 years of eCommerce experience. This single named reference does not constitute account-level pressure evidence.</p>
 <p>The absence of account data does not invalidate the pain patterns, sentiment signals, or competitive pressure observed in public reviews. It simply means this analysis cannot connect those patterns to specific buying committees or validate market-level urgency.</p>
 <p>For organizations seeking account-level WooCommerce churn intelligence, this review analysis provides context and pattern evidence but not actionable account lists.</p>
@@ -256,18 +258,24 @@ const post: BlogPost = {
 <p>The market regime analysis suggests a stable eCommerce platform category with no clear disruption signals, but with incremental competitive pressure on WooCommerce from all-in-one alternatives.</p>
 <p>Evidence suggests WooCommerce faces pricing pressure but retains customers through strong overall satisfaction, pricing flexibility perception, and user experience quality. The contradiction between weakness and strength evidence across multiple dimensions suggests a market in equilibrium rather than transition.</p>
 <p>Three vendor snapshots illustrate the competitive landscape:</p>
-<p><strong>Shopify:</strong>
-- Strengths: integration simplicity, feature completeness
-- Weaknesses: security concerns, technical debt accumulation
-- Position: all-in-one alternative capturing WooCommerce switchers seeking simplicity</p>
-<p><strong>Magento:</strong>
-- Strengths: support quality, feature depth
-- Weaknesses: performance complexity, reliability concerns
-- Position: enterprise alternative for high-complexity deployments</p>
-<p><strong>WooCommerce:</strong>
-- Strengths: performance (when optimized), user experience quality
-- Weaknesses: integration complexity, contract lock-in perception
-- Position: flexible WordPress-native solution with cumulative cost pressure</p>
+<p><strong>Shopify:</strong></p>
+<ul>
+<li>Strengths: integration simplicity, feature completeness</li>
+<li>Weaknesses: security concerns, technical debt accumulation</li>
+<li>Position: all-in-one alternative capturing WooCommerce switchers seeking simplicity</li>
+</ul>
+<p><strong>Magento:</strong></p>
+<ul>
+<li>Strengths: support quality, feature depth</li>
+<li>Weaknesses: performance complexity, reliability concerns</li>
+<li>Position: enterprise alternative for high-complexity deployments</li>
+</ul>
+<p><strong>WooCommerce:</strong></p>
+<ul>
+<li>Strengths: performance (when optimized), user experience quality</li>
+<li>Weaknesses: integration complexity, contract lock-in perception</li>
+<li>Position: flexible WordPress-native solution with cumulative cost pressure</li>
+</ul>
 <p>The market dynamics reflect a mature category with established alternatives rather than emerging disruption. WooCommerce's open-source foundation and WordPress integration create switching friction that limits churn velocity, even as pricing frustration builds.</p>
 <p>No category-wide regime shift is evident in this data. The competitive pressure on WooCommerce appears incremental and segment-specific rather than existential.</p>
 <p><strong>Confidence note:</strong> Category reasoning is based on limited evidence. The stable regime assessment reflects observable patterns, not comprehensive market coverage.</p>

--- a/plans/PR-Blog-Markdown-Lists-In-P-Tags.md
+++ b/plans/PR-Blog-Markdown-Lists-In-P-Tags.md
@@ -1,0 +1,127 @@
+# PR-Blog-Markdown-Lists-In-P-Tags
+
+## Why this slice exists
+
+The seo-geo-aeo-blog-post skill's baseline analyzer (introduced in PR
+#612, refreshed in #634/#636/#638) flagged that 14 of 79 published
+blog posts under `atlas-churn-ui/src/content/blog/` contain markdown
+bullet syntax (`- item`) nested inside `<p>` tags. The BlogPost
+contract says `content` is an HTML string and must use semantic tags
+(`<ul><li>`) -- the markdown leaks render as literal dashes in the
+browser, breaking list semantics and accessibility.
+
+Total occurrences across the 14 posts: 93 paragraph blocks containing
+list-like markdown. Affected slugs include the full 2026-04 batch of
+deep dives, switch-to guides, head-to-head comparisons, and best-fit
+guides. The 2026-03 Shopify switch guide is also affected.
+
+This slice converts the 14 already-published artifacts to use semantic
+`<ul><li>` blocks. It does NOT add a generator-side guard to prevent
+recurrence -- that lives in a separate slice (the seo-geo-aeo-blog-post
+skill audit catches the pattern post-publish; an upstream check during
+generation would require parsing the LLM's HTML output for the same
+shape).
+
+## Scope
+
+1. Convert every `<p>` block in the 14 affected post `.ts` files
+   that contains `\n- item` (or `\n* item`) lines to:
+     * a `<p>` carrying any prose preceding the bullets, and
+     * a sibling `<ul>` with each bullet rendered as a `<li>`.
+2. Preserve all other content verbatim, including non-bullet `<p>`
+   blocks, charts, FAQ items, and the BlogPost metadata.
+3. Verify with the analyzer that `Markdown in <p> tags` count drops
+   from 14 / 57 to 0 / 0.
+4. Verify with `npm run build` in `atlas-churn-ui` that the
+   converted posts still compile and render.
+
+### Files touched
+
+- `atlas-churn-ui/src/content/blog/best-hr-hcm-for-51-200-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/best-project-management-for-201-1000-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/close-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/help-scout-vs-zendesk-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/linode-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/power-bi-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/sentinelone-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-clickup-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/why-teams-leave-slack-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/woocommerce-deep-dive-2026-04.ts`
+- `plans/PR-Blog-Markdown-Lists-In-P-Tags.md`
+
+## Mechanism
+
+A one-off Node script scans each affected `.ts` file and applies a
+regex-based replacement against the `content` template literal. For
+each `<p>...</p>` block, the script:
+
+1. Splits the inner content on newlines.
+2. Walks the lines as a state machine: `prose` -> `bullets` ->
+   `trailing`. A bullet line is `^[ \t]*[-*][ \t]+(.+)$`.
+3. Emits one `<p>...</p>` carrying the prose lines (if any), followed
+   by `<ul>` with one `<li>` per bullet, followed by another `<p>`
+   for trailing content (rare).
+4. Continuation lines (non-bullet, non-empty) immediately after a
+   bullet are appended to the previous bullet's text -- defensive
+   against wrapped list items, though the current data does not
+   contain any.
+
+The script makes no other content edits. Posts that don't contain
+the bullet-in-`<p>` pattern are skipped untouched.
+
+## Intentional
+
+- Surgical content fix: only the 14 affected `.ts` files are
+  modified. No generator code change, no test changes, no schema
+  changes.
+- Bullets that already render as proper `<ul><li>` are unaffected --
+  the regex only matches a `<p>` whose inner content has a
+  newline followed by a `-` or `*` token, which `<ul>` blocks
+  don't satisfy.
+- Continuation-line behavior (appending wrap-around text to the
+  prior bullet) is implemented but exercises no current data. It's
+  documented in code for future generations.
+- The seo-geo-aeo-blog-post audit catches the same pattern post-
+  publish. After this PR the count goes to zero; if it climbs again
+  in a future generation, the analyzer is the canary.
+
+## Deferred
+
+- Generator-side detection / refusal at draft time. A check inside
+  `_apply_blog_quality_gate` could grep `content` for bullet-in-`<p>`
+  patterns and refuse to publish. That's a separate slice and would
+  require coordination with the LLM prompt to also avoid emitting
+  markdown lists inside `<p>` blocks in the first place.
+- Numbered-list (`1. item`) conversion. Current data does not
+  contain numbered lists nested in `<p>` blocks; if a future post
+  ships one, the converter will need an `<ol>` branch.
+- Cleanup of other markdown leaks (e.g., `**bold**` or backtick
+  spans inside `<p>`). The audit hasn't flagged these in production.
+
+## Verification
+
+- `node /home/juan-canfield/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js --repo=atlas-churn-ui` -> `Markdown in <p> tags: 0 / 0` (was `14 / 57`).
+- `npm run build` in `atlas-churn-ui` -> 83-URL sitemap, no TS errors.
+- `git diff --check` -> passed.
+- Spot-check on `close-deep-dive-2026-04.ts`: 4-item bullet block in
+  the "Key findings" paragraph converted to `<p>...</p><ul><li>...</li></ul>`;
+  surrounding prose preserved.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Affected post `.ts` files (14) -- insertions | ~600 |
+| Affected post `.ts` files (14) -- deletions | ~420 |
+| Plan doc | ~130 |
+| **Total** | **~1150** |
+
+Totals reflect raw insertions + deletions, not net LOC. The high
+deletion count comes from each multi-line `<p>...\n- item\n- item...</p>`
+block being rewritten as `<p>...</p>\n<ul>\n<li>...</li>\n...</ul>` --
+each converted block grows from N+1 lines (prose + N bullets in one
+`<p>`) to ~N+4 lines (`<p>`, `<ul>`, N `<li>`, `</ul>`).

--- a/plans/PR-Blog-Markdown-Lists-In-P-Tags.md
+++ b/plans/PR-Blog-Markdown-Lists-In-P-Tags.md
@@ -104,7 +104,12 @@ the bullet-in-`<p>` pattern are skipped untouched.
 
 ## Verification
 
-- `node /home/juan-canfield/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js --repo=atlas-churn-ui` -> `Markdown in <p> tags: 0 / 0` (was `14 / 57`).
+- `audit-published-posts.js --repo=atlas-churn-ui` -> `Markdown in <p> tags: 0 / 0` (was `14 / 57`). The analyzer ships in the
+  `seo-geo-aeo-blog-post` Claude Code skill at
+  `~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js`;
+  contributors who don't have the skill installed can run an
+  equivalent inline check:
+  `grep -c '<p>[^<]*\n\s*[-*]\s' atlas-churn-ui/src/content/blog/*.ts` -> `0` after the change.
 - `npm run build` in `atlas-churn-ui` -> 83-URL sitemap, no TS errors.
 - `git diff --check` -> passed.
 - Spot-check on `close-deep-dive-2026-04.ts`: 4-item bullet block in


### PR DESCRIPTION
## Convert markdown bullet syntax inside <p> tags to semantic <ul><li>

Plan: plans/PR-Blog-Markdown-Lists-In-P-Tags.md

14 of 79 published blog posts under \`atlas-churn-ui/src/content/blog/\` shipped with markdown bullet syntax (\`- item\`) nested inside \`<p>\` tags. The BlogPost contract treats \`content\` as HTML; the leaked markdown rendered as literal dashes, breaking list semantics and accessibility. This PR converts the 93 affected paragraph blocks across the 14 posts to semantic \`<ul><li>\` elements.

## Intentional

- Surgical content fix: only the 14 affected \`.ts\` files are modified. No generator code change, no test changes, no schema changes.
- Continuation-line handling (wrap-around text appended to the prior bullet) is implemented but exercises no current data; defensive against future generations that wrap long list items.
- Posts without the bullet-in-\`<p>\` pattern are untouched. The regex only matches \`<p>\` blocks whose inner content has \`\n- item\`, which already-correct \`<ul>\` blocks do not.

## Deferred

- Generator-side check during draft generation to refuse content containing bullet-in-\`<p>\`. That would require coordination with the LLM prompt and lives in a follow-up slice.
- Numbered-list (\`1. item\`) conversion. Current data has none.
- Other markdown leaks (\`**bold**\`, backtick spans inside \`<p>\`). The audit has not flagged these in production.

## Verification

- Skill analyzer \`Markdown in <p> tags\` count: 14 / 57 -> 0 / 0 (\`~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js\`)
- \`npm run build\` in atlas-churn-ui -> 83-URL sitemap, no TS errors.
- \`git diff --check\` -> passed.
- \`bash scripts/local_pr_review.sh\` -> passed.
- Spot-check on close-deep-dive-2026-04 "Key findings" paragraph: 4-item bullet block converted to \`<p>...</p><ul><li>...</li></ul>\`; surrounding prose preserved verbatim.

## Diff size

15 files, +737 / -424.