### PR TITLE
Block placeholder URLs in campaign drafts

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T17:42Z by codex-2026-05-19
+Last updated: 2026-05-19T17:50Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Ops-Placeholder-Url-Gate | `extracted_content_pipeline/campaign_generation.py`, `tests/test_extracted_campaign_generation.py`, `plans/PR-Content-Ops-Placeholder-Url-Gate.md` | codex-2026-05-19 | Campaign generation persistence guard, live-output smoke/link policy |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -39,8 +39,9 @@ from .services._parse_retry_helpers import (
 
 _PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
 _PLACEHOLDER_URL_RE = re.compile(
-    r"(?<![A-Za-z0-9.-])(?:https?://)?(?:www\.)?"
-    r"(?:example\.(?:com|org|net)|localhost)(?::\d+)?(?:[/?#:]|$)",
+    r"(?<![A-Za-z0-9.@-])(?:https?://)?(?:www\.)?"
+    r"(?:(?:[A-Za-z0-9-]+\.)*example\.(?:com|org|net)|localhost)"
+    r"(?::\d+)?(?=$|[\s/?#:.,;!?)\]}>'\"])",
     re.IGNORECASE,
 )
 

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -38,6 +38,11 @@ from .services._parse_retry_helpers import (
 
 
 _PROOF_TERM_TEXT_KEYS = ("excerpt_text", "quote", "text", "anchor", "value")
+_PLACEHOLDER_URL_RE = re.compile(
+    r"(?<![A-Za-z0-9.-])(?:https?://)?(?:www\.)?"
+    r"(?:example\.(?:com|org|net)|localhost)(?::\d+)?(?:[/?#:]|$)",
+    re.IGNORECASE,
+)
 
 
 def _normalize_channels(items: Sequence[Any]) -> tuple[str, ...]:
@@ -134,6 +139,10 @@ def _campaign_generation_user_prompt(
             "Return one JSON object with non-empty subject and body."
         ),
     )
+
+
+def _contains_placeholder_url(value: Any) -> bool:
+    return bool(_PLACEHOLDER_URL_RE.search(str(value or "")))
 
 
 @dataclass(frozen=True)
@@ -380,6 +389,16 @@ class CampaignGenerationService:
                         "target_id": target_id,
                         "channel": channel,
                         "reason": "unparseable_response",
+                    })
+                    continue
+                if _contains_placeholder_url(parsed.get("body")) or _contains_placeholder_url(
+                    parsed.get("cta")
+                ):
+                    skipped += 1
+                    errors.append({
+                        "target_id": target_id,
+                        "channel": channel,
+                        "reason": "placeholder_url",
                     })
                     continue
                 parsed, revalidation_error = self._revalidated_parsed(

--- a/plans/PR-Content-Ops-Placeholder-Url-Gate.md
+++ b/plans/PR-Content-Ops-Placeholder-Url-Gate.md
@@ -17,7 +17,8 @@ real asset, blog post, or booking URL.
    `body` and `cta` fields.
 2. Skip affected drafts with a clear `placeholder_url` error instead of
    persisting them.
-3. Add focused service tests for body and CTA placeholder URL rejection.
+3. Add focused service tests for body, CTA, scheme-less, punctuation-terminated,
+   subdomain, and email-address false-positive behavior.
 4. Register this slice in the coordination ledger.
 
 ### Files touched
@@ -59,7 +60,7 @@ Local checks:
 
 ```bash
 pytest tests/test_extracted_campaign_generation.py
-# 40 passed
+# 44 passed
 
 python -m py_compile extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py
 # passed
@@ -75,16 +76,26 @@ python scripts/audit_extracted_standalone.py --fail-on-debt
 
 bash scripts/check_ascii_python.sh
 # passed
+
+python scripts/smoke_content_ops_review_source_postgres.py \
+  --source g2 --vendor Slack --limit 1 \
+  --account-id content_ops_live_g2_gate_20260519_125733 \
+  --llm pipeline --min-drafts 2 --json
+# expected fail-closed: 0 generated, 2 skipped with reason=placeholder_url
+
+python scripts/export_extracted_campaign_drafts.py \
+  --account-id content_ops_live_g2_gate_20260519_125733 --format json
+# count=0
 ```
 
 ## Estimated diff size
 
 | File | LOC churn (approx) |
 |---|---:|
-| `extracted_content_pipeline/campaign_generation.py` | 30 |
-| `tests/test_extracted_campaign_generation.py` | 55 |
-| `docs/extraction/coordination/inflight.md` | 2 |
-| `plans/PR-Content-Ops-Placeholder-Url-Gate.md` | 70 |
-| **Total** | **157** |
+| `extracted_content_pipeline/campaign_generation.py` | 20 |
+| `tests/test_extracted_campaign_generation.py` | 178 |
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Content-Ops-Placeholder-Url-Gate.md` | 101 |
+| **Total** | **302** |
 
 Below the 400 LOC review budget.

--- a/plans/PR-Content-Ops-Placeholder-Url-Gate.md
+++ b/plans/PR-Content-Ops-Placeholder-Url-Gate.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-Placeholder-Url-Gate
+
+## Why this slice exists
+
+The first live provider proof after the bridge-mode import fix generated and
+persisted G2-grounded campaign drafts, but the LLM invented `example.com` CTA
+and article URLs because the imported review-source row did not provide a
+real selling asset URL. The evidence claims were grounded; the links were not.
+
+AI Content Ops should fail closed on placeholder URLs before saving drafts.
+This keeps live outputs demo-safe even when a host has not yet supplied a
+real asset, blog post, or booking URL.
+
+## Scope (this PR)
+
+1. Add a small campaign-generation guard for placeholder URLs in generated
+   `body` and `cta` fields.
+2. Skip affected drafts with a clear `placeholder_url` error instead of
+   persisting them.
+3. Add focused service tests for body and CTA placeholder URL rejection.
+4. Register this slice in the coordination ledger.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_generation.py`
+- `tests/test_extracted_campaign_generation.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Placeholder-Url-Gate.md`
+
+## Mechanism
+
+After campaign response parsing returns a candidate draft and before
+quality revalidation / persistence, `CampaignGenerationService.generate()`
+checks generated link-bearing fields for known placeholder hosts. If a
+placeholder URL is present, the service increments `skipped`, records
+`{"reason": "placeholder_url"}`, and continues without saving that draft.
+
+## Intentional
+
+- This is a hard runtime guard, not only a prompt edit. Prompt wording can
+  reduce bad generations, but the persistence boundary is where fake links
+  must be blocked.
+- This does not require quality revalidation to be enabled. Placeholder URLs
+  are unsafe regardless of the optional evidence-quality pass.
+- The guard targets placeholder URLs, not all missing links. A draft with no
+  URL can still be valid if the host did not supply an asset.
+
+## Deferred
+
+- Host-configured selling asset URLs for live smoke inputs remain a follow-up.
+  That will let the same G2 live proof pass without fabricated links while
+  preserving useful CTAs.
+- Broader URL policy for non-campaign asset types is deferred until each
+  live-output smoke is exercised.
+
+## Verification
+
+Local checks:
+
+```bash
+pytest tests/test_extracted_campaign_generation.py
+# 40 passed
+
+python -m py_compile extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py
+# passed
+
+bash scripts/validate_extracted_content_pipeline.sh
+# passed
+
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+# passed
+
+python scripts/audit_extracted_standalone.py --fail-on-debt
+# passed
+
+bash scripts/check_ascii_python.sh
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `extracted_content_pipeline/campaign_generation.py` | 30 |
+| `tests/test_extracted_campaign_generation.py` | 55 |
+| `docs/extraction/coordination/inflight.md` | 2 |
+| `plans/PR-Content-Ops-Placeholder-Url-Gate.md` | 70 |
+| **Total** | **157** |
+
+Below the 400 LOC review budget.

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -394,6 +394,80 @@ async def test_generate_skips_scheme_less_placeholder_url_with_www_prefix():
 
 
 @pytest.mark.asyncio
+async def test_generate_skips_placeholder_url_before_sentence_punctuation():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "Read the summary at example.com.",
+            "cta": "Book time at localhost, then bring your team.",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_placeholder_subdomain_url():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "Read the summary at https://demo.example.com/report",
+            "cta": "Keep building",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_treat_email_address_as_placeholder_url():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "Coordinate with ops@example.com before rollout.",
+            "cta": "Book time",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.errors == ()
+    assert len(campaigns.saved) == 1
+
+
+@pytest.mark.asyncio
 async def test_generate_includes_opportunity_payload_when_skill_has_no_placeholders():
     service, _, _, llm, _ = _service(
         [{"id": "opp-1", "company_name": "Acme", "pain": "pricing pressure"}],

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -290,6 +290,84 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
 
 
 @pytest.mark.asyncio
+async def test_generate_skips_draft_with_placeholder_url_in_body():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": '<p>Read the analysis: <a href="https://example.com/report">Report</a></p>',
+            "cta": "Read the report",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_draft_with_placeholder_url_in_cta():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "<p>Pricing note</p>",
+            "cta": "Book time: http://localhost:3000/demo",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_scheme_less_placeholder_urls():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "Read the analysis at example.com/report",
+            "cta": "Book time at localhost:3000/demo",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
 async def test_generate_includes_opportunity_payload_when_skill_has_no_placeholders():
     service, _, _, llm, _ = _service(
         [{"id": "opp-1", "company_name": "Acme", "pain": "pricing pressure"}],

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -368,6 +368,32 @@ async def test_generate_skips_scheme_less_placeholder_urls():
 
 
 @pytest.mark.asyncio
+async def test_generate_skips_scheme_less_placeholder_url_with_www_prefix():
+    service, _, campaigns, _, _ = _service(
+        [{"id": "opp-1", "company_name": "Acme"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "Read the summary at www.example.com/updates",
+            "cta": "Keep building",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "target_id": "opp-1",
+        "channel": "email",
+        "reason": "placeholder_url",
+    },)
+    assert campaigns.saved == []
+
+
+@pytest.mark.asyncio
 async def test_generate_includes_opportunity_payload_when_skill_has_no_placeholders():
     service, _, _, llm, _ = _service(
         [{"id": "opp-1", "company_name": "Acme", "pain": "pricing pressure"}],


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Placeholder-Url-Gate.md

Block AI Content Ops campaign drafts that contain placeholder URLs like `example.com`, `www.example.com`, or `localhost` before persistence. This closes the issue surfaced by the live G2 provider proof: evidence claims were grounded, but the LLM invented fake article/CTA links when no real selling asset URL was supplied.

## Intentional
- Enforce this outside optional quality revalidation because fake URLs are unsafe regardless of quality-gate configuration.
- Do not require every draft to contain a URL; missing links can be valid when the host has not supplied an asset.

## Deferred
- Host-configured selling asset URLs for live smoke inputs remain the next slice.
- Broader URL policy for non-campaign asset types is deferred until each live-output smoke is exercised.

## Verification
- `pytest tests/test_extracted_campaign_generation.py` -> 41 passed
- `python -m py_compile extracted_content_pipeline/campaign_generation.py tests/test_extracted_campaign_generation.py` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- Live G2 pipeline smoke without standalone workaround -> expected fail-closed: 0 generated, 2 skipped with `placeholder_url`
- Draft export for live-smoke account -> count=0
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
4 files, +199 / -1