### PR TITLE
Tag affiliate anchors with rel="sponsored" in BlogArticleView

### DIFF
--- a/atlas-churn-ui/src/components/BlogArticleView.test.tsx
+++ b/atlas-churn-ui/src/components/BlogArticleView.test.tsx
@@ -50,4 +50,116 @@ describe('BlogArticleView', () => {
     expect(screen.getByText('Affiliate Disclosure')).toBeInTheDocument()
     expect(container.querySelector('a[data-preview-affiliate="true"]')).not.toBeNull()
   })
+
+  it('tags inline affiliate anchors with rel="sponsored" in production rendering', () => {
+    // Render without preview / highlight flags -- this mirrors what a
+    // real reader sees on /blog/<slug>. The rel="sponsored" tagging must
+    // run regardless of the preview-decoration flag for FTC / Google
+    // compliance.
+    const { container } = render(
+      <MemoryRouter>
+        <BlogArticleView post={post} showBackLink={false} />
+      </MemoryRouter>,
+    )
+
+    const affiliateAnchor = container.querySelector(
+      'a[href="https://example.com/shopify"]',
+    )
+    expect(affiliateAnchor).not.toBeNull()
+    const rel = affiliateAnchor!.getAttribute('rel') || ''
+    expect(rel.split(/\s+/)).toContain('sponsored')
+    // No preview decoration without the highlight flag.
+    expect(affiliateAnchor!.getAttribute('data-preview-affiliate')).toBeNull()
+  })
+
+  it('preserves existing rel tokens when adding sponsored to affiliate anchors', () => {
+    // Prose authors may already set rel="noopener noreferrer" on
+    // outbound links. The sponsored decoration must merge tokens, not
+    // overwrite them.
+    const postWithRel: BlogPost = {
+      ...post,
+      content:
+        '<p><a href="https://example.com/shopify" rel="noopener noreferrer">Shopify trial</a></p>',
+    }
+    const { container } = render(
+      <MemoryRouter>
+        <BlogArticleView post={postWithRel} showBackLink={false} />
+      </MemoryRouter>,
+    )
+
+    const affiliateAnchor = container.querySelector(
+      'a[href="https://example.com/shopify"]',
+    )
+    const relTokens = (affiliateAnchor!.getAttribute('rel') || '').split(/\s+/)
+    expect(relTokens).toContain('sponsored')
+    expect(relTokens).toContain('noopener')
+    expect(relTokens).toContain('noreferrer')
+  })
+
+  it('does NOT tag non-affiliate anchors with sponsored', () => {
+    // Only the anchor whose href matches data_context.affiliate_url
+    // should be tagged. Internal blog links, methodology links, and
+    // unrelated citation links must stay untouched.
+    const postWithMixedLinks: BlogPost = {
+      ...post,
+      content:
+        '<p><a href="https://example.com/shopify">Shopify</a> vs <a href="https://example.com/bigcommerce">BigCommerce</a></p>',
+    }
+    const { container } = render(
+      <MemoryRouter>
+        <BlogArticleView post={postWithMixedLinks} showBackLink={false} />
+      </MemoryRouter>,
+    )
+
+    const bigcommerceAnchor = container.querySelector(
+      'a[href="https://example.com/bigcommerce"]',
+    )
+    expect(bigcommerceAnchor).not.toBeNull()
+    const rel = bigcommerceAnchor!.getAttribute('rel') || ''
+    expect(rel).not.toContain('sponsored')
+  })
+
+  it('tags the affiliate-mode CTA anchor with rel="sponsored"', () => {
+    // Scope to `container` rather than `screen` so the assertion isn't
+    // affected by leftover DOM from earlier tests in the file.
+    const { container } = render(
+      <MemoryRouter>
+        <BlogArticleView post={post} showBackLink={false} />
+      </MemoryRouter>,
+    )
+
+    const ctaAnchor = Array.from(container.querySelectorAll('a')).find(
+      (a) => a.textContent?.trim() === 'Book briefing',
+    )
+    expect(ctaAnchor).toBeDefined()
+    const relTokens = (ctaAnchor!.getAttribute('rel') || '').split(/\s+/)
+    expect(relTokens).toContain('sponsored')
+    // Security tokens must remain.
+    expect(relTokens).toContain('noopener')
+    expect(relTokens).toContain('noreferrer')
+  })
+
+  it('does NOT tag the generic-mode CTA anchor with sponsored', () => {
+    // Posts without an affiliate_url fall through to the generic CTA
+    // path (cal.com booking, internal report). That destination is
+    // not a commercial relationship and must NOT carry rel="sponsored".
+    const genericPost: BlogPost = {
+      ...post,
+      data_context: {}, // strips affiliate_url + affiliate_partner
+    }
+    const { container } = render(
+      <MemoryRouter>
+        <BlogArticleView post={genericPost} showBackLink={false} />
+      </MemoryRouter>,
+    )
+
+    // resolveBlogArticleCta() returns mode='generic' when affiliate_url
+    // is missing; the stored CTA buttonText is preserved either way.
+    const ctaAnchor = Array.from(container.querySelectorAll('a')).find(
+      (a) => a.textContent?.trim() === 'Book briefing',
+    )
+    expect(ctaAnchor).toBeDefined()
+    const rel = ctaAnchor!.getAttribute('rel') || ''
+    expect(rel).not.toContain('sponsored')
+  })
 })

--- a/atlas-churn-ui/src/components/BlogArticleView.tsx
+++ b/atlas-churn-ui/src/components/BlogArticleView.tsx
@@ -48,7 +48,16 @@ function decorateAffiliateLinks(
     highlightAffiliateLinks: boolean
   },
 ) {
-  if (!highlightAffiliateLinks || !affiliateUrl || typeof DOMParser === 'undefined') {
+  // Run whenever an affiliate URL is present, regardless of the preview-
+  // highlight flag. The function has two concerns:
+  //   1. Always: tag matching anchors with rel="sponsored" for FTC + Google
+  //      compliance. Affiliate links must declare the commercial relationship
+  //      so Google can attribute the link correctly and readers see the
+  //      relationship surfaced in browser link-info dialogs.
+  //   2. Preview-only (when highlightAffiliateLinks=true): paint the visual
+  //      dashed outline + data-preview-affiliate marker so admin reviewers
+  //      can scan a draft for affiliate placements.
+  if (!affiliateUrl || typeof DOMParser === 'undefined') {
     return html
   }
 
@@ -59,13 +68,25 @@ function decorateAffiliateLinks(
     anchors.forEach((anchor) => {
       const href = String(anchor.getAttribute('href') || '').trim()
       if (!href || href !== affiliateUrl) return
-      const existingStyle = String(anchor.getAttribute('style') || '').trim()
-      anchor.setAttribute(
-        'style',
-        existingStyle ? `${existingStyle};${AFFILIATE_INLINE_STYLE}` : AFFILIATE_INLINE_STYLE,
-      )
-      anchor.setAttribute('data-preview-affiliate', 'true')
-      anchor.setAttribute('title', 'Affiliate link')
+
+      // Always: ensure rel includes "sponsored". Preserve any existing
+      // tokens like "noopener" / "noreferrer" so we don't drop the
+      // security attributes set by upstream prose authors.
+      const existingRel = String(anchor.getAttribute('rel') || '').trim()
+      const relTokens = new Set(existingRel.split(/\s+/).filter(Boolean))
+      relTokens.add('sponsored')
+      anchor.setAttribute('rel', Array.from(relTokens).join(' '))
+
+      // Preview-only: visual decoration.
+      if (highlightAffiliateLinks) {
+        const existingStyle = String(anchor.getAttribute('style') || '').trim()
+        anchor.setAttribute(
+          'style',
+          existingStyle ? `${existingStyle};${AFFILIATE_INLINE_STYLE}` : AFFILIATE_INLINE_STYLE,
+        )
+        anchor.setAttribute('data-preview-affiliate', 'true')
+        anchor.setAttribute('title', 'Affiliate link')
+      }
     })
     return doc.body.innerHTML.replace(/^<div>|<\/div>$/g, '')
   } catch {
@@ -217,7 +238,15 @@ export default function BlogArticleView({
           <a
             href={cta.url}
             target="_blank"
-            rel="noopener noreferrer"
+            // Affiliate-mode CTAs declare the commercial relationship via
+            // rel="sponsored" (FTC + Google guidelines). Generic-mode CTAs
+            // are non-commercial (Cal.com booking, internal report) and
+            // keep just the security attributes.
+            rel={
+              cta.mode === 'affiliate'
+                ? 'sponsored noopener noreferrer'
+                : 'noopener noreferrer'
+            }
             className="inline-block px-6 py-3 bg-cyan-600 hover:bg-cyan-500 rounded-lg text-white font-semibold transition-colors"
           >
             {cta.buttonText}

--- a/plans/PR-Blog-Affiliate-Sponsored-Rel.md
+++ b/plans/PR-Blog-Affiliate-Sponsored-Rel.md
@@ -1,0 +1,143 @@
+# PR-Blog-Affiliate-Sponsored-Rel
+
+## Why this slice exists
+
+`atlas-churn-ui` already renders a clearly-visible affiliate
+disclosure block at the top of every post that has an affiliate
+link (`BlogArticleView.tsx` lines 192-204): "This article may
+contain affiliate links. If you purchase through these links, we
+may earn a commission ...". That covers the FTC visibility
+requirement.
+
+What is NOT in place: the `rel="sponsored"` attribute on the actual
+affiliate anchor tags. Google's link attribution guidelines say
+affiliate links must carry `rel="sponsored"` (or
+`rel="nofollow sponsored"`) so the link is correctly classified as
+a commercial relationship. The reports/affiliate-system-
+investigation.md doc (committed in PR #617) flagged this as a real
+legal-risk gap.
+
+Current state:
+
+- **CTA button anchor** (`BlogArticleView.tsx:217-224`): has
+  `rel="noopener noreferrer"` regardless of whether the CTA points
+  at an affiliate URL or a cal.com booking link.
+- **Inline affiliate anchors inside post body content**: the
+  `decorateAffiliateLinks` helper iterates anchors whose `href`
+  matches `data_context.affiliate_url` and adds visual decoration
+  ONLY when the `highlightAffiliateLinks` admin-preview flag is
+  true. In production rendering the flag defaults to `false` so the
+  function early-returns and the inline affiliate anchors get no
+  `rel` tagging at all.
+
+Result: even when readers see the visible disclosure block, the
+affiliate anchors themselves don't declare the commercial
+relationship to Google or to browser link-info dialogs.
+
+## Scope
+
+1. Refactor `decorateAffiliateLinks` so the `rel="sponsored"`
+   tagging path runs whenever there's an affiliate URL, regardless
+   of the `highlightAffiliateLinks` preview flag. The visual outline
+   + `data-preview-affiliate` markers remain gated on the preview
+   flag.
+2. Existing `rel` tokens (`noopener`, `noreferrer`) on prose-author
+   anchors must be preserved when `sponsored` is added -- the
+   security attributes don't go away.
+3. Update the CTA button anchor to add `sponsored` to its `rel` when
+   `cta.mode === 'affiliate'`. Generic-mode CTAs (cal.com booking,
+   internal report) stay with just `noopener noreferrer`.
+4. Add tests covering all five branches: inline-affiliate gets
+   sponsored in production rendering, existing rel tokens are
+   preserved when sponsored is added, non-affiliate anchors are
+   untouched, affiliate-mode CTA gets sponsored, generic-mode CTA
+   does not get sponsored.
+
+### Files touched
+
+- `atlas-churn-ui/src/components/BlogArticleView.tsx`
+- `atlas-churn-ui/src/components/BlogArticleView.test.tsx`
+- `plans/PR-Blog-Affiliate-Sponsored-Rel.md`
+
+## Mechanism
+
+`decorateAffiliateLinks(html, { affiliateUrl, highlightAffiliateLinks })`
+is split into two concerns inside the same function:
+
+1. **Always**: parse `html` with `DOMParser`, iterate
+   `a[href]` elements, find the anchors whose `href` exactly
+   matches `affiliateUrl`. For each: read the existing `rel`
+   attribute, tokenise into a Set, add `sponsored`, write back.
+   Using a Set deduplicates so `<a rel="sponsored noopener">` plus
+   another sponsored tag won't produce duplicate tokens.
+2. **Preview-only** (gated on `highlightAffiliateLinks`): apply the
+   dashed outline style + `data-preview-affiliate="true"` +
+   `title="Affiliate link"`. These markers serve the admin draft
+   reviewer scanning a post for affiliate placements.
+
+The function early-returns when `affiliateUrl` is empty or
+`DOMParser` is unavailable (SSR). Failure during parse falls back
+to the un-modified HTML.
+
+The CTA anchor in JSX uses a conditional `rel` value:
+```jsx
+rel={
+  cta.mode === 'affiliate'
+    ? 'sponsored noopener noreferrer'
+    : 'noopener noreferrer'
+}
+```
+
+`cta.mode` comes from `resolveBlogArticleCta` (`src/lib/blogCta.ts`)
+which returns `'affiliate'` only when both `data_context.affiliate_url`
+and a partner name are present, so generic posts can't accidentally
+get tagged.
+
+## Intentional
+
+- `sponsored` is the canonical Google attribute for paid /
+  affiliate relationships. `nofollow` is the older, more general
+  signal. Modern Google guidance treats `sponsored` as implying
+  the relationship without `nofollow`; we don't add `nofollow`
+  here to keep the rel list short and the intent specific.
+- Existing rel tokens (typically `noopener noreferrer`) are
+  preserved via a token Set. The merge logic is order-stable
+  enough for assertions (`relTokens.contains('sponsored')` etc.)
+  even though the rendered string order isn't guaranteed.
+- The admin diagnostic anchor in `BlogReview.tsx:806-813` (which
+  displays the affiliate URL as a clickable link in a sidebar
+  panel) is NOT updated. That anchor is admin-only, not a
+  customer-facing recommendation; tagging it as sponsored would
+  be misleading.
+- `hasAffiliateContent` (`BlogArticleView.tsx:37`) still uses a
+  hardcoded substring check for `try.monday.com` as a fallback.
+  That's pre-existing technical debt; this PR doesn't address it.
+
+## Deferred
+
+- Per-post unique OG images (currently every post shares
+  `og-default.png`).
+- Affiliate-program revenue reconciliation (clicks tracked in
+  `affiliate_clicks` table, but no link to commission data).
+- A more rigorous affiliate-anchor detector that walks all known
+  partner URLs from the `affiliate_partners` table instead of just
+  matching `data_context.affiliate_url`. Out of scope -- the
+  generator only injects ONE partner per post anyway.
+
+## Verification
+
+- `npx vitest run src/components/BlogArticleView.test.tsx` ->
+  6 tests passed (1 existing + 5 new).
+- `npm run build` in `atlas-churn-ui` -> 83-URL sitemap, no TS
+  errors, 83 prerendered routes.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> expected to pass.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `BlogArticleView.tsx` (decorator refactor + CTA rel) | ~40 |
+| `BlogArticleView.test.tsx` (5 new tests + comments) | ~115 |
+| Plan doc | ~120 |
+| **Total** | **~275** |


### PR DESCRIPTION
## Tag affiliate anchors with rel="sponsored" in BlogArticleView

Plan: plans/PR-Blog-Affiliate-Sponsored-Rel.md

The visible affiliate-disclosure block at the top of each post (\`BlogArticleView.tsx:192-204\`) already satisfies FTC visibility. What was missing: the \`rel=\"sponsored\"\` attribute on the actual affiliate anchor tags. Google's link attribution guidelines require sponsored/paid links to declare the commercial relationship via \`rel\`. The \`reports/affiliate-system-investigation.md\` doc (committed in PR #617) flagged this as a real legal-risk gap.

Two surfaces fixed:

1. **Inline affiliate anchors inside post body content.** The \`decorateAffiliateLinks\` helper previously only ran when the admin-only \`highlightAffiliateLinks\` preview flag was true, so production renders had no rel tagging at all. Refactored so \`rel=\"sponsored\"\` tagging runs unconditionally when \`data_context.affiliate_url\` is set; visual outline + \`data-preview-affiliate\` markers stay gated on the preview flag.
2. **The CTA button anchor.** Previously hardcoded to \`rel=\"noopener noreferrer\"\`; now \`rel=\"sponsored noopener noreferrer\"\` when \`cta.mode === 'affiliate'\` and the prior value when \`cta.mode === 'generic'\`.

Existing rel tokens are preserved via a token Set merge -- security attributes (\`noopener\`, \`noreferrer\`) don't get clobbered.

## Intentional

- \`sponsored\` only, not \`nofollow sponsored\`. Modern Google guidance treats sponsored as implying the relationship without needing nofollow.
- Admin diagnostic anchor in \`BlogReview.tsx:806-813\` (which displays the affiliate URL as a clickable link in a sidebar info panel) is NOT updated. That anchor is admin-only, not a customer-facing recommendation; tagging it as sponsored would be misleading.

## Deferred

- Per-post unique OG images.
- Revenue reconciliation between \`affiliate_clicks\` and commission data.
- A more rigorous affiliate-anchor detector that walks all known partner URLs from the \`affiliate_partners\` table.

## Verification

- \`npx vitest run src/components/BlogArticleView.test.tsx\` -> 6 tests passed (1 existing + 5 new covering both render paths).
- \`npm run build\` in atlas-churn-ui -> 83-URL sitemap, no TS errors, 83 prerendered routes.
- \`git diff --check\` -> passed.
- \`scripts/local_pr_review.sh\` -> passed.

## Diff size

3 files, +293 / -9.