### PR TITLE
Clear merged placeholder URL gate inflight row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T17:50Z by codex-2026-05-19
+Last updated: 2026-05-19T18:07Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Placeholder-Url-Gate | `extracted_content_pipeline/campaign_generation.py`, `tests/test_extracted_campaign_generation.py`, `plans/PR-Content-Ops-Placeholder-Url-Gate.md` | codex-2026-05-19 | Campaign generation persistence guard, live-output smoke/link policy |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Clear-Placeholder-Url-Gate-Inflight.md
+++ b/plans/PR-Clear-Placeholder-Url-Gate-Inflight.md
@@ -1,0 +1,51 @@
+# PR-Clear-Placeholder-Url-Gate-Inflight
+
+## Why this slice exists
+
+PR #641 merged, so its coordination row should not remain in
+`docs/extraction/coordination/inflight.md`. Leaving the row would make the
+next builder session think the campaign-generation placeholder URL guard is
+still reserved.
+
+## Scope (this PR)
+
+1. Remove the merged `PR-Content-Ops-Placeholder-Url-Gate` row from the
+   in-flight coordination ledger.
+2. Update the ledger timestamp.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Clear-Placeholder-Url-Gate-Inflight.md`
+
+## Mechanism
+
+This is a documentation-only ledger cleanup. No production code changes.
+
+## Intentional
+
+- The table is left empty because there are no remaining rows in this ledger
+  after the merged slice is removed.
+
+## Deferred
+
+- None.
+
+## Verification
+
+Local checks:
+
+```bash
+bash scripts/local_pr_review.sh
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Clear-Placeholder-Url-Gate-Inflight.md` | 51 |
+| **Total** | **54** |
+
+Below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Clear-Placeholder-Url-Gate-Inflight.md

Remove the merged PR #641 coordination row so future sessions do not treat the placeholder URL gate slice as still reserved.

## Intentional
- Documentation-only cleanup after PR #641 merged.

## Deferred
- None.

## Verification
- bash scripts/local_pr_review.sh

## Diff size
2 files, +52 / -2