### PR TITLE
Add real booking URL wiring to review-source smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T18:07Z by codex-2026-05-19
+Last updated: 2026-05-19T18:14Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Ops-Real-Asset-Url-CTA | `scripts/smoke_content_ops_review_source_postgres.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `plans/PR-Content-Ops-Real-Asset-Url-CTA.md` | codex-2026-05-19 | Review-source live provider smoke, campaign selling/booking URL contract |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Real-Asset-Url-CTA.md
+++ b/plans/PR-Content-Ops-Real-Asset-Url-CTA.md
@@ -1,0 +1,98 @@
+# PR-Content-Ops-Real-Asset-Url-CTA
+
+## Why this slice exists
+
+PR #641 correctly blocks placeholder URLs before campaign drafts are saved, but
+the live G2 provider proof now fail-closes because the smoke input does not
+provide a real selling or booking URL. The next production step is to let host
+operators provide a real CTA URL on the live smoke path so provider-generated
+drafts can pass with useful, non-fabricated links.
+
+This slice should not relax the placeholder URL gate. It gives the existing
+campaign prompt a real `selling.booking_url` value through the same opportunity
+JSON contract it already consumes.
+
+## Scope (this PR)
+
+1. Add a narrow `--booking-url` option to the review-source Postgres smoke.
+2. Inject the URL as source-row fallback metadata only for the smoke's imported
+   opportunities, preserving existing `--default-field` behavior.
+3. Add tests proving the booking URL reaches generation through the imported
+   opportunity payload and that blank values are ignored.
+
+### Files touched
+
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `tests/test_smoke_content_ops_review_source_postgres.py`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Real-Asset-Url-CTA.md`
+
+## Mechanism
+
+`scripts/smoke_content_ops_review_source_postgres.py` already parses
+repeatable `--default-field key=value` metadata and passes it through
+the ingestion inspector and source opportunity loader.
+This PR should add a first-class `--booking-url` operator flag that injects a
+nested `{"selling": {"booking_url": "<url>"}}` value into the same defaults map
+before ingestion and import.
+
+The campaign prompt already receives the normalized opportunity as
+`{opportunity_json}` in `CampaignGenerationService._generate_one()`, and the
+outreach skill already instructs the model to include `selling.booking_url`.
+
+## Intentional
+
+- This is smoke/operator wiring, not a new campaign-generation abstraction.
+  The generation service should keep accepting arbitrary opportunity metadata.
+- The placeholder URL gate remains fail-closed. Hosts must provide a real URL
+  for live CTA links.
+- This slice only covers the review-source Postgres smoke path that exposed the
+  bug. Broader asset URL UX is separate.
+
+## Deferred
+
+- General Content Ops UI/API fields for account-level selling assets.
+- Automatic lookup of published blog posts or booking URLs from host settings.
+- URL validation beyond blank/nonblank input. The existing placeholder URL gate
+  remains the enforcement point before persistence.
+
+## Verification
+
+Local checks:
+
+```bash
+pytest tests/test_smoke_content_ops_review_source_postgres.py
+# 13 passed
+
+python -m py_compile scripts/smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_review_source_postgres.py
+# passed
+
+bash scripts/local_pr_review.sh
+# passed
+
+python scripts/smoke_content_ops_review_source_postgres.py \
+  --source g2 --vendor Slack --limit 1 \
+  --account-id content_ops_live_g2_real_url_<timestamp> \
+  --llm pipeline --channels email_cold,email_followup --min-drafts 2 \
+  --default-field 'company_name=Acme Logistics' \
+  --default-field 'contact_email=ops@example.com' \
+  --default-field 'contact_name=Jordan Lee' \
+  --booking-url https://juancanfield.com/ --json
+# live provider/Postgres path passed: 2 generated, 2 saved, 0 skipped
+```
+
+If the focused checks pass, rerun the G2 live-provider smoke with a real
+booking URL and confirm it persists at least two drafts without
+`placeholder_url` errors.
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `scripts/smoke_content_ops_review_source_postgres.py` | 24 |
+| `tests/test_smoke_content_ops_review_source_postgres.py` | 41 |
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Content-Ops-Real-Asset-Url-CTA.md` | 96 |
+| **Total** | **164** |
+
+Below the 400 LOC review budget.

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -110,6 +110,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--booking-url",
+        default=None,
+        help=(
+            "Real booking or selling asset URL added to imported opportunities "
+            "as selling.booking_url."
+        ),
+    )
+    parser.add_argument(
         "--account-id",
         required=True,
         help="Tenant/account id used to scope imported opportunities and drafts.",
@@ -161,6 +169,20 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
 
 
+def _default_fields_for_args(args: argparse.Namespace) -> dict[str, Any]:
+    defaults: dict[str, Any] = parse_default_fields_or_exit(args.default_field)
+    booking_url = str(getattr(args, "booking_url", "") or "").strip()
+    if not booking_url:
+        return defaults
+    selling = defaults.get("selling")
+    selling_defaults = dict(selling) if isinstance(selling, Mapping) else {}
+    defaults["selling"] = {
+        **selling_defaults,
+        "booking_url": booking_url,
+    }
+    return defaults
+
+
 async def _fetch_review_inputs(
     pool: Any,
     args: argparse.Namespace,
@@ -204,7 +226,7 @@ async def run_review_source_postgres_smoke(
     *,
     source_rows_path: Path,
 ) -> tuple[int, dict[str, Any]]:
-    default_fields = parse_default_fields_or_exit(args.default_field)
+    default_fields = _default_fields_for_args(args)
     channels = _csv_list(args.channels)
     min_drafts = (
         int(args.min_drafts)

--- a/tests/test_smoke_content_ops_review_source_postgres.py
+++ b/tests/test_smoke_content_ops_review_source_postgres.py
@@ -177,6 +177,7 @@ def _args(**overrides):
             "contact_email=ops@example.com",
             "contact_name=Jordan Lee",
         ],
+        "booking_url": None,
         "account_id": "acct-smoke",
         "user_id": None,
         "opportunity_table": "campaign_opportunities",
@@ -200,6 +201,21 @@ def test_parse_args_defaults_to_offline_llm():
     ])
 
     assert args.llm == "offline"
+
+
+def test_default_fields_for_args_adds_booking_url_to_selling_context():
+    defaults = smoke._default_fields_for_args(
+        _args(booking_url=" https://app.example.test/book ")
+    )
+
+    assert defaults["company_name"] == "Acme Logistics"
+    assert defaults["selling"] == {"booking_url": "https://app.example.test/book"}
+
+
+def test_default_fields_for_args_ignores_blank_booking_url():
+    defaults = smoke._default_fields_for_args(_args(booking_url="   "))
+
+    assert "selling" not in defaults
 
 
 @pytest.mark.asyncio
@@ -238,6 +254,31 @@ async def test_review_source_postgres_smoke_imports_and_persists(monkeypatch, tm
     assert any("INSERT INTO b2b_campaigns" in call["query"] for call in pool.fetchval_calls)
     assert "FROM b2b_campaigns" in pool.fetch_calls[-1]["query"]
     assert pool.fetch_calls[2]["args"] == ("vendor_retention", "acct-smoke", "review-1", 1)
+
+
+@pytest.mark.asyncio
+async def test_review_source_postgres_smoke_imports_booking_url_metadata(
+    monkeypatch,
+    tmp_path,
+):
+    pool = _Pool(
+        summary_rows=[_summary_row()],
+        source_rows=[_source_row()],
+        opportunity_rows=[_opportunity_row()],
+        saved_draft_rows=[_saved_draft_row()],
+    )
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_review_source_postgres_smoke(
+        _args(booking_url="https://app.example.test/book"),
+        source_rows_path=tmp_path / "g2_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    insert_args = pool.execute_calls[1]["args"]
+    raw_payload = json.loads(insert_args[13])
+    assert raw_payload["selling"] == {"booking_url": "https://app.example.test/book"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Real-Asset-Url-CTA.md

Add a first-class --booking-url option to the review-source Postgres smoke so live provider runs can pass a real selling/booking URL into imported opportunities instead of generating placeholder links that the #641 guard correctly blocks.

## Intentional
- Uses the existing source-row default metadata path and imported opportunity JSON contract.
- Does not weaken the placeholder URL persistence gate.
- Keeps broader account-level selling asset configuration deferred.

## Deferred
- General Content Ops UI/API fields for account-level selling assets.
- Automatic lookup of published blog posts or booking URLs from host settings.
- URL validation beyond blank/nonblank input; placeholder enforcement remains at persistence.

## Verification
- pytest tests/test_smoke_content_ops_review_source_postgres.py
- python -m py_compile scripts/smoke_content_ops_review_source_postgres.py tests/test_smoke_content_ops_review_source_postgres.py
- bash scripts/local_pr_review.sh

## Diff size
4 files, +154 / -2