### PR TITLE
Clear merged real asset URL inflight row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T18:14Z by codex-2026-05-19
+Last updated: 2026-05-19T18:23Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Real-Asset-Url-CTA | `scripts/smoke_content_ops_review_source_postgres.py`, `tests/test_smoke_content_ops_review_source_postgres.py`, `plans/PR-Content-Ops-Real-Asset-Url-CTA.md` | codex-2026-05-19 | Review-source live provider smoke, campaign selling/booking URL contract |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Clear-Real-Asset-Url-CTA-Inflight.md
+++ b/plans/PR-Clear-Real-Asset-Url-CTA-Inflight.md
@@ -1,0 +1,47 @@
+# PR-Clear-Real-Asset-Url-CTA-Inflight
+
+## Why this slice exists
+
+PR #645 merged, so its coordination row should not remain in the in-flight ledger.
+Leaving it there would make future sessions think the real booking URL smoke slice is still reserved.
+
+## Scope (this PR)
+
+1. Remove the merged `PR-Content-Ops-Real-Asset-Url-CTA` row.
+2. Update the in-flight ledger timestamp.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Clear-Real-Asset-Url-CTA-Inflight.md`
+
+## Mechanism
+
+Documentation-only ledger cleanup. No production code changes.
+
+## Intentional
+
+- The in-flight table is left empty because no active Content Ops row remains after PR #645.
+
+## Deferred
+
+- None.
+
+## Verification
+
+Local checks:
+
+```bash
+bash scripts/local_pr_review.sh
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Clear-Real-Asset-Url-CTA-Inflight.md` | 47 |
+| **Total** | **50** |
+
+Below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Clear-Real-Asset-Url-CTA-Inflight.md

Remove the merged PR #645 coordination row so future sessions do not treat the real asset URL CTA slice as reserved.

## Intentional
- Documentation-only cleanup after PR #645 merged.

## Deferred
- None.

## Verification
- bash scripts/local_pr_review.sh

## Diff size
2 files, +48 / -2