### PR TITLE
Productize campaign selling context inputs

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T18:23Z by codex-2026-05-19
+Last updated: 2026-05-19T18:54Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Selling-Context-Inputs | `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/campaign_generation.py`, `tests/test_extracted_content_ops_execution.py`, `tests/test_extracted_campaign_generation.py` | codex-2026-05-19 | Campaign execution dispatcher, campaign prompt opportunity metadata |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -215,8 +215,25 @@ python scripts/smoke_content_ops_review_source_postgres.py \
   --account-id acct_123 \
   --default-field company_name="Acme Logistics" \
   --default-field contact_email=ops@example.com \
+  --booking-url https://book.customer.com/demo \
   --llm pipeline \
   --json
+```
+
+For hosted Content Ops execution, pass the same selling asset through request
+inputs so every generated campaign opportunity sees it in `opportunity_json`:
+
+```json
+{
+  "outputs": ["email_campaign"],
+  "inputs": {
+    "target_account": "Acme Logistics",
+    "offer": "Churn audit",
+    "selling": {
+      "booking_url": "https://book.customer.com/demo"
+    }
+  }
+}
 ```
 
 Public CFPB complaint narratives can also seed the same source-row path when

--- a/extracted_content_pipeline/campaign_generation.py
+++ b/extracted_content_pipeline/campaign_generation.py
@@ -146,6 +146,37 @@ def _contains_placeholder_url(value: Any) -> bool:
     return bool(_PLACEHOLDER_URL_RE.search(str(value or "")))
 
 
+def _clean_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): item
+        for key, item in value.items()
+        if str(key).strip() and item not in (None, "", [], {})
+    }
+
+
+def _merge_opportunity_defaults(
+    opportunity: Mapping[str, Any],
+    defaults: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    clean_defaults = _clean_mapping(defaults)
+    if not clean_defaults:
+        return dict(opportunity)
+    merged = dict(clean_defaults)
+    merged.update(_clean_mapping(opportunity))
+    default_selling = clean_defaults.get("selling")
+    row_selling = opportunity.get("selling")
+    if isinstance(default_selling, Mapping) and isinstance(row_selling, Mapping):
+        selling = {
+            **_clean_mapping(default_selling),
+            **_clean_mapping(row_selling),
+        }
+        if selling:
+            merged["selling"] = selling
+    return merged
+
+
 @dataclass(frozen=True)
 class CampaignGenerationConfig:
     skill_name: str = "digest/b2b_campaign_generation"
@@ -285,6 +316,7 @@ class CampaignGenerationService:
         quality_revalidation_enabled: bool | None = None,
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
+        opportunity_defaults: Mapping[str, Any] | None = None,
     ) -> CampaignGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -324,7 +356,10 @@ class CampaignGenerationService:
 
         requested = int(limit or self._config.limit)
         opportunities = [
-            normalize_campaign_opportunity(row, target_mode=target_mode)
+            normalize_campaign_opportunity(
+                _merge_opportunity_defaults(row, opportunity_defaults),
+                target_mode=target_mode,
+            )
             for row in await self._intelligence.read_campaign_opportunities(
                 scope=scope,
                 target_mode=target_mode,

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -380,25 +380,29 @@ async def _dispatch_email_campaign(
     scope: TenantScope,
     filters: Mapping[str, Any] | None,
 ) -> Any:
-    return await service.generate(
-        scope=scope,
-        target_mode=request.target_mode,
-        limit=request.limit,
-        filters=filters,
-        channels=_step_config_sequence(step.config, "channels"),
-        temperature=_step_config_float(step.config, "temperature"),
-        max_tokens=_step_config_int(step.config, "max_tokens"),
-        parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
-        quality_revalidation_enabled=_step_config_bool(
+    kwargs: dict[str, Any] = {
+        "scope": scope,
+        "target_mode": request.target_mode,
+        "limit": request.limit,
+        "filters": filters,
+        "channels": _step_config_sequence(step.config, "channels"),
+        "temperature": _step_config_float(step.config, "temperature"),
+        "max_tokens": _step_config_int(step.config, "max_tokens"),
+        "parse_retry_attempts": _step_config_int(step.config, "parse_retry_attempts"),
+        "quality_revalidation_enabled": _step_config_bool(
             step.config, "quality_revalidation_enabled"
         ),
-        quality_prompt_proof_term_limit=_step_config_int(
+        "quality_prompt_proof_term_limit": _step_config_int(
             step.config, "quality_prompt_proof_term_limit"
         ),
-        parse_retry_response_excerpt_chars=_step_config_int(
+        "parse_retry_response_excerpt_chars": _step_config_int(
             step.config, "parse_retry_response_excerpt_chars"
         ),
-    )
+    }
+    opportunity_defaults = _opportunity_defaults_from_inputs(request.inputs)
+    if opportunity_defaults is not None:
+        kwargs["opportunity_defaults"] = opportunity_defaults
+    return await service.generate(**kwargs)
 
 
 async def _dispatch_report(
@@ -643,6 +647,26 @@ def _step_config_sequence(
 def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:
     filters = inputs.get("filters")
     return filters if isinstance(filters, Mapping) else None
+
+
+def _opportunity_defaults_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    defaults: dict[str, Any] = {}
+    selling = inputs.get("selling")
+    selling_defaults = dict(selling) if isinstance(selling, Mapping) else {}
+    booking_url = (
+        _clean(inputs.get("booking_url"))
+        or _clean(inputs.get("selling_booking_url"))
+    )
+    if booking_url and not _clean(selling_defaults.get("booking_url")):
+        selling_defaults["booking_url"] = booking_url
+    selling_defaults = {
+        str(key): value
+        for key, value in selling_defaults.items()
+        if str(key).strip() and value not in (None, "", [], {})
+    }
+    if selling_defaults:
+        defaults["selling"] = selling_defaults
+    return defaults or None
 
 
 # PR-OptionA-4: explicit allowlist of MarketingCampaign.context fields.

--- a/plans/PR-Content-Selling-Context-Inputs.md
+++ b/plans/PR-Content-Selling-Context-Inputs.md
@@ -1,0 +1,78 @@
+# PR-Content-Selling-Context-Inputs
+
+## Why this slice exists
+
+PR-Content-Ops-Real-Asset-Url-CTA proved that live campaign drafts can use a real booking URL, but the URL is only wired through the review-source Postgres smoke script. The product execution path still has no first-class way for a host/API caller to pass selling context at request time. This slice makes `inputs.selling.booking_url` a real Content Ops execution input for email campaign generation while preserving the placeholder-URL fail-close gate already merged in `CampaignGenerationService`.
+
+## Scope (this PR)
+
+1. Thread request-level campaign opportunity defaults from `ContentOpsRequest.inputs` into the email campaign dispatcher.
+2. Teach `CampaignGenerationService.generate` to merge those defaults into each normalized opportunity without overwriting row-provided data.
+3. Regression-test both seams: dispatcher input propagation and real campaign prompt/source metadata visibility.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Selling-Context-Inputs.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/campaign_generation.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_campaign_generation.py`
+
+## Mechanism
+
+The API already accepts arbitrary bounded `inputs`; no route model change is required. `content_ops_execution._dispatch_email_campaign` extracts an opportunity-defaults mapping from `request.inputs`, currently limited to:
+
+```python
+{"selling": request.inputs["selling"]}
+```
+
+or a flat `booking_url` / `selling_booking_url` convenience input promoted to:
+
+```python
+{"selling": {"booking_url": "..."}}
+```
+
+The dispatcher passes that mapping as `opportunity_defaults` to `CampaignGenerationService.generate`. The service merges defaults into each opportunity after the repository read and before reasoning, channel shaping, prompt rendering, quality revalidation, and metadata persistence. Row fields win over defaults; nested `selling` mappings are merged so a row-specific `selling.booking_url` is not replaced by a request-level fallback.
+
+## Intentional
+
+- No new FastAPI model field: `inputs` is already the product extension point and is depth/size bounded by the API validator.
+- No prompt change: the packaged campaign skill already consumes `opportunity_json`, and `selling.booking_url` is already part of that contract.
+- No URL validation beyond the existing placeholder gate: hosts can pass customer-owned booking/asset URLs, and the persistence boundary still rejects placeholder URLs emitted by the LLM.
+- Only email campaign execution uses `opportunity_defaults` in this slice. Other opportunity-driven assets can adopt the same seam later if they need selling context.
+
+## Deferred
+
+- Generic CLI sugar for `--booking-url` outside the review-source smoke script. The core product/API path lands here first; source conversion/import CLIs can add convenience flags in a follow-up without changing generation behavior.
+- Richer selling context schema validation. For now the product preserves host-provided mappings instead of inventing a premature schema.
+
+## Verification
+
+Commands run:
+
+```bash
+pytest tests/test_extracted_content_ops_execution.py tests/test_extracted_campaign_generation.py  # 94 passed
+python -m py_compile extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/campaign_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_campaign_generation.py
+bash scripts/validate_extracted_content_pipeline.sh
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+python scripts/audit_extracted_standalone.py --fail-on-debt
+bash scripts/check_ascii_python.sh
+bash scripts/local_pr_review.sh --allow-dirty
+```
+
+## Estimated diff size
+
+| File | LOC churn (approx) |
+|---|---:|
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Content-Selling-Context-Inputs.md` | 72 |
+| `extracted_content_pipeline/README.md` | 17 |
+| `extracted_content_pipeline/content_ops_execution.py` | 50 |
+| `extracted_content_pipeline/campaign_generation.py` | 37 |
+| `tests/test_extracted_content_ops_execution.py` | 106 |
+| `tests/test_extracted_campaign_generation.py` | 72 |
+| **Total** | **357** |
+
+Below the 400 LOC review budget.

--- a/tests/test_extracted_campaign_generation.py
+++ b/tests/test_extracted_campaign_generation.py
@@ -290,6 +290,78 @@ async def test_generate_reads_opportunities_prompts_llm_and_saves_drafts():
 
 
 @pytest.mark.asyncio
+async def test_generate_merges_opportunity_defaults_into_prompt_and_metadata():
+    service, _intelligence, campaigns, llm, _skills = _service(
+        [{"id": "opp-1", "company_name": "Acme", "vendor": "Slack"}],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "<p>Pricing note. Book: https://customer.test/book</p>",
+            "cta": "Book time: https://customer.test/book",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        opportunity_defaults={
+            "selling": {
+                "booking_url": "https://customer.test/book",
+                "sender_name": "Juan",
+            }
+        },
+    )
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert '"booking_url":"https://customer.test/book"' in prompt
+    assert '"sender_name":"Juan"' in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert source["selling"] == {
+        "booking_url": "https://customer.test/book",
+        "sender_name": "Juan",
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_opportunity_selling_context_wins_over_defaults():
+    service, _intelligence, campaigns, llm, _skills = _service(
+        [
+            {
+                "id": "opp-1",
+                "company_name": "Acme",
+                "selling": {"booking_url": "https://row.test/book"},
+            }
+        ],
+        [json.dumps({
+            "subject": "Acme signal",
+            "body": "<p>Book: https://row.test/book</p>",
+            "cta": "Book time: https://row.test/book",
+        })],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        opportunity_defaults={
+            "selling": {
+                "booking_url": "https://default.test/book",
+                "sender_name": "Juan",
+            }
+        },
+    )
+
+    assert result.generated == 1
+    prompt = llm.calls[0]["messages"][0].content
+    assert '"booking_url":"https://row.test/book"' in prompt
+    assert "https://default.test/book" not in prompt
+    source = campaigns.saved[0]["drafts"][0].metadata["source_opportunity"]
+    assert source["selling"] == {
+        "booking_url": "https://row.test/book",
+        "sender_name": "Juan",
+    }
+
+
+@pytest.mark.asyncio
 async def test_generate_skips_draft_with_placeholder_url_in_body():
     service, _, campaigns, _, _ = _service(
         [{"id": "opp-1", "company_name": "Acme"}],

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -63,6 +63,7 @@ class _OpportunityService:
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
         topic: str | None = None,
+        opportunity_defaults: Mapping[str, Any] | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -81,6 +82,7 @@ class _OpportunityService:
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "quality_gates_enabled": quality_gates_enabled,
             "topic": topic,
+            "opportunity_defaults": dict(opportunity_defaults or {}),
             "extras": dict(extras),
         })
         return _Result()
@@ -96,6 +98,40 @@ class _ReasoningAwareOpportunityService(_OpportunityService):
         provider: Any | None,
     ) -> "_ReasoningAwareOpportunityService":
         return _ReasoningAwareOpportunityService(reasoning_context=provider)
+
+
+class _StrictCampaignService:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+        channels: Any | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        parse_retry_attempts: int | None = None,
+        quality_revalidation_enabled: bool | None = None,
+        quality_prompt_proof_term_limit: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
+    ) -> _Result:
+        del scope
+        del target_mode
+        del limit
+        del filters
+        del channels
+        del temperature
+        del max_tokens
+        del parse_retry_attempts
+        del quality_revalidation_enabled
+        del quality_prompt_proof_term_limit
+        del parse_retry_response_excerpt_chars
+        self.calls += 1
+        return _Result()
 
 
 def test_services_with_reasoning_context_can_target_specific_outputs() -> None:
@@ -303,6 +339,7 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
     assert campaign_call["filters"] == {"status": "ready"}
     # Plan default channels reach the service even without per-request override.
     assert campaign_call["channels"] == ("email_cold", "email_followup")
+    assert campaign_call["opportunity_defaults"] == {}
     assert campaign_call["default_report_type"] is None
     # extras locks the kwarg surface: a typo'd kwarg in PR-OptionA-2/3 would
     # silently land here and never reach the right service field.
@@ -316,6 +353,7 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
     # Plan default report type reaches the service.
     assert report_call["default_report_type"] == "vendor_pressure"
     assert report_call["channels"] is None
+    assert report_call["opportunity_defaults"] == {}
     assert report_call["extras"] == {}
 
 
@@ -532,6 +570,74 @@ async def test_execute_threads_user_selected_channels_into_email_campaign_servic
 
     assert result["status"] == "completed"
     assert campaign.calls[0]["channels"] == ("email_cold",)
+    assert campaign.calls[0]["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_omits_opportunity_defaults_when_selling_context_absent() -> None:
+    campaign = _StrictCampaignService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_selling_context_into_email_campaign_service() -> None:
+    campaign = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "selling": {
+                    "booking_url": "https://customer.test/book",
+                    "sender_name": "Juan",
+                },
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls[0]["opportunity_defaults"] == {
+        "selling": {
+            "booking_url": "https://customer.test/book",
+            "sender_name": "Juan",
+        }
+    }
+    assert campaign.calls[0]["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_promotes_flat_booking_url_into_selling_context() -> None:
+    campaign = _OpportunityService()
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+                "booking_url": "https://customer.test/book",
+            },
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls[0]["opportunity_defaults"] == {
+        "selling": {"booking_url": "https://customer.test/book"}
+    }
     assert campaign.calls[0]["extras"] == {}
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Selling-Context-Inputs.md

Productizes the real CTA/selling URL path beyond the review-source smoke script by making request-level selling context part of the email campaign execution seam. Content Ops callers can now pass inputs.selling.booking_url, or flat booking_url / selling_booking_url, and the campaign service merges it into each opportunity before reasoning, prompt rendering, quality gates, and metadata persistence.

## Intentional
- Uses inputs as the API extension point instead of adding a new route field.
- Passes opportunity_defaults only when selling context exists so older host-injected campaign services keep working for default requests.
- Keeps the existing placeholder URL fail-close gate as the persistence boundary.

## Deferred
- Generic source conversion/import CLI --booking-url support.
- Richer selling context schema validation.

## Verification
- pytest tests/test_extracted_content_ops_execution.py tests/test_extracted_campaign_generation.py -> 94 passed
- python -m py_compile extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/campaign_generation.py tests/test_extracted_content_ops_execution.py tests/test_extracted_campaign_generation.py -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
7 files, +348 / -15