### PR TITLE
Clear merged selling-context coordination row

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T18:54Z by codex-2026-05-19
+Last updated: 2026-05-19T18:55Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Selling-Context-Inputs | `extracted_content_pipeline/content_ops_execution.py`, `extracted_content_pipeline/campaign_generation.py`, `tests/test_extracted_content_ops_execution.py`, `tests/test_extracted_campaign_generation.py` | codex-2026-05-19 | Campaign execution dispatcher, campaign prompt opportunity metadata |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Clear-Selling-Context-Inflight.md
+++ b/plans/PR-Clear-Selling-Context-Inflight.md
@@ -1,0 +1,47 @@
+# PR-Clear-Selling-Context-Inflight
+
+## Why this slice exists
+
+PR #647 merged, so its coordination row in `docs/extraction/coordination/inflight.md` is stale. The coordination ledger should only show active work.
+
+## Scope (this PR)
+
+1. Remove the merged PR-Content-Selling-Context-Inputs row from the inflight ledger.
+2. Update the ledger timestamp.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Clear-Selling-Context-Inflight.md`
+
+## Mechanism
+
+Delete the single row for the merged selling-context slice. No product code changes.
+
+## Intentional
+
+- This is housekeeping only.
+- No changes to queue ordering or other coordination docs.
+
+## Deferred
+
+- None.
+
+## Verification
+
+Commands run:
+
+```bash
+bash scripts/local_pr_review.sh --allow-dirty
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC churn |
+|---|---:|
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `plans/PR-Clear-Selling-Context-Inflight.md` | 36 |
+| **Total** | **39** |
+
+Below the 400 LOC review budget.


### PR DESCRIPTION
Plan: plans/PR-Clear-Selling-Context-Inflight.md

Removes the stale inflight coordination row for PR #647 after merge.

## Intentional
- Housekeeping only.

## Deferred
- None.

## Verification
- bash scripts/local_pr_review.sh -> passed

## Diff size
2 files, +47 / -2