### PR TITLE
Add source-row booking URL CLI sugar

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,5 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Selling-Url-Source-Cli | `extracted_content_pipeline/campaign_source_adapters.py`; source-row CLIs; source adapter/generation/smoke tests | codex-2026-05-19 | Avoid concurrent edits to source-row default-field parsing or `--booking-url` CLI flags. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -320,7 +320,8 @@ directly:
 python scripts/run_extracted_campaign_generation_example.py \
   extracted_content_pipeline/examples/campaign_source_rows.jsonl \
   --source-rows \
-  --source-format jsonl
+  --source-format jsonl \
+  --booking-url https://book.customer.com/demo
 
 python scripts/run_extracted_campaign_generation_example.py \
   extracted_content_pipeline/examples/campaign_source_bundle.json \
@@ -348,7 +349,9 @@ generation, import, or smoke commands.
 For anonymous review exports such as G2 rows without buyer/contact columns,
 repeat `--default-field key=value` to bind the evidence to a target account at
 conversion, generation, inspection, smoke, or import time. Source-row values
-win when both the row and the default provide the same field.
+win when both the row and the default provide the same field. Use
+`--booking-url` on the source conversion or generation commands to apply a
+fallback `selling.booking_url` CTA to every converted opportunity.
 For customer bundle JSON files that group collections such as `reviews`,
 `support_tickets`, `surveys`, `calls`, `meetings`, `deals`, `account_notes`,
 `contracts`, `renewals`, or `subscriptions` under shared account metadata, use

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -379,6 +379,26 @@ def parse_default_fields_or_exit(values: Sequence[str] | None) -> dict[str, str]
         raise SystemExit(str(exc)) from exc
 
 
+def parse_default_fields_with_booking_url_or_exit(
+    values: Sequence[str] | None,
+    *,
+    booking_url: str | None = None,
+) -> dict[str, Any]:
+    """Parse CLI defaults and add an optional selling booking URL."""
+
+    defaults: dict[str, Any] = parse_default_fields_or_exit(values)
+    cleaned_url = str(booking_url or "").strip()
+    if not cleaned_url:
+        return defaults
+    selling = defaults.get("selling")
+    selling_defaults = dict(selling) if isinstance(selling, Mapping) else {}
+    defaults["selling"] = {
+        **selling_defaults,
+        "booking_url": cleaned_url,
+    }
+    return defaults
+
+
 def _clean_default_fields(default_fields: Mapping[str, Any] | None) -> dict[str, Any]:
     return {
         str(key): value
@@ -796,6 +816,7 @@ __all__ = [
     "SourceDataFormat",
     "load_source_campaign_opportunities_from_file",
     "parse_default_fields",
+    "parse_default_fields_with_booking_url_or_exit",
     "parse_default_fields_or_exit",
     "source_row_to_campaign_opportunity",
     "source_rows_to_campaign_opportunities",

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -236,6 +236,8 @@ Customer bundle JSON can group `reviews`, `support_tickets`, `surveys`,
 For JSONL or CSV source exports that do not carry shared account metadata,
 repeat `--default-field key=value` on the conversion, inspection, smoke,
 generation, or import command. Defaults are fallbacks; row-specific values win.
+Use `--booking-url` on the source conversion or offline generation commands to
+apply a fallback `selling.booking_url` CTA to every converted opportunity.
 Rows with `deal_id` or `opportunity_id` are inferred as CRM deal evidence; rows
 with `note_id` or `activity_id` are inferred as CRM note evidence.
 Rows with `contract_id`, `renewal_id`, or `subscription_id` are inferred as

--- a/plans/PR-Content-Selling-Url-Source-Cli.md
+++ b/plans/PR-Content-Selling-Url-Source-Cli.md
@@ -1,0 +1,87 @@
+# Content Selling URL Source CLI
+
+## Why this slice exists
+
+PR-Content-Selling-Context-Inputs made `inputs.selling.booking_url` a real
+hosted Content Ops execution input, but deliberately deferred generic CLI sugar.
+Source-row operators still have to remember nested `--default-field` plumbing
+or use the review-source smoke script. This slice makes the common source-row
+CLI path accept the same selling URL without changing generation behavior.
+
+## Scope (this PR)
+
+1. Add a shared source-adapter helper that combines repeatable flat
+   `--default-field` values with an optional `--booking-url` into
+   `selling.booking_url`.
+2. Wire the helper into the source-row builder CLI and offline campaign
+   generation example CLI.
+3. Replace the review-source Postgres smoke script's local helper with the
+   shared helper so the booking URL behavior has one implementation.
+4. Add focused tests for the helper and both generic CLIs.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `scripts/build_extracted_campaign_opportunities_from_sources.py`
+- `scripts/run_extracted_campaign_generation_example.py`
+- `scripts/smoke_content_ops_review_source_postgres.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_campaign_generation_example.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Selling-Url-Source-Cli.md`
+
+## Mechanism
+
+`parse_default_fields_with_booking_url_or_exit(values, booking_url=...)` reuses
+the existing `parse_default_fields_or_exit` validation, trims the booking URL,
+and merges it into a nested `selling` mapping:
+
+```python
+{"selling": {"booking_url": "https://example.test/book"}}
+```
+
+If existing defaults already include a mapping at `selling`, the helper
+preserves it and adds or replaces only `booking_url`. Blank booking URLs are
+ignored. Generic source-row CLIs pass the resulting mapping into the existing
+`load_source_campaign_opportunities_from_file(..., default_fields=...)` seam,
+so row values and existing source normalization precedence stay unchanged.
+
+## Intentional
+
+- No core generation change: PR-Content-Selling-Context-Inputs already made
+  generation consume `selling.booking_url` when it appears on opportunities.
+- No nested `--default-field selling.booking_url=...` parser. The product only
+  needs a clear operator flag for the high-value selling URL path.
+- The helper lives in the source adapter module because the value is applied as
+  source-row fallback metadata before opportunity normalization.
+
+## Deferred
+
+- Adding `--booking-url` to every Postgres/source smoke command remains a
+  follow-up if operators need it. This slice covers the generic builder and
+  offline generation commands that host users are most likely to run directly.
+- Richer selling context flags such as sender identity or published asset URLs
+  remain deferred until a host asks for them.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_smoke_content_ops_review_source_postgres.py` -> 99 passed
+- `python -m py_compile extracted_content_pipeline/campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py scripts/run_extracted_campaign_generation_example.py scripts/smoke_content_ops_review_source_postgres.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_smoke_content_ops_review_source_postgres.py` -> passed
+- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
+- `bash scripts/check_ascii_python.sh` -> passed
+- `bash scripts/local_pr_review.sh` -> passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Production + scripts | ~60 |
+| Tests | ~55 |
+| Docs + plan + coordination | ~90 |
+| **Total** | **~205** |
+
+Under the 400 LOC review budget.

--- a/scripts/build_extracted_campaign_opportunities_from_sources.py
+++ b/scripts/build_extracted_campaign_opportunities_from_sources.py
@@ -15,7 +15,7 @@ if str(ROOT) not in sys.path:
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields_or_exit,
+    parse_default_fields_with_booking_url_or_exit,
 )
 
 
@@ -52,6 +52,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--booking-url",
+        help="Fallback selling.booking_url applied to every source row.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="Write opportunity payload JSON to this path instead of stdout.",
@@ -68,7 +72,10 @@ def main(argv: list[str] | None = None) -> int:
         file_format=args.format,
         target_mode=args.target_mode,
         max_text_chars=args.max_text_chars,
-        default_fields=parse_default_fields_or_exit(args.default_field),
+        default_fields=parse_default_fields_with_booking_url_or_exit(
+            args.default_field,
+            booking_url=args.booking_url,
+        ),
     )
     payload = loaded.as_payload(
         target_mode=args.target_mode,

--- a/scripts/run_extracted_campaign_generation_example.py
+++ b/scripts/run_extracted_campaign_generation_example.py
@@ -23,7 +23,7 @@ from extracted_content_pipeline.campaign_customer_data import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields_or_exit,
+    parse_default_fields_with_booking_url_or_exit,
 )
 from extracted_content_pipeline.campaign_reasoning_data import (  # noqa: E402
     load_reasoning_provider_port,
@@ -132,6 +132,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Fallback metadata applied to every source row when --source-rows "
             "is selected. Repeat as key=value."
         ),
+    )
+    parser.add_argument(
+        "--booking-url",
+        help="Fallback selling.booking_url applied to source-row opportunities.",
     )
     parser.add_argument(
         "--limit",
@@ -329,7 +333,10 @@ async def _main() -> int:
         source_rows=bool(args.source_rows),
         source_format=args.source_format,
         max_source_text_chars=int(args.max_source_text_chars),
-        default_fields=parse_default_fields_or_exit(args.default_field),
+        default_fields=parse_default_fields_with_booking_url_or_exit(
+            args.default_field,
+            booking_url=args.booking_url if args.source_rows else None,
+        ),
     )
     if args.target_mode:
         payload["target_mode"] = args.target_mode

--- a/scripts/smoke_content_ops_review_source_postgres.py
+++ b/scripts/smoke_content_ops_review_source_postgres.py
@@ -26,7 +26,7 @@ from extracted_content_pipeline.campaign_postgres_import import (  # noqa: E402
 )
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
-    parse_default_fields_or_exit,
+    parse_default_fields_with_booking_url_or_exit,
 )
 from extracted_content_pipeline.ingestion_diagnostics import (  # noqa: E402
     inspect_ingestion_file,
@@ -170,17 +170,10 @@ def _validate_args(args: argparse.Namespace) -> None:
 
 
 def _default_fields_for_args(args: argparse.Namespace) -> dict[str, Any]:
-    defaults: dict[str, Any] = parse_default_fields_or_exit(args.default_field)
-    booking_url = str(getattr(args, "booking_url", "") or "").strip()
-    if not booking_url:
-        return defaults
-    selling = defaults.get("selling")
-    selling_defaults = dict(selling) if isinstance(selling, Mapping) else {}
-    defaults["selling"] = {
-        **selling_defaults,
-        "booking_url": booking_url,
-    }
-    return defaults
+    return parse_default_fields_with_booking_url_or_exit(
+        args.default_field,
+        booking_url=getattr(args, "booking_url", None),
+    )
 
 
 async def _fetch_review_inputs(

--- a/tests/test_extracted_campaign_generation_example.py
+++ b/tests/test_extracted_campaign_generation_example.py
@@ -355,6 +355,8 @@ def test_campaign_generation_example_cli_applies_source_default_fields(tmp_path)
             "company_name=Acme Logistics",
             "--default-field",
             "contact_email=ops@example.com",
+            "--booking-url",
+            "https://app.example.test/book",
             "--channels",
             "email_cold",
             "--limit",
@@ -370,6 +372,7 @@ def test_campaign_generation_example_cli_applies_source_default_fields(tmp_path)
     source = json.loads(completed.stdout)["drafts"][0]["metadata"]["source_opportunity"]
     assert source["company_name"] == "Acme Logistics"
     assert source["contact_email"] == "ops@example.com"
+    assert source["selling"] == {"booking_url": "https://app.example.test/book"}
     draft = json.loads(completed.stdout)["drafts"][0]
     assert "Teams evaluating Slack are reporting pain around" in draft["body"]
     assert "Acme Logistics appears to be weighing Slack" not in draft["body"]

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline import campaign_source_adapters as adapters
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
     parse_default_fields,
+    parse_default_fields_with_booking_url_or_exit,
     parse_default_fields_or_exit,
     source_row_to_campaign_opportunity,
     source_rows_to_campaign_opportunities,
@@ -243,6 +244,27 @@ def test_parse_default_fields_rejects_invalid_values() -> None:
 def test_parse_default_fields_or_exit_raises_clean_system_exit() -> None:
     with pytest.raises(SystemExit, match="key=value"):
         parse_default_fields_or_exit(["company_name"])
+
+
+def test_parse_default_fields_with_booking_url_nests_selling_context() -> None:
+    defaults = parse_default_fields_with_booking_url_or_exit(
+        ["company_name=Acme Logistics"],
+        booking_url=" https://app.example.test/book ",
+    )
+
+    assert defaults == {
+        "company_name": "Acme Logistics",
+        "selling": {"booking_url": "https://app.example.test/book"},
+    }
+
+
+def test_parse_default_fields_with_booking_url_ignores_blank_url() -> None:
+    defaults = parse_default_fields_with_booking_url_or_exit(
+        ["company_name=Acme Logistics"],
+        booking_url="   ",
+    )
+
+    assert defaults == {"company_name": "Acme Logistics"}
 
 
 def test_source_document_title_does_not_become_buyer_fields() -> None:
@@ -1426,6 +1448,36 @@ def test_source_adapter_cli_applies_default_fields(tmp_path: Path) -> None:
     opportunity = json.loads(completed.stdout)["opportunities"][0]
     assert opportunity["company_name"] == "Acme Logistics"
     assert opportunity["contact_email"] == "ops@example.com"
+
+
+def test_source_adapter_cli_applies_booking_url_to_selling_context(tmp_path: Path) -> None:
+    path = tmp_path / "sources.jsonl"
+    path.write_text(
+        json.dumps({
+            "id": "g2-review-1",
+            "vendor": "Slack",
+            "review_text": "Search gets slow once message history grows.",
+        }),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--format",
+            "jsonl",
+            "--booking-url",
+            "https://app.example.test/book",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    opportunity = json.loads(completed.stdout)["opportunities"][0]
+    assert opportunity["selling"] == {"booking_url": "https://app.example.test/book"}
 
 
 def test_source_adapter_cli_rejects_non_positive_text_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Selling-Url-Source-Cli.md

Make the selling CTA URL path operator-friendly for generic source-row conversion and offline generation. PR-Content-Selling-Context-Inputs already made `selling.booking_url` work at generation time; this PR adds the shared CLI parser helper and wires `--booking-url` into the source builder and campaign generation example.

## Intentional
- Reuse source-row `default_fields` plumbing instead of changing generation internals.
- Keep the flag scoped to generic source conversion and generation CLIs.
- Leave richer selling context flags deferred until a host asks for them.

## Deferred
- Adding `--booking-url` to every Postgres/source smoke command.
- Richer selling context schema validation and sender/published-asset flags.

## Verification
- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_smoke_content_ops_review_source_postgres.py` -> 99 passed
- `python -m py_compile extracted_content_pipeline/campaign_source_adapters.py scripts/build_extracted_campaign_opportunities_from_sources.py scripts/run_extracted_campaign_generation_example.py scripts/smoke_content_ops_review_source_postgres.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_campaign_generation_example.py tests/test_smoke_content_ops_review_source_postgres.py` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
10 files, +194 / -18