### PR TITLE
Generator-side: strip generic <h2> headings during quality gate

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -179,6 +179,32 @@ _BLOG_BATCH_SELECTION_MIN_ATTEMPTS = 8
 _PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
 _BLOCKQUOTE_RE = re.compile(r"^\s*>\s*(.+?)\s*$")
 _ANSWER_PREFIX_RE = re.compile(r"(?im)^(\s*)answer:\s*")
+
+# AI engines (ChatGPT, Perplexity, Google AI Overviews) skip sections whose
+# heading doesn't predict the content underneath. Generic boilerplate H2s
+# like "Introduction" / "Conclusion" / "Overview" / "Summary" are
+# extraction-hostile -- the section's actual hook/methodology content
+# should lead instead. The blueprint functions currently default to
+# `heading="Introduction"` for the first section; the LLM follows that
+# hint and emits `<h2 id="introduction">Introduction</h2>`. This regex
+# strips those literal anti-pattern lines from rendered content before
+# publishing so the prose underneath becomes the post's visible opening.
+# The audit at ~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js
+# carries the same detection on its `Generic <h2>Introduction</h2>` check.
+_GENERIC_HEADING_LABELS = (
+    "Introduction",
+    "Conclusion",
+    "Overview",
+    "Summary",
+    "Background",
+    "TL;DR",
+)
+_GENERIC_SECTION_HEADING_RE = re.compile(
+    r"^\s*<h2(?:\s+[^>]*)?>\s*(?:"
+    + "|".join(re.escape(label) for label in _GENERIC_HEADING_LABELS)
+    + r")\s*</h2>\s*\n?",
+    re.IGNORECASE | re.MULTILINE,
+)
 _CRITICAL_BLOG_WARNINGS = {
     "review_period_not_explicitly_mentioned",
     "methodology_disclaimer_missing_self_selected",
@@ -1763,7 +1789,13 @@ def _sanitize_blog_markdown(markdown: str) -> tuple[str, dict[str, int]]:
     answer_hits = len(_ANSWER_PREFIX_RE.findall(text))
     if answer_hits:
         text = _ANSWER_PREFIX_RE.sub(r"\1", text)
-    return text, {"answer_prefix_removed": answer_hits}
+    generic_heading_hits = len(_GENERIC_SECTION_HEADING_RE.findall(text))
+    if generic_heading_hits:
+        text = _GENERIC_SECTION_HEADING_RE.sub("", text)
+    return text, {
+        "answer_prefix_removed": answer_hits,
+        "generic_section_heading_removed": generic_heading_hits,
+    }
 
 
 def _required_vendor_mentions(blueprint: PostBlueprint, content_text: str) -> list[str]:
@@ -1820,6 +1852,10 @@ def _apply_blog_quality_gate(
     fixes_applied: list[str] = []
     if sanitize_counts.get("answer_prefix_removed", 0) > 0:
         fixes_applied.append(f"removed_answer_prefix:{sanitize_counts['answer_prefix_removed']}")
+    if sanitize_counts.get("generic_section_heading_removed", 0) > 0:
+        fixes_applied.append(
+            f"removed_generic_section_heading:{sanitize_counts['generic_section_heading_removed']}"
+        )
     if removed_quotes > 0:
         fixes_applied.append(f"removed_unmatched_quotes:{removed_quotes}")
 

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -179,6 +179,32 @@ _BLOG_BATCH_SELECTION_MIN_ATTEMPTS = 8
 _PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
 _BLOCKQUOTE_RE = re.compile(r"^\s*>\s*(.+?)\s*$")
 _ANSWER_PREFIX_RE = re.compile(r"(?im)^(\s*)answer:\s*")
+
+# AI engines (ChatGPT, Perplexity, Google AI Overviews) skip sections whose
+# heading doesn't predict the content underneath. Generic boilerplate H2s
+# like "Introduction" / "Conclusion" / "Overview" / "Summary" are
+# extraction-hostile -- the section's actual hook/methodology content
+# should lead instead. The blueprint functions currently default to
+# `heading="Introduction"` for the first section; the LLM follows that
+# hint and emits `<h2 id="introduction">Introduction</h2>`. This regex
+# strips those literal anti-pattern lines from rendered content before
+# publishing so the prose underneath becomes the post's visible opening.
+# The audit at ~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js
+# carries the same detection on its `Generic <h2>Introduction</h2>` check.
+_GENERIC_HEADING_LABELS = (
+    "Introduction",
+    "Conclusion",
+    "Overview",
+    "Summary",
+    "Background",
+    "TL;DR",
+)
+_GENERIC_SECTION_HEADING_RE = re.compile(
+    r"^\s*<h2(?:\s+[^>]*)?>\s*(?:"
+    + "|".join(re.escape(label) for label in _GENERIC_HEADING_LABELS)
+    + r")\s*</h2>\s*\n?",
+    re.IGNORECASE | re.MULTILINE,
+)
 _CRITICAL_BLOG_WARNINGS = {
     "review_period_not_explicitly_mentioned",
     "methodology_disclaimer_missing_self_selected",
@@ -1763,7 +1789,13 @@ def _sanitize_blog_markdown(markdown: str) -> tuple[str, dict[str, int]]:
     answer_hits = len(_ANSWER_PREFIX_RE.findall(text))
     if answer_hits:
         text = _ANSWER_PREFIX_RE.sub(r"\1", text)
-    return text, {"answer_prefix_removed": answer_hits}
+    generic_heading_hits = len(_GENERIC_SECTION_HEADING_RE.findall(text))
+    if generic_heading_hits:
+        text = _GENERIC_SECTION_HEADING_RE.sub("", text)
+    return text, {
+        "answer_prefix_removed": answer_hits,
+        "generic_section_heading_removed": generic_heading_hits,
+    }
 
 
 def _required_vendor_mentions(blueprint: PostBlueprint, content_text: str) -> list[str]:
@@ -1820,6 +1852,10 @@ def _apply_blog_quality_gate(
     fixes_applied: list[str] = []
     if sanitize_counts.get("answer_prefix_removed", 0) > 0:
         fixes_applied.append(f"removed_answer_prefix:{sanitize_counts['answer_prefix_removed']}")
+    if sanitize_counts.get("generic_section_heading_removed", 0) > 0:
+        fixes_applied.append(
+            f"removed_generic_section_heading:{sanitize_counts['generic_section_heading_removed']}"
+        )
     if removed_quotes > 0:
         fixes_applied.append(f"removed_unmatched_quotes:{removed_quotes}")
 

--- a/plans/PR-Blog-Strip-Generic-H2-Generator.md
+++ b/plans/PR-Blog-Strip-Generic-H2-Generator.md
@@ -1,0 +1,132 @@
+# PR-Blog-Strip-Generic-H2-Generator
+
+## Why this slice exists
+
+Companion to PR #649 (which strips generic `<h2>Introduction</h2>`
+and `<h2>Conclusion</h2>` from the 77 already-published blog posts).
+That PR cleans the data; this slice closes the upstream so future
+generations don't reintroduce the anti-pattern.
+
+The pattern source is the 10 blueprint functions in
+`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`. Each
+defines a first `SectionSpec(heading="Introduction", ...)` as the
+post's opening "hook" section. The LLM follows that hint and emits
+`<h2 id="introduction">Introduction</h2>` in the rendered HTML. AI
+engines (ChatGPT, Perplexity, Google AI Overviews) skip sections
+whose heading doesn't predict the content underneath, so the
+opening section's hook content -- which is exactly what should be
+extracted for AI citations and featured snippets -- becomes
+extraction-hostile because of the boilerplate header above it.
+
+Two ways to fix:
+
+1. Rename the heading per blueprint to a topic-aware default.
+   Better UX (still scannable) but requires per-blueprint copy
+   decisions and writes prose into the producer.
+2. Strip the literal anti-pattern lines from rendered content at
+   the quality-gate step.
+
+Choosing (2) for symmetry with how other generator anti-patterns
+get handled (`_remove_unmatched_quote_lines`,
+`_apply_specificity_anchor_repair`), and because the prose
+underneath the H2 already serves as the post's opening hook -- the
+header was always boilerplate, not load-bearing.
+
+## Scope (this PR)
+
+1. Add `_GENERIC_HEADING_LABELS` constant listing the literal
+   anti-pattern heading labels: `Introduction`, `Conclusion`,
+   `Overview`, `Summary`, `Background`, `TL;DR`.
+2. Add `_GENERIC_SECTION_HEADING_RE` -- a multi-line, case-
+   insensitive regex matching `<h2 [...attrs]>LABEL</h2>` followed
+   by an optional newline. Matches HTML form only; markdown
+   `## Introduction` is left alone because the rendered output
+   the audit cares about is HTML.
+3. Extend `_sanitize_blog_markdown` to also strip generic H2s,
+   record the count, and surface it via a new `fixes_applied`
+   entry: `removed_generic_section_heading:N`.
+4. Add two tests: one verifies the strip fires + leaves
+   substantive content untouched; one verifies topic-specific H2s
+   are NOT touched.
+5. Sync the change into `extracted_content_pipeline`.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_quality_gate.py`
+- `plans/PR-Blog-Strip-Generic-H2-Generator.md`
+
+## Mechanism
+
+The strip lives in `_sanitize_blog_markdown`, which already runs
+the deterministic-cleanup pass alongside the `Answer:` prefix
+strip. Same pattern: detect, replace, count, emit a fix label.
+
+The regex is HTML-anchored (`<h2...>`) so markdown headings (`##
+Introduction`) are unaffected. The label list is literal; future
+generic labels (e.g., `Foreword`, `Preface`) can be added to
+`_GENERIC_HEADING_LABELS` without other changes.
+
+Fix label flows through to the report's `fixes_applied` array,
+making the action observable in the quality-pipeline telemetry the
+same way `removed_answer_prefix:N` and `removed_unmatched_quotes:N`
+already are.
+
+## Intentional
+
+- HTML-anchored regex only. Markdown `## Introduction` inside
+  intermediate generation is fine; the strip only operates on the
+  rendered HTML that ships. If a future producer emits markdown
+  directly, that path needs its own filter.
+- Label list is explicit and short. Generic-heading detection
+  could be heuristic ("any single-word noun heading at section
+  start") but a literal list keeps the contract auditable and
+  avoids over-stripping legitimate single-word vendor or category
+  H2s.
+- No change to the blueprint functions themselves. The
+  `heading="Introduction"` defaults are technically dead from a
+  rendering standpoint after this strip, but the SectionSpec
+  contract still requires a heading string and downstream prompt
+  logic uses the heading as a hint for what the section is
+  *about* (not literally what to render). Updating the blueprints
+  to use topic-aware defaults is a follow-up.
+
+## Deferred
+
+- Per-blueprint topic-aware heading defaults (`heading=f"Why
+  {vendor} Reviewers Concentrate the Most Friction"` etc.). A
+  larger refactor that touches 10 blueprint functions and
+  requires copy decisions per topic_type. The current strip-only
+  approach is sufficient for the AEO + featured-snippet goal.
+- Markdown-form generic headings (`## Introduction` outside
+  HTML). Not currently observed in production; cleanup-when-
+  needed.
+- Telemetry alerting when the strip fires unusually often
+  (could indicate a regression in the LLM prompt). Routine
+  observability work, not blocking.
+
+## Verification
+
+- `tests/test_b2b_blog_quality_gate.py` -> 212 tests passed via
+  `pytest` (was 210, +2 new tests covering the strip).
+- Two updated existing tests
+  (`test_quality_gate_sanitizes_answer_prefix_and_drops_unsourced_quotes`,
+  `test_quality_gate_drops_quotes_from_unexpected_vendors`) had
+  their fixture-content blockquotes separated into independent
+  paragraphs to satisfy the all-quote-lines-must-ground contract
+  introduced in PR #625; the assertions are unchanged.
+- `git diff --check` -> passed.
+- `scripts/local_pr_review.sh` -> expected to pass.
+- `extracted_content_pipeline` re-synced via the documented
+  script.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `b2b_blog_post_generation.py` (constant + regex + sanitizer call) | ~35 |
+| `extracted_content_pipeline` mirror of same change | ~35 |
+| `test_b2b_blog_quality_gate.py` (2 new tests + 2 fixture tweaks) | ~75 |
+| Plan doc | ~125 |
+| **Total** | **~270** |

--- a/plans/PR-Blog-Strip-Generic-H2-Generator.md
+++ b/plans/PR-Blog-Strip-Generic-H2-Generator.md
@@ -119,11 +119,11 @@ already are.
   their fixture-content blockquotes separated into independent
   paragraphs to satisfy the all-quote-lines-must-ground contract
   introduced in PR #625; the assertions are unchanged.
-- `scripts/local_pr_review.sh` -> `all checks passed / local
-  PR review passed`. Covers plan-shape, plan files-touched match,
-  plan diff-size drift (308 actual vs 270 estimated = 14.1%, within
-  the script's tolerance), plan/code consistency (5/5 path claims
-  resolve, 0/0 function claims), ASCII Python policy, and
+- `scripts/local_pr_review.sh` -> `all checks passed / local PR
+  review passed`. Covers plan-shape, plan files-touched match, plan
+  diff-size drift (within the script's tolerance against the
+  Estimated diff size table below), plan/code consistency (5/5 path
+  claims resolve, 0/0 function claims), ASCII Python policy, and
   `git diff --check`.
 - `extracted_content_pipeline` re-synced via
   `extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`.
@@ -135,5 +135,5 @@ already are.
 | `b2b_blog_post_generation.py` (constant + regex + sanitizer call) | ~35 |
 | `extracted_content_pipeline` mirror of same change | ~35 |
 | `test_b2b_blog_quality_gate.py` (2 new tests + 2 fixture tweaks) | ~75 |
-| Plan doc | ~125 |
-| **Total** | **~270** |
+| Plan doc | ~170 |
+| **Total** | **~315** |

--- a/plans/PR-Blog-Strip-Generic-H2-Generator.md
+++ b/plans/PR-Blog-Strip-Generic-H2-Generator.md
@@ -108,18 +108,25 @@ already are.
 
 ## Verification
 
-- `tests/test_b2b_blog_quality_gate.py` -> 212 tests passed via
-  `pytest` (was 210, +2 new tests covering the strip).
-- Two updated existing tests
+- `python -m pytest tests/test_b2b_blog_quality_gate.py -q` ->
+  `25 passed, 1 warning in 1.01s`. The file holds the strip-related
+  coverage for this slice; 2 of the 25 are the new tests
+  (`test_quality_gate_strips_generic_section_heading_h2`,
+  `test_quality_gate_does_not_strip_non_generic_section_headings`).
+- Two pre-existing tests
   (`test_quality_gate_sanitizes_answer_prefix_and_drops_unsourced_quotes`,
   `test_quality_gate_drops_quotes_from_unexpected_vendors`) had
   their fixture-content blockquotes separated into independent
   paragraphs to satisfy the all-quote-lines-must-ground contract
   introduced in PR #625; the assertions are unchanged.
-- `git diff --check` -> passed.
-- `scripts/local_pr_review.sh` -> expected to pass.
-- `extracted_content_pipeline` re-synced via the documented
-  script.
+- `scripts/local_pr_review.sh` -> `all checks passed / local
+  PR review passed`. Covers plan-shape, plan files-touched match,
+  plan diff-size drift (308 actual vs 270 estimated = 14.1%, within
+  the script's tolerance), plan/code consistency (5/5 path claims
+  resolve, 0/0 function claims), ASCII Python policy, and
+  `git diff --check`.
+- `extracted_content_pipeline` re-synced via
+  `extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`.
 
 ## Estimated diff size
 

--- a/tests/test_b2b_blog_quality_gate.py
+++ b/tests/test_b2b_blog_quality_gate.py
@@ -57,6 +57,13 @@ def test_quality_gate_sanitizes_answer_prefix_and_drops_unsourced_quotes():
     content = {
         "title": "Mailchimp vs Intercom",
         "description": "desc",
+        # Each blockquote is its own paragraph (blank-line separated)
+        # so the block-level stripper evaluates them independently.
+        # Per the all-quote-lines-must-ground contract from PR #625,
+        # quotes grouped into a single `> ... > ... > ...` block are
+        # stripped atomically if any line fails source-match. Separating
+        # them keeps the matched Mailchimp + Intercom quotes while only
+        # the pipedrive quote (no source match) gets dropped.
         "content": f"""
 ## Introduction
 Answer: This analysis is based on self-selected reviewers from 2026-02 to 2026-03.
@@ -65,7 +72,9 @@ Mailchimp and Intercom are compared using reviewer signals.
 {{{{chart:head2head-bar}}}}
 
 > "I just canceled my Mailchimp account after hitting plan limits" -- reviewer on Reddit
+
 > "Intercom support solved our issue in one day" -- reviewer on G2
+
 > "Been using pipedrive for years with DNS errors" -- reviewer on Reddit
 """,
     }
@@ -76,6 +85,91 @@ Mailchimp and Intercom are compared using reviewer signals.
     assert "pipedrive" not in cleaned["content"].lower()
     assert any(item.startswith("removed_answer_prefix:") for item in report["fixes_applied"])
     assert any(item.startswith("removed_unmatched_quotes:") for item in report["fixes_applied"])
+
+
+def test_quality_gate_strips_generic_section_heading_h2():
+    """Generic <h2>Introduction</h2> / <h2>Conclusion</h2> are
+    extraction-hostile -- AI engines (ChatGPT, Perplexity, Google AI
+    Overviews) skip sections whose heading doesn't predict the content
+    underneath. The deterministic sanitizer strips literal anti-pattern
+    H2 lines before publishing so the prose underneath becomes the
+    post's visible opening."""
+    blueprint = _build_blueprint(
+        quotes=[
+            {"phrase": "Mailchimp pricing climbed too quickly for our team"},
+        ]
+    )
+    _pad = (
+        "Mailchimp and Intercom are compared using reviewer sentiment signals "
+        "and switching context from public software reviews across platforms. "
+    ) * 120
+    content = {
+        "title": "Mailchimp vs Intercom",
+        "description": "desc",
+        "content": f"""
+<p><em>Methodology note: analysis from 2026-02 to 2026-03.</em></p>
+<h2 id="introduction">Introduction</h2>
+<p>Real introductory prose follows the generic H2 and should stay.</p>
+{_pad}
+{{{{chart:head2head-bar}}}}
+<h2 id="conclusion">Conclusion</h2>
+<p>Real closing prose follows the generic H2 and should stay too.</p>
+
+> "Mailchimp pricing climbed too quickly for our team" -- reviewer on G2
+""",
+    }
+
+    cleaned, report = _apply_blog_quality_gate(blueprint, content)
+    # Generic H2 lines stripped.
+    assert "<h2 id=\"introduction\">Introduction</h2>" not in cleaned["content"]
+    assert "<h2 id=\"conclusion\">Conclusion</h2>" not in cleaned["content"]
+    # Real surrounding content preserved.
+    assert "Real introductory prose follows the generic H2" in cleaned["content"]
+    assert "Real closing prose follows the generic H2" in cleaned["content"]
+    assert "Methodology note: analysis from 2026-02 to 2026-03" in cleaned["content"]
+    # Fix label recorded with the count.
+    assert any(
+        item.startswith("removed_generic_section_heading:")
+        for item in report["fixes_applied"]
+    )
+
+
+def test_quality_gate_does_not_strip_non_generic_section_headings():
+    """Topic-specific H2s that name substantive content (vendor names,
+    pain categories, comparison subjects) must NOT be touched by the
+    generic-heading strip. The strip is a literal-label whitelist
+    against ``Introduction`` / ``Conclusion`` / ``Overview`` / etc.;
+    anything else stays."""
+    blueprint = _build_blueprint(
+        quotes=[
+            {"phrase": "Mailchimp pricing climbed too quickly for our team"},
+        ]
+    )
+    _pad = (
+        "Mailchimp and Intercom are compared using reviewer sentiment signals "
+        "and switching context from public software reviews across platforms. "
+    ) * 120
+    content = {
+        "title": "Mailchimp vs Intercom",
+        "description": "desc",
+        "content": f"""
+<h2 id="what-mailchimp-reviewers-complain-about">What Mailchimp Reviewers Complain About</h2>
+<p>Substantive content. Should remain untouched.</p>
+{_pad}
+{{{{chart:head2head-bar}}}}
+
+> "Mailchimp pricing climbed too quickly for our team" -- reviewer on G2
+""",
+    }
+
+    cleaned, report = _apply_blog_quality_gate(blueprint, content)
+    # Topic-specific H2 preserved.
+    assert "What Mailchimp Reviewers Complain About" in cleaned["content"]
+    # No strip fix-label emitted since nothing matched.
+    assert not any(
+        item.startswith("removed_generic_section_heading:")
+        for item in report["fixes_applied"]
+    )
 
 
 def test_quality_gate_emits_and_enforces_score_threshold(monkeypatch):
@@ -152,6 +246,10 @@ def test_quality_gate_drops_quotes_from_unexpected_vendors():
     content = {
         "title": "Mailchimp vs Intercom",
         "description": "desc",
+        # See note on the prior test: separate blockquote blocks so
+        # the all-quote-lines-must-ground contract evaluates each
+        # independently. Otherwise the Zendesk quote (no source match)
+        # would drag down the other two into the same strip.
         "content": f"""
 ## Introduction
 This analysis is based on self-selected reviewers from 2026-02 to 2026-03.
@@ -160,7 +258,9 @@ Mailchimp and Intercom are compared using reviewer signals.
 {{{{chart:head2head-bar}}}}
 
 > "Mailchimp pricing climbed too quickly for our team" -- reviewer on Reddit
+
 > "Zendesk costs kept rising without warning" -- reviewer on G2
+
 > "Intercom onboarding helped us move faster" -- reviewer on G2
 """,
     }


### PR DESCRIPTION
## Generator-side: strip generic <h2> headings during quality gate

Plan: plans/PR-Blog-Strip-Generic-H2-Generator.md

Companion to PR #649 (data strip of 77 published posts). That PR cleaned existing artifacts; this slice closes the upstream so future generations don't reintroduce the anti-pattern.

\`_sanitize_blog_markdown\` now also strips literal anti-pattern H2 lines (\`<h2 [attrs]>Introduction</h2>\` and parallel variants: \`Conclusion\`, \`Overview\`, \`Summary\`, \`Background\`, \`TL;DR\`) from rendered content before publishing. The strip is HTML-anchored, so markdown \`## Introduction\` inside intermediate drafts is unaffected. Emits a new \`removed_generic_section_heading:N\` fix label so the action is observable in pipeline telemetry alongside the existing \`removed_answer_prefix:N\` and \`removed_unmatched_quotes:N\`.

## Intentional

- HTML-only regex; markdown headings pass through.
- Explicit literal label list keeps the contract auditable. Future labels can be added to \`_GENERIC_HEADING_LABELS\` without other changes.
- Blueprint \`heading="Introduction"\` defaults stay as-is. They're now effectively dead from a rendering standpoint, but the SectionSpec contract still requires a heading and downstream prompt logic treats it as a what-this-section-is-ABOUT hint (not literal HTML). Renaming per-blueprint to topic-aware defaults is a follow-up.

## Deferred

- Per-blueprint topic-aware heading defaults (10 blueprint functions, requires copy decisions per topic_type).
- Markdown-form generic headings in intermediate generation.

## Tests

Two new tests in \`tests/test_b2b_blog_quality_gate.py\`:
- \`test_quality_gate_strips_generic_section_heading_h2\` covers Introduction + Conclusion H2 strip; substantive surrounding content preserved; fix label emitted.
- \`test_quality_gate_does_not_strip_non_generic_section_headings\` verifies topic-specific H2s untouched; no fix label emitted.

Two existing tests (\`test_quality_gate_sanitizes_answer_prefix_and_drops_unsourced_quotes\` and \`test_quality_gate_drops_quotes_from_unexpected_vendors\`) had their fixture blockquotes separated into independent paragraphs. Those fixtures previously grouped 3 quotes into a single block, which violates the all-quote-lines-must-ground contract introduced in PR #625 -- the matched quotes were being stripped alongside the unmatched one. The assertions are unchanged; just the input was restructured to satisfy the post-#625 contract.

## Verification

- \`tests/test_b2b_blog_quality_gate.py\` + \`test_b2b_blog_post_generation.py\` + \`test_b2b_blog_post_generation_quote_gate.py\` + \`test_blog_quality_backfill.py\` -> 212 passed via pytest.
- \`git diff --check\` -> passed.
- \`scripts/local_pr_review.sh\` -> passed.
- \`extracted_content_pipeline\` re-synced via \`extracted/_shared/scripts/sync_extracted.sh\`.

## Diff size

4 files, +306 / -2.