### PR TITLE
Add ticket FAQ Markdown output

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Selling-Url-Source-Cli | `extracted_content_pipeline/campaign_source_adapters.py`; source-row CLIs; source adapter/generation/smoke tests | codex-2026-05-19 | Avoid concurrent edits to source-row default-field parsing or `--booking-url` CLI flags. |
+| TBD | PR-Content-Ops-Ticket-FAQ-Markdown | `extracted_content_pipeline/ticket_faq_markdown.py`; FAQ markdown CLI/test/docs | codex-2026-05-19 | Avoid concurrent edits to support-ticket FAQ artifact generation. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -166,6 +166,20 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
   --output support_ticket_bundle_opportunities.json
 ```
 
+To produce a quick grounded FAQ artifact from those same support-ticket rows,
+write Markdown directly:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --output support_ticket_faq.md
+```
+
+The FAQ builder is deterministic and extractive: it groups ticket evidence by
+pain point, quotes compact snippets from the source rows, and lists ticket
+source ids under each answer.
+
 If Atlas already has scraped B2B review rows, export one reliable source as
 Content Ops source rows before generation. The G2 path is read-only, keeps only
 canonical enriched reviews, and exports the negative/mixed quote-grade phrase

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -60,6 +60,10 @@ source of truth for what remains.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content
   Ops output. It converts inline source material into normalized opportunities
   without LLM, database, or Atlas dependencies.
+- `ticket_faq_markdown` builds deterministic FAQ Markdown from support-ticket,
+  case, conversation, and complaint source-row evidence. The CLI
+  `scripts/build_extracted_ticket_faq_markdown.py` writes or prints a grounded
+  `.md` artifact for fast operator review before adding persistence or UI.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -223,6 +223,20 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
   --output support_ticket_bundle_opportunities.json
 ```
 
+For a fast non-campaign artifact, render the same ticket rows as a grounded
+Markdown FAQ:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --output support_ticket_faq.md
+```
+
+The FAQ file quotes source snippets and lists ticket ids, so operators can
+inspect grounding before choosing whether to generate campaigns or longer
+assets.
+
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 `description`, `summary`, `notes`, `feedback`, `feedback_text`,
 `response_text`, `comment_text`, `open_ended_response`, `content`, `body`,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -251,6 +251,9 @@
       "target": "extracted_content_pipeline/campaign_source_adapters.py"
     },
     {
+      "target": "extracted_content_pipeline/ticket_faq_markdown.py"
+    },
+    {
       "target": "extracted_content_pipeline/ingestion_diagnostics.py"
     },
     {

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1,0 +1,252 @@
+"""Build grounded FAQ Markdown from support-ticket source evidence."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+DEFAULT_TICKET_SOURCE_TYPES = (
+    "ticket",
+    "support_ticket",
+    "case",
+    "conversation",
+    "complaint",
+)
+DEFAULT_TITLE = "Customer Ticket FAQ"
+_WHITESPACE_RE = re.compile(r"\s+")
+_KEY_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+_ACTION_RULES = (
+    (("export", "report", "dashboard", "attribution"), (
+        "Check whether your plan and role include the needed export or reporting access.",
+        "If the option is missing, ask support or an admin to enable access or provide the export.",
+    )),
+    (("handoff", "follow-up", "workflow", "automation", "manual"), (
+        "Check the workflow or automation rule that should handle this step.",
+        "If the handoff still needs manual cleanup, document the exact step and escalate it.",
+    )),
+    (("login", "email", "profile", "password", "account"), (
+        "Confirm the account details you are trying to change or access.",
+        "If self-service does not work, contact support with the affected email or account id.",
+    )),
+)
+
+
+@dataclass(frozen=True)
+class TicketFAQMarkdownResult:
+    """FAQ Markdown plus metadata useful for CLI summaries and tests."""
+
+    markdown: str
+    items: tuple[dict[str, Any], ...]
+    source_count: int
+    ticket_source_count: int
+    output_checks: dict[str, bool]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "markdown": self.markdown,
+            "items": [dict(item) for item in self.items],
+            "source_count": self.source_count,
+            "ticket_source_count": self.ticket_source_count,
+            "output_checks": dict(self.output_checks),
+        }
+
+
+def build_ticket_faq_markdown(
+    opportunities: Sequence[Mapping[str, Any]],
+    *,
+    title: str = DEFAULT_TITLE,
+    max_items: int = 8,
+    max_evidence_per_item: int = 3,
+    source_types: Sequence[str] = DEFAULT_TICKET_SOURCE_TYPES,
+) -> TicketFAQMarkdownResult:
+    """Render an extractive FAQ from normalized source-row opportunities."""
+
+    if max_items < 1:
+        raise ValueError("max_items must be positive")
+    if max_evidence_per_item < 1:
+        raise ValueError("max_evidence_per_item must be positive")
+
+    allowed = {_source_type_key(item) for item in source_types if _source_type_key(item)}
+    groups: dict[str, list[dict[str, str]]] = defaultdict(list)
+    seen: set[tuple[str, str]] = set()
+
+    for opportunity_index, opportunity in enumerate(opportunities, start=1):
+        for evidence_index, evidence in enumerate(_evidence_rows(opportunity), start=1):
+            source_type = _source_type_key(evidence.get("source_type") or opportunity.get("source_type"))
+            # Empty allowed set means "no filter" rather than "reject all".
+            if allowed and source_type not in allowed:
+                continue
+            text = _compact(evidence.get("text"))
+            if not text:
+                continue
+            source_id = _clean(
+                evidence.get("source_id")
+                or opportunity.get("source_id")
+                or opportunity.get("target_id")
+                or opportunity.get("id")
+            )
+            dedupe_id = source_id or f"row:{opportunity_index}:evidence:{evidence_index}"
+            key = (dedupe_id, text)
+            if key in seen:
+                continue
+            seen.add(key)
+            groups[_topic(opportunity, evidence)].append({
+                "text": text,
+                "source_id": source_id or "unknown",
+                "source_key": source_id or dedupe_id,
+                "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
+            })
+
+    items = tuple(
+        _item(topic, rows[:max_evidence_per_item])
+        for topic, rows in sorted(groups.items(), key=lambda item: (-len(item[1]), item[0].lower()))[:max_items]
+    )
+    return TicketFAQMarkdownResult(
+        markdown=_render(title=title, items=items, source_count=len(opportunities), ticket_source_count=len(seen)),
+        items=items,
+        source_count=len(opportunities),
+        ticket_source_count=len(seen),
+        output_checks=_output_checks(items=items, ticket_source_count=len(seen)),
+    )
+
+
+def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    evidence = opportunity.get("evidence")
+    if isinstance(evidence, Sequence) and not isinstance(evidence, (str, bytes, bytearray)):
+        rows = tuple(row for row in evidence if isinstance(row, Mapping))
+        if rows:
+            return rows
+    return ({
+        "text": opportunity.get("text") or opportunity.get("description") or "",
+        "source_id": opportunity.get("source_id") or opportunity.get("target_id") or "",
+        "source_type": opportunity.get("source_type") or "",
+        "source_title": opportunity.get("source_title") or "",
+    },)
+
+
+def _topic(opportunity: Mapping[str, Any], evidence: Mapping[str, Any]) -> str:
+    pain_points = opportunity.get("pain_points")
+    if isinstance(pain_points, Sequence) and not isinstance(pain_points, (str, bytes, bytearray)):
+        for value in pain_points:
+            text = _compact(value)
+            if text:
+                return text.lower()
+    return (_compact(evidence.get("source_title") or opportunity.get("source_title")) or "customer support issues").lower()
+
+
+def _item(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
+    sources = tuple(_source_label(row) for row in rows)
+    source_keys = (row.get("source_key") or row.get("source_id", "") for row in rows)
+    source_ids = tuple(dict.fromkeys(value for value in source_keys if value))
+    snippets = " / ".join(_quote(row.get("text", "")) for row in rows)
+    return {
+        "topic": topic,
+        "question": f"What are customers asking about {topic}?",
+        "answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s).",
+        "action_items": _action_items(topic, snippets),
+        "source_ids": source_ids,
+        "source_labels": sources,
+        "evidence_count": len(rows),
+    }
+
+
+def _render(
+    *,
+    title: str,
+    items: Sequence[Mapping[str, Any]],
+    source_count: int,
+    ticket_source_count: int,
+) -> str:
+    lines = [
+        f"# {_md(title) or DEFAULT_TITLE}",
+        "",
+        f"_Source rows analyzed: {source_count}. Ticket evidence rows used: {ticket_source_count}._",
+        "",
+    ]
+    if not items:
+        lines.extend([
+            "No ticket FAQ items were generated.",
+            "",
+            "Provide source rows with support-ticket, case, conversation, or complaint evidence.",
+            "",
+        ])
+        return "\n".join(lines)
+    for index, item in enumerate(items, start=1):
+        lines.extend([
+            f"## {index}. {_md(item['question'])}",
+            "",
+            _md(item["answer"]),
+            "",
+            "**What to do next:**",
+            *[f"- {_md(step)}" for step in item["action_items"]],
+            "",
+            "**Sources:**",
+            *[f"- {_md(label)}" for label in item["source_labels"]],
+            "",
+        ])
+    return "\n".join(lines)
+
+
+def _source_label(row: Mapping[str, str]) -> str:
+    source_id = _clean(row.get("source_id"))
+    title = _clean(row.get("source_title"))
+    if source_id and title:
+        return f"`{source_id}` - {title}"
+    return f"`{source_id or 'unknown'}`"
+
+
+def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:
+    text = f"{topic} {evidence_text}".lower()
+    for terms, steps in _ACTION_RULES:
+        if any(term in text for term in terms):
+            return steps
+    return (
+        "Check whether this issue affects your current account or workflow.",
+        "Contact support with the cited ticket details if the answer does not resolve it.",
+    )
+
+
+def _output_checks(
+    *,
+    items: Sequence[Mapping[str, Any]],
+    ticket_source_count: int,
+) -> dict[str, bool]:
+    return {
+        "uses_user_vocabulary": all(_clean(item.get("topic")) for item in items),
+        "condensed": len(items) <= ticket_source_count,
+        "has_action_items": all(bool(item.get("action_items")) for item in items),
+    }
+
+
+def _quote(value: Any, *, limit: int = 220) -> str:
+    text = _compact(value)
+    if len(text) > limit:
+        text = f"{text[:limit].rstrip()}..."
+    return f'"{_md(text)}"'
+
+
+def _compact(value: Any) -> str:
+    return _WHITESPACE_RE.sub(" ", str(value or "")).strip()
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _source_type_key(value: Any) -> str:
+    return _KEY_SEPARATOR_RE.sub("_", _clean(value).lower()).strip("_")
+
+
+def _md(value: Any) -> str:
+    return _clean(value).replace("|", "\\|")
+
+
+__all__ = [
+    "DEFAULT_TICKET_SOURCE_TYPES",
+    "TicketFAQMarkdownResult",
+    "build_ticket_faq_markdown",
+]

--- a/plans/PR-Content-Ops-Ticket-FAQ-Markdown.md
+++ b/plans/PR-Content-Ops-Ticket-FAQ-Markdown.md
@@ -1,0 +1,91 @@
+# Content Ops Ticket FAQ Markdown
+
+## Why this slice exists
+
+The product can ingest support-ticket-like source rows and generate campaign
+drafts from them, but operators do not yet have a fast, inspectable output that
+turns those tickets into a grounded artifact. The requested first artifact is a
+lightweight `.md` FAQ file based on ingested customer tickets so we can inspect
+the evidence, verify grounding, and iterate quickly before adding storage or UI.
+
+## Scope (this PR)
+
+1. Add a deterministic ticket FAQ Markdown builder over normalized source-row
+   opportunities.
+2. Add a host-facing CLI that loads existing source-row JSON/JSONL/CSV files
+   and writes or prints a Markdown FAQ.
+3. Register the module in the extracted content manifest and CI runner.
+4. Document the command in README/runbook/status.
+5. Replace the stale merged #650 coordination row with this in-flight claim.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `scripts/build_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `extracted_content_pipeline/manifest.json`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/STATUS.md`
+- `docs/extraction/coordination/inflight.md`
+- `plans/PR-Content-Ops-Ticket-FAQ-Markdown.md`
+
+## Mechanism
+
+The builder consumes the existing normalized opportunity shape produced by
+`load_source_campaign_opportunities_from_file`. It keeps only ticket-like source
+types (`support_ticket`, `case`, `conversation`, `complaint`), groups evidence
+by the first pain point or source title, and renders one Markdown FAQ per group.
+Answers are extractive: they quote compact snippets from the source evidence,
+include a short "What to do next" action list, and list source ids/titles below
+each answer. The result also exposes a small output-check map for the three
+operator questions: user vocabulary, condensation, and action-item presence.
+
+The CLI is intentionally offline and deterministic:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --output support_ticket_faq.md
+```
+
+## Intentional
+
+- No LLM in this first slice. The first FAQ output should be auditable and
+  grounded before we add generative answer polish.
+- No database table, control-surface output, or review workflow yet. This is a
+  file artifact for fast iteration.
+- No changes to source-row normalization. The builder uses the existing
+  ingestion contract instead of creating a parallel ticket parser.
+
+## Deferred
+
+- Persisted `faq_markdown` generated-asset output and UI wiring.
+- Optional LLM polish pass that must preserve citations and source snippets.
+- Postgres-backed FAQ generation from imported opportunities.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py` -> 8 passed
+- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` -> passed
+- `python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --output /tmp/support_ticket_faq.md` -> passed
+- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
+- `bash scripts/check_ascii_python.sh` -> passed
+- `bash scripts/local_pr_review.sh` -> passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Production + CLI | ~250 |
+| Tests | ~175 |
+| Docs + manifest + coordination | ~155 |
+| **Total** | **~580** |
+
+This is slightly over the 400 LOC target because this is the first instance of
+the new FAQ artifact type and includes production code, CLI, tests, docs, and
+manifest wiring. The implementation itself stays small and deterministic.

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Build a grounded FAQ Markdown file from ticket-like source rows."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    DEFAULT_TITLE,
+    build_ticket_faq_markdown,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert support-ticket, case, conversation, or complaint source "
+            "rows into a grounded Markdown FAQ."
+        )
+    )
+    parser.add_argument("path", type=Path, help="Source JSON, JSONL, or CSV file.")
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl", "csv"),
+        default="auto",
+        help="Source file format. Defaults to suffix-based detection.",
+    )
+    parser.add_argument(
+        "--title",
+        default=DEFAULT_TITLE,
+        help="Markdown H1 title.",
+    )
+    parser.add_argument("--max-items", type=int, default=8)
+    parser.add_argument("--max-evidence-per-item", type=int, default=3)
+    parser.add_argument(
+        "--max-text-chars",
+        type=int,
+        default=1200,
+        help="Maximum source text characters copied into each evidence row.",
+    )
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help="Fallback metadata applied to every source row. Repeat as key=value.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write FAQ Markdown to this path instead of stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.max_items < 1:
+        raise SystemExit("--max-items must be positive")
+    if args.max_evidence_per_item < 1:
+        raise SystemExit("--max-evidence-per-item must be positive")
+    if args.max_text_chars < 1:
+        raise SystemExit("--max-text-chars must be positive")
+
+    loaded = load_source_campaign_opportunities_from_file(
+        args.path,
+        file_format=args.source_format,
+        max_text_chars=args.max_text_chars,
+        default_fields=parse_default_fields_or_exit(args.default_field),
+    )
+    result = build_ticket_faq_markdown(
+        loaded.opportunities,
+        title=args.title,
+        max_items=args.max_items,
+        max_evidence_per_item=args.max_evidence_per_item,
+    )
+    if args.output:
+        args.output.write_text(result.markdown, encoding="utf-8")
+    else:
+        print(result.markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
+  tests/test_extracted_ticket_faq_markdown.py \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \
   tests/test_content_ops_source_postgres_smoke_helpers.py \

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_source_adapters import (
+    load_source_campaign_opportunities_from_file,
+)
+from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
+SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
+
+
+def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
+    loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities)
+
+    assert result.source_count == 2
+    assert result.ticket_source_count == 2
+    assert [item["topic"] for item in result.items] == ["manual follow-up", "reporting friction"]
+    assert "campaign attribution data" in result.markdown
+    assert "`ticket-acme-1` - Reporting export blocked before renewal" in result.markdown
+    assert "**What to do next:**" in result.markdown
+    assert "Check whether your plan and role include the needed export" in result.markdown
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+
+
+def test_build_ticket_faq_markdown_uses_nested_ticket_thread_text() -> None:
+    loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_BUNDLE, file_format="json")
+
+    result = build_ticket_faq_markdown(loaded.opportunities)
+
+    assert "Every demo follow-up still has to be rebuilt by hand." in result.markdown
+    assert "The workflow automation feature is not available on the current plan." in result.markdown
+    assert "`support-riverbend-2` - Manual sequence cleanup after demos" in result.markdown
+
+
+def test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "review",
+        "pain_points": ["pricing"],
+        "evidence": [{"text": "Pricing is too high.", "source_id": "review-1", "source_type": "review"}],
+    }])
+
+    assert result.items == ()
+    assert "No ticket FAQ items were generated." in result.markdown
+    with pytest.raises(ValueError, match="max_items must be positive"):
+        build_ticket_faq_markdown([], max_items=0)
+    with pytest.raises(ValueError, match="max_evidence_per_item must be positive"):
+        build_ticket_faq_markdown([], max_evidence_per_item=0)
+
+
+def test_build_ticket_faq_markdown_accepts_ticket_source_type_alias() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "ticket",
+        "pain_points": ["billing"],
+        "evidence": [{"text": "I need help with billing.", "source_id": "ticket-1", "source_type": "ticket"}],
+    }])
+
+    assert result.ticket_source_count == 1
+    assert result.items[0]["source_ids"] == ("ticket-1",)
+    assert "I need help with billing." in result.markdown
+
+
+def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified_rows() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "support ticket",
+            "pain_points": ["login"],
+            "evidence": [{"text": "I cannot log in.", "source_type": "support-ticket"}],
+        },
+        {
+            "source_type": "support ticket",
+            "pain_points": ["login"],
+            "evidence": [{"text": "I cannot log in.", "source_type": "support ticket"}],
+        },
+    ])
+
+    assert len(result.items) == 1
+    assert result.ticket_source_count == 2
+    assert result.items[0]["evidence_count"] == 2
+    assert result.items[0]["source_ids"] == ("row:1:evidence:1", "row:2:evidence:1")
+    assert "Evidence comes from 2 ticket source(s)." in result.markdown
+
+
+def test_build_ticket_faq_markdown_counts_distinct_source_ids_per_item() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "support_ticket",
+        "pain_points": ["exports"],
+        "evidence": [
+            {"text": "Export failed on Monday.", "source_id": "ticket-1", "source_type": "support_ticket"},
+            {"text": "Export failed again Tuesday.", "source_id": "ticket-1", "source_type": "support_ticket"},
+        ],
+    }])
+
+    assert result.items[0]["evidence_count"] == 2
+    assert result.items[0]["source_ids"] == ("ticket-1",)
+    assert "Evidence comes from 1 ticket source(s)." in result.markdown
+
+
+def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
+    output = tmp_path / "ticket_faq.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(SUPPORT_TICKET_CSV),
+            "--source-format",
+            "csv",
+            "--title",
+            "Support FAQ",
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout == ""
+    markdown = output.read_text(encoding="utf-8")
+    assert markdown.startswith("# Support FAQ")
+    assert "Ticket evidence rows used: 2" in markdown
+    assert "ticket-acme-1" in markdown
+
+
+def test_ticket_faq_cli_stdout_limits_and_result_serializes() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(SUPPORT_TICKET_BUNDLE),
+            "--source-format",
+            "json",
+            "--max-items",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.startswith("# Customer Ticket FAQ")
+    assert completed.stdout.count("## ") == 1
+    loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
+    encoded = json.dumps(build_ticket_faq_markdown(loaded.opportunities).as_dict(), sort_keys=True)
+    assert "action_items" in encoded
+    assert "output_checks" in encoded


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ticket-FAQ-Markdown.md

Add a lightweight, deterministic `.md` FAQ artifact for customer support-ticket source rows. The builder reuses existing source-row ingestion, groups ticket-like evidence by pain point/title, quotes compact source snippets, and lists ticket source ids for quick grounding review.

## Intentional
- No LLM in this first slice; the FAQ is extractive and auditable.
- No DB table, control-surface output, or UI yet; this is a fast file artifact for iteration.
- Reuse the existing source-row adapter instead of adding a parallel ticket parser.

## Deferred
- Persisted `faq_markdown` generated-asset output and UI wiring.
- Optional LLM polish pass that preserves citations/source snippets.
- Postgres-backed FAQ generation from imported opportunities.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py` -> 5 passed
- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` -> passed
- `python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --output /tmp/support_ticket_faq.md` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
10 files, +523 / -1. Above the 400 LOC soft target because this is the first self-contained FAQ artifact and includes module, CLI, tests, docs, manifest, and coordination wiring.