### PR TITLE
Add FAQ Markdown Content Ops execution seam

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -19,11 +19,12 @@ Currently wired:
   `PostgresIntelligenceRepository` (campaign opportunities)
   plus the per-output Postgres repo + LLM/Skill adapters.
   All three slots stay `None` when LLM or pool is absent.
-- `blog_post` (E4, this slice): plugs the
+- `blog_post` (E4): plugs the
   `PostgresBlogBlueprintRepository` (PR #458) +
   `PostgresBlogPostRepository` + LLM/Skill adapters. Slot
-  stays `None` when LLM or pool is absent. After E4 the
-  bundle advertises 6 of 6 outputs.
+  stays `None` when LLM or pool is absent.
+- `faq_markdown`: deterministic ticket FAQ builder with no LLM or
+  database dependency, wired by default.
 
 See `plans/PR-Content-Ops-Execution-Services-Wire-4.md`.
 """
@@ -77,11 +78,15 @@ from extracted_content_pipeline.sales_brief_postgres import (
 from extracted_content_pipeline.signal_extraction import (
     SignalExtractionService,
 )
+from extracted_content_pipeline.ticket_faq_markdown import (
+    TicketFAQMarkdownService,
+)
 
 
 # Module-level singleton: SignalExtractionService is stateless, so
 # re-creating it per request would just churn allocations.
 _SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
+_FAQ_MARKDOWN_SERVICE: TicketFAQMarkdownService = TicketFAQMarkdownService()
 
 
 def _build_landing_page_service(
@@ -300,6 +305,7 @@ def build_content_ops_execution_services(
         report=report,
         sales_brief=sales_brief,
         blog_post=blog_post,
+        faq_markdown=_FAQ_MARKDOWN_SERVICE,
     )
 
 

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T18:55Z by codex-2026-05-19
+Last updated: 2026-05-19T23:10Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-Ticket-FAQ-Markdown | `extracted_content_pipeline/ticket_faq_markdown.py`; FAQ markdown CLI/test/docs | codex-2026-05-19 | Avoid concurrent edits to support-ticket FAQ artifact generation. |
+| TBD | PR-Content-Ops-FAQ-Generated-Asset-Seam | `ticket_faq_markdown.py`; control-surface generation/execution wiring; focused tests/docs | codex-2026-05-19 | Avoid concurrent edits to `faq_markdown` output integration. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -180,6 +180,10 @@ The FAQ builder is deterministic and extractive: it groups ticket evidence by
 pain point, quotes compact snippets from the source rows, and lists ticket
 source ids under each answer.
 
+The same artifact can run through the Content Ops execution seam by selecting
+`faq_markdown` and passing inline `source_material`. It remains zero-provider
+and zero-database unless the host adds persistence later.
+
 If Atlas already has scraped B2B review rows, export one reliable source as
 Content Ops source rows before generation. The G2 path is read-only, keeps only
 canonical enriched reviews, and exports the negative/mixed quote-grade phrase

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -63,7 +63,8 @@ source of truth for what remains.
 - `ticket_faq_markdown` builds deterministic FAQ Markdown from support-ticket,
   case, conversation, and complaint source-row evidence. The CLI
   `scripts/build_extracted_ticket_faq_markdown.py` writes or prints a grounded
-  `.md` artifact for fast operator review before adding persistence or UI.
+  `.md` artifact for fast operator review. The same builder is also available
+  as `faq_markdown` in the AI Content Ops control-surface execution path.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -46,6 +46,7 @@ class ContentOpsExecutionServices:
     landing_page: Any | None = None
     sales_brief: Any | None = None
     signal_extraction: Any | None = None
+    faq_markdown: Any | None = None
     reasoning_provider_configured: bool = False
     reasoning_provider_outputs: tuple[str, ...] = ()
 
@@ -68,6 +69,8 @@ class ContentOpsExecutionServices:
             return self.sales_brief
         if output == "signal_extraction":
             return self.signal_extraction
+        if output == "faq_markdown":
+            return self.faq_markdown
         return None
 
     def configured_outputs(self) -> tuple[str, ...]:
@@ -79,6 +82,7 @@ class ContentOpsExecutionServices:
             "landing_page",
             "sales_brief",
             "signal_extraction",
+            "faq_markdown",
         ):
             if _has_generate_method(self.for_output(output)):
                 outputs.append(output)
@@ -147,6 +151,8 @@ class ContentOpsExecutionServices:
             sales_brief=services["sales_brief"],
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
+            # faq_markdown stays as-is; it does not consume reasoning.
+            faq_markdown=self.faq_markdown,
             reasoning_provider_configured=bool(active_outputs),
             reasoning_provider_outputs=active_tuple,
         )
@@ -524,6 +530,27 @@ async def _dispatch_signal_extraction(
     )
 
 
+async def _dispatch_faq_markdown(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del filters
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        source_material=request.inputs.get("source_material"),
+        title=_step_config_text(step.config, "title"),
+        max_items=_step_config_int(step.config, "max_items"),
+        max_evidence_per_item=_step_config_int(step.config, "max_evidence_per_item"),
+        source_types=_step_config_sequence(step.config, "source_types"),
+        max_text_chars=_step_config_int(step.config, "max_text_chars"),
+    )
+
+
 async def _dispatch_default(
     *,
     step: GenerationPlanStep,
@@ -553,6 +580,7 @@ _DISPATCH: Mapping[str, Any] = {
     "landing_page": _dispatch_landing_page,
     "blog_post": _dispatch_blog_post,
     "signal_extraction": _dispatch_signal_extraction,
+    "faq_markdown": _dispatch_faq_markdown,
 }
 
 _MAX_REASONING_VALIDATION_FAILURES = 50

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -153,6 +153,17 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         required_inputs=("source_material",),
         default_parse_retry_attempts=0,
     ),
+    "faq_markdown": OutputDefinition(
+        id="faq_markdown",
+        label="FAQ Markdown",
+        description="Grounded FAQ Markdown from support-ticket source evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.0,
+        required_inputs=("source_material",),
+        default_max_items=8,
+        reasoning_requirement="absent",
+        default_parse_retry_attempts=0,
+    ),
 })
 
 

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -29,6 +29,7 @@ from .reasoning_policy import (
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
+from .ticket_faq_markdown import TicketFAQMarkdownConfig
 
 
 @dataclass(frozen=True)
@@ -201,6 +202,24 @@ def _signal_extraction_config_for_request(
     )
 
 
+def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMarkdownConfig:
+    defaults = TicketFAQMarkdownConfig()
+    return TicketFAQMarkdownConfig(
+        title=_text_input(request.inputs, "faq_title") or defaults.title,
+        max_items=request.limit,
+        max_evidence_per_item=(
+            _positive_int_input(request.inputs, "faq_max_evidence_per_item")
+            or defaults.max_evidence_per_item
+        ),
+        source_types=_text_sequence_input(request.inputs, "faq_source_types")
+        or defaults.source_types,
+        max_text_chars=(
+            _positive_int_input(request.inputs, "source_max_text_chars")
+            or defaults.max_text_chars
+        ),
+    )
+
+
 def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
     raw = inputs.get(key)
     if raw is None:
@@ -214,6 +233,24 @@ def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
     if value < 1:
         raise ValueError(f"{key} must be at least 1; got {value}")
     return value
+
+
+def _text_input(inputs: Mapping[str, Any], key: str) -> str | None:
+    value = str(inputs.get(key) or "").strip()
+    return value or None
+
+
+def _text_sequence_input(inputs: Mapping[str, Any], key: str) -> tuple[str, ...] | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        items = tuple(item.strip() for item in raw.split(",") if item.strip())
+    elif isinstance(raw, Sequence) and not isinstance(raw, (bytes, bytearray)):
+        items = tuple(str(item).strip() for item in raw if str(item).strip())
+    else:
+        return None
+    return items or None
 
 
 def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:
@@ -314,6 +351,20 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             status="runnable",
             config={
                 "limit": config.limit,
+                "max_text_chars": config.max_text_chars,
+            },
+        )
+    if output == "faq_markdown":
+        config = _faq_markdown_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="TicketFAQMarkdownService.generate",
+            status="runnable",
+            config={
+                "title": config.title,
+                "max_items": config.max_items,
+                "max_evidence_per_item": config.max_evidence_per_item,
+                "source_types": list(config.source_types),
                 "max_text_chars": config.max_text_chars,
             },
         )

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import re
 from typing import Any
+
+from .campaign_ports import TenantScope
+from .campaign_source_adapters import source_rows_to_campaign_opportunities
 
 
 DEFAULT_TICKET_SOURCE_TYPES = (
@@ -44,15 +47,86 @@ class TicketFAQMarkdownResult:
     source_count: int
     ticket_source_count: int
     output_checks: dict[str, bool]
+    warnings: tuple[dict[str, Any], ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         return {
+            "generated": len(self.items),
             "markdown": self.markdown,
             "items": [dict(item) for item in self.items],
             "source_count": self.source_count,
             "ticket_source_count": self.ticket_source_count,
             "output_checks": dict(self.output_checks),
+            "warnings": [dict(warning) for warning in self.warnings],
         }
+
+
+@dataclass(frozen=True)
+class TicketFAQMarkdownConfig:
+    """Config for service-shaped FAQ Markdown generation."""
+
+    title: str = DEFAULT_TITLE
+    max_items: int = 8
+    max_evidence_per_item: int = 3
+    source_types: tuple[str, ...] = DEFAULT_TICKET_SOURCE_TYPES
+    max_text_chars: int = 1200
+
+
+class TicketFAQMarkdownService:
+    """Build FAQ Markdown from inline source material."""
+
+    def __init__(self, config: TicketFAQMarkdownConfig | None = None) -> None:
+        self.config = config or TicketFAQMarkdownConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        source_material: Any,
+        title: str | None = None,
+        max_items: int | None = None,
+        max_evidence_per_item: int | None = None,
+        source_types: Sequence[str] | None = None,
+        max_text_chars: int | None = None,
+        **kwargs: Any,
+    ) -> TicketFAQMarkdownResult:
+        del scope
+        del kwargs
+        resolved_max_items = int(max_items) if max_items is not None else self.config.max_items
+        resolved_max_evidence = (
+            int(max_evidence_per_item)
+            if max_evidence_per_item is not None
+            else self.config.max_evidence_per_item
+        )
+        resolved_max_text_chars = (
+            int(max_text_chars)
+            if max_text_chars is not None
+            else self.config.max_text_chars
+        )
+        if resolved_max_text_chars < 1:
+            raise ValueError("max_text_chars must be positive")
+        normalized = source_rows_to_campaign_opportunities(
+            _rows_from_source_material(source_material),
+            target_mode=target_mode,
+            max_text_chars=resolved_max_text_chars,
+        )
+        resolved_source_types = (
+            tuple(source_types)
+            if source_types is not None
+            else self.config.source_types
+        )
+        result = build_ticket_faq_markdown(
+            normalized.opportunities,
+            title=title or self.config.title,
+            max_items=resolved_max_items,
+            max_evidence_per_item=resolved_max_evidence,
+            source_types=resolved_source_types,
+        )
+        return replace(
+            result,
+            warnings=tuple(warning.as_dict() for warning in normalized.warnings),
+        )
 
 
 def build_ticket_faq_markdown(
@@ -245,8 +319,37 @@ def _md(value: Any) -> str:
     return _clean(value).replace("|", "\\|")
 
 
+def _rows_from_source_material(source_material: Any) -> list[Any]:
+    if isinstance(source_material, str):
+        text = source_material.strip()
+        return [{"text": text, "source_type": "support_ticket"}] if text else []
+    if isinstance(source_material, Mapping):
+        for key in (
+            "support_tickets",
+            "tickets",
+            "cases",
+            "conversations",
+            "complaints",
+            "sources",
+            "rows",
+            "data",
+            "opportunities",
+        ):
+            value = source_material.get(key)
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                rows = list(value)
+                if rows:
+                    return rows
+        return [dict(source_material)]
+    if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
+        return list(source_material)
+    return []
+
+
 __all__ = [
     "DEFAULT_TICKET_SOURCE_TYPES",
+    "TicketFAQMarkdownConfig",
     "TicketFAQMarkdownResult",
+    "TicketFAQMarkdownService",
     "build_ticket_faq_markdown",
 ]

--- a/plans/PR-Content-Ops-FAQ-Generated-Asset-Seam.md
+++ b/plans/PR-Content-Ops-FAQ-Generated-Asset-Seam.md
@@ -1,0 +1,97 @@
+Plan: PR-Content-Ops-FAQ-Generated-Asset-Seam
+
+## Why this slice exists
+
+PR-Content-Ops-Ticket-FAQ-Markdown added a grounded FAQ Markdown builder and
+CLI, but the artifact is still outside the AI Content Ops control-surface
+execution path. Operators can build a `.md` file manually, but `/execute` cannot
+plan or run `faq_markdown` alongside the other outputs. This slice closes that
+first integration gap without adding database persistence or UI review flows.
+
+This PR is over the 400 LOC target after review-driven fixes because the seam is
+only complete if Atlas's default Content Ops service bundle wires the same
+deterministic FAQ service that the extracted executor advertises. Splitting that
+host wiring into a separate PR would leave `/execute` reporting
+`service_not_configured` for an implemented output.
+
+## Scope (this PR)
+
+1. Add `faq_markdown` to the control-surface output catalog as a zero-cost,
+   extractive output that requires `source_material`.
+2. Add a service-shaped FAQ executor around the existing deterministic builder.
+3. Wire `faq_markdown` through generation planning and content-ops execution.
+4. Wire Atlas's default Content Ops service bundle to expose the deterministic
+   FAQ service in production routes.
+5. Add focused tests for preview, plan, host bundle, and execution wiring.
+
+### Files touched
+
+- `docs/extraction/coordination/inflight.md`
+- `atlas_brain/_content_ops_services.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-FAQ-Generated-Asset-Seam.md`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+
+## Mechanism
+
+`TicketFAQMarkdownService.generate(...)` accepts inline `source_material`, uses
+the existing source-row adapter to normalize rows into opportunities, and then
+calls `build_ticket_faq_markdown(...)`. The control surface treats the output
+like `signal_extraction`: no LLM, no reasoning provider, no retry budget.
+
+Execution dispatch registers a `faq_markdown` handler that passes
+`source_material`, `target_mode`, and plan config into the service. The result
+continues to use `TicketFAQMarkdownResult.as_dict()`, so execution summaries get
+`markdown`, `items`, source counts, normalization warnings, and output checks
+without a new result shape.
+
+Atlas's host service factory now wires a singleton `TicketFAQMarkdownService`
+alongside `SignalExtractionService`, because both are deterministic and require
+no active LLM or database pool. DB-backed generated assets remain behind
+`enable_db_services`.
+
+## Intentional
+
+- No Postgres table, generated-asset API route, or review workflow in this PR.
+  The output is runnable through `/execute`, but persistence stays deferred.
+- No LLM polish or reasoning pass. This keeps the first FAQ integration grounded
+  and inspectable before adding summarization.
+- `limit` controls max FAQ items for `/execute`; the CLI keeps its richer
+  `--max-items` wording.
+
+## Deferred
+
+- Persist `faq_markdown` drafts as reviewable generated assets.
+- Add UI selection/rendering for the FAQ output.
+- Add optional public/help-center FAQ render mode after we inspect internal
+  review Markdown quality.
+
+## Verification
+
+- Focused pytest sweep over FAQ, host bundle, control-surface, plan, execution, and API tests -> 195 passed
+- Python compile sweep over edited modules/tests -> passed
+- validate_extracted_content_pipeline -> passed
+- forbid_atlas_reasoning_imports -> passed
+- audit_extracted_standalone --fail-on-debt -> passed
+- check_ascii_python -> passed
+- git diff --check -> passed
+- run_extracted_pipeline_checks -> 1480 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Service + control/execution wiring | ~205 |
+| Tests | ~220 |
+| Docs + coordination | ~25 |
+| **Total** | **~450-525** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -11,10 +11,10 @@ the host has wired. Currently:
   same shape as landing_page but each also takes a
   shared `PostgresIntelligenceRepository`. Skip together
   when LLM or pool is absent.
-- `blog_post` (E4, this slice): same shape as
-  landing_page (no IntelligenceRepository); plugs the
-  `PostgresBlogBlueprintRepository` (PR #458) +
-  `PostgresBlogPostRepository`.
+- `blog_post` (E4): same shape as landing_page (no
+  IntelligenceRepository); plugs the `PostgresBlogBlueprintRepository`
+  (PR #458) + `PostgresBlogPostRepository`.
+- `faq_markdown` (this slice): always wired (stateless).
 
 Tests use the factory's dependency-injection kwargs (`llm_factory`
 / `skills_factory` / `pool_factory`) to stub host
@@ -22,7 +22,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (14 tests):
+Test inventory (15 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -39,15 +39,16 @@ Test inventory (14 tests):
 11. `blog_post` populated when LLM + db enabled (E4 canary)
     and `for_output("blog_post")` returns the service.
 12. `blog_post` skips when no LLM (E4 fallback).
-13. `configured_outputs()` with LLM + db enabled advertises
-    all 6 outputs: `(email_campaign, blog_post, report,
-    landing_page, sales_brief, signal_extraction)` -- order
+13. `faq_markdown` runs through the full executor.
+14. `configured_outputs()` with LLM + db enabled advertises
+    all 7 outputs: `(email_campaign, blog_post, report,
+    landing_page, sales_brief, signal_extraction, faq_markdown)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-14. `configured_outputs()` without an active LLM (even with
+15. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
-    `signal_extraction`.
+    `signal_extraction` and `faq_markdown`.
 """
 
 from __future__ import annotations
@@ -125,6 +126,40 @@ async def test_signal_extraction_runs_through_host_bundle() -> None:
     assert step["result"]["target_mode"] == "vendor_retention"
 
 
+@pytest.mark.asyncio
+async def test_faq_markdown_runs_through_host_bundle() -> None:
+    """`faq_markdown` is deterministic like `signal_extraction`, so
+    the host bundle wires it without LLM or DB services."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": [{
+                    "ticket_id": "ticket-1",
+                    "source_type": "ticket",
+                    "message": "How do I fix failed exports?",
+                    "pain_category": "exports",
+                }]
+            },
+        },
+        services=services,
+    )
+
+    assert result["status"] == "completed", result
+    step = result["steps"][0]
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+    assert step["result"]["generated"] == 1
+    assert "How do I fix failed exports?" in step["result"]["markdown"]
+
+
 def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
     """E2 canary: when the LLM factory returns a non-None client
     AND `enable_db_services=True`, the bundle's `landing_page`
@@ -146,6 +181,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
         "landing_page",
         "sales_brief",
         "signal_extraction",
+        "faq_markdown",
     )
 
 
@@ -163,7 +199,7 @@ def test_landing_page_slot_stays_none_when_no_active_llm() -> None:
     )
 
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
@@ -184,7 +220,7 @@ def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
         enable_db_services=True,
     )
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_landing_page_slot_stays_none_in_production_default() -> None:
@@ -203,7 +239,7 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
     )
 
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_campaign_wired_when_llm_active_and_db_enabled() -> None:
@@ -263,7 +299,7 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
     assert services.campaign is None
     assert services.report is None
     assert services.sales_brief is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_e3_services_skip_together_when_pool_is_none() -> None:
@@ -284,7 +320,7 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.report is None
     assert services.sales_brief is None
     assert services.blog_post is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_blog_post_wired_when_llm_active_and_db_enabled() -> None:
@@ -306,7 +342,7 @@ def test_blog_post_wired_when_llm_active_and_db_enabled() -> None:
 def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
     """E4 fallback: blog_post slot stays `None` when no LLM
     is active. Same short-circuit shape as landing_page
-    (PR #454). With no LLM only signal_extraction remains
+    (PR #454). With no LLM only deterministic outputs remain
     advertised."""
 
     services = build_content_ops_execution_services(
@@ -316,14 +352,14 @@ def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
         enable_db_services=True,
     )
     assert services.blog_post is None
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
 
 
 def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
     """`configured_outputs()` is the source of truth the catalog
     endpoint surfaces in `execution.configured_outputs`. With
     LLM wired AND `enable_db_services=True`, the bundle
-    advertises landing_page + signal_extraction."""
+    advertises every wired output."""
 
     services = build_content_ops_execution_services(
         llm_factory=_make_llm_stub,
@@ -338,12 +374,13 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         "landing_page",
         "sales_brief",
         "signal_extraction",
+        "faq_markdown",
     )
 
 
 def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
     """Without an active LLM (even with `enable_db_services=True`),
-    only `signal_extraction` is advertised."""
+    only deterministic outputs are advertised."""
 
     services = build_content_ops_execution_services(
         llm_factory=_no_llm,
@@ -351,4 +388,4 @@ def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
         pool_factory=_make_pool_stub,
         enable_db_services=True,
     )
-    assert services.configured_outputs() == ("signal_extraction",)
+    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -117,6 +117,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     preset_ids = {item["id"] for item in payload["presets"]}
     assert "email_campaign" in output_ids
     assert "landing_page" in output_ids
+    assert "faq_markdown" in output_ids
     assert outputs["signal_extraction"]["implemented"] is True
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
@@ -126,6 +127,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
+    assert outputs["faq_markdown"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {"configured": False, "configured_outputs": []}
     assert payload["reasoning"] == {"configured": False}
     assert "email_only" in preset_ids
@@ -144,6 +146,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
             campaign=_CampaignService(),
             report=_CampaignService(),
             signal_extraction=_CampaignService(),
+            faq_markdown=_CampaignService(),
         )
     )
 
@@ -153,7 +156,12 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     outputs = {item["id"]: item for item in payload["outputs"]}
     assert payload["execution"] == {
         "configured": True,
-        "configured_outputs": ["email_campaign", "report", "signal_extraction"],
+        "configured_outputs": [
+            "email_campaign",
+            "faq_markdown",
+            "report",
+            "signal_extraction",
+        ],
     }
     assert outputs["email_campaign"]["execution_configured"] is True
     assert outputs["email_campaign"]["can_execute"] is True
@@ -161,6 +169,8 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     assert outputs["report"]["can_execute"] is True
     assert outputs["signal_extraction"]["execution_configured"] is True
     assert outputs["signal_extraction"]["can_execute"] is True
+    assert outputs["faq_markdown"]["execution_configured"] is True
+    assert outputs["faq_markdown"]["can_execute"] is True
     assert outputs["blog_post"]["execution_configured"] is False
     assert outputs["blog_post"]["can_execute"] is False
     assert payload["reasoning"] == {"configured": False}

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -111,6 +111,23 @@ def test_preview_allows_signal_extraction_when_source_material_present():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_allows_faq_markdown_when_source_material_present():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [{"source_type": "ticket", "text": "How do I change my email?"}],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["faq_markdown"]
+    assert preview["blocked_outputs"] == []
+    assert preview["estimated_cost_usd"] == 0.0
+
+
 def test_preview_blocks_when_estimate_exceeds_budget():
     preview = preview_from_mapping(
             {
@@ -166,6 +183,7 @@ def test_output_catalog_states_reasoning_requirement():
     assert OUTPUT_CATALOG["sales_brief"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
+    assert OUTPUT_CATALOG["faq_markdown"].reasoning_requirement == "absent"
 
 
 def test_request_from_mapping_rejects_zero_limit():

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -401,6 +401,33 @@ def test_plan_maps_signal_extraction_to_signal_extraction_service():
     }
 
 
+def test_plan_maps_faq_markdown_to_ticket_faq_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "limit": 4,
+            "inputs": {
+                "source_material": [{"source_type": "ticket", "text": "How do I change my email?"}],
+                "faq_title": "Support FAQ",
+                "faq_max_evidence_per_item": 2,
+                "faq_source_types": "ticket, support-ticket",
+                "source_max_text_chars": 80,
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "TicketFAQMarkdownService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "title": "Support FAQ",
+        "max_items": 4,
+        "max_evidence_per_item": 2,
+        "source_types": ["ticket", "support-ticket"],
+        "max_text_chars": 80,
+    }
+
+
 def test_plan_threads_signal_extraction_source_text_cap():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -13,6 +13,7 @@ from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
 from extracted_content_pipeline.signal_extraction import SignalExtractionService
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
 
 
 @dataclass(frozen=True)
@@ -487,6 +488,36 @@ async def test_execute_runs_signal_extraction_service_from_source_material() -> 
     assert opportunity["target_id"] == "review-1"
     assert opportunity["evidence"][0]["text"] == "Pricing"
     assert step["result"]["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "limit": 2,
+            "inputs": {
+                "faq_title": "Support FAQ",
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-1",
+                        "source_type": "ticket",
+                        "subject": "Profile email change",
+                        "message": "How do I change my email address?",
+                        "pain_category": "login",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService()),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["output"] == "faq_markdown"
+    assert step["result"]["generated"] == 1
+    assert step["result"]["markdown"].startswith("# Support FAQ")
+    assert "How do I change my email address?" in step["result"]["markdown"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -10,7 +10,11 @@ import pytest
 from extracted_content_pipeline.campaign_source_adapters import (
     load_source_campaign_opportunities_from_file,
 )
-from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.ticket_faq_markdown import (
+    TicketFAQMarkdownService,
+    build_ticket_faq_markdown,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,6 +40,100 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "condensed": True,
         "has_action_items": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_generates_from_inline_source_material() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "subject": "Login email change",
+                    "source_type": "ticket",
+                    "message": "How do I change my email address?",
+                    "pain_category": "login",
+                }
+            ]
+        },
+        max_items=2,
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert "How do I change my email address?" in result.markdown
+    assert "`ticket-1` - Login email change" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_preserves_explicit_empty_source_type_filter() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[{
+            "source_id": "review-1",
+            "source_type": "review",
+            "text": "Export settings are hard to find.",
+            "pain_category": "exports",
+        }],
+        source_types=(),
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert "Export settings are hard to find." in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_exposes_source_normalization_warnings() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "ticket_id": "ticket-1",
+                "source_type": "ticket",
+                "subject": "Export issue",
+                "message": "The export keeps timing out.",
+            },
+            {
+                "ticket_id": "ticket-2",
+                "source_type": "ticket",
+                "subject": "Missing body",
+            },
+        ],
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert result.as_dict()["warnings"][0]["code"] == "missing_source_text"
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_skips_empty_source_material_containers() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [],
+            "rows": [{
+                "ticket_id": "ticket-1",
+                "source_type": "ticket",
+                "message": "The dashboard export is not working.",
+                "pain_category": "exports",
+            }],
+        },
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert "The dashboard export is not working." in result.markdown
 
 
 def test_build_ticket_faq_markdown_uses_nested_ticket_thread_text() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Generated-Asset-Seam.md

Add FAQ Markdown as a runnable AI Content Ops output using the existing deterministic ticket FAQ builder, and wire Atlas's default Content Ops service bundle so production `/execute` can run the seam instead of reporting `service_not_configured`.

## Intentional
- No Postgres table, generated-asset API route, or review workflow in this PR; persistence stays deferred.
- No LLM polish or reasoning pass. This keeps the first FAQ integration grounded and inspectable before adding summarization.
- `limit` controls max FAQ items for `/execute`; the CLI keeps its richer `--max-items` wording.
- The PR is over the 400 LOC target because review fixes made host service wiring part of the same executable seam.

## Deferred
- Persist `faq_markdown` drafts as reviewable generated assets.
- Add UI selection/rendering for the FAQ output.
- Add optional public/help-center FAQ render mode after internal Markdown review.

## Verification
- Focused pytest sweep over FAQ, host bundle, control-surface, plan, execution, and API tests -> 195 passed
- Python compile sweep over edited modules/tests -> passed
- validate_extracted_content_pipeline -> passed
- forbid_atlas_reasoning_imports -> passed
- audit_extracted_standalone --fail-on-debt -> passed
- check_ascii_python -> passed
- git diff --check -> passed
- run_extracted_pipeline_checks -> 1480 passed, 1 existing torch/pynvml warning
- local_pr_review -> passed

## Diff size
15 files, +551 / -29