### PR TITLE
Persist FAQ Markdown generated asset drafts

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -23,8 +23,8 @@ Currently wired:
   `PostgresBlogBlueprintRepository` (PR #458) +
   `PostgresBlogPostRepository` + LLM/Skill adapters. Slot
   stays `None` when LLM or pool is absent.
-- `faq_markdown`: deterministic ticket FAQ builder with no LLM or
-  database dependency, wired by default.
+- `faq_markdown`: deterministic ticket FAQ builder. It runs without
+  DB, and persists drafts when DB services are enabled.
 
 See `plans/PR-Content-Ops-Execution-Services-Wire-4.md`.
 """
@@ -80,6 +80,9 @@ from extracted_content_pipeline.signal_extraction import (
 )
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownService,
+)
+from extracted_content_pipeline.ticket_faq_postgres import (
+    PostgresTicketFAQRepository,
 )
 
 
@@ -203,6 +206,14 @@ def _build_blog_post_service(
     )
 
 
+def _build_ticket_faq_service(*, pool: Any) -> TicketFAQMarkdownService | None:
+    """Build the persisted FAQ Markdown service when a DB pool is active."""
+
+    if pool is None:
+        return None
+    return TicketFAQMarkdownService(ticket_faqs=PostgresTicketFAQRepository(pool=pool))
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -259,6 +270,7 @@ def build_content_ops_execution_services(
     report = None
     sales_brief = None
     blog_post = None
+    faq_markdown = _FAQ_MARKDOWN_SERVICE
     if enable_db_services:
         llm = llm_factory()
         skills = skills_factory()
@@ -297,6 +309,7 @@ def build_content_ops_execution_services(
             skills=skills,
             pool=pool,
         )
+        faq_markdown = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
@@ -305,7 +318,7 @@ def build_content_ops_execution_services(
         report=report,
         sales_brief=sales_brief,
         blog_post=blog_post,
-        faq_markdown=_FAQ_MARKDOWN_SERVICE,
+        faq_markdown=faq_markdown,
     )
 
 

--- a/atlas_brain/storage/migrations/325_ticket_faq_markdown.sql
+++ b/atlas_brain/storage/migrations/325_ticket_faq_markdown.sql
@@ -1,0 +1,27 @@
+-- Ticket FAQ Markdown: deterministic FAQ documents generated from support
+-- tickets, cases, conversations, and complaint source rows. One row is one
+-- reviewable Markdown document; individual FAQ entries live in items JSONB.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_markdown (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    title TEXT NOT NULL,
+    markdown TEXT NOT NULL,
+    items JSONB NOT NULL DEFAULT '[]'::jsonb,
+    source_count INTEGER NOT NULL DEFAULT 0,
+    ticket_source_count INTEGER NOT NULL DEFAULT 0,
+    output_checks JSONB NOT NULL DEFAULT '{}'::jsonb,
+    warnings JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_markdown_target
+    ON ticket_faq_markdown (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_markdown_status
+    ON ticket_faq_markdown (account_id, status, created_at DESC);

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T23:10Z by codex-2026-05-19
+Last updated: 2026-05-19T23:45Z by codex-2026-05-19
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Generated-Asset-Seam | `ticket_faq_markdown.py`; control-surface generation/execution wiring; focused tests/docs | codex-2026-05-19 | Avoid concurrent edits to `faq_markdown` output integration. |
+| TBD | PR-Content-Ops-FAQ-Generated-Asset-Persistence | `ticket_faq_markdown.py`; `ticket_faq_ports.py`; `ticket_faq_postgres.py`; FAQ migration; host wiring/tests/docs | codex-2026-05-19 | Avoid concurrent edits to `faq_markdown` persistence and generated-asset storage seam. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -181,8 +181,9 @@ pain point, quotes compact snippets from the source rows, and lists ticket
 source ids under each answer.
 
 The same artifact can run through the Content Ops execution seam by selecting
-`faq_markdown` and passing inline `source_material`. It remains zero-provider
-and zero-database unless the host adds persistence later.
+`faq_markdown` and passing inline `source_material`. It remains zero-provider.
+When the host wires `PostgresTicketFAQRepository`, execution also persists the
+Markdown document into `ticket_faq_markdown` and returns `saved_ids`.
 
 If Atlas already has scraped B2B review rows, export one reliable source as
 Content Ops source rows before generation. The G2 path is read-only, keeps only

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -64,7 +64,9 @@ source of truth for what remains.
   case, conversation, and complaint source-row evidence. The CLI
   `scripts/build_extracted_ticket_faq_markdown.py` writes or prints a grounded
   `.md` artifact for fast operator review. The same builder is also available
-  as `faq_markdown` in the AI Content Ops control-surface execution path.
+  as `faq_markdown` in the AI Content Ops control-surface execution path and can
+  persist drafts through `PostgresTicketFAQRepository` when DB services are
+  enabled.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -77,6 +77,10 @@
       "target": "extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql"
     },
     {
+      "source": "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql",
+      "target": "extracted_content_pipeline/storage/migrations/325_ticket_faq_markdown.sql"
+    },
+    {
       "source": "atlas_brain/storage/migrations/066_b2b_campaigns.sql",
       "target": "extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql"
     },
@@ -252,6 +256,12 @@
     },
     {
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
+    },
+    {
+      "target": "extracted_content_pipeline/ticket_faq_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/ticket_faq_postgres.py"
     },
     {
       "target": "extracted_content_pipeline/ingestion_diagnostics.py"

--- a/extracted_content_pipeline/storage/migrations/325_ticket_faq_markdown.sql
+++ b/extracted_content_pipeline/storage/migrations/325_ticket_faq_markdown.sql
@@ -1,0 +1,27 @@
+-- Ticket FAQ Markdown: deterministic FAQ documents generated from support
+-- tickets, cases, conversations, and complaint source rows. One row is one
+-- reviewable Markdown document; individual FAQ entries live in items JSONB.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_markdown (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    title TEXT NOT NULL,
+    markdown TEXT NOT NULL,
+    items JSONB NOT NULL DEFAULT '[]'::jsonb,
+    source_count INTEGER NOT NULL DEFAULT 0,
+    ticket_source_count INTEGER NOT NULL DEFAULT 0,
+    output_checks JSONB NOT NULL DEFAULT '{}'::jsonb,
+    warnings JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_markdown_target
+    ON ticket_faq_markdown (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_markdown_status
+    ON ticket_faq_markdown (account_id, status, created_at DESC);

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from .campaign_ports import TenantScope
 from .campaign_source_adapters import source_rows_to_campaign_opportunities
+from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
 DEFAULT_TICKET_SOURCE_TYPES = (
@@ -48,6 +49,7 @@ class TicketFAQMarkdownResult:
     ticket_source_count: int
     output_checks: dict[str, bool]
     warnings: tuple[dict[str, Any], ...] = ()
+    saved_ids: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -58,6 +60,7 @@ class TicketFAQMarkdownResult:
             "ticket_source_count": self.ticket_source_count,
             "output_checks": dict(self.output_checks),
             "warnings": [dict(warning) for warning in self.warnings],
+            "saved_ids": list(self.saved_ids),
         }
 
 
@@ -75,8 +78,14 @@ class TicketFAQMarkdownConfig:
 class TicketFAQMarkdownService:
     """Build FAQ Markdown from inline source material."""
 
-    def __init__(self, config: TicketFAQMarkdownConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: TicketFAQMarkdownConfig | None = None,
+        *,
+        ticket_faqs: TicketFAQRepository | None = None,
+    ) -> None:
         self.config = config or TicketFAQMarkdownConfig()
+        self._ticket_faqs = ticket_faqs
 
     async def generate(
         self,
@@ -91,7 +100,6 @@ class TicketFAQMarkdownService:
         max_text_chars: int | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
-        del scope
         del kwargs
         resolved_max_items = int(max_items) if max_items is not None else self.config.max_items
         resolved_max_evidence = (
@@ -116,17 +124,38 @@ class TicketFAQMarkdownService:
             if source_types is not None
             else self.config.source_types
         )
+        title_text = title or self.config.title
         result = build_ticket_faq_markdown(
             normalized.opportunities,
-            title=title or self.config.title,
+            title=title_text,
             max_items=resolved_max_items,
             max_evidence_per_item=resolved_max_evidence,
             source_types=resolved_source_types,
         )
-        return replace(
+        result = replace(
             result,
             warnings=tuple(warning.as_dict() for warning in normalized.warnings),
         )
+        if self._ticket_faqs is None or not result.items:
+            return result
+        saved_ids = await self._ticket_faqs.save_drafts(
+            [
+                TicketFAQDraft(
+                    target_id=_target_id(normalized.opportunities),
+                    target_mode=target_mode,
+                    title=title_text,
+                    markdown=result.markdown,
+                    items=result.items,
+                    source_count=result.source_count,
+                    ticket_source_count=result.ticket_source_count,
+                    output_checks=result.output_checks,
+                    warnings=result.warnings,
+                    metadata={"source_types": list(resolved_source_types)},
+                )
+            ],
+            scope=scope,
+        )
+        return replace(result, saved_ids=tuple(str(item) for item in saved_ids))
 
 
 def build_ticket_faq_markdown(
@@ -309,6 +338,15 @@ def _compact(value: Any) -> str:
 
 def _clean(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _target_id(opportunities: Sequence[Mapping[str, Any]]) -> str:
+    for opportunity in opportunities:
+        for key in ("target_id", "source_id", "id", "company_name", "vendor_name"):
+            value = _clean(opportunity.get(key))
+            if value:
+                return value
+    return "ticket_faq_markdown"
 
 
 def _source_type_key(value: Any) -> str:

--- a/extracted_content_pipeline/ticket_faq_ports.py
+++ b/extracted_content_pipeline/ticket_faq_ports.py
@@ -1,0 +1,88 @@
+"""Standalone ports for persisted ticket FAQ Markdown drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class TicketFAQDraft:
+    """A generated, not-yet-approved ticket FAQ Markdown document."""
+
+    target_id: str
+    target_mode: str
+    title: str
+    markdown: str
+    items: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    source_count: int = 0
+    ticket_source_count: int = 0
+    output_checks: Mapping[str, Any] = field(default_factory=dict)
+    warnings: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "title": self.title,
+            "markdown": self.markdown,
+            "items": [dict(item) for item in self.items],
+            "source_count": self.source_count,
+            "ticket_source_count": self.ticket_source_count,
+            "output_checks": dict(self.output_checks),
+            "warnings": [dict(warning) for warning in self.warnings],
+            "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
+        }
+
+
+class TicketFAQRepository(Protocol):
+    """Persistence contract for generated ticket FAQ Markdown drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[TicketFAQDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return assigned FAQ draft ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[TicketFAQDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        faq_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft status and return True on hit."""
+
+    async def update_statuses(
+        self,
+        faq_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched scope."""
+
+
+__all__ = [
+    "TicketFAQDraft",
+    "TicketFAQRepository",
+]

--- a/extracted_content_pipeline/ticket_faq_postgres.py
+++ b/extracted_content_pipeline/ticket_faq_postgres.py
@@ -1,0 +1,181 @@
+"""Postgres repository adapter for ticket FAQ Markdown drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+from .ticket_faq_ports import TicketFAQDraft
+
+
+def _draft_metadata(draft: TicketFAQDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_sequence(value: Any) -> tuple[Mapping[str, Any], ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(item for item in decoded if isinstance(item, Mapping))
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=str(row.get("id") or ""),
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        title=str(row.get("title") or ""),
+        markdown=str(row.get("markdown") or ""),
+        items=_json_sequence(row.get("items")),
+        source_count=int(row.get("source_count") or 0),
+        ticket_source_count=int(row.get("ticket_source_count") or 0),
+        output_checks=_json_mapping(row.get("output_checks")),
+        warnings=_json_sequence(row.get("warnings")),
+        metadata=_json_mapping(row.get("metadata")),
+        status=str(row.get("status") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresTicketFAQRepository:
+    """Async Postgres adapter for generated ticket FAQ Markdown."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[TicketFAQDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            faq_id = await self.pool.fetchval(
+                """
+                INSERT INTO ticket_faq_markdown (
+                    account_id, target_id, target_mode, title, markdown,
+                    items, source_count, ticket_source_count, output_checks,
+                    warnings, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6::jsonb, $7, $8, $9::jsonb,
+                    $10::jsonb, $11::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.title,
+                draft.markdown,
+                json_dump_jsonb([dict(item) for item in draft.items]),
+                int(draft.source_count),
+                int(draft.ticket_source_count),
+                json_dump_jsonb(dict(draft.output_checks or {})),
+                json_dump_jsonb([dict(warning) for warning in draft.warnings]),
+                json_dump_jsonb(_draft_metadata(draft, scope)),
+            )
+            saved.append(str(faq_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[TicketFAQDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        sql = (
+            "SELECT id, target_id, target_mode, title, markdown, items, "
+            "source_count, ticket_source_count, output_checks, warnings, "
+            "metadata, status "
+            "FROM ticket_faq_markdown WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        faq_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE ticket_faq_markdown
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $3
+            """,
+            faq_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+    async def update_statuses(
+        self,
+        faq_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in faq_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE ticket_faq_markdown
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+__all__ = [
+    "PostgresTicketFAQRepository",
+]

--- a/plans/PR-Content-Ops-FAQ-Generated-Asset-Persistence.md
+++ b/plans/PR-Content-Ops-FAQ-Generated-Asset-Persistence.md
@@ -1,0 +1,111 @@
+Plan: PR-Content-Ops-FAQ-Generated-Asset-Persistence
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Generated-Asset-Seam made `faq_markdown` runnable through
+AI Content Ops execution, but the result is still ephemeral: `/execute` returns
+Markdown and then loses it. That is useful for smoke testing, not for a hosted
+product workflow where operators expect generated outputs to be reviewed,
+approved, exported, or published later.
+
+This slice adds the persistence seam only. It keeps the deterministic FAQ
+builder intact, saves generated FAQ Markdown drafts when a repository is
+configured, and reports saved IDs in the execution result. Generated-asset API,
+export CLI, review CLI, and frontend switchboard support are intentionally
+deferred so this PR stays focused on the runtime persistence contract.
+
+This PR is over the 400 LOC target because the persistence seam needs the full
+generated-asset storage contract in one place: port, Postgres adapter,
+migration, service save hook, host wiring, and regression tests. Splitting the
+adapter from the service hook would leave either untested storage code or a
+save path with no concrete host implementation.
+
+## Scope (this PR)
+
+1. Add a `TicketFAQDraft` / `TicketFAQRepository` port for persisted FAQ
+   Markdown drafts.
+2. Add a Postgres adapter and owned migration for the `ticket_faq_markdown`
+   table.
+3. Extend `TicketFAQMarkdownService` with an optional repository; if configured
+   and the builder generated FAQ items, save one draft and expose `saved_ids`.
+4. Wire Atlas's Content Ops service factory to use the Postgres FAQ repository
+   when DB-backed services are enabled, while preserving deterministic no-DB
+   execution.
+5. Update tests/docs/coordination for the new persisted seam.
+
+### Files touched
+
+- `atlas_brain/_content_ops_services.py`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `extracted_content_pipeline/ticket_faq_ports.py`
+- `extracted_content_pipeline/ticket_faq_postgres.py`
+- `atlas_brain/storage/migrations/325_ticket_faq_markdown.sql`
+- `extracted_content_pipeline/storage/migrations/325_ticket_faq_markdown.sql`
+- `plans/PR-Content-Ops-FAQ-Generated-Asset-Persistence.md`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_postgres.py`
+
+## Mechanism
+
+`TicketFAQMarkdownService` keeps the same public `generate(...)` signature. The
+constructor gains an optional `ticket_faqs` repository. When `generate(...)`
+produces at least one FAQ item and `ticket_faqs` is configured, it builds a
+single `TicketFAQDraft` containing the Markdown, items, source counts,
+normalization warnings, and output checks, then persists it with
+`ticket_faqs.save_drafts(...)`.
+
+Without a repository, behavior remains exactly as the previous seam shipped:
+the service returns Markdown and metadata with `saved_ids=()`. This lets the
+CLI/offline and no-DB host paths remain deterministic.
+
+The Postgres adapter mirrors the existing generated-asset adapters:
+tenant-scoped `save_drafts`, `list_drafts`, `update_status`, and
+`update_statuses`. The Atlas migration is canonical because Atlas startup runs
+`atlas_brain/storage/migrations`; the extracted package receives a synced copy
+through `manifest.json`.
+
+## Intentional
+
+- No generated-asset API or CLI switchboard update in this PR. Persisting first
+  gives the next slice a concrete repository contract to route to.
+- One persisted draft per FAQ generation run, not one row per FAQ item. The
+  Markdown document is the asset; individual FAQ entries stay in `items` JSONB.
+- No LLM, quality pack, or reasoning pass. The output remains extractive and
+  grounded in support-ticket source rows.
+- The default no-DB service remains wired so `/execute` can still return FAQ
+  Markdown in lightweight host installs.
+
+## Deferred
+
+- Add `faq_markdown` to generated-asset API list/export/review routes.
+- Add `faq_markdown` to generated-asset export/review CLIs.
+- Add frontend review/export UI support for the persisted FAQ asset.
+- Add optional public/help-center FAQ render mode after internal Markdown
+  review quality is validated.
+
+## Verification
+
+- Focused pytest sweep over FAQ service, FAQ Postgres adapter, and Atlas host
+  service bundle -> 34 passed
+- Python compile sweep over edited modules/tests -> passed
+- validate_extracted_content_pipeline -> passed
+- forbid_atlas_reasoning_imports -> passed
+- audit_extracted_standalone --fail-on-debt -> passed
+- check_ascii_python -> passed
+- git diff --check -> passed
+- run_extracted_pipeline_checks -> 1482 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Ports, Postgres adapter, migration | ~295 |
+| Service + host wiring | ~95 |
+| Tests | ~255 |
+| Docs + coordination | ~70 |
+| **Total** | **~715** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -22,7 +22,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (15 tests):
+Test inventory (16 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -40,13 +40,14 @@ Test inventory (15 tests):
     and `for_output("blog_post")` returns the service.
 12. `blog_post` skips when no LLM (E4 fallback).
 13. `faq_markdown` runs through the full executor.
-14. `configured_outputs()` with LLM + db enabled advertises
+14. `faq_markdown` persists when DB services are enabled.
+15. `configured_outputs()` with LLM + db enabled advertises
     all 7 outputs: `(email_campaign, blog_post, report,
     landing_page, sales_brief, signal_extraction, faq_markdown)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-15. `configured_outputs()` without an active LLM (even with
+16. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     `signal_extraction` and `faq_markdown`.
 """
@@ -89,6 +90,15 @@ def _make_pool_stub() -> Any:
     Bundle population doesn't trigger that."""
 
     return SimpleNamespace()
+
+
+class _FAQPoolStub:
+    def __init__(self) -> None:
+        self.fetchval_calls: list[dict[str, Any]] = []
+
+    async def fetchval(self, query: str, *args: Any) -> str:
+        self.fetchval_calls.append({"query": query, "args": args})
+        return "faq-uuid-1"
 
 
 def _no_llm() -> None:
@@ -158,6 +168,37 @@ async def test_faq_markdown_runs_through_host_bundle() -> None:
     assert step["status"] == "completed"
     assert step["result"]["generated"] == 1
     assert "How do I fix failed exports?" in step["result"]["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_faq_markdown_persists_when_db_services_enabled() -> None:
+    pool = _FAQPoolStub()
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": [{
+                    "ticket_id": "ticket-1",
+                    "source_type": "ticket",
+                    "message": "How do I fix failed exports?",
+                    "pain_category": "exports",
+                }]
+            },
+        },
+        services=services,
+    )
+
+    step = result["steps"][0]
+    assert step["status"] == "completed"
+    assert step["result"]["saved_ids"] == ["faq-uuid-1"]
+    assert "INSERT INTO ticket_faq_markdown" in pool.fetchval_calls[0]["query"]
 
 
 def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -23,6 +23,15 @@ SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_
 SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
 
 
+class _FAQRepository:
+    def __init__(self) -> None:
+        self.saved = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.saved.append({"drafts": drafts, "scope": scope})
+        return ("faq-uuid-1",)
+
+
 def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
 
@@ -134,6 +143,58 @@ async def test_ticket_faq_service_skips_empty_source_material_containers() -> No
 
     assert result.as_dict()["generated"] == 1
     assert "The dashboard export is not working." in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_saves_generated_markdown_when_repository_configured() -> None:
+    repository = _FAQRepository()
+    service = TicketFAQMarkdownService(ticket_faqs=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        source_material=[{
+            "ticket_id": "ticket-1",
+            "source_type": "ticket",
+            "message": "The attribution export is missing renewals.",
+            "pain_category": "exports",
+        }],
+        title="Renewal FAQ",
+    )
+
+    assert result.as_dict()["saved_ids"] == ["faq-uuid-1"]
+    assert len(repository.saved) == 1
+    draft = repository.saved[0]["drafts"][0]
+    assert draft.target_id == "ticket-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.title == "Renewal FAQ"
+    assert "The attribution export is missing renewals." in draft.markdown
+    assert draft.metadata["source_types"] == [
+        "ticket",
+        "support_ticket",
+        "case",
+        "conversation",
+        "complaint",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_does_not_save_empty_results() -> None:
+    repository = _FAQRepository()
+    service = TicketFAQMarkdownService(ticket_faqs=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[{
+            "source_id": "review-1",
+            "source_type": "review",
+            "text": "Pricing is high.",
+        }],
+    )
+
+    assert result.as_dict()["saved_ids"] == []
+    assert repository.saved == []
 
 
 def test_build_ticket_faq_markdown_uses_nested_ticket_thread_text() -> None:

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": query, "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+        return self.execute_result
+
+
+def _draft() -> TicketFAQDraft:
+    return TicketFAQDraft(
+        target_id="ticket-1",
+        target_mode="vendor_retention",
+        title="Support FAQ",
+        markdown="# Support FAQ\n\n## Question",
+        items=({"question": "What changed?", "source_ids": ["ticket-1"]},),
+        source_count=3,
+        ticket_source_count=2,
+        output_checks={"has_action_items": True},
+        warnings=({"code": "missing_source_text", "row_index": 2},),
+        metadata={"source_types": ["ticket"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_markdown_document_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["faq-uuid-1"]
+    repo = PostgresTicketFAQRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-1"))
+
+    assert saved == ("faq-uuid-1",)
+    query = pool.fetchval_calls[0]["query"]
+    args = pool.fetchval_calls[0]["args"]
+    assert "INSERT INTO ticket_faq_markdown" in query
+    assert args[:5] == (
+        "acct-1",
+        "ticket-1",
+        "vendor_retention",
+        "Support FAQ",
+        "# Support FAQ\n\n## Question",
+    )
+    assert json.loads(args[5])[0]["question"] == "What changed?"
+    assert args[6:8] == (3, 2)
+    assert json.loads(args[8]) == {"has_action_items": True}
+    assert json.loads(args[9])[0]["code"] == "missing_source_text"
+    metadata = json.loads(args[10])
+    assert metadata["source_types"] == ["ticket"]
+    assert metadata["scope"]["account_id"] == "acct-1"
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_status_target_mode_and_limit() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{
+        "id": "faq-uuid-1",
+        "target_id": "ticket-1",
+        "target_mode": "vendor_retention",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ",
+        "items": json.dumps([{"question": "Q"}]),
+        "source_count": 3,
+        "ticket_source_count": 2,
+        "output_checks": json.dumps({"condensed": True}),
+        "warnings": json.dumps([]),
+        "metadata": json.dumps({"source_types": ["ticket"]}),
+        "status": "draft",
+    }]
+    repo = PostgresTicketFAQRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor_retention",
+        limit=20,
+    )
+
+    assert len(drafts) == 1
+    assert drafts[0].id == "faq-uuid-1"
+    assert drafts[0].items[0]["question"] == "Q"
+    assert drafts[0].output_checks == {"condensed": True}
+    query = pool.fetch_calls[0]["query"]
+    assert "status = $2" in query
+    assert "target_mode = $3" in query
+    assert "LIMIT $4" in query
+    assert pool.fetch_calls[0]["args"] == ("acct-1", "draft", "vendor_retention", 20)
+
+
+@pytest.mark.asyncio
+async def test_update_status_returns_false_on_miss() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "faq-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is False
+    assert "UPDATE ticket_faq_markdown" in pool.execute_calls[0]["query"]
+    assert pool.execute_calls[0]["args"] == ("faq-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_returns_matched_ids() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "faq-uuid-1"}]
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["faq-uuid-1", ""],
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ("faq-uuid-1",)
+    assert "id = ANY($1::uuid[])" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == (["faq-uuid-1"], "approved", "acct-1")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Generated-Asset-Persistence.md

Persist `faq_markdown` execution results as generated asset drafts when a host configures the FAQ repository. This keeps the deterministic/offline path intact while giving DB-backed hosts saved draft IDs and a concrete Postgres storage contract.

## Intentional
- No generated-asset API or CLI switchboard update in this PR; routing `faq_markdown` through list/export/review is deferred to the next slice.
- One persisted draft per FAQ generation run, not one row per FAQ item. The Markdown document is the asset.
- No LLM, quality pack, or reasoning pass. FAQ output remains extractive and grounded in support-ticket source rows.
- This PR is over the 400 LOC target because the persistence seam needs port, adapter, migration, service save hook, host wiring, and regression tests together.
- The Atlas migration is canonical and synced into the extracted package because Atlas startup runs `atlas_brain/storage/migrations`.

## Deferred
- Add `faq_markdown` to generated-asset API list/export/review routes.
- Add `faq_markdown` to generated-asset export/review CLIs.
- Add frontend review/export UI support for the persisted FAQ asset.
- Add optional public/help-center FAQ render mode after internal Markdown review quality is validated.

## Verification
- Focused pytest sweep over FAQ service, FAQ Postgres adapter, and Atlas host service bundle -> 34 passed
- Python compile sweep over edited modules/tests -> passed
- validate_extracted_content_pipeline -> passed
- forbid_atlas_reasoning_imports -> passed
- audit_extracted_standalone --fail-on-debt -> passed
- check_ascii_python -> passed
- git diff --check -> passed
- run_extracted_pipeline_checks -> 1482 passed, 1 existing torch/pynvml warning
- local_pr_review -> passed

## Diff size
14 files, +760 / -15