### PR TITLE
Add FAQ Markdown generated-asset switchboards

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-19T23:45Z by codex-2026-05-19
+Last updated: 2026-05-20T00:00Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Generated-Asset-Persistence | `ticket_faq_markdown.py`; `ticket_faq_ports.py`; `ticket_faq_postgres.py`; FAQ migration; host wiring/tests/docs | codex-2026-05-19 | Avoid concurrent edits to `faq_markdown` persistence and generated-asset storage seam. |
+| TBD | PR-Content-Ops-FAQ-Generated-Asset-Switchboards | `ticket_faq_export.py`; generated-asset API/CLI switchboards; FAQ export/review tests/docs | codex-2026-05-20 | Avoid concurrent edits to generated-asset list/export/review routing for `faq_markdown`. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -663,17 +663,18 @@ python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id ac
 python scripts/review_extracted_campaign_drafts.py <campaign-id> --account-id acct_123 --status cancelled --reason "customer rejected"
 ```
 
-Generated reports, landing pages, and sales briefs use the matching asset
-review CLI:
+Generated reports, landing pages, sales briefs, and FAQ Markdown documents use
+the matching asset review CLI:
 
 ```bash
 python scripts/review_extracted_content_assets.py --asset report --id <report-id> --account-id acct_123 --status approved
 python scripts/review_extracted_content_assets.py --asset landing_page --id <landing-page-id> --account-id acct_123 --status queued
 python scripts/review_extracted_content_assets.py --asset sales_brief --id <brief-id> --account-id acct_123 --status rejected
+python scripts/review_extracted_content_assets.py --asset faq_markdown --id <faq-id> --account-id acct_123 --status approved
 ```
 
 FastAPI hosts can mount the generated asset router for the same report, landing
-page, and sales brief review loop:
+page, sales brief, and FAQ Markdown review loop:
 
 ```python
 from fastapi import Depends
@@ -1056,10 +1057,12 @@ Several small utility shims provide product-owned local behavior by default so t
 - `report_export.py`: read-only structured report export for host review flows
 - `landing_page_export.py`: read-only landing page export for host review flows
 - `sales_brief_export.py`: read-only sales brief export for host review flows
+- `ticket_faq_export.py`: read-only ticket FAQ Markdown export for host review
+  flows
 - `scripts/export_extracted_content_assets.py`: host-facing report, landing
-  page, and sales brief export CLI
+  page, sales brief, and FAQ Markdown export CLI
 - `scripts/review_extracted_content_assets.py`: host-facing report, landing
-  page, and sales brief status-update CLI
+  page, sales brief, and FAQ Markdown status-update CLI
 - `campaign_postgres_seller_targets.py`: seller target CRUD/list helpers for
   Amazon seller campaign installs
 - `campaign_postgres_seller_opportunities.py`: prepares Amazon seller

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -82,14 +82,17 @@ source of truth for what remains.
 - `sales_brief_export` provides a read-only draft export path over generated
   sales briefs so hosts can review JSON/CSV outputs without handwritten SQL or
   a mounted sales brief API.
+- `ticket_faq_export` provides a read-only draft export path over generated
+  ticket FAQ Markdown documents so hosts can review JSON/CSV outputs without
+  handwritten SQL or a mounted FAQ API.
 - `scripts/export_extracted_content_assets.py` exposes the report, blog post,
-  landing page, and sales brief export helpers as a host-facing JSON/CSV CLI
-  backed by the product-owned Postgres repositories.
+  landing page, sales brief, and FAQ Markdown export helpers as a host-facing
+  JSON/CSV CLI backed by the product-owned Postgres repositories.
 - `scripts/review_extracted_content_assets.py` exposes scoped status updates
-  for exported report, blog post, landing page, and sales brief drafts without
-  handwritten SQL.
+  for exported report, blog post, landing page, sales brief, and FAQ Markdown
+  drafts without handwritten SQL.
 - `api.generated_assets` provides a FastAPI router factory around generated
-  report, blog post, landing page, and sales brief list/export/review
+  report, blog post, landing page, sales brief, and FAQ Markdown list/export/review
   workflows. Hosts inject pool providers, tenant scope, and auth dependencies.
 - `api.reasoning_contexts` provides a FastAPI router factory around DB-backed
   campaign reasoning context list/upsert/delete workflows. Hosts inject pool

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -28,12 +28,14 @@ from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
 from ..sales_brief_export import export_sales_brief_drafts
 from ..sales_brief_postgres import PostgresSalesBriefRepository
+from ..ticket_faq_export import export_ticket_faq_drafts
+from ..ticket_faq_postgres import PostgresTicketFAQRepository
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
 
-ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 
 
 def _require_fastapi() -> None:
@@ -368,6 +370,14 @@ async def _export_for_asset(
             brief_type=brief_type,
             limit=limit,
         )
+    if asset == "faq_markdown":
+        return await export_ticket_faq_drafts(
+            PostgresTicketFAQRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            limit=limit,
+        )
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
 
 
@@ -387,6 +397,8 @@ async def _update_asset_status(
         return await PostgresLandingPageRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "faq_markdown":
+        return await PostgresTicketFAQRepository(pool).update_status(asset_id, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
 
 
@@ -406,6 +418,8 @@ async def _update_asset_statuses(
         return await PostgresLandingPageRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "faq_markdown":
+        return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
 
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -744,9 +744,9 @@ The mounted list/export routes use the same export helper as the CLI, so JSON
 and CSV responses include the generation-usage and reasoning summary fields
 documented above.
 
-Export generated reports, blog posts, landing pages, or sales briefs through
-the generated asset CLI when the host needs the same review loop for
-non-campaign outputs:
+Export generated reports, blog posts, landing pages, sales briefs, or FAQ
+Markdown documents through the generated asset CLI when the host needs the same
+review loop for non-campaign outputs:
 
 ```bash
 python scripts/export_extracted_content_assets.py \
@@ -776,6 +776,13 @@ python scripts/export_extracted_content_assets.py \
   --target-mode vendor_retention \
   --brief-type pre_call \
   --limit 20
+
+python scripts/export_extracted_content_assets.py \
+  --asset faq_markdown \
+  --account-id acct_123 \
+  --target-mode support_account \
+  --format csv \
+  --output ticket_faq_drafts.csv
 ```
 
 Move reviewed generated assets through host-defined lifecycle statuses without
@@ -805,6 +812,12 @@ python scripts/review_extracted_content_assets.py \
   --id <brief-id> \
   --account-id acct_123 \
   --status ready_for_call
+
+python scripts/review_extracted_content_assets.py \
+  --asset faq_markdown \
+  --id <faq-id> \
+  --account-id acct_123 \
+  --status approved
 ```
 
 Or mount the generated asset API router beside the campaign draft router:
@@ -832,9 +845,10 @@ The generated asset router exposes:
 | `GET` | `/content-assets/{asset}/drafts/export` | Export generated asset drafts as CSV or JSON. |
 | `POST` | `/content-assets/{asset}/drafts/review` | Update one generated asset status by id. |
 
-Supported `{asset}` values are `report`, `blog_post`, `landing_page`, and
-`sales_brief`. Review statuses are host-defined strings; the product does not
-impose a fixed status vocabulary for these generated asset tables.
+Supported `{asset}` values are `report`, `blog_post`, `landing_page`,
+`sales_brief`, and `faq_markdown`. Review statuses are host-defined strings;
+the product does not impose a fixed status vocabulary for these generated asset
+tables.
 
 Amazon seller installs can mount the seller-specific router:
 

--- a/extracted_content_pipeline/docs/standalone_productization.md
+++ b/extracted_content_pipeline/docs/standalone_productization.md
@@ -198,11 +198,17 @@ read-only review path for generated sales briefs. It calls the host-injected
 brief sections and metadata, and derives top-level generation and reasoning
 summary columns for operator review without requiring direct SQL access.
 
+`extracted_content_pipeline/ticket_faq_export.py` owns the equivalent read-only
+review path for generated ticket FAQ Markdown documents. It calls the
+host-injected `TicketFAQRepository.list_drafts()` port, emits JSON or CSV rows,
+and preserves the Markdown body, FAQ items, output checks, warnings, and
+metadata for operator review without requiring direct SQL access.
+
 `scripts/export_extracted_content_assets.py` exposes those generated-asset
 export helpers to operators. Hosts choose `--asset report`, `--asset
-landing_page`, or `--asset sales_brief`; the CLI creates the product-owned
-Postgres repository, applies the relevant filters, and writes JSON or CSV
-without requiring ad hoc SQL.
+landing_page`, `--asset sales_brief`, or `--asset faq_markdown`; the CLI
+creates the product-owned Postgres repository, applies the relevant filters,
+and writes JSON or CSV without requiring ad hoc SQL.
 
 `scripts/review_extracted_content_assets.py` owns the matching status-update
 loop for generated assets. Hosts pass `--asset`, `--id`, `--status`, and an
@@ -217,8 +223,9 @@ the blog-post generator.
 
 `extracted_content_pipeline/api/generated_assets.py` owns the host-mounted
 FastAPI surface for generated asset review workflows. It exposes list, CSV/JSON
-export, and status-update routes for reports, landing pages, and sales briefs
-while requiring the host to inject database, tenant scope, and auth providers.
+export, and status-update routes for reports, landing pages, sales briefs, and
+FAQ Markdown documents while requiring the host to inject database, tenant
+scope, and auth providers.
 
 `extracted_content_pipeline/campaign_postgres_review.py` owns the write side of
 that host review loop. It updates selected `b2b_campaigns` rows by explicit

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -216,6 +216,9 @@
       "target": "extracted_content_pipeline/sales_brief_export.py"
     },
     {
+      "target": "extracted_content_pipeline/ticket_faq_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_postgres_review.py"
     },
     {

--- a/extracted_content_pipeline/ticket_faq_export.py
+++ b/extracted_content_pipeline/ticket_faq_export.py
@@ -1,0 +1,135 @@
+"""Read-only ticket FAQ Markdown draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .campaign_ports import TenantScope
+from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "title",
+    "source_count",
+    "ticket_source_count",
+    "passed_output_checks",
+    "warning_count",
+    "markdown",
+    "items",
+    "output_checks",
+    "warnings",
+    "metadata",
+    "id",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class TicketFAQDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_ticket_faq_drafts(
+    repository: TicketFAQRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    limit: int = 20,
+) -> TicketFAQDraftExportResult:
+    """Return generated ticket FAQ Markdown drafts for host review/export."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        limit=normalized_limit,
+    )
+    return TicketFAQDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: TicketFAQDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["warning_count"] = len(draft.warnings)
+    row["passed_output_checks"] = _passed_output_checks(draft.output_checks)
+    return row
+
+
+def _passed_output_checks(value: Any) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    return sum(1 for item in value.values() if item is True)
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "TicketFAQDraftExportResult",
+    "export_ticket_faq_drafts",
+]

--- a/plans/PR-Content-Ops-FAQ-Generated-Asset-Switchboards.md
+++ b/plans/PR-Content-Ops-FAQ-Generated-Asset-Switchboards.md
@@ -1,0 +1,98 @@
+# PR-Content-Ops-FAQ-Generated-Asset-Switchboards
+
+## Why this slice exists
+
+`faq_markdown` can now run through Content Ops and persist drafts into
+`ticket_faq_markdown`, but the generated-asset review switchboards still only
+know the older asset types. Hosts can generate FAQ Markdown, but they cannot use
+the standard list/export/review API or CLIs to inspect and approve those drafts.
+
+This slice closes the deferred switchboard item from
+`PR-Content-Ops-FAQ-Generated-Asset-Persistence`.
+
+The diff is over the 400 LOC target because the switchboard is only useful if
+the API, export CLI, review CLI, docs, and tests land together. Splitting the
+export helper from the switchboards would leave a non-runnable helper; splitting
+API from CLI would leave one host review surface stale.
+
+## Scope (this PR)
+
+1. Add a read-only FAQ Markdown export helper that mirrors the existing
+   generated-asset export result shape.
+2. Add `faq_markdown` to the generated-asset FastAPI list/export/review router.
+3. Add `faq_markdown` to the generated-asset export and review CLIs.
+4. Register the new owned export helper in the extracted manifest.
+5. Update docs/status so host operators can find the FAQ review path.
+6. Add focused tests for export helper behavior, API routing, and both CLIs.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Generated-Asset-Switchboards.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/ticket_faq_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `extracted_content_pipeline/manifest.json`
+- `scripts/export_extracted_content_assets.py`
+- `scripts/review_extracted_content_assets.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+- `extracted_content_pipeline/docs/standalone_productization.md`
+- `tests/test_extracted_ticket_faq_export.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_content_asset_export_cli.py`
+- `tests/test_extracted_content_asset_review_cli.py`
+
+## Mechanism
+
+`ticket_faq_export.py` will call `TicketFAQRepository.list_drafts(...)`, apply
+the existing tenant/status/target-mode filters, and return an export result with
+dictionary and CSV render methods. The CSV columns stay FAQ-specific:
+`target_id`, `target_mode`, `title`, source counts, output-check summary, the
+Markdown body, structured items/warnings/metadata, id, and status.
+
+The API router and CLIs will add `faq_markdown` to their `ASSET_CHOICES` and
+branch to `PostgresTicketFAQRepository` for list/export/status updates. No new
+route shape or command is introduced.
+
+## Intentional
+
+- `faq_markdown` uses the existing `target_mode` filter only. It does not add a
+  FAQ-specific query parameter because the persisted table has no separate FAQ
+  facet.
+- The export helper preserves the full Markdown body in CSV, matching the
+  existing generated-asset exports that include full content bodies.
+- Review statuses remain host-defined strings. This matches the existing
+  generated-asset review policy.
+
+## Deferred
+
+- UI rendering for persisted FAQ drafts remains a later host-dashboard slice.
+  This PR only makes the existing API/CLI review seams complete.
+- Batch export formatting optimizations for very large Markdown bodies are not
+  included; hosts can use JSON export for richer downstream handling.
+
+## Verification
+
+Local checks:
+
+- pytest tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py -> 42 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_export.py extracted_content_pipeline/api/generated_assets.py scripts/export_extracted_content_assets.py scripts/review_extracted_content_assets.py tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py -> passed
+- bash scripts/validate_extracted_content_pipeline.sh -> passed
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
+- bash scripts/check_ascii_python.sh -> passed
+- bash scripts/run_extracted_pipeline_checks.sh -> 1490 passed, 1 existing torch/pynvml warning
+- bash scripts/local_pr_review.sh -> passed after commit
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Production, docs, tests, and plan | 618 |
+| **Total** | **618** |
+
+Actual staged size: 16 files, +591/-27 LOC. This is over the 400 LOC target, but
+the overage is the focused cost of closing the complete generated-asset review
+seam for one asset type across API, CLIs, docs, and tests.

--- a/scripts/export_extracted_content_assets.py
+++ b/scripts/export_extracted_content_assets.py
@@ -35,9 +35,13 @@ from extracted_content_pipeline.sales_brief_export import (  # noqa: E402
 from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
     PostgresSalesBriefRepository,
 )
+from extracted_content_pipeline.ticket_faq_export import export_ticket_faq_drafts  # noqa: E402
+from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
+    PostgresTicketFAQRepository,
+)
 
 
-ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -56,7 +60,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="draft",
         help="Status to export. Use empty string for all statuses.",
     )
-    parser.add_argument("--target-mode", default=None, help="Report/sales brief target_mode filter.")
+    parser.add_argument("--target-mode", default=None, help="Report/sales brief/FAQ target_mode filter.")
     parser.add_argument("--report-type", default=None, help="Report type filter.")
     parser.add_argument("--topic-type", default=None, help="Blog post topic_type filter.")
     parser.add_argument("--campaign-name", default=None, help="Landing page campaign_name filter.")
@@ -144,6 +148,14 @@ async def _export_for_asset(args: argparse.Namespace, pool: Any):
             status=status,
             target_mode=args.target_mode,
             brief_type=args.brief_type,
+            limit=args.limit,
+        )
+    if args.asset == "faq_markdown":
+        return await export_ticket_faq_drafts(
+            PostgresTicketFAQRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=args.target_mode,
             limit=args.limit,
         )
     raise ValueError(f"Unsupported asset: {args.asset}")

--- a/scripts/review_extracted_content_assets.py
+++ b/scripts/review_extracted_content_assets.py
@@ -27,9 +27,12 @@ from extracted_content_pipeline.report_postgres import PostgresReportRepository 
 from extracted_content_pipeline.sales_brief_postgres import (  # noqa: E402
     PostgresSalesBriefRepository,
 )
+from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
+    PostgresTicketFAQRepository,
+)
 
 
-ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief")
+ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -102,6 +105,12 @@ async def _review_asset(args: argparse.Namespace, pool: Any) -> bool:
         )
     if args.asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_status(
+            args.asset_id,
+            args.status,
+            scope=scope,
+        )
+    if args.asset == "faq_markdown":
+        return await PostgresTicketFAQRepository(pool).update_status(
             args.asset_id,
             args.status,
             scope=scope,

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -67,6 +67,7 @@ pytest \
   tests/test_extracted_blog_post_export.py \
   tests/test_extracted_landing_page_export.py \
   tests/test_extracted_sales_brief_export.py \
+  tests/test_extracted_ticket_faq_export.py \
   tests/test_extracted_campaign_postgres_review.py \
   tests/test_extracted_campaign_postgres_seller_targets.py \
   tests/test_extracted_campaign_postgres_seller_opportunities.py \

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -118,6 +118,23 @@ def _sales_brief_row():
     }
 
 
+def _ticket_faq_row():
+    return {
+        "id": "faq-uuid-1",
+        "status": "draft",
+        "target_id": "acct_1",
+        "target_mode": "support_account",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ\n\n## How do I reset login?",
+        "items": [{"question": "How do I reset login?", "answer": "Use the reset link."}],
+        "source_count": 3,
+        "ticket_source_count": 2,
+        "output_checks": {"uses_user_vocabulary": True, "has_action_items": True},
+        "warnings": [{"code": "thin_evidence"}],
+        "metadata": {},
+    }
+
+
 def _client(
     pool,
     *,
@@ -226,6 +243,46 @@ def test_generated_asset_router_exports_sales_brief_json_without_status_filter()
     assert args == ("", "vendor_retention", "pre_call", 20)
 
 
+def test_generated_asset_router_lists_ticket_faq_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_ticket_faq_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/faq_markdown/drafts"
+        "?target_mode=support_account&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["id"] == "faq-uuid-1"
+    assert body["rows"][0]["title"] == "Support FAQ"
+    assert body["rows"][0]["passed_output_checks"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in query
+    assert args == ("acct_1", "draft", "support_account", 5)
+
+
+def test_generated_asset_router_exports_ticket_faq_csv() -> None:
+    pool = _Pool(rows=[_ticket_faq_row()])
+
+    response = _client(pool).get(
+        "/content-assets/faq_markdown/drafts/export"
+        "?format=csv&target_mode=support_account"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_faq_markdown.csv" in response.headers["content-disposition"]
+    assert "target_id,target_mode,title" in response.text
+    assert "Support FAQ" in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in query
+    assert args == ("", "draft", "support_account", 20)
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 
@@ -249,6 +306,31 @@ def test_generated_asset_router_reviews_report_with_host_defined_status() -> Non
     query, args = pool.execute_calls[0]
     assert "UPDATE reports" in query
     assert args == ("report-uuid-1", "published", "acct_1")
+
+
+def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
+    pool = _Pool()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/faq_markdown/drafts/review",
+        json={"id": "11111111-1111-1111-1111-111111111111", "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "account_id": "acct_1",
+        "asset": "faq_markdown",
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "approved",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE ticket_faq_markdown" in query
+    assert args == ("11111111-1111-1111-1111-111111111111", "approved", "acct_1")
 
 
 def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:

--- a/tests/test_extracted_content_asset_export_cli.py
+++ b/tests/test_extracted_content_asset_export_cli.py
@@ -104,6 +104,23 @@ def _sales_brief_row():
     }
 
 
+def _ticket_faq_row():
+    return {
+        "id": "faq-uuid-1",
+        "status": "draft",
+        "target_id": "acct_1",
+        "target_mode": "support_account",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ\n\n## How do I reset login?",
+        "items": [{"question": "How do I reset login?", "answer": "Use the reset link."}],
+        "source_count": 3,
+        "ticket_source_count": 2,
+        "output_checks": {"uses_user_vocabulary": True, "has_action_items": True},
+        "warnings": [],
+        "metadata": {},
+    }
+
+
 @pytest.mark.asyncio
 async def test_asset_export_cli_outputs_report_json(monkeypatch, capsys) -> None:
     cli = _load_cli_module()
@@ -263,6 +280,44 @@ async def test_asset_export_cli_outputs_sales_brief_json(monkeypatch, capsys) ->
     assert args == ("", "vendor_retention", "pre_call", 3)
     assert output["rows"][0]["brief_type"] == "pre_call"
     assert output["rows"][0]["reasoning_wedge"] == "support_erosion"
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_outputs_ticket_faq_json(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool(rows=[_ticket_faq_row()])
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "faq_markdown",
+            "--account-id",
+            "acct_1",
+            "--target-mode",
+            "support_account",
+            "--limit",
+            "2",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.fetch_calls[0]
+    assert exit_code == 0
+    assert "FROM ticket_faq_markdown" in query
+    assert args == ("acct_1", "draft", "support_account", 2)
+    assert output["rows"][0]["title"] == "Support FAQ"
+    assert output["rows"][0]["passed_output_checks"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -205,6 +205,49 @@ async def test_asset_review_cli_updates_sales_brief_status(monkeypatch, capsys) 
 
 
 @pytest.mark.asyncio
+async def test_asset_review_cli_updates_ticket_faq_status(monkeypatch, capsys) -> None:
+    cli = _load_cli_module()
+    pool = _Pool()
+
+    async def create_pool(database_url):
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "review",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "faq_markdown",
+            "--id",
+            "faq-uuid-1",
+            "--status",
+            "approved",
+            "--account-id",
+            "acct_1",
+        ],
+    )
+
+    exit_code = await cli._main()
+
+    output = json.loads(capsys.readouterr().out)
+    query, args = pool.execute_calls[0]
+    assert exit_code == 0
+    assert "UPDATE ticket_faq_markdown" in query
+    assert args == ("faq-uuid-1", "approved", "acct_1")
+    assert output == {
+        "account_id": "acct_1",
+        "asset": "faq_markdown",
+        "id": "faq-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_asset_review_cli_allows_host_defined_status(monkeypatch, capsys) -> None:
     cli = _load_cli_module()
     pool = _Pool()

--- a/tests/test_extracted_ticket_faq_export.py
+++ b/tests/test_extracted_ticket_faq_export.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.ticket_faq_export import export_ticket_faq_drafts
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+class _Repository:
+    def __init__(self, drafts=()) -> None:
+        self.drafts = tuple(drafts)
+        self.calls: list[dict[str, object]] = []
+
+    async def list_drafts(self, *, scope, status=None, target_mode=None, limit=None):
+        self.calls.append({
+            "scope": scope,
+            "status": status,
+            "target_mode": target_mode,
+            "limit": limit,
+        })
+        return self.drafts
+
+
+def _draft() -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id="faq-uuid-1",
+        status="draft",
+        target_id="acct_1",
+        target_mode="support_account",
+        title="Support FAQ",
+        markdown="# Support FAQ\n\n## How do I reset login?",
+        items=[{
+            "question": "How do I reset login?",
+            "answer": "Use the reset link.",
+        }],
+        source_count=3,
+        ticket_source_count=2,
+        output_checks={"uses_user_vocabulary": True, "has_action_items": True},
+        warnings=[{"code": "thin_evidence"}],
+        metadata={"scope": {"account_id": "acct_1"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_ticket_faq_drafts_passes_filters_to_repository() -> None:
+    repo = _Repository([_draft()])
+
+    result = await export_ticket_faq_drafts(
+        repo,
+        scope=TenantScope(account_id="acct_1"),
+        status="draft",
+        target_mode="support_account",
+        limit=5,
+    )
+
+    assert repo.calls == [{
+        "scope": TenantScope(account_id="acct_1"),
+        "status": "draft",
+        "target_mode": "support_account",
+        "limit": 5,
+    }]
+    assert result.as_dict()["filters"] == {
+        "status": "draft",
+        "account_id": "acct_1",
+        "target_mode": "support_account",
+    }
+    assert result.as_dict()["rows"][0]["passed_output_checks"] == 2
+    assert result.as_dict()["rows"][0]["warning_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_draft_export_result_renders_csv() -> None:
+    result = await export_ticket_faq_drafts(
+        _Repository([_draft()]),
+        scope={"account_id": "acct_1"},
+    )
+
+    csv_text = result.as_csv()
+
+    assert result.as_dict()["count"] == 1
+    assert csv_text.startswith("target_id,target_mode,title")
+    assert "Support FAQ" in csv_text
+    assert "uses_user_vocabulary" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_export_ticket_faq_drafts_rejects_negative_limit() -> None:
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        await export_ticket_faq_drafts(_Repository(), limit=-1)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Generated-Asset-Switchboards.md

Persisted `faq_markdown` drafts now have the same host review path as the other generated Content Ops assets. This adds a FAQ export helper and wires `faq_markdown` into the generated-asset API, export CLI, and review CLI.

## Intentional
- `faq_markdown` uses the existing `target_mode` filter only; the persisted FAQ table has no additional FAQ-specific facet.
- Review statuses remain host-defined strings, matching the generated-asset policy.
- The diff is over the 400 LOC target because API, CLIs, docs, and tests need to land together for the host review seam to be usable.

## Deferred
- Host dashboard UI rendering for persisted FAQ drafts remains a later slice.
- Batch formatting optimizations for very large Markdown bodies are deferred; hosts can use JSON export for richer downstream handling.

## Verification
- `pytest tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_asset_api.py tests/test_extracted_content_asset_export_cli.py tests/test_extracted_content_asset_review_cli.py` -> 42 passed
- `python -m py_compile ...` for touched Python modules/tests -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1490 passed, 1 existing torch/pynvml warning
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
16 files, +596 / -27
