### PR TITLE
Add FAQ Markdown execution smoke coverage

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T00:00Z by codex-2026-05-20
+Last updated: 2026-05-20T01:00Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Generated-Asset-Switchboards | `ticket_faq_export.py`; generated-asset API/CLI switchboards; FAQ export/review tests/docs | codex-2026-05-20 | Avoid concurrent edits to generated-asset list/export/review routing for `faq_markdown`. |
+| TBD | PR-Content-Ops-FAQ-Execution-Smoke | `smoke_extracted_content_ops_execution.py`; execution smoke tests/docs for `faq_markdown` | codex-2026-05-20 | Avoid concurrent edits to the offline Content Ops execution smoke. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -914,10 +914,11 @@ python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,landing_page --with-reasoning --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,landing_page --with-reasoning --reasoning-provider postgres-fixture --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json
 ```
 
 This validates the full campaign preset and the deterministic source-material
-normalization path through host-injected services without opening database,
+normalization and FAQ Markdown paths through host-injected services without opening database,
 network, sender, or LLM handles. `--no-quality-gates` is an execution-smoke
 override for checking the request wiring; production hosts should leave quality
 gates enabled unless they intentionally disable them in their own policy layer.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -186,14 +186,14 @@ source of truth for what remains.
   telemetry without making dashboard storage a product dependency.
 - `content_ops_execution` provides the host-injected execution seam for
   runnable AI Content Ops control-surface plans. It dispatches executable
-  outputs to configured campaign, blog-post, report, landing-page, and
-  sales-brief services, plus deterministic signal extraction, without
+  outputs to configured campaign, blog-post, report, landing-page, sales-brief,
+  and FAQ Markdown services, plus deterministic signal extraction, without
   constructing hidden database, LLM, or Atlas dependencies.
 - `scripts/smoke_extracted_content_ops_execution.py` provides a no-network,
   no-database smoke for the multi-asset Content Ops execution seam. It runs the
-  full campaign preset and signal-extraction path through injected offline
-  services so hosts can validate execution wiring separately from real provider
-  credentials.
+  full campaign preset, signal-extraction path, and FAQ Markdown output through
+  injected offline services so hosts can validate execution wiring separately
+  from real provider credentials.
 - `campaign_generation` retries unparseable LLM JSON once by default through
   product config, improving draft yield without moving provider retry policy
   into Atlas runtime code.

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -305,13 +305,15 @@ python scripts/smoke_extracted_content_ops_execution.py
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,report --target-mode challenger_intel --no-quality-gates --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,landing_page --with-reasoning --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
+python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json
 ```
 
 The smoke uses injected deterministic services and exercises the same
 `execute_content_ops_from_mapping(...)` seam as the API route. It does not
 open network, database, sender, or LLM handles. The signal extraction command
 validates the deterministic source-material-to-opportunity path through the
-same execution seam. `--no-quality-gates` verifies request wiring for hosts
+same execution seam; the FAQ command validates source-material-to-Markdown
+rendering plus output checks. `--no-quality-gates` verifies request wiring for hosts
 that need to smoke-test policy overrides; production hosts should leave quality
 gates enabled unless their own policy layer disables them.
 `--with-reasoning` attaches a fake host reasoning provider to the generated-

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -1039,10 +1039,17 @@ python scripts/smoke_extracted_content_ops_execution.py \
   --outputs email_campaign,landing_page \
   --with-reasoning \
   --json
+
+python scripts/smoke_extracted_content_ops_execution.py \
+  --outputs faq_markdown \
+  --source-type support_ticket \
+  --source-title "login reset" \
+  --json
 ```
 
-The smoke uses fake generated-asset services and defaults to a `sample`
-offline provider object. It fails if the JSON result omits
+The smoke uses fake generated-asset services plus the deterministic FAQ
+Markdown service, and defaults to a `sample` offline provider object. It fails
+if the JSON result omits
 `result.reasoning_contexts_used`, the step-level `reasoning.contexts_used`
 audit field, or `reasoning.consumed_contexts` when the usage count is
 positive. That lets hosts verify the execution seam without opening database,

--- a/plans/PR-Content-Ops-FAQ-Execution-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Execution-Smoke.md
@@ -1,0 +1,85 @@
+# PR-Content-Ops-FAQ-Execution-Smoke
+
+## Why this slice exists
+
+`faq_markdown` is now a runnable Content Ops output and has persisted
+generated-asset review/export support, but the offline execution smoke still
+cannot prove that output through the same `POST /content-ops/execute` seam. The
+smoke service bundle does not include `TicketFAQMarkdownService`, and the smoke
+payload validator treats every non-signal output as requiring `saved_ids`.
+
+This slice makes the host smoke prove FAQ Markdown execution without requiring
+Postgres, providers, or Atlas runtime imports.
+
+## Scope (this PR)
+
+1. Wire `TicketFAQMarkdownService` into the offline execution smoke services.
+2. Add a configurable source type to the smoke source row so FAQ generation can
+   identify support-ticket evidence.
+3. Teach the smoke validator that `faq_markdown` is a deterministic Markdown
+   output validated by Markdown, FAQ items, and output checks rather than
+   `saved_ids`.
+4. Add focused subprocess coverage for `--outputs faq_markdown`.
+5. Update docs/status examples for the new smoke command.
+6. Replace the stale in-flight row with this slice's coordination claim.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Execution-Smoke.md`
+- `docs/extraction/coordination/inflight.md`
+- `scripts/smoke_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_ops_execution_smoke.py`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+
+## Mechanism
+
+The smoke script will import `TicketFAQMarkdownService` and provide it through
+`ContentOpsExecutionServices(faq_markdown=...)`. The smoke payload will include
+`source_type` from a new `--source-type` option, defaulting to `support_ticket`,
+so the FAQ builder receives support-ticket-shaped source material.
+
+`_step_has_output_payload(...)` will keep the existing `saved_ids` policy for
+provider-backed generated assets, keep the `opportunities` policy for
+`signal_extraction`, and add an explicit FAQ policy: Markdown must be non-empty,
+items must be present, and every `output_checks` value must be exactly `True`.
+
+## Intentional
+
+- This is still an offline smoke. It does not persist FAQ drafts or exercise the
+  generated-asset export/review switchboards from the previous PR.
+- `faq_markdown` remains excluded from reasoning usage validation because the
+  FAQ builder is deterministic and does not consume reasoning contexts.
+- The smoke validates the three FAQ output checks indirectly through
+  `output_checks`; detailed FAQ rendering tests stay in
+  `tests/test_extracted_ticket_faq_markdown.py`.
+
+## Deferred
+
+- A real Postgres-backed FAQ persistence smoke can follow if host operators need
+  one. The current goal is execution seam coverage without database setup.
+- Dashboard rendering for persisted FAQ drafts remains a later UI slice.
+
+## Verification
+
+Local checks:
+
+- pytest tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_ticket_faq_markdown.py -> 30 passed
+- python -m py_compile scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py -> passed
+- bash scripts/validate_extracted_content_pipeline.sh -> passed
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
+- bash scripts/check_ascii_python.sh -> passed
+- bash scripts/run_extracted_pipeline_checks.sh -> 1493 passed, 1 existing torch/pynvml warning
+- bash scripts/local_pr_review.sh -> passed after commit
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Smoke script | 35 |
+| Tests | 45 |
+| Docs and plan | 115 |
+| **Total** | **195** |

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -20,6 +20,7 @@ from extracted_content_pipeline.content_ops_execution import (  # noqa: E402
     execute_content_ops_from_mapping,
 )
 from extracted_content_pipeline.signal_extraction import SignalExtractionService  # noqa: E402
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService  # noqa: E402
 
 
 _POSTGRES_FIXTURE_PAYLOAD: dict[str, Any] = {
@@ -255,6 +256,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="Pricing became hard to justify after renewal.",
     )
     parser.add_argument("--source-id", default="source-smoke-1")
+    parser.add_argument("--source-type", default="support_ticket")
+    parser.add_argument("--source-title", default="pricing after renewal")
     parser.add_argument("--source-vendor", default="HubSpot")
     parser.add_argument("--source-contact-email", default="buyer@example.com")
     parser.add_argument(
@@ -305,6 +308,8 @@ def _payload(args: argparse.Namespace) -> dict[str, Any]:
                     "id": args.source_id,
                     "company": args.target_account,
                     "vendor": args.source_vendor,
+                    "source_type": args.source_type,
+                    "source_title": args.source_title,
                     "text": args.source_material,
                     "contact_email": args.source_contact_email,
                 }
@@ -344,6 +349,7 @@ def _services(
         landing_page=landing_page,
         sales_brief=opportunity_service("sales_brief"),
         signal_extraction=SignalExtractionService(),
+        faq_markdown=TicketFAQMarkdownService(),
     )
     if reasoning:
         provider = (
@@ -388,6 +394,15 @@ def _step_has_output_payload(
         return False
     if step.get("output") == "signal_extraction":
         return bool(result_payload.get("opportunities"))
+    if step.get("output") == "faq_markdown":
+        checks = result_payload.get("output_checks")
+        return (
+            bool(result_payload.get("markdown"))
+            and bool(result_payload.get("items"))
+            and isinstance(checks, Mapping)
+            and bool(checks)
+            and all(value is True for value in checks.values())
+        )
     return bool(result_payload.get("saved_ids"))
 
 

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -227,6 +227,39 @@ def test_content_ops_execution_smoke_cli_runs_signal_extraction_json() -> None:
     )
 
 
+def test_content_ops_execution_smoke_cli_runs_faq_markdown_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--outputs",
+            "faq_markdown",
+            "--source-title",
+            "login reset",
+            "--source-material",
+            "I cannot reset my password from the login page.",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    step = payload["steps"][0]
+    result = step["result"]
+    assert payload["status"] == "completed"
+    assert step["output"] == "faq_markdown"
+    assert result["generated"] == 1
+    assert result["items"][0]["topic"] == "login reset"
+    assert result["output_checks"] == {
+        "condensed": True,
+        "has_action_items": True,
+        "uses_user_vocabulary": True,
+    }
+    assert "What to do next" in result["markdown"]
+
+
 def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> None:
     completed = subprocess.run(
         [
@@ -240,6 +273,8 @@ def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> No
             "Salesforce",
             "--source-contact-email",
             "ops@example.com",
+            "--source-type",
+            "case",
             "--source-max-text-chars",
             "11",
             "--source-material",
@@ -256,6 +291,7 @@ def test_content_ops_execution_smoke_cli_parameterizes_signal_source_row() -> No
     assert opportunity["target_id"] == "source-42"
     assert opportunity["vendor"] == "Salesforce"
     assert opportunity["contact_email"] == "ops@example.com"
+    assert opportunity["source_type"] == "case"
     assert opportunity["evidence"][0]["text"] == "The renewal"
 
 
@@ -322,3 +358,45 @@ def test_execution_errors_accepts_signal_extraction_opportunities() -> None:
             }
         ],
     }) == []
+
+
+def test_execution_errors_accepts_checked_faq_markdown_output() -> None:
+    smoke = _load_smoke_module()
+
+    assert smoke._execution_errors({
+        "status": "completed",
+        "steps": [
+            {
+                "output": "faq_markdown",
+                "status": "completed",
+                "result": {
+                    "markdown": "# FAQ",
+                    "items": [{"question": "How do I reset login?"}],
+                    "output_checks": {
+                        "uses_user_vocabulary": True,
+                        "condensed": True,
+                        "has_action_items": True,
+                    },
+                },
+            }
+        ],
+    }) == []
+
+
+def test_execution_errors_rejects_faq_markdown_without_passing_checks() -> None:
+    smoke = _load_smoke_module()
+
+    assert smoke._execution_errors({
+        "status": "completed",
+        "steps": [
+            {
+                "output": "faq_markdown",
+                "status": "completed",
+                "result": {
+                    "markdown": "# FAQ",
+                    "items": [{"question": "How do I reset login?"}],
+                    "output_checks": {"has_action_items": False},
+                },
+            }
+        ],
+    }) == ["step 1 missing output payload"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Execution-Smoke.md

`faq_markdown` is runnable and reviewable, but the offline execution smoke could not prove that output through the Content Ops execution seam. This wires the smoke to the real deterministic FAQ service and validates Markdown/items/output_checks without requiring Postgres, LLM, sender, or Atlas runtime dependencies.

## Intentional
- `faq_markdown` remains excluded from reasoning usage validation because the FAQ builder is deterministic and does not consume reasoning contexts.
- The smoke validates Markdown/items/output_checks instead of `saved_ids` because no persistence repository is configured.

## Deferred
- Real Postgres-backed FAQ persistence smoke remains a later host-operator slice.
- Dashboard rendering for persisted FAQ drafts remains a later UI slice.

## Verification
- `pytest tests/test_extracted_content_ops_execution_smoke.py tests/test_extracted_ticket_faq_markdown.py` -> 30 passed
- `python -m py_compile scripts/smoke_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1493 passed, 1 existing torch/pynvml warning
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
8 files, +199 / -11
