### PR TITLE
Prove FAQ Markdown renders as structured lists

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -118,7 +118,7 @@ jobs:
         # pydantic-settings; this is purely the cross-boundary seam test.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T01:00Z by codex-2026-05-20
+Last updated: 2026-05-20T01:13Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Execution-Smoke | `smoke_extracted_content_ops_execution.py`; execution smoke tests/docs for `faq_markdown` | codex-2026-05-20 | Avoid concurrent edits to the offline Content Ops execution smoke. |
+| TBD | PR-Content-Ops-FAQ-Markdown-Render-Proof | `tests/test_extracted_ticket_faq_markdown.py`; FAQ Markdown render-proof test | codex-2026-05-20 | Avoid concurrent edits to the ticket FAQ Markdown tests. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -285,9 +285,11 @@ def _render(
             _md(item["answer"]),
             "",
             "**What to do next:**",
+            "",
             *[f"- {_md(step)}" for step in item["action_items"]],
             "",
             "**Sources:**",
+            "",
             *[f"- {_md(label)}" for label in item["source_labels"]],
             "",
         ])

--- a/plans/PR-Content-Ops-FAQ-Markdown-Render-Proof.md
+++ b/plans/PR-Content-Ops-FAQ-Markdown-Render-Proof.md
@@ -1,0 +1,93 @@
+# PR-Content-Ops-FAQ-Markdown-Render-Proof
+
+## Why this slice exists
+
+The FAQ Markdown output is now wired into Content Ops generation, storage,
+export, review, and the offline execution smoke. The remaining proof gap is
+whether the generated Markdown is actually renderable as a readable FAQ from
+real packaged support-ticket rows. Discovery found the current bold labels and
+bullets render as paragraphs rather than HTML lists because the Markdown lacks
+blank lines before the bullet blocks. This slice fixes that at the source and
+locks the rendered structure.
+
+## Scope (this PR)
+
+1. Fix FAQ Markdown spacing so action and source bullets render as lists.
+2. Add a render-proof regression test for FAQ Markdown generated from the
+   packaged support-ticket CSV.
+3. Render the generated Markdown through the already declared Python Markdown
+   dependency and assert the customer-visible structure survives rendering.
+4. Leave FAQ generation content and grouping behavior unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Markdown-Render-Proof.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this in-flight slice. |
+| `.github/workflows/extracted_pipeline_checks.yml` | Install the declared Markdown renderer in extracted CI. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Add Markdown-compatible blank lines before FAQ bullet lists. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Add render-proof coverage for generated FAQ Markdown. |
+
+## Mechanism
+
+The production renderer now emits a blank line after each bold list label
+before the bullets. That keeps the visible Markdown shape the same while
+allowing standard Markdown renderers to emit real unordered lists.
+
+The extracted CI workflow installs the same Markdown package already declared
+in `requirements.txt` so the render proof runs in CI instead of passing only in
+developer environments that happen to have the package installed.
+
+The test loads the existing support-ticket CSV fixture through the same source
+adapter used by the FAQ CLI, builds the FAQ Markdown with the production
+builder, renders it with the declared Markdown package, and inspects the HTML
+with the standard-library HTML parser.
+
+The assertions cover the three output checks:
+
+1. User vocabulary survives in rendered headings and body text.
+2. Similar rows are condensed into the generated FAQ items rather than
+   duplicated beyond the builder result.
+3. The rendered FAQ includes a clear "What to do next" action section with
+   bullet items, plus source links as rendered list items.
+
+## Intentional
+
+- No model call is added. The deterministic builder should cover the first
+  useful version of a grounded FAQ; LLM polishing can be a later opt-in layer.
+- No production HTML renderer is added. Hosts can render Markdown however they
+  prefer; this slice verifies the generated Markdown is compatible with the
+  declared Markdown renderer.
+- The test inspects rendered HTML structure, not exact HTML formatting, because
+  renderer whitespace and tag formatting are implementation details.
+
+## Deferred
+
+- A visual/browser rendering check can be added if a hosted FAQ page UI is
+  introduced.
+- An optional LLM rewrite or semantic clustering pass can be evaluated after
+  deterministic FAQ output is validated against real customer data.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py - 15 passed.
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- git diff --check - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - 1494 passed, 1 existing torch/pynvml warning.
+- bash scripts/local_pr_review.sh - passed after CI dependency amendment.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Markdown-Render-Proof.md` | +93 |
+| `docs/extraction/coordination/inflight.md` | +1 / -1 |
+| `.github/workflows/extracted_pipeline_checks.yml` | +1 / -1 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +2 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +83 |
+| Total | ~184 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from html.parser import HTMLParser
 import json
 import subprocess
 import sys
 from pathlib import Path
 
+import markdown
 import pytest
 
 from extracted_content_pipeline.campaign_source_adapters import (
@@ -21,6 +23,50 @@ ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
 SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
 SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
+
+
+class _RenderedFAQHTML(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.h1: list[str] = []
+        self.h2: list[str] = []
+        self.paragraphs: list[str] = []
+        self.list_items: list[str] = []
+        self.strong: list[str] = []
+        self.ul_count = 0
+        self._stack: list[str] = []
+        self._buffers: dict[str, list[str]] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        self._stack.append(tag)
+        if tag == "ul":
+            self.ul_count += 1
+        if tag in {"h1", "h2", "p", "li", "strong"}:
+            self._buffers[tag] = []
+
+    def handle_data(self, data: str) -> None:
+        for tag in ("h1", "h2", "p", "li", "strong"):
+            if tag in self._stack and tag in self._buffers:
+                self._buffers[tag].append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        text = " ".join("".join(self._buffers.pop(tag, [])).split())
+        if text:
+            if tag == "h1":
+                self.h1.append(text)
+            elif tag == "h2":
+                self.h2.append(text)
+            elif tag == "p":
+                self.paragraphs.append(text)
+            elif tag == "li":
+                self.list_items.append(text)
+            elif tag == "strong":
+                self.strong.append(text)
+        if self._stack and self._stack[-1] == tag:
+            self._stack.pop()
+        elif tag in self._stack:
+            self._stack.remove(tag)
 
 
 class _FAQRepository:
@@ -44,6 +90,43 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     assert "`ticket-acme-1` - Reporting export blocked before renewal" in result.markdown
     assert "**What to do next:**" in result.markdown
     assert "Check whether your plan and role include the needed export" in result.markdown
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+
+
+def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows() -> None:
+    loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities)
+    rendered = _RenderedFAQHTML()
+    rendered.feed(markdown.markdown(result.markdown))
+
+    assert rendered.h1 == ["Customer Ticket FAQ"]
+    assert rendered.h2 == [
+        "1. What are customers asking about manual follow-up?",
+        "2. What are customers asking about reporting friction?",
+    ]
+    assert rendered.strong.count("What to do next:") == 2
+    assert rendered.strong.count("Sources:") == 2
+    assert rendered.ul_count == 4
+    assert any(
+        "Support notes show campaign handoffs are still being reconciled manually"
+        in paragraph
+        for paragraph in rendered.paragraphs
+    )
+    assert any(
+        "Check the workflow or automation rule that should handle this step."
+        in item
+        for item in rendered.list_items
+    )
+    assert any(
+        "ticket-acme-1 - Reporting export blocked before renewal" in item
+        for item in rendered.list_items
+    )
+    assert len(result.items) == 2
     assert result.output_checks == {
         "uses_user_vocabulary": True,
         "condensed": True,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Markdown-Render-Proof.md

The FAQ Markdown path was wired, but we had not proven that its output renders as a readable FAQ from real support-ticket rows. Discovery found the action/source bullets were rendered as paragraph text by the declared Markdown package because the generated Markdown missed blank lines before bullet blocks. This fixes the Markdown spacing and adds a render-proof regression using the packaged support-ticket CSV.

## Intentional
- No LLM path is added; the deterministic builder remains the first FAQ implementation.
- No production HTML renderer is added; hosts still own their render surface.
- The test inspects rendered HTML structure instead of exact formatting.

## Deferred
- Browser-level visual checks wait for a hosted FAQ page UI.
- Optional LLM polishing or semantic clustering remains a later layer.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py - 15 passed.
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- git diff --check - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 1494 passed, 1 existing torch/pynvml warning.
- bash scripts/local_pr_review.sh - passed.

## Diff size
4 files, +174 / -2