### PR TITLE
Expose FAQ Markdown drafts in asset review UI

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -269,6 +269,7 @@ export type GeneratedAssetType =
   | 'report'
   | 'landing_page'
   | 'sales_brief'
+  | 'faq_markdown'
 
 export interface GeneratedAssetDraft {
   id?: string
@@ -285,6 +286,8 @@ export interface GeneratedAssetDraft {
   summary?: string
   headline?: string
   content?: string
+  markdown?: string
+  items?: Array<Record<string, unknown>> | string
   tags?: string[] | string
   hero?: Record<string, unknown>
   sections?: Array<Record<string, unknown>> | string
@@ -301,6 +304,10 @@ export interface GeneratedAssetDraft {
   reference_count?: number
   tag_count?: number
   chart_count?: number
+  source_count?: number
+  ticket_source_count?: number
+  output_checks?: Record<string, unknown> | string
+  passed_output_checks?: number
   persona?: string
   value_prop?: string
   [key: string]: unknown

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -35,6 +35,13 @@ type AssetFact = {
   value: string
 }
 
+type FAQItemPreview = {
+  question: string
+  answer: string
+  actionItems: string[]
+  sourceLabels: string[]
+}
+
 const ASSETS: Array<{
   id: GeneratedAssetType
   label: string
@@ -59,6 +66,11 @@ const ASSETS: Array<{
     id: 'sales_brief',
     label: 'Sales Briefs',
     description: 'Pre-call and account-facing sales enablement assets.',
+  },
+  {
+    id: 'faq_markdown',
+    label: 'FAQ Markdown',
+    description: 'Grounded FAQ documents generated from support-ticket evidence.',
   },
 ]
 
@@ -218,7 +230,7 @@ export default function ContentOpsAssetsReview() {
         </div>
       </header>
 
-      <section className="grid gap-3 md:grid-cols-4">
+      <section className="grid gap-3 md:grid-cols-5">
         {ASSETS.map((item) => (
           <button
             key={item.id}
@@ -522,6 +534,7 @@ function AssetDetailDrawer({
   const facts = assetFacts(row, asset)
   const sections = sectionList(row.sections)
   const references = valueList(row.reference_ids)
+  const faqItems = asset === 'faq_markdown' ? faqItemList(row.items) : []
   const drawerRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
 
@@ -664,6 +677,58 @@ function AssetDetailDrawer({
           </section>
         )}
 
+        {faqItems.length > 0 && (
+          <section className="mt-6">
+            <h3 className="text-sm font-semibold text-slate-200">FAQ Items</h3>
+            <div className="mt-3 space-y-3">
+              {faqItems.map((item, index) => (
+                <div
+                  key={`${item.question}-${index}`}
+                  className="rounded-md border border-slate-800 bg-slate-900/60 p-4"
+                >
+                  <div className="text-sm font-medium text-white">
+                    {item.question || `Question ${index + 1}`}
+                  </div>
+                  {item.answer && (
+                    <p className="mt-2 text-sm leading-6 text-slate-400">
+                      {item.answer}
+                    </p>
+                  )}
+                  {item.actionItems.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        What to do next
+                      </div>
+                      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+                        {item.actionItems.map((action, actionIndex) => (
+                          <li key={`${action}-${actionIndex}`}>{action}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {item.sourceLabels.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Sources
+                      </div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {item.sourceLabels.map((source, sourceIndex) => (
+                          <span
+                            key={`${source}-${sourceIndex}`}
+                            className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300"
+                          >
+                            {source}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
         {references.length > 0 && (
           <section className="mt-6">
             <h3 className="text-sm font-semibold text-slate-200">References</h3>
@@ -741,6 +806,13 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
       .filter(Boolean)
       .join(' | ')
   }
+  if (asset === 'faq_markdown') {
+    return [
+      row.target_mode,
+      numberLabel(row.ticket_source_count, 'ticket row'),
+      numberLabel(row.source_count, 'source row'),
+    ].filter(Boolean).join(' | ')
+  }
   return [row.target_mode, row.report_type, row.summary]
     .map(textValue)
     .filter(Boolean)
@@ -778,6 +850,12 @@ function addAssetSpecificFacts(
   if (asset === 'landing_page') {
     addFact(facts, 'campaign', row.campaign_name)
     addFact(facts, 'persona', row.persona)
+    return
+  }
+  if (asset === 'faq_markdown') {
+    addFact(facts, 'ticket rows', row.ticket_source_count)
+    addFact(facts, 'source rows', row.source_count)
+    addFact(facts, 'checks passed', row.passed_output_checks)
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -829,6 +907,21 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
       ].filter(Boolean),
     })
   }
+  if (asset === 'faq_markdown') {
+    const items = faqItemList(row.items)
+    const first = items[0]
+    const checks = outputCheckLabels(row.output_checks)
+    const sourceMeta =
+      first?.sourceLabels.slice(0, 2).map((source) => `source: ${source}`) ?? []
+    return previewOrNull({
+      heading: first?.question || textValue(row.title),
+      body: excerpt(first?.answer || textValue(row.markdown)),
+      meta: [
+        ...sourceMeta,
+        ...checks.slice(0, 3).map((check) => `check: ${check}`),
+      ],
+    })
+  }
   const section = firstSection(row.sections)
   const sectionTitles = sectionList(row.sections)
     .map((item) => item.title)
@@ -857,23 +950,35 @@ function firstSection(value: unknown): { title: string; body: string } {
 }
 
 function sectionList(value: unknown): Array<{ title: string; body: string }> {
-  let sections = Array.isArray(value) ? value : []
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value)
-      sections = Array.isArray(parsed) ? parsed : []
-    } catch {
-      sections = []
-    }
-  }
-  return sections
-    .filter((item): item is Record<string, unknown> =>
-      Boolean(item && typeof item === 'object' && !Array.isArray(item)),
-    )
+  return recordList(value)
     .map((section) => ({
       title: textValue(section.title) || textValue(section.heading),
       body: textValue(section.body_markdown) || textValue(section.body),
     }))
+}
+
+function faqItemList(value: unknown): FAQItemPreview[] {
+  return recordList(value).map((item) => ({
+    question: textValue(item.question) || textValue(item.topic),
+    answer: textValue(item.answer),
+    actionItems: valueList(item.action_items),
+    sourceLabels: valueList(item.source_labels),
+  })).filter((item) => item.question || item.answer)
+}
+
+function recordList(value: unknown): Record<string, unknown>[] {
+  let rows = Array.isArray(value) ? value : []
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      rows = Array.isArray(parsed) ? parsed : []
+    } catch {
+      rows = []
+    }
+  }
+  return rows.filter((item): item is Record<string, unknown> =>
+    Boolean(item && typeof item === 'object' && !Array.isArray(item)),
+  )
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {
@@ -902,6 +1007,19 @@ function valueList(value: unknown): string[] {
   const text = textValue(value)
   if (!text) return []
   return text.split(',').map((item) => item.trim()).filter(Boolean)
+}
+
+function outputCheckLabels(value: unknown): string[] {
+  const checks = recordValue(value)
+  if (!checks) return []
+  return Object.entries(checks)
+    .filter(([, passed]) => passed === true)
+    .map(([key]) => key.replace(/_/g, ' '))
+}
+
+function numberLabel(value: unknown, label: string): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return ''
+  return `${value} ${label}${value === 1 ? '' : 's'}`
 }
 
 function excerpt(value: string, limit = 260): string {

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T01:13Z by codex-2026-05-20
+Last updated: 2026-05-20T01:32Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Markdown-Render-Proof | `tests/test_extracted_ticket_faq_markdown.py`; FAQ Markdown render-proof test | codex-2026-05-20 | Avoid concurrent edits to the ticket FAQ Markdown tests. |
+| TBD | PR-Content-Ops-FAQ-Asset-Review-UI | `plans/PR-Content-Ops-FAQ-Asset-Review-UI.md`; `docs/extraction/coordination/inflight.md`; `atlas-intel-ui/src/api/contentOps.ts`; `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-20 | Avoid concurrent edits to the generated asset review UI. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-FAQ-Asset-Review-UI.md
+++ b/plans/PR-Content-Ops-FAQ-Asset-Review-UI.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-FAQ-Asset-Review-UI
+
+## Why this slice exists
+
+faq_markdown is now generated, persisted, exported, reviewable through the
+backend API, and render-proofed as Markdown. The Atlas Intel Generated Asset
+Review UI still exposes only reports, blog posts, landing pages, and sales
+briefs. Operators cannot select FAQ drafts from the UI even though the route
+already supports them.
+
+## Scope (this PR)
+
+1. Add faq_markdown to the frontend generated-asset type union.
+2. Add a FAQ Markdown asset card to the Generated Asset Review page.
+3. Render FAQ-specific previews, facts, and detail sections from the structured
+   `items` payload returned by the API.
+4. Avoid unsafe raw Markdown HTML rendering.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Asset-Review-UI.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace the merged stale row with this in-flight slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Add FAQ Markdown to the generated asset type and FAQ row fields. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Add the FAQ card plus safe preview/detail rendering. |
+
+## Mechanism
+
+The API type union will include faq_markdown, matching the backend asset
+choices. The review page will add a fifth asset card and branch on
+the FAQ asset id where the existing page already branches by asset:
+subtitle, asset-specific facts, preview, and detail drawer content.
+
+FAQ detail rendering reads `items` as an array of records and renders question,
+answer, action items, and source labels with React text nodes. It does not use
+`dangerouslySetInnerHTML` or a browser Markdown renderer; the raw row remains
+available for diagnostics.
+
+## Intentional
+
+- No backend/API route changes. The generated asset API already supports FAQ
+  Markdown.
+- No Markdown-to-HTML rendering in the browser. The structured `items` payload
+  is safer and more reviewable for operators.
+- No new frontend test runner is introduced. This UI currently relies on
+  TypeScript build coverage.
+
+## Deferred
+
+- A richer public FAQ page renderer can be added if FAQ drafts become a hosted
+  customer-facing page, not just an operator review artifact.
+- Per-item approve/reject remains out of scope; status review still applies to
+  the whole generated FAQ document.
+
+## Verification
+
+- npm ci in atlas-intel-ui - passed, with 6 existing audit findings.
+- npm run build in atlas-intel-ui - passed.
+- npx eslint src/api/contentOps.ts src/pages/ContentOpsAssetsReview.tsx in atlas-intel-ui - passed.
+- npm run lint in atlas-intel-ui - fails on pre-existing no-explicit-any errors
+  in atlas-intel-ui/src/pages/b2b/B2BReports.tsx outside this PR diff.
+- git diff --check - passed.
+- bash scripts/local_pr_review.sh - passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Asset-Review-UI.md` | +74 |
+| `docs/extraction/coordination/inflight.md` | +1 / -1 |
+| `atlas-intel-ui/src/api/contentOps.ts` | +7 |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | +141 / -12 |
+| Total | ~218 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Asset-Review-UI.md

FAQ Markdown drafts are generated, persisted, exported, and reviewable through the backend, but the Atlas Intel Generated Asset Review UI did not expose the asset type. This adds the FAQ asset to the frontend contract and review page, with safe structured preview/detail rendering from the API items payload.

## Intentional
- Render FAQ details from structured items with React text nodes instead of unsafe raw Markdown HTML.
- No backend route changes; the generated asset API already supports FAQ Markdown.
- No new frontend test runner; this UI relies on TypeScript build coverage.

## Deferred
- A richer public FAQ page renderer waits for a hosted customer-facing FAQ surface.
- Per-item review remains out of scope; document-level review status is unchanged.

## Verification
- npm ci in atlas-intel-ui - passed, with 6 existing audit findings.
- npm run build in atlas-intel-ui - passed.
- npx eslint src/api/contentOps.ts src/pages/ContentOpsAssetsReview.tsx in atlas-intel-ui - passed.
- npm run lint in atlas-intel-ui - fails on pre-existing no-explicit-any errors in atlas-intel-ui/src/pages/b2b/B2BReports.tsx outside this PR diff.
- git diff --check - passed.
- bash scripts/local_pr_review.sh - passed.

## Diff size
4 files, +213 / -14