### PR TITLE
Add FAQ Markdown date-window filtering

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T01:32Z by codex-2026-05-20
+Last updated: 2026-05-20T02:01Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Asset-Review-UI | `plans/PR-Content-Ops-FAQ-Asset-Review-UI.md`; `docs/extraction/coordination/inflight.md`; `atlas-intel-ui/src/api/contentOps.ts`; `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | codex-2026-05-20 | Avoid concurrent edits to the generated asset review UI. |
+| TBD | PR-Content-Ops-FAQ-Date-Window | `plans/PR-Content-Ops-FAQ-Date-Window.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `extracted_content_pipeline/generation_plan.py`; `extracted_content_pipeline/content_ops_execution.py`; `scripts/build_extracted_ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py`; `tests/test_extracted_content_generation_plan.py`; `tests/test_extracted_content_ops_execution.py`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown recency filtering and docs. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -173,12 +173,15 @@ write Markdown directly:
 python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
+  --window-days 90 \
   --output support_ticket_faq.md
 ```
 
 The FAQ builder is deterministic and extractive: it groups ticket evidence by
 pain point, quotes compact snippets from the source rows, and lists ticket
-source ids under each answer.
+source ids under each answer. Add `--as-of-date YYYY-MM-DD` with
+`--window-days` when you need a reproducible audit window instead of today's
+date.
 
 The same artifact can run through the Content Ops execution seam by selecting
 `faq_markdown` and passing inline `source_material`. It remains zero-provider.

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -548,6 +548,8 @@ async def _dispatch_faq_markdown(
         max_evidence_per_item=_step_config_int(step.config, "max_evidence_per_item"),
         source_types=_step_config_sequence(step.config, "source_types"),
         max_text_chars=_step_config_int(step.config, "max_text_chars"),
+        window_days=_step_config_int(step.config, "window_days"),
+        as_of_date=_step_config_text(step.config, "as_of_date"),
     )
 
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -230,12 +230,14 @@ Markdown FAQ:
 python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
+  --window-days 90 \
   --output support_ticket_faq.md
 ```
 
 The FAQ file quotes source snippets and lists ticket ids, so operators can
 inspect grounding before choosing whether to generate campaigns or longer
-assets.
+assets. Add `--as-of-date YYYY-MM-DD` with `--window-days` for reproducible
+canary runs.
 
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 `description`, `summary`, `notes`, `feedback`, `feedback_text`,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -217,6 +217,8 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
             _positive_int_input(request.inputs, "source_max_text_chars")
             or defaults.max_text_chars
         ),
+        window_days=_positive_int_input(request.inputs, "faq_window_days"),
+        as_of_date=_text_input(request.inputs, "faq_as_of_date"),
     )
 
 
@@ -356,17 +358,22 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
         )
     if output == "faq_markdown":
         config = _faq_markdown_config_for_request(request)
+        step_config: dict[str, Any] = {
+            "title": config.title,
+            "max_items": config.max_items,
+            "max_evidence_per_item": config.max_evidence_per_item,
+            "source_types": list(config.source_types),
+            "max_text_chars": config.max_text_chars,
+        }
+        if config.window_days is not None:
+            step_config["window_days"] = config.window_days
+        if config.as_of_date is not None:
+            step_config["as_of_date"] = config.as_of_date
         return GenerationPlanStep(
             output=output,
             runner="TicketFAQMarkdownService.generate",
             status="runnable",
-            config={
-                "title": config.title,
-                "max_items": config.max_items,
-                "max_evidence_per_item": config.max_evidence_per_item,
-                "source_types": list(config.source_types),
-                "max_text_chars": config.max_text_chars,
-            },
+            config=step_config,
         )
     return GenerationPlanStep(
         output=output,

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -9,6 +9,7 @@ call. Thrilling bureaucracy, but the useful kind.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Any, Mapping, Sequence
 
 from .blog_generation import BlogPostGenerationConfig
@@ -204,6 +205,15 @@ def _signal_extraction_config_for_request(
 
 def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMarkdownConfig:
     defaults = TicketFAQMarkdownConfig()
+    window_days = _positive_int_input(request.inputs, "faq_window_days")
+    as_of_date = _text_input(request.inputs, "faq_as_of_date")
+    if as_of_date is not None and window_days is None:
+        raise ValueError("faq_as_of_date requires faq_window_days")
+    if as_of_date is not None:
+        try:
+            date.fromisoformat(as_of_date)
+        except ValueError:
+            raise ValueError("faq_as_of_date must use YYYY-MM-DD format") from None
     return TicketFAQMarkdownConfig(
         title=_text_input(request.inputs, "faq_title") or defaults.title,
         max_items=request.limit,
@@ -217,8 +227,8 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
             _positive_int_input(request.inputs, "source_max_text_chars")
             or defaults.max_text_chars
         ),
-        window_days=_positive_int_input(request.inputs, "faq_window_days"),
-        as_of_date=_text_input(request.inputs, "faq_as_of_date"),
+        window_days=window_days,
+        as_of_date=as_of_date,
     )
 
 
@@ -367,7 +377,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
         }
         if config.window_days is not None:
             step_config["window_days"] = config.window_days
-        if config.as_of_date is not None:
+        if config.window_days is not None and config.as_of_date is not None:
             step_config["as_of_date"] = config.as_of_date
         return GenerationPlanStep(
             output=output,

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -347,6 +347,8 @@ def _source_label(row: Mapping[str, str]) -> str:
 
 def _date_window(*, window_days: int | None, as_of_date: Any) -> tuple[date, date] | None:
     if window_days is None:
+        if _clean(as_of_date):
+            raise ValueError("as_of_date requires window_days")
         return None
     days = int(window_days)
     if days < 1:
@@ -381,10 +383,15 @@ def _field_value(row: Mapping[str, Any], key: str) -> Any:
     if key in row:
         return row.get(key)
     target = _source_type_key(key)
+    compact_target = _compact_key(key)
     for raw_key, value in row.items():
-        if _source_type_key(raw_key) == target:
+        if _source_type_key(raw_key) == target or _compact_key(raw_key) == compact_target:
             return value
     return None
+
+
+def _compact_key(value: Any) -> str:
+    return _KEY_SEPARATOR_RE.sub("", _clean(value).lower())
 
 
 def _parse_source_date(value: Any) -> date | None:
@@ -409,10 +416,21 @@ def _parse_source_date(value: Any) -> date | None:
 def _parse_as_of_date(value: Any) -> date | None:
     if value in (None, ""):
         return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
     parsed = _parse_source_date(value)
-    if parsed is None:
+    try:
+        strict = date.fromisoformat(text)
+    except ValueError:
         raise ValueError("as_of_date must be a valid ISO date")
-    return parsed
+    if parsed != strict:
+        raise ValueError("as_of_date must be a valid ISO date")
+    return strict
 
 
 def _date_window_metadata(*, window_days: int | None, as_of_date: Any) -> dict[str, Any]:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
+from datetime import date, datetime, timedelta
 import re
 from typing import Any
 
@@ -23,6 +24,19 @@ DEFAULT_TICKET_SOURCE_TYPES = (
 DEFAULT_TITLE = "Customer Ticket FAQ"
 _WHITESPACE_RE = re.compile(r"\s+")
 _KEY_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+_DATE_KEYS = (
+    "created_at",
+    "created",
+    "ticket_created_at",
+    "case_created_at",
+    "submitted_at",
+    "opened_at",
+    "received_at",
+    "updated_at",
+    "closed_at",
+    "date",
+    "timestamp",
+)
 _ACTION_RULES = (
     (("export", "report", "dashboard", "attribution"), (
         "Check whether your plan and role include the needed export or reporting access.",
@@ -73,6 +87,8 @@ class TicketFAQMarkdownConfig:
     max_evidence_per_item: int = 3
     source_types: tuple[str, ...] = DEFAULT_TICKET_SOURCE_TYPES
     max_text_chars: int = 1200
+    window_days: int | None = None
+    as_of_date: str | None = None
 
 
 class TicketFAQMarkdownService:
@@ -98,6 +114,8 @@ class TicketFAQMarkdownService:
         max_evidence_per_item: int | None = None,
         source_types: Sequence[str] | None = None,
         max_text_chars: int | None = None,
+        window_days: int | None = None,
+        as_of_date: Any = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
@@ -112,6 +130,12 @@ class TicketFAQMarkdownService:
             if max_text_chars is not None
             else self.config.max_text_chars
         )
+        resolved_window_days = (
+            int(window_days)
+            if window_days is not None
+            else self.config.window_days
+        )
+        resolved_as_of_date = as_of_date if as_of_date is not None else self.config.as_of_date
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be positive")
         normalized = source_rows_to_campaign_opportunities(
@@ -131,6 +155,8 @@ class TicketFAQMarkdownService:
             max_items=resolved_max_items,
             max_evidence_per_item=resolved_max_evidence,
             source_types=resolved_source_types,
+            window_days=resolved_window_days,
+            as_of_date=resolved_as_of_date,
         )
         result = replace(
             result,
@@ -150,7 +176,13 @@ class TicketFAQMarkdownService:
                     ticket_source_count=result.ticket_source_count,
                     output_checks=result.output_checks,
                     warnings=result.warnings,
-                    metadata={"source_types": list(resolved_source_types)},
+                    metadata={
+                        "source_types": list(resolved_source_types),
+                        **_date_window_metadata(
+                            window_days=resolved_window_days,
+                            as_of_date=resolved_as_of_date,
+                        ),
+                    },
                 )
             ],
             scope=scope,
@@ -165,6 +197,8 @@ def build_ticket_faq_markdown(
     max_items: int = 8,
     max_evidence_per_item: int = 3,
     source_types: Sequence[str] = DEFAULT_TICKET_SOURCE_TYPES,
+    window_days: int | None = None,
+    as_of_date: Any = None,
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -174,11 +208,18 @@ def build_ticket_faq_markdown(
         raise ValueError("max_evidence_per_item must be positive")
 
     allowed = {_source_type_key(item) for item in source_types if _source_type_key(item)}
+    date_window = _date_window(window_days=window_days, as_of_date=as_of_date)
     groups: dict[str, list[dict[str, str]]] = defaultdict(list)
     seen: set[tuple[str, str]] = set()
 
     for opportunity_index, opportunity in enumerate(opportunities, start=1):
         for evidence_index, evidence in enumerate(_evidence_rows(opportunity), start=1):
+            if date_window is not None and not _inside_date_window(
+                opportunity,
+                evidence,
+                date_window=date_window,
+            ):
+                continue
             source_type = _source_type_key(evidence.get("source_type") or opportunity.get("source_type"))
             # Empty allowed set means "no filter" rather than "reject all".
             if allowed and source_type not in allowed:
@@ -302,6 +343,86 @@ def _source_label(row: Mapping[str, str]) -> str:
     if source_id and title:
         return f"`{source_id}` - {title}"
     return f"`{source_id or 'unknown'}`"
+
+
+def _date_window(*, window_days: int | None, as_of_date: Any) -> tuple[date, date] | None:
+    if window_days is None:
+        return None
+    days = int(window_days)
+    if days < 1:
+        raise ValueError("window_days must be positive")
+    as_of = _parse_as_of_date(as_of_date) or date.today()
+    return (as_of - timedelta(days=days), as_of)
+
+
+def _inside_date_window(
+    opportunity: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    *,
+    date_window: tuple[date, date],
+) -> bool:
+    source_date = _source_date(evidence) or _source_date(opportunity)
+    if source_date is None:
+        return False
+    start, end = date_window
+    return start <= source_date <= end
+
+
+def _source_date(row: Mapping[str, Any]) -> date | None:
+    for key in _DATE_KEYS:
+        value = _field_value(row, key)
+        parsed = _parse_source_date(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _field_value(row: Mapping[str, Any], key: str) -> Any:
+    if key in row:
+        return row.get(key)
+    target = _source_type_key(key)
+    for raw_key, value in row.items():
+        if _source_type_key(raw_key) == target:
+            return value
+    return None
+
+
+def _parse_source_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).date()
+    except ValueError:
+        pass
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def _parse_as_of_date(value: Any) -> date | None:
+    if value in (None, ""):
+        return None
+    parsed = _parse_source_date(value)
+    if parsed is None:
+        raise ValueError("as_of_date must be a valid ISO date")
+    return parsed
+
+
+def _date_window_metadata(*, window_days: int | None, as_of_date: Any) -> dict[str, Any]:
+    if window_days is None:
+        return {}
+    metadata: dict[str, Any] = {"window_days": int(window_days)}
+    parsed = _parse_as_of_date(as_of_date)
+    if parsed is not None:
+        metadata["as_of_date"] = parsed.isoformat()
+    return metadata
 
 
 def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:

--- a/plans/PR-Content-Ops-FAQ-Date-Window.md
+++ b/plans/PR-Content-Ops-FAQ-Date-Window.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-FAQ-Date-Window
+
+## Why this slice exists
+
+The support-ticket FAQ pipeline can load customer CSV files and generate
+grounded Markdown, but it cannot yet honestly support the "CSV - Last 90 days"
+claim. Operators can pre-filter files outside Atlas, but the product seam should
+also enforce a recency window when requested so stale tickets do not influence
+FAQ entries.
+
+## Scope (this PR)
+
+1. Add optional date-window filtering to the ticket FAQ Markdown builder and
+   service.
+2. Thread faq_window_days and faq_as_of_date through the Content Ops generation
+   plan and executor for the FAQ Markdown output.
+3. Add CLI flags for the standalone FAQ Markdown script.
+4. Document the last-90-days command shape in the README and host runbook.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Date-Window.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this in-flight slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Optional recency filtering and config fields. |
+| `extracted_content_pipeline/generation_plan.py` | Map FAQ recency inputs into step config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Pass FAQ recency config into the service. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Add standalone CLI flags. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Builder/service/CLI regression coverage. |
+| `tests/test_extracted_content_generation_plan.py` | Plan config regression coverage. |
+| `tests/test_extracted_content_ops_execution.py` | Executor threading regression coverage. |
+| `extracted_content_pipeline/README.md` | Document the CSV recency command. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Document the host runbook recency command. |
+
+## Mechanism
+
+The FAQ builder will accept an optional positive window_days value and optional
+as_of_date. When a window is supplied, it will keep only source opportunities or
+evidence rows with a recognized date field inside the inclusive window. Rows
+without a parseable date are excluded only when a date window is active.
+
+Date lookup stays local to ticket_faq_markdown.py instead of changing the shared
+source adapter. That keeps the new behavior FAQ-specific and avoids changing
+campaign/source ingestion semantics.
+
+## Intentional
+
+- No default date filter. Existing FAQ calls remain unchanged unless the caller
+  passes faq_window_days or the CLI passes --window-days.
+- No semantic intent clustering in this slice. This only makes the recency part
+  of the customer-facing claim real.
+- No frontend control is added. The API/CLI can pass the inputs now; a later UI
+  slice can expose a form field if needed.
+
+## Deferred
+
+- Semantic intent clustering for Step 02 remains a follow-up slice.
+- Inline edit/publish for Step 06 remains a follow-up slice; review/export is
+  already available.
+- A polished frontend date-window selector can ride with the broader FAQ
+  workflow UI.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py - 18 passed
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - 99 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - passed
+- bash scripts/validate_extracted_content_pipeline.sh - passed
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed
+- bash scripts/check_ascii_python.sh - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1496 passed, 1 existing torch/pynvml warning
+- bash scripts/local_pr_review.sh - pending after review fix
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Date-Window.md` | +91 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +122 / -1 |
+| `extracted_content_pipeline/generation_plan.py` | +14 / -7 |
+| `extracted_content_pipeline/content_ops_execution.py` | +2 |
+| `scripts/build_extracted_ticket_faq_markdown.py` | +13 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +117 |
+| `tests/test_extracted_content_generation_plan.py` | +6 |
+| `tests/test_extracted_content_ops_execution.py` | +12 |
+| `extracted_content_pipeline/README.md` | +4 / -1 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | +3 / -1 |
+| Total | ~396 |

--- a/plans/PR-Content-Ops-FAQ-Date-Window.md
+++ b/plans/PR-Content-Ops-FAQ-Date-Window.md
@@ -8,6 +8,11 @@ claim. Operators can pre-filter files outside Atlas, but the product seam should
 also enforce a recency window when requested so stale tickets do not influence
 FAQ entries.
 
+This PR is slightly above the 400-line target because review feedback required
+strict as-of-date validation at the library, plan, and CLI boundaries plus
+regression tests for each path. Keeping that validation with the date-window
+feature avoids shipping a reproducibility footgun.
+
 ## Scope (this PR)
 
 1. Add optional date-window filtering to the ticket FAQ Markdown builder and
@@ -64,28 +69,27 @@ campaign/source ingestion semantics.
 ## Verification
 
 - pytest tests/test_extracted_ticket_faq_markdown.py - 18 passed
-- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - 99 passed
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - 104 passed
 - python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - passed
 - bash scripts/validate_extracted_content_pipeline.sh - passed
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed
 - python scripts/audit_extracted_standalone.py --fail-on-debt - passed
 - bash scripts/check_ascii_python.sh - passed
-- bash scripts/run_extracted_pipeline_checks.sh - 1496 passed, 1 existing torch/pynvml warning
-- bash scripts/local_pr_review.sh - pending after review fix
+- bash scripts/run_extracted_pipeline_checks.sh - 1502 passed, 1 existing torch/pynvml warning
 
 ## Estimated diff size
 
 | File | Estimated LOC |
 |---|---:|
-| `plans/PR-Content-Ops-FAQ-Date-Window.md` | +91 |
+| `plans/PR-Content-Ops-FAQ-Date-Window.md` | +95 |
 | `docs/extraction/coordination/inflight.md` | +2 / -2 |
-| `extracted_content_pipeline/ticket_faq_markdown.py` | +122 / -1 |
-| `extracted_content_pipeline/generation_plan.py` | +14 / -7 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +140 / -1 |
+| `extracted_content_pipeline/generation_plan.py` | +24 / -7 |
 | `extracted_content_pipeline/content_ops_execution.py` | +2 |
 | `scripts/build_extracted_ticket_faq_markdown.py` | +13 |
-| `tests/test_extracted_ticket_faq_markdown.py` | +117 |
-| `tests/test_extracted_content_generation_plan.py` | +6 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +138 |
+| `tests/test_extracted_content_generation_plan.py` | +31 |
 | `tests/test_extracted_content_ops_execution.py` | +12 |
 | `extracted_content_pipeline/README.md` | +4 / -1 |
 | `extracted_content_pipeline/docs/host_install_runbook.md` | +3 / -1 |
-| Total | ~396 |
+| Total | ~484 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date
 from pathlib import Path
 import sys
 
@@ -82,6 +83,13 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--max-text-chars must be positive")
     if args.window_days is not None and args.window_days < 1:
         raise SystemExit("--window-days must be positive")
+    if args.as_of_date and args.window_days is None:
+        raise SystemExit("--as-of-date requires --window-days")
+    if args.as_of_date:
+        try:
+            date.fromisoformat(args.as_of_date)
+        except ValueError:
+            raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
 
     loaded = load_source_campaign_opportunities_from_file(
         args.path,

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -44,6 +44,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-items", type=int, default=8)
     parser.add_argument("--max-evidence-per-item", type=int, default=3)
     parser.add_argument(
+        "--window-days",
+        type=int,
+        help="Keep only rows dated within this many days of --as-of-date or today.",
+    )
+    parser.add_argument(
+        "--as-of-date",
+        help="YYYY-MM-DD date used with --window-days for reproducible windows.",
+    )
+    parser.add_argument(
         "--max-text-chars",
         type=int,
         default=1200,
@@ -71,6 +80,8 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--max-evidence-per-item must be positive")
     if args.max_text_chars < 1:
         raise SystemExit("--max-text-chars must be positive")
+    if args.window_days is not None and args.window_days < 1:
+        raise SystemExit("--window-days must be positive")
 
     loaded = load_source_campaign_opportunities_from_file(
         args.path,
@@ -83,6 +94,8 @@ def main(argv: list[str] | None = None) -> int:
         title=args.title,
         max_items=args.max_items,
         max_evidence_per_item=args.max_evidence_per_item,
+        window_days=args.window_days,
+        as_of_date=args.as_of_date,
     )
     if args.output:
         args.output.write_text(result.markdown, encoding="utf-8")

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -412,6 +412,8 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
                 "faq_max_evidence_per_item": 2,
                 "faq_source_types": "ticket, support-ticket",
                 "source_max_text_chars": 80,
+                "faq_window_days": 90,
+                "faq_as_of_date": "2026-05-20",
             },
         }
     )
@@ -425,6 +427,8 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
         "max_evidence_per_item": 2,
         "source_types": ["ticket", "support-ticket"],
         "max_text_chars": 80,
+        "window_days": 90,
+        "as_of_date": "2026-05-20",
     }
 
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -432,6 +432,33 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
     }
 
 
+def test_plan_rejects_faq_as_of_date_without_window_days():
+    with pytest.raises(ValueError, match="faq_as_of_date requires faq_window_days"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": [{"source_type": "ticket", "text": "How do I change my email?"}],
+                    "faq_as_of_date": "2026-05-20",
+                },
+            }
+        )
+
+
+def test_plan_rejects_invalid_faq_as_of_date():
+    with pytest.raises(ValueError, match="faq_as_of_date must use YYYY-MM-DD format"):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": [{"source_type": "ticket", "text": "How do I change my email?"}],
+                    "faq_window_days": 90,
+                    "faq_as_of_date": "2026-05-20T00:00:00",
+                },
+            }
+        )
+
+
 def test_plan_threads_signal_extraction_source_text_cap():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -502,11 +502,22 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
                     {
                         "ticket_id": "ticket-1",
                         "source_type": "ticket",
+                        "created_at": "2026-05-01",
                         "subject": "Profile email change",
                         "message": "How do I change my email address?",
                         "pain_category": "login",
+                    },
+                    {
+                        "ticket_id": "ticket-old",
+                        "source_type": "ticket",
+                        "created_at": "2026-01-01",
+                        "subject": "Billing export",
+                        "message": "Billing export is confusing.",
+                        "pain_category": "billing",
                     }
                 ],
+                "faq_window_days": 90,
+                "faq_as_of_date": "2026-05-20",
             },
         },
         services=ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService()),
@@ -518,6 +529,7 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
     assert step["result"]["generated"] == 1
     assert step["result"]["markdown"].startswith("# Support FAQ")
     assert "How do I change my email address?" in step["result"]["markdown"]
+    assert "Billing export is confusing." not in step["result"]["markdown"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -78,6 +78,35 @@ class _FAQRepository:
         return ("faq-uuid-1",)
 
 
+def _write_ticket_csv(tmp_path: Path, *rows: str) -> Path:
+    source = tmp_path / "tickets.csv"
+    source.write_text(
+        "\n".join((
+            "Ticket ID,Created At,Subject,Description,Pain Category",
+            *rows,
+            "",
+        )),
+        encoding="utf-8",
+    )
+    return source
+
+
+def _run_ticket_faq_cli(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(path),
+            "--source-format",
+            "csv",
+            *args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
 
@@ -139,7 +168,7 @@ def test_build_ticket_faq_markdown_filters_to_requested_date_window() -> None:
         [
             {
                 "source_type": "support_ticket",
-                "created_at": "2026-05-01T12:00:00Z",
+                "createdAt": "2026-05-01T12:00:00Z",
                 "pain_points": ["login"],
                 "evidence": [{
                     "text": "How do I update my login email?",
@@ -178,7 +207,13 @@ def test_build_ticket_faq_markdown_filters_to_requested_date_window() -> None:
     with pytest.raises(ValueError, match="window_days must be positive"):
         build_ticket_faq_markdown([], window_days=0)
     with pytest.raises(ValueError, match="as_of_date must be a valid ISO date"):
+        build_ticket_faq_markdown([], window_days=90, as_of_date="not-a-date")
+    with pytest.raises(ValueError, match="as_of_date must be a valid ISO date"):
         build_ticket_faq_markdown([], window_days=90, as_of_date="2026-99-99")
+    with pytest.raises(ValueError, match="as_of_date must be a valid ISO date"):
+        build_ticket_faq_markdown([], window_days=90, as_of_date="2026-05-20abc")
+    with pytest.raises(ValueError, match="as_of_date requires window_days"):
+        build_ticket_faq_markdown([], as_of_date="2026-05-20")
 
 
 @pytest.mark.asyncio
@@ -433,68 +468,43 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:
-    source = tmp_path / "tickets.csv"
-    source.write_text(
-        "\n".join([
-            "Ticket ID,Created At,Subject,Description,Pain Category",
+    source = _write_ticket_csv(
+        tmp_path,
             "ticket-new,2026-05-01,Login email,How do I change my login email?,login",
             "ticket-old,2026-01-01,Billing export,Billing export is confusing.,billing",
-            "",
-        ]),
-        encoding="utf-8",
     )
 
-    completed = subprocess.run(
-        [
-            sys.executable,
-            str(CLI),
-            str(source),
-            "--source-format",
-            "csv",
-            "--window-days",
-            "90",
-            "--as-of-date",
-            "2026-05-20",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
+    completed = _run_ticket_faq_cli(
+        source,
+        "--window-days",
+        "90",
+        "--as-of-date",
+        "2026-05-20",
     )
 
+    assert completed.returncode == 0
     assert "ticket-new" in completed.stdout
     assert "ticket-old" not in completed.stdout
     assert "Ticket evidence rows used: 1" in completed.stdout
 
 
-def test_ticket_faq_cli_rejects_invalid_as_of_date(tmp_path: Path) -> None:
-    source = tmp_path / "tickets.csv"
-    source.write_text(
-        "\n".join([
-            "Ticket ID,Created At,Subject,Description,Pain Category",
+@pytest.mark.parametrize("value", ("2026-99-99", "2026-05-20abc", "2026/05/20"))
+def test_ticket_faq_cli_rejects_invalid_as_of_date(tmp_path: Path, value: str) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
             "ticket-new,2026-05-01,Login email,How do I change my login email?,login",
-            "",
-        ]),
-        encoding="utf-8",
     )
 
-    completed = subprocess.run(
-        [
-            sys.executable,
-            str(CLI),
-            str(source),
-            "--source-format",
-            "csv",
-            "--window-days",
-            "90",
-            "--as-of-date",
-            "2026-99-99",
-        ],
-        capture_output=True,
-        text=True,
+    completed = _run_ticket_faq_cli(
+        source,
+        "--window-days",
+        "90",
+        "--as-of-date",
+        value,
     )
 
     assert completed.returncode != 0
-    assert "as_of_date must be a valid ISO date" in completed.stderr
+    assert "--as-of-date must use YYYY-MM-DD format" in completed.stderr
 
 
 def test_ticket_faq_cli_stdout_limits_and_result_serializes() -> None:
@@ -519,3 +529,14 @@ def test_ticket_faq_cli_stdout_limits_and_result_serializes() -> None:
     encoded = json.dumps(build_ticket_faq_markdown(loaded.opportunities).as_dict(), sort_keys=True)
     assert "action_items" in encoded
     assert "output_checks" in encoded
+
+
+def test_ticket_faq_cli_rejects_as_of_date_without_window(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+            "ticket-new,2026-05-01,Login email,How do I change my login email?,login",
+    )
+    completed = _run_ticket_faq_cli(source, "--as-of-date", "2026-05-20")
+
+    assert completed.returncode == 1
+    assert "--as-of-date requires --window-days" in completed.stderr

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -134,6 +134,53 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
     }
 
 
+def test_build_ticket_faq_markdown_filters_to_requested_date_window() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "created_at": "2026-05-01T12:00:00Z",
+                "pain_points": ["login"],
+                "evidence": [{
+                    "text": "How do I update my login email?",
+                    "source_id": "ticket-new",
+                    "source_type": "support_ticket",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "created_at": "2026-01-01",
+                "pain_points": ["billing"],
+                "evidence": [{
+                    "text": "Billing export is confusing.",
+                    "source_id": "ticket-old",
+                    "source_type": "support_ticket",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "pain_points": ["exports"],
+                "evidence": [{
+                    "text": "Export settings are missing.",
+                    "source_id": "ticket-undated",
+                    "source_type": "support_ticket",
+                }],
+            },
+        ],
+        window_days=90,
+        as_of_date="2026-05-20",
+    )
+
+    assert result.ticket_source_count == 1
+    assert "ticket-new" in result.markdown
+    assert "ticket-old" not in result.markdown
+    assert "ticket-undated" not in result.markdown
+    with pytest.raises(ValueError, match="window_days must be positive"):
+        build_ticket_faq_markdown([], window_days=0)
+    with pytest.raises(ValueError, match="as_of_date must be a valid ISO date"):
+        build_ticket_faq_markdown([], window_days=90, as_of_date="2026-99-99")
+
+
 @pytest.mark.asyncio
 async def test_ticket_faq_service_generates_from_inline_source_material() -> None:
     service = TicketFAQMarkdownService()
@@ -239,10 +286,13 @@ async def test_ticket_faq_service_saves_generated_markdown_when_repository_confi
         source_material=[{
             "ticket_id": "ticket-1",
             "source_type": "ticket",
+            "created_at": "2026-05-01",
             "message": "The attribution export is missing renewals.",
             "pain_category": "exports",
         }],
         title="Renewal FAQ",
+        window_days=90,
+        as_of_date="2026-05-20",
     )
 
     assert result.as_dict()["saved_ids"] == ["faq-uuid-1"]
@@ -259,6 +309,8 @@ async def test_ticket_faq_service_saves_generated_markdown_when_repository_confi
         "conversation",
         "complaint",
     ]
+    assert draft.metadata["window_days"] == 90
+    assert draft.metadata["as_of_date"] == "2026-05-20"
 
 
 @pytest.mark.asyncio
@@ -378,6 +430,71 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert markdown.startswith("# Support FAQ")
     assert "Ticket evidence rows used: 2" in markdown
     assert "ticket-acme-1" in markdown
+
+
+def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:
+    source = tmp_path / "tickets.csv"
+    source.write_text(
+        "\n".join([
+            "Ticket ID,Created At,Subject,Description,Pain Category",
+            "ticket-new,2026-05-01,Login email,How do I change my login email?,login",
+            "ticket-old,2026-01-01,Billing export,Billing export is confusing.,billing",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source),
+            "--source-format",
+            "csv",
+            "--window-days",
+            "90",
+            "--as-of-date",
+            "2026-05-20",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "ticket-new" in completed.stdout
+    assert "ticket-old" not in completed.stdout
+    assert "Ticket evidence rows used: 1" in completed.stdout
+
+
+def test_ticket_faq_cli_rejects_invalid_as_of_date(tmp_path: Path) -> None:
+    source = tmp_path / "tickets.csv"
+    source.write_text(
+        "\n".join([
+            "Ticket ID,Created At,Subject,Description,Pain Category",
+            "ticket-new,2026-05-01,Login email,How do I change my login email?,login",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(source),
+            "--source-format",
+            "csv",
+            "--window-days",
+            "90",
+            "--as-of-date",
+            "2026-99-99",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "as_of_date must be a valid ISO date" in completed.stderr
 
 
 def test_ticket_faq_cli_stdout_limits_and_result_serializes() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Date-Window.md

Add optional recency-window filtering to the deterministic FAQ Markdown path so support-ticket CSV runs can honestly use a last-90-days scope when requested. The filter is local to FAQ generation and does not change shared source ingestion behavior.

## Intentional
- Existing FAQ generation remains unfiltered unless callers pass faq_window_days or the CLI passes --window-days.
- Date filtering stays in the FAQ Markdown layer instead of changing shared source ingestion semantics.
- No frontend date selector in this slice; API/CLI callers can already pass the values.

## Deferred
- Semantic intent clustering for Step 02 remains a follow-up slice.
- Inline edit/publish for Step 06 remains a follow-up slice; review/export is already available.
- A polished frontend date-window selector can ride with the broader FAQ workflow UI.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - 98 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py - passed
- bash scripts/validate_extracted_content_pipeline.sh - passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed
- bash scripts/check_ascii_python.sh - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1496 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
11 files, +342 / -12
