### PR TITLE
Add FAQ intent clustering

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T02:01Z by codex-2026-05-20
+Last updated: 2026-05-20T02:43Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Date-Window | `plans/PR-Content-Ops-FAQ-Date-Window.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `extracted_content_pipeline/generation_plan.py`; `extracted_content_pipeline/content_ops_execution.py`; `scripts/build_extracted_ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py`; `tests/test_extracted_content_generation_plan.py`; `tests/test_extracted_content_ops_execution.py`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/host_install_runbook.md` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown recency filtering and docs. |
+| TBD | PR-Content-Ops-FAQ-Intent-Clustering | `plans/PR-Content-Ops-FAQ-Intent-Clustering.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown grouping and intent rules. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -24,6 +24,16 @@ DEFAULT_TICKET_SOURCE_TYPES = (
 DEFAULT_TITLE = "Customer Ticket FAQ"
 _WHITESPACE_RE = re.compile(r"\s+")
 _KEY_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+DEFAULT_INTENT_RULES = (
+    ("reporting friction", ("export", "report", "dashboard", "attribution")),
+    ("manual follow-up", ("handoff", "follow-up", "workflow", "automation", "manual")),
+    ("login reset", ("login reset", "password reset", "reset password", "reset my password")),
+    ("email and profile updates", ("change my email", "update the email", "email address", "profile")),
+    ("login and account access", ("login", "account access")),
+    ("billing and payments", ("billing", "invoice", "payment", "receipt", "charge")),
+    ("integration setup", ("integration", "api", "webhook", "sync", "connection")),
+    ("renewal and cancellation", ("renewal", "cancel", "cancellation", "contract")),
+)
 _DATE_KEYS = (
     "created_at",
     "created",
@@ -89,6 +99,7 @@ class TicketFAQMarkdownConfig:
     max_text_chars: int = 1200
     window_days: int | None = None
     as_of_date: str | None = None
+    intent_rules: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_INTENT_RULES
 
 
 class TicketFAQMarkdownService:
@@ -116,6 +127,7 @@ class TicketFAQMarkdownService:
         max_text_chars: int | None = None,
         window_days: int | None = None,
         as_of_date: Any = None,
+        intent_rules: Sequence[tuple[str, Sequence[str]]] | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
@@ -148,6 +160,11 @@ class TicketFAQMarkdownService:
             if source_types is not None
             else self.config.source_types
         )
+        resolved_intent_rules = (
+            tuple((topic, tuple(keywords)) for topic, keywords in intent_rules)
+            if intent_rules is not None
+            else self.config.intent_rules
+        )
         title_text = title or self.config.title
         result = build_ticket_faq_markdown(
             normalized.opportunities,
@@ -157,6 +174,7 @@ class TicketFAQMarkdownService:
             source_types=resolved_source_types,
             window_days=resolved_window_days,
             as_of_date=resolved_as_of_date,
+            intent_rules=resolved_intent_rules,
         )
         result = replace(
             result,
@@ -199,6 +217,7 @@ def build_ticket_faq_markdown(
     source_types: Sequence[str] = DEFAULT_TICKET_SOURCE_TYPES,
     window_days: int | None = None,
     as_of_date: Any = None,
+    intent_rules: Sequence[tuple[str, Sequence[str]]] = DEFAULT_INTENT_RULES,
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -238,7 +257,7 @@ def build_ticket_faq_markdown(
             if key in seen:
                 continue
             seen.add(key)
-            groups[_topic(opportunity, evidence)].append({
+            groups[_topic(opportunity, evidence, intent_rules=intent_rules)].append({
                 "text": text,
                 "source_id": source_id or "unknown",
                 "source_key": source_id or dedupe_id,
@@ -272,7 +291,15 @@ def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], .
     },)
 
 
-def _topic(opportunity: Mapping[str, Any], evidence: Mapping[str, Any]) -> str:
+def _topic(
+    opportunity: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    *,
+    intent_rules: Sequence[tuple[str, Sequence[str]]],
+) -> str:
+    intent = _intent_topic(opportunity, evidence, intent_rules=intent_rules)
+    if intent:
+        return intent
     pain_points = opportunity.get("pain_points")
     if isinstance(pain_points, Sequence) and not isinstance(pain_points, (str, bytes, bytearray)):
         for value in pain_points:
@@ -280,6 +307,41 @@ def _topic(opportunity: Mapping[str, Any], evidence: Mapping[str, Any]) -> str:
             if text:
                 return text.lower()
     return (_compact(evidence.get("source_title") or opportunity.get("source_title")) or "customer support issues").lower()
+
+
+def _intent_topic(
+    opportunity: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+    *,
+    intent_rules: Sequence[tuple[str, Sequence[str]]],
+) -> str:
+    text = " ".join((
+        _compact(evidence.get("source_title") or opportunity.get("source_title")),
+        _compact(evidence.get("text")),
+        _compact(opportunity.get("text") or opportunity.get("description")),
+        _pain_text(opportunity),
+    )).lower()
+    if not text:
+        return ""
+    for topic, keywords in intent_rules:
+        if any(_keyword_matches(text, keyword) for keyword in keywords):
+            return _clean(topic).lower()
+    return ""
+
+
+def _keyword_matches(text: str, keyword: Any) -> bool:
+    value = _clean(keyword).lower()
+    if not value:
+        return False
+    pattern = rf"(?<![a-z0-9]){re.escape(value)}(?![a-z0-9])"
+    return re.search(pattern, text) is not None
+
+
+def _pain_text(opportunity: Mapping[str, Any]) -> str:
+    pain_points = opportunity.get("pain_points")
+    if isinstance(pain_points, Sequence) and not isinstance(pain_points, (str, bytes, bytearray)):
+        return " ".join(_compact(value) for value in pain_points if _compact(value))
+    return _compact(pain_points)
 
 
 def _item(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
@@ -526,6 +588,7 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
 
 
 __all__ = [
+    "DEFAULT_INTENT_RULES",
     "DEFAULT_TICKET_SOURCE_TYPES",
     "TicketFAQMarkdownConfig",
     "TicketFAQMarkdownResult",

--- a/plans/PR-Content-Ops-FAQ-Intent-Clustering.md
+++ b/plans/PR-Content-Ops-FAQ-Intent-Clustering.md
@@ -1,0 +1,86 @@
+# Content Ops FAQ Intent Clustering
+
+## Why this slice exists
+
+The support-ticket FAQ path now supports uploaded/loaded ticket rows and a
+recency window, but its clustering is still too literal: FAQ topics are mostly
+pulled from `pain_points` or source titles. That means tickets with the same
+user intent but different titles can render as separate FAQ entries, which
+weakens the product claim that the pipeline clusters by intent and ranks by
+volume.
+
+This slice adds a small deterministic intent-clustering layer to the FAQ
+Markdown builder. It stays extractive and provider-free, and it avoids mixing
+in the separate storytelling/LLM generation track.
+
+## Scope (this PR)
+
+1. Add default FAQ intent rules for common support-ticket intents.
+2. Thread optional intent rules through `TicketFAQMarkdownConfig`, service
+   generation, and `build_ticket_faq_markdown`.
+3. Use the intent cluster before falling back to existing pain/category/title
+   grouping.
+4. Add focused tests proving repeated user intent collapses into one FAQ item
+   and custom intent rules can be supplied by a host.
+5. Replace the stale FAQ date-window in-flight row with this active slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Intent-Clustering.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale FAQ date-window claim with this active slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Add configurable deterministic intent rules at the FAQ grouping source. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Builder and service regression coverage for intent clustering. |
+
+## Mechanism
+
+Add a module-level default intent taxonomy shaped as `(topic, keywords)` pairs.
+For each evidence row, `_topic(...)` will inspect the pain fields, source title,
+and evidence text, then return the first matching configured topic. If no rule
+matches, it preserves the current fallback: first explicit pain point, then
+source title, then `customer support issues`.
+
+The rules are optional parameters, so hosts can override or disable the packaged
+taxonomy without changing source ingestion or output rendering.
+
+## Intentional
+
+- This is deterministic string matching, not semantic embeddings or LLM
+  clustering. That is enough to support the FAQ Markdown smoke path without
+  adding provider cost or nondeterminism.
+- Existing explicit pain/category values remain the fallback so current output
+  shape does not regress when no intent rule matches.
+- The default taxonomy is intentionally small and support-ticket focused; it is
+  not a generic knowledge graph.
+- The stale FAQ date-window coordination row is removed in the same file edit
+  because that PR is merged and this PR claims the next FAQ slice.
+
+## Deferred
+
+- Semantic clustering beyond keyword rules remains deferred until a real host
+  export shows the deterministic taxonomy is insufficient.
+- Operator-side edit/publish workflow remains separate from Markdown
+  generation.
+- UI copy for the six-step FAQ workflow is not changed here.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 26 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
+- git diff --check - passed
+- bash scripts/validate_extracted_content_pipeline.sh - passed
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed
+- bash scripts/check_ascii_python.sh - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1506 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Intent-Clustering.md` | +86 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +65 / -2 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +111 |
+| Total | ~268 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -14,6 +14,7 @@ from extracted_content_pipeline.campaign_source_adapters import (
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.ticket_faq_markdown import (
+    TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
     build_ticket_faq_markdown,
 )
@@ -124,6 +125,85 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "condensed": True,
         "has_action_items": True,
     }
+
+
+def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Profile change question",
+                "evidence": [{
+                    "text": "How do I change my login email?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Account access issue",
+                "evidence": [{
+                    "text": "I need to update the email on my account.",
+                    "source_id": "ticket-2",
+                    "source_type": "support_ticket",
+                }],
+            },
+        ]
+    )
+
+    assert [item["topic"] for item in result.items] == ["email and profile updates"]
+    assert result.items[0]["evidence_count"] == 2
+    assert result.items[0]["source_ids"] == ("ticket-1", "ticket-2")
+    assert "How do I change my login email?" in result.markdown
+    assert "I need to update the email on my account." in result.markdown
+    assert result.output_checks["condensed"] is True
+
+
+def test_build_ticket_faq_markdown_accepts_host_intent_rules() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Data sync is behind",
+                "evidence": [{
+                    "text": "The warehouse sync is delayed every morning.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Connector lag",
+                "evidence": [{
+                    "text": "Our CRM connector does not finish before standup.",
+                    "source_id": "ticket-2",
+                    "source_type": "support_ticket",
+                }],
+            },
+        ],
+        intent_rules=(("data freshness", ("warehouse sync", "connector lag")),),
+    )
+
+    assert [item["topic"] for item in result.items] == ["data freshness"]
+    assert result.items[0]["evidence_count"] == 2
+
+
+def test_build_ticket_faq_markdown_normalizes_intent_whitespace() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Profile update",
+                "evidence": [{
+                    "text": "How do I change\nmy\temail before renewal?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert [item["topic"] for item in result.items] == ["email and profile updates"]
 
 
 def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows() -> None:
@@ -240,6 +320,37 @@ async def test_ticket_faq_service_generates_from_inline_source_material() -> Non
     assert result.as_dict()["generated"] == 1
     assert "How do I change my email address?" in result.markdown
     assert "`ticket-1` - Login email change" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_uses_configured_intent_rules() -> None:
+    service = TicketFAQMarkdownService(
+        TicketFAQMarkdownConfig(intent_rules=(("access setup", ("invite link", "new user")),))
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "source_type": "support_ticket",
+                    "subject": "Invite link does not work",
+                    "message": "The invite link expired before the new user joined.",
+                },
+                {
+                    "ticket_id": "ticket-2",
+                    "source_type": "support_ticket",
+                    "subject": "New user cannot get in",
+                    "message": "A new user needs another invite link.",
+                },
+            ]
+        },
+    )
+
+    assert [item["topic"] for item in result.items] == ["access setup"]
+    assert result.items[0]["evidence_count"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Intent-Clustering.md

Add deterministic FAQ intent clustering at the FAQ Markdown grouping source so repeated support-ticket intent collapses into one grounded FAQ item without introducing an LLM or embedding dependency.

## Intentional
- Deterministic keyword rules, not semantic embeddings or LLM clustering.
- Host intent rules can override or disable the packaged taxonomy through the builder/service config.
- Existing pain/category/title grouping remains the fallback when no intent rule matches.

## Deferred
- Semantic clustering beyond keyword rules remains deferred until a real host export proves this taxonomy is insufficient.
- Operator-side edit/publish workflow remains separate from Markdown generation.
- UI copy for the six-step FAQ workflow is not changed here.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 25 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
- git diff --check - passed
- bash scripts/validate_extracted_content_pipeline.sh - passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed
- bash scripts/check_ascii_python.sh - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1505 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
4 files, +246 / -4