### PR TITLE
Expose FAQ ticket volume counts

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T02:43Z by codex-2026-05-20
+Last updated: 2026-05-20T03:02Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Intent-Clustering | `plans/PR-Content-Ops-FAQ-Intent-Clustering.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown grouping and intent rules. |
+| TBD | PR-Content-Ops-FAQ-Volume-Counts | `plans/PR-Content-Ops-FAQ-Volume-Counts.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown item counts and volume ranking metadata. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -265,7 +265,7 @@ def build_ticket_faq_markdown(
             })
 
     items = tuple(
-        _item(topic, rows[:max_evidence_per_item])
+        _item(topic, rows, max_evidence_per_item=max_evidence_per_item)
         for topic, rows in sorted(groups.items(), key=lambda item: (-len(item[1]), item[0].lower()))[:max_items]
     )
     return TicketFAQMarkdownResult(
@@ -344,11 +344,17 @@ def _pain_text(opportunity: Mapping[str, Any]) -> str:
     return _compact(pain_points)
 
 
-def _item(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
-    sources = tuple(_source_label(row) for row in rows)
+def _item(
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    max_evidence_per_item: int,
+) -> dict[str, Any]:
+    display_rows = rows[:max_evidence_per_item]
+    sources = tuple(_source_label(row) for row in display_rows)
     source_keys = (row.get("source_key") or row.get("source_id", "") for row in rows)
     source_ids = tuple(dict.fromkeys(value for value in source_keys if value))
-    snippets = " / ".join(_quote(row.get("text", "")) for row in rows)
+    snippets = " / ".join(_quote(row.get("text", "")) for row in display_rows)
     return {
         "topic": topic,
         "question": f"What are customers asking about {topic}?",
@@ -356,7 +362,9 @@ def _item(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
         "action_items": _action_items(topic, snippets),
         "source_ids": source_ids,
         "source_labels": sources,
-        "evidence_count": len(rows),
+        "evidence_count": len(display_rows),
+        "displayed_evidence_count": len(display_rows),
+        "ticket_count": len(source_ids),
     }
 
 

--- a/plans/PR-Content-Ops-FAQ-Volume-Counts.md
+++ b/plans/PR-Content-Ops-FAQ-Volume-Counts.md
@@ -1,0 +1,71 @@
+# Content Ops FAQ Volume Counts
+
+## Why this slice exists
+
+FAQ Markdown now clusters support tickets by deterministic intent, and the
+builder already ranks clusters by the full number of matched evidence rows.
+However, `_item(...)` only receives the capped display rows, so the rendered
+answer and item metadata can underreport volume. A 10-ticket intent cluster with
+`max_evidence_per_item=3` can look like it only came from 3 tickets.
+
+This weakens the customer-facing "Rank by Volume" workflow claim. This slice
+keeps the source-level ranking behavior and makes the total cluster volume
+visible without changing ingestion or adding LLM behavior.
+
+## Scope (this PR)
+
+1. Pass the full grouped evidence rows into the FAQ item builder.
+2. Keep snippet/source-label rendering capped by `max_evidence_per_item`.
+3. Add `ticket_count` and `displayed_evidence_count` item metadata so hosts can
+   distinguish total volume from displayed evidence.
+4. Render the total ticket-source count in the answer sentence.
+5. Add regression coverage for a capped high-volume intent cluster.
+6. Replace the stale FAQ intent-clustering in-flight row with this active slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Volume-Counts.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale FAQ intent-clustering claim with this active slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Preserve total cluster volume while capping displayed snippets. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for volume count vs displayed snippet count. |
+
+## Mechanism
+
+`build_ticket_faq_markdown(...)` will pass each full sorted group to `_item(...)`
+alongside `max_evidence_per_item`. `_item(...)` will compute total unique source
+ids from the full group, then slice only the display rows for snippets and source
+labels. Existing `evidence_count` keeps its old meaning: displayed evidence row
+count. New metadata carries the total volume.
+
+## Intentional
+
+- No change to source ingestion, date filtering, or intent clustering.
+- No change to the `max_evidence_per_item` display cap; the Markdown remains
+  readable even when a cluster has many tickets.
+- `evidence_count` remains backward-compatible as the displayed count. New
+  `ticket_count` exposes the full volume.
+
+## Deferred
+
+- UI ordering badges or volume chips are deferred to a frontend slice.
+- Semantic clustering beyond deterministic intent rules remains deferred.
+- Operator-side edit/publish workflow remains separate from Markdown generation.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 27 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
+- git diff --check - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1507 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Volume-Counts.md` | +72 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +13 / -5 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +29 |
+| Total | ~123 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -188,6 +188,35 @@ def test_build_ticket_faq_markdown_accepts_host_intent_rules() -> None:
     assert result.items[0]["evidence_count"] == 2
 
 
+def test_build_ticket_faq_markdown_keeps_total_volume_when_display_is_capped() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": f"Sync delay {index}",
+                "evidence": [{
+                    "text": f"The warehouse sync is delayed for team {index}.",
+                    "source_id": f"ticket-{index}",
+                    "source_type": "support_ticket",
+                }],
+            }
+            for index in range(1, 5)
+        ],
+        max_evidence_per_item=2,
+        intent_rules=(("data freshness", ("warehouse sync",)),),
+    )
+
+    item = result.items[0]
+    assert item["topic"] == "data freshness"
+    assert item["ticket_count"] == 4
+    assert item["evidence_count"] == 2
+    assert item["displayed_evidence_count"] == 2
+    assert item["source_ids"] == ("ticket-1", "ticket-2", "ticket-3", "ticket-4")
+    assert len(item["source_labels"]) == 2
+    assert "Evidence comes from 4 ticket source(s)." in item["answer"]
+    assert "ticket-3" not in result.markdown
+
+
 def test_build_ticket_faq_markdown_normalizes_intent_whitespace() -> None:
     result = build_ticket_faq_markdown(
         [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Volume-Counts.md

Preserve full support-ticket cluster volume in FAQ Markdown items while keeping displayed snippets capped. This makes the existing volume ranking visible in output metadata and answer copy without changing ingestion or adding LLM behavior.

## Intentional
- Displayed snippets remain capped by max_evidence_per_item.
- evidence_count remains the displayed evidence count for compatibility.
- ticket_count exposes full unique ticket-source volume.

## Deferred
- UI volume badges or chips remain a frontend slice.
- Semantic clustering beyond deterministic intent rules remains deferred.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 27 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
- git diff --check - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1507 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
4 files, +115 / -7