### PR TITLE
Use customer wording for FAQ questions

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T03:02Z by codex-2026-05-20
+Last updated: 2026-05-20T03:21Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Volume-Counts | `plans/PR-Content-Ops-FAQ-Volume-Counts.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown item counts and volume ranking metadata. |
+| TBD | PR-Content-Ops-FAQ-Customer-Wording | `plans/PR-Content-Ops-FAQ-Customer-Wording.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown question wording. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -22,8 +22,15 @@ DEFAULT_TICKET_SOURCE_TYPES = (
     "complaint",
 )
 DEFAULT_TITLE = "Customer Ticket FAQ"
+MAX_EXTRACTED_QUESTION_CHARS = 140
 _WHITESPACE_RE = re.compile(r"\s+")
 _KEY_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+_URL_RE = re.compile(r"https?://\S+|www\.\S+", re.IGNORECASE)
+_SPEAKER_LABEL_RE = re.compile(
+    r"(?:^|\n|[.!?]\s+)\s*(customer|user|requester|client|agent|support|representative|rep|admin)\s*:",
+    re.IGNORECASE,
+)
+_CUSTOMER_SPEAKERS = {"customer", "user", "requester", "client"}
 DEFAULT_INTENT_RULES = (
     ("reporting friction", ("export", "report", "dashboard", "attribution")),
     ("manual follow-up", ("handoff", "follow-up", "workflow", "automation", "manual")),
@@ -355,9 +362,11 @@ def _item(
     source_keys = (row.get("source_key") or row.get("source_id", "") for row in rows)
     source_ids = tuple(dict.fromkeys(value for value in source_keys if value))
     snippets = " / ".join(_quote(row.get("text", "")) for row in display_rows)
+    question, question_source = _question(topic, display_rows)
     return {
         "topic": topic,
-        "question": f"What are customers asking about {topic}?",
+        "question": question,
+        "question_source": question_source,
         "answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s).",
         "action_items": _action_items(topic, snippets),
         "source_ids": source_ids,
@@ -366,6 +375,77 @@ def _item(
         "displayed_evidence_count": len(display_rows),
         "ticket_count": len(source_ids),
     }
+
+
+def _question(topic: str, rows: Sequence[Mapping[str, str]]) -> tuple[str, str]:
+    for row in rows:
+        text = _question_text(row.get("text", ""))
+        if text:
+            return (text, "customer_wording")
+    return (f"What are customers asking about {topic}?", "topic_fallback")
+
+
+def _question_text(value: Any) -> str:
+    for text in _question_candidate_texts(value):
+        if "?" in text:
+            prefix = text.split("?", 1)[0].strip()
+            sentence_parts = [part.strip() for part in re.split(r"[.!:;]+", prefix) if part.strip()]
+            candidate = sentence_parts[-1] if sentence_parts else prefix
+            normalized = _normalize_question_text(candidate)
+            if _usable_question(normalized):
+                return normalized
+            continue
+        normalized = _question_start_text(text)
+        if normalized:
+            return normalized
+    return ""
+
+
+def _question_candidate_texts(value: Any) -> tuple[str, ...]:
+    text = _clean(value)
+    if not text:
+        return ()
+    matches = list(_SPEAKER_LABEL_RE.finditer(text))
+    if not matches:
+        return (_compact(_URL_RE.sub("", text)),)
+
+    candidates = []
+    leading = _question_segment(text[:matches[0].start()])
+    if leading:
+        candidates.append(leading)
+    for index, match in enumerate(matches):
+        speaker = match.group(1).lower()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        if speaker in _CUSTOMER_SPEAKERS:
+            segment = _question_segment(text[match.end():end])
+            if segment:
+                candidates.append(segment)
+    return tuple(candidates)
+
+
+def _question_segment(value: str) -> str:
+    return _compact(_URL_RE.sub("", value))
+
+
+def _question_start_text(text: str) -> str:
+    question_starts = ("how ", "what ", "where ", "when ", "why ", "can ", "could ", "do ", "does ", "is ")
+    lowered = text.lower()
+    if lowered.startswith(question_starts):
+        normalized = _normalize_question_text(text)
+        if _usable_question(normalized):
+            return normalized
+    return ""
+
+
+def _usable_question(value: str) -> bool:
+    return bool(value) and len(value) <= MAX_EXTRACTED_QUESTION_CHARS
+
+
+def _normalize_question_text(value: str) -> str:
+    candidate = _compact(value).rstrip("?.!,;: ")
+    if not candidate:
+        return ""
+    return f"{candidate}?"
 
 
 def _render(

--- a/plans/PR-Content-Ops-FAQ-Customer-Wording.md
+++ b/plans/PR-Content-Ops-FAQ-Customer-Wording.md
@@ -1,0 +1,76 @@
+# Content Ops FAQ Customer Wording
+
+## Why this slice exists
+
+The FAQ Markdown builder is now date-windowed, clustered by deterministic
+intent, and exposes total ticket volume. The next output-quality gap is the FAQ
+question text itself: `_item(...)` still renders a generic topic question such
+as "What are customers asking about email and profile updates?" even when the
+source ticket contains a direct customer question like "How do I change my login
+email?".
+
+This weakens the "Extract Customer Wording" workflow claim. This slice derives
+FAQ questions from the source ticket wording when a concise question-like text
+is present, while keeping the current generic fallback.
+
+## Scope (this PR)
+
+1. Extract a customer-worded FAQ question from displayed evidence rows when one
+   is present.
+2. Preserve the existing topic-based fallback when source text is not a usable
+   question.
+3. Add item metadata that records whether the question came from customer
+   wording or the fallback.
+4. Add regression coverage for customer wording and fallback behavior.
+5. Replace the stale FAQ volume-count in-flight row with this active slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Customer-Wording.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale FAQ volume-count claim with this active slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Derive FAQ question text from source ticket wording when available. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for customer-worded questions and fallback. |
+
+## Mechanism
+
+`_item(...)` already receives the displayed evidence rows used for snippets.
+This PR adds a small `_question(...)` helper that scans those rows in order,
+normalizes whitespace, and returns the first concise question-like sentence. If
+no such sentence exists, it returns the existing topic-based fallback. The item
+also records `question_source` as either `customer_wording` or `topic_fallback`.
+Question extraction strips URLs, ignores explicit agent/support prompts, accepts
+leading unlabeled customer text before an agent label, treats speaker labels as
+turn-boundary markers instead of arbitrary inline prose, and applies the same
+length guard to both punctuated and normalized question-start fallbacks.
+
+## Intentional
+
+- No LLM rewrite or paraphrase. The customer-worded question is extractive.
+- No change to answer generation, action items, clustering, or date filtering.
+- The helper only uses displayed rows so the rendered question is traceable to
+  visible evidence.
+
+## Deferred
+
+- Semantic question synthesis across many tickets remains deferred.
+- UI edit/publish workflow remains separate from Markdown generation.
+- Broader tone polish for answers remains a future output-quality slice.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 36 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
+- git diff --check - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1516 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Customer-Wording.md` | +75 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +81 / -1 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +177 |
+| Total | ~338 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -152,11 +152,188 @@ def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
     )
 
     assert [item["topic"] for item in result.items] == ["email and profile updates"]
+    assert result.items[0]["question"] == "How do I change my login email?"
+    assert result.items[0]["question_source"] == "customer_wording"
     assert result.items[0]["evidence_count"] == 2
     assert result.items[0]["source_ids"] == ("ticket-1", "ticket-2")
     assert "How do I change my login email?" in result.markdown
     assert "I need to update the email on my account." in result.markdown
     assert result.output_checks["condensed"] is True
+
+
+def test_build_ticket_faq_markdown_falls_back_to_topic_question() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Export issue",
+                "evidence": [{
+                    "text": "The dashboard export button disappears for analysts.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["topic"] == "reporting friction"
+    assert result.items[0]["question"] == "What are customers asking about reporting friction?"
+    assert result.items[0]["question_source"] == "topic_fallback"
+
+
+def test_build_ticket_faq_markdown_falls_back_from_long_customer_question() -> None:
+    long_question = "How do I " + ("change every nested account setting " * 8).strip() + "?"
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Profile update",
+                "evidence": [{
+                    "text": long_question,
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert len(long_question) > 140
+    assert result.items[0]["topic"] == "email and profile updates"
+    assert result.items[0]["question"] == "What are customers asking about email and profile updates?"
+    assert result.items[0]["question_source"] == "topic_fallback"
+
+
+def test_build_ticket_faq_markdown_extracts_question_sentence_from_ticket_text() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "For context, I tried updating profile settings all morning. How do I reset my password?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_normalizes_missing_question_mark() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "How do I reset my password",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_strips_customer_speaker_label() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "Customer: How do I reset my password",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_ignores_agent_questions() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "Customer: Login is broken. Agent: Can you share a screenshot?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "What are customers asking about login reset?"
+    assert result.items[0]["question_source"] == "topic_fallback"
+
+
+def test_build_ticket_faq_markdown_uses_unlabeled_customer_text_before_agent_label() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "How do I reset my password?\nAgent: Can you share a screenshot?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_keeps_inline_support_colon_as_customer_text() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "I copied this from support: How do I reset my password?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+
+
+def test_build_ticket_faq_markdown_ignores_url_query_markers() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Help article",
+                "evidence": [{
+                    "text": "I opened https://example.com/help?article=123 and the page is blank.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "What are customers asking about help article?"
+    assert result.items[0]["question_source"] == "topic_fallback"
 
 
 def test_build_ticket_faq_markdown_accepts_host_intent_rules() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Customer-Wording.md

Derive FAQ question text from visible support-ticket wording when the source contains a concise question, while keeping the existing topic fallback for non-question evidence.

## Intentional
- No LLM rewrite or paraphrase; customer-worded questions are extractive.
- The topic fallback remains for non-question source text.
- Question source is recorded as customer_wording or topic_fallback.

## Deferred
- Semantic question synthesis remains deferred.
- UI edit/publish workflow remains separate from Markdown generation.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 28 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
- git diff --check - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1508 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
4 files, +122 / -3