### PR TITLE
Tighten FAQ Markdown output checks

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -809,7 +809,7 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
   if (asset === 'faq_markdown') {
     return [
       row.target_mode,
-      numberLabel(row.ticket_source_count, 'ticket row'),
+      numberLabel(row.ticket_source_count, 'ticket source'),
       numberLabel(row.source_count, 'source row'),
     ].filter(Boolean).join(' | ')
   }
@@ -853,7 +853,7 @@ function addAssetSpecificFacts(
     return
   }
   if (asset === 'faq_markdown') {
-    addFact(facts, 'ticket rows', row.ticket_source_count)
+    addFact(facts, 'ticket sources', row.ticket_source_count)
     addFact(facts, 'source rows', row.source_count)
     addFact(facts, 'checks passed', row.passed_output_checks)
     return

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Output-Checks | `plans/PR-Content-Ops-FAQ-Output-Checks.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown output-check semantics. |
+| TBD | PR-Content-Ops-FAQ-Output-Checks | `plans/PR-Content-Ops-FAQ-Output-Checks.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`; `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown output-check semantics and generated-asset review labels. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T03:21Z by codex-2026-05-20
+Last updated: 2026-05-20T04:01Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Customer-Wording | `plans/PR-Content-Ops-FAQ-Customer-Wording.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown question wording. |
+| TBD | PR-Content-Ops-FAQ-Output-Checks | `plans/PR-Content-Ops-FAQ-Output-Checks.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown output-check semantics. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -237,6 +237,7 @@ def build_ticket_faq_markdown(
     date_window = _date_window(window_days=window_days, as_of_date=as_of_date)
     groups: dict[str, list[dict[str, str]]] = defaultdict(list)
     seen: set[tuple[str, str]] = set()
+    source_keys: set[str] = set()
 
     for opportunity_index, opportunity in enumerate(opportunities, start=1):
         for evidence_index, evidence in enumerate(_evidence_rows(opportunity), start=1):
@@ -259,15 +260,17 @@ def build_ticket_faq_markdown(
                 or opportunity.get("target_id")
                 or opportunity.get("id")
             )
-            dedupe_id = source_id or f"row:{opportunity_index}:evidence:{evidence_index}"
+            source_key = source_id or f"row:{opportunity_index}"
+            dedupe_id = source_id or f"{source_key}:evidence:{evidence_index}"
             key = (dedupe_id, text)
             if key in seen:
                 continue
             seen.add(key)
+            source_keys.add(source_key)
             groups[_topic(opportunity, evidence, intent_rules=intent_rules)].append({
                 "text": text,
                 "source_id": source_id or "unknown",
-                "source_key": source_id or dedupe_id,
+                "source_key": source_key,
                 "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
             })
 
@@ -276,11 +279,15 @@ def build_ticket_faq_markdown(
         for topic, rows in sorted(groups.items(), key=lambda item: (-len(item[1]), item[0].lower()))[:max_items]
     )
     return TicketFAQMarkdownResult(
-        markdown=_render(title=title, items=items, source_count=len(opportunities), ticket_source_count=len(seen)),
+        markdown=_render(title=title, items=items, source_count=len(opportunities), ticket_source_count=len(source_keys)),
         items=items,
         source_count=len(opportunities),
-        ticket_source_count=len(seen),
-        output_checks=_output_checks(items=items, ticket_source_count=len(seen)),
+        ticket_source_count=len(source_keys),
+        output_checks=_output_checks(
+            items=items,
+            ticket_source_count=len(source_keys),
+            rendered_ticket_source_count=_rendered_ticket_source_count(items),
+        ),
     )
 
 
@@ -398,6 +405,9 @@ def _question_text(value: Any) -> str:
         normalized = _question_start_text(text)
         if normalized:
             return normalized
+        normalized = _first_person_issue_question_text(text)
+        if normalized:
+            return normalized
     return ""
 
 
@@ -437,6 +447,41 @@ def _question_start_text(text: str) -> str:
     return ""
 
 
+def _first_person_issue_question_text(text: str) -> str:
+    sentence = _first_sentence(text)
+    lowered = sentence.lower()
+    patterns = (
+        ("i cannot ", "How do I "),
+        ("i can't ", "How do I "),
+        ("i can not ", "How do I "),
+        ("i need to ", "How do I "),
+        ("i want to ", "How do I "),
+        ("i have to ", "How do I "),
+        ("i am trying to ", "How do I "),
+        ("i'm trying to ", "How do I "),
+        ("we cannot ", "How do we "),
+        ("we can't ", "How do we "),
+        ("we can not ", "How do we "),
+        ("we need to ", "How do we "),
+        ("we want to ", "How do we "),
+        ("we have to ", "How do we "),
+        ("we are trying to ", "How do we "),
+        ("we're trying to ", "How do we "),
+    )
+    for prefix, question_prefix in patterns:
+        if lowered.startswith(prefix):
+            remainder = sentence[len(prefix):].strip()
+            normalized = _normalize_question_text(f"{question_prefix}{remainder}")
+            if _usable_question(normalized):
+                return normalized
+    return ""
+
+
+def _first_sentence(text: str) -> str:
+    parts = [part.strip() for part in re.split(r"[.!?;:\n]+", text, maxsplit=1) if part.strip()]
+    return parts[0] if parts else ""
+
+
 def _usable_question(value: str) -> bool:
     return bool(value) and len(value) <= MAX_EXTRACTED_QUESTION_CHARS
 
@@ -458,7 +503,7 @@ def _render(
     lines = [
         f"# {_md(title) or DEFAULT_TITLE}",
         "",
-        f"_Source rows analyzed: {source_count}. Ticket evidence rows used: {ticket_source_count}._",
+        f"_Source rows analyzed: {source_count}. Ticket sources used: {ticket_source_count}._",
         "",
     ]
     if not items:
@@ -608,14 +653,27 @@ def _output_checks(
     *,
     items: Sequence[Mapping[str, Any]],
     ticket_source_count: int,
+    rendered_ticket_source_count: int,
 ) -> dict[str, bool]:
     has_items = bool(items)
+    covers_all_sources = rendered_ticket_source_count == ticket_source_count
     return {
         "uses_user_vocabulary": has_items
         and all(item.get("question_source") == "customer_wording" for item in items),
-        "condensed": has_items and (ticket_source_count <= 1 or len(items) < ticket_source_count),
+        "condensed": has_items
+        and covers_all_sources
+        and (ticket_source_count <= 1 or len(items) < ticket_source_count),
         "has_action_items": has_items and all(bool(item.get("action_items")) for item in items),
     }
+
+
+def _rendered_ticket_source_count(items: Sequence[Mapping[str, Any]]) -> int:
+    source_ids: set[str] = set()
+    for item in items:
+        values = item.get("source_ids")
+        if isinstance(values, Sequence) and not isinstance(values, (str, bytes, bytearray)):
+            source_ids.update(_clean(value) for value in values if _clean(value))
+    return len(source_ids)
 
 
 def _quote(value: Any, *, limit: int = 220) -> str:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -609,10 +609,12 @@ def _output_checks(
     items: Sequence[Mapping[str, Any]],
     ticket_source_count: int,
 ) -> dict[str, bool]:
+    has_items = bool(items)
     return {
-        "uses_user_vocabulary": all(_clean(item.get("topic")) for item in items),
-        "condensed": len(items) <= ticket_source_count,
-        "has_action_items": all(bool(item.get("action_items")) for item in items),
+        "uses_user_vocabulary": has_items
+        and all(item.get("question_source") == "customer_wording" for item in items),
+        "condensed": has_items and (ticket_source_count <= 1 or len(items) < ticket_source_count),
+        "has_action_items": has_items and all(bool(item.get("action_items")) for item in items),
     }
 
 

--- a/plans/PR-Content-Ops-FAQ-Output-Checks.md
+++ b/plans/PR-Content-Ops-FAQ-Output-Checks.md
@@ -10,8 +10,7 @@ passes for any non-empty topic, and `condensed` passes even when every ticket
 becomes its own FAQ item.
 
 That makes the three FAQ output checks too easy to satisfy. This slice makes
-the checks honest without changing rendering, storage, or generated-asset API
-shape.
+the checks honest without changing storage or generated-asset API shape.
 
 ## Scope (this PR)
 
@@ -30,26 +29,50 @@ shape.
 | `plans/PR-Content-Ops-FAQ-Output-Checks.md` | Plan doc for this slice. |
 | `docs/extraction/coordination/inflight.md` | Replace stale merged FAQ row with this active slice. |
 | `extracted_content_pipeline/ticket_faq_markdown.py` | Tighten FAQ output-check predicates. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Align rendered review labels with the stricter ticket-source denominator. |
 | `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for honest output checks. |
 | `tests/test_extracted_content_ops_execution_smoke.py` | Keep the FAQ execution smoke aligned with the stricter output checks. |
+| `scripts/smoke_extracted_content_ops_execution.py` | Keep the documented FAQ smoke default aligned with the stricter output checks. |
 
 ## Mechanism
 
 `_output_checks(...)` remains the single output-quality summary point. It will
 continue returning the same three keys so callers do not need a response-shape
-migration:
+migration.
+
+All three checks return `False` when the builder generates no FAQ items (empty
+`items` sequence). When items are present:
 
 - `uses_user_vocabulary`: true only when every rendered item used
   `question_source="customer_wording"`.
-- `condensed`: true only when at least one FAQ item is generated and either the
-  input has one ticket source or multiple ticket sources collapse into fewer
-  FAQ items than source tickets.
-- `has_action_items`: unchanged, true only when every item has action steps.
+- `condensed`: true when the input has at most one ticket source, or when
+  multiple ticket sources collapse into strictly fewer FAQ items than source
+  tickets.
+- `has_action_items`: true only when every item has at least one action step.
+
+The ticket-source denominator is based on distinct source keys, not evidence
+row count, so multiple snippets from one ticket do not look like multi-ticket
+condensation. Rows without a source id use a row-level fallback source key
+while evidence-level fallback keys remain available for de-duping repeated
+snippets.
+
+`condensed` also requires the rendered FAQ items to cover all ticket sources.
+That keeps `max_items` truncation from looking like true condensation when many
+unrelated ticket issues are simply dropped from the final Markdown.
+
+The question extractor treats narrow first-person customer issue statements
+such as "I cannot reset my password" as customer wording by converting them
+into action-oriented FAQ questions using the same terms. This keeps declarative
+support tickets from failing `uses_user_vocabulary` just because the customer
+did not write the ticket as a question.
 
 ## Intentional
 
 - No new output-check keys. The existing API shape stays stable.
-- No changes to Markdown rendering. This is telemetry/contract hardening only.
+- The Markdown summary label changes from evidence rows to ticket sources so
+  the rendered copy matches the stricter distinct-source denominator.
+- The asset review UI label changes from ticket rows to ticket sources for the
+  same reason; the stored field name remains `ticket_source_count`.
 - No LLM or semantic clustering. Deterministic intent clustering remains the
   current source of condensation.
 
@@ -61,18 +84,23 @@ migration:
 
 ## Verification
 
-- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 36 passed
-- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py - passed
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 40 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py scripts/smoke_extracted_content_ops_execution.py - passed
+- python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json >/tmp/faq_smoke.json && python -m json.tool /tmp/faq_smoke.json >/dev/null - passed
+- npx eslint src/pages/ContentOpsAssetsReview.tsx (from atlas-intel-ui) - passed
+- npm run build (from atlas-intel-ui, after npm ci) - passed
 - git diff --check - passed
-- bash scripts/run_extracted_pipeline_checks.sh - 1516 passed, 1 existing torch/pynvml warning
+- bash scripts/run_extracted_pipeline_checks.sh - 1520 passed, 1 existing torch/pynvml warning
 
 ## Estimated diff size
 
 | File | Estimated LOC |
 |---|---:|
-| `plans/PR-Content-Ops-FAQ-Output-Checks.md` | +77 |
+| `plans/PR-Content-Ops-FAQ-Output-Checks.md` | +102 |
 | `docs/extraction/coordination/inflight.md` | +2 / -2 |
-| `extracted_content_pipeline/ticket_faq_markdown.py` | +5 / -3 |
-| `tests/test_extracted_ticket_faq_markdown.py` | +11 / -4 |
-| `tests/test_extracted_content_ops_execution_smoke.py` | +1 / -1 |
-| Total | ~106 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +69 / -9 |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | +2 / -2 |
+| `scripts/smoke_extracted_content_ops_execution.py` | +1 / -1 |
+| `tests/test_extracted_content_ops_execution_smoke.py` | +0 / -2 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +96 / -7 |
+| Total | ~295 |

--- a/plans/PR-Content-Ops-FAQ-Output-Checks.md
+++ b/plans/PR-Content-Ops-FAQ-Output-Checks.md
@@ -1,0 +1,78 @@
+# Content Ops FAQ Output Checks
+
+## Why this slice exists
+
+The FAQ Markdown builder now supports ticket CSV ingestion, date windows,
+deterministic intent clustering, ticket volume counts, customer-worded
+questions, and generated-asset review. The remaining quality gap is the
+machine-readable `output_checks` contract: `uses_user_vocabulary` currently
+passes for any non-empty topic, and `condensed` passes even when every ticket
+becomes its own FAQ item.
+
+That makes the three FAQ output checks too easy to satisfy. This slice makes
+the checks honest without changing rendering, storage, or generated-asset API
+shape.
+
+## Scope (this PR)
+
+1. Tighten `uses_user_vocabulary` so it reflects customer-worded FAQ questions.
+2. Tighten `condensed` so multi-ticket inputs must collapse below the ticket
+   count instead of merely staying equal to it.
+3. Preserve `has_action_items` as the existing action-step check.
+4. Add regression coverage for passing and failing output-check states.
+5. Replace the merged stale FAQ customer-wording in-flight row with this active
+   slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Output-Checks.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale merged FAQ row with this active slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Tighten FAQ output-check predicates. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for honest output checks. |
+| `tests/test_extracted_content_ops_execution_smoke.py` | Keep the FAQ execution smoke aligned with the stricter output checks. |
+
+## Mechanism
+
+`_output_checks(...)` remains the single output-quality summary point. It will
+continue returning the same three keys so callers do not need a response-shape
+migration:
+
+- `uses_user_vocabulary`: true only when every rendered item used
+  `question_source="customer_wording"`.
+- `condensed`: true only when at least one FAQ item is generated and either the
+  input has one ticket source or multiple ticket sources collapse into fewer
+  FAQ items than source tickets.
+- `has_action_items`: unchanged, true only when every item has action steps.
+
+## Intentional
+
+- No new output-check keys. The existing API shape stays stable.
+- No changes to Markdown rendering. This is telemetry/contract hardening only.
+- No LLM or semantic clustering. Deterministic intent clustering remains the
+  current source of condensation.
+
+## Deferred
+
+- Semantic clustering beyond keyword rules remains deferred until a real host
+  fixture proves deterministic clustering is insufficient.
+- Per-item edit/publish UX remains separate from Markdown output checks.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 36 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py - passed
+- git diff --check - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1516 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Output-Checks.md` | +77 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +5 / -3 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +11 / -4 |
+| `tests/test_extracted_content_ops_execution_smoke.py` | +1 / -1 |
+| Total | ~106 |

--- a/scripts/smoke_extracted_content_ops_execution.py
+++ b/scripts/smoke_extracted_content_ops_execution.py
@@ -253,7 +253,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--campaign-name", default="Content Ops smoke")
     parser.add_argument(
         "--source-material",
-        default="Pricing became hard to justify after renewal.",
+        default="I cannot reset my password from the login page.",
     )
     parser.add_argument("--source-id", default="source-smoke-1")
     parser.add_argument("--source-type", default="support_ticket")

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -236,8 +236,6 @@ def test_content_ops_execution_smoke_cli_runs_faq_markdown_json() -> None:
             "faq_markdown",
             "--source-title",
             "login reset",
-            "--source-material",
-            "How do I reset my password from the login page?",
             "--json",
         ],
         check=True,

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -237,7 +237,7 @@ def test_content_ops_execution_smoke_cli_runs_faq_markdown_json() -> None:
             "--source-title",
             "login reset",
             "--source-material",
-            "I cannot reset my password from the login page.",
+            "How do I reset my password from the login page?",
             "--json",
         ],
         check=True,

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -121,8 +121,8 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     assert "**What to do next:**" in result.markdown
     assert "Check whether your plan and role include the needed export" in result.markdown
     assert result.output_checks == {
-        "uses_user_vocabulary": True,
-        "condensed": True,
+        "uses_user_vocabulary": False,
+        "condensed": False,
         "has_action_items": True,
     }
 
@@ -158,6 +158,7 @@ def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
     assert result.items[0]["source_ids"] == ("ticket-1", "ticket-2")
     assert "How do I change my login email?" in result.markdown
     assert "I need to update the email on my account." in result.markdown
+    assert result.output_checks["uses_user_vocabulary"] is True
     assert result.output_checks["condensed"] is True
 
 
@@ -179,6 +180,7 @@ def test_build_ticket_faq_markdown_falls_back_to_topic_question() -> None:
     assert result.items[0]["topic"] == "reporting friction"
     assert result.items[0]["question"] == "What are customers asking about reporting friction?"
     assert result.items[0]["question_source"] == "topic_fallback"
+    assert result.output_checks["uses_user_vocabulary"] is False
 
 
 def test_build_ticket_faq_markdown_falls_back_from_long_customer_question() -> None:
@@ -443,8 +445,8 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
     )
     assert len(result.items) == 2
     assert result.output_checks == {
-        "uses_user_vocabulary": True,
-        "condensed": True,
+        "uses_user_vocabulary": False,
+        "condensed": False,
         "has_action_items": True,
     }
 
@@ -703,6 +705,11 @@ def test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits
 
     assert result.items == ()
     assert "No ticket FAQ items were generated." in result.markdown
+    assert result.output_checks == {
+        "uses_user_vocabulary": False,
+        "condensed": False,
+        "has_action_items": False,
+    }
     with pytest.raises(ValueError, match="max_items must be positive"):
         build_ticket_faq_markdown([], max_items=0)
     with pytest.raises(ValueError, match="max_evidence_per_item must be positive"):

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -243,6 +243,26 @@ def test_build_ticket_faq_markdown_normalizes_missing_question_mark() -> None:
     assert result.items[0]["question_source"] == "customer_wording"
 
 
+def test_build_ticket_faq_markdown_turns_first_person_issue_into_customer_question() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Password reset",
+                "evidence": [{
+                    "text": "I cannot reset my password from the login page.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert result.items[0]["question"] == "How do I reset my password from the login page?"
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert result.output_checks["uses_user_vocabulary"] is True
+
+
 def test_build_ticket_faq_markdown_strips_customer_speaker_label() -> None:
     result = build_ticket_faq_markdown(
         [
@@ -745,7 +765,7 @@ def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified
     assert len(result.items) == 1
     assert result.ticket_source_count == 2
     assert result.items[0]["evidence_count"] == 2
-    assert result.items[0]["source_ids"] == ("row:1:evidence:1", "row:2:evidence:1")
+    assert result.items[0]["source_ids"] == ("row:1", "row:2")
     assert "Evidence comes from 2 ticket source(s)." in result.markdown
 
 
@@ -761,7 +781,69 @@ def test_build_ticket_faq_markdown_counts_distinct_source_ids_per_item() -> None
 
     assert result.items[0]["evidence_count"] == 2
     assert result.items[0]["source_ids"] == ("ticket-1",)
+    assert result.ticket_source_count == 1
     assert "Evidence comes from 1 ticket source(s)." in result.markdown
+
+
+def test_build_ticket_faq_markdown_counts_distinct_ticket_sources_for_output_checks() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "support_ticket",
+        "source_title": "Login reset",
+        "evidence": [
+            {
+                "text": "How do I reset my password?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            },
+            {
+                "text": "How do I update the account email?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "source_title": "Profile change question",
+            },
+        ],
+    }])
+
+    assert result.ticket_source_count == 1
+    assert result.items[0]["source_ids"] == ("ticket-1",)
+    assert result.output_checks["condensed"] is True
+
+
+def test_build_ticket_faq_markdown_counts_unidentified_source_rows_once() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "support_ticket",
+        "source_title": "Login reset",
+        "evidence": [
+            {"text": "How do I reset my password?", "source_type": "support_ticket"},
+            {"text": "How do I update the account email?", "source_type": "support_ticket"},
+        ],
+    }])
+
+    assert result.ticket_source_count == 1
+    assert result.items[0]["source_ids"] == ("row:1",)
+    assert result.output_checks["condensed"] is True
+
+
+def test_build_ticket_faq_markdown_does_not_treat_max_items_truncation_as_condensed() -> None:
+    opportunities = [
+        {
+            "source_type": "support_ticket",
+            "source_title": f"Unique issue {index}",
+            "evidence": [{
+                "text": f"How do I handle unique issue {index}?",
+                "source_id": f"ticket-{index}",
+                "source_type": "support_ticket",
+            }],
+        }
+        for index in range(1, 10)
+    ]
+
+    result = build_ticket_faq_markdown(opportunities, max_items=8)
+
+    assert len(result.items) == 8
+    assert result.ticket_source_count == 9
+    assert result.output_checks["uses_user_vocabulary"] is True
+    assert result.output_checks["condensed"] is False
 
 
 def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
@@ -787,7 +869,7 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert completed.stdout == ""
     markdown = output.read_text(encoding="utf-8")
     assert markdown.startswith("# Support FAQ")
-    assert "Ticket evidence rows used: 2" in markdown
+    assert "Ticket sources used: 2" in markdown
     assert "ticket-acme-1" in markdown
 
 
@@ -809,7 +891,7 @@ def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:
     assert completed.returncode == 0
     assert "ticket-new" in completed.stdout
     assert "ticket-old" not in completed.stdout
-    assert "Ticket evidence rows used: 1" in completed.stdout
+    assert "Ticket sources used: 1" in completed.stdout
 
 
 @pytest.mark.parametrize("value", ("2026-99-99", "2026-05-20abc", "2026/05/20"))


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Output-Checks.md

Tightens the FAQ Markdown output-check contract so it actually measures customer-worded questions, real condensation across distinct ticket sources, and per-item action steps instead of passing on weak topic/output presence.

## Intentional
- Keep the existing output_checks keys and generated-asset response shape stable.
- Count distinct ticket sources instead of evidence rows so multiple snippets from one ticket do not fake multi-ticket condensation.
- Require rendered FAQ items to cover all ticket sources before claiming condensation, so max_items truncation cannot fake quality.
- Treat narrow first-person support-ticket statements as customer wording instead of requiring users to write every issue as a question.
- Update rendered labels and smoke defaults only where needed to match the stricter source semantics.
- Keep clustering deterministic; no LLM or semantic clustering in this slice.

## Deferred
- Semantic clustering beyond keyword rules remains deferred until a real host fixture proves deterministic clustering is insufficient.
- Per-item edit/publish UX remains separate from Markdown output checks.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py::test_content_ops_execution_smoke_cli_runs_faq_markdown_json - 40 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py scripts/smoke_extracted_content_ops_execution.py - passed
- python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json >/tmp/faq_smoke.json && python -m json.tool /tmp/faq_smoke.json >/dev/null - passed
- npx eslint src/pages/ContentOpsAssetsReview.tsx (from atlas-intel-ui) - passed
- npm run build (from atlas-intel-ui, after npm ci) - passed
- git diff --check - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1520 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
7 files, +276 / -23
