### PR TITLE
Version-control B2B affiliate partner rows (migration 326)

### DIFF
--- a/atlas_brain/storage/migrations/326_seed_b2b_affiliate_partners.sql
+++ b/atlas_brain/storage/migrations/326_seed_b2b_affiliate_partners.sql
@@ -1,0 +1,95 @@
+-- Version-control the B2B affiliate partner rows.
+--
+-- Before this migration, only Amazon Associates (088) was seeded from a
+-- migration; the five B2B partners below existed solely as live
+-- affiliate_partners rows created via the /b2b/tenant/affiliates API. That
+-- left no git history, no code review, and no disaster-recovery path -- a
+-- restore from a stale backup would silently lose or mismatch partner data.
+--
+-- Each row mirrors the live DB exactly (dumped 2026-05-19). product_aliases
+-- is reproduced verbatim because it is load-bearing in two places: the
+-- blog generator's vendor matcher (_pick_affiliate_partner_for_vendors) and
+-- the /opportunities competitor JOIN -- both match competitor/vendor names
+-- against product_name OR any alias. Dropping or altering aliases would
+-- change which posts get an affiliate link on a rebuilt database.
+--
+-- ON CONFLICT ((lower(product_name))) DO NOTHING matches the expression
+-- unique index idx_affiliate_partners_product and the 088 precedent: on the
+-- live DB where these rows already exist the migration is a no-op; on a
+-- fresh database it seeds them. Going forward, each NEW partner should get
+-- its own migration so the addition is independently reviewable.
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'HubSpot Partner',
+    'HubSpot',
+    '{}'::text[],
+    'CRM',
+    'https://hubspot.com/?ref=atlas',
+    'cpa',
+    '$150/signup',
+    NULL,
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'Pipedrive Partner',
+    'Pipedrive',
+    '{}'::text[],
+    'CRM',
+    'https://pipedrive.com/?ref=atlas',
+    'recurring',
+    '20% first year',
+    NULL,
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'Shopify Affiliates',
+    'Shopify',
+    ARRAY['shopify plus', 'shopify basic', 'shopify advanced']::text[],
+    'E-commerce',
+    'https://shopify.pxf.io/c/7062841/1424184/13624',
+    'cpa',
+    'up to $150/merchant',
+    'Impact Radius program. Publisher ID: 7062841. Username: canfieldjuan.',
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'HelpDesk',
+    'HelpDesk',
+    ARRAY['helpdesk.com']::text[],
+    'Helpdesk',
+    'https://www.helpdesk.com/?a=OWvKUHFvg&utm_campaign=pp_helpdesk-default&utm_source=PP',
+    'recurring',
+    '20% recurring',
+    'PartnerStack program. Affiliate ID: OWvKUHFvg.',
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'Monday.com',
+    'Monday.com',
+    ARRAY['monday', 'monday CRM', 'monday work OS']::text[],
+    'Project Management',
+    'https://try.monday.com/1p7bntdd5bui',
+    'rev_share',
+    '$100/signup',
+    NULL,
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;

--- a/atlas_brain/storage/migrations/326_seed_b2b_affiliate_partners.sql
+++ b/atlas_brain/storage/migrations/326_seed_b2b_affiliate_partners.sql
@@ -6,12 +6,17 @@
 -- left no git history, no code review, and no disaster-recovery path -- a
 -- restore from a stale backup would silently lose or mismatch partner data.
 --
--- Each row mirrors the live DB exactly (dumped 2026-05-19). product_aliases
--- is reproduced verbatim because it is load-bearing in two places: the
--- blog generator's vendor matcher (_pick_affiliate_partner_for_vendors) and
--- the /opportunities competitor JOIN -- both match competitor/vendor names
--- against product_name OR any alias. Dropping or altering aliases would
--- change which posts get an affiliate link on a rebuilt database.
+-- Each row reproduces the live DB business columns (dumped 2026-05-19):
+-- name, product_name, product_aliases, category, affiliate_url,
+-- commission_type, commission_value, notes, enabled. The identity/audit
+-- columns (id, created_at, updated_at) intentionally use schema DEFAULTs, so
+-- a fresh insert is row-equivalent but not byte-for-byte identical to a dump.
+-- product_aliases is reproduced verbatim because it is load-bearing in two
+-- places: the blog generator's vendor matcher
+-- (_pick_affiliate_partner_for_vendors) and the /opportunities competitor
+-- JOIN -- both match competitor/vendor names against product_name OR any
+-- alias. Dropping or altering aliases would change which posts get an
+-- affiliate link on a rebuilt database.
 --
 -- ON CONFLICT ((lower(product_name))) DO NOTHING matches the expression
 -- unique index idx_affiliate_partners_product and the 088 precedent: on the

--- a/plans/PR-Affiliate-Partner-Migrations.md
+++ b/plans/PR-Affiliate-Partner-Migrations.md
@@ -1,0 +1,125 @@
+# PR-Affiliate-Partner-Migrations
+
+## Why this slice exists
+
+The affiliate-system investigation (`reports/affiliate-system-investigation.md`,
+item #2 / #3) flagged that only Amazon Associates is version-controlled
+(`atlas_brain/storage/migrations/088_seed_amazon_affiliate.sql`). The five
+B2B affiliate partners that actually drive revenue -- HubSpot, Pipedrive,
+Shopify, HelpDesk, Monday.com -- existed solely as live `affiliate_partners`
+rows created via the `/b2b/tenant/affiliates` API. That left:
+
+- **No git history / no review** for partner URLs, commission terms, or the
+  `product_aliases` arrays that decide which posts get an affiliate link.
+- **No disaster-recovery path.** A restore from a stale backup would silently
+  lose or mismatch partner data; nothing reconstructs these rows.
+- **No audit trail.** A wrong URL or category edited directly in the DB has no
+  reviewer in the loop.
+
+This slice closes that gap by seeding the five existing partners from a
+migration, so the partner definitions live in version control like every
+other schema fact.
+
+## Scope (this PR)
+
+1. Add `326_seed_b2b_affiliate_partners.sql` -- five idempotent
+   `INSERT ... ON CONFLICT ((lower(product_name))) DO NOTHING` statements,
+   one per partner, mirroring the live DB rows dumped 2026-05-19.
+2. Reproduce `product_aliases` verbatim, because the arrays are load-bearing
+   in two query paths (see Mechanism).
+3. No code change. The generator, API, and frontend already read these rows;
+   this PR only moves the row *definitions* into version control.
+
+### Files touched
+
+- `atlas_brain/storage/migrations/326_seed_b2b_affiliate_partners.sql`
+- `plans/PR-Affiliate-Partner-Migrations.md`
+
+## Mechanism
+
+The migration runner (`atlas_brain/storage/migrations/__init__.py`) discovers
+`*.sql` files in sorted (numeric-prefix) order, tracks applied migrations by
+filename in `schema_migrations`, and runs each pending file exactly once via
+`pool.execute(sql)`. The next free prefix after `325_ticket_faq_markdown.sql`
+is 326.
+
+`ON CONFLICT ((lower(product_name)))` targets the expression unique index
+`idx_affiliate_partners_product ON affiliate_partners (LOWER(product_name))`
+from migration 063, matching the 088 precedent. `DO NOTHING` makes the
+migration a no-op on the live DB where the rows already exist, and a seed on
+a fresh database -- safe under any re-application.
+
+`product_aliases` is reproduced verbatim because two query paths match
+competitor/vendor names against `product_name` OR any alias:
+
+- the blog generator's vendor matcher
+  `_pick_affiliate_partner_for_vendors` (e.g. vendor "monday" resolves to
+  Monday.com via the `monday` alias), and
+- the `/b2b/tenant/affiliates/opportunities` competitor JOIN
+  (`LOWER(rc.competitor_name) = ANY(SELECT LOWER(unnest(ap.product_aliases)))`).
+
+Altering or dropping aliases would change which posts receive an affiliate
+link on a rebuilt database, so the arrays are copied exactly --
+`{shopify plus, shopify basic, shopify advanced}`,
+`{helpdesk.com}`, `{monday, monday CRM, monday work OS}`, and empty for
+HubSpot / Pipedrive.
+
+## Intentional
+
+- **One batch migration, not five.** The report's "one partner = one
+  migration" rule applies going *forward*, when a partner is added in
+  isolation and wants its own reviewable diff. The five existing partners are
+  a single bounded back-fill event, so one migration matches the slice.
+- **`DO NOTHING`, not `DO UPDATE`.** The runner tracks by filename and runs
+  once, but `DO NOTHING` is the safe choice if the file is ever re-applied: it
+  never clobbers a live row that may have diverged intentionally. Matches 088.
+- **Notes kept verbatim, including program IDs.** The Shopify Publisher ID
+  (`7062841`) and HelpDesk Affiliate ID (`OWvKUHFvg`) are already shipped
+  publicly inside the affiliate URLs in the published blog HTML, so
+  version-controlling them in `notes` is no new exposure.
+- **`created_at` left to `DEFAULT NOW()`.** The matcher orders partners by
+  `created_at` only as a tiebreaker when two partners match the *same* vendor,
+  which does not happen across the five distinct vendors here. Preserving the
+  original timestamps would add noise without changing behavior.
+
+## Deferred
+
+- **Per-partner migrations for future additions.** New partners after this
+  back-fill should each ship their own `NNN_seed_<partner>.sql` so the
+  addition is independently reviewable.
+- **Delete the dead `_fetch_affiliate_partner_by_category` stub.** It was
+  deprecated to `return None` (b2b_blog_post_generation.py ~6608) after the
+  editorial-mismatch fix; it is intentionally dead, kept only because some
+  tests still mock the name. A follow-up can remove it once those mocks are
+  retired.
+- **Schema-level placeholder guard** (`CHECK (affiliate_url NOT LIKE
+  'https://example.com/%')`). The generator already filters placeholder rows
+  at match time (`_is_placeholder_partner`); a DB-level constraint is
+  defense-in-depth, not blocking.
+- **Admin UI for partner management** (report item #6) and click-to-commission
+  reconciliation (item #7) remain out of scope.
+
+## Verification
+
+- Idempotent no-op against the live DB (rows already present), inside a
+  rolled-back transaction:
+  `psql ... <<'SQL' BEGIN; \i .../326_seed_b2b_affiliate_partners.sql;
+  SELECT COUNT(*) ...; ROLLBACK; SQL`
+  -> `INSERT 0 0` x5, `count` `6` before and after, `ROLLBACK`. Live count
+  re-checked after: `6` (untouched).
+- Fresh-insert + fidelity, inside a rolled-back transaction:
+  `BEGIN; DELETE FROM affiliate_partners WHERE product_name <> 'Amazon';`
+  (`DELETE 5`, `after_delete = 1`) -> `\i .../326...` (`INSERT 0 1` x5,
+  `after_reinsert = 6`) -> `SELECT product_name, product_aliases, category,
+  commission_type, commission_value, notes, enabled ...` returned all five
+  rows matching the 2026-05-19 dump exactly (aliases, categories, commission
+  terms, and notes verbatim) -> `ROLLBACK`. Live count after: `6`.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `326_seed_b2b_affiliate_partners.sql` (5 inserts + header) | ~95 |
+| Plan doc | ~120 |
+| **Total** | **~215** |


### PR DESCRIPTION
Plan: plans/PR-Affiliate-Partner-Migrations.md

Version-controls the five B2B affiliate partner rows (HubSpot, Pipedrive, Shopify, HelpDesk, Monday.com) that previously existed only as live `affiliate_partners` rows created via the `/b2b/tenant/affiliates` API. Closes affiliate-system-investigation items #2/#3: no git history, no review, no disaster-recovery path for partner URLs / commission terms / `product_aliases`. No code change — the generator, API, and frontend already read these rows; this PR moves the row *definitions* into version control.

## Intentional
- **One batch migration, not five.** The "one partner = one migration" rule applies going forward; the five existing partners are a single bounded back-fill.
- **`ON CONFLICT ((lower(product_name))) DO NOTHING`**, targeting the expression unique index from migration 063 — matches the 088 Amazon precedent. No-op on the live DB, seed on a fresh one.
- **`product_aliases` reproduced verbatim.** Load-bearing in two query paths: the generator vendor matcher (`_pick_affiliate_partner_for_vendors`) and the `/opportunities` competitor JOIN (`= ANY(SELECT LOWER(unnest(ap.product_aliases)))`). Altering them would change which posts get an affiliate link on a rebuilt DB.
- **Notes kept verbatim, including program IDs.** The Shopify Publisher ID and HelpDesk Affiliate ID already ship publicly inside the affiliate URLs in the published blog HTML, so version-controlling them is no new exposure.

## Deferred
- Per-partner migrations for future additions (each independently reviewable).
- Deleting the dead `_fetch_affiliate_partner_by_category` stub (deprecated to `return None`; kept only because some tests still mock the name).
- Schema-level placeholder `CHECK` constraint (generator already filters via `_is_placeholder_partner`).
- Admin UI (item #6) and click→commission reconciliation (item #7).

## Verification
- Idempotent no-op against the live schema in a rolled-back transaction: `BEGIN; \i .../326_seed_b2b_affiliate_partners.sql; ROLLBACK;` → `INSERT 0 0` ×5, count `6` before/after; live count re-checked after rollback: `6`.
- Fresh-insert + fidelity in a rolled-back transaction: `DELETE FROM affiliate_partners WHERE product_name <> 'Amazon'` (`DELETE 5`) → `\i .../326...` (`INSERT 0 1` ×5) → `SELECT` of all five rows matched the 2026-05-19 dump exactly (aliases, categories, commission terms, notes verbatim) → `ROLLBACK`. Live count after: `6`.
- `scripts/local_pr_review.sh` → `local PR review passed` (plan shape, plan/code consistency 2/2 path claims, diff drift 2.3%, `git diff --check`).

## Diff size
~220 LOC (migration ~95, plan doc ~120). Within the ~215 estimate (2.3% drift).