### PR TITLE
Persist blog SEO fields from Content Ops drafts

### DIFF
--- a/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
+++ b/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
@@ -1,0 +1,211 @@
+# AI Content Ops Blog SEO/AEO/GEO Discovery
+
+**Date:** 2026-05-20
+**Scope:** Automated blog post generation in the Atlas AI Content Ops Station.
+
+## Short Answer
+
+Atlas partially generates SEO and AEO-ready blog drafts today.
+
+It does not have a clean, explicit GEO contract yet, and at least one AI Content Ops persistence path does not appear to write the generated SEO fields into the public `blog_posts` columns that the public API and frontend read.
+
+The safest current claim is:
+
+> The blog generator can produce SEO and answer-engine-ready drafts when the run uses the SEO/AEO prompt and the publishing path preserves the generated metadata.
+
+Avoid claiming fully automated SEO, AEO, and GEO optimization until the gaps below are closed.
+
+## What Exists
+
+### SEO Generation
+
+The blog prompts request SEO fields directly:
+
+- `seo_title`
+- `seo_description`
+- `target_keyword`
+- `secondary_keywords`
+- `faq`
+
+Relevant files:
+
+- `extracted_content_pipeline/skills/digest/blog_post_generation.md`
+- `extracted_content_pipeline/skills/digest/b2b_blog_post_generation.md`
+- `atlas_brain/skills/digest/blog_post_generation.md`
+- `atlas_brain/skills/digest/b2b_blog_post_generation.md`
+
+The prompt rules include title length, meta description length, target keyword placement, secondary keywords, internal links, outbound authority links, FAQ answers, and featured-snippet-friendly structure.
+
+### AEO Generation
+
+The consumer blog prompt has an explicit `AEO (Answer Engine Optimization)` section. It tells the model to structure posts for ChatGPT, Perplexity, and Google AI Overviews by using:
+
+- direct answers near the start of each section
+- self-contained H2 sections
+- question-format H2 headings
+- concrete numbers and date anchoring
+- clear entity names
+- structured comparison tables
+
+The B2B prompt does not use a separate AEO heading, but it asks for many of the same patterns:
+
+- direct 40-60 word answer after question-like H2s
+- self-contained sections
+- full vendor names
+- date anchoring
+- FAQ answers backed by data
+
+### Public Rendering
+
+The public frontend can render several SEO/AEO artifacts when the fields are present:
+
+- SEO title and description
+- canonical blog URLs
+- `BlogPosting` JSON-LD
+- `BreadcrumbList` JSON-LD
+- `FAQPage` JSON-LD when FAQ items exist
+- keyword metadata from `target_keyword` and `secondary_keywords`
+
+Relevant files:
+
+- `atlas-churn-ui/vite.config.ts`
+- `atlas-churn-ui/src/pages/BlogPost.tsx`
+- `atlas-churn-ui/src/components/BlogArticleView.tsx`
+- `atlas-intel-ui/src/components/SeoHead.tsx`
+
+### Legacy B2B Blog Path
+
+The legacy/autonomous B2B blog generation path writes SEO fields into first-class database columns:
+
+- `seo_title`
+- `seo_description`
+- `target_keyword`
+- `secondary_keywords`
+- `faq`
+
+Relevant file:
+
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+
+This path also has fallback logic for missing SEO title, SEO description, and target keyword.
+
+## Main Gaps
+
+### Gap 1: GEO Is Not a First-Class Contract
+
+The prompts mention AI answer engines and include AEO patterns that overlap with GEO, but there is no separate GEO field, checklist, score, or pass/fail gate.
+
+That means the system can produce GEO-friendly content, but the repo does not currently prove or enforce "GEO optimized" as a distinct output.
+
+Needed:
+
+- decide whether GEO is a separate contract or part of AEO
+- define a GEO checklist if it is separate
+- add validation or review output that says what passed
+
+### Gap 2: AI Content Ops Blog Persistence May Bury SEO Fields
+
+The newer extracted AI Content Ops blog service builds a `BlogPostDraft` with SEO fields in `draft.metadata`.
+
+Relevant file:
+
+- `extracted_content_pipeline/blog_generation.py`
+
+But `PostgresBlogPostRepository.save_drafts()` writes only core draft fields and stores metadata under `data_context["_metadata"]`.
+
+Relevant file:
+
+- `extracted_content_pipeline/blog_post_postgres.py`
+
+The public blog API reads first-class columns instead:
+
+- `seo_title`
+- `seo_description`
+- `target_keyword`
+- `secondary_keywords`
+- `faq`
+- `related_slugs`
+
+Relevant file:
+
+- `atlas_brain/api/blog_public.py`
+
+Those columns exist in:
+
+- `atlas_brain/storage/migrations/120_blog_seo.sql`
+
+Risk:
+
+Generated SEO/AEO metadata from the extracted AI Content Ops Station path may be saved in `data_context["_metadata"]` but not exposed to the public API or frontend as SEO fields.
+
+### Gap 3: Quality Gate Does Not Validate SEO/AEO/GEO Metadata
+
+`extracted_quality_gate.blog_pack.evaluate_blog_post()` validates long-form blog quality, word count, chart placeholders, internal links, quote use, unsupported data claims, and related content quality issues.
+
+It does not appear to validate:
+
+- `seo_title` length or keyword placement
+- `seo_description` length or keyword inclusion
+- target keyword presence
+- FAQ count or answer quality
+- answer-first section format
+- question-style H2 usage
+- BlogPosting/FAQ schema readiness
+- GEO/AEO citable-section requirements as a named score
+
+Relevant files:
+
+- `extracted_quality_gate/blog_pack.py`
+- `extracted_content_pipeline/blog_generation.py`
+
+Risk:
+
+The prompt asks for SEO/AEO, but the quality gate does not independently enforce it before a draft is saved.
+
+### Gap 4: Two Blog Generation Paths Are Easy to Confuse
+
+There are at least two relevant paths:
+
+1. Legacy/autonomous blog generation, which writes SEO fields directly.
+2. Extracted AI Content Ops `BlogPostGenerationService`, which stores SEO fields in draft metadata and relies on a repository that does not write the first-class SEO columns.
+
+Risk:
+
+We may be looking at a working SEO implementation in one path while the actual AI Content Ops Station path used by the product has a weaker contract.
+
+### Gap 5: Current Product Claim Needs Careful Wording
+
+The repo supports this claim:
+
+> Generates data-backed blog drafts with SEO fields, FAQ output, and AEO-style structure.
+
+The repo does not yet fully support this stronger claim:
+
+> Automatically generates, validates, and publishes fully SEO/GEO/AEO optimized blog posts.
+
+## Discovery Questions
+
+1. Which blog path powers the AI Content Ops Station experience we want to sell: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` or `extracted_content_pipeline/blog_generation.py`?
+2. When a customer generates a blog post from the Station, does the draft get published through the DB/API path or exported to static frontend `.ts` content?
+3. Should GEO be a separate checklist, or should we treat GEO as part of AEO for now?
+4. What should the report show the customer: raw generated article, SEO fields, AEO checklist, GEO checklist, or all of those?
+5. What proof do we need before saying the output is SEO/GEO/AEO-ready?
+
+## Recommended Next Slice
+
+Before changing copy or selling this as SEO/GEO/AEO generation, tighten the product contract:
+
+1. Add first-class SEO fields to the extracted AI Content Ops `BlogPostDraft` persistence path, or map `metadata` into the existing public SEO columns.
+2. Add a small SEO/AEO/GEO readiness summary to blog draft export/review output.
+3. Add tests proving that a generated blog draft persists `seo_title`, `seo_description`, `target_keyword`, `secondary_keywords`, and `faq` into the fields read by the public API.
+4. Decide whether GEO gets its own named validator now or remains described as AEO/answer-engine readiness.
+
+## Suggested Customer-Facing Language For Now
+
+Use:
+
+> Blog drafts include SEO metadata, FAQ answers, and answer-engine-friendly article structure.
+
+Avoid until validated:
+
+> Fully optimized for SEO, GEO, and AEO.

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -47,6 +47,7 @@ def _row_to_draft(row: Mapping[str, Any]) -> BlogPostDraft:
     metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
     if row.get("llm_model") and "generation_model" not in metadata:
         metadata["generation_model"] = str(row.get("llm_model"))
+    _hydrate_seo_metadata(metadata, row)
 
     return BlogPostDraft(
         id=str(row.get("id") or ""),
@@ -74,6 +75,41 @@ def _source_report_date(value: Any) -> date | None:
     return None
 
 
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _metadata_json_list(metadata: Mapping[str, Any], key: str) -> tuple[bool, list[Any]]:
+    if key not in metadata:
+        return False, []
+    value = metadata.get(key)
+    if isinstance(value, str):
+        decoded = decode_jsonb_field(value, default=[])
+        value = decoded
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return True, list(value)
+    return True, []
+
+
+def _hydrate_seo_metadata(metadata: JsonDict, row: Mapping[str, Any]) -> None:
+    for key in ("seo_title", "seo_description", "target_keyword"):
+        value = _optional_text(row.get(key))
+        if value:
+            metadata[key] = value
+    for key in ("secondary_keywords", "faq"):
+        if key not in row:
+            continue
+        value = decode_jsonb_field(row.get(key), default=[])
+        items = (
+            list(value)
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+            else []
+        )
+        if items or key not in metadata:
+            metadata[key] = items
+
+
 @dataclass(frozen=True)
 class PostgresBlogPostRepository:
     """Async Postgres adapter for generated blog-post drafts."""
@@ -90,17 +126,25 @@ class PostgresBlogPostRepository:
         account_id = scope.account_id or ""
         for draft in drafts:
             data_context = _draft_data_context(draft, scope)
+            has_secondary_keywords, secondary_keywords = _metadata_json_list(
+                draft.metadata,
+                "secondary_keywords",
+            )
+            has_faq, faq = _metadata_json_list(draft.metadata, "faq")
             blog_post_id = await self.pool.fetchval(
                 """
                 INSERT INTO blog_posts (
                     account_id, slug, title, description, topic_type,
                     tags, content, charts, data_context, status,
-                    llm_model, source_report_date
+                    llm_model, source_report_date,
+                    seo_title, seo_description, target_keyword,
+                    secondary_keywords, faq
                 )
                 VALUES (
                     $1, $2, $3, $4, $5,
                     $6::jsonb, $7, $8::jsonb, $9::jsonb, 'draft',
-                    $10, $11
+                    $10, $11,
+                    $12, $13, $14, $15::jsonb, $16::jsonb
                 )
                 ON CONFLICT (slug) DO UPDATE SET
                     account_id = EXCLUDED.account_id,
@@ -113,7 +157,24 @@ class PostgresBlogPostRepository:
                     data_context = EXCLUDED.data_context,
                     status = EXCLUDED.status,
                     llm_model = EXCLUDED.llm_model,
-                    source_report_date = EXCLUDED.source_report_date
+                    source_report_date = EXCLUDED.source_report_date,
+                    seo_title = COALESCE(EXCLUDED.seo_title, blog_posts.seo_title),
+                    seo_description = COALESCE(
+                        EXCLUDED.seo_description,
+                        blog_posts.seo_description
+                    ),
+                    target_keyword = COALESCE(
+                        EXCLUDED.target_keyword,
+                        blog_posts.target_keyword
+                    ),
+                    secondary_keywords = CASE
+                        WHEN $17 THEN EXCLUDED.secondary_keywords
+                        ELSE blog_posts.secondary_keywords
+                    END,
+                    faq = CASE
+                        WHEN $18 THEN EXCLUDED.faq
+                        ELSE blog_posts.faq
+                    END
                 WHERE blog_posts.status != 'published'
                   AND blog_posts.account_id = EXCLUDED.account_id
                 RETURNING id
@@ -129,6 +190,13 @@ class PostgresBlogPostRepository:
                 json_dump_jsonb(data_context),
                 str(draft.metadata.get("generation_model") or "") or None,
                 _source_report_date(data_context.get("source_report_date")),
+                _optional_text(draft.metadata.get("seo_title")),
+                _optional_text(draft.metadata.get("seo_description")),
+                _optional_text(draft.metadata.get("target_keyword")),
+                json_dump_jsonb(secondary_keywords),
+                json_dump_jsonb(faq),
+                has_secondary_keywords,
+                has_faq,
             )
             if blog_post_id:
                 saved.append(str(blog_post_id))
@@ -152,7 +220,8 @@ class PostgresBlogPostRepository:
             clauses.append(f"topic_type = ${len(params)}")
         sql = (
             "SELECT id, slug, title, description, topic_type, tags, content, "
-            "charts, data_context, llm_model, status "
+            "charts, data_context, llm_model, status, "
+            "seo_title, seo_description, target_keyword, secondary_keywords, faq "
             "FROM blog_posts WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -73,6 +73,10 @@
       "target": "extracted_content_pipeline/storage/migrations/084_blog_posts.sql"
     },
     {
+      "source": "atlas_brain/storage/migrations/120_blog_seo.sql",
+      "target": "extracted_content_pipeline/storage/migrations/120_blog_seo.sql"
+    },
+    {
       "source": "atlas_brain/storage/migrations/264_blog_post_rejection_count.sql",
       "target": "extracted_content_pipeline/storage/migrations/264_blog_post_rejection_count.sql"
     },

--- a/extracted_content_pipeline/storage/migrations/120_blog_seo.sql
+++ b/extracted_content_pipeline/storage/migrations/120_blog_seo.sql
@@ -1,0 +1,11 @@
+-- SEO metadata columns for blog posts.
+ALTER TABLE blog_posts
+    ADD COLUMN IF NOT EXISTS seo_title TEXT,
+    ADD COLUMN IF NOT EXISTS seo_description TEXT,
+    ADD COLUMN IF NOT EXISTS target_keyword TEXT,
+    ADD COLUMN IF NOT EXISTS secondary_keywords JSONB NOT NULL DEFAULT '[]',
+    ADD COLUMN IF NOT EXISTS faq JSONB NOT NULL DEFAULT '[]',
+    ADD COLUMN IF NOT EXISTS related_slugs JSONB NOT NULL DEFAULT '[]';
+
+CREATE INDEX IF NOT EXISTS idx_blog_posts_keyword
+    ON blog_posts (target_keyword) WHERE target_keyword IS NOT NULL;

--- a/plans/PR-Blog-SEO-Field-Persistence.md
+++ b/plans/PR-Blog-SEO-Field-Persistence.md
@@ -1,0 +1,111 @@
+# PR-Blog-SEO-Field-Persistence
+
+## Why this slice exists
+
+The AI Content Ops blog generator already asks the LLM for SEO/AEO-facing
+fields (`seo_title`, `seo_description`, `target_keyword`,
+`secondary_keywords`, and `faq`) and threads them into `BlogPostDraft.metadata`.
+The Postgres adapter for the extracted Content Ops blog path then stores that
+metadata under `data_context["_metadata"]` instead of writing the first-class
+`blog_posts` SEO columns that the public blog API and frontend read.
+
+That creates a product gap: the generated draft can contain SEO-ready data while
+the published/public path sees empty SEO columns.
+
+This slice closes only that persistence mismatch. It does not redefine GEO,
+add a new quality gate, or change generation prompts.
+
+This slice is slightly over the 400 LOC target because it includes the discovery
+note that identified the SEO/AEO/GEO contract gap alongside the focused runtime
+fix. The code change remains small, but keeping the evidence note with the
+persistence fix gives the reviewer the product context without chasing a
+separate branch.
+
+## Scope (this PR)
+
+1. Persist generated blog SEO fields into the existing `blog_posts` SEO columns
+   from `PostgresBlogPostRepository.save_drafts(...)`.
+2. Add the existing Atlas blog SEO migration to the extracted package's synced
+   migration manifest so standalone installs have the columns too.
+3. Read those SEO columns back into `BlogPostDraft.metadata` from
+   `PostgresBlogPostRepository.list_drafts(...)`.
+4. Add focused regression coverage for save and read behavior.
+5. Include the discovery note that identified the SEO/AEO/GEO contract gap.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-SEO-Field-Persistence.md` | Plan doc for this slice. |
+| `docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md` | Discovery note for current SEO/AEO/GEO state and gaps. |
+| `extracted_content_pipeline/blog_post_postgres.py` | Persist and hydrate SEO metadata through first-class columns. |
+| `extracted_content_pipeline/manifest.json` | Register the synced blog SEO migration. |
+| `extracted_content_pipeline/storage/migrations/120_blog_seo.sql` | Synced copy of the existing Atlas SEO column migration. |
+| `tests/test_extracted_blog_post_postgres.py` | Regression coverage for SEO field persistence and hydration. |
+
+## Mechanism
+
+`BlogPostGenerationService._build_draft(...)` already puts the generated SEO
+fields in `draft.metadata`. The Postgres adapter will map those metadata values
+into the existing `blog_posts` columns during insert/update:
+
+- `seo_title`
+- `seo_description`
+- `target_keyword`
+- `secondary_keywords`
+- `faq`
+
+The adapter's list path will select those same columns and merge them back into
+`BlogPostDraft.metadata` so generated-asset exports and review helpers see the
+same metadata shape regardless of whether the value came from
+`data_context["_metadata"]` or a first-class column.
+
+The Atlas migration already exists at `atlas_brain/storage/migrations/120_blog_seo.sql`.
+This slice copies that migration into the extracted package and records the
+source mapping in `manifest.json`; it does not add a new Atlas migration.
+
+## Intentional
+
+- No new Atlas schema migration is needed. The columns already exist in
+  `atlas_brain/storage/migrations/120_blog_seo.sql`; the extracted migration is
+  a synced package copy.
+- No prompt changes. The generator already requests the SEO fields.
+- No GEO validator in this slice. GEO needs a product definition before it can
+  become a deterministic pass/fail contract.
+- Metadata remains in `data_context["_metadata"]` as well. That preserves the
+  existing extracted generated-asset export shape and avoids a breaking change
+  for callers already reading metadata there.
+
+## Deferred
+
+- Add a named SEO/AEO/GEO readiness summary to blog review/export output.
+- Decide whether GEO is a separate product contract or part of AEO readiness.
+- Add quality-gate checks for SEO title length, meta description length, FAQ
+  count, answer-first sections, and citable section structure.
+- Audit the publish path end to end after this persistence fix lands.
+
+## Verification
+
+- Focused Postgres adapter tests -> 7 passed.
+- Python compile check over the edited adapter and test module -> passed.
+- Diff whitespace check -> passed.
+- Extracted content pipeline validation -> passed.
+- Atlas reasoning import guard for extracted_content_pipeline -> passed.
+- Standalone extracted audit with fail-on-debt -> passed.
+- ASCII Python policy check -> passed.
+- Extracted package sync -> refreshed 43 files.
+- Full extracted pipeline checks -> 1522 passed, 1 existing torch/pynvml warning.
+- Local PR review advisory run before commit -> passed; plan/code consistency skipped because the branch was not committed yet.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan + discovery doc | ~285 |
+| Postgres adapter | ~85 |
+| Migration + manifest | ~20 |
+| Tests | ~135 |
+| **Total** | **~525** |
+
+This may land slightly over the 400 LOC target. The overage is justified in
+Why this slice exists.

--- a/tests/test_extracted_blog_post_postgres.py
+++ b/tests/test_extracted_blog_post_postgres.py
@@ -45,6 +45,14 @@ def _draft() -> BlogPostDraft:
         metadata={
             "generation_model": "fake-llm",
             "generation_usage": {"input_tokens": 12, "output_tokens": 6},
+            "seo_title": "Acme Pricing Pressure 2026",
+            "seo_description": "Acme pricing pressure from recent review data.",
+            "target_keyword": "acme pricing pressure",
+            "secondary_keywords": ["acme pricing", "acme alternatives"],
+            "faq": [{
+                "question": "Why are Acme customers frustrated by pricing?",
+                "answer": "Recent review evidence points to pricing pressure.",
+            }],
         },
     )
 
@@ -66,8 +74,22 @@ async def test_save_drafts_persists_scope_metadata_and_returns_ids() -> None:
     data_context = json.loads(args[8])
     assert data_context["scope"]["account_id"] == "acct-1"
     assert data_context["_metadata"]["generation_model"] == "fake-llm"
+    assert data_context["_metadata"]["target_keyword"] == "acme pricing pressure"
     assert args[9] == "fake-llm"
     assert args[10] == date(2026, 5, 9)
+    assert args[11] == "Acme Pricing Pressure 2026"
+    assert args[12] == "Acme pricing pressure from recent review data."
+    assert args[13] == "acme pricing pressure"
+    assert json.loads(args[14]) == ["acme pricing", "acme alternatives"]
+    assert json.loads(args[15]) == [{
+        "question": "Why are Acme customers frustrated by pricing?",
+        "answer": "Recent review evidence points to pricing pressure.",
+    }]
+    assert args[16] is True
+    assert args[17] is True
+    sql = pool.fetchval_calls[0]["query"]
+    assert "seo_title, seo_description, target_keyword" in sql
+    assert "secondary_keywords, faq" in sql
 
 
 @pytest.mark.asyncio
@@ -81,6 +103,40 @@ async def test_save_drafts_skips_cross_tenant_slug_conflict() -> None:
     assert saved == ()
     sql = pool.fetchval_calls[0]["query"]
     assert "blog_posts.account_id = EXCLUDED.account_id" in sql
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_preserves_existing_seo_on_conflict_when_metadata_omits_it() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["blog-post-uuid-1"]
+    repo = PostgresBlogPostRepository(pool)
+    base = _draft()
+    draft = BlogPostDraft(
+        slug=base.slug,
+        title=base.title,
+        description=base.description,
+        topic_type=base.topic_type,
+        tags=base.tags,
+        content=base.content,
+        charts=base.charts,
+        data_context=base.data_context,
+        metadata={"generation_model": "fake-llm"},
+    )
+
+    await repo.save_drafts([draft], scope=TenantScope(account_id="acct-1"))
+
+    args = pool.fetchval_calls[0]["args"]
+    assert args[11] is None
+    assert args[12] is None
+    assert args[13] is None
+    assert json.loads(args[14]) == []
+    assert json.loads(args[15]) == []
+    assert args[16] is False
+    assert args[17] is False
+    sql = pool.fetchval_calls[0]["query"]
+    assert "seo_title = COALESCE(EXCLUDED.seo_title, blog_posts.seo_title)" in sql
+    assert "WHEN $17 THEN EXCLUDED.secondary_keywords" in sql
+    assert "WHEN $18 THEN EXCLUDED.faq" in sql
 
 
 @pytest.mark.asyncio
@@ -100,6 +156,14 @@ async def test_list_drafts_filters_by_status_topic_and_scope() -> None:
                 "_metadata": {"generation_model": "fake-llm"},
             }),
             "llm_model": "fake-llm",
+            "seo_title": "Acme Pricing Pressure 2026",
+            "seo_description": "Acme pricing pressure from recent review data.",
+            "target_keyword": "acme pricing pressure",
+            "secondary_keywords": json.dumps(["acme pricing", "acme alternatives"]),
+            "faq": json.dumps([{
+                "question": "Why are Acme customers frustrated by pricing?",
+                "answer": "Recent review evidence points to pricing pressure.",
+            }]),
         }
     ]
     repo = PostgresBlogPostRepository(pool)
@@ -117,13 +181,62 @@ async def test_list_drafts_filters_by_status_topic_and_scope() -> None:
     assert drafts[0].charts == ({"id": "chart-1"},)
     assert drafts[0].data_context == {"vendor": "Acme"}
     assert drafts[0].metadata["generation_model"] == "fake-llm"
+    assert drafts[0].metadata["seo_title"] == "Acme Pricing Pressure 2026"
+    assert drafts[0].metadata["seo_description"] == (
+        "Acme pricing pressure from recent review data."
+    )
+    assert drafts[0].metadata["target_keyword"] == "acme pricing pressure"
+    assert drafts[0].metadata["secondary_keywords"] == [
+        "acme pricing",
+        "acme alternatives",
+    ]
+    assert drafts[0].metadata["faq"] == [{
+        "question": "Why are Acme customers frustrated by pricing?",
+        "answer": "Recent review evidence points to pricing pressure.",
+    }]
     sql = pool.fetch_calls[0]["query"]
     args = pool.fetch_calls[0]["args"]
+    assert "seo_title, seo_description, target_keyword" in sql
+    assert "secondary_keywords, faq" in sql
     assert "account_id = $1" in sql
     assert "status = $2" in sql
     assert "topic_type = $3" in sql
     assert "LIMIT $4" in sql
     assert args == ("acct-1", "draft", "vendor_alternative", 10)
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_preserves_metadata_seo_arrays_when_columns_are_empty() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "slug": "acme-pricing-pressure",
+            "title": "Acme Pricing Pressure",
+            "description": "Pricing pressure dominates.",
+            "topic_type": "vendor_alternative",
+            "tags": json.dumps([]),
+            "content": "body",
+            "charts": json.dumps([]),
+            "data_context": json.dumps({
+                "_metadata": {
+                    "secondary_keywords": ["legacy keyword"],
+                    "faq": [{"question": "Legacy?", "answer": "Yes."}],
+                },
+            }),
+            "llm_model": None,
+            "seo_title": None,
+            "seo_description": None,
+            "target_keyword": None,
+            "secondary_keywords": json.dumps([]),
+            "faq": json.dumps([]),
+        }
+    ]
+    repo = PostgresBlogPostRepository(pool)
+
+    drafts = await repo.list_drafts(scope=TenantScope(account_id="acct-1"))
+
+    assert drafts[0].metadata["secondary_keywords"] == ["legacy keyword"]
+    assert drafts[0].metadata["faq"] == [{"question": "Legacy?", "answer": "Yes."}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Blog-SEO-Field-Persistence.md

Persist generated AI Content Ops blog SEO fields into the first-class blog_posts SEO columns that the public API and frontend already read.

## Intentional
- Map generated SEO metadata into existing columns while preserving metadata in data_context for existing generated-asset exports.
- Add the extracted package copy of the existing Atlas blog SEO migration; no new Atlas schema migration is introduced.
- Keep GEO readiness deferred until the product contract is defined.

## Deferred
- Add explicit SEO/AEO/GEO readiness summaries and quality-gate checks.
- Audit the publish path end to end after this persistence fix lands.

## Verification
- Focused Postgres adapter tests: 6 passed.
- Full extracted pipeline checks: 1521 passed, 1 existing torch/pynvml warning.
- Clean local PR review: passed.

## Diff size
6 files, +460 / -4.
