### PR TITLE
Add FAQ lifecycle smoke for Content Ops

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T04:01Z by codex-2026-05-20
+Last updated: 2026-05-20T16:14Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Output-Checks | `plans/PR-Content-Ops-FAQ-Output-Checks.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`; `scripts/smoke_extracted_content_ops_execution.py`; `tests/test_extracted_content_ops_execution_smoke.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown output-check semantics and generated-asset review labels. |
+| TBD | PR-Content-Ops-FAQ-Lifecycle-Smoke | `plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md`; `docs/extraction/coordination/inflight.md`; `scripts/smoke_content_ops_faq_lifecycle.py`; `tests/test_smoke_content_ops_faq_lifecycle.py`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/STATUS.md` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown lifecycle smoke/docs. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -188,6 +188,19 @@ The same artifact can run through the Content Ops execution seam by selecting
 When the host wires `PostgresTicketFAQRepository`, execution also persists the
 Markdown document into `ticket_faq_markdown` and returns `saved_ids`.
 
+To prove the persisted review lifecycle in one command, run the FAQ lifecycle
+smoke. It generates from source rows, exports the saved draft, updates it to a
+host-defined review status, and exports the reviewed row:
+
+```bash
+python scripts/smoke_content_ops_faq_lifecycle.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --account-id acct_123 \
+  --review-status published \
+  --json
+```
+
 If Atlas already has scraped B2B review rows, export one reliable source as
 Content Ops source rows before generation. The G2 path is read-only, keeps only
 canonical enriched reviews, and exports the negative/mixed quote-grade phrase
@@ -918,6 +931,7 @@ python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,landing_page --with-reasoning --reasoning-provider postgres-fixture --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json
+python scripts/smoke_content_ops_faq_lifecycle.py --account-id acct_123 --review-status published --json
 ```
 
 This validates the full campaign preset and the deterministic source-material

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -85,6 +85,9 @@ source of truth for what remains.
 - `ticket_faq_export` provides a read-only draft export path over generated
   ticket FAQ Markdown documents so hosts can review JSON/CSV outputs without
   handwritten SQL or a mounted FAQ API.
+- `scripts/smoke_content_ops_faq_lifecycle.py` proves the support-ticket FAQ
+  lifecycle in one host command: source rows -> persisted Markdown draft ->
+  export -> review/status update -> reviewed-status export.
 - `scripts/export_extracted_content_assets.py` exposes the report, blog post,
   landing page, sales brief, and FAQ Markdown export helpers as a host-facing
   JSON/CSV CLI backed by the product-owned Postgres repositories.

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -239,6 +239,18 @@ inspect grounding before choosing whether to generate campaigns or longer
 assets. Add `--as-of-date YYYY-MM-DD` with `--window-days` for reproducible
 canary runs.
 
+When `ticket_faq_markdown` migrations are installed, prove the persisted review
+loop with the FAQ lifecycle smoke:
+
+```bash
+python scripts/smoke_content_ops_faq_lifecycle.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --account-id acct_123 \
+  --review-status published \
+  --json
+```
+
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
 `description`, `summary`, `notes`, `feedback`, `feedback_text`,
 `response_text`, `comment_text`, `open_ended_response`, `content`, `body`,
@@ -1046,6 +1058,11 @@ python scripts/smoke_extracted_content_ops_execution.py \
   --outputs faq_markdown \
   --source-type support_ticket \
   --source-title "login reset" \
+  --json
+
+python scripts/smoke_content_ops_faq_lifecycle.py \
+  --account-id acct_123 \
+  --review-status published \
   --json
 ```
 

--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md
@@ -1,0 +1,106 @@
+# Content Ops FAQ Lifecycle Smoke
+
+## Why this slice exists
+
+The support-ticket FAQ path now covers source-row ingestion, deterministic FAQ
+Markdown generation, Postgres persistence, export, and review/status updates.
+Those seams are individually tested, but there is no single host-facing command
+that proves the customer workflow works end to end:
+
+1. source rows in,
+2. FAQ Markdown draft saved,
+3. draft exported for review,
+4. draft moved to a host-defined publish/review status,
+5. reviewed draft exported by status.
+
+This slice closes that proof gap without adding another generation path or
+changing the FAQ artifact shape.
+
+This PR intentionally exceeds the 400 LOC soft cap because the operator smoke
+and its fake-pool lifecycle tests need to ship together; splitting them would
+leave either an untested host command or tests for a command that does not exist.
+
+## Scope (this PR)
+
+1. Add a focused FAQ lifecycle smoke command for host installs.
+2. Reuse the real FAQ service, Postgres repository, export helper, and review
+   status update seam.
+3. Add fake-pool tests for the success path, schema fail-closed behavior, and
+   status/export failure behavior.
+4. Update Content Ops docs/status to mention the one-command lifecycle proof.
+5. Replace the stale merged FAQ output-check in-flight row with this active
+   slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale merged FAQ row with this active slice. |
+| `scripts/smoke_content_ops_faq_lifecycle.py` | Host-facing source rows -> persisted FAQ -> export -> review/status smoke. |
+| `tests/test_smoke_content_ops_faq_lifecycle.py` | Focused CLI/run-function coverage with an asyncpg-shaped fake pool. |
+| `scripts/run_extracted_pipeline_checks.sh` | Include the new lifecycle smoke test in the extracted gauntlet. |
+| `extracted_content_pipeline/README.md` | Add the lifecycle smoke command to the FAQ docs. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Add the host install runbook command. |
+| `extracted_content_pipeline/STATUS.md` | Record the lifecycle smoke capability. |
+
+## Mechanism
+
+`scripts/smoke_content_ops_faq_lifecycle.py` loads a JSON/JSONL/CSV source-row
+file using the existing source adapter path, injects `PostgresTicketFAQRepository`
+into `TicketFAQMarkdownService`, and calls `generate(...)` with the provided
+`TenantScope`. When the service returns a saved FAQ id, the smoke exports the
+new draft through `export_ticket_faq_drafts`, updates the same id through
+`PostgresTicketFAQRepository.update_status(...)`, and exports the reviewed status
+again.
+
+The smoke validates each integration point instead of only checking that calls
+return:
+
+- `ticket_faq_markdown` table exists before generation starts.
+- generation returns at least the requested number of saved ids.
+- draft export returns the saved id and Markdown.
+- status update returns a hit.
+- reviewed-status export returns the same id with the requested status.
+
+## Intentional
+
+- No new storage table or API route. This proves the existing product seams.
+- No LLM/provider dependency. FAQ Markdown remains deterministic and extractive.
+- No source import into `campaign_opportunities`; FAQ generation consumes source
+  rows directly and persists to `ticket_faq_markdown`.
+- Review status remains host-defined. The smoke defaults to `published` because
+  the goal is a publish-ready lifecycle, but hosts can pass another status.
+
+## Deferred
+
+- A real hosted UI button for this lifecycle remains a frontend/API follow-up.
+- Semantic clustering remains separate from this lifecycle proof.
+- Live database execution is host/operator responsibility; this PR tests the
+  DB contract with an asyncpg-shaped fake pool and keeps the CLI ready for a
+  real DSN.
+
+## Verification
+
+- pytest tests/test_smoke_content_ops_faq_lifecycle.py - 4 passed
+- pytest tests/test_smoke_content_ops_faq_lifecycle.py tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material - 12 passed
+- python -m py_compile scripts/smoke_content_ops_faq_lifecycle.py tests/test_smoke_content_ops_faq_lifecycle.py - passed
+- python scripts/smoke_content_ops_faq_lifecycle.py --help - passed
+- git diff --check - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1524 passed, 1 existing torch/pynvml warning
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md` | +105 |
+| `docs/extraction/coordination/inflight.md` | +1 / -1 |
+| `scripts/smoke_content_ops_faq_lifecycle.py` | +296 |
+| `tests/test_smoke_content_ops_faq_lifecycle.py` | +175 |
+| `scripts/run_extracted_pipeline_checks.sh` | +1 |
+| `extracted_content_pipeline/README.md` | +14 |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | +17 |
+| `extracted_content_pipeline/STATUS.md` | +3 |
+| Total | ~612 |
+
+The overage is justified in **Why this slice exists**.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -27,6 +27,7 @@ pytest \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_ticket_faq_markdown.py \
+  tests/test_smoke_content_ops_faq_lifecycle.py \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \
   tests/test_content_ops_source_postgres_smoke_helpers.py \

--- a/scripts/smoke_content_ops_faq_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_lifecycle.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Smoke-test support-ticket FAQ generation through review/publish lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.ticket_faq_export import export_ticket_faq_drafts  # noqa: E402
+from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    TicketFAQMarkdownService,
+)
+from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
+    PostgresTicketFAQRepository,
+)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
+
+DEFAULT_SOURCE_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+DEFAULT_REVIEW_STATUS = "published"
+
+
+def _default_database_url() -> str | None:
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    dsn = str(getattr(db_settings, "dsn", "") or "").strip()
+    return dsn or None
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the FAQ lifecycle smoke; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Smoke-test support-ticket source rows through FAQ Markdown "
+            "generation, Postgres persistence, export, and review status update."
+        )
+    )
+    parser.add_argument("path", type=Path, nargs="?", default=DEFAULT_SOURCE_PATH)
+    parser.add_argument("--source-format", choices=("auto", "json", "jsonl", "csv"), default="csv")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--title", default="Customer Ticket FAQ")
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--min-source-rows", type=int, default=1)
+    parser.add_argument("--min-saved-faqs", type=int, default=1)
+    parser.add_argument("--review-status", default=DEFAULT_REVIEW_STATUS)
+    parser.add_argument("--export-limit", type=int, default=20)
+    parser.add_argument("--max-text-chars", type=int, default=1200)
+    parser.add_argument("--allow-ingestion-warnings", action="store_true")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help="Fallback metadata applied to every source row. Repeat as key=value.",
+    )
+    parser.add_argument("--output-result", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if int(args.min_source_rows) < 1:
+        raise SystemExit("--min-source-rows must be positive")
+    if int(args.min_saved_faqs) < 1:
+        raise SystemExit("--min-saved-faqs must be positive")
+    if int(args.export_limit) < 1:
+        raise SystemExit("--export-limit must be positive")
+    if int(args.max_text_chars) < 1:
+        raise SystemExit("--max-text-chars must be positive")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not str(args.review_status or "").strip():
+        raise SystemExit("--review-status must be non-empty")
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+
+
+async def run_faq_lifecycle_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    default_fields = parse_default_fields_or_exit(args.default_field)
+    source_path = Path(args.path)
+    pool = await _create_pool(str(args.database_url))
+    errors: list[str] = []
+    source_rows = 0
+    saved_ids: list[str] = []
+    draft_export: dict[str, Any] | None = None
+    reviewed_export: dict[str, Any] | None = None
+    generation: dict[str, Any] | None = None
+    try:
+        try:
+            if not await _relation_exists(pool, "ticket_faq_markdown"):
+                errors.append(
+                    "required Content Ops table missing: ticket_faq_markdown. "
+                    "Run python scripts/run_extracted_content_pipeline_migrations.py "
+                    "--database-url \"$EXTRACTED_DATABASE_URL\" before this smoke."
+                )
+            loaded = load_source_campaign_opportunities_from_file(
+                source_path,
+                file_format=str(args.source_format),
+                target_mode=str(args.target_mode),
+                max_text_chars=int(args.max_text_chars),
+                default_fields=default_fields,
+            )
+            source_rows = len(loaded.opportunities)
+            if source_rows < int(args.min_source_rows):
+                errors.append(
+                    f"expected at least {int(args.min_source_rows)} source row(s), got {source_rows}"
+                )
+            if loaded.warnings and not bool(args.allow_ingestion_warnings):
+                errors.append(
+                    "source normalization produced warnings; provide --default-field "
+                    "bindings or pass --allow-ingestion-warnings"
+                )
+            if not errors:
+                repo = PostgresTicketFAQRepository(pool)
+                service = TicketFAQMarkdownService(ticket_faqs=repo)
+                result = await service.generate(
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    target_mode=str(args.target_mode),
+                    source_material={"opportunities": loaded.opportunities},
+                    title=str(args.title),
+                    max_text_chars=int(args.max_text_chars),
+                )
+                generation = result.as_dict()
+                saved_ids = [str(item) for item in result.saved_ids if str(item).strip()]
+                if len(saved_ids) < int(args.min_saved_faqs):
+                    errors.append(
+                        f"expected at least {int(args.min_saved_faqs)} saved FAQ(s), got {len(saved_ids)}"
+                    )
+            if not errors:
+                repo = PostgresTicketFAQRepository(pool)
+                draft_result = await export_ticket_faq_drafts(
+                    repo,
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    status="draft",
+                    target_mode=str(args.target_mode),
+                    limit=int(args.export_limit),
+                )
+                draft_export = draft_result.as_dict()
+                errors.extend(_export_errors(draft_export, saved_ids, expected_status="draft"))
+            if not errors:
+                repo = PostgresTicketFAQRepository(pool)
+                updated = await repo.update_status(
+                    saved_ids[0],
+                    str(args.review_status),
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                )
+                if not updated:
+                    errors.append(f"review status update missed saved FAQ id: {saved_ids[0]}")
+            if not errors:
+                repo = PostgresTicketFAQRepository(pool)
+                reviewed_result = await export_ticket_faq_drafts(
+                    repo,
+                    scope=TenantScope(account_id=str(args.account_id), user_id=args.user_id),
+                    status=str(args.review_status),
+                    target_mode=str(args.target_mode),
+                    limit=int(args.export_limit),
+                )
+                reviewed_export = reviewed_result.as_dict()
+                errors.extend(
+                    _export_errors(
+                        reviewed_export,
+                        saved_ids[:1],
+                        expected_status=str(args.review_status),
+                    )
+                )
+        except Exception as exc:  # pragma: no cover - exercised by live hosts
+            errors.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    payload = {
+        "ok": not errors,
+        "source": str(source_path),
+        "source_format": str(args.source_format),
+        "source_rows": source_rows,
+        "saved_ids": saved_ids,
+        "generation": generation,
+        "draft_export": draft_export,
+        "reviewed_export": reviewed_export,
+        "review_status": str(args.review_status),
+        "errors": errors,
+    }
+    if args.output_result:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+    return (0 if not errors else 1), payload
+
+
+async def _relation_exists(pool: Any, table_name: str) -> bool:
+    value = await pool.fetchval("SELECT to_regclass($1)::text", table_name)
+    return bool(value)
+
+
+def _export_errors(
+    export_payload: Mapping[str, Any],
+    saved_ids: list[str],
+    *,
+    expected_status: str,
+) -> list[str]:
+    rows = export_payload.get("rows")
+    if not isinstance(rows, list):
+        return ["export rows missing"]
+    by_id = {
+        str(row.get("id") or ""): row
+        for row in rows
+        if isinstance(row, Mapping)
+    }
+    errors: list[str] = []
+    for saved_id in saved_ids:
+        row = by_id.get(saved_id)
+        if row is None:
+            errors.append(f"export missing saved FAQ id: {saved_id}")
+            continue
+        if str(row.get("status") or "") != expected_status:
+            errors.append(
+                f"exported FAQ {saved_id} had status {row.get('status')!r}, expected {expected_status!r}"
+            )
+        if not str(row.get("markdown") or "").strip():
+            errors.append(f"exported FAQ {saved_id} missing markdown")
+    return errors
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if payload.get("ok"):
+        print(
+            "Content Ops FAQ lifecycle smoke passed: "
+            f"source_rows={payload.get('source_rows')} "
+            f"saved_faqs={len(payload.get('saved_ids') or [])} "
+            f"review_status={payload.get('review_status')}"
+        )
+        return
+    print("Content Ops FAQ lifecycle smoke failed:", file=sys.stderr)
+    for error in payload.get("errors") or []:
+        print(f"- {error}", file=sys.stderr)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    _load_dotenv_files()
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, payload = await run_faq_lifecycle_smoke(args)
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_lifecycle.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_faq_lifecycle",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+
+
+class _Pool:
+    def __init__(
+        self,
+        *,
+        existing_relations=None,
+        update_hits: bool = True,
+    ) -> None:
+        self.existing_relations = (
+            set(existing_relations)
+            if existing_relations is not None
+            else {"ticket_faq_markdown"}
+        )
+        self.update_hits = update_hits
+        self.rows: list[dict] = []
+        self.fetchval_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.execute_calls: list[dict] = []
+        self.closed = False
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        if "to_regclass" in str(query):
+            return args[0] if args and args[0] in self.existing_relations else None
+        faq_id = f"faq-uuid-{len(self.rows) + 1}"
+        self.rows.append({
+            "id": faq_id,
+            "account_id": args[0],
+            "target_id": args[1],
+            "target_mode": args[2],
+            "title": args[3],
+            "markdown": args[4],
+            "items": args[5],
+            "source_count": args[6],
+            "ticket_source_count": args[7],
+            "output_checks": args[8],
+            "warnings": args[9],
+            "metadata": args[10],
+            "status": "draft",
+        })
+        return faq_id
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        account_id = args[0] if args else ""
+        status = args[1] if "status = $2" in str(query) and len(args) > 1 else None
+        target_mode_index = 2 if "target_mode = $3" in str(query) else None
+        target_mode = args[target_mode_index] if target_mode_index is not None and len(args) > target_mode_index else None
+        rows = [
+            row
+            for row in self.rows
+            if row["account_id"] == account_id
+            and (status is None or row["status"] == status)
+            and (target_mode is None or row["target_mode"] == target_mode)
+        ]
+        return rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        if not self.update_hits:
+            return "UPDATE 0"
+        updated = 0
+        for row in self.rows:
+            if row["id"] == args[0] and row["account_id"] == args[2]:
+                row["status"] = args[1]
+                updated += 1
+        return f"UPDATE {updated}"
+
+    async def close(self):
+        self.closed = True
+
+
+async def _return_pool(pool):
+    return pool
+
+
+def _args(**overrides):
+    values = {
+        "path": SUPPORT_TICKET_CSV,
+        "source_format": "csv",
+        "target_mode": "vendor_retention",
+        "title": "Customer Ticket FAQ",
+        "account_id": "acct-smoke",
+        "user_id": None,
+        "min_source_rows": 2,
+        "min_saved_faqs": 1,
+        "review_status": "published",
+        "export_limit": 20,
+        "max_text_chars": 1200,
+        "allow_ingestion_warnings": False,
+        "default_field": [],
+        "output_result": None,
+        "json": False,
+        "database_url": "postgres://example",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports(monkeypatch):
+    pool = _Pool()
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_faq_lifecycle_smoke(_args())
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source_rows"] == 2
+    assert payload["saved_ids"] == ["faq-uuid-1"]
+    assert payload["generation"]["saved_ids"] == ["faq-uuid-1"]
+    assert payload["draft_export"]["rows"][0]["id"] == "faq-uuid-1"
+    assert payload["draft_export"]["rows"][0]["status"] == "draft"
+    assert payload["reviewed_export"]["rows"][0]["id"] == "faq-uuid-1"
+    assert payload["reviewed_export"]["rows"][0]["status"] == "published"
+    assert "# Customer Ticket FAQ" in payload["reviewed_export"]["rows"][0]["markdown"]
+    assert pool.closed is True
+    assert pool.execute_calls
+
+
+@pytest.mark.asyncio
+async def test_faq_lifecycle_smoke_fails_closed_when_table_missing(monkeypatch):
+    pool = _Pool(existing_relations=())
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_faq_lifecycle_smoke(_args())
+
+    assert code == 1
+    assert any("ticket_faq_markdown" in error for error in payload["errors"])
+    assert payload["generation"] is None
+    assert len(pool.fetchval_calls) == 1
+    assert pool.execute_calls == []
+    assert pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_faq_lifecycle_smoke_reports_review_status_miss(monkeypatch):
+    pool = _Pool(update_hits=False)
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+
+    code, payload = await smoke.run_faq_lifecycle_smoke(_args())
+
+    assert code == 1
+    assert payload["saved_ids"] == ["faq-uuid-1"]
+    assert any("review status update missed saved FAQ id" in error for error in payload["errors"])
+    assert payload["reviewed_export"] is None
+    assert pool.closed is True
+
+
+def test_faq_lifecycle_smoke_rejects_invalid_args() -> None:
+    args = _args(min_saved_faqs=0)
+
+    with pytest.raises(SystemExit, match="--min-saved-faqs must be positive"):
+        smoke._validate_args(args)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md

Adds a host-facing smoke command that proves the support-ticket FAQ lifecycle end to end: source rows in, Markdown draft persisted, draft exported, review status updated, and reviewed-status export returned.

## Intentional
- Reuse the existing TicketFAQMarkdownService, PostgresTicketFAQRepository, export helper, and update_status seam.
- Keep FAQ generation deterministic and zero-provider.
- Do not import source rows into campaign_opportunities for this path; FAQ consumes source rows directly.
- Keep review status host-defined, defaulting the smoke to published.

## Deferred
- Hosted UI button for this lifecycle remains a frontend/API follow-up.
- Semantic clustering remains separate from lifecycle proof.
- Live database execution remains host/operator responsibility; this PR tests the DB contract with an asyncpg-shaped fake pool and leaves the CLI ready for a real DSN.

## Verification
- pytest tests/test_smoke_content_ops_faq_lifecycle.py - 4 passed
- pytest tests/test_smoke_content_ops_faq_lifecycle.py tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material - 12 passed
- python -m py_compile scripts/smoke_content_ops_faq_lifecycle.py tests/test_smoke_content_ops_faq_lifecycle.py - passed
- python scripts/smoke_content_ops_faq_lifecycle.py --help - passed
- git diff --check - passed
- bash scripts/run_extracted_pipeline_checks.sh - 1524 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh - passed

## Diff size
8 files, +613 / -1
