### PR TITLE
Tighten FAQ output contract demo

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T16:14Z by codex-2026-05-20
+Last updated: 2026-05-20T16:25Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Lifecycle-Smoke | `plans/PR-Content-Ops-FAQ-Lifecycle-Smoke.md`; `docs/extraction/coordination/inflight.md`; `scripts/smoke_content_ops_faq_lifecycle.py`; `tests/test_smoke_content_ops_faq_lifecycle.py`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/docs/host_install_runbook.md`; `extracted_content_pipeline/STATUS.md` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown lifecycle smoke/docs. |
+| TBD | PR-Content-Ops-FAQ-Output-Contract | `plans/PR-Content-Ops-FAQ-Output-Contract.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/examples/support_ticket_sources.csv`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `scripts/build_extracted_ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown output checks, packaged support-ticket fixture, and FAQ CLI. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -174,14 +174,18 @@ python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
   --window-days 90 \
+  --require-output-checks \
   --output support_ticket_faq.md
 ```
 
 The FAQ builder is deterministic and extractive: it groups ticket evidence by
 pain point, quotes compact snippets from the source rows, and lists ticket
-source ids under each answer. Add `--as-of-date YYYY-MM-DD` with
-`--window-days` when you need a reproducible audit window instead of today's
-date.
+source ids under each answer. The packaged support-ticket CSV is intentionally
+small but repeated: it proves customer-worded headings, intent condensation,
+and action items. Add `--as-of-date YYYY-MM-DD` with `--window-days` when you
+need a reproducible audit window instead of today's date. Pass
+`--require-output-checks` in host smoke runs when weak FAQ output should fail
+the command instead of producing a reviewable draft.
 
 The same artifact can run through the Content Ops execution seam by selecting
 `faq_markdown` and passing inline `source_material`. It remains zero-provider.

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -63,10 +63,11 @@ source of truth for what remains.
 - `ticket_faq_markdown` builds deterministic FAQ Markdown from support-ticket,
   case, conversation, and complaint source-row evidence. The CLI
   `scripts/build_extracted_ticket_faq_markdown.py` writes or prints a grounded
-  `.md` artifact for fast operator review. The same builder is also available
-  as `faq_markdown` in the AI Content Ops control-surface execution path and can
-  persist drafts through `PostgresTicketFAQRepository` when DB services are
-  enabled.
+  `.md` artifact for fast operator review, and `--require-output-checks`
+  fails the command when customer vocabulary, condensation, or action-item
+  checks do not pass. The same builder is also available as `faq_markdown` in
+  the AI Content Ops control-surface execution path and can persist drafts
+  through `PostgresTicketFAQRepository` when DB services are enabled.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/examples/support_ticket_sources.csv
+++ b/extracted_content_pipeline/examples/support_ticket_sources.csv
@@ -1,3 +1,5 @@
 Ticket ID,Account Name,Vendor Name,Contact Email,Contact Name,Contact Title,Subject,Description,Pain Category,Source URL
-ticket-acme-1,Acme Logistics,HubSpot,ops@example.com,Jordan Lee,VP Revenue Operations,Reporting export blocked before renewal,The operations team cannot export campaign attribution data without upgrading to a higher tier.,reporting friction,https://example.com/tickets/acme-1
-ticket-northstar-1,Northstar Foods,LegacyCRM,growth@example.com,Riley Chen,Director of Growth,Sequence handoff errors keep recurring,Support notes show campaign handoffs are still being reconciled manually after every webinar.,manual follow-up,https://example.com/tickets/northstar-1
+ticket-acme-1,Acme Logistics,HubSpot,ops@example.com,Jordan Lee,VP Revenue Operations,Change login email,How do I change my login email?,email and profile updates,https://example.com/tickets/acme-1
+ticket-acme-2,Acme Logistics,HubSpot,ops@example.com,Jordan Lee,VP Revenue Operations,Update account email,I need to update the email on my account.,email and profile updates,https://example.com/tickets/acme-2
+ticket-northstar-1,Northstar Foods,LegacyCRM,growth@example.com,Riley Chen,Director of Growth,Export campaign reports,How do we export campaign attribution data before renewal?,reporting friction,https://example.com/tickets/northstar-1
+ticket-northstar-2,Northstar Foods,LegacyCRM,growth@example.com,Riley Chen,Director of Growth,Reporting dashboard export,We cannot export the reporting dashboard for analysts.,reporting friction,https://example.com/tickets/northstar-2

--- a/plans/PR-Content-Ops-FAQ-Output-Contract.md
+++ b/plans/PR-Content-Ops-FAQ-Output-Contract.md
@@ -1,0 +1,96 @@
+Plan: PR-Content-Ops-FAQ-Output-Contract
+
+## Why this slice exists
+
+The support-ticket FAQ path now runs end to end, but the packaged demo fixture
+does not prove the output contract the product describes: customer vocabulary,
+intent condensation, and actionable next steps. The default CSV has two
+unrelated tickets and no customer-worded questions, so the deterministic FAQ
+builder can prove lifecycle wiring while still reporting weak output checks.
+
+This slice tightens the source fixture and host CLI so the quick FAQ demo can
+be used as a real product confidence check, not only a persistence smoke.
+
+## Scope (this PR)
+
+1. Replace the packaged support-ticket CSV with a small repeated-intent
+   fixture that exercises customer wording, volume ranking, and condensation.
+2. Update FAQ Markdown tests to assert the packaged fixture passes the
+   three-point output checks.
+3. Add a host-facing `--require-output-checks` CLI flag to fail the Markdown
+   build when any output check is false.
+4. Update docs for the stricter FAQ demo command.
+5. Remove the merged FAQ lifecycle smoke row from the coordination ledger and
+   claim this slice.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Output-Contract.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/examples/support_ticket_sources.csv`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `scripts/build_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+- `tests/test_smoke_content_ops_source_file_postgres.py`
+
+## Mechanism
+
+The FAQ builder already emits `output_checks` with the three product checks:
+`uses_user_vocabulary`, `condensed`, and `has_action_items`. This PR does not
+add a second quality layer. It makes the packaged support-ticket fixture
+exercise those checks and lets operators opt into failing the CLI if the checks
+do not all pass:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py ... --require-output-checks
+```
+
+The CLI still writes the same Markdown artifact. The new flag only changes the
+exit contract when checks fail.
+
+## Intentional
+
+- No LLM call is introduced. FAQ Markdown remains deterministic and extractive.
+- The default `build_extracted_ticket_faq_markdown.py` behavior remains
+  backwards-compatible unless `--require-output-checks` is supplied.
+- The fixture stays small. It is a confidence demo, not a large benchmark.
+- The stale PR #666 coordination row is removed here because this PR touches
+  the same ledger before opening a new PR.
+
+## Deferred
+
+- A hosted UI review/publish button remains separate from this command-line
+  confidence path.
+- Broader semantic clustering remains separate from the current deterministic
+  intent-rule grouping.
+- Real customer help desk exports should still drive future source alias work.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_source_adapters.py::test_packaged_support_ticket_csv_example_loads_provider_labels tests/test_extracted_campaign_source_adapters.py::test_build_sources_cli_converts_packaged_support_ticket_csv tests/test_smoke_content_ops_faq_lifecycle.py::test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports tests/test_smoke_content_ops_source_file_postgres.py::test_source_file_postgres_smoke_imports_and_persists tests/test_extracted_ticket_faq_markdown.py` - 45 passed
+- `python -m py_compile scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py`
+- `python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --require-output-checks --output /tmp/support_ticket_faq.md`
+- `git diff --check`
+- `bash scripts/run_extracted_pipeline_checks.sh` - 1526 passed, 1 existing torch/pynvml warning
+- `bash scripts/local_pr_review.sh`
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Output-Contract.md` | +82 |
+| `docs/extraction/coordination/inflight.md` | +2 / -2 |
+| `extracted_content_pipeline/examples/support_ticket_sources.csv` | +4 / -2 |
+| `extracted_content_pipeline/README.md` | +7 / -3 |
+| `extracted_content_pipeline/STATUS.md` | +5 / -4 |
+| `scripts/build_extracted_ticket_faq_markdown.py` | +12 |
+| `tests/test_extracted_campaign_source_adapters.py` | +9 / -6 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +55 / -16 |
+| `tests/test_smoke_content_ops_faq_lifecycle.py` | +6 / -1 |
+| `tests/test_smoke_content_ops_source_file_postgres.py` | +21 / -7 |
+| **Total** | **258** |
+
+This is below the 400 LOC review budget.

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -70,6 +70,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help="Write FAQ Markdown to this path instead of stdout.",
     )
+    parser.add_argument(
+        "--require-output-checks",
+        action="store_true",
+        help="Fail when generated FAQ output checks are not all true.",
+    )
     return parser.parse_args(argv)
 
 
@@ -105,11 +110,18 @@ def main(argv: list[str] | None = None) -> int:
         window_days=args.window_days,
         as_of_date=args.as_of_date,
     )
+    failed_checks = _failed_output_checks(result.output_checks)
+    if args.require_output_checks and failed_checks:
+        raise SystemExit(f"FAQ output checks failed: {', '.join(failed_checks)}")
     if args.output:
         args.output.write_text(result.markdown, encoding="utf-8")
     else:
         print(result.markdown, end="")
     return 0
+
+
+def _failed_output_checks(output_checks: dict[str, bool]) -> list[str]:
+    return [name for name, passed in sorted(output_checks.items()) if passed is not True]
 
 
 if __name__ == "__main__":

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -877,23 +877,24 @@ def test_packaged_support_ticket_csv_example_loads_provider_labels() -> None:
 
     assert [row["target_id"] for row in loaded.opportunities] == [
         "ticket-acme-1",
+        "ticket-acme-2",
         "ticket-northstar-1",
+        "ticket-northstar-2",
     ]
     assert [row["source_type"] for row in loaded.opportunities] == [
+        "support_ticket",
+        "support_ticket",
         "support_ticket",
         "support_ticket",
     ]
     assert loaded.opportunities[0]["company_name"] == "Acme Logistics"
     assert loaded.opportunities[0]["vendor_name"] == "HubSpot"
-    assert loaded.opportunities[0]["source_title"] == "Reporting export blocked before renewal"
+    assert loaded.opportunities[0]["source_title"] == "Change login email"
     assert loaded.opportunities[0]["evidence"][0] == {
-        "text": (
-            "The operations team cannot export campaign attribution data without "
-            "upgrading to a higher tier."
-        ),
+        "text": "How do I change my login email?",
         "source_id": "ticket-acme-1",
         "source_type": "support_ticket",
-        "source_title": "Reporting export blocked before renewal",
+        "source_title": "Change login email",
     }
     assert loaded.warnings == ()
 
@@ -946,7 +947,9 @@ def test_build_sources_cli_converts_packaged_support_ticket_csv(tmp_path: Path) 
     assert result.stdout == ""
     assert [row["target_id"] for row in payload["opportunities"]] == [
         "ticket-acme-1",
+        "ticket-acme-2",
         "ticket-northstar-1",
+        "ticket-northstar-2",
     ]
     assert payload["opportunities"][0]["source_type"] == "support_ticket"
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -113,16 +113,21 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
 
     result = build_ticket_faq_markdown(loaded.opportunities)
 
-    assert result.source_count == 2
-    assert result.ticket_source_count == 2
-    assert [item["topic"] for item in result.items] == ["manual follow-up", "reporting friction"]
-    assert "campaign attribution data" in result.markdown
-    assert "`ticket-acme-1` - Reporting export blocked before renewal" in result.markdown
+    assert result.source_count == 4
+    assert result.ticket_source_count == 4
+    assert [item["topic"] for item in result.items] == [
+        "email and profile updates",
+        "reporting friction",
+    ]
+    assert [item["ticket_count"] for item in result.items] == [2, 2]
+    assert "How do I change my login email?" in result.markdown
+    assert "How do we export campaign attribution data before renewal?" in result.markdown
+    assert "`ticket-acme-1` - Change login email" in result.markdown
     assert "**What to do next:**" in result.markdown
-    assert "Check whether your plan and role include the needed export" in result.markdown
+    assert "contact support with the affected email or account id." in result.markdown
     assert result.output_checks == {
-        "uses_user_vocabulary": False,
-        "condensed": False,
+        "uses_user_vocabulary": True,
+        "condensed": True,
         "has_action_items": True,
     }
 
@@ -443,30 +448,30 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
 
     assert rendered.h1 == ["Customer Ticket FAQ"]
     assert rendered.h2 == [
-        "1. What are customers asking about manual follow-up?",
-        "2. What are customers asking about reporting friction?",
+        "1. How do I change my login email?",
+        "2. How do we export campaign attribution data before renewal?",
     ]
     assert rendered.strong.count("What to do next:") == 2
     assert rendered.strong.count("Sources:") == 2
     assert rendered.ul_count == 4
     assert any(
-        "Support notes show campaign handoffs are still being reconciled manually"
+        "I need to update the email on my account."
         in paragraph
         for paragraph in rendered.paragraphs
     )
     assert any(
-        "Check the workflow or automation rule that should handle this step."
+        "Check whether your plan and role include the needed export"
         in item
         for item in rendered.list_items
     )
     assert any(
-        "ticket-acme-1 - Reporting export blocked before renewal" in item
+        "ticket-acme-1 - Change login email" in item
         for item in rendered.list_items
     )
     assert len(result.items) == 2
     assert result.output_checks == {
-        "uses_user_vocabulary": False,
-        "condensed": False,
+        "uses_user_vocabulary": True,
+        "condensed": True,
         "has_action_items": True,
     }
 
@@ -869,7 +874,7 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert completed.stdout == ""
     markdown = output.read_text(encoding="utf-8")
     assert markdown.startswith("# Support FAQ")
-    assert "Ticket sources used: 2" in markdown
+    assert "Ticket sources used: 4" in markdown
     assert "ticket-acme-1" in markdown
 
 
@@ -935,6 +940,40 @@ def test_ticket_faq_cli_stdout_limits_and_result_serializes() -> None:
     encoded = json.dumps(build_ticket_faq_markdown(loaded.opportunities).as_dict(), sort_keys=True)
     assert "action_items" in encoded
     assert "output_checks" in encoded
+
+
+def test_ticket_faq_cli_requires_output_checks_for_packaged_rows() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            str(SUPPORT_TICKET_CSV),
+            "--source-format",
+            "csv",
+            "--require-output-checks",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "How do I change my login email?" in completed.stdout
+    assert "FAQ output checks failed" not in completed.stderr
+
+
+def test_ticket_faq_cli_fails_required_output_checks_for_weak_rows(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+            "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
+            "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
+    )
+
+    completed = _run_ticket_faq_cli(source, "--require-output-checks")
+
+    assert completed.returncode == 1
+    assert "FAQ output checks failed" in completed.stderr
+    assert "condensed" in completed.stderr
+    assert "uses_user_vocabulary" in completed.stderr
 
 
 def test_ticket_faq_cli_rejects_as_of_date_without_window(tmp_path: Path) -> None:

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -126,9 +126,14 @@ async def test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports(monke
 
     assert code == 0
     assert payload["ok"] is True
-    assert payload["source_rows"] == 2
+    assert payload["source_rows"] == 4
     assert payload["saved_ids"] == ["faq-uuid-1"]
     assert payload["generation"]["saved_ids"] == ["faq-uuid-1"]
+    assert payload["generation"]["output_checks"] == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
     assert payload["draft_export"]["rows"][0]["id"] == "faq-uuid-1"
     assert payload["draft_export"]["rows"][0]["status"] == "draft"
     assert payload["reviewed_export"]["rows"][0]["id"] == "faq-uuid-1"

--- a/tests/test_smoke_content_ops_source_file_postgres.py
+++ b/tests/test_smoke_content_ops_source_file_postgres.py
@@ -128,19 +128,31 @@ async def test_source_file_postgres_smoke_imports_and_persists(monkeypatch):
     pool = _Pool(
         saved_draft_rows=[
             _saved_draft_row("ticket-acme-1"),
+            _saved_draft_row("ticket-acme-2"),
             _saved_draft_row("ticket-northstar-1"),
+            _saved_draft_row("ticket-northstar-2"),
         ],
     )
     monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
 
     async def fake_generate_imported_target_drafts(**kwargs):
-        assert kwargs["target_ids"] == ["ticket-acme-1", "ticket-northstar-1"]
+        assert kwargs["target_ids"] == [
+            "ticket-acme-1",
+            "ticket-acme-2",
+            "ticket-northstar-1",
+            "ticket-northstar-2",
+        ]
         return {
-            "requested": 2,
-            "generated": 2,
+            "requested": 4,
+            "generated": 4,
             "skipped": 0,
             "reasoning_contexts_used": 0,
-            "saved_ids": ["campaign-ticket-acme-1", "campaign-ticket-northstar-1"],
+            "saved_ids": [
+                "campaign-ticket-acme-1",
+                "campaign-ticket-acme-2",
+                "campaign-ticket-northstar-1",
+                "campaign-ticket-northstar-2",
+            ],
             "errors": [],
         }
 
@@ -154,12 +166,14 @@ async def test_source_file_postgres_smoke_imports_and_persists(monkeypatch):
 
     assert code == 0
     assert payload["ok"] is True
-    assert payload["source_rows"] == 2
-    assert payload["import"]["inserted"] == 2
-    assert payload["drafts"]["generated"] == 2
+    assert payload["source_rows"] == 4
+    assert payload["import"]["inserted"] == 4
+    assert payload["drafts"]["generated"] == 4
     assert [row["target_id"] for row in payload["saved_drafts"]] == [
         "ticket-acme-1",
+        "ticket-acme-2",
         "ticket-northstar-1",
+        "ticket-northstar-2",
     ]
     assert pool.closed is True
     assert "DELETE FROM \"campaign_opportunities\"" in pool.execute_calls[0]["query"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Output-Contract.md

Make the support-ticket FAQ demo prove the product output contract, not just lifecycle wiring. The packaged CSV now exercises repeated customer intents, customer-worded FAQ headings, rank-by-volume condensation, and action items; the Markdown CLI can optionally fail when any output check is false.

## Intentional
- FAQ generation remains deterministic and zero-provider.
- The new CLI quality gate is opt-in; default Markdown generation stays backwards-compatible.
- The packaged fixture stays small while demonstrating repeated intent and source grounding.
- The stale PR #666 coordination row is removed because this PR claims the same ledger.

## Deferred
- Hosted UI review/publish button remains a frontend/API follow-up.
- Broader semantic clustering remains separate from deterministic intent-rule grouping.
- Real customer help desk exports should still drive future source alias work.

## Verification
- Focused FAQ/source smoke sweep: 45 passed
- py_compile: passed
- FAQ CLI --require-output-checks command: passed
- git diff --check: passed
- bash scripts/run_extracted_pipeline_checks.sh: 1526 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh: passed

## Diff size
10 files, +217 / -41