### PR TITLE
Affiliate partner drift audit (reconcile live rows vs migrations)

### DIFF
--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -118,7 +118,7 @@ post-seed edits and orphan seeds without blocking.
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~340 |
-| `tests/test_affiliate_partner_drift.py` | ~225 |
-| Plan doc | ~135 |
-| **Total** | **~700** |
+| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~390 |
+| `tests/test_affiliate_partner_drift.py` | ~270 |
+| Plan doc | ~145 |
+| **Total** | **~805** |

--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -22,7 +22,11 @@ the partner definitions seeded by migrations, and fails when they diverge.
 1. Add `scripts/audit_affiliate_partner_drift.py` (matches the existing
    `scripts/audit_*` convention; same `_status`/`_exit_code`/JSON-report shape
    as `scripts/check_reasoning_rollout_readiness.py`).
-2. Reconcile live rows against migration seeds with three checks:
+2. Reconcile live rows against migration seeds with four checks:
+   - `migration_seeds_parseable` -- **FAIL** if the parser cannot map a
+     migration's `INSERT INTO affiliate_partners` (column/value mismatch or
+     missing VALUES). A parse regression must not be silently dropped, since
+     reconciliation would then run against an incomplete seed set.
    - `all_live_partners_versioned` -- **FAIL** if a live partner's
      `product_name` is seeded by no migration.
    - `no_seed_value_divergence` -- **WARN** if a seeded partner's migration
@@ -47,12 +51,18 @@ tested everywhere -- CI included -- while only `_run` touches the live
 database (the same `:5433/atlas` the app uses, via `init_database()`).
 
 `parse_seeded_partners` finds each `INSERT INTO affiliate_partners (...)
-VALUES (...)` block with a quote- and bracket-aware tokenizer (not a naive
+VALUES ...` block with a quote- and bracket-aware tokenizer (not a naive
 regex), so it handles both seed formats already in the tree: the packed
 7-column 088 Amazon row and the 9-column 326 rows with `ARRAY[...]::text[]`
-and `'{...}'::text[]` aliases, `NULL`, and `true`/`false`. Values are
-normalized to Python types; later migrations override earlier ones for the
-same `product_name` (apply-order semantics).
+and `'{...}'::text[]` aliases, `NULL`, and `true`/`false`. It reads **every**
+value tuple in a multi-row `VALUES (...), (...)` insert, not just the first,
+so a future batched seed is not silently truncated. A column/value count
+mismatch (or a missing VALUES clause) is **not** silently skipped: it is
+returned as an error and surfaced by the `migration_seeds_parseable` FAIL
+check, because quietly dropping a seed would make the reconciliation compare
+against stale data and report a misleading pass. Values are normalized to
+Python types; later migrations override earlier ones for the same
+`product_name` (apply-order semantics).
 
 `reconcile` compares by `lower(product_name)`. Aliases are compared as sets
 (the matcher is order-insensitive, so a reordered array is not drift). `notes`
@@ -93,11 +103,12 @@ post-seed edits and orphan seeds without blocking.
 
 ## Verification
 
-- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `6 passed in
-  0.06s` (parser on both 088 + 326 formats, empty-array/quote-escape, and the
-  clean / unversioned-FAIL / value-divergence-WARN reconcile paths).
+- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `9 passed in
+  0.06s` (parser on both 088 + 326 formats, multi-row VALUES,
+  empty-array/quote-escape, column/value-mismatch surfacing, and the clean /
+  unversioned-FAIL / value-divergence-WARN / unparseable-FAIL reconcile paths).
 - `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas`
-  -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 3, warn: 0,
+  -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 4, warn: 0,
   fail: 0}`, exit `0`. Confirms the parser reads the real 088 + 326 seeds and
   that migration 326 fully reconciles with the live table (every live partner
   versioned, no value divergence).

--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -132,7 +132,7 @@ post-seed edits and orphan seeds without blocking.
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~390 |
-| `tests/test_affiliate_partner_drift.py` | ~270 |
-| Plan doc | ~145 |
-| **Total** | **~805** |
+| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~420 |
+| `tests/test_affiliate_partner_drift.py` | ~300 |
+| Plan doc | ~160 |
+| **Total** | **~880** |

--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -22,11 +22,16 @@ the partner definitions seeded by migrations, and fails when they diverge.
 1. Add `scripts/audit_affiliate_partner_drift.py` (matches the existing
    `scripts/audit_*` convention; same `_status`/`_exit_code`/JSON-report shape
    as `scripts/check_reasoning_rollout_readiness.py`).
-2. Reconcile live rows against migration seeds with four checks:
+2. Reconcile live rows against migration seeds with five checks:
    - `migration_seeds_parseable` -- **FAIL** if the parser cannot map a
      migration's `INSERT INTO affiliate_partners` (column/value mismatch or
      missing VALUES). A parse regression must not be silently dropped, since
      reconciliation would then run against an incomplete seed set.
+   - `partner_mutations_modeled` -- **WARN** if a migration `UPDATE`s or
+     `DELETE`s `affiliate_partners`. The audit models only INSERT seeds, so a
+     mutation may explain a divergence/orphan result for the affected partner;
+     surface it (pointing at the migration) rather than letting it look like
+     clean drift.
    - `all_live_partners_versioned` -- **FAIL** if a live partner's
      `product_name` is seeded by no migration.
    - `no_seed_value_divergence` -- **WARN** if a seeded partner's migration
@@ -84,6 +89,14 @@ post-seed edits and orphan seeds without blocking.
   DB may be a deliberate operational change; the audit surfaces it and lets
   the operator decide whether the DB or the migration is authoritative, rather
   than blocking deploys on a judgment call.
+- **WARN, not FAIL, on UPDATE/DELETE migrations.** Modeling only INSERT seeds
+  is sufficient today (every migration is INSERT-only). Rather than parse and
+  apply arbitrary UPDATE/DELETE -- a much larger, fragile parser -- the audit
+  detects their presence and warns, naming the migration. A legitimate
+  mutation migration is not an error, so it must not hard-fail the audit; but
+  it must not be silently ignored either, since it could otherwise masquerade
+  as clean value-divergence. Extending the parser to apply mutations is a
+  deferred follow-up if one is ever written.
 - **Hand-written tokenizer over a SQL library.** The seed format is small and
   fixed; a dependency-free tokenizer keeps the audit self-contained and its
   behavior fully covered by the fixture tests.
@@ -103,12 +116,13 @@ post-seed edits and orphan seeds without blocking.
 
 ## Verification
 
-- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `9 passed in
+- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `11 passed in
   0.06s` (parser on both 088 + 326 formats, multi-row VALUES,
-  empty-array/quote-escape, column/value-mismatch surfacing, and the clean /
-  unversioned-FAIL / value-divergence-WARN / unparseable-FAIL reconcile paths).
+  empty-array/quote-escape, column/value-mismatch surfacing, UPDATE/DELETE
+  mutation detection, and the clean / unversioned-FAIL / value-divergence-WARN
+  / unparseable-FAIL / unmodeled-mutation-WARN reconcile paths).
 - `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas`
-  -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 4, warn: 0,
+  -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 5, warn: 0,
   fail: 0}`, exit `0`. Confirms the parser reads the real 088 + 326 seeds and
   that migration 326 fully reconciles with the live table (every live partner
   versioned, no value divergence).

--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -1,0 +1,113 @@
+# PR-Affiliate-Partner-Drift-Check
+
+## Why this slice exists
+
+`affiliate-system-investigation.md` item #2 had two halves. Migration 326
+(PR #664) did the first: version-control the existing partner rows. This
+slice does the second -- "stop creating partners via raw API calls in prod"
+-- by making drift *detectable*.
+
+The `/b2b/tenant/affiliates` API still exposes full `POST`/`PATCH`/`DELETE`.
+Nothing prevents a partner row from being created directly in the DB again,
+re-introducing exactly the ungoverned data the migration just cleaned up: no
+git history, no review, no disaster-recovery path. Capturing the current rows
+without a way to catch the *next* drift would be patching the symptom, not
+the source.
+
+This adds an audit that reconciles the live `affiliate_partners` table against
+the partner definitions seeded by migrations, and fails when they diverge.
+
+## Scope (this PR)
+
+1. Add `scripts/audit_affiliate_partner_drift.py` (matches the existing
+   `scripts/audit_*` convention; same `_status`/`_exit_code`/JSON-report shape
+   as `scripts/check_reasoning_rollout_readiness.py`).
+2. Reconcile live rows against migration seeds with three checks:
+   - `all_live_partners_versioned` -- **FAIL** if a live partner's
+     `product_name` is seeded by no migration.
+   - `no_seed_value_divergence` -- **WARN** if a seeded partner's migration
+     definition differs from the live row on a business field
+     (`name`, `category`, `affiliate_url`, `commission_type`,
+     `commission_value`, `notes`, `product_aliases`).
+   - `no_orphan_seeds` -- **WARN** if a migration seeds a `product_name` with
+     no live row.
+3. Add `tests/test_affiliate_partner_drift.py` covering the pure parser and
+   reconciler (no DB), including both migration formats and each drift case.
+
+### Files touched
+
+- `scripts/audit_affiliate_partner_drift.py`
+- `tests/test_affiliate_partner_drift.py`
+- `plans/PR-Affiliate-Partner-Drift-Check.md`
+
+## Mechanism
+
+The parser and reconciler are pure functions (no DB), so they run and are
+tested everywhere -- CI included -- while only `_run` touches the live
+database (the same `:5433/atlas` the app uses, via `init_database()`).
+
+`parse_seeded_partners` finds each `INSERT INTO affiliate_partners (...)
+VALUES (...)` block with a quote- and bracket-aware tokenizer (not a naive
+regex), so it handles both seed formats already in the tree: the packed
+7-column 088 Amazon row and the 9-column 326 rows with `ARRAY[...]::text[]`
+and `'{...}'::text[]` aliases, `NULL`, and `true`/`false`. Values are
+normalized to Python types; later migrations override earlier ones for the
+same `product_name` (apply-order semantics).
+
+`reconcile` compares by `lower(product_name)`. Aliases are compared as sets
+(the matcher is order-insensitive, so a reordered array is not drift). `notes`
+normalizes `''` and `NULL` as equal. `enabled` is deliberately excluded from
+divergence -- toggling a partner on/off is legitimate operational state, not
+a version-control gap.
+
+The script exits non-zero only on a `fail` (an unversioned live partner), so
+it is safe to wire into a pre-deploy hook or run manually; warnings surface
+post-seed edits and orphan seeds without blocking.
+
+## Intentional
+
+- **Operator/pre-deploy script, not a CI gate.** The self-hosted deployment's
+  CI has no access to the live `:5433/atlas` DB, which is the only place real
+  drift is visible. The DB-touching path is therefore run by the operator; the
+  CI-runnable value (the parser + reconciler) is covered by unit tests.
+- **WARN, not FAIL, on value divergence.** A URL/commission edit made in the
+  DB may be a deliberate operational change; the audit surfaces it and lets
+  the operator decide whether the DB or the migration is authoritative, rather
+  than blocking deploys on a judgment call.
+- **Hand-written tokenizer over a SQL library.** The seed format is small and
+  fixed; a dependency-free tokenizer keeps the audit self-contained and its
+  behavior fully covered by the fixture tests.
+- **Larger than 400 LOC by design.** This is a net-new audit with its own
+  parser and full test coverage, not a change to existing code; the bulk is
+  the tokenizer and its tests.
+
+## Deferred
+
+- **Auto-generating a migration from a drifted DB row.** The audit reports
+  drift; turning a live row into a migration stub is a separate convenience.
+- **Restricting the partner API to read-only in prod.** A heavier alternative
+  that removes the only partner-management path; not warranted while the audit
+  makes drift visible.
+- **Wiring the audit into a scheduled task / alert.** Routine observability,
+  not blocking.
+
+## Verification
+
+- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `6 passed in
+  0.06s` (parser on both 088 + 326 formats, empty-array/quote-escape, and the
+  clean / unversioned-FAIL / value-divergence-WARN reconcile paths).
+- `python scripts/audit_affiliate_partner_drift.py` against live `:5433/atlas`
+  -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 3, warn: 0,
+  fail: 0}`, exit `0`. Confirms the parser reads the real 088 + 326 seeds and
+  that migration 326 fully reconciles with the live table (every live partner
+  versioned, no value divergence).
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~300 |
+| `tests/test_affiliate_partner_drift.py` | ~190 |
+| Plan doc | ~125 |
+| **Total** | **~615** |

--- a/plans/PR-Affiliate-Partner-Drift-Check.md
+++ b/plans/PR-Affiliate-Partner-Drift-Check.md
@@ -96,7 +96,7 @@ post-seed edits and orphan seeds without blocking.
 - `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `6 passed in
   0.06s` (parser on both 088 + 326 formats, empty-array/quote-escape, and the
   clean / unversioned-FAIL / value-divergence-WARN reconcile paths).
-- `python scripts/audit_affiliate_partner_drift.py` against live `:5433/atlas`
+- `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas`
   -> `summary` `{seeded_partners: 6, live_partners: 6, pass: 3, warn: 0,
   fail: 0}`, exit `0`. Confirms the parser reads the real 088 + 326 seeds and
   that migration 326 fully reconciles with the live table (every live partner
@@ -107,7 +107,7 @@ post-seed edits and orphan seeds without blocking.
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~300 |
-| `tests/test_affiliate_partner_drift.py` | ~190 |
-| Plan doc | ~125 |
-| **Total** | **~615** |
+| `scripts/audit_affiliate_partner_drift.py` (parser + reconciler + DB run) | ~340 |
+| `tests/test_affiliate_partner_drift.py` | ~225 |
+| Plan doc | ~135 |
+| **Total** | **~700** |

--- a/scripts/audit_affiliate_partner_drift.py
+++ b/scripts/audit_affiliate_partner_drift.py
@@ -200,40 +200,73 @@ def _parse_value(tok: str) -> Any:
     return tok
 
 
-def parse_seeded_partners(sql: str) -> list[dict[str, Any]]:
-    """Extract every `INSERT INTO affiliate_partners (...) VALUES (...)` row in
-    a migration's SQL text as a dict of column -> Python value."""
+def parse_seeded_partners(sql: str) -> tuple[list[dict[str, Any]], list[str]]:
+    """Extract every affiliate_partners row seeded in a migration's SQL.
+
+    Returns (rows, errors). Each row is a dict of column -> Python value.
+    Handles multi-row inserts (`VALUES (...), (...), ...`) -- every tuple is
+    read, not just the first. A column/value count mismatch is NOT silently
+    skipped: it is recorded in `errors` so the caller can surface it as a
+    failure rather than reconciling against silently-dropped definitions.
+    """
     rows: list[dict[str, Any]] = []
+    errors: list[str] = []
     for m in re.finditer(
         r"INSERT\s+INTO\s+affiliate_partners\s*\(", sql, re.IGNORECASE
     ):
         cols_str, after_cols = _read_paren_group(sql, m.end() - 1)
-        vm = re.compile(r"\s*VALUES\s*\(", re.IGNORECASE).match(sql, after_cols)
+        vm = re.compile(r"\s*VALUES\s*", re.IGNORECASE).match(sql, after_cols)
         if not vm:
+            errors.append("INSERT INTO affiliate_partners with no VALUES clause")
             continue
-        vals_str, _ = _read_paren_group(sql, vm.end() - 1)
         columns = [c.strip() for c in _split_top_level(cols_str)]
-        values = [_parse_value(v) for v in _split_top_level(vals_str)]
-        if len(columns) != len(values):
-            # Malformed / unexpected layout: skip rather than mis-map.
+        # Read one-or-more parenthesized value tuples separated by commas.
+        pos = vm.end()
+        while pos < len(sql) and sql[pos].isspace():
+            pos += 1
+        if pos >= len(sql) or sql[pos] != "(":
+            errors.append("VALUES clause with no value tuple")
             continue
-        rows.append(dict(zip(columns, values)))
-    return rows
+        while pos < len(sql) and sql[pos] == "(":
+            vals_str, pos = _read_paren_group(sql, pos)
+            values = [_parse_value(v) for v in _split_top_level(vals_str)]
+            if len(columns) != len(values):
+                errors.append(
+                    f"column/value count mismatch "
+                    f"({len(columns)} columns vs {len(values)} values)"
+                )
+            else:
+                rows.append(dict(zip(columns, values)))
+            while pos < len(sql) and sql[pos].isspace():
+                pos += 1
+            if pos < len(sql) and sql[pos] == ",":
+                pos += 1
+                while pos < len(sql) and sql[pos].isspace():
+                    pos += 1
+                continue
+            break
+    return rows, errors
 
 
-def parse_seeded_partners_dir(migrations_dir: pathlib.Path) -> dict[str, dict[str, Any]]:
+def parse_seeded_partners_dir(
+    migrations_dir: pathlib.Path,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
     """Parse every migration file, keyed by lower(product_name). Later
     migrations override earlier ones for the same product_name (mirrors the
-    apply order; the last definition is the current intended seed)."""
+    apply order; the last definition is the current intended seed). Returns
+    (seeded, errors); errors are prefixed with the originating filename."""
     seeded: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
     for path in sorted(migrations_dir.glob("*.sql")):
-        for row in parse_seeded_partners(path.read_text()):
+        rows, errs = parse_seeded_partners(path.read_text())
+        errors.extend(f"{path.name}: {e}" for e in errs)
+        for row in rows:
             product = row.get("product_name")
             if not product:
                 continue
             row["__migration__"] = path.name
             seeded[str(product).lower()] = row
-    return seeded
+    return seeded, errors
 
 
 # ---------------------------------------------------------------------------
@@ -264,9 +297,15 @@ def _field_equal(field: str, migration_val: Any, db_val: Any) -> bool:
 def reconcile(
     db_partners: list[dict[str, Any]],
     seeded: dict[str, dict[str, Any]],
+    parse_errors: list[str] | tuple[str, ...] = (),
 ) -> list[dict[str, Any]]:
     """Compare live partners against migration-seeded definitions and return a
-    list of status checks (same shape as the rollout-readiness audit)."""
+    list of status checks (same shape as the rollout-readiness audit).
+
+    `parse_errors` (migration INSERTs the parser could not map) are surfaced
+    as a hard FAIL: if seed parsing regressed, the reconciliation below is
+    comparing against an incomplete seed set and its pass/warn results cannot
+    be trusted, so the audit must not report success."""
     unversioned: list[dict[str, Any]] = []
     divergent: list[dict[str, Any]] = []
 
@@ -305,6 +344,12 @@ def reconcile(
 
     return [
         {
+            "name": "migration_seeds_parseable",
+            "status": "pass" if not parse_errors else "fail",
+            "required": True,
+            "detail": {"parse_errors": list(parse_errors)},
+        },
+        {
             "name": "all_live_partners_versioned",
             "status": "pass" if not unversioned else "fail",
             "required": True,
@@ -335,7 +380,7 @@ def _exit_code(checks: list[dict[str, Any]]) -> int:
 
 
 async def _run() -> dict[str, Any]:
-    seeded = parse_seeded_partners_dir(MIGRATIONS_DIR)
+    seeded, parse_errors = parse_seeded_partners_dir(MIGRATIONS_DIR)
     await init_database()
     pool = get_db_pool()
     rows = await pool.fetch(
@@ -360,7 +405,7 @@ async def _run() -> dict[str, Any]:
         }
         for r in rows
     ]
-    checks = reconcile(db_partners, seeded)
+    checks = reconcile(db_partners, seeded, parse_errors)
     return {
         "checks": checks,
         "summary": {

--- a/scripts/audit_affiliate_partner_drift.py
+++ b/scripts/audit_affiliate_partner_drift.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Reconcile live affiliate_partners rows against migration-seeded definitions.
+
+Closes the second half of affiliate-system-investigation item #2: migration
+326 version-controlled the existing partners, but the /b2b/tenant/affiliates
+API can still create partner rows directly in the DB, re-introducing
+ungoverned data with no migration, no review, and no disaster-recovery path.
+
+This audit detects that drift:
+
+  * FAIL  -- a live partner whose product_name is not seeded by any migration
+            (the core "every partner must be version-controlled" rule).
+  * WARN  -- a partner that IS seeded, but whose migration definition diverges
+            from the live row (URL / commission / aliases / category / notes
+            edited in the DB after seeding). Surfaces post-seed API edits
+            without blocking; the operator decides whether the DB or the
+            migration is authoritative.
+  * WARN  -- a migration seeds a product_name with no live row (seeded then
+            deleted/disabled-and-removed). Informational.
+
+`enabled` is intentionally excluded from divergence: toggling a partner on/off
+is legitimate operational state, not a drift signal.
+
+The parser and reconciler are pure (no DB) so they are unit-tested directly;
+only `_run` touches the live database (the same :5433/atlas the app uses).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+import re
+import sys
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.storage.database import close_database, get_db_pool, init_database
+
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+
+# Business columns reconciled for divergence. product_name is the key (not a
+# value); enabled is operational state, not a definitional fact.
+_DIVERGENCE_FIELDS = (
+    "name",
+    "category",
+    "affiliate_url",
+    "commission_type",
+    "commission_value",
+    "notes",
+    "product_aliases",
+)
+
+
+# ---------------------------------------------------------------------------
+# SQL parsing (pure -- no DB)
+# ---------------------------------------------------------------------------
+
+
+def _read_paren_group(s: str, open_idx: int) -> tuple[str, int]:
+    """Return (inner_text, index_after_close) for the parenthesized group whose
+    opening '(' is at open_idx. Respects single-quoted strings (with '' escape)
+    and nested parens; bracket pairs ([]) do not affect paren depth."""
+    if s[open_idx] != "(":
+        raise ValueError("expected '(' at open_idx")
+    depth = 0
+    j = open_idx
+    in_str = False
+    while j < len(s):
+        c = s[j]
+        if in_str:
+            if c == "'":
+                if j + 1 < len(s) and s[j + 1] == "'":
+                    j += 2
+                    continue
+                in_str = False
+            j += 1
+            continue
+        if c == "'":
+            in_str = True
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return s[open_idx + 1 : j], j + 1
+        j += 1
+    raise ValueError("unbalanced parentheses")
+
+
+def _split_top_level(s: str) -> list[str]:
+    """Split on commas at paren/bracket depth 0, respecting single-quoted
+    strings (with '' escape)."""
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    in_str = False
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if in_str:
+            buf.append(c)
+            if c == "'":
+                if i + 1 < len(s) and s[i + 1] == "'":
+                    buf.append(s[i + 1])
+                    i += 2
+                    continue
+                in_str = False
+            i += 1
+            continue
+        if c == "'":
+            in_str = True
+            buf.append(c)
+        elif c in "([":
+            depth += 1
+            buf.append(c)
+        elif c in ")]":
+            depth -= 1
+            buf.append(c)
+        elif c == "," and depth == 0:
+            parts.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _parse_pg_array(literal: str) -> list[str]:
+    """Parse a Postgres array literal body like {a,"b c","d e"} into a list.
+    `literal` includes the surrounding braces."""
+    inner = literal[1:-1]
+    if not inner.strip():
+        return []
+    items: list[str] = []
+    buf: list[str] = []
+    in_q = False
+    quoted = False
+    i = 0
+    while i < len(inner):
+        c = inner[i]
+        if in_q:
+            if c == "\\" and i + 1 < len(inner):
+                buf.append(inner[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_q = False
+                i += 1
+                continue
+            buf.append(c)
+            i += 1
+            continue
+        if c == '"':
+            in_q = True
+            quoted = True
+            i += 1
+            continue
+        if c == ",":
+            val = "".join(buf)
+            items.append(val if quoted else val.strip())
+            buf = []
+            quoted = False
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    val = "".join(buf)
+    items.append(val if quoted else val.strip())
+    return items
+
+
+def _parse_value(tok: str) -> Any:
+    """Normalize a single SQL value token to a Python value."""
+    tok = tok.strip()
+    # Strip a trailing ::type or ::type[] cast.
+    tok = re.sub(r"::\s*[a-zA-Z_]+(\s*\[\s*\])?\s*$", "", tok).strip()
+    low = tok.lower()
+    if low == "null":
+        return None
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if tok.startswith("'") and tok.endswith("'") and len(tok) >= 2:
+        unescaped = tok[1:-1].replace("''", "'")
+        if unescaped.startswith("{") and unescaped.endswith("}"):
+            return _parse_pg_array(unescaped)
+        return unescaped
+    if tok.upper().startswith("ARRAY[") and tok.rstrip().endswith("]"):
+        inner = tok[tok.index("[") + 1 : tok.rindex("]")]
+        return [_parse_value(it) for it in _split_top_level(inner)]
+    return tok
+
+
+def parse_seeded_partners(sql: str) -> list[dict[str, Any]]:
+    """Extract every `INSERT INTO affiliate_partners (...) VALUES (...)` row in
+    a migration's SQL text as a dict of column -> Python value."""
+    rows: list[dict[str, Any]] = []
+    for m in re.finditer(
+        r"INSERT\s+INTO\s+affiliate_partners\s*\(", sql, re.IGNORECASE
+    ):
+        cols_str, after_cols = _read_paren_group(sql, m.end() - 1)
+        vm = re.compile(r"\s*VALUES\s*\(", re.IGNORECASE).match(sql, after_cols)
+        if not vm:
+            continue
+        vals_str, _ = _read_paren_group(sql, vm.end() - 1)
+        columns = [c.strip() for c in _split_top_level(cols_str)]
+        values = [_parse_value(v) for v in _split_top_level(vals_str)]
+        if len(columns) != len(values):
+            # Malformed / unexpected layout: skip rather than mis-map.
+            continue
+        rows.append(dict(zip(columns, values)))
+    return rows
+
+
+def parse_seeded_partners_dir(migrations_dir: pathlib.Path) -> dict[str, dict[str, Any]]:
+    """Parse every migration file, keyed by lower(product_name). Later
+    migrations override earlier ones for the same product_name (mirrors the
+    apply order; the last definition is the current intended seed)."""
+    seeded: dict[str, dict[str, Any]] = {}
+    for path in sorted(migrations_dir.glob("*.sql")):
+        for row in parse_seeded_partners(path.read_text()):
+            product = row.get("product_name")
+            if not product:
+                continue
+            row["__migration__"] = path.name
+            seeded[str(product).lower()] = row
+    return seeded
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation (pure -- no DB)
+# ---------------------------------------------------------------------------
+
+
+def _norm_scalar(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return value
+
+
+def _norm_aliases(value: Any) -> frozenset[str]:
+    if not value:
+        return frozenset()
+    return frozenset(str(a) for a in value)
+
+
+def _field_equal(field: str, migration_val: Any, db_val: Any) -> bool:
+    if field == "product_aliases":
+        return _norm_aliases(migration_val) == _norm_aliases(db_val)
+    return _norm_scalar(migration_val) == _norm_scalar(db_val)
+
+
+def reconcile(
+    db_partners: list[dict[str, Any]],
+    seeded: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compare live partners against migration-seeded definitions and return a
+    list of status checks (same shape as the rollout-readiness audit)."""
+    unversioned: list[dict[str, Any]] = []
+    divergent: list[dict[str, Any]] = []
+
+    db_keys = set()
+    for partner in db_partners:
+        product = str(partner.get("product_name") or "")
+        key = product.lower()
+        db_keys.add(key)
+        seed = seeded.get(key)
+        if seed is None:
+            unversioned.append(
+                {"product_name": product, "enabled": partner.get("enabled")}
+            )
+            continue
+        diffs = {}
+        for field in _DIVERGENCE_FIELDS:
+            if not _field_equal(field, seed.get(field), partner.get(field)):
+                diffs[field] = {
+                    "migration": seed.get(field),
+                    "live": partner.get(field),
+                }
+        if diffs:
+            divergent.append(
+                {
+                    "product_name": product,
+                    "migration": seed.get("__migration__"),
+                    "fields": diffs,
+                }
+            )
+
+    seeded_without_live = sorted(
+        seed["__migration__"] + ": " + str(seed.get("product_name"))
+        for key, seed in seeded.items()
+        if key not in db_keys
+    )
+
+    return [
+        {
+            "name": "all_live_partners_versioned",
+            "status": "pass" if not unversioned else "fail",
+            "required": True,
+            "detail": {"unversioned_partners": unversioned},
+        },
+        {
+            "name": "no_seed_value_divergence",
+            "status": "pass" if not divergent else "warn",
+            "required": False,
+            "detail": {"divergent_partners": divergent},
+        },
+        {
+            "name": "no_orphan_seeds",
+            "status": "pass" if not seeded_without_live else "warn",
+            "required": False,
+            "detail": {"seeds_without_live_row": seeded_without_live},
+        },
+    ]
+
+
+def _exit_code(checks: list[dict[str, Any]]) -> int:
+    return 1 if any(item["status"] == "fail" for item in checks) else 0
+
+
+# ---------------------------------------------------------------------------
+# DB I/O
+# ---------------------------------------------------------------------------
+
+
+async def _run() -> dict[str, Any]:
+    seeded = parse_seeded_partners_dir(MIGRATIONS_DIR)
+    await init_database()
+    pool = get_db_pool()
+    rows = await pool.fetch(
+        """
+        SELECT name, product_name, product_aliases, category, affiliate_url,
+               commission_type, commission_value, notes, enabled
+        FROM affiliate_partners
+        ORDER BY product_name
+        """
+    )
+    db_partners = [
+        {
+            "name": r["name"],
+            "product_name": r["product_name"],
+            "product_aliases": list(r["product_aliases"]) if r["product_aliases"] else [],
+            "category": r["category"],
+            "affiliate_url": r["affiliate_url"],
+            "commission_type": r["commission_type"],
+            "commission_value": r["commission_value"],
+            "notes": r["notes"],
+            "enabled": r["enabled"],
+        }
+        for r in rows
+    ]
+    checks = reconcile(db_partners, seeded)
+    return {
+        "checks": checks,
+        "summary": {
+            "seeded_partners": len(seeded),
+            "live_partners": len(db_partners),
+            "pass": sum(1 for c in checks if c["status"] == "pass"),
+            "warn": sum(1 for c in checks if c["status"] == "warn"),
+            "fail": sum(1 for c in checks if c["status"] == "fail"),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    async def _main() -> int:
+        try:
+            result = await _run()
+        finally:
+            await close_database()
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+        return _exit_code(result["checks"])
+
+    raise SystemExit(asyncio.run(_main()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_affiliate_partner_drift.py
+++ b/scripts/audit_affiliate_partner_drift.py
@@ -248,25 +248,45 @@ def parse_seeded_partners(sql: str) -> tuple[list[dict[str, Any]], list[str]]:
     return rows, errors
 
 
+def find_partner_mutations(sql: str) -> list[str]:
+    """Return descriptors for UPDATE/DELETE statements targeting
+    affiliate_partners. The audit models only INSERT seeds, so a mutation
+    means a live row's value (or absence) may be the intended result of a
+    migration this parser does not apply -- the caller surfaces these so the
+    blind spot is visible rather than silently skewing reconciliation."""
+    found: list[str] = []
+    if re.search(r"\bUPDATE\s+affiliate_partners\b", sql, re.IGNORECASE):
+        found.append("UPDATE")
+    if re.search(r"\bDELETE\s+FROM\s+affiliate_partners\b", sql, re.IGNORECASE):
+        found.append("DELETE")
+    return found
+
+
 def parse_seeded_partners_dir(
     migrations_dir: pathlib.Path,
-) -> tuple[dict[str, dict[str, Any]], list[str]]:
+) -> tuple[dict[str, dict[str, Any]], list[str], list[str]]:
     """Parse every migration file, keyed by lower(product_name). Later
     migrations override earlier ones for the same product_name (mirrors the
     apply order; the last definition is the current intended seed). Returns
-    (seeded, errors); errors are prefixed with the originating filename."""
+    (seeded, errors, mutations); errors and mutations are prefixed with the
+    originating filename."""
     seeded: dict[str, dict[str, Any]] = {}
     errors: list[str] = []
+    mutations: list[str] = []
     for path in sorted(migrations_dir.glob("*.sql")):
-        rows, errs = parse_seeded_partners(path.read_text())
+        text = path.read_text()
+        rows, errs = parse_seeded_partners(text)
         errors.extend(f"{path.name}: {e}" for e in errs)
+        mutations.extend(
+            f"{path.name}: {kind} affiliate_partners" for kind in find_partner_mutations(text)
+        )
         for row in rows:
             product = row.get("product_name")
             if not product:
                 continue
             row["__migration__"] = path.name
             seeded[str(product).lower()] = row
-    return seeded, errors
+    return seeded, errors, mutations
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +318,7 @@ def reconcile(
     db_partners: list[dict[str, Any]],
     seeded: dict[str, dict[str, Any]],
     parse_errors: list[str] | tuple[str, ...] = (),
+    mutations: list[str] | tuple[str, ...] = (),
 ) -> list[dict[str, Any]]:
     """Compare live partners against migration-seeded definitions and return a
     list of status checks (same shape as the rollout-readiness audit).
@@ -305,7 +326,15 @@ def reconcile(
     `parse_errors` (migration INSERTs the parser could not map) are surfaced
     as a hard FAIL: if seed parsing regressed, the reconciliation below is
     comparing against an incomplete seed set and its pass/warn results cannot
-    be trusted, so the audit must not report success."""
+    be trusted, so the audit must not report success.
+
+    `mutations` (UPDATE/DELETE on affiliate_partners) are surfaced as a WARN,
+    not a FAIL: a legitimate migration may intentionally edit a partner, so its
+    presence is not an error -- but the audit only models INSERT seeds, so a
+    value-divergence or orphan result for an affected partner may be explained
+    by a mutation this parser does not apply. The warning points the operator
+    at the responsible migration rather than letting that case look like clean
+    drift."""
     unversioned: list[dict[str, Any]] = []
     divergent: list[dict[str, Any]] = []
 
@@ -350,6 +379,12 @@ def reconcile(
             "detail": {"parse_errors": list(parse_errors)},
         },
         {
+            "name": "partner_mutations_modeled",
+            "status": "pass" if not mutations else "warn",
+            "required": False,
+            "detail": {"unmodeled_mutations": list(mutations)},
+        },
+        {
             "name": "all_live_partners_versioned",
             "status": "pass" if not unversioned else "fail",
             "required": True,
@@ -380,7 +415,7 @@ def _exit_code(checks: list[dict[str, Any]]) -> int:
 
 
 async def _run() -> dict[str, Any]:
-    seeded, parse_errors = parse_seeded_partners_dir(MIGRATIONS_DIR)
+    seeded, parse_errors, mutations = parse_seeded_partners_dir(MIGRATIONS_DIR)
     await init_database()
     pool = get_db_pool()
     rows = await pool.fetch(
@@ -405,7 +440,7 @@ async def _run() -> dict[str, Any]:
         }
         for r in rows
     ]
-    checks = reconcile(db_partners, seeded, parse_errors)
+    checks = reconcile(db_partners, seeded, parse_errors, mutations)
     return {
         "checks": checks,
         "summary": {

--- a/tests/test_affiliate_partner_drift.py
+++ b/tests/test_affiliate_partner_drift.py
@@ -1,0 +1,198 @@
+"""Unit tests for the affiliate-partner drift audit's pure parser + reconciler.
+
+No database required -- these cover the SQL-parsing and reconciliation logic
+directly, which is the part that runs everywhere (CI included). The live-DB
+path (`_run`) is exercised by the operator against :5433/atlas.
+"""
+
+import importlib.util
+import pathlib
+
+_SPEC = importlib.util.spec_from_file_location(
+    "audit_affiliate_partner_drift",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "audit_affiliate_partner_drift.py",
+)
+drift = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(drift)
+
+
+# --- 326-style: 9 columns, one value per line, array + NULL literals ---------
+
+SQL_326_STYLE = """
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'Monday.com',
+    'Monday.com',
+    ARRAY['monday', 'monday CRM', 'monday work OS']::text[],
+    'Project Management',
+    'https://try.monday.com/1p7bntdd5bui',
+    'rev_share',
+    '$100/signup',
+    NULL,
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+
+INSERT INTO affiliate_partners (
+    name, product_name, product_aliases, category, affiliate_url,
+    commission_type, commission_value, notes, enabled
+) VALUES (
+    'Shopify Affiliates',
+    'Shopify',
+    '{"shopify plus","shopify basic","shopify advanced"}'::text[],
+    'E-commerce',
+    'https://shopify.pxf.io/c/7062841/1424184/13624',
+    'cpa',
+    'up to $150/merchant',
+    'Impact Radius program. Publisher ID: 7062841.',
+    true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+"""
+
+# --- 088-style: 7 columns (no aliases/notes), packed values ------------------
+
+SQL_088_STYLE = """
+INSERT INTO affiliate_partners (
+    name, product_name, category, affiliate_url,
+    commission_type, commission_value, enabled
+) VALUES (
+    'Amazon Associates', 'Amazon', 'consumer',
+    'https://www.amazon.com?tag=atlas0e9b-20',
+    'percentage', '1-10%', true
+) ON CONFLICT ((lower(product_name))) DO NOTHING;
+"""
+
+
+def test_parses_326_style_with_arrays_and_null():
+    rows = drift.parse_seeded_partners(SQL_326_STYLE)
+    assert len(rows) == 2
+    monday = next(r for r in rows if r["product_name"] == "Monday.com")
+    assert monday["product_aliases"] == ["monday", "monday CRM", "monday work OS"]
+    assert monday["category"] == "Project Management"
+    assert monday["commission_value"] == "$100/signup"
+    assert monday["notes"] is None
+    assert monday["enabled"] is True
+
+    shopify = next(r for r in rows if r["product_name"] == "Shopify")
+    # Curly-brace array literal form parses identically to ARRAY[...].
+    assert shopify["product_aliases"] == [
+        "shopify plus",
+        "shopify basic",
+        "shopify advanced",
+    ]
+    assert shopify["notes"] == "Impact Radius program. Publisher ID: 7062841."
+
+
+def test_parses_088_style_packed_values_fewer_columns():
+    rows = drift.parse_seeded_partners(SQL_088_STYLE)
+    assert len(rows) == 1
+    amazon = rows[0]
+    assert amazon["product_name"] == "Amazon"
+    assert amazon["affiliate_url"] == "https://www.amazon.com?tag=atlas0e9b-20"
+    # Columns not present in this INSERT simply aren't keys.
+    assert "product_aliases" not in amazon
+    assert amazon["enabled"] is True
+
+
+def test_empty_array_and_quote_escape():
+    assert drift._parse_value("'{}'::text[]") == []
+    # Embedded apostrophe via '' escape.
+    assert drift._parse_value("'it''s fine'") == "it's fine"
+    assert drift._parse_value("NULL") is None
+    assert drift._parse_value("true") is True
+
+
+def test_reconcile_clean_when_all_match():
+    # Build seeded map directly from parsed rows (avoid touching the filesystem).
+    parsed = {
+        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
+        for r in drift.parse_seeded_partners(SQL_326_STYLE)
+    }
+    db = [
+        {
+            "name": "Monday.com",
+            "product_name": "Monday.com",
+            "product_aliases": ["monday work OS", "monday", "monday CRM"],  # reordered
+            "category": "Project Management",
+            "affiliate_url": "https://try.monday.com/1p7bntdd5bui",
+            "commission_type": "rev_share",
+            "commission_value": "$100/signup",
+            "notes": None,
+            "enabled": True,
+        },
+        {
+            "name": "Shopify Affiliates",
+            "product_name": "Shopify",
+            "product_aliases": ["shopify plus", "shopify basic", "shopify advanced"],
+            "category": "E-commerce",
+            "affiliate_url": "https://shopify.pxf.io/c/7062841/1424184/13624",
+            "commission_type": "cpa",
+            "commission_value": "up to $150/merchant",
+            "notes": "Impact Radius program. Publisher ID: 7062841.",
+            "enabled": True,
+        },
+    ]
+    checks = {c["name"]: c for c in drift.reconcile(db, parsed)}
+    assert checks["all_live_partners_versioned"]["status"] == "pass"
+    # Alias reorder must NOT trigger divergence (compared as sets).
+    assert checks["no_seed_value_divergence"]["status"] == "pass"
+    assert checks["no_orphan_seeds"]["status"] == "pass"
+    assert drift._exit_code(list(checks.values())) == 0
+
+
+def test_reconcile_flags_unversioned_partner_as_fail():
+    parsed = {
+        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
+        for r in drift.parse_seeded_partners(SQL_088_STYLE)
+    }
+    db = [
+        {"product_name": "Amazon", "product_aliases": [], "name": "Amazon Associates",
+         "category": "consumer", "affiliate_url": "https://www.amazon.com?tag=atlas0e9b-20",
+         "commission_type": "percentage", "commission_value": "1-10%", "notes": None, "enabled": True},
+        # Created via API, never migrated:
+        {"product_name": "Notion", "product_aliases": [], "name": "Notion Partner",
+         "category": "Project Management", "affiliate_url": "https://notion.so/?ref=x",
+         "commission_type": "cpa", "commission_value": "$50", "notes": None, "enabled": True},
+    ]
+    checks = {c["name"]: c for c in drift.reconcile(db, parsed)}
+    assert checks["all_live_partners_versioned"]["status"] == "fail"
+    unversioned = checks["all_live_partners_versioned"]["detail"]["unversioned_partners"]
+    assert [p["product_name"] for p in unversioned] == ["Notion"]
+    assert drift._exit_code(list(checks.values())) == 1
+
+
+def test_reconcile_warns_on_value_divergence():
+    parsed = {
+        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
+        for r in drift.parse_seeded_partners(SQL_326_STYLE)
+    }
+    db = [
+        {
+            "name": "Monday.com",
+            "product_name": "Monday.com",
+            "product_aliases": ["monday", "monday CRM", "monday work OS"],
+            "category": "Project Management",
+            # URL edited in the DB after seeding:
+            "affiliate_url": "https://try.monday.com/EDITED-IN-DB",
+            "commission_type": "rev_share",
+            "commission_value": "$100/signup",
+            "notes": None,
+            "enabled": False,  # toggled off -- must NOT count as divergence
+        },
+    ]
+    checks = {c["name"]: c for c in drift.reconcile(db, parsed)}
+    # Unversioned check still passes (Monday IS seeded).
+    assert checks["all_live_partners_versioned"]["status"] == "pass"
+    # Divergence is a warning, not a failure.
+    div = checks["no_seed_value_divergence"]
+    assert div["status"] == "warn"
+    fields = div["detail"]["divergent_partners"][0]["fields"]
+    assert "affiliate_url" in fields
+    assert "enabled" not in fields  # excluded by design
+    # Monday seeded but Shopify (also in SQL_326) has no live row -> orphan warn.
+    assert checks["no_orphan_seeds"]["status"] == "warn"
+    # Warnings do not fail the audit.
+    assert drift._exit_code(list(checks.values())) == 0

--- a/tests/test_affiliate_partner_drift.py
+++ b/tests/test_affiliate_partner_drift.py
@@ -243,3 +243,29 @@ def test_reconcile_fails_when_seeds_unparseable():
     }
     assert checks["migration_seeds_parseable"]["status"] == "fail"
     assert drift._exit_code(list(checks.values())) == 1
+
+
+def test_finds_partner_mutations():
+    assert drift.find_partner_mutations(SQL_326_STYLE) == []  # INSERT-only
+    assert drift.find_partner_mutations(
+        "UPDATE affiliate_partners SET affiliate_url = 'x' WHERE product_name = 'HubSpot';"
+    ) == ["UPDATE"]
+    both = drift.find_partner_mutations(
+        "DELETE FROM affiliate_partners WHERE enabled = false;\n"
+        "UPDATE affiliate_partners SET notes = NULL;"
+    )
+    assert set(both) == {"UPDATE", "DELETE"}
+
+
+def test_reconcile_warns_on_unmodeled_mutation_without_failing():
+    # A mutation migration is not an error, but the audit can't model its
+    # effect -- surface it as a warning, not a failure.
+    checks = {
+        c["name"]: c
+        for c in drift.reconcile(
+            [], {}, mutations=["340_fix_hubspot_url.sql: UPDATE affiliate_partners"]
+        )
+    }
+    assert checks["partner_mutations_modeled"]["status"] == "warn"
+    assert checks["migration_seeds_parseable"]["status"] == "pass"
+    assert drift._exit_code(list(checks.values())) == 0

--- a/tests/test_affiliate_partner_drift.py
+++ b/tests/test_affiliate_partner_drift.py
@@ -67,7 +67,8 @@ INSERT INTO affiliate_partners (
 
 
 def test_parses_326_style_with_arrays_and_null():
-    rows = drift.parse_seeded_partners(SQL_326_STYLE)
+    rows, errors = drift.parse_seeded_partners(SQL_326_STYLE)
+    assert errors == []
     assert len(rows) == 2
     monday = next(r for r in rows if r["product_name"] == "Monday.com")
     assert monday["product_aliases"] == ["monday", "monday CRM", "monday work OS"]
@@ -87,7 +88,8 @@ def test_parses_326_style_with_arrays_and_null():
 
 
 def test_parses_088_style_packed_values_fewer_columns():
-    rows = drift.parse_seeded_partners(SQL_088_STYLE)
+    rows, errors = drift.parse_seeded_partners(SQL_088_STYLE)
+    assert errors == []
     assert len(rows) == 1
     amazon = rows[0]
     assert amazon["product_name"] == "Amazon"
@@ -105,12 +107,17 @@ def test_empty_array_and_quote_escape():
     assert drift._parse_value("true") is True
 
 
+def _seed_map(sql: str) -> dict:
+    rows, errors = drift.parse_seeded_partners(sql)
+    assert errors == []
+    return {
+        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"} for r in rows
+    }
+
+
 def test_reconcile_clean_when_all_match():
     # Build seeded map directly from parsed rows (avoid touching the filesystem).
-    parsed = {
-        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
-        for r in drift.parse_seeded_partners(SQL_326_STYLE)
-    }
+    parsed = _seed_map(SQL_326_STYLE)
     db = [
         {
             "name": "Monday.com",
@@ -144,10 +151,7 @@ def test_reconcile_clean_when_all_match():
 
 
 def test_reconcile_flags_unversioned_partner_as_fail():
-    parsed = {
-        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
-        for r in drift.parse_seeded_partners(SQL_088_STYLE)
-    }
+    parsed = _seed_map(SQL_088_STYLE)
     db = [
         {"product_name": "Amazon", "product_aliases": [], "name": "Amazon Associates",
          "category": "consumer", "affiliate_url": "https://www.amazon.com?tag=atlas0e9b-20",
@@ -165,10 +169,7 @@ def test_reconcile_flags_unversioned_partner_as_fail():
 
 
 def test_reconcile_warns_on_value_divergence():
-    parsed = {
-        r["product_name"].lower(): {**r, "__migration__": "326_seed.sql"}
-        for r in drift.parse_seeded_partners(SQL_326_STYLE)
-    }
+    parsed = _seed_map(SQL_326_STYLE)
     db = [
         {
             "name": "Monday.com",
@@ -196,3 +197,49 @@ def test_reconcile_warns_on_value_divergence():
     assert checks["no_orphan_seeds"]["status"] == "warn"
     # Warnings do not fail the audit.
     assert drift._exit_code(list(checks.values())) == 0
+
+
+# --- multi-row VALUES: every tuple must be read, not just the first ----------
+
+SQL_MULTI_ROW = """
+INSERT INTO affiliate_partners (
+    name, product_name, category, affiliate_url, commission_type,
+    commission_value, enabled
+) VALUES
+    ('A Co', 'Avendor', 'crm', 'https://a.example/?ref=x', 'cpa', '$10', true),
+    ('B Co', 'Bvendor', 'crm', 'https://b.example/?ref=x', 'cpa', '$20', false)
+ON CONFLICT ((lower(product_name))) DO NOTHING;
+"""
+
+
+def test_parses_multi_row_values():
+    rows, errors = drift.parse_seeded_partners(SQL_MULTI_ROW)
+    assert errors == []
+    assert [r["product_name"] for r in rows] == ["Avendor", "Bvendor"]
+    assert rows[0]["enabled"] is True
+    assert rows[1]["enabled"] is False
+
+
+def test_column_value_mismatch_is_surfaced_not_silently_dropped():
+    bad = (
+        "INSERT INTO affiliate_partners (name, product_name, category) "
+        "VALUES ('X', 'Xvendor', 'crm', 'EXTRA') "
+        "ON CONFLICT ((lower(product_name))) DO NOTHING;"
+    )
+    rows, errors = drift.parse_seeded_partners(bad)
+    assert rows == []  # the mismatched tuple is not mis-mapped
+    assert len(errors) == 1
+    assert "mismatch" in errors[0]
+
+
+def test_reconcile_fails_when_seeds_unparseable():
+    # A parse error must fail the audit: reconciliation below would be against
+    # an incomplete seed set, so a "pass" would be misleading.
+    checks = {
+        c["name"]: c
+        for c in drift.reconcile(
+            [], {}, parse_errors=["326_seed.sql: column/value count mismatch (9 vs 8)"]
+        )
+    }
+    assert checks["migration_seeds_parseable"]["status"] == "fail"
+    assert drift._exit_code(list(checks.values())) == 1


### PR DESCRIPTION
Plan: plans/PR-Affiliate-Partner-Drift-Check.md

Closes the second half of affiliate-system-investigation item #2. Migration 326 (PR #664) version-controlled the existing partner rows; this slice makes future drift *detectable*. The `/b2b/tenant/affiliates` API still allows direct `POST`/`PATCH`/`DELETE`, so a partner can be created in the DB again with no migration, no review, no disaster-recovery path. This adds an audit that reconciles the live `affiliate_partners` table against migration-seeded definitions.

## Intentional
- **Operator/pre-deploy script, not a CI gate.** CI has no access to the live `:5433/atlas` DB (the only place real drift is visible). The DB path is operator-run; the CI-runnable parser + reconciler are unit-tested.
- **Three checks:** `all_live_partners_versioned` (**FAIL** — live partner seeded by no migration), `no_seed_value_divergence` (**WARN** — seeded partner whose migration differs from the live row), `no_orphan_seeds` (**WARN** — seed with no live row).
- **WARN, not FAIL, on divergence.** A DB-side URL/commission edit may be deliberate; surface it, let the operator decide authority, don't block deploys on a judgment call.
- **`enabled` excluded from divergence** — toggling a partner on/off is operational state, not a version-control gap. **Aliases compared as sets** (matcher is order-insensitive). **`notes` `''`==`NULL`**.
- **Hand-written tokenizer over a SQL library** — small fixed seed format, kept dependency-free and fully fixture-tested (handles both the packed 088 row and the 326 `ARRAY[...]` / `'{...}'` rows).
- **>400 LOC by design** — net-new audit + full test coverage, not a change to existing code.

## Deferred
- Auto-generating a migration stub from a drifted row.
- Restricting the partner API to read-only in prod (heavier; removes the management path).
- Wiring the audit into a scheduled task / alert.

## Verification
- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `6 passed in 0.06s` (both seed formats, empty-array/quote-escape, and clean / unversioned-FAIL / value-divergence-WARN reconcile paths).
- `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas` -> `summary {seeded_partners: 6, live_partners: 6, pass: 3, warn: 0, fail: 0}`, exit `0` — confirms the parser reads the real 088 + 326 seeds and that migration 326 fully reconciles with the live table.
- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape, plan/code consistency 4/4 path + 1/1 function claims, diff drift 0.4%, `git diff --check`).

## Diff size
~703 LOC (script ~340, tests ~225, plan ~135). Larger than 400 by design — net-new audit with its own parser + tests.