### PR TITLE
Add blog SEO/AEO readiness summary

### DIFF
--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -7,6 +7,7 @@ import csv
 from dataclasses import dataclass
 from io import StringIO
 import json
+import re
 from typing import Any
 
 from .blog_ports import BlogPostDraft, BlogPostRepository
@@ -30,6 +31,9 @@ _EXPORT_COLUMNS = (
     "reasoning_context_used",
     "reasoning_wedge",
     "reasoning_confidence",
+    "passed_output_checks",
+    "output_checks",
+    "seo_aeo_readiness",
     "tags",
     "content",
     "charts",
@@ -103,6 +107,10 @@ def _draft_row(draft: BlogPostDraft) -> JsonDict:
     row["tag_count"] = len(draft.tags)
     row["chart_count"] = len(draft.charts)
     row.update(_metadata_summary(draft.metadata))
+    readiness = _seo_aeo_readiness(draft)
+    row["output_checks"] = readiness["checks"]
+    row["passed_output_checks"] = readiness["passed"]
+    row["seo_aeo_readiness"] = readiness
     return row
 
 
@@ -119,6 +127,83 @@ def _metadata_summary(value: Any) -> JsonDict:
         "reasoning_wedge": reasoning.get("wedge"),
         "reasoning_confidence": reasoning.get("confidence"),
     }
+
+
+_QUESTION_H2_RE = re.compile(
+    r"^##\s+(?:who|what|when|where|why|how|is|are|can|should|does|do|which)\b.*\?",
+    re.IGNORECASE | re.MULTILINE,
+)
+_H2_RE = re.compile(r"^##\s+.+$", re.MULTILINE)
+
+
+def _seo_aeo_readiness(draft: BlogPostDraft) -> JsonDict:
+    metadata = _metadata_mapping(draft.metadata)
+    checks = {
+        "seo_title_ready": _text_len_between(metadata.get("seo_title"), max_len=60),
+        "seo_description_ready": _text_len_between(
+            metadata.get("seo_description"),
+            max_len=155,
+        ),
+        "target_keyword_present": bool(_clean_text(metadata.get("target_keyword"))),
+        "secondary_keywords_present": len(_metadata_list(metadata.get("secondary_keywords"))) >= 1,
+        "faq_ready": len(_metadata_list(metadata.get("faq"))) >= 3,
+        "aeo_structure_detected": _aeo_structure_detected(draft.content),
+    }
+    missing = [key for key, value in checks.items() if not value]
+    passed = sum(1 for value in checks.values() if value)
+    return {
+        "status": "ready" if not missing else "needs_review",
+        "passed": passed,
+        "total": len(checks),
+        "missing": missing,
+        "checks": checks,
+    }
+
+
+def _text_len_between(value: Any, *, max_len: int) -> bool:
+    text = _clean_text(value)
+    return bool(text) and len(text) <= max_len
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _metadata_list(value: Any) -> list[Any]:
+    if isinstance(value, str) and value.strip():
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        value = decoded
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _aeo_structure_detected(content: Any) -> bool:
+    body = str(content or "")
+    if _QUESTION_H2_RE.search(body):
+        return True
+    for match in _H2_RE.finditer(body):
+        section_start = match.end()
+        next_heading = _H2_RE.search(body, section_start)
+        section = body[section_start:next_heading.start() if next_heading else None]
+        first_paragraph = _first_paragraph(section)
+        word_count = len(first_paragraph.split())
+        if 40 <= word_count <= 80:
+            return True
+    return False
+
+
+def _first_paragraph(section: str) -> str:
+    for chunk in re.split(r"\n\s*\n", section.strip()):
+        text = re.sub(r"^[>\-\*\s]+", "", chunk.strip())
+        if text and not text.startswith("{{chart:") and not text.startswith("<table"):
+            return text
+    return ""
 
 
 def _metadata_mapping(value: Any) -> JsonDict:

--- a/plans/PR-Blog-SEO-AEO-Readiness-Summary.md
+++ b/plans/PR-Blog-SEO-AEO-Readiness-Summary.md
@@ -1,0 +1,90 @@
+# PR-Blog-SEO-AEO-Readiness-Summary
+
+## Why this slice exists
+
+PR-Blog-SEO-Field-Persistence made generated blog SEO fields durable by writing
+them into the first-class `blog_posts` SEO columns and hydrating them back into
+draft metadata. Operators can now preserve the fields, but the generated-asset
+review/export surface still does not tell them whether a draft has the basic
+SEO/AEO pieces we are comfortable claiming.
+
+This slice adds a deterministic readiness summary for blog drafts only. It
+keeps the claim narrow: SEO metadata and answer-engine-friendly structure. GEO
+remains deferred until the product contract is defined.
+
+## Scope (this PR)
+
+1. Add blog post SEO/AEO readiness checks to the blog draft export helper.
+2. Surface `output_checks`, `passed_output_checks`, and a
+   `seo_aeo_readiness` summary in blog generated-asset rows.
+3. Include the readiness fields in CSV export columns.
+4. Add focused tests for ready and incomplete drafts, plus generated-asset API
+   visibility.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-SEO-AEO-Readiness-Summary.md` | Plan doc for this slice. |
+| `extracted_content_pipeline/blog_post_export.py` | Add deterministic SEO/AEO readiness summary fields. |
+| `tests/test_extracted_blog_post_export.py` | Cover ready/incomplete readiness output and CSV columns. |
+| `tests/test_extracted_content_asset_api.py` | Prove blog generated-asset API rows expose readiness fields. |
+
+## Mechanism
+
+The blog export row already merges generation metadata into the review row.
+This slice adds a pure helper that inspects the draft metadata and content and
+returns boolean checks for:
+
+- SEO title present and at most 60 characters.
+- SEO description present and at most 155 characters.
+- Target keyword present.
+- At least one secondary keyword.
+- At least three FAQ entries.
+- Question-style H2 heading or answer-first section structure detectable in the
+  Markdown content.
+
+The row exposes those booleans as `output_checks`, counts passed checks in
+`passed_output_checks`, and adds `seo_aeo_readiness` with total, passed,
+missing, and status fields. The title/description checks use `*_ready` names
+because they validate both presence and length.
+
+## Intentional
+
+- No prompt changes. This slice measures the current output contract instead of
+  changing generation behavior.
+- No GEO score. GEO needs a definition before it can become a validator.
+- No frontend UI code. The generated-asset UI already has generic support for
+  `output_checks` / `passed_output_checks`; this slice focuses on the backend
+  row shape.
+- The AEO structure check is intentionally heuristic. It detects obvious
+  question-style H2s or answer-first section openings; it is not a full content
+  quality gate.
+
+## Deferred
+
+- Add a dedicated SEO/AEO/GEO quality gate before draft save.
+- Add a first-class GEO readiness definition.
+- Add richer frontend labels for blog readiness if the generic generated-asset
+  display is not enough.
+- Audit public publish pages end to end after readiness output lands.
+
+## Verification
+
+- Focused blog export and generated-asset API tests -> 7 passed.
+- Python compile check over edited modules/tests -> passed.
+- Diff whitespace check -> passed.
+- Extracted content pipeline validation -> passed.
+- Atlas reasoning import guard for extracted_content_pipeline -> passed.
+- Standalone extracted audit with fail-on-debt -> passed.
+- ASCII Python policy check -> passed.
+- Full extracted pipeline checks -> 1527 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Blog export helper | ~85 |
+| Tests | ~95 |
+| **Total** | **~270** |

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -45,10 +45,35 @@ def _draft(**overrides) -> BlogPostDraft:
         description="Pricing pressure dominates.",
         topic_type="vendor_alternative",
         tags=("pricing", "retention"),
-        content="body",
+        content=(
+            "## Why is Acme pricing pressure showing up?\n\n"
+            "Acme pricing pressure is visible in recent review patterns, "
+            "especially when buyers describe renewal friction, budget concerns, "
+            "and comparison shopping. This section starts with a direct answer "
+            "so reviewers can quickly understand the point before reading the "
+            "supporting detail."
+        ),
         charts=({"id": "chart-1"},),
         data_context={"vendor": "Acme"},
         metadata={
+            "seo_title": "Acme Pricing Pressure 2026",
+            "seo_description": "Acme pricing pressure from recent review data.",
+            "target_keyword": "acme pricing pressure",
+            "secondary_keywords": ["acme pricing", "acme alternatives"],
+            "faq": [
+                {
+                    "question": "Why is Acme pricing a concern?",
+                    "answer": "Pricing pressure appears in review data.",
+                },
+                {
+                    "question": "Who should compare Acme alternatives?",
+                    "answer": "Teams with budget pressure should compare options.",
+                },
+                {
+                    "question": "What should buyers check?",
+                    "answer": "Buyers should check contract and support terms.",
+                },
+            ],
             "generation_usage": {
                 "input_tokens": 12,
                 "output_tokens": 6,
@@ -118,12 +143,28 @@ async def test_export_blog_post_drafts_derives_review_summary_fields() -> None:
     assert row["reasoning_context_used"] is True
     assert row["reasoning_wedge"] == "price_squeeze"
     assert row["reasoning_confidence"] == "high"
+    assert row["passed_output_checks"] == 6
+    assert row["output_checks"] == {
+        "seo_title_ready": True,
+        "seo_description_ready": True,
+        "target_keyword_present": True,
+        "secondary_keywords_present": True,
+        "faq_ready": True,
+        "aeo_structure_detected": True,
+    }
+    assert row["seo_aeo_readiness"] == {
+        "status": "ready",
+        "passed": 6,
+        "total": 6,
+        "missing": [],
+        "checks": row["output_checks"],
+    }
 
 
 @pytest.mark.asyncio
 async def test_export_blog_post_drafts_defaults_summary_fields_without_metadata() -> None:
     result = await export_blog_post_drafts(
-        _Repository(drafts=[_draft(metadata={})]),
+        _Repository(drafts=[_draft(content="body", metadata={})]),
         limit=1,
     )
 
@@ -135,6 +176,16 @@ async def test_export_blog_post_drafts_defaults_summary_fields_without_metadata(
     assert row["reasoning_context_used"] is False
     assert row["reasoning_wedge"] is None
     assert row["reasoning_confidence"] is None
+    assert row["passed_output_checks"] == 0
+    assert row["seo_aeo_readiness"]["status"] == "needs_review"
+    assert row["seo_aeo_readiness"]["missing"] == [
+        "seo_title_ready",
+        "seo_description_ready",
+        "target_keyword_present",
+        "secondary_keywords_present",
+        "faq_ready",
+        "aeo_structure_detected",
+    ]
 
 
 def test_blog_post_export_result_renders_csv() -> None:
@@ -155,8 +206,27 @@ def test_blog_post_export_result_renders_csv() -> None:
     csv_text = result.as_csv()
 
     assert csv_text.startswith("slug,title,description,topic_type")
+    assert "passed_output_checks,output_checks,seo_aeo_readiness" in csv_text
     assert "acme-pricing-pressure" in csv_text
     assert "{\"\"generation_parse_attempts\"\":2}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_detects_answer_first_sections() -> None:
+    content = (
+        "## Acme Pricing Pattern\n\n"
+        "Acme pricing pressure appears in review data when buyers describe "
+        "renewal friction, budget pressure, and increased comparison shopping. "
+        "The point is not that every buyer has the same problem, but that the "
+        "article opens the section with a direct answer before detail."
+    )
+
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[_draft(content=content)]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    assert result.rows[0]["output_checks"]["aeo_structure_detected"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -70,7 +70,11 @@ def _blog_post_row():
         "description": "Pricing pressure dominates.",
         "topic_type": "vendor_alternative",
         "tags": ["pricing"],
-        "content": "body",
+        "content": (
+            "## Why is Acme pricing pressure showing up?\n\n"
+            "Acme pricing pressure is visible in recent review patterns when "
+            "buyers describe renewal friction and budget concerns."
+        ),
         "charts": [],
         "data_context": {
             "_metadata": {
@@ -79,6 +83,15 @@ def _blog_post_row():
             }
         },
         "llm_model": "fake-llm",
+        "seo_title": "Acme Pricing Pressure 2026",
+        "seo_description": "Acme pricing pressure from recent review data.",
+        "target_keyword": "acme pricing pressure",
+        "secondary_keywords": ["acme pricing"],
+        "faq": [
+            {"question": "Why is Acme pricing a concern?", "answer": "Pricing appears in reviews."},
+            {"question": "Who should compare alternatives?", "answer": "Teams under budget pressure."},
+            {"question": "What should buyers check?", "answer": "Renewal and support terms."},
+        ],
     }
 
 
@@ -202,6 +215,8 @@ def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     assert body["rows"][0]["status"] == "draft"
     assert body["rows"][0]["slug"] == "acme-pricing-pressure"
     assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
+    assert body["rows"][0]["passed_output_checks"] == 6
+    assert body["rows"][0]["seo_aeo_readiness"]["status"] == "ready"
     query, args = pool.fetch_calls[0]
     assert "FROM blog_posts" in query
     assert args == ("acct_1", "draft", "vendor_alternative", 5)


### PR DESCRIPTION
## Summary
- add deterministic blog SEO/AEO readiness checks to generated-asset export rows
- expose `output_checks`, `passed_output_checks`, and `seo_aeo_readiness` for blog drafts and CSV exports
- cover ready, incomplete, answer-first, and generated-asset API behavior

## Plan
- `plans/PR-Blog-SEO-AEO-Readiness-Summary.md`

## Verification
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1527 passed, 1 existing torch/pynvml warning
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- `bash scripts/local_pr_review.sh` -> passed