### PR TITLE
Add blog SEO/AEO quality gate

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -484,6 +484,12 @@ def _quality_context(
         "source_quotes": _source_quote_tuple(blueprint.get("quotable_phrases")),
         "required_vendors": _string_tuple(blueprint.get("required_vendors")),
         "grounded_vendors": frozenset(_string_tuple(blueprint.get("grounded_vendors"))),
+        "require_seo_aeo": True,
+        "seo_title": parsed.get("seo_title"),
+        "seo_description": parsed.get("seo_description"),
+        "target_keyword": parsed.get("target_keyword"),
+        "secondary_keywords": parsed.get("secondary_keywords"),
+        "faq": parsed.get("faq"),
     }
 
 

--- a/extracted_quality_gate/blog_pack.py
+++ b/extracted_quality_gate/blog_pack.py
@@ -42,6 +42,11 @@ Recognised ``input.context`` keys:
   - ``grounded_vendors``: set[str] -- vendor names supported by chart
     data; sentences naming an ungrounded vendor become an
     ``unsupported_data_claim`` warning.
+  - ``require_seo_aeo``: bool -- when true, validate blog SEO metadata,
+    FAQ output, and simple answer-engine-friendly section structure.
+  - ``seo_title`` / ``seo_description`` / ``target_keyword``:
+    generated SEO fields.
+  - ``secondary_keywords`` / ``faq``: generated SEO/AEO list fields.
 
 Recognised ``policy.thresholds`` keys (all optional, all have defaults):
   - ``min_words``: int (default 1500)
@@ -49,6 +54,9 @@ Recognised ``policy.thresholds`` keys (all optional, all have defaults):
   - ``pass_score``: int (default 70)
   - ``blocking_penalty``: int (default 18) -- score deducted per blocker
   - ``warning_penalty``: int (default 6) -- score deducted per warning
+  - ``seo_title_max_chars``: int (default 60)
+  - ``seo_description_max_chars``: int (default 155)
+  - ``min_faq_entries``: int (default 3)
 """
 
 from __future__ import annotations
@@ -70,6 +78,11 @@ _PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
 _BLOCKQUOTE_RE = re.compile(r"^\s*>\s*(.+)$")
 _CHART_REF_RE = re.compile(r"\{\{chart:([a-zA-Z0-9\-_]+)\}\}")
 _INTERNAL_LINK_RE = re.compile(r"/blog/([a-z0-9\-]+)")
+_QUESTION_H2_RE = re.compile(
+    r"^##\s+(?:who|what|when|where|why|how|is|are|can|should|does|do|which)\b.*\?",
+    re.IGNORECASE | re.MULTILINE,
+)
+_H2_RE = re.compile(r"^##\s+.+$", re.MULTILINE)
 
 # Markers that turn an otherwise-neutral sentence into a "data claim".
 # A sentence containing one of these is subject to vendor-grounding
@@ -170,6 +183,9 @@ _DEFAULT_THRESHOLDS: Mapping[str, int] = {
     "pass_score": 70,
     "blocking_penalty": 18,
     "warning_penalty": 6,
+    "seo_title_max_chars": 60,
+    "seo_description_max_chars": 155,
+    "min_faq_entries": 3,
 }
 
 
@@ -522,6 +538,9 @@ def evaluate_blog_post(
                     )
                 )
 
+    if context.get("require_seo_aeo"):
+        findings.extend(_seo_aeo_findings(body, context, policy=policy))
+
     return _build_report(
         findings=findings,
         word_count=word_count,
@@ -530,6 +549,124 @@ def evaluate_blog_post(
         quote_count=len(blockquotes),
         policy=policy,
     )
+
+
+def _seo_aeo_findings(
+    body: str,
+    context: Mapping[str, Any],
+    *,
+    policy: QualityPolicy | None,
+) -> list[GateFinding]:
+    findings: list[GateFinding] = []
+    seo_title = _clean_text(context.get("seo_title"))
+    seo_description = _clean_text(context.get("seo_description"))
+    target_keyword = _clean_text(context.get("target_keyword"))
+    secondary_keywords = _sequence_items(context.get("secondary_keywords"))
+    faq = _sequence_items(context.get("faq"))
+    seo_title_max = _threshold(policy, "seo_title_max_chars")
+    seo_description_max = _threshold(policy, "seo_description_max_chars")
+    min_faq_entries = _threshold(policy, "min_faq_entries")
+
+    if not seo_title:
+        findings.append(_seo_blocker("missing_seo_title", field_name="seo_title"))
+    elif len(seo_title) > seo_title_max:
+        findings.append(
+            _seo_blocker(
+                "seo_title_too_long",
+                message=f"seo_title_too_long:{len(seo_title)}_chars_max_{seo_title_max}",
+                field_name="seo_title",
+                metadata={"length": len(seo_title), "max_chars": seo_title_max},
+            )
+        )
+
+    if not seo_description:
+        findings.append(
+            _seo_blocker("missing_seo_description", field_name="seo_description")
+        )
+    elif len(seo_description) > seo_description_max:
+        findings.append(
+            _seo_blocker(
+                "seo_description_too_long",
+                message=(
+                    f"seo_description_too_long:{len(seo_description)}_chars_max_"
+                    f"{seo_description_max}"
+                ),
+                field_name="seo_description",
+                metadata={"length": len(seo_description), "max_chars": seo_description_max},
+            )
+        )
+
+    if not target_keyword:
+        findings.append(
+            _seo_blocker("missing_target_keyword", field_name="target_keyword")
+        )
+    if not secondary_keywords:
+        findings.append(
+            _seo_blocker(
+                "missing_secondary_keywords",
+                field_name="secondary_keywords",
+            )
+        )
+    if len(faq) < min_faq_entries:
+        findings.append(
+            _seo_blocker(
+                "too_few_faq_entries",
+                message=f"too_few_faq_entries:{len(faq)}_need_{min_faq_entries}",
+                field_name="faq",
+                metadata={"count": len(faq), "min_count": min_faq_entries},
+            )
+        )
+    if not _aeo_structure_detected(body):
+        findings.append(_seo_blocker("aeo_structure_missing", field_name="content"))
+    return findings
+
+
+def _seo_blocker(
+    code: str,
+    *,
+    message: str | None = None,
+    field_name: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> GateFinding:
+    return GateFinding(
+        code=code,
+        message=message or code,
+        severity=GateSeverity.BLOCKER,
+        field_name=field_name,
+        metadata=dict(metadata or {}),
+    )
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _sequence_items(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(item for item in value if item)
+    return ()
+
+
+def _aeo_structure_detected(body: str) -> bool:
+    if _QUESTION_H2_RE.search(body):
+        return True
+    for match in _H2_RE.finditer(body):
+        section_start = match.end()
+        next_heading = _H2_RE.search(body, section_start)
+        section = body[section_start:next_heading.start() if next_heading else None]
+        first_paragraph = _first_paragraph(section)
+        word_count = len(first_paragraph.split())
+        if 40 <= word_count <= 80:
+            return True
+    return False
+
+
+def _first_paragraph(section: str) -> str:
+    for chunk in re.split(r"\n\s*\n", section.strip()):
+        text = re.sub(r"^[>\-\*\s]+", "", chunk.strip())
+        if text and not text.startswith("{{chart:") and not text.startswith("<table"):
+            return text
+    return ""
 
 
 def _find_unsupported_claims(

--- a/plans/PR-Blog-SEO-AEO-Quality-Gate.md
+++ b/plans/PR-Blog-SEO-AEO-Quality-Gate.md
@@ -1,0 +1,83 @@
+# PR-Blog-SEO-AEO-Quality-Gate
+
+## Why this slice exists
+
+PR-Blog-SEO-AEO-Readiness-Summary made generated blog rows show whether the
+basic SEO/AEO contract is present after generation. That is useful for review,
+but it still allows an incomplete blog draft to be saved first.
+
+This slice moves the same contract into the blog quality gate for the extracted
+AI Content Ops blog generator. The goal is narrow: generated blog drafts should
+not save when the SEO/AEO fields that support the product claim are missing or
+obviously out of bounds.
+
+## Scope (this PR)
+
+1. Add opt-in SEO/AEO findings to `extracted_quality_gate.blog_pack`.
+2. Pass parsed blog SEO/AEO fields from `BlogPostGenerationService` into the
+   quality context.
+3. Add tests proving missing SEO/AEO fields block generated blog saves.
+4. Add quality-pack unit tests for the new SEO/AEO findings.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-SEO-AEO-Quality-Gate.md` | Plan doc for this slice. |
+| `extracted_quality_gate/blog_pack.py` | Add opt-in SEO/AEO validators. |
+| `extracted_content_pipeline/blog_generation.py` | Opt blog generation into the SEO/AEO gate. |
+| `tests/test_extracted_quality_gate_blog_pack.py` | Cover SEO/AEO quality findings. |
+| `tests/test_extracted_blog_generation.py` | Prove incomplete SEO/AEO drafts do not save. |
+
+## Mechanism
+
+The quality pack stays pure and reusable. It only runs the new SEO/AEO checks
+when the caller sets `require_seo_aeo` in the quality context. The extracted
+blog generator sets that flag and passes the parsed SEO metadata into the
+context before save.
+
+The gate validates:
+
+- SEO title is present and within the configured title character limit.
+- SEO description is present and within the configured description character
+  limit.
+- Target keyword is present.
+- At least one secondary keyword is present.
+- The FAQ list meets the configured minimum count.
+- The body has a simple answer-engine-friendly structure: either a
+  question-style H2 or an answer-first H2 section opening.
+
+## Intentional
+
+- No GEO validator. GEO remains undefined as a separate product contract.
+- No prompt changes. This slice enforces the current prompt contract instead of
+  rewriting generation instructions.
+- No frontend work. The prior readiness-summary slice already surfaces the
+  review/export state after save.
+- The SEO/AEO contract is opt-in at the quality-pack layer so other direct
+  quality-pack consumers are not forced to pass metadata unless they choose to.
+
+## Deferred
+
+- Add a first-class GEO definition if the product wants to claim GEO separately.
+- Share the readiness helper between export and quality-gate code if the
+  heuristic grows beyond this small contract.
+- Add repair-loop instructions that specifically mention missing SEO/AEO
+  fields if parse retry expands to quality-repair retry.
+
+## Verification
+
+- Focused blog generation and blog quality-pack tests -> 61 passed.
+- Python compile check over edited modules/tests -> passed.
+- Diff whitespace check -> passed.
+- Full extracted pipeline checks -> 1530 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Quality gate | ~140 |
+| Blog generator context | ~15 |
+| Tests | ~160 |
+| **Total** | **~390** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -100,6 +100,26 @@ def _blueprint():
 
 def _valid_content() -> str:
     body = " ".join([
+        "## How is HubSpot pricing pressure changing buyer shortlists?\n\n"
+        "HubSpot",
+        "pricing",
+        "pressure",
+        "is",
+        "changing",
+        "buyer",
+        "shortlists",
+        "because",
+        "teams",
+        "are",
+        "checking",
+        "renewal",
+        "costs",
+        "before",
+        "they",
+        "commit",
+        "to",
+        "another",
+        "contract.",
         "Teams",
         "describe",
         "pricing",
@@ -138,6 +158,20 @@ def _valid_blog_json(**overrides):
         "seo_description": "A data-backed look at HubSpot pricing pressure.",
         "target_keyword": "hubspot pricing pressure",
         "secondary_keywords": ["hubspot alternatives", "crm renewal pricing"],
+        "faq": [
+            {
+                "question": "Why is HubSpot pricing pressure changing shortlists?",
+                "answer": "Teams are comparing renewal costs earlier.",
+            },
+            {
+                "question": "Who should review alternatives?",
+                "answer": "Teams facing budget pressure should compare options.",
+            },
+            {
+                "question": "What should buyers check?",
+                "answer": "Buyers should check renewal terms and support needs.",
+            },
+        ],
         "topic_type": "vendor_alternative",
         "content": _valid_content(),
         "charts": [{"chart_id": "pricing", "title": "Pricing"}],
@@ -283,6 +317,42 @@ async def test_generate_blocks_low_quality_posts_without_saving() -> None:
     assert result.generated == 0
     assert result.skipped == 1
     assert result.errors[0]["reason"] == "quality_blocked"
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_missing_seo_aeo_fields_without_saving() -> None:
+    payload = json.loads(_valid_blog_json())
+    for key in (
+        "seo_title",
+        "seo_description",
+        "target_keyword",
+        "secondary_keywords",
+        "faq",
+    ):
+        payload.pop(key)
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        responses=[json.dumps(payload)],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert set(result.errors[0]["blockers"]) == {
+        "missing_seo_title",
+        "missing_seo_description",
+        "missing_target_keyword",
+        "missing_secondary_keywords",
+        "too_few_faq_entries:0_need_3",
+    }
     assert blog_posts.saved == []
 
 

--- a/tests/test_extracted_quality_gate_blog_pack.py
+++ b/tests/test_extracted_quality_gate_blog_pack.py
@@ -48,6 +48,23 @@ _LONG_GOOD_BODY = (
 )
 
 
+def _seo_aeo_context(**overrides) -> dict:
+    context = {
+        "require_seo_aeo": True,
+        "seo_title": "HubSpot Pricing Pressure",
+        "seo_description": "A data-backed look at HubSpot pricing pressure.",
+        "target_keyword": "hubspot pricing pressure",
+        "secondary_keywords": ("hubspot alternatives",),
+        "faq": (
+            {"question": "Why does pricing pressure matter?", "answer": "It affects renewal decisions."},
+            {"question": "Who should compare alternatives?", "answer": "Teams facing higher renewal costs."},
+            {"question": "What should buyers review?", "answer": "Contract terms and support needs."},
+        ),
+    }
+    context.update(overrides)
+    return context
+
+
 # ---- Decision shape ----
 
 
@@ -110,6 +127,79 @@ def test_custom_min_words_via_policy():
     codes = {f.code for f in report.findings}
     assert "content_too_short" not in codes
     assert "content_below_seo_target" not in codes
+
+
+# ---- SEO/AEO metadata contract ----
+
+
+def test_seo_aeo_context_passes_with_metadata_and_question_h2():
+    body = "## How does HubSpot pricing pressure affect renewals?\n\n" + _LONG_GOOD_BODY
+
+    report = evaluate_blog_post(_make_input(body, **_seo_aeo_context()))
+
+    assert report.passed is True
+    assert report.decision == GateDecision.PASS
+
+
+def test_seo_aeo_context_blocks_missing_metadata():
+    body = "## How does HubSpot pricing pressure affect renewals?\n\n" + _LONG_GOOD_BODY
+
+    report = evaluate_blog_post(
+        _make_input(
+            body,
+            **_seo_aeo_context(
+                seo_title="",
+                seo_description="",
+                target_keyword="",
+                secondary_keywords=(),
+                faq=(),
+            ),
+        )
+    )
+
+    assert report.passed is False
+    assert set(report.metadata["blocking_codes"]) == {
+        "missing_seo_title",
+        "missing_seo_description",
+        "missing_target_keyword",
+        "missing_secondary_keywords",
+        "too_few_faq_entries",
+    }
+
+
+def test_seo_aeo_context_blocks_long_metadata_and_missing_structure():
+    report = evaluate_blog_post(
+        _make_input(
+            _LONG_GOOD_BODY,
+            **_seo_aeo_context(
+                seo_title="x" * 61,
+                seo_description="x" * 156,
+            ),
+        )
+    )
+
+    assert report.passed is False
+    assert set(report.metadata["blocking_codes"]) == {
+        "seo_title_too_long",
+        "seo_description_too_long",
+        "aeo_structure_missing",
+    }
+
+
+def test_seo_aeo_detects_answer_first_section_opening():
+    body = (
+        "## HubSpot Pricing Pressure\n\n"
+        "HubSpot pricing pressure is showing up earlier in renewal planning because "
+        "teams want to understand cost, implementation effort, support coverage, "
+        "and migration risk before they sign another contract. The opening section "
+        "answers the topic directly before adding supporting examples, which makes "
+        "the article easier for readers and answer engines to parse.\n\n"
+        + _LONG_GOOD_BODY
+    )
+
+    report = evaluate_blog_post(_make_input(body, **_seo_aeo_context()))
+
+    assert "aeo_structure_missing" not in report.metadata["blocking_codes"]
 
 
 # ---- Chart placeholders ----


### PR DESCRIPTION
## Summary
- add opt-in SEO/AEO validators to the pure blog quality pack
- have the extracted blog generator pass parsed SEO/AEO fields into the save-time quality gate
- block incomplete SEO/AEO blog drafts before `save_drafts` and cover the behavior with focused tests

## Plan
- `plans/PR-Blog-SEO-AEO-Quality-Gate.md`

## Verification
- `pytest tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py` -> 61 passed
- `python -m py_compile extracted_quality_gate/blog_pack.py extracted_content_pipeline/blog_generation.py tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1530 passed, 1 existing torch/pynvml warning
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- `bash scripts/local_pr_review.sh` -> passed