### PR TITLE
Define blog GEO readiness contract

### DIFF
--- a/docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md
+++ b/docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md
@@ -1,0 +1,195 @@
+# AI Content Ops Blog GEO Contract
+
+**Date:** 2026-05-20
+**Scope:** AI Content Ops blog drafts and published blog pages.
+
+## Short Definition
+
+For Atlas, GEO means **Generative Engine Optimization**: structuring a blog post
+so AI answer engines can understand the topic, extract a useful answer, identify
+the entities involved, and cite or summarize the page without needing hidden
+context.
+
+GEO is not a ranking guarantee. It does not mean ChatGPT, Perplexity, Claude,
+Copilot, or Google AI Overviews will show the page. It means the generated draft
+and the published page meet the conditions we can control.
+
+## Product Claim
+
+Safe claim after draft-level implementation:
+
+> Generates GEO-ready blog drafts with clear entities, answer-first sections,
+> concrete evidence, FAQ coverage, and safe citation structure.
+
+Safe claim after draft-level and publish-level implementation:
+
+> Publishes GEO-ready blog pages with clear entities, answer-first sections,
+> concrete evidence, FAQ schema, BlogPosting schema, canonical URLs, and
+> crawler-visible article content.
+
+Avoid:
+
+> Guarantees placement in ChatGPT, Perplexity, Claude, Copilot, or Google AI
+> Overviews.
+
+Avoid until both draft and publish checks exist:
+
+> Fully optimized for SEO, AEO, and GEO.
+
+## Relationship To SEO And AEO
+
+SEO helps search engines index and understand the page. The current Atlas SEO
+contract covers metadata, keywords, links, canonical URLs, schema, and public
+rendering.
+
+AEO helps a page answer specific questions cleanly. The current Atlas AEO
+contract covers question-style sections, direct answers, FAQ output, and
+answer-first structure.
+
+GEO builds on both, but adds a stricter requirement: an AI answer engine should
+be able to lift one section from the page and still know:
+
+- what question is being answered
+- which entity or product the answer is about
+- what evidence supports the answer
+- how current the evidence is
+- whether the answer is safe to cite without the rest of the article
+
+## Readiness Levels
+
+### GEO Draft Ready
+
+A blog draft is GEO draft ready when the generated content itself is fit for AI
+answer extraction.
+
+This is the level that belongs in the extracted content pipeline quality gate
+and generated-asset review/export rows.
+
+Minimum checks:
+
+1. `entity_clarity`
+   - The title or opening section names the primary entity, product, vendor, or
+     category.
+   - H2 sections avoid vague headings like "Overview", "Conclusion",
+     "Key Takeaways", or "Final Thoughts" unless the heading also names the
+     entity or question.
+
+2. `answer_first_sections`
+   - At least one H2 is written as a question, or at least one H2 section opens
+     with a direct 40-80 word answer.
+   - The opening paragraph after a qualifying H2 can stand alone without
+     requiring the previous section.
+
+3. `citable_section_structure`
+   - At least two H2 sections are self-contained.
+   - A self-contained section names the topic/entity and gives a complete answer
+     inside the first paragraph.
+
+4. `evidence_specificity`
+   - The article includes concrete evidence such as review counts, percentages,
+     time windows, source names, customer wording, or quoted source material.
+   - Evidence must be visible in the article body, not only hidden in metadata.
+
+5. `freshness_context`
+   - The article states a time window, publication date, review period, or other
+     recency cue when making data-backed claims.
+
+6. `faq_coverage`
+   - The draft includes at least three FAQ entries.
+   - FAQ questions use natural customer/search language rather than internal
+     shorthand.
+
+7. `citation_safety`
+   - The quality gate does not find unsupported data claims, fake internal links,
+     unresolved placeholders, or placeholder `href="#"` links.
+   - If the article uses source quotes, they appear in the body and are not
+     only referenced in metadata.
+
+Draft-ready output shape:
+
+```json
+{
+  "geo_readiness": {
+    "status": "ready",
+    "passed": 7,
+    "total": 7,
+    "missing": [],
+    "checks": {
+      "entity_clarity": true,
+      "answer_first_sections": true,
+      "citable_section_structure": true,
+      "evidence_specificity": true,
+      "freshness_context": true,
+      "faq_coverage": true,
+      "citation_safety": true
+    }
+  }
+}
+```
+
+### GEO Publish Ready
+
+A blog page is GEO publish ready when the public URL exposes the draft in a way
+AI crawlers and search engines can inspect.
+
+This level belongs in frontend/public-route verification, not just in the
+generation pipeline.
+
+Minimum checks:
+
+1. `crawler_visible_html`
+   - The article body is present in the returned HTML or reliably rendered for
+     crawlers through the current frontend strategy.
+
+2. `canonical_url`
+   - The page has a canonical URL.
+
+3. `blogposting_schema`
+   - The page outputs `BlogPosting` JSON-LD with headline, description,
+     published date, modified date when available, author or organization, and
+     URL.
+
+4. `faq_schema`
+   - When FAQ entries exist, the page outputs `FAQPage` JSON-LD.
+
+5. `breadcrumb_schema`
+   - The page outputs `BreadcrumbList` JSON-LD or equivalent breadcrumb
+     structure.
+
+6. `open_graph_image`
+   - The page has a usable `og:image`, either per-post or a good default.
+
+7. `indexable_response`
+   - The page returns a successful indexable response and is not blocked by
+     robots metadata for the target deployment.
+
+## Implementation Guidance
+
+Do not make `geo_readiness` a single opaque score. Use named checks so operators
+can see what failed and fix the draft.
+
+Recommended order:
+
+1. Add `geo_readiness` to blog generated-asset rows and CSV export.
+2. Add content-level GEO checks to the extracted blog quality gate.
+3. Add public-route verification for GEO publish readiness.
+4. Only then update customer-facing copy from "answer-engine-friendly" to
+   "GEO-ready".
+
+## Customer-Facing Language
+
+Before implementation:
+
+> Blog drafts include SEO metadata, FAQ answers, and answer-engine-friendly
+> article structure.
+
+After draft-level checks:
+
+> Blog drafts are checked for GEO readiness: clear entities, answer-first
+> sections, concrete evidence, FAQ coverage, and safe citation structure.
+
+After draft and publish checks:
+
+> Blog posts are generated and published with SEO, AEO, and GEO readiness checks
+> for metadata, answer extraction, structured data, and crawler-visible article
+> pages.

--- a/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
+++ b/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
@@ -7,7 +7,12 @@
 
 Atlas partially generates SEO and AEO-ready blog drafts today.
 
-It does not have a clean, explicit GEO contract yet, and at least one AI Content Ops persistence path does not appear to write the generated SEO fields into the public `blog_posts` columns that the public API and frontend read.
+It now has a first-pass GEO contract in
+`docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md`, but the contract
+is not fully implemented as a validator yet. At the time of the original audit,
+at least one AI Content Ops persistence path did not appear to write the
+generated SEO fields into the public `blog_posts` columns that the public API
+and frontend read.
 
 The safest current claim is:
 
@@ -93,15 +98,22 @@ This path also has fallback logic for missing SEO title, SEO description, and ta
 
 ### Gap 1: GEO Is Not a First-Class Contract
 
-The prompts mention AI answer engines and include AEO patterns that overlap with GEO, but there is no separate GEO field, checklist, score, or pass/fail gate.
+Status: definition added, implementation still pending.
 
-That means the system can produce GEO-friendly content, but the repo does not currently prove or enforce "GEO optimized" as a distinct output.
+The prompts mention AI answer engines and include AEO patterns that overlap with GEO. A first-class product definition now exists in:
+
+- `docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md`
+
+That contract defines GEO as Generative Engine Optimization: structuring a blog post so AI answer engines can understand the topic, extract a useful answer, identify the entities involved, and cite or summarize the page without needing hidden context.
+
+The system can produce GEO-friendly content, but the repo does not yet fully
+prove or enforce "GEO-ready" as a distinct output.
 
 Needed:
 
-- decide whether GEO is a separate contract or part of AEO
-- define a GEO checklist if it is separate
-- add validation or review output that says what passed
+- add `geo_readiness` to generated-asset review/export output
+- add draft-level GEO checks to the blog quality gate
+- add publish-level checks for crawler-visible HTML and structured data
 
 ### Gap 2: AI Content Ops Blog Persistence May Bury SEO Fields
 
@@ -187,7 +199,7 @@ The repo does not yet fully support this stronger claim:
 
 1. Which blog path powers the AI Content Ops Station experience we want to sell: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` or `extracted_content_pipeline/blog_generation.py`?
 2. When a customer generates a blog post from the Station, does the draft get published through the DB/API path or exported to static frontend `.ts` content?
-3. Should GEO be a separate checklist, or should we treat GEO as part of AEO for now?
+3. Which GEO checks should block draft save versus only show in review output?
 4. What should the report show the customer: raw generated article, SEO fields, AEO checklist, GEO checklist, or all of those?
 5. What proof do we need before saying the output is SEO/GEO/AEO-ready?
 
@@ -196,9 +208,9 @@ The repo does not yet fully support this stronger claim:
 Before changing copy or selling this as SEO/GEO/AEO generation, tighten the product contract:
 
 1. Add first-class SEO fields to the extracted AI Content Ops `BlogPostDraft` persistence path, or map `metadata` into the existing public SEO columns.
-2. Add a small SEO/AEO/GEO readiness summary to blog draft export/review output.
+2. Add a small GEO readiness summary to blog draft export/review output.
 3. Add tests proving that a generated blog draft persists `seo_title`, `seo_description`, `target_keyword`, `secondary_keywords`, and `faq` into the fields read by the public API.
-4. Decide whether GEO gets its own named validator now or remains described as AEO/answer-engine readiness.
+4. Add publish-level GEO checks before claiming fully SEO/GEO/AEO-ready pages.
 
 ## Suggested Customer-Facing Language For Now
 

--- a/plans/PR-Blog-GEO-Contract-Definition.md
+++ b/plans/PR-Blog-GEO-Contract-Definition.md
@@ -1,0 +1,64 @@
+# PR-Blog-GEO-Contract-Definition
+
+## Why this slice exists
+
+The blog SEO/AEO work now preserves SEO fields, surfaces readiness output, and
+blocks incomplete SEO/AEO drafts before save. GEO is still undefined, which
+means we cannot safely claim "GEO-ready" or build a validator without making up
+the rules inside code.
+
+This slice defines GEO as a product and engineering contract first.
+
+## Scope (this PR)
+
+1. Add a first-class GEO contract doc for AI Content Ops blog posts.
+2. Separate draft readiness from publish readiness.
+3. Define the minimum checks required before Atlas can claim GEO readiness.
+4. Cross-link the contract from the discovery audit that identified the gap.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Contract-Definition.md` | Plan doc for this slice. |
+| `docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md` | First-class GEO definition. |
+| `docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md` | Link the new contract and update the status of Gap 1. |
+
+## Mechanism
+
+The contract doc defines:
+
+- What GEO means for Atlas.
+- What GEO does not promise.
+- The difference between GEO draft readiness and GEO publish readiness.
+- The exact checklist a validator should implement.
+- The customer-facing language that is safe before and after implementation.
+
+## Intentional
+
+- No code changes in this slice. A validator needs a stable written contract
+  before it becomes a gate.
+- No claim that GEO guarantees ChatGPT, Perplexity, or AI Overview placement.
+- No replacement of SEO or AEO. GEO builds on them, but it adds evidence,
+  citation, entity, and publish-surface requirements.
+
+## Deferred
+
+- Implement `geo_readiness` output on generated blog asset rows.
+- Add a save-time GEO gate after deciding which checks belong in generation
+  versus public rendering.
+- Add publish-surface verification for canonical, JSON-LD, FAQ schema, and
+  crawler-visible article HTML.
+
+## Verification
+
+- Diff whitespace check -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| GEO contract doc | ~195 |
+| Discovery audit update | ~30 |
+| **Total** | **~290** |


### PR DESCRIPTION
## Summary
- define GEO for AI Content Ops blog posts as a product and engineering contract
- separate GEO draft readiness from GEO publish readiness
- update the SEO/AEO/GEO discovery audit so Gap 1 points at the new contract and tracks implementation as pending

## Plan
- `plans/PR-Blog-GEO-Contract-Definition.md`

## Verification
- `git diff --check` -> passed
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- `bash scripts/local_pr_review.sh` -> passed