### PR TITLE
Render richer support-ticket FAQ articles

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T16:40Z by codex-2026-05-20
+Last updated: 2026-05-20T16:49Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Ops-FAQ-Article-Renderer | `plans/PR-Content-Ops-FAQ-Article-Renderer.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown rendering, FAQ article shape, and FAQ Markdown tests. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -179,11 +179,12 @@ python scripts/build_extracted_ticket_faq_markdown.py \
 ```
 
 The FAQ builder is deterministic and extractive: it groups ticket evidence by
-pain point, quotes compact snippets from the source rows, and lists ticket
-source ids under each answer. The packaged support-ticket CSV is intentionally
-small but repeated: it proves customer-worded headings, intent condensation,
-and action items. Add `--as-of-date YYYY-MM-DD` with `--window-days` when you
-need a reproducible audit window instead of today's date. Pass
+pain point, writes article-style answers with numbered next steps, and cites
+ticket quotes under each answer. The packaged support-ticket CSV is
+intentionally small but repeated: it proves customer-worded headings, intent
+condensation, action items, and source grounding. Add `--as-of-date
+YYYY-MM-DD` with `--window-days` when you need a reproducible audit window
+instead of today's date. Pass
 `--require-output-checks` in host smoke runs when weak FAQ output should fail
 the command instead of producing a reviewable draft.
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -63,11 +63,12 @@ source of truth for what remains.
 - `ticket_faq_markdown` builds deterministic FAQ Markdown from support-ticket,
   case, conversation, and complaint source-row evidence. The CLI
   `scripts/build_extracted_ticket_faq_markdown.py` writes or prints a grounded
-  `.md` artifact for fast operator review, and `--require-output-checks`
-  fails the command when customer vocabulary, condensation, or action-item
-  checks do not pass. The same builder is also available as `faq_markdown` in
-  the AI Content Ops control-surface execution path and can persist drafts
-  through `PostgresTicketFAQRepository` when DB services are enabled.
+  `.md` article with numbered next steps, escalation guidance, and cited ticket
+  quotes. `--require-output-checks` fails the command when customer
+  vocabulary, condensation, or action-item checks do not pass. The same builder
+  is also available as `faq_markdown` in the AI Content Ops control-surface
+  execution path and can persist drafts through `PostgresTicketFAQRepository`
+  when DB services are enabled.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -370,12 +370,20 @@ def _item(
     source_ids = tuple(dict.fromkeys(value for value in source_keys if value))
     snippets = " / ".join(_quote(row.get("text", "")) for row in display_rows)
     question, question_source = _question(topic, display_rows)
+    summary = _summary(topic=topic, rows=display_rows, source_count=len(source_ids))
+    steps = _article_steps(topic, snippets)
+    escalation = _escalation_guidance(topic, snippets)
+    evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     return {
         "topic": topic,
         "question": question,
         "question_source": question_source,
         "answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s).",
         "action_items": _action_items(topic, snippets),
+        "summary": summary,
+        "steps": steps,
+        "when_to_contact_support": escalation,
+        "evidence_quotes": evidence_quotes,
         "source_ids": source_ids,
         "source_labels": sources,
         "evidence_count": len(display_rows),
@@ -518,15 +526,19 @@ def _render(
         lines.extend([
             f"## {index}. {_md(item['question'])}",
             "",
-            _md(item["answer"]),
+            _md(item.get("summary") or item["answer"]),
             "",
             "**What to do next:**",
             "",
-            *[f"- {_md(step)}" for step in item["action_items"]],
+            *[f"{step_index}. {_md(step)}" for step_index, step in enumerate(_list(item.get("steps") or item["action_items"]), start=1)],
+            "",
+            "**When to contact support:**",
+            "",
+            _md(item.get("when_to_contact_support") or "Contact support with the cited ticket details if the answer does not resolve it."),
             "",
             "**Sources:**",
             "",
-            *[f"- {_md(label)}" for label in item["source_labels"]],
+            *[f"- {_md(quote)}" for quote in _list(item.get("evidence_quotes"))],
             "",
         ])
     return "\n".join(lines)
@@ -538,6 +550,65 @@ def _source_label(row: Mapping[str, str]) -> str:
     if source_id and title:
         return f"`{source_id}` - {title}"
     return f"`{source_id or 'unknown'}`"
+
+
+def _summary(*, topic: str, rows: Sequence[Mapping[str, str]], source_count: int) -> str:
+    issue = _topic_label(topic)
+    example = _quote(rows[0].get("text", ""), limit=180) if rows else "the cited ticket evidence"
+    if source_count > 1:
+        return (
+            f"Customers are asking about {issue} across {source_count} ticket sources. "
+            f"The clearest customer wording is {example}, so this FAQ should answer "
+            "that request directly and then point users to support when self-service is blocked."
+        )
+    return (
+        f"A customer asked about {issue}: {example}. This FAQ should answer the "
+        "request directly and then point the user to support when self-service is blocked."
+    )
+
+
+def _article_steps(topic: str, evidence_text: str) -> tuple[str, ...]:
+    steps = _action_items(topic, evidence_text)
+    return (
+        steps[0],
+        steps[1],
+        "Include the cited ticket details if you need support to investigate.",
+    )
+
+
+def _escalation_guidance(topic: str, evidence_text: str) -> str:
+    text = f"{topic} {evidence_text}".lower()
+    if any(term in text for term in ("export", "report", "dashboard", "attribution")):
+        return (
+            "Contact support or an admin if the export is missing, locked by plan "
+            "or role, or still unavailable after permissions are checked."
+        )
+    if any(term in text for term in ("login", "email", "profile", "password", "account")):
+        return (
+            "Contact support if you cannot access the account, the email field is "
+            "locked, or the confirmation message never arrives."
+        )
+    return (
+        "Contact support when the self-service path is unavailable or the issue "
+        "still affects the workflow after the steps above."
+    )
+
+
+def _evidence_quote(row: Mapping[str, str]) -> str:
+    label = _source_label(row)
+    text = _quote(row.get("text", ""), limit=220)
+    return f"{label}: {text}"
+
+
+def _topic_label(topic: str) -> str:
+    text = _clean(topic).replace("_", " ")
+    return text or "this support issue"
+
+
+def _list(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(value)
+    return ()
 
 
 def _date_window(*, window_days: int | None, as_of_date: Any) -> tuple[date, date] | None:
@@ -680,7 +751,7 @@ def _quote(value: Any, *, limit: int = 220) -> str:
     text = _compact(value)
     if len(text) > limit:
         text = f"{text[:limit].rstrip()}..."
-    return f'"{_md(text)}"'
+    return f'"{text}"'
 
 
 def _compact(value: Any) -> str:

--- a/plans/PR-Content-Ops-FAQ-Article-Renderer.md
+++ b/plans/PR-Content-Ops-FAQ-Article-Renderer.md
@@ -1,0 +1,79 @@
+Plan: PR-Content-Ops-FAQ-Article-Renderer
+
+## Why this slice exists
+
+PR #667 proved the FAQ output checks, but the generated Markdown still reads
+like a thin evidence summary. A sellable FAQ article should give a user a clear
+answer and concrete next steps while staying grounded in the source tickets.
+
+This slice upgrades the deterministic FAQ renderer at the source: richer
+article sections, numbered steps, support escalation guidance, and cited ticket
+evidence. It does not add an LLM or invent product-specific UI instructions.
+
+## Scope (this PR)
+
+1. Extend FAQ item payloads with summary, steps, escalation guidance, and
+   evidence quote fields.
+2. Render those fields as richer Markdown sections.
+3. Update tests for the richer Markdown shape and grounding.
+4. Update docs/status to describe the article-style output.
+5. Claim the slice in the coordination ledger.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Article-Renderer.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+The existing grouping/ranking/dedup logic stays intact. `_item(...)` will add
+derived article fields from the already-selected evidence rows:
+
+- `summary`: concise answer grounded in ticket volume and snippets.
+- `steps`: numbered next steps using the existing action-rule policy.
+- `when_to_contact_support`: generic escalation guidance.
+- `evidence_quotes`: compact ticket quotes with source ids/titles.
+
+`_render(...)` then emits those fields as Markdown. The old `answer` and
+`action_items` keys remain populated for compatibility.
+
+## Intentional
+
+- No provider call. The FAQ remains deterministic, fast, and auditable.
+- No product-specific click paths are invented. Steps stay generic unless
+  source text/action rules support the category.
+- Existing public function signatures stay unchanged.
+
+## Deferred
+
+- LLM-assisted FAQ rewriting remains separate from this deterministic renderer.
+- Help-center publishing UI remains separate from the Markdown generation path.
+- Real customer help desk exports remain the trigger for more source-specific
+  answer policies.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py - 42 passed
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed
+- python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --require-output-checks --output /tmp/support_ticket_faq_article.md - passed
+- git diff --check - passed
+- bash scripts/run_extracted_pipeline_checks.sh - 1530 passed, 1 existing torch/pynvml warning
+- bash scripts/local_pr_review.sh - passed
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Article-Renderer.md` | +65 |
+| `docs/extraction/coordination/inflight.md` | +2 / -1 |
+| `extracted_content_pipeline/README.md` | +5 / -2 |
+| `extracted_content_pipeline/STATUS.md` | +5 / -2 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | +65 / -10 |
+| `tests/test_extracted_ticket_faq_markdown.py` | +45 / -15 |
+| **Total** | **217** |
+
+This is below the 400 LOC review budget.

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -35,6 +35,7 @@ class _RenderedFAQHTML(HTMLParser):
         self.list_items: list[str] = []
         self.strong: list[str] = []
         self.ul_count = 0
+        self.ol_count = 0
         self._stack: list[str] = []
         self._buffers: dict[str, list[str]] = {}
 
@@ -43,6 +44,8 @@ class _RenderedFAQHTML(HTMLParser):
         self._stack.append(tag)
         if tag == "ul":
             self.ul_count += 1
+        if tag == "ol":
+            self.ol_count += 1
         if tag in {"h1", "h2", "p", "li", "strong"}:
             self._buffers[tag] = []
 
@@ -120,6 +123,19 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "reporting friction",
     ]
     assert [item["ticket_count"] for item in result.items] == [2, 2]
+    assert result.items[0]["summary"].startswith(
+        "Customers are asking about email and profile updates across 2 ticket sources."
+    )
+    assert result.items[0]["steps"] == (
+        "Confirm the account details you are trying to change or access.",
+        "If self-service does not work, contact support with the affected email or account id.",
+        "Include the cited ticket details if you need support to investigate.",
+    )
+    assert "email field is locked" in result.items[0]["when_to_contact_support"]
+    assert result.items[0]["evidence_quotes"] == (
+        '`ticket-acme-1` - Change login email: "How do I change my login email?"',
+        '`ticket-acme-2` - Update account email: "I need to update the email on my account."',
+    )
     assert "How do I change my login email?" in result.markdown
     assert "How do we export campaign attribution data before renewal?" in result.markdown
     assert "`ticket-acme-1` - Change login email" in result.markdown
@@ -439,6 +455,25 @@ def test_build_ticket_faq_markdown_normalizes_intent_whitespace() -> None:
     assert [item["topic"] for item in result.items] == ["email and profile updates"]
 
 
+def test_build_ticket_faq_markdown_escapes_pipe_once_in_article_sections() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Export format",
+                "evidence": [{
+                    "text": "How do I export the A | B report?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }
+        ]
+    )
+
+    assert "A \\| B report" in result.markdown
+    assert "A \\\\| B report" not in result.markdown
+
+
 def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows() -> None:
     loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
 
@@ -452,13 +487,16 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
         "2. How do we export campaign attribution data before renewal?",
     ]
     assert rendered.strong.count("What to do next:") == 2
+    assert rendered.strong.count("When to contact support:") == 2
     assert rendered.strong.count("Sources:") == 2
-    assert rendered.ul_count == 4
+    assert rendered.ol_count == 2
+    assert rendered.ul_count == 2
     assert any(
-        "I need to update the email on my account."
+        "Customers are asking about email and profile updates across 2 ticket sources."
         in paragraph
         for paragraph in rendered.paragraphs
     )
+    assert any("email field is locked" in paragraph for paragraph in rendered.paragraphs)
     assert any(
         "Check whether your plan and role include the needed export"
         in item
@@ -771,7 +809,7 @@ def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified
     assert result.ticket_source_count == 2
     assert result.items[0]["evidence_count"] == 2
     assert result.items[0]["source_ids"] == ("row:1", "row:2")
-    assert "Evidence comes from 2 ticket source(s)." in result.markdown
+    assert "across 2 ticket sources" in result.markdown
 
 
 def test_build_ticket_faq_markdown_counts_distinct_source_ids_per_item() -> None:
@@ -787,7 +825,7 @@ def test_build_ticket_faq_markdown_counts_distinct_source_ids_per_item() -> None
     assert result.items[0]["evidence_count"] == 2
     assert result.items[0]["source_ids"] == ("ticket-1",)
     assert result.ticket_source_count == 1
-    assert "Evidence comes from 1 ticket source(s)." in result.markdown
+    assert "A customer asked about reporting friction" in result.markdown
 
 
 def test_build_ticket_faq_markdown_counts_distinct_ticket_sources_for_output_checks() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Article-Renderer.md

Upgrade deterministic support-ticket FAQ Markdown from a thin evidence summary into article-style output with grounded summaries, numbered next steps, escalation guidance, and cited ticket quotes.

## Intentional
- No provider call. FAQ output remains deterministic, fast, and auditable.
- No product-specific click paths are invented. Steps stay generic unless source text/action rules support the category.
- Existing public function signatures stay unchanged.

## Deferred
- LLM-assisted FAQ rewriting remains separate from this deterministic renderer.
- Help-center publishing UI remains separate from the Markdown generation path.
- Real customer help desk exports remain the trigger for more source-specific answer policies.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py: 41 passed
- py_compile: passed
- FAQ CLI --require-output-checks command: passed
- git diff --check: passed
- bash scripts/run_extracted_pipeline_checks.sh: 1530 passed, 1 existing torch/pynvml warning
- bash scripts/local_pr_review.sh: passed

## Diff size
6 files, +190 / -18