### PR TITLE
Add blog GEO readiness summary

### DIFF
--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -34,6 +34,7 @@ _EXPORT_COLUMNS = (
     "passed_output_checks",
     "output_checks",
     "seo_aeo_readiness",
+    "geo_readiness",
     "tags",
     "content",
     "charts",
@@ -111,6 +112,7 @@ def _draft_row(draft: BlogPostDraft) -> JsonDict:
     row["output_checks"] = readiness["checks"]
     row["passed_output_checks"] = readiness["passed"]
     row["seo_aeo_readiness"] = readiness
+    row["geo_readiness"] = _geo_readiness(draft)
     return row
 
 
@@ -134,6 +136,23 @@ _QUESTION_H2_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _H2_RE = re.compile(r"^##\s+.+$", re.MULTILINE)
+_UNRESOLVED_TOKEN_RE = re.compile(r"\{\{([^{}]+)\}\}")
+_BLOCKQUOTE_RE = re.compile(r"^\s*>\s*(.+)$", re.MULTILINE)
+_FRESHNESS_RE = re.compile(
+    r"\b(?:20\d{2}|Q[1-4]\s+20\d{2}|last\s+\d+\s+(?:days?|weeks?|months?|years?)|"
+    r"past\s+\d+\s+(?:days?|weeks?|months?|years?))\b",
+    re.IGNORECASE,
+)
+_EVIDENCE_RE = re.compile(
+    r"\b(?:\d+[\d,]*(?:\.\d+)?%?|\d+\s+(?:reviews?|tickets?|responses?|"
+    r"customers?|users?|accounts?)|review(?:s| data| patterns)?|ticket(?:s| data)?|"
+    r"customer wording|source(?:s)?|survey(?:s)?)\b",
+    re.IGNORECASE,
+)
+_VAGUE_H2_RE = re.compile(
+    r"^##\s+(?:overview|introduction|conclusion|key takeaways|final thoughts|summary)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 def _seo_aeo_readiness(draft: BlogPostDraft) -> JsonDict:
@@ -148,6 +167,31 @@ def _seo_aeo_readiness(draft: BlogPostDraft) -> JsonDict:
         "secondary_keywords_present": len(_metadata_list(metadata.get("secondary_keywords"))) >= 1,
         "faq_ready": len(_metadata_list(metadata.get("faq"))) >= 3,
         "aeo_structure_detected": _aeo_structure_detected(draft.content),
+    }
+    missing = [key for key, value in checks.items() if not value]
+    passed = sum(1 for value in checks.values() if value)
+    return {
+        "status": "ready" if not missing else "needs_review",
+        "passed": passed,
+        "total": len(checks),
+        "missing": missing,
+        "checks": checks,
+    }
+
+
+def _geo_readiness(draft: BlogPostDraft) -> JsonDict:
+    metadata = _metadata_mapping(draft.metadata)
+    data_context = _metadata_mapping(draft.data_context)
+    body = str(draft.content or "")
+    topic_terms = _topic_terms(draft, metadata=metadata, data_context=data_context)
+    checks = {
+        "entity_clarity": _entity_clarity(draft, body, topic_terms=topic_terms),
+        "answer_first_sections": _aeo_structure_detected(body),
+        "citable_section_structure": _citable_section_structure(body, topic_terms=topic_terms),
+        "evidence_specificity": _evidence_specificity(body),
+        "freshness_context": _freshness_context(body, data_context),
+        "faq_coverage": len(_metadata_list(metadata.get("faq"))) >= 3,
+        "citation_safety": _citation_safety(body),
     }
     missing = [key for key, value in checks.items() if not value]
     passed = sum(1 for value in checks.values() if value)
@@ -196,6 +240,110 @@ def _aeo_structure_detected(content: Any) -> bool:
         if 40 <= word_count <= 80:
             return True
     return False
+
+
+def _topic_terms(
+    draft: BlogPostDraft,
+    *,
+    metadata: Mapping[str, Any],
+    data_context: Mapping[str, Any],
+) -> tuple[str, ...]:
+    candidates = (
+        data_context.get("vendor"),
+        data_context.get("vendor_name"),
+        data_context.get("product"),
+        data_context.get("product_name"),
+        data_context.get("category"),
+        data_context.get("topic"),
+        metadata.get("target_keyword"),
+        draft.title,
+    )
+    terms: list[str] = []
+    for candidate in candidates:
+        text = _clean_text(candidate)
+        if len(text) >= 3 and text.lower() not in {item.lower() for item in terms}:
+            terms.append(text)
+    return tuple(terms)
+
+
+def _entity_clarity(
+    draft: BlogPostDraft,
+    body: str,
+    *,
+    topic_terms: tuple[str, ...],
+) -> bool:
+    if _VAGUE_H2_RE.search(body):
+        return False
+    searchable = f"{draft.title}\n{body[:600]}".lower()
+    if not topic_terms:
+        return bool(_clean_text(draft.title))
+    return any(term.lower() in searchable for term in topic_terms)
+
+
+def _citable_section_structure(body: str, *, topic_terms: tuple[str, ...]) -> bool:
+    sections = _h2_sections(body)
+    if len(sections) < 2:
+        return False
+    return sum(
+        1
+        for heading, section in sections
+        if _self_contained_section(heading, section, topic_terms=topic_terms)
+    ) >= 2
+
+
+def _h2_sections(body: str) -> list[tuple[str, str]]:
+    matches = list(_H2_RE.finditer(body))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        next_start = matches[index + 1].start() if index + 1 < len(matches) else None
+        heading = match.group(0).removeprefix("##").strip()
+        sections.append((heading, body[match.end():next_start]))
+    return sections
+
+
+def _self_contained_section(
+    heading: str,
+    section: str,
+    *,
+    topic_terms: tuple[str, ...],
+) -> bool:
+    first_paragraph = _first_paragraph(section)
+    word_count = len(first_paragraph.split())
+    if not 40 <= word_count <= 120:
+        return False
+    if not topic_terms:
+        return True
+    searchable = f"{heading} {first_paragraph}".lower()
+    return any(term.lower() in searchable for term in topic_terms)
+
+
+def _evidence_specificity(body: str) -> bool:
+    if _BLOCKQUOTE_RE.search(body):
+        return True
+    return bool(_EVIDENCE_RE.search(body))
+
+
+def _freshness_context(body: str, data_context: Mapping[str, Any]) -> bool:
+    for key in ("review_period", "source_report_date", "published_at", "date"):
+        if _clean_text(data_context.get(key)):
+            return True
+    return bool(_FRESHNESS_RE.search(body))
+
+
+def _citation_safety(body: str) -> bool:
+    if 'href="#"' in body or "href='#'" in body:
+        return False
+    unresolved_tokens = [
+        token.strip()
+        for token in _UNRESOLVED_TOKEN_RE.findall(body)
+        if not token.strip().startswith("chart:")
+    ]
+    if unresolved_tokens:
+        return False
+    lower_body = body.lower()
+    if "lorem ipsum" in lower_body or "/blog/placeholder" in lower_body:
+        return False
+    return True
 
 
 def _first_paragraph(section: str) -> str:

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -153,6 +153,66 @@ _VAGUE_H2_RE = re.compile(
     r"^##\s+(?:overview|introduction|conclusion|key takeaways|final thoughts|summary)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+_VISIBLE_ENTITY_RE = re.compile(
+    r"\b(?:[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*|[A-Z][a-z0-9]{2,}|[A-Z]{2,})\b"
+)
+_GENERIC_ENTITY_WORDS = frozenset(
+    {
+        "account",
+        "accounts",
+        "analysis",
+        "answer",
+        "article",
+        "blog",
+        "buyer",
+        "buyers",
+        "category",
+        "company",
+        "comparison",
+        "content",
+        "contract",
+        "customer",
+        "customers",
+        "data",
+        "draft",
+        "evidence",
+        "faq",
+        "feature",
+        "features",
+        "final",
+        "geo",
+        "guide",
+        "help",
+        "how",
+        "overview",
+        "pricing",
+        "product",
+        "question",
+        "questions",
+        "report",
+        "retention",
+        "review",
+        "reviews",
+        "risk",
+        "section",
+        "source",
+        "support",
+        "team",
+        "teams",
+        "the",
+        "thoughts",
+        "ticket",
+        "tickets",
+        "user",
+        "users",
+        "what",
+        "when",
+        "where",
+        "which",
+        "while",
+        "why",
+    }
+)
 
 
 def _seo_aeo_readiness(draft: BlogPostDraft) -> JsonDict:
@@ -275,8 +335,25 @@ def _entity_clarity(
         return False
     searchable = f"{draft.title}\n{body[:600]}".lower()
     if not topic_terms:
-        return False
+        return _visible_entity_present(draft.title, body[:600])
     return any(term.lower() in searchable for term in topic_terms)
+
+
+def _visible_entity_present(title: str, opening: str) -> bool:
+    title_entities = _visible_entity_tokens(title)
+    if title_entities:
+        return True
+    opening_entities = _visible_entity_tokens(opening)
+    return any(opening_entities.count(entity) >= 2 for entity in set(opening_entities))
+
+
+def _visible_entity_tokens(value: str) -> list[str]:
+    entities: list[str] = []
+    for match in _VISIBLE_ENTITY_RE.finditer(value):
+        token = match.group(0).strip()
+        if token.lower() not in _GENERIC_ENTITY_WORDS:
+            entities.append(token.lower())
+    return entities
 
 
 def _citable_section_structure(body: str, *, topic_terms: tuple[str, ...]) -> bool:

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -256,7 +256,6 @@ def _topic_terms(
         data_context.get("category"),
         data_context.get("topic"),
         metadata.get("target_keyword"),
-        draft.title,
     )
     terms: list[str] = []
     for candidate in candidates:
@@ -276,7 +275,7 @@ def _entity_clarity(
         return False
     searchable = f"{draft.title}\n{body[:600]}".lower()
     if not topic_terms:
-        return bool(_clean_text(draft.title))
+        return False
     return any(term.lower() in searchable for term in topic_terms)
 
 

--- a/plans/PR-Blog-GEO-Readiness-Summary.md
+++ b/plans/PR-Blog-GEO-Readiness-Summary.md
@@ -1,0 +1,80 @@
+# PR-Blog-GEO-Readiness-Summary
+
+## Why this slice exists
+
+PR-Blog-GEO-Contract-Definition defined GEO draft readiness, but generated blog
+review/export rows still only show SEO/AEO readiness. Operators need to see
+which generated drafts satisfy the new GEO contract before we decide which GEO
+checks should block saves.
+
+This slice adds read-only GEO readiness output to blog generated-asset rows and
+CSV exports.
+
+## Scope (this PR)
+
+1. Add deterministic `geo_readiness` checks to blog draft export rows.
+2. Add `geo_readiness` to blog CSV export columns.
+3. Keep existing `output_checks` / `passed_output_checks` wired to SEO/AEO so
+   no generic generated-asset UI behavior changes in this slice.
+4. Add focused tests for ready and incomplete GEO readiness output.
+5. Add generated-asset API coverage proving blog rows expose `geo_readiness`.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Readiness-Summary.md` | Plan doc for this slice. |
+| `extracted_content_pipeline/blog_post_export.py` | Add blog GEO readiness summary fields. |
+| `tests/test_extracted_blog_post_export.py` | Cover ready/incomplete GEO readiness and CSV columns. |
+| `tests/test_extracted_content_asset_api.py` | Prove generated-asset API rows expose GEO readiness. |
+
+## Mechanism
+
+The export helper inspects the generated draft content, metadata, and
+data_context to derive the seven draft-level checks from the GEO contract:
+
+- `entity_clarity`
+- `answer_first_sections`
+- `citable_section_structure`
+- `evidence_specificity`
+- `freshness_context`
+- `faq_coverage`
+- `citation_safety`
+
+The row exposes a `geo_readiness` object with the same shape as the existing
+`seo_aeo_readiness`: status, passed, total, missing, and checks.
+
+## Intentional
+
+- No save-time GEO gate. This slice adds visibility before blocking behavior.
+- No publish-level GEO checks. Those belong to frontend/public-route
+  verification, not blog draft export.
+- No product copy changes.
+- No prompt changes.
+- `output_checks` remains SEO/AEO-only until the UI has a clear contract for
+  showing multiple readiness groups.
+
+## Deferred
+
+- Decide which GEO checks should block draft save.
+- Add save-time GEO gate after review output is proven useful.
+- Add publish-level GEO verification for crawler-visible HTML, canonical URLs,
+  BlogPosting schema, FAQ schema, breadcrumbs, OG images, and indexability.
+- Consider sharing GEO helper logic with the blog quality gate once the
+  review-only contract stabilizes.
+
+## Verification
+
+- Focused blog export and generated-asset API tests -> 8 passed.
+- Python compile check over edited modules/tests -> passed.
+- Diff whitespace check -> passed.
+- Full extracted pipeline checks -> 1531 passed, 1 existing torch/pynvml warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Blog export helper | ~150 |
+| Tests | ~75 |
+| **Total** | **~305** |

--- a/plans/PR-Blog-GEO-Readiness-Summary.md
+++ b/plans/PR-Blog-GEO-Readiness-Summary.md
@@ -65,7 +65,7 @@ The row exposes a `geo_readiness` object with the same shape as the existing
 
 ## Verification
 
-- Focused blog export and generated-asset API tests -> 8 passed.
+- Focused blog export and generated-asset API tests -> 10 passed.
 - Python compile check over edited modules/tests -> passed.
 - Diff whitespace check -> passed.
 - Full extracted pipeline checks -> 1531 passed, 1 existing torch/pynvml warning.
@@ -75,6 +75,6 @@ The row exposes a `geo_readiness` object with the same shape as the existing
 | Area | Estimated LOC |
 |---|---:|
 | Plan | ~80 |
-| Blog export helper | ~150 |
-| Tests | ~75 |
-| **Total** | **~305** |
+| Blog export helper | ~260 |
+| Tests | ~100 |
+| **Total** | **~440** |

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -289,6 +289,29 @@ async def test_export_blog_post_drafts_does_not_treat_generic_title_as_entity() 
 
 
 @pytest.mark.asyncio
+async def test_export_blog_post_drafts_uses_visible_entity_without_metadata() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[
+            _draft(
+                title="Acme Pricing Pressure Guide",
+                content=(
+                    "## How should teams read Acme pricing pressure?\n\n"
+                    "Acme pricing pressure is visible in recent review patterns "
+                    "when buyers describe renewal friction, budget concerns, and "
+                    "comparison shopping. This visible draft text names the entity "
+                    "directly even when metadata has not been populated yet."
+                ),
+                data_context={},
+                metadata={},
+            )
+        ]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    assert result.rows[0]["geo_readiness"]["checks"]["entity_clarity"] is True
+
+
+@pytest.mark.asyncio
 async def test_export_blog_post_drafts_detects_answer_first_sections() -> None:
     content = (
         "## Acme Pricing Pattern\n\n"

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -47,14 +47,21 @@ def _draft(**overrides) -> BlogPostDraft:
         tags=("pricing", "retention"),
         content=(
             "## Why is Acme pricing pressure showing up?\n\n"
-            "Acme pricing pressure is visible in recent review patterns, "
-            "especially when buyers describe renewal friction, budget concerns, "
-            "and comparison shopping. This section starts with a direct answer "
-            "so reviewers can quickly understand the point before reading the "
-            "supporting detail."
+            "Acme pricing pressure is visible in the last 90 days of review "
+            "patterns, especially across 214 reviews where buyers describe "
+            "renewal friction, budget concerns, and comparison shopping. The "
+            "answer is that Acme buyers are not only comparing features; they "
+            "are checking whether the contract still fits the budget before "
+            "another renewal cycle starts.\n\n"
+            "## How should teams read the Acme pricing evidence?\n\n"
+            "Acme pricing evidence should be read as a renewal-risk signal, not "
+            "as proof that every buyer has the same problem. The useful pattern "
+            "is that customers keep using similar wording about budget pressure, "
+            "contract terms, and alternative comparisons when they explain why "
+            "pricing has become harder to justify."
         ),
         charts=({"id": "chart-1"},),
-        data_context={"vendor": "Acme"},
+        data_context={"vendor": "Acme", "review_period": "last 90 days"},
         metadata={
             "seo_title": "Acme Pricing Pressure 2026",
             "seo_description": "Acme pricing pressure from recent review data.",
@@ -159,6 +166,21 @@ async def test_export_blog_post_drafts_derives_review_summary_fields() -> None:
         "missing": [],
         "checks": row["output_checks"],
     }
+    assert row["geo_readiness"] == {
+        "status": "ready",
+        "passed": 7,
+        "total": 7,
+        "missing": [],
+        "checks": {
+            "entity_clarity": True,
+            "answer_first_sections": True,
+            "citable_section_structure": True,
+            "evidence_specificity": True,
+            "freshness_context": True,
+            "faq_coverage": True,
+            "citation_safety": True,
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -186,6 +208,8 @@ async def test_export_blog_post_drafts_defaults_summary_fields_without_metadata(
         "faq_ready",
         "aeo_structure_detected",
     ]
+    assert row["geo_readiness"]["status"] == "needs_review"
+    assert row["geo_readiness"]["checks"]["citation_safety"] is True
 
 
 def test_blog_post_export_result_renders_csv() -> None:
@@ -206,9 +230,37 @@ def test_blog_post_export_result_renders_csv() -> None:
     csv_text = result.as_csv()
 
     assert csv_text.startswith("slug,title,description,topic_type")
-    assert "passed_output_checks,output_checks,seo_aeo_readiness" in csv_text
+    assert "passed_output_checks,output_checks,seo_aeo_readiness,geo_readiness" in csv_text
     assert "acme-pricing-pressure" in csv_text
     assert "{\"\"generation_parse_attempts\"\":2}" in csv_text
+
+
+@pytest.mark.asyncio
+async def test_export_blog_post_drafts_surfaces_incomplete_geo_readiness() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[
+            _draft(
+                title="",
+                content="## Overview\n\nNo clear answer yet. {{todo}}",
+                data_context={},
+                metadata={},
+            )
+        ]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    readiness = result.rows[0]["geo_readiness"]
+    assert readiness["status"] == "needs_review"
+    assert readiness["passed"] == 0
+    assert readiness["missing"] == [
+        "entity_clarity",
+        "answer_first_sections",
+        "citable_section_structure",
+        "evidence_specificity",
+        "freshness_context",
+        "faq_coverage",
+        "citation_safety",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -264,6 +264,31 @@ async def test_export_blog_post_drafts_surfaces_incomplete_geo_readiness() -> No
 
 
 @pytest.mark.asyncio
+async def test_export_blog_post_drafts_does_not_treat_generic_title_as_entity() -> None:
+    result = await export_blog_post_drafts(
+        _Repository(drafts=[
+            _draft(
+                title="Customer Retention Guide",
+                content=(
+                    "## How should teams reduce retention risk?\n\n"
+                    "Teams should reduce retention risk by reading recent support "
+                    "patterns, identifying repeated confusion, and turning repeated "
+                    "questions into clear help-center answers. The useful answer is "
+                    "not hidden in a generic title; it needs a real entity, product, "
+                    "vendor, or category signal before this can count as GEO entity "
+                    "clarity for review."
+                ),
+                data_context={},
+                metadata={},
+            )
+        ]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    assert result.rows[0]["geo_readiness"]["checks"]["entity_clarity"] is False
+
+
+@pytest.mark.asyncio
 async def test_export_blog_post_drafts_detects_answer_first_sections() -> None:
     content = (
         "## Acme Pricing Pattern\n\n"

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -72,11 +72,23 @@ def _blog_post_row():
         "tags": ["pricing"],
         "content": (
             "## Why is Acme pricing pressure showing up?\n\n"
-            "Acme pricing pressure is visible in recent review patterns when "
-            "buyers describe renewal friction and budget concerns."
+            "Acme pricing pressure is visible in the last 90 days of review "
+            "patterns, especially across 214 reviews where buyers describe "
+            "renewal friction, budget concerns, and comparison shopping. The "
+            "answer is that Acme buyers are not only comparing features; they "
+            "are checking whether the contract still fits the budget before "
+            "another renewal cycle starts.\n\n"
+            "## How should teams read the Acme pricing evidence?\n\n"
+            "Acme pricing evidence should be read as a renewal-risk signal, not "
+            "as proof that every buyer has the same problem. The useful pattern "
+            "is that customers keep using similar wording about budget pressure, "
+            "contract terms, and alternative comparisons when they explain why "
+            "pricing has become harder to justify."
         ),
         "charts": [],
         "data_context": {
+            "vendor": "Acme",
+            "review_period": "last 90 days",
             "_metadata": {
                 "generation_usage": {"input_tokens": 9, "output_tokens": 4},
                 "reasoning_context": {"wedge": "price_squeeze", "confidence": "high"},
@@ -217,6 +229,8 @@ def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     assert body["rows"][0]["reasoning_wedge"] == "price_squeeze"
     assert body["rows"][0]["passed_output_checks"] == 6
     assert body["rows"][0]["seo_aeo_readiness"]["status"] == "ready"
+    assert body["rows"][0]["geo_readiness"]["status"] == "ready"
+    assert body["rows"][0]["geo_readiness"]["passed"] == 7
     query, args = pool.fetch_calls[0]
     assert "FROM blog_posts" in query
     assert args == ("acct_1", "draft", "vendor_alternative", 5)


### PR DESCRIPTION
## Summary
- add draft-level `geo_readiness` to blog generated-asset rows and CSV exports
- implement the seven named GEO draft checks from the contract doc
- keep `output_checks` / `passed_output_checks` scoped to SEO/AEO for now
- cover ready, incomplete, CSV, and generated-asset API behavior

## Plan
- `plans/PR-Blog-GEO-Readiness-Summary.md`

## Verification
- `pytest tests/test_extracted_blog_post_export.py tests/test_extracted_content_asset_api.py::test_generated_asset_router_lists_blog_post_drafts_with_filters` -> 8 passed
- `python -m py_compile extracted_content_pipeline/blog_post_export.py tests/test_extracted_blog_post_export.py tests/test_extracted_content_asset_api.py` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1531 passed, 1 existing torch/pynvml warning
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- `bash scripts/local_pr_review.sh` -> passed