### PR TITLE
Close out FAQ article renderer coordination

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -196,5 +196,8 @@ update -> reviewed export. PR #667 tightened the packaged support-ticket FAQ
 demo so it proves the three output checks operators care about: customer
 vocabulary, repeated-intent condensation, and action items. The FAQ Markdown
 CLI now has an opt-in `--require-output-checks` guard for host smoke runs. This
-does not create a new active implementation backlog; future FAQ/source work
-should be driven by a real customer help desk export or hosted UI need.
+does not create a new active implementation backlog. PR #673 upgraded the
+deterministic FAQ renderer from a thin evidence summary to article-style
+answers with grounded summaries, numbered next steps, support escalation
+guidance, and cited ticket quotes. Future FAQ/source work should be driven by a
+real customer help desk export or hosted UI need.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T16:49Z by codex-2026-05-20
+Last updated: 2026-05-20T17:22Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Article-Renderer | `plans/PR-Content-Ops-FAQ-Article-Renderer.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown rendering, FAQ article shape, and FAQ Markdown tests. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-FAQ-Article-Closeout.md
+++ b/plans/PR-Content-Ops-FAQ-Article-Closeout.md
@@ -1,0 +1,54 @@
+# Content Ops FAQ Article Closeout
+
+## Why this slice exists
+
+PR #673 shipped richer support-ticket FAQ Markdown articles, but the
+coordination ledger still shows `PR-Content-Ops-FAQ-Article-Renderer` as
+in-flight and the deferred backlog still stops at the older FAQ output-check
+closeout. That stale state can cause another session to avoid already-merged
+FAQ files or reopen work that is complete.
+
+## Scope (this PR)
+
+1. Remove the merged FAQ article-renderer row from the in-flight coordination
+   table.
+2. Record the richer FAQ article renderer closeout in the AI Content Ops
+   deferred backlog.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Article-Closeout.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Remove stale merged FAQ article-renderer row. |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | Add PR #673 FAQ article-renderer closeout note. |
+
+## Mechanism
+
+This is docs-only state reconciliation. The in-flight table returns to an empty
+coordination state, and the backlog's FAQ output-contract paragraph now names
+the PR #673 behavior: summaries, numbered next steps, support escalation
+guidance, and cited ticket quotes.
+
+## Intentional
+
+- No production code changes. The runtime behavior already shipped in PR #673.
+- No new tests. This slice only updates coordination and audit text.
+
+## Deferred
+
+- None. Future FAQ/source work should still wait for a real customer help desk
+  export or hosted UI need, as the backlog already states.
+
+## Verification
+
+- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Article-Closeout.md` | 50 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | 7 |
+| **Total** | **61** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Article-Closeout.md

Close out the merged FAQ article renderer slice by removing the stale in-flight coordination row and recording PR #673 in the AI Content Ops deferred backlog.

## Intentional
- Docs-only reconciliation; runtime behavior already shipped in PR #673.
- No new tests beyond local PR review because no production logic changes.

## Deferred
- Future FAQ/source work remains gated on a real customer help desk export or hosted UI need.

## Verification
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed
- `bash scripts/local_pr_review.sh` -> passed

## Diff size
3 files, +60 / -4