### PR TITLE
Add blog GEO quality gate

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -485,6 +485,8 @@ def _quality_context(
         "required_vendors": _string_tuple(blueprint.get("required_vendors")),
         "grounded_vendors": frozenset(_string_tuple(blueprint.get("grounded_vendors"))),
         "require_seo_aeo": True,
+        "require_geo": True,
+        "title": parsed.get("title"),
         "seo_title": parsed.get("seo_title"),
         "seo_description": parsed.get("seo_description"),
         "target_keyword": parsed.get("target_keyword"),

--- a/extracted_quality_gate/blog_pack.py
+++ b/extracted_quality_gate/blog_pack.py
@@ -44,9 +44,12 @@ Recognised ``input.context`` keys:
     ``unsupported_data_claim`` warning.
   - ``require_seo_aeo``: bool -- when true, validate blog SEO metadata,
     FAQ output, and simple answer-engine-friendly section structure.
+  - ``require_geo``: bool -- when true, validate draft-level GEO readiness
+    for generated blog posts.
   - ``seo_title`` / ``seo_description`` / ``target_keyword``:
     generated SEO fields.
   - ``secondary_keywords`` / ``faq``: generated SEO/AEO list fields.
+  - ``title``: str -- generated title for visible GEO entity checks.
 
 Recognised ``policy.thresholds`` keys (all optional, all have defaults):
   - ``min_words``: int (default 1500)
@@ -83,6 +86,46 @@ _QUESTION_H2_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _H2_RE = re.compile(r"^##\s+.+$", re.MULTILINE)
+_FRESHNESS_RE = re.compile(
+    r"\b(?:20\d{2}|Q[1-4]\s+20\d{2}|last\s+\d+\s+(?:days?|weeks?|months?|years?)|"
+    r"past\s+\d+\s+(?:days?|weeks?|months?|years?))\b",
+    re.IGNORECASE,
+)
+_EVIDENCE_RE = re.compile(
+    r"\b(?:\d+[\d,]*(?:\.\d+)?%?|\d+\s+(?:reviews?|tickets?|responses?|"
+    r"customers?|users?|accounts?)|review(?:s| data| patterns)?|ticket(?:s| data)?|"
+    r"customer wording|source(?:s)?|survey(?:s)?)\b",
+    re.IGNORECASE,
+)
+_VAGUE_H2_RE = re.compile(
+    r"^##\s+(?:overview|introduction|conclusion|key takeaways|final thoughts|summary)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_VISIBLE_ENTITY_RE = re.compile(
+    r"\b(?:[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*|[A-Z][a-z0-9]{2,}|[A-Z]{2,})\b"
+)
+_GENERIC_ENTITY_WORDS = frozenset(
+    {
+        "account", "accounts", "analysis", "answer", "article", "blog",
+        "buyer", "buyers", "category", "company", "comparison", "content",
+        "contract", "customer", "customers", "data", "draft", "evidence",
+        "faq", "feature", "features", "final", "geo", "guide", "help",
+        "how", "overview", "pricing", "product", "question", "questions",
+        "report", "retention", "review", "reviews", "risk", "section",
+        "source", "support", "team", "teams", "the", "thoughts", "ticket",
+        "tickets", "user", "users", "what", "when", "where", "which",
+        "while", "why",
+    }
+)
+_GEO_CITATION_SAFETY_CODES = frozenset(
+    {
+        "nonexistent_internal_links",
+        "placeholder_links_href_hash",
+        "unresolved_placeholders",
+        "unsupported_data_claim",
+        "unknown_chart_placeholders",
+    }
+)
 
 # Markers that turn an otherwise-neutral sentence into a "data claim".
 # A sentence containing one of these is subject to vendor-grounding
@@ -540,6 +583,10 @@ def evaluate_blog_post(
 
     if context.get("require_seo_aeo"):
         findings.extend(_seo_aeo_findings(body, context, policy=policy))
+    if context.get("require_geo"):
+        findings.extend(
+            _geo_findings(body, context, policy=policy, existing_findings=findings)
+        )
 
     return _build_report(
         findings=findings,
@@ -548,6 +595,164 @@ def evaluate_blog_post(
         target_words=target_words,
         quote_count=len(blockquotes),
         policy=policy,
+    )
+
+
+def _geo_findings(
+    body: str,
+    context: Mapping[str, Any],
+    *,
+    policy: QualityPolicy | None,
+    existing_findings: Sequence[GateFinding],
+) -> list[GateFinding]:
+    findings: list[GateFinding] = []
+    data_context = _mapping_dict(context.get("data_context"))
+    topic_terms = _geo_topic_terms(context, data_context)
+    title = _clean_text(context.get("title") or context.get("suggested_title"))
+    faq = _sequence_items(context.get("faq"))
+    if not _geo_entity_clarity(title, body, topic_terms=topic_terms):
+        findings.append(_geo_blocker("geo_entity_clarity_missing", field_name="title"))
+    if not _aeo_structure_detected(body):
+        findings.append(_geo_blocker("geo_answer_first_sections_missing", field_name="content"))
+    if not _geo_citable_section_structure(body, topic_terms=topic_terms):
+        findings.append(_geo_blocker("geo_citable_section_structure_missing", field_name="content"))
+    if not _geo_evidence_specificity(body):
+        findings.append(_geo_blocker("geo_evidence_specificity_missing", field_name="content"))
+    if not _geo_freshness_context(body, data_context):
+        findings.append(_geo_blocker("geo_freshness_context_missing", field_name="content"))
+    min_faq_entries = _threshold(policy, "min_faq_entries")
+    if len(faq) < min_faq_entries:
+        findings.append(_geo_blocker("geo_faq_coverage_missing", field_name="faq"))
+    if not _geo_citation_safety(body, existing_findings):
+        findings.append(_geo_blocker("geo_citation_safety_failed", field_name="content"))
+    return findings
+
+
+def _geo_topic_terms(
+    context: Mapping[str, Any],
+    data_context: Mapping[str, Any],
+) -> tuple[str, ...]:
+    candidates = (
+        data_context.get("vendor"),
+        data_context.get("vendor_name"),
+        data_context.get("product"),
+        data_context.get("product_name"),
+        data_context.get("category"),
+        data_context.get("topic"),
+        context.get("target_keyword"),
+    )
+    terms: list[str] = []
+    for candidate in candidates:
+        text = _clean_text(candidate)
+        if len(text) >= 3 and text.lower() not in {item.lower() for item in terms}:
+            terms.append(text)
+    return tuple(terms)
+
+
+def _geo_entity_clarity(
+    title: str,
+    body: str,
+    *,
+    topic_terms: tuple[str, ...],
+) -> bool:
+    if _VAGUE_H2_RE.search(body):
+        return False
+    searchable = f"{title}\n{body[:600]}".lower()
+    if topic_terms:
+        return any(term.lower() in searchable for term in topic_terms)
+    return _visible_entity_present(title, body[:600])
+
+
+def _visible_entity_present(title: str, opening: str) -> bool:
+    title_entities = _visible_entity_tokens(title)
+    if title_entities:
+        return True
+    opening_entities = _visible_entity_tokens(opening)
+    return any(opening_entities.count(entity) >= 2 for entity in set(opening_entities))
+
+
+def _visible_entity_tokens(value: str) -> list[str]:
+    entities: list[str] = []
+    for match in _VISIBLE_ENTITY_RE.finditer(value):
+        token = match.group(0).strip()
+        if token.lower() not in _GENERIC_ENTITY_WORDS:
+            entities.append(token.lower())
+    return entities
+
+
+def _geo_citable_section_structure(
+    body: str,
+    *,
+    topic_terms: tuple[str, ...],
+) -> bool:
+    sections = _h2_sections(body)
+    if len(sections) < 2:
+        return False
+    return sum(
+        1
+        for heading, section in sections
+        if _geo_self_contained_section(heading, section, topic_terms=topic_terms)
+    ) >= 2
+
+
+def _h2_sections(body: str) -> list[tuple[str, str]]:
+    matches = list(_H2_RE.finditer(body))
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        next_start = matches[index + 1].start() if index + 1 < len(matches) else None
+        heading = match.group(0).removeprefix("##").strip()
+        sections.append((heading, body[match.end():next_start]))
+    return sections
+
+
+def _geo_self_contained_section(
+    heading: str,
+    section: str,
+    *,
+    topic_terms: tuple[str, ...],
+) -> bool:
+    first_paragraph = _first_paragraph(section)
+    word_count = len(first_paragraph.split())
+    if not 40 <= word_count <= 120:
+        return False
+    if topic_terms:
+        searchable = f"{heading} {first_paragraph}".lower()
+        if any(term.lower() in searchable for term in topic_terms):
+            return True
+    return _visible_entity_present(heading, first_paragraph)
+
+
+def _geo_evidence_specificity(body: str) -> bool:
+    if _extract_blockquotes(body):
+        return True
+    return bool(_EVIDENCE_RE.search(body))
+
+
+def _geo_freshness_context(body: str, data_context: Mapping[str, Any]) -> bool:
+    for key in ("review_period", "source_report_date", "published_at", "date"):
+        if _clean_text(data_context.get(key)):
+            return True
+    return bool(_FRESHNESS_RE.search(body))
+
+
+def _geo_citation_safety(
+    body: str,
+    existing_findings: Sequence[GateFinding],
+) -> bool:
+    if any(finding.code in _GEO_CITATION_SAFETY_CODES for finding in existing_findings):
+        return False
+    lower_body = body.lower()
+    if "lorem ipsum" in lower_body or "/blog/placeholder" in lower_body:
+        return False
+    return True
+
+
+def _geo_blocker(code: str, *, field_name: str | None = None) -> GateFinding:
+    return GateFinding(
+        code=code,
+        message=code,
+        severity=GateSeverity.BLOCKER,
+        field_name=field_name,
     )
 
 
@@ -645,6 +850,10 @@ def _sequence_items(value: Any) -> tuple[Any, ...]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return tuple(item for item in value if item)
     return ()
+
+
+def _mapping_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
 
 
 def _aeo_structure_detected(body: str) -> bool:

--- a/plans/PR-Blog-GEO-Quality-Gate.md
+++ b/plans/PR-Blog-GEO-Quality-Gate.md
@@ -1,0 +1,76 @@
+# PR-Blog-GEO-Quality-Gate
+
+## Why this slice exists
+
+PR-Blog-GEO-Readiness-Summary made draft-level GEO readiness visible in
+generated-asset review/export rows. The next step is to stop saving newly
+generated blog drafts that miss the core draft-level GEO contract.
+
+This slice adds an opt-in GEO quality gate for extracted AI Content Ops blog
+generation.
+
+## Scope (this PR)
+
+1. Add opt-in GEO draft validators to `extracted_quality_gate.blog_pack`.
+2. Have `BlogPostGenerationService` opt generated blogs into the GEO gate.
+3. Add quality-pack tests for passing and failing GEO draft checks.
+4. Add generation tests proving GEO-incomplete drafts do not save.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Quality-Gate.md` | Plan doc for this slice. |
+| `extracted_quality_gate/blog_pack.py` | Add opt-in GEO draft blockers. |
+| `extracted_content_pipeline/blog_generation.py` | Pass parsed/generated fields into the GEO gate. |
+| `tests/test_extracted_quality_gate_blog_pack.py` | Cover GEO gate pass/fail behavior. |
+| `tests/test_extracted_blog_generation.py` | Prove generated drafts block on missing GEO structure. |
+
+## Mechanism
+
+The quality pack remains pure and opt-in. Callers set `require_geo` in the
+quality context when they want GEO blockers. The extracted blog generator sets
+that flag because generated blog drafts are now expected to satisfy the draft
+GEO contract before save.
+
+The gate checks:
+
+- `geo_entity_clarity_missing`
+- `geo_answer_first_sections_missing`
+- `geo_citable_section_structure_missing`
+- `geo_evidence_specificity_missing`
+- `geo_freshness_context_missing`
+- `geo_faq_coverage_missing`
+- `geo_citation_safety_failed`
+
+## Intentional
+
+- No publish-level checks. Crawler-visible HTML, canonical URLs, schema, OG
+  images, and indexability belong in a frontend/public-route slice.
+- No prompt changes.
+- No claim that GEO guarantees AI-engine placement.
+- Existing non-GEO direct quality-pack consumers remain unchanged unless they
+  set `require_geo`.
+
+## Deferred
+
+- Add publish-level GEO verification.
+- Add targeted repair-loop retry text for GEO blockers.
+- Share helper logic with the export/readiness module if the contract grows.
+
+## Verification
+
+- Focused quality-pack and blog-generation tests passed.
+- Touched-module Python compile check passed.
+- Whitespace diff check passed.
+- Extracted pipeline check suite passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Quality gate | ~180 |
+| Blog generation context | ~10 |
+| Tests | ~140 |
+| **Total** | **~400** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -99,53 +99,20 @@ def _blueprint():
 
 
 def _valid_content() -> str:
-    body = " ".join([
+    body = (
         "## How is HubSpot pricing pressure changing buyer shortlists?\n\n"
-        "HubSpot",
-        "pricing",
-        "pressure",
-        "is",
-        "changing",
-        "buyer",
-        "shortlists",
-        "because",
-        "teams",
-        "are",
-        "checking",
-        "renewal",
-        "costs",
-        "before",
-        "they",
-        "commit",
-        "to",
-        "another",
-        "contract.",
-        "Teams",
-        "describe",
-        "pricing",
-        "pressure",
-        "during",
-        "renewals",
-        "and",
-        "compare",
-        "alternatives",
-        "against",
-        "implementation",
-        "effort",
-        "support",
-        "needs",
-        "and",
-        "budget",
-        "planning",
-        "cycles",
-        "before",
-        "migration",
-        "decisions",
-        "are",
-        "made",
-        "carefully",
-        "today",
-    ])
+        "HubSpot pricing pressure is visible in the last 90 days of review patterns, "
+        "especially across 214 reviews where buyers describe renewal friction, budget "
+        "concerns, and comparison shopping. The answer is changing buyer shortlists "
+        "because teams are checking renewal costs before they commit to another "
+        "contract.\n\n"
+        "## How should teams read the HubSpot pricing evidence?\n\n"
+        "HubSpot pricing evidence should be read as a renewal-risk signal, not as "
+        "proof that every buyer has the same problem. The useful pattern is that "
+        "customers keep using similar wording about budget pressure, contract terms, "
+        "and alternative comparisons when they explain why pricing has become harder "
+        "to justify."
+    )
     return body + "\n\n{{chart:pricing}}\n"
 
 
@@ -346,12 +313,43 @@ async def test_generate_blocks_missing_seo_aeo_fields_without_saving() -> None:
     assert result.generated == 0
     assert result.skipped == 1
     assert result.errors[0]["reason"] == "quality_blocked"
-    assert set(result.errors[0]["blockers"]) == {
+    assert set(result.errors[0]["blockers"]) >= {
         "missing_seo_title",
         "missing_seo_description",
         "missing_target_keyword",
         "missing_secondary_keywords",
         "too_few_faq_entries:0_need_3",
+    }
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_blocks_missing_geo_contract_without_saving() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["content"] = (
+        "## How is HubSpot pricing pressure changing shortlists?\n\n"
+        "HubSpot pricing pressure changes shortlists because buyers compare "
+        "renewal terms before they commit to another contract."
+    )
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        responses=[json.dumps(payload)],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert set(result.errors[0]["blockers"]) >= {
+        "geo_citable_section_structure_missing",
+        "geo_evidence_specificity_missing",
+        "geo_freshness_context_missing",
     }
     assert blog_posts.saved == []
 

--- a/tests/test_extracted_quality_gate_blog_pack.py
+++ b/tests/test_extracted_quality_gate_blog_pack.py
@@ -65,6 +65,33 @@ def _seo_aeo_context(**overrides) -> dict:
     return context
 
 
+def _geo_context(**overrides) -> dict:
+    context = _seo_aeo_context(
+        require_geo=True,
+        title="HubSpot Pricing Pressure Guide",
+        data_context={"vendor": "HubSpot", "review_period": "last 90 days"},
+    )
+    context.update(overrides)
+    return context
+
+
+_GEO_READY_BODY = (
+    "## How is HubSpot pricing pressure changing buyer shortlists?\n\n"
+    "HubSpot pricing pressure is visible in the last 90 days of review patterns, "
+    "especially across 214 reviews where buyers describe renewal friction, budget "
+    "concerns, and comparison shopping. The answer is that HubSpot buyers are not "
+    "only comparing features; they are checking whether the contract still fits "
+    "the budget before another renewal cycle starts.\n\n"
+    "## How should teams read the HubSpot pricing evidence?\n\n"
+    "HubSpot pricing evidence should be read as a renewal-risk signal, not as proof "
+    "that every buyer has the same problem. The useful pattern is that customers "
+    "keep using similar wording about budget pressure, contract terms, and "
+    "alternative comparisons when they explain why pricing has become harder to "
+    "justify.\n\n"
+    + _LONG_GOOD_BODY
+)
+
+
 # ---- Decision shape ----
 
 
@@ -200,6 +227,75 @@ def test_seo_aeo_detects_answer_first_section_opening():
     report = evaluate_blog_post(_make_input(body, **_seo_aeo_context()))
 
     assert "aeo_structure_missing" not in report.metadata["blocking_codes"]
+
+
+# ---- GEO draft contract ----
+
+
+def test_geo_context_passes_with_ready_draft_structure():
+    report = evaluate_blog_post(_make_input(_GEO_READY_BODY, **_geo_context()))
+
+    assert report.passed is True
+    assert not any(code.startswith("geo_") for code in report.metadata["blocking_codes"])
+
+
+def test_geo_context_blocks_missing_draft_contract_pieces():
+    body = "## Overview\n\nGeneric notes without evidence, freshness, or a usable answer."
+
+    report = evaluate_blog_post(
+        _make_input(
+            body,
+            **_geo_context(
+                title="Customer Retention Guide",
+                data_context={},
+                faq=(),
+            ),
+        )
+    )
+
+    assert set(report.metadata["blocking_codes"]) >= {
+        "geo_entity_clarity_missing",
+        "geo_answer_first_sections_missing",
+        "geo_citable_section_structure_missing",
+        "geo_evidence_specificity_missing",
+        "geo_freshness_context_missing",
+        "geo_faq_coverage_missing",
+    }
+
+
+def test_geo_context_blocks_citation_safety_when_existing_findings_fail():
+    body = _GEO_READY_BODY + "\n\nSee {{todo}} before publishing."
+
+    report = evaluate_blog_post(_make_input(body, **_geo_context()))
+
+    assert "unresolved_placeholders" in report.metadata["blocking_codes"]
+    assert "geo_citation_safety_failed" in report.metadata["blocking_codes"]
+
+
+def test_geo_context_honors_policy_min_faq_entries():
+    report = evaluate_blog_post(
+        _make_input(
+            _GEO_READY_BODY,
+            **_geo_context(
+                faq=(
+                    {
+                        "question": "Why does pricing pressure matter?",
+                        "answer": "It affects renewal decisions.",
+                    },
+                    {
+                        "question": "What should buyers review?",
+                        "answer": "Buyers should check renewal terms.",
+                    },
+                ),
+            ),
+        ),
+        policy=QualityPolicy(
+            name="blog_post",
+            thresholds={"min_faq_entries": 2},
+        ),
+    )
+
+    assert "geo_faq_coverage_missing" not in report.metadata["blocking_codes"]
 
 
 # ---- Chart placeholders ----


### PR DESCRIPTION
## Summary
- add opt-in GEO blockers to the blog quality pack for entity clarity, answer-first sections, citable section structure, evidence, freshness, FAQ coverage, and citation safety
- opt generated blog drafts into the GEO gate before saving
- cover pass/fail GEO behavior in quality-pack and blog-generation tests

## Verification
- pytest tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py
- python -m py_compile extracted_quality_gate/blog_pack.py extracted_content_pipeline/blog_generation.py
- git diff --check
- bash scripts/run_extracted_pipeline_checks.sh
- bash scripts/local_pr_review.sh