### PR TITLE
Make FAQ Markdown action language human and configurable

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,10 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T17:22Z by codex-2026-05-20
+Last updated: 2026-05-20T17:34Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| TBD | PR-Content-Ops-FAQ-Human-Action-Language | `plans/PR-Content-Ops-FAQ-Human-Action-Language.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `extracted_content_pipeline/generation_plan.py`; `extracted_content_pipeline/content_ops_execution.py`; `scripts/build_extracted_ticket_faq_markdown.py`; `extracted_content_pipeline/README.md`; `tests/test_extracted_ticket_faq_markdown.py`; `tests/test_extracted_content_generation_plan.py`; `tests/test_extracted_content_ops_execution.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown action copy, support-contact threading, and FAQ Markdown tests. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -174,6 +174,7 @@ python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
   --window-days 90 \
+  --support-contact "1-800-555-0100" \
   --require-output-checks \
   --output support_ticket_faq.md
 ```
@@ -184,9 +185,10 @@ ticket quotes under each answer. The packaged support-ticket CSV is
 intentionally small but repeated: it proves customer-worded headings, intent
 condensation, action items, and source grounding. Add `--as-of-date
 YYYY-MM-DD` with `--window-days` when you need a reproducible audit window
-instead of today's date. Pass
-`--require-output-checks` in host smoke runs when weak FAQ output should fail
-the command instead of producing a reviewable draft.
+instead of today's date. Pass `--support-contact` when the published FAQ should
+show a support phone number, email, or help URL; the builder never invents one.
+Pass `--require-output-checks` in host smoke runs when weak FAQ output should
+fail the command instead of producing a reviewable draft.
 
 The same artifact can run through the Content Ops execution seam by selecting
 `faq_markdown` and passing inline `source_material`. It remains zero-provider.

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -550,6 +550,7 @@ async def _dispatch_faq_markdown(
         max_text_chars=_step_config_int(step.config, "max_text_chars"),
         window_days=_step_config_int(step.config, "window_days"),
         as_of_date=_step_config_text(step.config, "as_of_date"),
+        support_contact=_step_config_text(step.config, "support_contact"),
     )
 
 

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -229,6 +229,8 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
         ),
         window_days=window_days,
         as_of_date=as_of_date,
+        support_contact=_text_input(request.inputs, "faq_support_contact")
+        or defaults.support_contact,
     )
 
 
@@ -379,6 +381,8 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             step_config["window_days"] = config.window_days
         if config.window_days is not None and config.as_of_date is not None:
             step_config["as_of_date"] = config.as_of_date
+        if config.support_contact:
+            step_config["support_contact"] = config.support_contact
         return GenerationPlanStep(
             output=output,
             runner="TicketFAQMarkdownService.generate",

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -56,16 +56,16 @@ _DATE_KEYS = (
 )
 _ACTION_RULES = (
     (("export", "report", "dashboard", "attribution"), (
-        "Check whether your plan and role include the needed export or reporting access.",
-        "If the option is missing, ask support or an admin to enable access or provide the export.",
+        "Open the reporting or analytics area and choose the date range you need.",
+        "Look for an Export or Download option, then ask an admin to check your role and plan access if it is missing.",
     )),
     (("handoff", "follow-up", "workflow", "automation", "manual"), (
-        "Check the workflow or automation rule that should handle this step.",
-        "If the handoff still needs manual cleanup, document the exact step and escalate it.",
+        "Find the workflow or automation rule that should handle this step.",
+        "Check the last failed handoff, note which step stopped, and send that detail to support if it still needs manual cleanup.",
     )),
     (("login", "email", "profile", "password", "account"), (
-        "Confirm the account details you are trying to change or access.",
-        "If self-service does not work, contact support with the affected email or account id.",
+        "Open your profile, account settings, or login settings and find the email, password, or account field you need to change.",
+        "Save the change, then check the old and new inboxes for a confirmation message.",
     )),
 )
 
@@ -106,6 +106,7 @@ class TicketFAQMarkdownConfig:
     max_text_chars: int = 1200
     window_days: int | None = None
     as_of_date: str | None = None
+    support_contact: str | None = None
     intent_rules: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_INTENT_RULES
 
 
@@ -134,6 +135,7 @@ class TicketFAQMarkdownService:
         max_text_chars: int | None = None,
         window_days: int | None = None,
         as_of_date: Any = None,
+        support_contact: str | None = None,
         intent_rules: Sequence[tuple[str, Sequence[str]]] | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
@@ -155,6 +157,11 @@ class TicketFAQMarkdownService:
             else self.config.window_days
         )
         resolved_as_of_date = as_of_date if as_of_date is not None else self.config.as_of_date
+        resolved_support_contact = (
+            support_contact
+            if support_contact is not None
+            else self.config.support_contact
+        )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be positive")
         normalized = source_rows_to_campaign_opportunities(
@@ -181,6 +188,7 @@ class TicketFAQMarkdownService:
             source_types=resolved_source_types,
             window_days=resolved_window_days,
             as_of_date=resolved_as_of_date,
+            support_contact=resolved_support_contact,
             intent_rules=resolved_intent_rules,
         )
         result = replace(
@@ -203,6 +211,7 @@ class TicketFAQMarkdownService:
                     warnings=result.warnings,
                     metadata={
                         "source_types": list(resolved_source_types),
+                        **_support_contact_metadata(resolved_support_contact),
                         **_date_window_metadata(
                             window_days=resolved_window_days,
                             as_of_date=resolved_as_of_date,
@@ -224,6 +233,7 @@ def build_ticket_faq_markdown(
     source_types: Sequence[str] = DEFAULT_TICKET_SOURCE_TYPES,
     window_days: int | None = None,
     as_of_date: Any = None,
+    support_contact: str | None = None,
     intent_rules: Sequence[tuple[str, Sequence[str]]] = DEFAULT_INTENT_RULES,
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
@@ -275,7 +285,12 @@ def build_ticket_faq_markdown(
             })
 
     items = tuple(
-        _item(topic, rows, max_evidence_per_item=max_evidence_per_item)
+        _item(
+            topic,
+            rows,
+            max_evidence_per_item=max_evidence_per_item,
+            support_contact=support_contact,
+        )
         for topic, rows in sorted(groups.items(), key=lambda item: (-len(item[1]), item[0].lower()))[:max_items]
     )
     return TicketFAQMarkdownResult(
@@ -363,6 +378,7 @@ def _item(
     rows: Sequence[Mapping[str, str]],
     *,
     max_evidence_per_item: int,
+    support_contact: str | None,
 ) -> dict[str, Any]:
     display_rows = rows[:max_evidence_per_item]
     sources = tuple(_source_label(row) for row in display_rows)
@@ -371,8 +387,8 @@ def _item(
     snippets = " / ".join(_quote(row.get("text", "")) for row in display_rows)
     question, question_source = _question(topic, display_rows)
     summary = _summary(topic=topic, rows=display_rows, source_count=len(source_ids))
-    steps = _article_steps(topic, snippets)
-    escalation = _escalation_guidance(topic, snippets)
+    steps = _article_steps(topic, snippets, support_contact=support_contact)
+    escalation = _escalation_guidance(topic, snippets, support_contact=support_contact)
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     return {
         "topic": topic,
@@ -559,39 +575,56 @@ def _summary(*, topic: str, rows: Sequence[Mapping[str, str]], source_count: int
         return (
             f"Customers are asking about {issue} across {source_count} ticket sources. "
             f"The clearest customer wording is {example}, so this FAQ should answer "
-            "that request directly and then point users to support when self-service is blocked."
+            "that request directly and tell users exactly what to try next."
         )
     return (
         f"A customer asked about {issue}: {example}. This FAQ should answer the "
-        "request directly and then point the user to support when self-service is blocked."
+        "request directly and tell the user exactly what to try next."
     )
 
 
-def _article_steps(topic: str, evidence_text: str) -> tuple[str, ...]:
+def _article_steps(topic: str, evidence_text: str, *, support_contact: str | None) -> tuple[str, ...]:
     steps = _action_items(topic, evidence_text)
     return (
         steps[0],
         steps[1],
-        "Include the cited ticket details if you need support to investigate.",
+        _support_step(support_contact),
     )
 
 
-def _escalation_guidance(topic: str, evidence_text: str) -> str:
+def _escalation_guidance(topic: str, evidence_text: str, *, support_contact: str | None) -> str:
     text = f"{topic} {evidence_text}".lower()
     if any(term in text for term in ("export", "report", "dashboard", "attribution")):
         return (
-            "Contact support or an admin if the export is missing, locked by plan "
-            "or role, or still unavailable after permissions are checked."
+            f"{_support_sentence(support_contact)} if the export is missing, "
+            "locked by plan or role, or still unavailable after an admin checks permissions."
         )
     if any(term in text for term in ("login", "email", "profile", "password", "account")):
         return (
-            "Contact support if you cannot access the account, the email field is "
-            "locked, or the confirmation message never arrives."
+            f"{_support_sentence(support_contact)} if you cannot access the account, "
+            "the field is locked, or the confirmation message never arrives."
         )
     return (
-        "Contact support when the self-service path is unavailable or the issue "
-        "still affects the workflow after the steps above."
+        f"{_support_sentence(support_contact)} if the issue still affects the workflow "
+        "after you try the steps above."
     )
+
+
+def _support_step(support_contact: str | None) -> str:
+    contact = _clean(support_contact)
+    if contact:
+        return (
+            f"If it still does not work, contact support at {contact} and include "
+            "the cited ticket details."
+        )
+    return "If it still does not work, contact support and include the cited ticket details."
+
+
+def _support_sentence(support_contact: str | None) -> str:
+    contact = _clean(support_contact)
+    if contact:
+        return f"Contact support at {contact}"
+    return "Contact support"
 
 
 def _evidence_quote(row: Mapping[str, str]) -> str:
@@ -709,14 +742,21 @@ def _date_window_metadata(*, window_days: int | None, as_of_date: Any) -> dict[s
     return metadata
 
 
+def _support_contact_metadata(support_contact: str | None) -> dict[str, str]:
+    contact = _clean(support_contact)
+    if not contact:
+        return {}
+    return {"support_contact": contact}
+
+
 def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:
     text = f"{topic} {evidence_text}".lower()
     for terms, steps in _ACTION_RULES:
         if any(term in text for term in terms):
             return steps
     return (
-        "Check whether this issue affects your current account or workflow.",
-        "Contact support with the cited ticket details if the answer does not resolve it.",
+        "Review the account, page, or workflow named in the ticket.",
+        "Write down what you tried and the exact message or behavior you saw.",
     )
 
 

--- a/plans/PR-Content-Ops-FAQ-Human-Action-Language.md
+++ b/plans/PR-Content-Ops-FAQ-Human-Action-Language.md
@@ -1,0 +1,87 @@
+# Content Ops FAQ Human Action Language
+
+## Why this slice exists
+
+The richer FAQ Markdown renderer shipped article-style answers, but the default
+action copy still used vague phrases such as "self-service" and could only say
+"contact support" without a phone number, email, or help URL. That weakens the
+customer-facing output: the FAQ should lead the user through clear next steps
+and use a real support contact only when the host provides one.
+
+## Scope (this PR)
+
+1. Add optional support contact configuration for FAQ
+   Markdown generation.
+2. Thread the contact through the standalone CLI, generation plan, and Content
+   Ops execution dispatch.
+3. Replace vague action language with concrete, plain-English steps for login,
+   reporting/export, workflow, and fallback issues.
+4. Update focused tests for the builder, CLI, plan, and execution seams.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Human-Action-Language.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this in-flight slice for coordination. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Add support-contact config and human action copy. |
+| `extracted_content_pipeline/generation_plan.py` | Thread FAQ support contact into plan config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Pass support contact to the FAQ service. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Add support contact CLI flag. |
+| `extracted_content_pipeline/README.md` | Document support-contact usage. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Builder/CLI regressions for contact and language. |
+| `tests/test_extracted_content_generation_plan.py` | Plan config coverage. |
+| `tests/test_extracted_content_ops_execution.py` | Execution wiring coverage. |
+
+## Mechanism
+
+The renderer keeps deterministic, extractive grouping. It now accepts an
+optional contact string and passes it through the FAQ item builder, article-step
+builder, and escalation-guidance builder. When the contact is present, the final
+action step names it directly. When absent, the output still says to contact
+support but does not invent a phone number or URL.
+
+The language update removes "self-service" from summaries, next steps, and
+escalation guidance. Instead, each FAQ entry gives concrete steps such as
+checking account settings, looking for export/download controls, checking role
+or plan permissions, and then contacting the configured support channel when
+those steps fail.
+
+## Intentional
+
+- No hard-coded support phone number. Hosts supply the CLI support-contact
+  option or FAQ support-contact input; otherwise the FAQ says "contact support".
+- No LLM generation. The FAQ path stays deterministic and grounded in source
+  rows.
+- No signature-breaking changes. Existing callers keep working because the new
+  argument is optional.
+
+## Deferred
+
+- Platform-specific action templates remain out of scope until a real host
+  export or product guide tells us the exact settings/export paths.
+
+## Verification
+
+- Focused pytest for FAQ Markdown, FAQ plan mapping, and FAQ execution wiring:
+  45 passed.
+- Python compile for touched Python files and tests: passed.
+- Packaged support-ticket FAQ CLI with a support contact and required output
+  checks: passed.
+- Local PR review: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Human-Action-Language.md` | 70 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 90 |
+| `extracted_content_pipeline/generation_plan.py` | 4 |
+| `extracted_content_pipeline/content_ops_execution.py` | 2 |
+| `scripts/build_extracted_ticket_faq_markdown.py` | 8 |
+| `extracted_content_pipeline/README.md` | 8 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 55 |
+| `tests/test_extracted_content_generation_plan.py` | 3 |
+| `tests/test_extracted_content_ops_execution.py` | 2 |
+| **Total** | **246** |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -71,6 +71,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Write FAQ Markdown to this path instead of stdout.",
     )
     parser.add_argument(
+        "--support-contact",
+        help="Phone, email, or URL shown when the FAQ tells users to contact support.",
+    )
+    parser.add_argument(
         "--require-output-checks",
         action="store_true",
         help="Fail when generated FAQ output checks are not all true.",
@@ -109,6 +113,7 @@ def main(argv: list[str] | None = None) -> int:
         max_evidence_per_item=args.max_evidence_per_item,
         window_days=args.window_days,
         as_of_date=args.as_of_date,
+        support_contact=args.support_contact,
     )
     failed_checks = _failed_output_checks(result.output_checks)
     if args.require_output_checks and failed_checks:

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -414,6 +414,7 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
                 "source_max_text_chars": 80,
                 "faq_window_days": 90,
                 "faq_as_of_date": "2026-05-20",
+                "faq_support_contact": "1-800-555-0100",
             },
         }
     )
@@ -429,6 +430,7 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
         "max_text_chars": 80,
         "window_days": 90,
         "as_of_date": "2026-05-20",
+        "support_contact": "1-800-555-0100",
     }
 
 

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -518,6 +518,7 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
                 ],
                 "faq_window_days": 90,
                 "faq_as_of_date": "2026-05-20",
+                "faq_support_contact": "1-800-555-0100",
             },
         },
         services=ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService()),
@@ -529,6 +530,7 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
     assert step["result"]["generated"] == 1
     assert step["result"]["markdown"].startswith("# Support FAQ")
     assert "How do I change my email address?" in step["result"]["markdown"]
+    assert "contact support at 1-800-555-0100" in step["result"]["markdown"]
     assert "Billing export is confusing." not in step["result"]["markdown"]
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -114,7 +114,7 @@ def _run_ticket_faq_cli(path: Path, *args: str) -> subprocess.CompletedProcess[s
 def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
 
-    result = build_ticket_faq_markdown(loaded.opportunities)
+    result = build_ticket_faq_markdown(loaded.opportunities, support_contact="1-800-555-0100")
 
     assert result.source_count == 4
     assert result.ticket_source_count == 4
@@ -127,11 +127,11 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "Customers are asking about email and profile updates across 2 ticket sources."
     )
     assert result.items[0]["steps"] == (
-        "Confirm the account details you are trying to change or access.",
-        "If self-service does not work, contact support with the affected email or account id.",
-        "Include the cited ticket details if you need support to investigate.",
+        "Open your profile, account settings, or login settings and find the email, password, or account field you need to change.",
+        "Save the change, then check the old and new inboxes for a confirmation message.",
+        "If it still does not work, contact support at 1-800-555-0100 and include the cited ticket details.",
     )
-    assert "email field is locked" in result.items[0]["when_to_contact_support"]
+    assert "the field is locked" in result.items[0]["when_to_contact_support"]
     assert result.items[0]["evidence_quotes"] == (
         '`ticket-acme-1` - Change login email: "How do I change my login email?"',
         '`ticket-acme-2` - Update account email: "I need to update the email on my account."',
@@ -140,12 +140,22 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
     assert "How do we export campaign attribution data before renewal?" in result.markdown
     assert "`ticket-acme-1` - Change login email" in result.markdown
     assert "**What to do next:**" in result.markdown
-    assert "contact support with the affected email or account id." in result.markdown
+    assert "self-service" not in result.markdown.lower()
+    assert "contact support at 1-800-555-0100" in result.markdown
     assert result.output_checks == {
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
     }
+
+
+def test_build_ticket_faq_markdown_does_not_invent_support_contact() -> None:
+    loaded = load_source_campaign_opportunities_from_file(SUPPORT_TICKET_CSV, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities)
+
+    assert "contact support at" not in result.markdown.lower()
+    assert "If it still does not work, contact support and include the cited ticket details." in result.markdown
 
 
 def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
@@ -496,9 +506,9 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
         in paragraph
         for paragraph in rendered.paragraphs
     )
-    assert any("email field is locked" in paragraph for paragraph in rendered.paragraphs)
+    assert any("the field is locked" in paragraph for paragraph in rendered.paragraphs)
     assert any(
-        "Check whether your plan and role include the needed export"
+        "Open the reporting or analytics area and choose the date range you need."
         in item
         for item in rendered.list_items
     )
@@ -901,6 +911,8 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
             "csv",
             "--title",
             "Support FAQ",
+            "--support-contact",
+            "1-800-555-0100",
             "--output",
             str(output),
         ],
@@ -914,6 +926,7 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert markdown.startswith("# Support FAQ")
     assert "Ticket sources used: 4" in markdown
     assert "ticket-acme-1" in markdown
+    assert "contact support at 1-800-555-0100" in markdown
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Human-Action-Language.md

Make support-ticket FAQ Markdown lead users with concrete next steps and a host-provided support contact instead of vague self-service language.

## Intentional
- No hard-coded support phone number; hosts provide the CLI support-contact option or FAQ support-contact input.
- FAQ generation stays deterministic and extractive.
- Existing callers keep working because new fields are optional.

## Deferred
- Platform-specific action templates wait for a real host export or product guide.

## Verification
- Focused pytest for FAQ Markdown, FAQ plan mapping, and FAQ execution wiring -> 45 passed
- Python compile for touched Python files and tests -> passed
- Packaged support-ticket FAQ CLI with support contact and required output checks -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
10 files, +191 / -34