### PR TITLE
Add blog GEO repair loop

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -137,6 +137,26 @@ def _blog_generation_user_prompt(
     )
 
 
+def _blog_quality_repair_user_prompt(
+    *,
+    base_prompt: str,
+    blockers: Sequence[str],
+    previous_json: str,
+) -> str:
+    blocker_text = "\n".join(f"- {item}" for item in blockers)
+    return (
+        f"{base_prompt}\n\n"
+        "The previous blog JSON parsed, but it failed the blog quality gate.\n"
+        "Quality blockers:\n"
+        f"{blocker_text}\n\n"
+        "Return the full blog JSON object again. Keep the valid fields that already "
+        "worked, but revise the draft so it fixes every blocker above. Do not return "
+        "commentary, markdown fences, or partial JSON.\n\n"
+        "Previous parsed JSON:\n"
+        f"{previous_json}"
+    )
+
+
 class BlogPostGenerationService:
     """Generate blog-post drafts through product-owned ports."""
 
@@ -268,13 +288,43 @@ class BlogPostGenerationService:
                 quality_gates_enabled=resolved_quality_gates_enabled,
             )
             if not quality["passed"]:
-                skipped += 1
-                errors.append({
-                    "blueprint_id": blueprint_id,
-                    "reason": "quality_blocked",
-                    "blockers": quality["blockers"],
-                })
-                continue
+                try:
+                    repaired = await self._repair_quality_once(
+                        prompt_template,
+                        parsed=parsed,
+                        quality=quality,
+                        blueprint=blueprint,
+                        target_mode=target_mode,
+                        temperature=resolved_temperature,
+                        max_tokens=resolved_max_tokens,
+                        parse_retry_attempts=resolved_parse_retry_attempts,
+                        topic=resolved_topic,
+                    )
+                except Exception as exc:
+                    skipped += 1
+                    errors.append({
+                        "blueprint_id": blueprint_id,
+                        "reason": "quality_repair_failed",
+                        "error": str(exc),
+                    })
+                    continue
+                if repaired:
+                    repaired_quality = self._quality_check(
+                        repaired,
+                        blueprint=blueprint,
+                        quality_gates_enabled=resolved_quality_gates_enabled,
+                    )
+                    quality = repaired_quality
+                    if repaired_quality["passed"]:
+                        parsed = repaired
+                if not quality["passed"]:
+                    skipped += 1
+                    errors.append({
+                        "blueprint_id": blueprint_id,
+                        "reason": "quality_blocked",
+                        "blockers": quality["blockers"],
+                    })
+                    continue
             if _has_prompt_reasoning_context(blueprint):
                 reasoning_contexts_used += 1
                 consumed_reasoning_contexts.extend(
@@ -339,18 +389,11 @@ class BlogPostGenerationService:
         parse_retry_response_excerpt_chars: int,
         topic: str = "",
     ) -> dict[str, Any] | None:
-        blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
-        if "{blueprint_json}" in prompt_template:
-            system_prompt = prompt_template.replace("{blueprint_json}", blueprint_json)
-            base_user_prompt = "Generate one blog post from the blueprint above."
-        else:
-            system_prompt = prompt_template
-            base_user_prompt = f"Generate one blog post from this blueprint JSON:\n{blueprint_json}"
-        # PR-Blog-Topic-Per-Call: operator-supplied topic substitutes into
-        # the ``{topic}`` placeholder. Empty topic resolves to "" so hosts
-        # on the prior prompt (without ``{topic}``) are unaffected -- the
-        # ``replace()`` is a no-op when the placeholder isn't present.
-        system_prompt = system_prompt.replace("{topic}", topic)
+        system_prompt, base_user_prompt = _blog_generation_prompts(
+            prompt_template,
+            blueprint=blueprint,
+            topic=topic,
+        )
         attempts = parse_attempt_limit(parse_retry_attempts)
         last_response = ""
         total_usage: dict[str, Any] = {}
@@ -384,12 +427,75 @@ class BlogPostGenerationService:
                     "_model": response.model,
                     "_usage": total_usage,
                     "_parse_attempts": attempt_no,
+                    "_quality_repair_attempts": 0,
                 }
             last_response = clip_invalid_response(
                 response.content,
                 limit=max(0, int(parse_retry_response_excerpt_chars or 0)),
             )
         return None
+
+    async def _repair_quality_once(
+        self,
+        prompt_template: str,
+        *,
+        parsed: Mapping[str, Any],
+        quality: Mapping[str, Any],
+        blueprint: Mapping[str, Any],
+        target_mode: str,
+        temperature: float,
+        max_tokens: int,
+        parse_retry_attempts: int,
+        topic: str = "",
+    ) -> dict[str, Any] | None:
+        blockers = tuple(str(item) for item in quality.get("blockers") or () if item)
+        if not blockers:
+            return None
+        parse_attempts_used = int(parsed.get("_parse_attempts") or 1)
+        retries_used_for_parsing = max(0, parse_attempts_used - 1)
+        if retries_used_for_parsing >= max(0, int(parse_retry_attempts or 0)):
+            return None
+        system_prompt, base_user_prompt = _blog_generation_prompts(
+            prompt_template,
+            blueprint=blueprint,
+            topic=topic,
+        )
+        response = await self._llm.complete(
+            [
+                LLMMessage(role="system", content=system_prompt),
+                LLMMessage(
+                    role="user",
+                    content=_blog_quality_repair_user_prompt(
+                        base_prompt=base_user_prompt,
+                        blockers=blockers,
+                        previous_json=_public_blog_json(parsed),
+                    ),
+                ),
+            ],
+            max_tokens=max_tokens,
+            temperature=temperature,
+            metadata={
+                "target_mode": target_mode,
+                "blueprint_id": _blueprint_id(blueprint),
+                "skill_name": self._config.skill_name,
+                "asset_type": "blog_post",
+                "attempt_no": parse_attempts_used + 1,
+                "quality_repair_attempt_no": 1,
+            },
+        )
+        repaired = parse_blog_post_response(response.content)
+        if not repaired:
+            return None
+        return {
+            **repaired,
+            "_model": response.model,
+            "_usage": accumulate_usage(
+                dict(parsed.get("_usage") or {}),
+                response.usage,
+            ),
+            "_parse_attempts": parse_attempts_used,
+            "_quality_repair_attempts": int(parsed.get("_quality_repair_attempts") or 0) + 1,
+        }
 
     def _quality_check(
         self,
@@ -441,6 +547,7 @@ class BlogPostGenerationService:
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
+            "generation_quality_repair_attempts": parsed.get("_quality_repair_attempts") or 0,
         }
         # PR-Blog-Reasoning-Parity: surface reasoning audit fields on
         # the draft metadata when the blueprint carried merged context.
@@ -493,6 +600,36 @@ def _quality_context(
         "secondary_keywords": parsed.get("secondary_keywords"),
         "faq": parsed.get("faq"),
     }
+
+
+def _blog_generation_prompts(
+    prompt_template: str,
+    *,
+    blueprint: Mapping[str, Any],
+    topic: str = "",
+) -> tuple[str, str]:
+    blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
+    if "{blueprint_json}" in prompt_template:
+        system_prompt = prompt_template.replace("{blueprint_json}", blueprint_json)
+        base_user_prompt = "Generate one blog post from the blueprint above."
+    else:
+        system_prompt = prompt_template
+        base_user_prompt = f"Generate one blog post from this blueprint JSON:\n{blueprint_json}"
+    # PR-Blog-Topic-Per-Call: operator-supplied topic substitutes into
+    # the ``{topic}`` placeholder. Empty topic resolves to "" so hosts
+    # on the prior prompt (without ``{topic}``) are unaffected -- the
+    # ``replace()`` is a no-op when the placeholder isn't present.
+    system_prompt = system_prompt.replace("{topic}", topic)
+    return system_prompt, base_user_prompt
+
+
+def _public_blog_json(parsed: Mapping[str, Any]) -> str:
+    payload = {
+        key: value
+        for key, value in parsed.items()
+        if not str(key).startswith("_")
+    }
+    return json.dumps(payload, separators=(",", ":"), default=str)
 
 
 def _blueprint_id(blueprint: Mapping[str, Any]) -> str:

--- a/plans/PR-Blog-GEO-Repair-Loop.md
+++ b/plans/PR-Blog-GEO-Repair-Loop.md
@@ -1,0 +1,66 @@
+# PR-Blog-GEO-Repair-Loop
+
+## Why this slice exists
+
+PR-Blog-GEO-Quality-Gate blocks generated blog drafts that miss the
+draft-level GEO contract. Blocking is useful, but the generator should get one
+targeted chance to fix a parsed draft before the row is skipped.
+
+This slice adds a save-time repair prompt for blog drafts that parse cleanly
+but fail the blog quality gate.
+
+## Scope (this PR)
+
+1. Reuse the existing parse-retry budget for one quality repair attempt.
+2. Add a targeted quality-repair prompt for blog quality blockers.
+3. Preserve accumulated generation usage across the initial draft and repair.
+4. Record repair-attempt metadata on saved blog drafts.
+5. Add tests for successful repair and no-budget blocking behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Repair-Loop.md` | Plan doc for this slice. |
+| `extracted_content_pipeline/blog_generation.py` | Add quality repair prompt and retry path. |
+| `tests/test_extracted_blog_generation.py` | Cover repair success and no-budget block behavior. |
+
+## Mechanism
+
+The generator already has a parse retry budget. This PR spends any unused retry
+budget on a quality repair. If the first response parses successfully but fails
+the quality gate, and at least one retry remains, the service asks the model to
+return the full blog JSON again while fixing the listed blockers.
+
+If parsing already consumed the retry budget, the quality failure still blocks
+without another LLM call.
+
+## Intentional
+
+- No new default budget multiplier.
+- No repair loop for unparseable responses beyond the existing parse retry.
+- No frontend or publish-level GEO checks.
+- No changes to non-blog asset generators.
+
+## Deferred
+
+- Add publish-level GEO verification for public blog routes.
+- Add richer blocker-specific repair instructions if failure diagnostics become
+  more granular.
+- Expose repair-attempt counts in review/export surfaces if operators need it.
+
+## Verification
+
+- Focused blog-generation tests passed.
+- Touched-module Python compile check passed.
+- Whitespace diff check passed.
+- Extracted pipeline check suite passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Blog generation | ~160 |
+| Tests | ~90 |
+| **Total** | **~310** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -272,6 +272,7 @@ async def test_generate_blocks_low_quality_posts_without_saving() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=[_valid_blog_json(content="Too short.")],
         config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 70},
@@ -301,6 +302,7 @@ async def test_generate_blocks_missing_seo_aeo_fields_without_saving() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
@@ -334,6 +336,7 @@ async def test_generate_blocks_missing_geo_contract_without_saving() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
@@ -355,12 +358,115 @@ async def test_generate_blocks_missing_geo_contract_without_saving() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_repairs_geo_quality_block_with_retry_budget() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["content"] = (
+        "## How is HubSpot pricing pressure changing shortlists?\n\n"
+        "HubSpot pricing pressure changes shortlists because buyers compare "
+        "renewal terms before they commit to another contract."
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        responses=[json.dumps(payload), _valid_blog_json()],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.errors == ()
+    assert len(llm.calls) == 2
+    retry_prompt = llm.calls[1]["messages"][1].content
+    assert "Quality blockers:" in retry_prompt
+    assert "geo_citable_section_structure_missing" in retry_prompt
+    assert llm.calls[1]["metadata"]["quality_repair_attempt_no"] == 1
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["generation_usage"] == {"input_tokens": 26, "output_tokens": 34}
+    assert draft.metadata["generation_parse_attempts"] == 1
+    assert draft.metadata["generation_quality_repair_attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_repair_quality_block_without_retry_budget() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["content"] = (
+        "## How is HubSpot pricing pressure changing shortlists?\n\n"
+        "HubSpot pricing pressure changes shortlists because buyers compare "
+        "renewal terms before they commit to another contract."
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        responses=[json.dumps(payload), _valid_blog_json()],
+        config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert len(llm.calls) == 1
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_quality_repair_failure_skips_one_blueprint_not_batch() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["content"] = (
+        "## How is HubSpot pricing pressure changing shortlists?\n\n"
+        "HubSpot pricing pressure changes shortlists because buyers compare "
+        "renewal terms before they commit to another contract."
+    )
+    rows = [
+        _blueprint(),
+        {**_blueprint(), "id": "bp-2", "slug": "hubspot-pricing-pressure-2"},
+    ]
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        rows=rows,
+        responses=[
+            json.dumps(payload),
+            RuntimeError("repair backend timeout"),
+            _valid_blog_json(slug="hubspot-pricing-pressure-2"),
+        ],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=2)
+
+    assert result.generated == 1
+    assert result.skipped == 1
+    assert result.errors == ({
+        "blueprint_id": "bp-1",
+        "reason": "quality_repair_failed",
+        "error": "repair backend timeout",
+    },)
+    assert len(llm.calls) == 3
+    assert blog_posts.saved[0]["drafts"][0].slug == "hubspot-pricing-pressure-2"
+
+
+@pytest.mark.asyncio
 async def test_generate_routes_missing_content_to_quality_blocked_not_unparseable() -> None:
     payload = json.loads(_valid_blog_json())
     payload.pop("content")
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 70},
@@ -493,7 +599,14 @@ async def test_generate_per_call_llm_tuning_overrides_win_over_construction_conf
 async def test_generate_llm_tuning_kwargs_none_falls_back_to_construction_config():
     service, _bps, _drafts, llm, _skills = _service(
         responses=[_valid_blog_json()],
-        config=BlogPostGenerationConfig(temperature=0.7, max_tokens=999),
+        config=BlogPostGenerationConfig(
+            temperature=0.7,
+            max_tokens=999,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
     )
 
     await service.generate(


### PR DESCRIPTION
## Summary
- reuse unused parse-retry budget for one blog quality repair attempt
- add a targeted repair prompt that lists blog quality blockers and asks for the full JSON again
- accumulate usage across initial generation and repair, and record repair-attempt metadata on saved drafts
- cover successful repair and no-budget blocking behavior in blog-generation tests

## Verification
- pytest tests/test_extracted_blog_generation.py
- python -m py_compile extracted_content_pipeline/blog_generation.py
- git diff --check
- bash scripts/run_extracted_pipeline_checks.sh
- bash scripts/local_pr_review.sh