### PR TITLE
Affiliate drift audit: match schema-qualified / quoted table names

### DIFF
--- a/plans/PR-Affiliate-Partner-Drift-Qualified-Names.md
+++ b/plans/PR-Affiliate-Partner-Drift-Qualified-Names.md
@@ -1,0 +1,85 @@
+# PR-Affiliate-Partner-Drift-Qualified-Names
+
+## Why this slice exists
+
+Follow-up to PR #668 (the affiliate-partner drift audit). That PR was merged
+while a final review-driven fix was still being pushed, so the squash-merge
+landed the P1 + P2 parser fixes (multi-row VALUES, surfaced parse errors,
+`UPDATE`/`DELETE` mutation detection) but **not** the last round: matching
+schema-qualified and quoted table names.
+
+As merged, both the INSERT parser and the mutation detector match only the
+bare `affiliate_partners`. A migration using valid SQL like
+`INSERT INTO public.affiliate_partners (...)`, `UPDATE "affiliate_partners"`,
+or `DELETE FROM public."affiliate_partners"` would be silently missed -- the
+audit would report `pass` while a seed or mutation went unseen. That is the
+exact gap the reviewers (Codex P1 + P2 on #668) flagged. Every migration in
+the tree today is unqualified, so the merged audit is correct now; this slice
+closes the gap for future migrations.
+
+## Scope (this PR)
+
+1. Add a shared `_AFF_TABLE` regex fragment that matches the
+   `affiliate_partners` table with an optional schema qualifier and optional
+   double-quoted identifiers, guarded so a longer name like
+   `affiliate_partners_history` is not mistaken for it.
+2. Use `_AFF_TABLE` in all three matchers: the `INSERT INTO` parser and the
+   `UPDATE` / `DELETE FROM` mutation detectors.
+3. Add tests for schema-qualified and quoted INSERTs, qualified and quoted
+   mutations, and the prefixed-name (`affiliate_partners_history`) negative
+   case.
+
+### Files touched
+
+- `scripts/audit_affiliate_partner_drift.py`
+- `tests/test_affiliate_partner_drift.py`
+- `plans/PR-Affiliate-Partner-Drift-Qualified-Names.md`
+
+## Mechanism
+
+`_AFF_TABLE` is `(?:(?:"[^"]+"|<ident>)\s*\.\s*)?(?:"affiliate_partners"|
+affiliate_partners(?![\w$]))`: an optional schema part (quoted or bare
+identifier followed by a dot) and the table itself, matched either as an exact
+quoted identifier or unquoted with a negative lookahead so it cannot swallow a
+longer name. The three matchers concatenate it after their respective
+keywords, so qualified/quoted forms are recognized while the existing
+unqualified migrations continue to match unchanged. The INSERT matcher still
+ends in `\s*\(`, preserving the `m.end() - 1` handoff to the tuple reader.
+
+## Intentional
+
+- **Regex broadening, not a SQL-library swap.** The seed/mutation surface is
+  small and now covers the realistic forms (qualified, quoted, multi-row, both
+  seed layouts). A dependency-free matcher keeps the audit self-contained and
+  fully fixture-tested.
+- **Case-insensitive table match.** Quoted identifiers are technically
+  case-sensitive in Postgres, but every real table name here is lowercase;
+  matching `"AFFILIATE_PARTNERS"` too is harmless over-coverage.
+
+## Deferred
+
+- Fully parsing and *applying* `UPDATE`/`DELETE` effects (vs. detecting and
+  warning) remains the deferred follow-up noted in #668, only relevant once a
+  mutation migration is actually written.
+
+## Verification
+
+- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `14 passed in
+  0.07s` (adds schema-qualified + quoted INSERTs, qualified + quoted
+  mutations, and the `affiliate_partners_history` negative case to the #668
+  suite).
+- `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas`
+  -> `summary {seeded_partners: 6, live_partners: 6, pass: 5, warn: 0,
+  fail: 0}`, exit `0` -- the real (unqualified) migrations still match, and
+  the broadened regex does not false-trigger on the `REFERENCES
+  affiliate_partners(id) ON DELETE CASCADE` clause in migration 063.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `scripts/audit_affiliate_partner_drift.py` (`_AFF_TABLE` + 3 matchers) | ~20 |
+| `tests/test_affiliate_partner_drift.py` (3 tests) | ~40 |
+| Plan doc | ~95 |
+| **Total** | **~155** |

--- a/scripts/audit_affiliate_partner_drift.py
+++ b/scripts/audit_affiliate_partner_drift.py
@@ -60,6 +60,19 @@ _DIVERGENCE_FIELDS = (
 # SQL parsing (pure -- no DB)
 # ---------------------------------------------------------------------------
 
+# A reference to the affiliate_partners table that tolerates the valid SQL
+# forms a migration might use: an optional schema qualifier and double-quoted
+# identifiers -- e.g. `affiliate_partners`, `public.affiliate_partners`,
+# `"affiliate_partners"`, `public."affiliate_partners"`. The negative lookahead
+# on the unquoted form stops it matching a longer name like
+# `affiliate_partners_history`; the quoted form is matched exactly. Used by both
+# the INSERT parser and the UPDATE/DELETE mutation detector so neither silently
+# misses a qualified/quoted statement.
+_AFF_TABLE = (
+    r'(?:(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*)?'
+    r'(?:"affiliate_partners"|affiliate_partners(?![\w$]))'
+)
+
 
 def _read_paren_group(s: str, open_idx: int) -> tuple[str, int]:
     """Return (inner_text, index_after_close) for the parenthesized group whose
@@ -212,7 +225,7 @@ def parse_seeded_partners(sql: str) -> tuple[list[dict[str, Any]], list[str]]:
     rows: list[dict[str, Any]] = []
     errors: list[str] = []
     for m in re.finditer(
-        r"INSERT\s+INTO\s+affiliate_partners\s*\(", sql, re.IGNORECASE
+        r"INSERT\s+INTO\s+" + _AFF_TABLE + r"\s*\(", sql, re.IGNORECASE
     ):
         cols_str, after_cols = _read_paren_group(sql, m.end() - 1)
         vm = re.compile(r"\s*VALUES\s*", re.IGNORECASE).match(sql, after_cols)
@@ -255,9 +268,9 @@ def find_partner_mutations(sql: str) -> list[str]:
     migration this parser does not apply -- the caller surfaces these so the
     blind spot is visible rather than silently skewing reconciliation."""
     found: list[str] = []
-    if re.search(r"\bUPDATE\s+affiliate_partners\b", sql, re.IGNORECASE):
+    if re.search(r"\bUPDATE\s+" + _AFF_TABLE, sql, re.IGNORECASE):
         found.append("UPDATE")
-    if re.search(r"\bDELETE\s+FROM\s+affiliate_partners\b", sql, re.IGNORECASE):
+    if re.search(r"\bDELETE\s+FROM\s+" + _AFF_TABLE, sql, re.IGNORECASE):
         found.append("DELETE")
     return found
 

--- a/tests/test_affiliate_partner_drift.py
+++ b/tests/test_affiliate_partner_drift.py
@@ -257,6 +257,45 @@ def test_finds_partner_mutations():
     assert set(both) == {"UPDATE", "DELETE"}
 
 
+def test_parses_schema_qualified_and_quoted_inserts():
+    qualified = """
+    INSERT INTO public.affiliate_partners (name, product_name, category, affiliate_url, commission_type, commission_value, enabled)
+    VALUES ('Q Co', 'Qvendor', 'crm', 'https://q.example/?ref=x', 'cpa', '$5', true)
+    ON CONFLICT ((lower(product_name))) DO NOTHING;
+    """
+    quoted = """
+    INSERT INTO "affiliate_partners" (name, product_name, category, affiliate_url, commission_type, commission_value, enabled)
+    VALUES ('R Co', 'Rvendor', 'crm', 'https://r.example/?ref=x', 'cpa', '$5', true)
+    ON CONFLICT ((lower(product_name))) DO NOTHING;
+    """
+    rows_q, errs_q = drift.parse_seeded_partners(qualified)
+    assert errs_q == [] and [r["product_name"] for r in rows_q] == ["Qvendor"]
+    rows_r, errs_r = drift.parse_seeded_partners(quoted)
+    assert errs_r == [] and [r["product_name"] for r in rows_r] == ["Rvendor"]
+
+
+def test_does_not_match_prefixed_table_name():
+    # A different table whose name merely starts with affiliate_partners must
+    # not be treated as the partners table.
+    other = (
+        "INSERT INTO affiliate_partners_history (id, note) VALUES (1, 'x');"
+    )
+    rows, errs = drift.parse_seeded_partners(other)
+    assert rows == [] and errs == []
+    assert drift.find_partner_mutations(
+        "DELETE FROM affiliate_partners_history WHERE id = 1;"
+    ) == []
+
+
+def test_finds_qualified_and_quoted_mutations():
+    assert drift.find_partner_mutations(
+        "UPDATE public.affiliate_partners SET affiliate_url = 'x';"
+    ) == ["UPDATE"]
+    assert drift.find_partner_mutations(
+        'DELETE FROM "affiliate_partners" WHERE enabled = false;'
+    ) == ["DELETE"]
+
+
 def test_reconcile_warns_on_unmodeled_mutation_without_failing():
     # A mutation migration is not an error, but the audit can't model its
     # effect -- surface it as a warning, not a failure.


### PR DESCRIPTION
Plan: plans/PR-Affiliate-Partner-Drift-Qualified-Names.md

Follow-up to #668. That PR was squash-merged while the final review-driven fix was still being pushed, so the merge landed the P1+P2 parser fixes (multi-row VALUES, surfaced parse errors, UPDATE/DELETE detection) but **not** the last round: matching schema-qualified and quoted table names (Codex P1+P2 on #668).

As merged, the INSERT parser and mutation detector match only bare `affiliate_partners`, so valid SQL like `INSERT INTO public.affiliate_partners (...)` or `DELETE FROM "affiliate_partners"` would be silently missed. Every migration in the tree today is unqualified, so the merged audit is correct now; this lands the fix for future migrations.

## Intentional
- Shared `_AFF_TABLE` fragment (optional schema qualifier + quoted identifiers) used in all three matchers, guarded so `affiliate_partners_history` isn't mistaken for the table.
- Regex broadening, not a SQL-library swap — the surface is small and now covers qualified, quoted, multi-row, and both seed layouts; kept dependency-free and fixture-tested.

## Deferred
- Fully parsing/applying UPDATE/DELETE effects (vs. detect-and-warn) — unchanged from #668, only relevant once a mutation migration exists.

## Verification
- `python -m pytest tests/test_affiliate_partner_drift.py -q` -> `14 passed in 0.07s` (adds qualified + quoted INSERTs, qualified + quoted mutations, and the `affiliate_partners_history` negative case).
- `scripts/audit_affiliate_partner_drift.py` run against live `:5433/atlas` -> `summary {seeded_partners: 6, live_partners: 6, pass: 5, warn: 0, fail: 0}`, exit 0 — real (unqualified) migrations still match; no false-trigger on the `REFERENCES affiliate_partners(id) ON DELETE CASCADE` in migration 063.
- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape, 3/3 path claims, diff drift 7.7%, `git diff --check`).

## Diff size
~143 LOC (script ~20, tests ~40, plan ~95).