### PR TITLE
Improve FAQ financial action language

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T17:44Z by codex-2026-05-20
+Last updated: 2026-05-20T17:55Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-CFPB-Live-Fetch-Compat | `plans/PR-Content-Ops-CFPB-Live-Fetch-Compat.md`; `docs/extraction/coordination/inflight.md`; `scripts/export_content_ops_cfpb_sources.py`; `tests/test_export_content_ops_cfpb_sources.py` | codex-2026-05-20 | Avoid concurrent edits to the CFPB source exporter request/query contract and its tests. |
+| TBD | PR-Content-Ops-FAQ-Financial-Action-Language | `plans/PR-Content-Ops-FAQ-Financial-Action-Language.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown action-classifier ordering and financial action language tests. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -63,6 +63,10 @@ _ACTION_RULES = (
         "Find the workflow or automation rule that should handle this step.",
         "Check the last failed handoff, note which step stopped, and send that detail to support if it still needs manual cleanup.",
     )),
+    (("billing", "invoice", "payment", "receipt", "charge", "fee", "fees", "interest", "loan", "lease", "statement", "dispute"), (
+        "Open the bill, statement, payment history, or dispute record connected to the issue.",
+        "Compare the charge, fee, payment, or balance against your receipt, contract, or written confirmation.",
+    )),
     (("login", "email", "profile", "password", "account"), (
         "Open your profile, account settings, or login settings and find the email, password, or account field you need to change.",
         "Save the change, then check the old and new inboxes for a confirmation message.",
@@ -598,6 +602,11 @@ def _escalation_guidance(topic: str, evidence_text: str, *, support_contact: str
         return (
             f"{_support_sentence(support_contact)} if the export is missing, "
             "locked by plan or role, or still unavailable after an admin checks permissions."
+        )
+    if any(term in text for term in ("billing", "invoice", "payment", "receipt", "charge", "fee", "fees", "interest", "loan", "lease", "statement", "dispute")):
+        return (
+            f"{_support_sentence(support_contact)} if the charge, fee, payment, "
+            "balance, or dispute still looks wrong after you compare it with your records."
         )
     if any(term in text for term in ("login", "email", "profile", "password", "account")):
         return (

--- a/plans/PR-Content-Ops-FAQ-Financial-Action-Language.md
+++ b/plans/PR-Content-Ops-FAQ-Financial-Action-Language.md
@@ -1,0 +1,69 @@
+# Content Ops FAQ Financial Action Language
+
+## Why this slice exists
+
+The live CFPB source-row smoke proved the real-public data path works, but it
+also exposed a generic FAQ quality issue: financial complaints containing words
+like "account" can be routed to login/profile action steps. The fix belongs in
+the FAQ action classifier, not in the CFPB exporter, so all ticket-like sources
+benefit.
+
+## Scope (this PR)
+
+1. Add a financial/billing action branch before the generic account/login
+   branch.
+2. Add escalation guidance for fees, payments, statements, loans, disputes, and
+   account charges.
+3. Lock the behavior with CFPB-shaped source-row tests while keeping the
+   renderer source-agnostic.
+4. Remove the merged CFPB live-fetch coordination row and claim this slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Financial-Action-Language.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Replace stale CFPB row with this FAQ-quality slice claim. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Add financial action and escalation rules. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for CFPB-shaped financial rows. |
+
+## Mechanism
+
+The action classifier remains deterministic and source-agnostic. It checks the
+topic plus evidence text against ordered keyword groups. This PR adds a
+financial group before the login/account group so terms like fees, billing,
+payments, statements, loans, disputes, and charges produce financial next steps
+instead of profile-setting steps.
+
+The test fixture uses CFPB-shaped source rows because that is what exposed the
+bug, but the assertions only depend on generic source-row fields:
+`source_type`, `source_title`, `pain_points`, and evidence text.
+
+## Intentional
+
+- No CFPB-specific branch in the renderer.
+- No LLM generation. FAQ output stays deterministic and easy to audit.
+- No platform-specific legal or financial advice; the output tells users to
+  gather records, compare charges, contact support, and keep evidence.
+
+## Deferred
+
+- More specialized action templates for real customer product docs remain
+  deferred until a host supplies those docs or a real ticket export.
+
+## Verification
+
+- Focused pytest for FAQ Markdown: 44 passed.
+- Python compile for FAQ renderer and tests: passed.
+- Packaged support-ticket FAQ CLI with required output checks: passed.
+- Local PR review: passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Financial-Action-Language.md` | 65 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 35 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 55 |
+| **Total** | **159** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -801,6 +801,49 @@ def test_build_ticket_faq_markdown_accepts_ticket_source_type_alias() -> None:
     assert "I need help with billing." in result.markdown
 
 
+def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_shaped_rows() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Credit card or prepaid card - Fees or interest",
+                "pain_points": ["Fees or interest"],
+                "evidence": [{
+                    "text": (
+                        "I logged into my account and saw a foreign transaction "
+                        "fee that should not have been charged."
+                    ),
+                    "source_id": "cfpb:3559709",
+                    "source_type": "support_ticket",
+                    "source_title": "Credit card or prepaid card - Fees or interest",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Vehicle loan or lease - Managing the loan or lease",
+                "pain_points": ["Managing the loan or lease"],
+                "evidence": [{
+                    "text": (
+                        "My loan payoff balance and payment extension do not "
+                        "match what the representative told me."
+                    ),
+                    "source_id": "cfpb:3205066",
+                    "source_type": "support_ticket",
+                    "source_title": "Vehicle loan or lease - Managing the loan or lease",
+                }],
+            },
+        ],
+        support_contact="https://www.consumerfinance.gov/complaint/",
+    )
+
+    markdown = result.markdown
+    assert "Open the bill, statement, payment history, or dispute record connected to the issue." in markdown
+    assert "Compare the charge, fee, payment, or balance against your receipt, contract, or written confirmation." in markdown
+    assert "charge, fee, payment, balance, or dispute still looks wrong" in markdown
+    assert "Open your profile, account settings, or login settings" not in markdown
+    assert "https://www.consumerfinance.gov/complaint/" in markdown
+
+
 def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified_rows() -> None:
     result = build_ticket_faq_markdown([
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Financial-Action-Language.md

Improve FAQ financial action selection after real CFPB source rows showed billing/account complaints could hit login/profile steps.

## Intentional
- No CFPB-specific branch in the renderer.
- FAQ generation remains deterministic and source-agnostic.
- No legal or financial advice; the output tells users to gather records, compare charges, contact support, and keep evidence.

## Deferred
- Product-specific action templates wait for host product docs or real customer ticket exports.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py -> 44 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py -> passed
- python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --support-contact 1-800-555-0100 --require-output-checks -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
4 files, +123 / -2