### PR TITLE
Add blog GEO publish verifier

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -1,0 +1,157 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
+const rootDir = resolve(import.meta.dirname, '..')
+const blogDir = join(rootDir, 'src/content/blog')
+const distDir = join(rootDir, 'dist')
+const sitemapPath = join(distDir, 'sitemap.xml')
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function readText(path) {
+  if (!existsSync(path)) fail(`Missing file: ${path}`)
+  return readFileSync(path, 'utf-8')
+}
+
+function collectBlogSlugs() {
+  const slugs = []
+  for (const file of readdirSync(blogDir)) {
+    if (!file.endsWith('.ts') || file === 'index.ts') continue
+    const content = readText(join(blogDir, file))
+    const match = content.match(/slug:\s*'([^']+)'/)
+    if (!match) fail(`Missing slug in ${file}`)
+    slugs.push(match[1])
+  }
+  if (!slugs.length) fail('No blog slugs found')
+  return slugs.sort()
+}
+
+function attrValue(tag, attr) {
+  const pattern = new RegExp(`${attr}=["']([^"']+)["']`, 'i')
+  const match = tag.match(pattern)
+  return match ? match[1] : ''
+}
+
+function findLink(html, rel) {
+  const links = html.match(/<link\b[^>]*>/gi) || []
+  return links.find(tag => attrValue(tag, 'rel').toLowerCase() === rel) || ''
+}
+
+function findMeta(html, attr, key) {
+  const metas = html.match(/<meta\b[^>]*>/gi) || []
+  return metas.find(tag => attrValue(tag, attr) === key) || ''
+}
+
+function parseJsonLd(html, slug) {
+  const scripts = [...html.matchAll(
+    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  )]
+  const objects = []
+  for (const script of scripts) {
+    try {
+      objects.push(JSON.parse(script[1]))
+    } catch (error) {
+      fail(`Invalid JSON-LD for ${slug}: ${error.message}`)
+    }
+  }
+  return objects
+}
+
+function flattenJsonLdTypes(objects) {
+  const nodes = []
+  for (const object of objects) {
+    if (object && typeof object === 'object' && Array.isArray(object['@graph'])) {
+      nodes.push(...object['@graph'])
+    } else {
+      nodes.push(object)
+    }
+  }
+  return nodes.filter(node => node && typeof node === 'object')
+}
+
+function typeMatches(node, typeName) {
+  const type = node['@type']
+  if (Array.isArray(type)) return type.includes(typeName)
+  return type === typeName
+}
+
+function assertNoNoindex(html, slug) {
+  const robotsMeta = findMeta(html, 'name', 'robots')
+  if (!robotsMeta) return
+  const content = attrValue(robotsMeta, 'content').toLowerCase()
+  if (content.includes('noindex')) {
+    fail(`/blog/${slug} has a noindex robots directive`)
+  }
+}
+
+function assertBlogPosting(node, canonical, slug) {
+  for (const field of ['headline', 'description', 'image', 'author', 'publisher']) {
+    if (!node[field]) fail(`/blog/${slug} BlogPosting missing ${field}`)
+  }
+  const mainEntity = node.mainEntityOfPage
+  if (!mainEntity || mainEntity['@id'] !== canonical) {
+    fail(`/blog/${slug} BlogPosting mainEntityOfPage must be ${canonical}`)
+  }
+}
+
+function assertBreadcrumbs(node, canonical, slug) {
+  const items = Array.isArray(node.itemListElement) ? node.itemListElement : []
+  if (items.length < 3) fail(`/blog/${slug} breadcrumb list is incomplete`)
+  const last = items[items.length - 1]
+  if (!last || last.item !== canonical) {
+    fail(`/blog/${slug} breadcrumb final item must be ${canonical}`)
+  }
+}
+
+function verifyBlogPage(slug, sitemap) {
+  const canonical = `${BASE_URL}/blog/${slug}`
+  const htmlPath = join(distDir, 'blog', slug, 'index.html')
+  const html = readText(htmlPath)
+
+  const canonicalLink = findLink(html, 'canonical')
+  if (attrValue(canonicalLink, 'href') !== canonical) {
+    fail(`/blog/${slug} canonical link must be ${canonical}`)
+  }
+
+  const ogUrl = findMeta(html, 'property', 'og:url')
+  if (attrValue(ogUrl, 'content') !== canonical) {
+    fail(`/blog/${slug} og:url must be ${canonical}`)
+  }
+
+  const ogType = findMeta(html, 'property', 'og:type')
+  if (attrValue(ogType, 'content') !== 'article') {
+    fail(`/blog/${slug} og:type must be article`)
+  }
+
+  const ogImage = findMeta(html, 'property', 'og:image')
+  const ogImageValue = attrValue(ogImage, 'content')
+  if (!ogImageValue || !ogImageValue.startsWith(BASE_URL)) {
+    fail(`/blog/${slug} og:image must be an absolute Atlas URL`)
+  }
+
+  assertNoNoindex(html, slug)
+
+  const nodes = flattenJsonLdTypes(parseJsonLd(html, slug))
+  const blogPosting = nodes.find(node => typeMatches(node, 'BlogPosting'))
+  if (!blogPosting) fail(`/blog/${slug} missing BlogPosting JSON-LD`)
+  assertBlogPosting(blogPosting, canonical, slug)
+
+  const breadcrumbs = nodes.find(node => typeMatches(node, 'BreadcrumbList'))
+  if (!breadcrumbs) fail(`/blog/${slug} missing BreadcrumbList JSON-LD`)
+  assertBreadcrumbs(breadcrumbs, canonical, slug)
+
+  if (!sitemap.includes(`<loc>${canonical}</loc>`)) {
+    fail(`/blog/${slug} missing from sitemap.xml`)
+  }
+}
+
+const slugs = collectBlogSlugs()
+const sitemap = readText(sitemapPath)
+for (const slug of slugs) {
+  verifyBlogPage(slug, sitemap)
+}
+
+console.log(`Verified GEO prerender metadata for ${slugs.length} blog pages`)

--- a/plans/PR-Blog-GEO-Publish-Check.md
+++ b/plans/PR-Blog-GEO-Publish-Check.md
@@ -1,0 +1,71 @@
+# PR-Blog-GEO-Publish-Check
+
+## Why this slice exists
+
+Generated blog drafts now have draft-level SEO/AEO/GEO readiness checks before
+save, plus a targeted repair loop. The next gap is publish-level visibility:
+the public blog HTML that crawlers and answer engines fetch must keep the
+required metadata visible without client-side JavaScript.
+
+This slice adds a build-output verifier for the Vite public blog prerender.
+
+## Scope (this PR)
+
+1. Add an `atlas-intel-ui` verification script for prerendered blog pages.
+2. Check every static blog slug in `src/content/blog`.
+3. Fail if any built page is missing canonical URL, OG metadata, BlogPosting
+   JSON-LD, BreadcrumbList JSON-LD, sitemap inclusion, or indexability.
+4. Add an npm script so operators and CI can run the verifier after build.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Publish-Check.md` | Plan doc for this slice. |
+| `atlas-intel-ui/package.json` | Add the verification npm script. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify built public blog HTML. |
+
+## Mechanism
+
+The verifier reads static blog slugs from `atlas-intel-ui/src/content/blog`,
+then checks `atlas-intel-ui/dist/blog/<slug>/index.html` and
+`atlas-intel-ui/dist/sitemap.xml` after `npm run build`.
+
+Each blog page must include crawler-visible:
+
+- `<link rel="canonical">`
+- Open Graph URL, type, and image metadata
+- `BlogPosting` JSON-LD
+- `BreadcrumbList` JSON-LD
+- sitemap URL
+- no `noindex` robots directive
+
+## Intentional
+
+- No runtime frontend behavior changes.
+- No new test framework dependency.
+- No FAQPage requirement until public static blog content includes FAQ entries.
+- No generated draft contract changes.
+
+## Deferred
+
+- Emit and verify FAQPage JSON-LD once published static blog posts include FAQ
+  entries.
+- Wire the verifier into remote CI if the team wants frontend build checks to
+  gate every PR.
+
+## Verification
+
+- Atlas UI production build passed.
+- Blog GEO prerender verification passed across 14 blog pages.
+- Script syntax check passed.
+- Whitespace diff check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Package script | ~5 |
+| Verification script | ~120 |
+| **Total** | **~185** |


### PR DESCRIPTION
## Summary
- add an atlas-intel-ui verifier for built public blog HTML
- verify every static blog page has crawler-visible canonical, OG metadata, BlogPosting JSON-LD, BreadcrumbList JSON-LD, sitemap inclusion, and no noindex directive
- expose the verifier as npm run verify:blog-geo

## Verification
- npm run build
- npm run verify:blog-geo
- node --check scripts/verify-blog-geo-prerender.mjs
- git diff --check
- bash scripts/local_pr_review.sh

Note: npm run lint currently fails on existing no-explicit-any errors in atlas-intel-ui/src/pages/b2b/B2BReports.tsx, which this PR does not touch.