### PR TITLE
Improve FAQ complaint narrative questions

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T17:55Z by codex-2026-05-20
+Last updated: 2026-05-20T20:49Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Financial-Action-Language | `plans/PR-Content-Ops-FAQ-Financial-Action-Language.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ Markdown action-classifier ordering and financial action language tests. |
+| TBD | PR-Content-Ops-FAQ-Complaint-Narrative-Questions | `plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ billing intent rules and complaint-narrative question extraction. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -37,7 +37,21 @@ DEFAULT_INTENT_RULES = (
     ("login reset", ("login reset", "password reset", "reset password", "reset my password")),
     ("email and profile updates", ("change my email", "update the email", "email address", "profile")),
     ("login and account access", ("login", "account access")),
-    ("billing and payments", ("billing", "invoice", "payment", "receipt", "charge")),
+    ("billing and payments", (
+        "billing",
+        "invoice",
+        "payment",
+        "receipt",
+        "charge",
+        "charged",
+        "fee",
+        "fees",
+        "interest",
+        "loan",
+        "lease",
+        "statement",
+        "dispute",
+    )),
     ("integration setup", ("integration", "api", "webhook", "sync", "connection")),
     ("renewal and cancellation", ("renewal", "cancel", "cancellation", "contract")),
 )
@@ -497,6 +511,24 @@ def _first_person_issue_question_text(text: str) -> str:
         ("we're trying to ", "How do we "),
     )
     for prefix, question_prefix in patterns:
+        if lowered.startswith(prefix):
+            remainder = sentence[len(prefix):].strip()
+            normalized = _normalize_question_text(f"{question_prefix}{remainder}")
+            if _usable_question(normalized):
+                return normalized
+    complaint_patterns = (
+        ("i was ", "What should I do if I was "),
+        ("i got ", "What should I do if I got "),
+        ("i received ", "What should I do if I received "),
+        ("i paid ", "What should I do if I paid "),
+        ("my ", "What should I do if my "),
+        ("we were ", "What should we do if we were "),
+        ("we got ", "What should we do if we got "),
+        ("we received ", "What should we do if we received "),
+        ("we paid ", "What should we do if we paid "),
+        ("our ", "What should we do if our "),
+    )
+    for prefix, question_prefix in complaint_patterns:
         if lowered.startswith(prefix):
             remainder = sentence[len(prefix):].strip()
             normalized = _normalize_question_text(f"{question_prefix}{remainder}")

--- a/plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md
+++ b/plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md
@@ -1,0 +1,79 @@
+# Content Ops FAQ Complaint Narrative Questions
+
+## Why this slice exists
+
+The CFPB source-row path exposed a generic FAQ issue: complaint-shaped rows are
+often first-person narratives, not literal question sentences. The FAQ output
+check for customer vocabulary should not fail just because a support-ticket-like
+source says "I was charged..." instead of "Why was I charged...?"
+
+The fix belongs in the generic FAQ question extractor and billing intent rules,
+not in the CFPB exporter or a CFPB-specific renderer branch.
+
+## Scope (this PR)
+
+1. Expand billing intent keywords so fees, charged, loans, statements, leases,
+   interest, and disputes group with billing/payment complaints.
+2. Derive human FAQ questions from first-person complaint narratives such as
+   "I was ...", "my ...", "we were ...", and "our ...".
+3. Add regression coverage using CFPB-shaped source rows through generic FAQ
+   fields only.
+4. Replace the merged FAQ financial-action coordination row with this slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this FAQ narrative-quality slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Align billing intent keywords and complaint narrative question extraction. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression coverage for complaint-narrative question extraction. |
+
+## Mechanism
+
+The FAQ builder already extracts direct question sentences and converts common
+first-person request starts such as "I need to ..." into "How do I ..."
+questions. This PR extends that same generic extractor to complaint starts:
+"I was ...", "I got ...", "I received ...", "I paid ...", "my ...", "we were
+...", "we got ...", "we received ...", "we paid ...", and "our ...".
+
+Those become short "What should I/we do if ..." FAQ questions, preserving the
+customer's vocabulary while making the heading readable.
+
+The billing intent rule is also aligned with the financial action rule so a
+fee or charge complaint does not split away from billing/payment topics.
+
+## Intentional
+
+- No CFPB-specific branch in the FAQ renderer.
+- No LLM generation. FAQ output stays deterministic and easy to audit.
+- No legal or financial advice; the existing action language still tells users
+  to compare records and contact support when the issue remains unresolved.
+
+## Deferred
+
+- The CFPB-to-FAQ live smoke command is the next slice after this generic FAQ
+  behavior lands.
+- Product-specific action templates remain deferred until a host supplies real
+  product docs or real customer ticket exports.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_markdown.py - 45 passed.
+- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py - passed.
+- python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --support-contact 1-800-555-0100 --require-output-checks - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- Local PR review: pending.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md` | 75 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 35 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 45 |
+| **Total** | **159** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -193,6 +193,48 @@ def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
     assert result.output_checks["condensed"] is True
 
 
+def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Checking account - Fees",
+                "pain_points": ["Fees"],
+                "evidence": [{
+                    "text": "I was charged overdraft fees after I closed the account.",
+                    "source_id": "cfpb:1",
+                    "source_type": "support_ticket",
+                    "source_title": "Checking account - Fees",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Loan payment issue",
+                "pain_points": ["Fees"],
+                "evidence": [{
+                    "text": "My payment was applied to the wrong loan balance.",
+                    "source_id": "cfpb:2",
+                    "source_type": "support_ticket",
+                    "source_title": "Loan payment issue",
+                }],
+            },
+        ],
+        support_contact="https://example.com/support",
+    )
+
+    assert result.items[0]["question"] == (
+        "What should I do if I was charged overdraft fees after I closed the account?"
+    )
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+    assert "Open the bill, statement, payment history, or dispute record" in result.markdown
+    assert "contact support at https://example.com/support" in result.markdown
+
+
 def test_build_ticket_faq_markdown_falls_back_to_topic_question() -> None:
     result = build_ticket_faq_markdown(
         [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md

Improve FAQ handling for complaint-shaped support rows by deriving human questions from first-person narratives and aligning billing intent grouping with financial action language.

## Intentional
- No CFPB-specific branch in the FAQ renderer.
- FAQ generation remains deterministic and source-agnostic.
- No legal or financial advice; existing action language still tells users to compare records and contact support when unresolved.

## Deferred
- CFPB-to-FAQ live smoke command follows as the next slice.
- Product-specific action templates wait for host product docs or real customer ticket exports.

## Verification
- pytest tests/test_extracted_ticket_faq_markdown.py -> 45 passed
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py -> passed
- python scripts/build_extracted_ticket_faq_markdown.py extracted_content_pipeline/examples/support_ticket_sources.csv --source-format csv --support-contact 1-800-555-0100 --require-output-checks -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
4 files, +156 / -3