### PR TITLE
Prerender FTC affiliate disclosure for no-JS crawlers

### DIFF
--- a/atlas-churn-ui/vite.config.ts
+++ b/atlas-churn-ui/vite.config.ts
@@ -6,6 +6,26 @@ import { resolve, join } from 'node:path'
 const BASE_URL = 'https://churnsignals.co'
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
 
+// FTC affiliate disclosure for no-JS agents -- AEO crawlers (GPTBot,
+// PerplexityBot, ClaudeBot, Bingbot) and social unfurl bots that never run the
+// React app. BlogArticleView renders the same disclosure for human readers via
+// useEffect, but a crawler sees only the prerendered shell, so without this the
+// FTC notice is invisible to exactly the audience the prerender exists for.
+// The block sits OUTSIDE #root (React never touches it) and inside <noscript>
+// (JS browsers never render it -- no flash, no duplicate of the React copy).
+// Copy is kept in sync with BlogArticleView.tsx's disclosure text.
+const AFFILIATE_DISCLOSURE_NOSCRIPT =
+  '<noscript>' +
+  '<div style="max-width:48rem;margin:0 auto;padding:0.75rem 1rem;' +
+  'font-size:0.75rem;color:#64748b;border:1px solid #334155;border-radius:0.5rem">' +
+  '<strong>Disclosure:</strong> This article may contain affiliate links. ' +
+  'If you purchase through these links, we may earn a commission at no ' +
+  'additional cost to you. Our analysis and recommendations are based on ' +
+  'verified review data, not affiliate relationships. ' +
+  'See our <a href="/methodology">methodology</a>.' +
+  '</div>' +
+  '</noscript>'
+
 function sitemapPlugin() {
   return {
     name: 'generate-sitemap',
@@ -71,6 +91,8 @@ interface PrerenderedRoute {
   jsonLd?: object
   faqJsonLd?: object
   breadcrumbJsonLd?: object
+  // Static HTML injected into <body> before #root (no-JS-only via <noscript>).
+  bodyHtml?: string
 }
 
 function htmlEscape(s: string): string {
@@ -199,6 +221,14 @@ function prerenderPlugin() {
           ],
         }
 
+        // Parity with BlogArticleView.hasAffiliateContent: a non-empty
+        // data_context.affiliate_url, or Monday.com's affiliate URL inlined in
+        // the body. Posts that carry an affiliate link must ship the FTC
+        // disclosure in the static HTML so no-JS crawlers see it.
+        const hasAffiliate =
+          /"affiliate_url"\s*:\s*"[^"]+"/.test(content) ||
+          content.includes('try.monday.com')
+
         const faqItems = extractFaq(content)
         const faqJsonLd = faqItems.length > 0 ? {
           '@context': 'https://schema.org',
@@ -219,6 +249,7 @@ function prerenderPlugin() {
           jsonLd: blogPosting,
           faqJsonLd,
           breadcrumbJsonLd,
+          bodyHtml: hasAffiliate ? AFFILIATE_DISCLOSURE_NOSCRIPT : undefined,
         })
       }
 
@@ -288,10 +319,19 @@ function prerenderPlugin() {
         // Inject the route's own title + the rest of the head block
         // before </head>. The base shell no longer has a <title> to
         // replace, so the new one lands inside the head HTML block.
-        const rendered = baseHtmlStripped.replace(
+        let rendered = baseHtmlStripped.replace(
           '</head>',
           `    <title>${htmlEscape(route.title)}</title>\n${headHtml}\n  </head>`,
         )
+        // Inject the no-JS disclosure (when present) just before #root, so it
+        // lives outside React's render tree and is visible only to no-JS
+        // agents.
+        if (route.bodyHtml) {
+          rendered = rendered.replace(
+            '<div id="root"></div>',
+            `${route.bodyHtml}\n    <div id="root"></div>`,
+          )
+        }
         const segments = route.path.split('/').filter(Boolean)
         const outDir = segments.length === 0 ? distDir : join(distDir, ...segments)
         if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true })

--- a/plans/PR-Blog-Affiliate-Disclosure-Prerender.md
+++ b/plans/PR-Blog-Affiliate-Disclosure-Prerender.md
@@ -1,0 +1,103 @@
+# PR-Blog-Affiliate-Disclosure-Prerender
+
+## Why this slice exists
+
+`BlogArticleView.tsx` renders an FTC affiliate-disclosure block for any post
+with affiliate content, but it does so in a React `useEffect` -- so the
+disclosure only exists after the SPA hydrates. The audience that most needs to
+see a disclosure in the *static* HTML is exactly the audience that never runs
+the JS:
+
+- **AEO crawlers** (GPTBot, PerplexityBot, ClaudeBot, Bingbot) that quote and
+  cite blog content without executing the app.
+- **Social unfurl bots** (LinkedIn, Slack, iMessage) that render a preview
+  from the raw HTML.
+
+The prerender plugin already emits per-route `dist/blog/<slug>/index.html`
+with head metadata + JSON-LD, but the `<body>` is still the empty
+`<div id="root"></div>` shell -- so a no-JS agent sees no disclosure on the 28
+posts that carry an affiliate link. This slice injects the disclosure into the
+prerendered HTML for those posts so the FTC notice is present without JS.
+
+## Scope (this PR)
+
+1. Add an `AFFILIATE_DISCLOSURE_NOSCRIPT` constant: a `<noscript>`-wrapped
+   disclosure block whose copy mirrors `BlogArticleView.tsx`.
+2. Add an optional `bodyHtml` field to `PrerenderedRoute`.
+3. In the blog-route loop, set `bodyHtml` on posts whose `.ts` source has a
+   non-empty `affiliate_url` (or inlines Monday.com's affiliate URL) -- parity
+   with `BlogArticleView.hasAffiliateContent`.
+4. In the render loop, inject `bodyHtml` immediately before `<div id="root">`.
+
+### Files touched
+
+- `atlas-churn-ui/vite.config.ts`
+- `plans/PR-Blog-Affiliate-Disclosure-Prerender.md`
+
+## Mechanism
+
+The disclosure is wrapped in `<noscript>` and injected *before*
+`<div id="root">`, i.e. outside React's mount container:
+
+- **No-JS agents** (crawlers, unfurl bots, no-JS humans) render the
+  `<noscript>` content -- the FTC notice and a `/methodology` link.
+- **JS browsers** never render `<noscript>` content, so there is no visual
+  flash and no duplicate of the React-rendered disclosure. Because the block
+  is outside `#root`, React's `createRoot().render()` never touches it.
+
+The affiliate predicate matches `BlogArticleView.hasAffiliateContent`:
+`/"affiliate_url"\s*:\s*"[^"]+"/` (a non-empty `data_context.affiliate_url`)
+OR `try.monday.com` inlined in the body. The disclosure copy is held as a
+string constant kept in sync with the component's wording.
+
+## Intentional
+
+- **Disclosure only -- no `rel="sponsored"` rewriting.** The original
+  crawler-visibility idea paired the disclosure with tagging affiliate anchors
+  `rel="sponsored"`. That half is moot here: the prerendered `<body>` has no
+  `<a>` tags at all (the article prose is rendered by React at runtime), so
+  there is nothing to decorate. The disclosure block is the entire
+  crawler-visible surface achievable without full body prerender.
+- **`<noscript>`, not a visible body block.** A plain injected block would
+  flash before React mounts and duplicate the component's disclosure;
+  `<noscript>` is the precise semantic for "no-JS agents only."
+- **Copy duplicated, not imported.** The plugin runs at build time over raw
+  `.ts` source text and cannot import the React component; the disclosure
+  string is duplicated with a comment pointing at the source of truth.
+- **Inline-styled, minimal.** The audience is mostly text-extracting bots; a
+  small inline style covers the rare no-JS human without pulling in CSS.
+
+## Deferred
+
+- **Full body prerender / SSR.** Rendering the article prose (and its
+  affiliate `<a>` tags, which could then carry `rel="sponsored"` statically)
+  into the prerendered HTML is a much larger slice -- React SSR or a
+  markdown-to-HTML build step. The disclosure is the high-value, low-risk
+  subset; full body prerender is the follow-up if AEO citation quality needs
+  the prose itself in the static HTML.
+- **Per-post custom OG image.** Unchanged from prior SEO-infra work.
+
+## Verification
+
+- `npm run build` (in `atlas-churn-ui`) -> `built in 4.44s`, `Sitemap
+  generated with 83 URLs`, `Pre-rendered 83 public routes`, no TS errors
+  (route count unchanged -- the change augments bodies, it does not add
+  routes).
+- `grep -rl "may contain affiliate links" dist/blog/*/index.html | wc -l`
+  -> `28` (matches the 28 posts with a non-empty `affiliate_url`).
+- Affiliate post `dist/blog/asana-deep-dive-2026-04/index.html` body is
+  `<body>\n    <noscript><div ...><strong>Disclosure:</strong> ... See our
+  <a href="/methodology">methodology</a>.</div></noscript>\n    <div
+  id="root"></div>` -- disclosure + methodology link present, injected before
+  `#root`.
+- Non-affiliate post `dist/blog/hubspot-deep-dive-2026-04/index.html`:
+  `grep -c "may contain affiliate links"` -> `0` (correctly absent).
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `atlas-churn-ui/vite.config.ts` (constant + field + predicate + injection) | ~40 |
+| Plan doc | ~115 |
+| **Total** | **~155** |


### PR DESCRIPTION
Plan: plans/PR-Blog-Affiliate-Disclosure-Prerender.md

`BlogArticleView` renders the FTC affiliate disclosure for human readers in a React `useEffect`, so it only exists after the SPA hydrates. The audience that most needs it in the *static* HTML — AEO crawlers (GPTBot, PerplexityBot, ClaudeBot, Bingbot) and social unfurl bots — never runs the JS. The prerender plugin emits per-route head metadata + JSON-LD but leaves the `<body>` as the empty `<div id="root"></div>` shell, so no-JS agents see no disclosure on the 28 posts carrying an affiliate link. This injects it.

## Intentional
- **`<noscript>` injected before `<div id="root">`** — outside React's mount container (createRoot never touches it) and hidden from JS browsers (no flash, no duplicate of the React-rendered disclosure). No-JS agents render it.
- **Disclosure only, no `rel="sponsored"` rewriting** — the prerendered body has no `<a>` tags (article prose is React-rendered at runtime), so there's nothing to decorate. The disclosure is the entire crawler-visible surface achievable without full body prerender.
- **Affiliate predicate mirrors `hasAffiliateContent`** — non-empty `affiliate_url` or inlined `try.monday.com`.
- **Copy duplicated, not imported** — the build-time plugin can't import the React component; the string is kept in sync with a comment pointing at the source.

## Deferred
- Full body prerender / SSR (would let affiliate anchors carry `rel="sponsored"` statically and put article prose in front of AEO bots) — larger slice, follow-up if citation quality needs it.

## Verification
- `npm run build` (atlas-churn-ui) -> `built in 4.44s`, `Pre-rendered 83 public routes`, no TS errors (route count unchanged).
- `grep -rl "may contain affiliate links" dist/blog/*/index.html | wc -l` -> `28` (matches the 28 posts with a non-empty `affiliate_url`).
- Affiliate post `dist/blog/asana-deep-dive-2026-04/index.html`: `<noscript>` disclosure + `/methodology` link injected before `<div id="root">`.
- Non-affiliate post `dist/blog/hubspot-deep-dive-2026-04/index.html`: disclosure correctly absent (`grep -c` -> 0).
- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape, path claims, diff drift 6.5%, `git diff --check`).

## Diff size
~145 LOC (vite.config.ts ~40, plan ~115).