### PR TITLE
Add CFPB FAQ Markdown smoke

### DIFF
--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T20:49Z by codex-2026-05-20
+Last updated: 2026-05-20T16:48Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-FAQ-Complaint-Narrative-Questions | `plans/PR-Content-Ops-FAQ-Complaint-Narrative-Questions.md`; `docs/extraction/coordination/inflight.md`; `extracted_content_pipeline/ticket_faq_markdown.py`; `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | Avoid concurrent edits to FAQ billing intent rules and complaint-narrative question extraction. |
+| TBD | PR-Content-Ops-CFPB-FAQ-Live-Smoke | `plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md`; `docs/extraction/coordination/inflight.md`; `scripts/smoke_content_ops_cfpb_faq_markdown.py`; `tests/test_smoke_content_ops_cfpb_faq_markdown.py`; `scripts/run_extracted_pipeline_checks.sh`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md` | codex-2026-05-20 | Avoid concurrent edits to the CFPB-to-FAQ smoke command, extracted check list, and CFPB FAQ docs. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -294,6 +294,20 @@ python scripts/export_content_ops_cfpb_sources.py \
   --output cfpb_sources.jsonl
 ```
 
+To prove the public CFPB source can produce a grounded FAQ Markdown artifact
+without a database or provider credentials, run the FAQ smoke. It fetches live
+complaint narratives, converts them through the generic source-row adapter, and
+fails if the FAQ output checks do not pass:
+
+```bash
+python scripts/smoke_content_ops_cfpb_faq_markdown.py \
+  --search-term fees \
+  --limit 3 \
+  --support-contact "https://support.example.com" \
+  --output-markdown cfpb_faq.md \
+  --json
+```
+
 ```bash
 python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --company "Example Bank" \

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -132,6 +132,9 @@ source of truth for what remains.
   support-ticket-like source path the same Postgres import and draft
   persistence smoke, with offline default mode and optional `--llm pipeline`
   provider mode.
+- `scripts/smoke_content_ops_cfpb_faq_markdown.py` proves the same public CFPB
+  source path can produce a grounded FAQ Markdown artifact without a database
+  or provider credentials, and fails closed when FAQ output checks do not pass.
 - `ingestion_diagnostics` plus `scripts/inspect_extracted_content_ingestion.py`
   provide offline readiness reports for opportunity/source-row exports before
   import or generation. The hosted control-surface API also exposes

--- a/plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md
+++ b/plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md
@@ -1,0 +1,80 @@
+# Content Ops CFPB FAQ Live Smoke
+
+## Why this slice exists
+
+The CFPB exporter can fetch real public complaint narratives, and the FAQ
+Markdown builder can render grounded article-style answers. Operators still
+need one command that proves those two seams work together: live CFPB source
+rows in, source-agnostic FAQ Markdown out, with the FAQ output checks enforced.
+
+This closes the gap between exporting CFPB rows and showing an actual grounded
+FAQ artifact from real public support-ticket-like data.
+
+## Scope (this PR)
+
+1. Add a host-facing CFPB FAQ Markdown smoke command.
+2. Keep CFPB-specific logic at the source-export boundary; FAQ generation
+   continues to consume generic source rows.
+3. Add tests for successful Markdown generation, too-few-row failure,
+   output-check failure, and JSON stdout behavior without live network calls.
+4. Document the smoke command in the Content Ops README and status notes.
+5. Replace the merged FAQ narrative coordination row with this slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this CFPB FAQ smoke slice. |
+| `scripts/smoke_content_ops_cfpb_faq_markdown.py` | New live-source to FAQ Markdown smoke command. |
+| `tests/test_smoke_content_ops_cfpb_faq_markdown.py` | Smoke command regression tests with fake CFPB fetches. |
+| `scripts/run_extracted_pipeline_checks.sh` | Include the new smoke tests in the extracted gauntlet. |
+| `extracted_content_pipeline/README.md` | Add the CFPB FAQ Markdown smoke example. |
+| `extracted_content_pipeline/STATUS.md` | Record the new live-source FAQ smoke capability. |
+
+## Mechanism
+
+The new smoke command imports the existing CFPB exporter and calls its fetch
+function with the same filter and request-header options already used by the
+source-row exporter. It writes fetched rows to JSONL, loads that file through
+the generic source-row adapter, and calls the existing FAQ Markdown builder.
+
+The smoke fails closed when fewer rows are fetched than requested, the FAQ
+builder produces no items, or any FAQ output check is false. JSON mode keeps
+stdout machine-readable on both success and failure.
+
+## Intentional
+
+- No CFPB-specific branch is added to the FAQ renderer.
+- No LLM, database, or provider dependency is added.
+- Tests monkeypatch the CFPB fetch function instead of calling the public CFPB
+  endpoint in CI.
+
+## Deferred
+
+- A hosted UI button for generating a FAQ from a CFPB sample remains separate
+  UI work.
+- Live network execution remains an operator command, not a CI requirement.
+
+## Verification
+
+- pytest tests/test_smoke_content_ops_cfpb_faq_markdown.py - 4 passed.
+- python -m py_compile scripts/smoke_content_ops_cfpb_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- Local PR review: pending.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md` | 70 |
+| `docs/extraction/coordination/inflight.md` | 4 |
+| `scripts/smoke_content_ops_cfpb_faq_markdown.py` | 160 |
+| `tests/test_smoke_content_ops_cfpb_faq_markdown.py` | 120 |
+| `scripts/run_extracted_pipeline_checks.sh` | 1 |
+| `extracted_content_pipeline/README.md` | 12 |
+| `extracted_content_pipeline/STATUS.md` | 4 |
+| **Total** | **371** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_smoke_content_ops_faq_lifecycle.py \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \
+  tests/test_smoke_content_ops_cfpb_faq_markdown.py \
   tests/test_content_ops_source_postgres_smoke_helpers.py \
   tests/test_smoke_content_ops_source_file_postgres.py \
   tests/test_smoke_content_ops_review_source_postgres.py \

--- a/scripts/smoke_content_ops_cfpb_faq_markdown.py
+++ b/scripts/smoke_content_ops_cfpb_faq_markdown.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Smoke-test live CFPB source rows through FAQ Markdown generation."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_source_adapters import load_source_campaign_opportunities_from_file  # noqa: E402
+from extracted_content_pipeline.ticket_faq_markdown import DEFAULT_TITLE, build_ticket_faq_markdown  # noqa: E402
+
+
+def _load_cfpb_exporter_module():
+    path = ROOT / "scripts" / "export_content_ops_cfpb_sources.py"
+    spec = importlib.util.spec_from_file_location("content_ops_cfpb_exporter", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load CFPB source exporter: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_cfpb = _load_cfpb_exporter_module()
+fetch_cfpb_source_rows = _cfpb.fetch_cfpb_source_rows
+render_jsonl = _cfpb.render_jsonl
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test live CFPB rows through FAQ Markdown generation."
+    )
+    parser.add_argument("--company", default=None)
+    parser.add_argument("--product", default=None)
+    parser.add_argument("--issue", default=None)
+    parser.add_argument("--search-term", default=None)
+    parser.add_argument("--api-url", default=_cfpb.DEFAULT_API_URL)
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument("--max-rows-scanned", type=int, default=_cfpb.DEFAULT_MAX_ROWS_SCANNED)
+    parser.add_argument("--timeout", type=float, default=_cfpb.DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--source-system", default=_cfpb.DEFAULT_SOURCE_SYSTEM)
+    parser.add_argument("--source-type", default=_cfpb.DEFAULT_SOURCE_TYPE)
+    parser.add_argument("--user-agent", default=_cfpb.DEFAULT_USER_AGENT)
+    parser.add_argument("--referer", default=_cfpb.DEFAULT_REFERER)
+    parser.add_argument("--title", default=DEFAULT_TITLE)
+    parser.add_argument("--max-items", type=int, default=8)
+    parser.add_argument("--max-evidence-per-item", type=int, default=3)
+    parser.add_argument("--max-text-chars", type=int, default=1200)
+    parser.add_argument("--support-contact", default=None)
+    parser.add_argument("--output-source-rows", type=Path, default=None)
+    parser.add_argument("--output-markdown", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    for name in ("limit", "max_items", "max_evidence_per_item", "max_text_chars"):
+        if int(getattr(args, name)) < 1:
+            raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+    if int(args.max_rows_scanned) < int(args.limit):
+        raise SystemExit("--max-rows-scanned must be >= --limit")
+    if float(args.timeout) <= 0:
+        raise SystemExit("--timeout must be positive")
+
+
+def run_cfpb_faq_markdown_smoke(
+    args: argparse.Namespace,
+    *,
+    source_rows_path: Path,
+) -> tuple[int, dict[str, Any]]:
+    errors: list[str] = []
+    rows: list[dict[str, Any]] = []
+    faq: dict[str, Any] | None = None
+    try:
+        rows = fetch_cfpb_source_rows(
+            api_url=str(args.api_url),
+            company=args.company,
+            product=args.product,
+            issue=args.issue,
+            search_term=args.search_term,
+            limit=int(args.limit),
+            max_rows_scanned=int(args.max_rows_scanned),
+            timeout=float(args.timeout),
+            source_system=str(args.source_system),
+            source_type=str(args.source_type),
+            user_agent=str(args.user_agent),
+            referer=str(args.referer),
+            require_narrative=True,
+        )
+        if len(rows) < int(args.limit):
+            errors.append(f"expected {int(args.limit)} CFPB source row(s), got {len(rows)}")
+        _write_jsonl(rows, source_rows_path)
+        if not errors:
+            loaded = load_source_campaign_opportunities_from_file(
+                source_rows_path,
+                file_format="jsonl",
+                max_text_chars=int(args.max_text_chars),
+            )
+            result = build_ticket_faq_markdown(
+                loaded.opportunities,
+                title=str(args.title),
+                max_items=int(args.max_items),
+                max_evidence_per_item=int(args.max_evidence_per_item),
+                support_contact=args.support_contact,
+            )
+            faq = result.as_dict()
+            failed = _failed_output_checks(result.output_checks)
+            if not result.items:
+                errors.append("FAQ Markdown generated no items")
+            if failed:
+                errors.append(f"FAQ output checks failed: {', '.join(failed)}")
+            if args.output_markdown and not errors:
+                args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+                args.output_markdown.write_text(result.markdown, encoding="utf-8")
+    except Exception as exc:  # pragma: no cover - exercised by live hosts
+        errors.append(f"{type(exc).__name__}: {exc}")
+    return (0 if not errors else 1), {
+        "ok": not errors,
+        "source": "cfpb",
+        "source_rows": len(rows),
+        "source_rows_path": str(source_rows_path),
+        "markdown_path": str(args.output_markdown) if args.output_markdown else None,
+        "faq": faq,
+        "errors": errors,
+    }
+
+
+def _write_jsonl(rows: Sequence[Mapping[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = render_jsonl(rows)
+    path.write_text(payload + ("\n" if payload else ""), encoding="utf-8")
+
+
+def _failed_output_checks(output_checks: Mapping[str, bool]) -> list[str]:
+    return [name for name, passed in sorted(output_checks.items()) if passed is not True]
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(dict(payload), indent=2, sort_keys=True))
+    elif payload.get("ok") and payload.get("markdown_path"):
+        print(f"Content Ops CFPB FAQ Markdown smoke passed: markdown={payload.get('markdown_path')}")
+    elif payload.get("ok"):
+        faq = payload.get("faq") if isinstance(payload.get("faq"), Mapping) else {}
+        print(str(faq.get("markdown") or ""), end="")
+    else:
+        print("Content Ops CFPB FAQ Markdown smoke failed:", file=sys.stderr)
+        for error in payload.get("errors") or []:
+            print(f"- {error}", file=sys.stderr)
+
+
+def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    if args.output_source_rows:
+        code, payload = run_cfpb_faq_markdown_smoke(args, source_rows_path=args.output_source_rows)
+    else:
+        with tempfile.TemporaryDirectory(prefix="content-ops-cfpb-faq-") as tmpdir:
+            code, payload = run_cfpb_faq_markdown_smoke(args, source_rows_path=Path(tmpdir) / "cfpb_sources.jsonl")
+    _print_payload(payload, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_smoke_content_ops_cfpb_faq_markdown.py
+++ b/tests/test_smoke_content_ops_cfpb_faq_markdown.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_cfpb_faq_markdown.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_cfpb_faq_markdown", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+def _row(row_id: str, text: str) -> dict[str, str]:
+    return {
+        "id": f"cfpb:{row_id}",
+        "source_id": f"cfpb:{row_id}",
+        "source": "cfpb",
+        "source_system": "cfpb",
+        "source_type": "support_ticket",
+        "vendor_name": "Example Bank",
+        "text": text,
+        "pain_category": "Fees",
+        "source_title": "Checking account - Fees",
+    }
+
+
+def _args(**overrides):
+    values = {
+        "company": "Example Bank",
+        "product": None,
+        "issue": "Fees",
+        "search_term": "fees",
+        "api_url": "https://example.test/cfpb",
+        "limit": 2,
+        "max_rows_scanned": 5,
+        "timeout": 3.5,
+        "source_system": "cfpb",
+        "source_type": "support_ticket",
+        "user_agent": "HostFetcher/2.0",
+        "referer": "https://host.example/source-export",
+        "title": "CFPB FAQ",
+        "max_items": 8,
+        "max_evidence_per_item": 3,
+        "max_text_chars": 1200,
+        "support_contact": "https://example.com/support",
+        "output_source_rows": None,
+        "output_markdown": None,
+        "json": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_cfpb_faq_smoke_builds_grounded_markdown(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+    monkeypatch.setattr(
+        smoke,
+        "fetch_cfpb_source_rows",
+        lambda **kwargs: calls.append(kwargs) or [
+            _row("1", "I was charged overdraft fees after I closed the account."),
+            _row("2", "My payment was applied to the wrong loan balance."),
+        ],
+    )
+
+    code, payload = smoke.run_cfpb_faq_markdown_smoke(
+        _args(output_markdown=tmp_path / "cfpb_faq.md"),
+        source_rows_path=tmp_path / "cfpb_sources.jsonl",
+    )
+
+    assert code == 0
+    assert payload["faq"]["output_checks"] == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+    assert calls[0]["require_narrative"] is True
+    markdown = (tmp_path / "cfpb_faq.md").read_text(encoding="utf-8")
+    assert "What should I do if I was charged overdraft fees" in markdown
+    assert "Open the bill, statement, payment history, or dispute record" in markdown
+
+
+def test_cfpb_faq_smoke_fails_when_fetch_returns_too_few_rows(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_row("1", "I was charged a fee.")])
+
+    code, payload = smoke.run_cfpb_faq_markdown_smoke(_args(limit=2), source_rows_path=tmp_path / "rows.jsonl")
+
+    assert code == 1
+    assert payload["errors"] == ["expected 2 CFPB source row(s), got 1"]
+
+
+def test_cfpb_faq_smoke_fails_when_output_checks_fail(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        smoke,
+        "fetch_cfpb_source_rows",
+        lambda **_kwargs: [_row("1", "Fee appeared after closure."), _row("2", "Fees changed.")],
+    )
+
+    code, payload = smoke.run_cfpb_faq_markdown_smoke(_args(), source_rows_path=tmp_path / "rows.jsonl")
+
+    assert code == 1
+    assert payload["faq"]["output_checks"]["uses_user_vocabulary"] is False
+    assert payload["errors"] == ["FAQ output checks failed: uses_user_vocabulary"]
+
+
+def test_json_output_and_invalid_args(capsys) -> None:
+    payload = {"ok": False, "errors": ["broken"]}
+    smoke._print_payload(payload, as_json=True)
+    assert json.loads(capsys.readouterr().out) == payload
+    with pytest.raises(SystemExit, match="--limit must be positive"):
+        smoke._validate_args(_args(limit=0))
+    with pytest.raises(SystemExit, match="--max-rows-scanned must be >= --limit"):
+        smoke._validate_args(_args(limit=2, max_rows_scanned=1))


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md

Add a host-facing smoke command that fetches CFPB source rows and renders grounded FAQ Markdown through the generic source-row and FAQ builder seams.

## Intentional
- CFPB-specific logic stays at the source-export boundary.
- No LLM, database, or provider dependency is added.
- Tests monkeypatch CFPB fetches; live network execution remains operator-only.

## Deferred
- Hosted UI entry point remains separate UI work.
- Live network execution remains outside CI.

## Verification
- pytest tests/test_smoke_content_ops_cfpb_faq_markdown.py -> 4 passed
- python -m py_compile scripts/smoke_content_ops_cfpb_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed

## Diff size
7 files, +390 / -2