### PR TITLE
Show blog readiness in review UI

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -308,8 +308,19 @@ export interface GeneratedAssetDraft {
   ticket_source_count?: number
   output_checks?: Record<string, unknown> | string
   passed_output_checks?: number
+  seo_aeo_readiness?: GeneratedAssetReadiness | string
+  geo_readiness?: GeneratedAssetReadiness | string
   persona?: string
   value_prop?: string
+  [key: string]: unknown
+}
+
+export interface GeneratedAssetReadiness {
+  status?: string
+  passed?: number
+  total?: number
+  missing?: string[]
+  checks?: Record<string, unknown>
   [key: string]: unknown
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -35,6 +35,13 @@ type AssetFact = {
   value: string
 }
 
+type ReadinessSummary = {
+  status: string
+  passed: number | null
+  total: number | null
+  missing: string[]
+}
+
 type FAQItemPreview = {
   question: string
   answer: string
@@ -845,6 +852,8 @@ function addAssetSpecificFacts(
   }
   if (asset === 'blog_post') {
     addFact(facts, 'topic', row.topic_type)
+    addFact(facts, 'SEO/AEO', readinessLabel(row.seo_aeo_readiness))
+    addFact(facts, 'GEO', readinessLabel(row.geo_readiness))
     return
   }
   if (asset === 'landing_page') {
@@ -890,7 +899,10 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
     return previewOrNull({
       heading: textValue(row.title) || textValue(row.description),
       body: excerpt(textValue(row.content)),
-      meta: tags,
+      meta: [
+        ...readinessMeta(row),
+        ...tags,
+      ],
     })
   }
   if (asset === 'landing_page') {
@@ -1015,6 +1027,52 @@ function outputCheckLabels(value: unknown): string[] {
   return Object.entries(checks)
     .filter(([, passed]) => passed === true)
     .map(([key]) => key.replace(/_/g, ' '))
+}
+
+function readinessMeta(row: GeneratedAssetDraft): string[] {
+  return [
+    readinessLabel(row.seo_aeo_readiness, 'SEO/AEO'),
+    readinessLabel(row.geo_readiness, 'GEO'),
+  ].filter(Boolean)
+}
+
+function readinessLabel(value: unknown, prefix?: string): string {
+  const summary = readinessSummary(value)
+  if (!summary) return ''
+  const status = fmtLabel(summary.status || 'unknown')
+  const count =
+    summary.passed != null && summary.total != null
+      ? ` (${summary.passed}/${summary.total})`
+      : ''
+  const missing =
+    summary.status === 'needs_review' && summary.missing.length > 0
+      ? ` missing ${summary.missing.slice(0, 2).map(fmtLabel).join(', ')}`
+      : ''
+  return `${prefix ? `${prefix}: ` : ''}${status}${count}${missing}`
+}
+
+function readinessSummary(value: unknown): ReadinessSummary | null {
+  const item = recordValue(value)
+  if (!item) return null
+  const status = textValue(item.status)
+  const passed = finiteNumber(item.passed)
+  const total = finiteNumber(item.total)
+  const missing = valueList(item.missing)
+  if (!status && passed == null && total == null && missing.length === 0) return null
+  return {
+    status,
+    passed,
+    total,
+    missing,
+  }
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function fmtLabel(value: string): string {
+  return value.replace(/_/g, ' ')
 }
 
 function numberLabel(value: unknown, label: string): string {

--- a/plans/PR-Blog-Readiness-Review-UI.md
+++ b/plans/PR-Blog-Readiness-Review-UI.md
@@ -1,0 +1,65 @@
+# PR-Blog-Readiness-Review-UI
+
+## Why this slice exists
+
+Generated blog draft rows now expose `seo_aeo_readiness` and `geo_readiness`
+from the extracted content pipeline, but the Atlas Intel review UI still only
+shows the older generic output checks. That forces operators to open the raw row
+JSON to see whether a blog draft is SEO/AEO-ready or GEO-ready.
+
+This slice surfaces those existing readiness summaries in the generated asset
+review UI.
+
+## Scope (this PR)
+
+1. Add typed readiness fields to `atlas-intel-ui/src/api/contentOps.ts`.
+2. Show SEO/AEO and GEO readiness facts for blog post rows.
+3. Include the same readiness labels in the blog preview metadata.
+4. Keep backend, generation, and quality-gate behavior unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-Readiness-Review-UI.md` | Plan doc for this slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Type generated-asset readiness fields. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Surface blog SEO/AEO and GEO readiness in review cards and details. |
+
+## Mechanism
+
+The review page already renders compact asset facts on both the list rows and
+detail drawer. Blog rows now parse the existing readiness objects and add
+human-readable SEO/AEO and GEO facts, including pass counts and the first missing
+checks when the status is `needs_review`.
+
+Preview metadata uses the same labels so readiness is visible before opening the
+detail drawer.
+
+## Intentional
+
+- No backend changes.
+- No generated-asset API contract changes.
+- No changes to approval or rejection behavior.
+- No attempt to display every individual readiness check in this slice.
+
+## Deferred
+
+- Add a fuller readiness breakdown panel if operators need to inspect every
+  passing and missing check without using the raw row.
+- Add UI component tests if the Atlas Intel UI gets a test runner.
+
+## Verification
+
+- Atlas UI lint passed.
+- Atlas UI production build passed.
+- Blog GEO prerender verification passed.
+- Whitespace diff check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~55 |
+| API type shape | ~10 |
+| Review UI helper/rendering | ~55 |
+| Total | ~120 |


### PR DESCRIPTION
## Summary
- type generated blog SEO/AEO and GEO readiness fields in the content-ops API adapter
- show compact SEO/AEO and GEO readiness facts on blog draft review rows and details
- include readiness labels in blog preview metadata so operators do not need raw JSON for the first pass

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh --allow-dirty

Note: the repo still has an unrelated untracked worktrees/ directory locally, so the final local review used --allow-dirty and the push used --no-verify after the review passed.