### PR TITLE
Close out FAQ CFPB Content Ops backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -199,5 +199,11 @@ CLI now has an opt-in `--require-output-checks` guard for host smoke runs. This
 does not create a new active implementation backlog. PR #673 upgraded the
 deterministic FAQ renderer from a thin evidence summary to article-style
 answers with grounded summaries, numbered next steps, support escalation
-guidance, and cited ticket quotes. Future FAQ/source work should be driven by a
-real customer help desk export or hosted UI need.
+guidance, and cited ticket quotes. PR #684 added generic complaint-narrative
+question extraction and billing intent grouping so real public complaint rows
+such as CFPB narratives can still satisfy the customer-vocabulary check without
+CFPB-specific renderer logic. PR #687 added a live CFPB-to-FAQ Markdown smoke
+that fetches public complaint rows, converts them through the generic
+source-row adapter, and fails closed when FAQ output checks do not pass.
+Future FAQ/source work should be driven by a real customer help desk export or
+hosted UI need.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,10 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T16:48Z by codex-2026-05-20
+Last updated: 2026-05-20T17:08Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| TBD | PR-Content-Ops-CFPB-FAQ-Live-Smoke | `plans/PR-Content-Ops-CFPB-FAQ-Live-Smoke.md`; `docs/extraction/coordination/inflight.md`; `scripts/smoke_content_ops_cfpb_faq_markdown.py`; `tests/test_smoke_content_ops_cfpb_faq_markdown.py`; `scripts/run_extracted_pipeline_checks.sh`; `extracted_content_pipeline/README.md`; `extracted_content_pipeline/STATUS.md` | codex-2026-05-20 | Avoid concurrent edits to the CFPB-to-FAQ smoke command, extracted check list, and CFPB FAQ docs. |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-FAQ-CFPB-Closeout.md
+++ b/plans/PR-Content-Ops-FAQ-CFPB-Closeout.md
@@ -1,0 +1,57 @@
+# Content Ops FAQ CFPB Closeout
+
+## Why this slice exists
+
+PR #684 and PR #687 closed the latest FAQ/source follow-ups: complaint-shaped
+CFPB rows now produce human FAQ questions, and operators have a live CFPB to
+FAQ Markdown smoke command. The coordination ledger still shows the merged
+CFPB FAQ smoke as in flight, and the active backlog stops at PR #673.
+
+This slice keeps the source-of-truth docs aligned before starting another
+implementation thread.
+
+## Scope (this PR)
+
+1. Remove the merged CFPB FAQ smoke claim from the in-flight ledger.
+2. Update the AI Content Ops deferred backlog with the PR #684 and PR #687 FAQ
+   closeout.
+3. Leave README and STATUS alone because PR #687 already updated those product
+   docs.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-CFPB-Closeout.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Remove merged CFPB FAQ smoke row. |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | Record the latest FAQ/CFPB closeout and keep future work gated on real host data or UI need. |
+
+## Mechanism
+
+The in-flight table becomes empty again because the CFPB FAQ smoke PR has
+merged. The backlog FAQ paragraph now records the two latest shipped slices and
+keeps the existing policy: future FAQ/source work should be driven by real
+customer help desk exports or hosted UI needs, not speculative source shapes.
+
+## Intentional
+
+- Docs-only closeout; no runtime behavior changes.
+- No README or STATUS edits because they already mention the CFPB FAQ smoke.
+
+## Deferred
+
+- Next implementation work remains dependent on a real host export, hosted UI
+  need, or a deliberate shift back to extracted reasoning core productization.
+
+## Verification
+
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-CFPB-Closeout.md` | 55 |
+| `docs/extraction/coordination/inflight.md` | 3 |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | 12 |
+| **Total** | **70** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-CFPB-Closeout.md

Close the coordination loop after the complaint-narrative FAQ and CFPB FAQ smoke slices merged.

## Intentional
- Docs-only closeout; no runtime behavior changes.
- README and STATUS are untouched because #687 already updated them.

## Deferred
- Further FAQ/source work waits for real host exports, hosted UI need, or reasoning-core productization.

## Verification
- bash scripts/local_pr_review.sh -> passed

## Diff size
3 files, +66 / -4