### PR TITLE
Verify blog SEO publish metadata

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -16,23 +16,46 @@ function readText(path) {
   return readFileSync(path, 'utf-8')
 }
 
-function collectBlogSlugs() {
-  const slugs = []
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseStringField(content, field) {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
+  const match = content.match(pattern)
+  if (!match) return ''
+  return match[1].replace(/\\'/g, "'")
+}
+
+function collectBlogPosts() {
+  const posts = []
   for (const file of readdirSync(blogDir)) {
     if (!file.endsWith('.ts') || file === 'index.ts') continue
     const content = readText(join(blogDir, file))
-    const match = content.match(/slug:\s*'([^']+)'/)
-    if (!match) fail(`Missing slug in ${file}`)
-    slugs.push(match[1])
+    const slug = parseStringField(content, 'slug')
+    const title = parseStringField(content, 'title')
+    const description = parseStringField(content, 'description')
+    const seoTitle = parseStringField(content, 'seo_title')
+    const seoDescription = parseStringField(content, 'seo_description')
+    if (!slug) fail(`Missing slug in ${file}`)
+    if (!title) fail(`Missing title in ${file}`)
+    if (!description) fail(`Missing description in ${file}`)
+    posts.push({
+      slug,
+      title,
+      description,
+      seoTitle,
+      seoDescription,
+    })
   }
-  if (!slugs.length) fail('No blog slugs found')
-  return slugs.sort()
+  if (!posts.length) fail('No blog posts found')
+  return posts.sort((a, b) => a.slug.localeCompare(b.slug))
 }
 
 function attrValue(tag, attr) {
-  const pattern = new RegExp(`${attr}=["']([^"']+)["']`, 'i')
+  const pattern = new RegExp(`${escapeRegExp(attr)}=(["'])(.*?)\\1`, 'i')
   const match = tag.match(pattern)
-  return match ? match[1] : ''
+  return match ? match[2] : ''
 }
 
 function findLink(html, rel) {
@@ -43,6 +66,20 @@ function findLink(html, rel) {
 function findMeta(html, attr, key) {
   const metas = html.match(/<meta\b[^>]*>/gi) || []
   return metas.find(tag => attrValue(tag, attr) === key) || ''
+}
+
+function findTitle(html) {
+  const match = html.match(/<title>([\s\S]*?)<\/title>/i)
+  return match ? decodeHtml(match[1].trim()) : ''
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
 }
 
 function parseJsonLd(html, slug) {
@@ -97,6 +134,35 @@ function assertBlogPosting(node, canonical, slug) {
   }
 }
 
+function assertMetaContent(html, attr, key, expected, slug) {
+  const meta = findMeta(html, attr, key)
+  const actual = decodeHtml(attrValue(meta, 'content'))
+  if (actual !== expected) {
+    fail(`/blog/${slug} ${key} must be ${expected}`)
+  }
+}
+
+function assertSeoMeta(html, post) {
+  const title = `${post.seoTitle || post.title} | Atlas Intelligence`
+  const description = post.seoDescription || post.description
+
+  if (findTitle(html) !== title) {
+    fail(`/blog/${post.slug} title tag must be ${title}`)
+  }
+
+  assertMetaContent(html, 'name', 'description', description, post.slug)
+  assertMetaContent(html, 'property', 'og:title', title, post.slug)
+  assertMetaContent(html, 'property', 'og:description', description, post.slug)
+  assertMetaContent(html, 'name', 'twitter:title', title, post.slug)
+  assertMetaContent(html, 'name', 'twitter:description', description, post.slug)
+
+  const twitterImage = findMeta(html, 'name', 'twitter:image')
+  const twitterImageValue = attrValue(twitterImage, 'content')
+  if (!twitterImageValue || !twitterImageValue.startsWith(BASE_URL)) {
+    fail(`/blog/${post.slug} twitter:image must be an absolute Atlas URL`)
+  }
+}
+
 function assertBreadcrumbs(node, canonical, slug) {
   const items = Array.isArray(node.itemListElement) ? node.itemListElement : []
   if (items.length < 3) fail(`/blog/${slug} breadcrumb list is incomplete`)
@@ -106,10 +172,13 @@ function assertBreadcrumbs(node, canonical, slug) {
   }
 }
 
-function verifyBlogPage(slug, sitemap) {
+function verifyBlogPage(post, sitemap) {
+  const { slug } = post
   const canonical = `${BASE_URL}/blog/${slug}`
   const htmlPath = join(distDir, 'blog', slug, 'index.html')
   const html = readText(htmlPath)
+
+  assertSeoMeta(html, post)
 
   const canonicalLink = findLink(html, 'canonical')
   if (attrValue(canonicalLink, 'href') !== canonical) {
@@ -148,10 +217,10 @@ function verifyBlogPage(slug, sitemap) {
   }
 }
 
-const slugs = collectBlogSlugs()
+const posts = collectBlogPosts()
 const sitemap = readText(sitemapPath)
-for (const slug of slugs) {
-  verifyBlogPage(slug, sitemap)
+for (const post of posts) {
+  verifyBlogPage(post, sitemap)
 }
 
-console.log(`Verified GEO prerender metadata for ${slugs.length} blog pages`)
+console.log(`Verified GEO prerender metadata for ${posts.length} blog pages`)

--- a/plans/PR-Blog-SEO-Publish-Meta-Check.md
+++ b/plans/PR-Blog-SEO-Publish-Meta-Check.md
@@ -1,0 +1,69 @@
+# PR-Blog-SEO-Publish-Meta-Check
+
+## Why this slice exists
+
+The blog publish verifier already protects crawler-visible GEO basics such as
+canonical URLs, OG URL/type/image, BlogPosting JSON-LD, breadcrumbs, sitemap
+inclusion, and indexability. It does not yet verify the source SEO title and
+description actually make it into the prerendered HTML.
+
+That leaves a practical SEO regression gap: a blog post could have good source
+metadata while the published route ships the wrong title, missing description,
+or incomplete social preview tags.
+
+## Scope (this PR)
+
+1. Extend `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` to read each
+   blog post's source title and description metadata.
+2. Verify the prerendered title tag and meta description match the source
+   SEO fields, falling back to the display title and description.
+3. Verify OG title/description and Twitter title/description/image are present
+   and aligned with the same source metadata.
+4. Keep route rendering, blog content, and generation behavior unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-SEO-Publish-Meta-Check.md` | Plan doc for this slice. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Add source-aware SEO and social meta verification. |
+
+## Mechanism
+
+The verifier now parses the existing TypeScript blog content files for `slug`,
+`title`, `description`, `seo_title`, and `seo_description`. For each built blog
+page, it compares the prerendered HTML against the expected title and
+description values.
+
+The check stays local to the existing publish verifier so the GitHub UI workflow
+continues to catch public blog metadata regressions in one place.
+
+## Intentional
+
+- No frontend rendering changes.
+- No content changes.
+- No attempt to parse every possible TypeScript expression in blog files. The
+  current blog content uses simple string fields, which is the contract this
+  verifier enforces.
+- No FAQ schema verification in this slice because current checked-in blog
+  posts do not include FAQ data.
+
+## Deferred
+
+- Add FAQPage schema verification when blog content includes FAQ entries.
+- Add per-post image verification if generated posts get unique OG images.
+
+## Verification
+
+- Atlas UI lint passed.
+- Atlas UI production build passed.
+- Blog GEO prerender verification passed across 14 blog pages.
+- Whitespace diff check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Publish verifier | ~75 |
+| Total | ~135 |


### PR DESCRIPTION
## Summary
- strengthen the blog GEO prerender verifier with source-aware SEO metadata checks
- verify title tag, meta description, OG title/description, and Twitter title/description/image for every built blog post
- keep rendering, content, and generation behavior unchanged

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh --allow-dirty

The pre-push hook also ran local PR review successfully during push.