### PR TITLE
Verify blog JSON-LD publish contract

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -35,15 +35,18 @@ function collectBlogPosts() {
     const slug = parseStringField(content, 'slug')
     const title = parseStringField(content, 'title')
     const description = parseStringField(content, 'description')
+    const date = parseStringField(content, 'date')
     const seoTitle = parseStringField(content, 'seo_title')
     const seoDescription = parseStringField(content, 'seo_description')
     if (!slug) fail(`Missing slug in ${file}`)
     if (!title) fail(`Missing title in ${file}`)
     if (!description) fail(`Missing description in ${file}`)
+    if (!date) fail(`Missing date in ${file}`)
     posts.push({
       slug,
       title,
       description,
+      date,
       seoTitle,
       seoDescription,
     })
@@ -124,14 +127,52 @@ function assertNoNoindex(html, slug) {
   }
 }
 
-function assertBlogPosting(node, canonical, slug) {
+function expectedTitle(post) {
+  return post.seoTitle || post.title
+}
+
+function expectedDescription(post) {
+  return post.seoDescription || post.description
+}
+
+function assertSame(actual, expected, label, slug) {
+  if (actual !== expected) {
+    fail(`/blog/${slug} ${label} must be ${expected}`)
+  }
+}
+
+function assertOrganization(node, label, slug) {
+  if (!node || node['@type'] !== 'Organization') {
+    fail(`/blog/${slug} BlogPosting ${label} must be an Organization`)
+  }
+  assertSame(node.name, 'Atlas Intelligence', `BlogPosting ${label} name`, slug)
+  const sameAs = Array.isArray(node.sameAs) ? node.sameAs : []
+  if (!sameAs.includes('https://twitter.com/atlasintel')) {
+    fail(`/blog/${slug} BlogPosting ${label} missing Twitter sameAs`)
+  }
+  if (!sameAs.includes('https://www.linkedin.com/company/atlas-intelligence')) {
+    fail(`/blog/${slug} BlogPosting ${label} missing LinkedIn sameAs`)
+  }
+}
+
+function assertBlogPosting(node, post, canonical, ogImageValue) {
+  const { slug } = post
   for (const field of ['headline', 'description', 'image', 'author', 'publisher']) {
     if (!node[field]) fail(`/blog/${slug} BlogPosting missing ${field}`)
   }
+  assertSame(node.headline, expectedTitle(post), 'BlogPosting headline', slug)
+  assertSame(node.description, expectedDescription(post), 'BlogPosting description', slug)
+  assertSame(node.datePublished, post.date, 'BlogPosting datePublished', slug)
+  assertSame(node.dateModified, post.date, 'BlogPosting dateModified', slug)
+  assertSame(node.image, ogImageValue, 'BlogPosting image', slug)
+
   const mainEntity = node.mainEntityOfPage
   if (!mainEntity || mainEntity['@id'] !== canonical) {
     fail(`/blog/${slug} BlogPosting mainEntityOfPage must be ${canonical}`)
   }
+
+  assertOrganization(node.author, 'author', slug)
+  assertOrganization(node.publisher, 'publisher', slug)
 }
 
 function assertMetaContent(html, attr, key, expected, slug) {
@@ -143,8 +184,8 @@ function assertMetaContent(html, attr, key, expected, slug) {
 }
 
 function assertSeoMeta(html, post) {
-  const title = `${post.seoTitle || post.title} | Atlas Intelligence`
-  const description = post.seoDescription || post.description
+  const title = `${expectedTitle(post)} | Atlas Intelligence`
+  const description = expectedDescription(post)
 
   if (findTitle(html) !== title) {
     fail(`/blog/${post.slug} title tag must be ${title}`)
@@ -206,7 +247,7 @@ function verifyBlogPage(post, sitemap) {
   const nodes = flattenJsonLdTypes(parseJsonLd(html, slug))
   const blogPosting = nodes.find(node => typeMatches(node, 'BlogPosting'))
   if (!blogPosting) fail(`/blog/${slug} missing BlogPosting JSON-LD`)
-  assertBlogPosting(blogPosting, canonical, slug)
+  assertBlogPosting(blogPosting, post, canonical, ogImageValue)
 
   const breadcrumbs = nodes.find(node => typeMatches(node, 'BreadcrumbList'))
   if (!breadcrumbs) fail(`/blog/${slug} missing BreadcrumbList JSON-LD`)

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -11,6 +11,20 @@ import { resolve, join } from 'node:path'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
+const ATLAS_SAME_AS = [
+  'https://twitter.com/atlasintel',
+  'https://www.linkedin.com/company/atlas-intelligence',
+]
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseStringField(content: string, field: string): string {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
+  const match = content.match(pattern)
+  return match ? match[1].replace(/\\'/g, "'") : ''
+}
 
 // ---------------------------------------------------------------------------
 // Sitemap plugin
@@ -135,17 +149,18 @@ function prerenderPlugin() {
       for (const file of readdirSync(blogDir)) {
         if (!file.endsWith('.ts') || file === 'index.ts') continue
         const content = readFileSync(join(blogDir, file), 'utf-8')
-        const slug = (content.match(/slug:\s*'([^']+)'/) || [])[1]
+        const slug = parseStringField(content, 'slug')
         if (!slug) continue
 
         const seoTitle =
-          (content.match(/seo_title:\s*'([^']+)'/) || [])[1] ||
-          (content.match(/title:\s*'([^']+)'/) || [])[1] ||
+          parseStringField(content, 'seo_title') ||
+          parseStringField(content, 'title') ||
           'Atlas Intelligence Blog'
         const seoDesc =
-          (content.match(/seo_description:\s*'([^']+)'/) || [])[1] ||
-          (content.match(/description:\s*'([^']+)'/) || [])[1] ||
+          parseStringField(content, 'seo_description') ||
+          parseStringField(content, 'description') ||
           'Amazon seller intelligence and competitive analysis insights.'
+        const date = parseStringField(content, 'date')
 
         blogRoutes.push({
           path: `/blog/${slug}`,
@@ -160,12 +175,19 @@ function prerenderPlugin() {
                 '@type': 'BlogPosting',
                 headline: seoTitle,
                 description: seoDesc,
+                datePublished: date || undefined,
+                dateModified: date || undefined,
                 image: DEFAULT_OG_IMAGE,
-                author: { '@type': 'Organization', name: 'Atlas Intelligence' },
+                author: {
+                  '@type': 'Organization',
+                  name: 'Atlas Intelligence',
+                  sameAs: ATLAS_SAME_AS,
+                },
                 publisher: {
                   '@type': 'Organization',
                   name: 'Atlas Intelligence',
                   url: BASE_URL,
+                  sameAs: ATLAS_SAME_AS,
                   logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
                 },
                 mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${slug}` },

--- a/plans/PR-Blog-JSONLD-Publish-Contract.md
+++ b/plans/PR-Blog-JSONLD-Publish-Contract.md
@@ -1,0 +1,73 @@
+# PR-Blog-JSONLD-Publish-Contract
+
+## Why this slice exists
+
+The blog publish verifier now checks source-aligned title, description, OG, and
+Twitter metadata. Its BlogPosting JSON-LD check is still mostly presence-based:
+it verifies required fields exist, but not that those fields match the source
+blog post contract.
+
+That leaves a crawler-visible structured-data regression gap. A page could ship
+the right meta tags while BlogPosting JSON-LD carries stale headline,
+description, date, image, or organization data.
+
+## Scope (this PR)
+
+1. Extend `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` to parse each
+   blog post source date.
+2. Verify BlogPosting headline and description match the same source-derived
+   title and description used by SEO metadata.
+3. Verify BlogPosting published/modified dates match the source post date.
+4. Verify BlogPosting image matches the route's OG image.
+5. Verify author and publisher organization identity fields stay present.
+6. Update `atlas-intel-ui/vite.config.ts` so prerendered BlogPosting JSON-LD
+   emits the source-aligned fields the verifier requires.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-JSONLD-Publish-Contract.md` | Plan doc for this slice. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Add source-aligned BlogPosting JSON-LD assertions. |
+| `atlas-intel-ui/vite.config.ts` | Emit source-aligned BlogPosting dates and organization identity in prerendered HTML. |
+
+## Mechanism
+
+The verifier derives expected BlogPosting values from the existing TypeScript
+blog source files and the prerendered HTML. It compares JSON-LD headline,
+description, dates, mainEntityOfPage, image, author, and publisher values
+against that expected contract.
+
+The prerender plugin now uses the same exact-field source parsing and emits the
+date and organization identity fields needed by the publish contract.
+
+This keeps publish-surface SEO/GEO checks in one CI-covered verifier.
+
+## Intentional
+
+- No runtime React rendering changes.
+- No content changes.
+- No generated-post pipeline changes.
+- No new schema types.
+
+## Deferred
+
+- Add FAQPage schema verification when blog content includes FAQ entries.
+- Add per-post image verification if generated posts get unique OG images.
+- Consider validating HowTo schema once migration posts reliably emit it.
+
+## Verification
+
+- Atlas UI lint passed.
+- Atlas UI production build passed.
+- Blog GEO prerender verification passed across 14 blog pages.
+- Whitespace diff check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Publish verifier | ~70 |
+| Prerender metadata | ~35 |
+| Total | ~165 |


### PR DESCRIPTION
## Summary
- strengthen the blog GEO prerender verifier to assert BlogPosting values, not just field presence
- emit source-aligned BlogPosting dates and organization identity in prerendered blog HTML
- keep runtime React rendering and blog content unchanged

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh --allow-dirty

The pre-push hook also ran local PR review successfully during push.