### PR TITLE
Improve complaint-source FAQ policy

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -205,5 +205,11 @@ such as CFPB narratives can still satisfy the customer-vocabulary check without
 CFPB-specific renderer logic. PR #687 added a live CFPB-to-FAQ Markdown smoke
 that fetches public complaint rows, converts them through the generic
 source-row adapter, and fails closed when FAQ output checks do not pass.
-Future FAQ/source work should be driven by a real customer help desk export or
-hosted UI need.
+The local CFPB export at `/home/juan-canfield/Downloads/archive (1)/rows.csv`
+has 1,282,355 rows, 383,564 with usable complaint narratives. A 50-row debt
+collection sample exposed generic gaps: provider-style complaint narrative
+fields needed direct source-row aliases, and debt/credit-report complaints
+needed financial complaint action policy before SaaS-style reporting/account
+rules. PR-Content-Ops-FAQ-Complaint-Source-Policy owns that source-level fix.
+Future FAQ/source work should be driven by a real customer help desk export,
+hosted UI need, or another real dataset exposing a generic policy gap.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,5 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
+| PR-Content-Ops-FAQ-Complaint-Source-Policy | Generic complaint source aliases and FAQ financial complaint actions | `extracted_content_pipeline/campaign_source_adapters.py`, `extracted_content_pipeline/ticket_faq_markdown.py`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | open PR #691 blog publish metadata |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -71,6 +71,7 @@ _SOURCE_ID_KEYS = (
     "contract_id",
     "subscription_id",
     "document_id",
+    "complaint_id",
     "ticket_id",
     "ticket_number",
     "case_id",
@@ -90,6 +91,9 @@ _TEXT_KEYS = (
     "body",
     "quote",
     "complaint",
+    "complaint_narrative",
+    "consumer_complaint_narrative",
+    "narrative",
     "message",
     "description",
     "issue_description",
@@ -149,7 +153,7 @@ _SOURCE_TITLE_COLLISION_KEYS = (
     "title",
     "name",
 )
-_PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "topic", "category")
+_PAIN_KEYS = ("pain_points", "pain_categories", "pain_category", "issue", "topic", "category")
 _PARENT_EXCLUDE_KEYS = set(_ROW_LIST_KEYS) | set(_SOURCE_TITLE_COLLISION_KEYS)
 _COMPANY_KEYS = (
     "company_name",
@@ -222,7 +226,7 @@ _SOURCE_TYPE_PRECEDENCE = (
     (("renewal_id",), "renewal"),
     (("contract_id",), "contract"),
     (("subscription_id",), "subscription"),
-    (("complaint",), "complaint"),
+    (("complaint", "complaint_id", "complaint_narrative", "consumer_complaint_narrative"), "complaint"),
     (("ticket_id", "ticket_number", "request_id"), "support_ticket"),
     (("case_id", "case_number"), "case"),
     (("conversation_id", "conversation_number"), "conversation"),

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -31,7 +31,39 @@ _SPEAKER_LABEL_RE = re.compile(
     re.IGNORECASE,
 )
 _CUSTOMER_SPEAKERS = {"customer", "user", "requester", "client"}
+_SUPPORTED_QUESTION_SOURCES = {"customer_wording", "source_policy"}
+_GENERIC_QUESTION_TEXTS = {
+    "help?",
+    "need help?",
+    "please help?",
+    "can you help?",
+    "what should i do?",
+    "what can i do?",
+}
 DEFAULT_INTENT_RULES = (
+    ("credit report disputes", (
+        "credit report",
+        "credit file",
+        "credit bureau",
+        "credit bureaus",
+        "credit reporting",
+        "incorrect information",
+    )),
+    ("debt collection disputes", (
+        "debt not owed",
+        "not owe",
+        "do not owe",
+        "collect debt",
+        "debt collection",
+        "collector",
+        "debt collector",
+        "collection letter",
+        "collection agency",
+        "debt validation",
+        "validation letter",
+        "medical debt",
+        "settled the debt",
+    )),
     ("reporting friction", ("export", "report", "dashboard", "attribution")),
     ("manual follow-up", ("handoff", "follow-up", "workflow", "automation", "manual")),
     ("login reset", ("login reset", "password reset", "reset password", "reset my password")),
@@ -69,6 +101,14 @@ _DATE_KEYS = (
     "timestamp",
 )
 _ACTION_RULES = (
+    (("credit report", "credit file", "credit bureau", "credit bureaus", "credit reporting", "incorrect information"), (
+        "Get your latest credit reports and mark the account, date, balance, or status that looks wrong.",
+        "File a dispute with the credit bureau and the company that supplied the information, then keep the confirmation numbers and copies of your records.",
+    )),
+    (("debt not owed", "not owe", "do not owe", "collect debt", "debt collection", "collector", "debt collector", "collection letter", "collection agency", "debt validation", "validation letter", "medical debt", "settled the debt"), (
+        "Ask the collector in writing to identify the original creditor, the amount, the account, and why they say you owe it.",
+        "Compare the notice with your payment, settlement, insurance, or provider records before you pay or share more information.",
+    )),
     (("export", "report", "dashboard", "attribution"), (
         "Open the reporting or analytics area and choose the date range you need.",
         "Look for an Export or Download option, then ask an admin to check your role and plan access if it is missing.",
@@ -431,18 +471,30 @@ def _question(topic: str, rows: Sequence[Mapping[str, str]]) -> tuple[str, str]:
         text = _question_text(row.get("text", ""))
         if text:
             return (text, "customer_wording")
+    policy_question = _policy_question(topic)
+    if policy_question:
+        return (policy_question, "source_policy")
     return (f"What are customers asking about {topic}?", "topic_fallback")
 
 
 def _question_text(value: Any) -> str:
     for text in _question_candidate_texts(value):
         if "?" in text:
-            prefix = text.split("?", 1)[0].strip()
+            prefix, remainder = text.split("?", 1)
+            prefix = prefix.strip()
             sentence_parts = [part.strip() for part in re.split(r"[.!:;]+", prefix) if part.strip()]
             candidate = sentence_parts[-1] if sentence_parts else prefix
             normalized = _normalize_question_text(candidate)
             if _usable_question(normalized):
                 return normalized
+            tail = _compact(remainder)
+            if tail:
+                normalized = _question_start_text(tail)
+                if normalized:
+                    return normalized
+                normalized = _first_person_issue_question_text(tail)
+                if normalized:
+                    return normalized
             continue
         normalized = _question_start_text(text)
         if normalized:
@@ -543,7 +595,8 @@ def _first_sentence(text: str) -> str:
 
 
 def _usable_question(value: str) -> bool:
-    return bool(value) and len(value) <= MAX_EXTRACTED_QUESTION_CHARS
+    lowered = _compact(value).lower()
+    return bool(value) and len(value) <= MAX_EXTRACTED_QUESTION_CHARS and lowered not in _GENERIC_QUESTION_TEXTS
 
 
 def _normalize_question_text(value: str) -> str:
@@ -551,6 +604,15 @@ def _normalize_question_text(value: str) -> str:
     if not candidate:
         return ""
     return f"{candidate}?"
+
+
+def _policy_question(topic: str) -> str:
+    normalized = _topic_label(topic).lower()
+    if normalized == "credit report disputes":
+        return "What should I do if information on my credit report is wrong?"
+    if normalized == "debt collection disputes":
+        return "What should I do if a collector says I owe a debt I do not recognize?"
+    return ""
 
 
 def _render(
@@ -630,6 +692,16 @@ def _article_steps(topic: str, evidence_text: str, *, support_contact: str | Non
 
 def _escalation_guidance(topic: str, evidence_text: str, *, support_contact: str | None) -> str:
     text = f"{topic} {evidence_text}".lower()
+    if any(term in text for term in ("credit report", "credit file", "credit bureau", "credit bureaus", "credit reporting", "incorrect information")):
+        return (
+            f"{_support_sentence(support_contact)} if the account still appears "
+            "incorrect after you dispute it or if the furnisher does not explain the record."
+        )
+    if any(term in text for term in ("debt not owed", "not owe", "do not owe", "collect debt", "debt collection", "collector", "debt collector", "collection letter", "collection agency", "debt validation", "validation letter", "medical debt", "settled the debt")):
+        return (
+            f"{_support_sentence(support_contact)} if the collector will not validate "
+            "the debt, keeps contacting you about a debt you do not recognize, or reports it again."
+        )
     if any(term in text for term in ("export", "report", "dashboard", "attribution")):
         return (
             f"{_support_sentence(support_contact)} if the export is missing, "
@@ -811,7 +883,7 @@ def _output_checks(
     covers_all_sources = rendered_ticket_source_count == ticket_source_count
     return {
         "uses_user_vocabulary": has_items
-        and all(item.get("question_source") == "customer_wording" for item in items),
+        and all(item.get("question_source") in _SUPPORTED_QUESTION_SOURCES for item in items),
         "condensed": has_items
         and covers_all_sources
         and (ticket_source_count <= 1 or len(items) < ticket_source_count),

--- a/plans/PR-Content-Ops-FAQ-Complaint-Source-Policy.md
+++ b/plans/PR-Content-Ops-FAQ-Complaint-Source-Policy.md
@@ -1,0 +1,76 @@
+# Content Ops FAQ Complaint Source Policy
+
+## Why this slice exists
+
+A local CFPB complaint export at `/home/juan-canfield/Downloads/archive (1)/rows.csv` exposed two source-level gaps in the generic FAQ path:
+
+1. Raw complaint exports with provider-style fields such as `Consumer complaint narrative`, `Complaint ID`, and `Issue` do not normalize cleanly through the generic source adapter without a CFPB-specific conversion step.
+2. CFPB-like financial complaint rows can be misclassified by generic B2B/support keywords (`report`, `account`, `payment`) and receive wrong next steps such as dashboard export or profile-setting guidance.
+
+This slice fixes those issues at the generic source/FAQ policy layer so CFPB, bank complaint, help desk complaint, and similar source rows improve together.
+
+## Scope (this PR)
+
+1. Extend generic source-row aliases for complaint narratives and complaint IDs.
+2. Preserve `issue`-style fields as pain points so FAQ grouping can use the source's own issue taxonomy.
+3. Add generic financial complaint/debt/credit-report FAQ intent and action guidance before narrower B2B/support rules.
+4. Add regression tests using CFPB-shaped rows, without adding CFPB-specific branches to the FAQ renderer.
+5. Log this active slice in the coordination ledger.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Complaint-Source-Policy.md`
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `docs/extraction/coordination/inflight.md`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `tests/test_extracted_campaign_source_adapters.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+
+## Mechanism
+
+The source adapter already normalizes provider-style headings by comparing normalized and compact field names. Adding `complaint_id`, `consumer_complaint_narrative`, `complaint_narrative`, and `issue` to the existing generic alias tables lets raw complaint CSV/JSON rows become normal source opportunities.
+
+The FAQ renderer keeps the same `intent_rules` mechanism but orders broad financial complaint categories before generic reporting/account rules. The action guidance remains deterministic and extractive: debt/credit-report/payment issues get dispute/documentation/credit-report steps instead of SaaS dashboard/profile steps.
+
+## Intentional
+
+- No CFPB-specific renderer branch. CFPB remains one source producer; FAQ generation stays generic.
+- No new live CFPB dependency in tests. Tests use small CFPB-shaped fixtures so CI is stable.
+- No source adapter signature changes. Hosts can keep using existing CSV/JSON/JSONL ingestion.
+- The downloaded 737 MB dataset is not committed. It is local validation data only.
+
+## Deferred
+
+- A frozen, real CFPB fixture can land later if we want repeatable large-sample quality tracking in CI.
+- More financial-domain FAQ action packs can follow if another real dataset exposes distinct categories not covered here.
+- Live CFPB API retry/fallback remains separate from local dataset processing because this slice fixes local/raw-source quality.
+
+## Verification
+
+Commands run:
+
+```bash
+pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py -q  # 112 passed
+python -m py_compile extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py  # passed
+python scripts/build_extracted_ticket_faq_markdown.py /tmp/cfpb_raw_debt_collection_50.csv --source-format csv --title 'Debt Collection Complaint FAQ' --max-items 8 --max-evidence-per-item 3 --support-contact 'https://example.com/support' --require-output-checks --output /tmp/cfpb_raw_debt_collection_50_faq.md  # passed
+bash scripts/validate_extracted_content_pipeline.sh  # passed
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline  # passed
+python scripts/audit_extracted_standalone.py --fail-on-debt  # passed
+bash scripts/check_ascii_python.sh  # passed
+bash scripts/local_pr_review.sh  # passed
+bash scripts/run_extracted_pipeline_checks.sh  # 1554 passed, 1 existing torch/pynvml warning
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Complaint-Source-Policy.md` | 65 |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | 10 |
+| `docs/extraction/coordination/inflight.md` | 1 |
+| `extracted_content_pipeline/campaign_source_adapters.py` | 8 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 70 |
+| `tests/test_extracted_campaign_source_adapters.py` | 26 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 60 |
+| **Total** | **240** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -46,7 +46,7 @@ def test_source_type_precedence_table_matches_current_contract() -> None:
         (("renewal_id",), "renewal"),
         (("contract_id",), "contract"),
         (("subscription_id",), "subscription"),
-        (("complaint",), "complaint"),
+        (("complaint", "complaint_id", "complaint_narrative", "consumer_complaint_narrative"), "complaint"),
         (("ticket_id", "ticket_number", "request_id"), "support_ticket"),
         (("case_id", "case_number"), "case"),
         (("conversation_id", "conversation_number"), "conversation"),
@@ -160,6 +160,30 @@ def test_source_rows_normalize_and_warn_for_missing_text() -> None:
     assert first["target_mode"] == "vendor_retention"
     assert first["evidence"][0]["source_type"] == "transcript"
     assert "missing_source_text" in [warning.code for warning in loaded.warnings]
+
+
+def test_source_row_maps_provider_complaint_narrative_aliases() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "Complaint ID": "3182593",
+        "Consumer complaint narrative": "I received a collection letter for a debt I do not owe.",
+        "Issue": "Attempts to collect debt not owed",
+        "Product": "Debt collection",
+        "Company": "Example Collector",
+        "Date received": "03/01/2019",
+    })
+
+    assert warnings == ()
+    assert opportunity["id"] == "3182593"
+    assert opportunity["target_id"] == "3182593"
+    assert opportunity["source_id"] == "3182593"
+    assert opportunity["source_type"] == "complaint"
+    assert opportunity["company_name"] == "Example Collector"
+    assert opportunity["pain_points"] == ["Attempts to collect debt not owed"]
+    assert opportunity["evidence"] == [{
+        "text": "I received a collection letter for a debt I do not owe.",
+        "source_id": "3182593",
+        "source_type": "complaint",
+    }]
 
 
 def test_source_rows_apply_default_fields_without_overriding_row_values() -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -886,6 +886,100 @@ def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_shaped_rows() -
     assert "https://www.consumerfinance.gov/complaint/" in markdown
 
 
+def test_build_ticket_faq_markdown_uses_debt_collection_steps_before_account_steps() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "complaint",
+            "pain_points": ["Attempts to collect debt not owed"],
+            "evidence": [{
+                "text": "I received a collection letter for a debt I do not owe.",
+                "source_id": "cfpb:3182593",
+                "source_type": "complaint",
+            }],
+        }],
+        support_contact="https://example.com/support",
+    )
+
+    markdown = result.markdown
+    assert result.items[0]["topic"] == "debt collection disputes"
+    assert "Ask the collector in writing to identify the original creditor" in markdown
+    assert "Compare the notice with your payment, settlement, insurance, or provider records" in markdown
+    assert "Open your profile, account settings, or login settings" not in markdown
+    assert "Open the reporting or analytics area" not in markdown
+
+
+def test_build_ticket_faq_markdown_uses_credit_report_steps_before_reporting_steps() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "complaint",
+            "pain_points": ["Incorrect information on your report"],
+            "evidence": [{
+                "text": "There are many mistakes appearing in my credit report.",
+                "source_id": "cfpb:3187954",
+                "source_type": "complaint",
+            }],
+        }],
+        support_contact="https://example.com/support",
+    )
+
+    markdown = result.markdown
+    assert result.items[0]["topic"] == "credit report disputes"
+    assert "Get your latest credit reports and mark the account" in markdown
+    assert "File a dispute with the credit bureau and the company that supplied the information" in markdown
+    assert "Open the reporting or analytics area" not in markdown
+
+
+def test_build_ticket_faq_markdown_replaces_vague_questions_with_source_policy_question() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "complaint",
+        "pain_points": ["Incorrect information on your report"],
+        "evidence": [{
+            "text": "Need help? There are mistakes appearing in my credit report.",
+            "source_id": "cfpb:3187954",
+            "source_type": "complaint",
+        }],
+    }])
+
+    assert result.items[0]["question"] == "What should I do if information on my credit report is wrong?"
+    assert result.items[0]["question_source"] == "source_policy"
+    assert result.output_checks["uses_user_vocabulary"] is True
+    assert "## 1. Need help?" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_substantive_question_after_vague_opener() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "support_ticket",
+        "pain_points": ["login reset"],
+        "evidence": [{
+            "text": "Need help? I cannot reset my password.",
+            "source_id": "ticket-1",
+            "source_type": "support_ticket",
+        }],
+    }])
+
+    assert result.items[0]["question"] == "How do I reset my password?"
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert result.output_checks["uses_user_vocabulary"] is True
+    assert "## 1. Need help?" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_does_not_classify_generic_investigation_as_credit_report() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "support_ticket",
+        "pain_points": ["reporting friction"],
+        "evidence": [{
+            "text": "Need help? I cannot export the investigation dashboard report.",
+            "source_id": "ticket-1",
+            "source_type": "support_ticket",
+        }],
+    }])
+
+    assert result.items[0]["topic"] == "reporting friction"
+    assert result.items[0]["question"] == "How do I export the investigation dashboard report?"
+    assert "Open the reporting or analytics area" in result.markdown
+    assert "credit bureau" not in result.markdown
+
+
 def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified_rows() -> None:
     result = build_ticket_faq_markdown([
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Complaint-Source-Policy.md

Fixes the source-level gaps exposed by the local CFPB complaint export: raw provider-style complaint fields now normalize through the generic source adapter, and debt/credit-report complaint FAQs get financial complaint actions instead of SaaS reporting/profile steps.

## Intentional
- No CFPB-specific renderer branch; FAQ generation remains generic.
- No live CFPB dependency in tests; tests use CFPB-shaped fixtures.
- No source adapter or FAQ public API signature changes.
- The downloaded 737 MB CFPB dataset is local validation data only and is not committed.

## Deferred
- Frozen real CFPB fixture for larger repeatability checks.
- Additional financial-domain action packs only when another real dataset exposes a generic gap.
- Live CFPB API retry/fallback remains separate from local raw-source processing.

## Verification
- pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py -q -> 112 passed
- python -m py_compile extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py -> passed
- Raw local CFPB 50-row CSV slice through generic FAQ CLI with --require-output-checks -> passed
- bash scripts/validate_extracted_content_pipeline.sh -> passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed
- bash scripts/check_ascii_python.sh -> passed
- bash scripts/local_pr_review.sh -> passed
- bash scripts/run_extracted_pipeline_checks.sh -> 1554 passed, 1 existing torch/pynvml warning

## Diff size
7 files, +242 / -7