### PR TITLE
Use source dates for blog sitemap lastmod

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -213,6 +213,14 @@ function assertBreadcrumbs(node, canonical, slug) {
   }
 }
 
+function sitemapLastmod(sitemap, canonical) {
+  const pattern = new RegExp(
+    `<url>\\s*<loc>${escapeRegExp(canonical)}</loc>\\s*<lastmod>([^<]+)</lastmod>`,
+  )
+  const match = sitemap.match(pattern)
+  return match ? match[1] : ''
+}
+
 function verifyBlogPage(post, sitemap) {
   const { slug } = post
   const canonical = `${BASE_URL}/blog/${slug}`
@@ -255,6 +263,11 @@ function verifyBlogPage(post, sitemap) {
 
   if (!sitemap.includes(`<loc>${canonical}</loc>`)) {
     fail(`/blog/${slug} missing from sitemap.xml`)
+  }
+
+  const lastmod = sitemapLastmod(sitemap, canonical)
+  if (lastmod !== post.date) {
+    fail(`/blog/${slug} sitemap lastmod must be ${post.date}`)
   }
 }
 

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -16,6 +16,13 @@ const ATLAS_SAME_AS = [
   'https://www.linkedin.com/company/atlas-intelligence',
 ]
 
+interface SitemapUrl {
+  loc: string
+  lastmod?: string
+  priority: string
+  changefreq: string
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
@@ -45,20 +52,24 @@ function sitemapPlugin() {
       }
 
       const blogDir = resolve(import.meta.dirname, 'src/content/blog')
+      const blogDates = new Map<string, string>()
       for (const file of readdirSync(blogDir)) {
         if (file.endsWith('.ts') && file !== 'index.ts') {
           const content = readFileSync(join(blogDir, file), 'utf-8')
-          const m = content.match(/slug:\s*'([^']+)'/)
-          if (m && !slugs.includes(m[1])) slugs.push(m[1])
+          const slug = parseStringField(content, 'slug')
+          const date = parseStringField(content, 'date')
+          if (slug && !slugs.includes(slug)) slugs.push(slug)
+          if (slug && date) blogDates.set(slug, date)
         }
       }
 
       const today = new Date().toISOString().split('T')[0]
-      const urls = [
+      const urls: SitemapUrl[] = [
         { loc: `${BASE_URL}/landing`, priority: '1.0', changefreq: 'weekly' },
         { loc: `${BASE_URL}/blog`, priority: '0.9', changefreq: 'daily' },
         ...slugs.map(slug => ({
           loc: `${BASE_URL}/blog/${slug}`,
+          lastmod: blogDates.get(slug) || today,
           priority: '0.7',
           changefreq: 'monthly',
         })),
@@ -69,7 +80,7 @@ function sitemapPlugin() {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urls.map(u => `  <url>
     <loc>${u.loc}</loc>
-    <lastmod>${today}</lastmod>
+    <lastmod>${u.lastmod || today}</lastmod>
     <changefreq>${u.changefreq}</changefreq>
     <priority>${u.priority}</priority>
   </url>`).join('\n')}

--- a/plans/PR-Blog-Sitemap-Source-Lastmod.md
+++ b/plans/PR-Blog-Sitemap-Source-Lastmod.md
@@ -1,0 +1,67 @@
+# PR-Blog-Sitemap-Source-Lastmod
+
+## Why this slice exists
+
+The public blog publish verifier now protects canonical URLs, SEO metadata,
+BlogPosting JSON-LD, breadcrumbs, sitemap inclusion, and indexability. The
+sitemap still gives every blog post the build date as `lastmod`, even when each
+post already has a stable source `date`.
+
+That makes the crawler-facing freshness signal noisier than it needs to be.
+Rebuilding the site should not make every blog post look newly modified.
+
+## Scope (this PR)
+
+1. Update `atlas-intel-ui/vite.config.ts` so blog sitemap entries use each
+   post's source `date` as `lastmod`.
+2. Keep non-blog sitemap entries on the build date.
+3. Extend `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` to assert each
+   blog sitemap `lastmod` matches the source post date.
+4. Keep route rendering, blog content, and generated metadata unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-Sitemap-Source-Lastmod.md` | Plan doc for this slice. |
+| `atlas-intel-ui/vite.config.ts` | Use source post dates for blog sitemap lastmod. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify sitemap lastmod against source post dates. |
+
+## Mechanism
+
+The sitemap plugin already scans each blog source file. It now records the
+source `date` alongside each slug and writes that date into the blog URL
+`lastmod` field.
+
+The publish verifier already parses the same source date for BlogPosting checks.
+It now also reads each sitemap URL block and compares `lastmod` to the source
+date.
+
+## Intentional
+
+- No content changes.
+- No runtime React rendering changes.
+- No change to landing, blog index, or root sitemap freshness behavior.
+- No generated-post pipeline changes.
+
+## Deferred
+
+- Add `lastmod` from update timestamps if generated blog posts eventually track
+  separate published and modified dates.
+- Add FAQPage schema verification when blog content includes FAQ entries.
+
+## Verification
+
+- Atlas UI lint passed.
+- Atlas UI production build passed.
+- Blog GEO prerender verification passed across 14 blog pages.
+- Whitespace diff check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Sitemap plugin | ~25 |
+| Publish verifier | ~20 |
+| Total | ~105 |


### PR DESCRIPTION
## Summary
- use each blog post's source date for sitemap lastmod instead of the build date
- keep non-blog sitemap entries on build-date freshness
- extend the blog GEO publish verifier to assert sitemap lastmod matches each source post date

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh --allow-dirty

The pre-push hook also ran local PR review successfully during push.