### PR TITLE
Harden blog sitemap metadata generation

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -71,9 +71,12 @@ function findMeta(html, attr, key) {
   return metas.find(tag => attrValue(tag, attr) === key) || ''
 }
 
-function findTitle(html) {
-  const match = html.match(/<title>([\s\S]*?)<\/title>/i)
-  return match ? decodeHtml(match[1].trim()) : ''
+function findTitle(html, slug) {
+  const matches = [...html.matchAll(/<title>([\s\S]*?)<\/title>/gi)]
+  if (matches.length !== 1) {
+    fail(`/blog/${slug} must have exactly one title tag`)
+  }
+  return decodeHtml(matches[0][1].trim())
 }
 
 function decodeHtml(value) {
@@ -187,7 +190,7 @@ function assertSeoMeta(html, post) {
   const title = `${expectedTitle(post)} | Atlas Intelligence`
   const description = expectedDescription(post)
 
-  if (findTitle(html) !== title) {
+  if (findTitle(html, post.slug) !== title) {
     fail(`/blog/${post.slug} title tag must be ${title}`)
   }
 

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -85,7 +85,6 @@ function sitemapPlugin() {
     name: 'generate-sitemap',
     closeBundle() {
       const posts = collectBlogSourceMetadata()
-      if (!posts.length) return
 
       const today = new Date().toISOString().split('T')[0]
       const urls: SitemapUrl[] = [

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -23,6 +23,16 @@ interface SitemapUrl {
   changefreq: string
 }
 
+interface BlogSourceMetadata {
+  file: string
+  slug: string
+  title: string
+  description: string
+  date: string
+  seoTitle: string
+  seoDescription: string
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
@@ -33,6 +43,40 @@ function parseStringField(content: string, field: string): string {
   return match ? match[1].replace(/\\'/g, "'") : ''
 }
 
+function collectBlogSourceMetadata(): BlogSourceMetadata[] {
+  const blogDir = resolve(import.meta.dirname, 'src/content/blog')
+  if (!existsSync(blogDir)) return []
+
+  const posts: BlogSourceMetadata[] = []
+  for (const file of readdirSync(blogDir).sort()) {
+    if (!file.endsWith('.ts') || file === 'index.ts') continue
+    const content = readFileSync(join(blogDir, file), 'utf-8')
+    const slug = parseStringField(content, 'slug')
+    const title = parseStringField(content, 'title')
+    const description = parseStringField(content, 'description')
+    const date = parseStringField(content, 'date')
+    const seoTitle = parseStringField(content, 'seo_title')
+    const seoDescription = parseStringField(content, 'seo_description')
+
+    if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
+    if (!title) throw new Error(`Missing title in blog source: ${file}`)
+    if (!description) throw new Error(`Missing description in blog source: ${file}`)
+    if (!date) throw new Error(`Missing date in blog source: ${file}`)
+
+    posts.push({
+      file,
+      slug,
+      title,
+      description,
+      date,
+      seoTitle,
+      seoDescription,
+    })
+  }
+
+  return posts.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
 // ---------------------------------------------------------------------------
 // Sitemap plugin
 // ---------------------------------------------------------------------------
@@ -40,36 +84,16 @@ function sitemapPlugin() {
   return {
     name: 'generate-sitemap',
     closeBundle() {
-      const indexPath = resolve(import.meta.dirname, 'src/content/blog/index.ts')
-      if (!existsSync(indexPath)) return
-
-      const indexContent = readFileSync(indexPath, 'utf-8')
-      const slugRegex = /slug:\s*'([^']+)'/g
-      const slugs: string[] = []
-      let match
-      while ((match = slugRegex.exec(indexContent)) !== null) {
-        slugs.push(match[1])
-      }
-
-      const blogDir = resolve(import.meta.dirname, 'src/content/blog')
-      const blogDates = new Map<string, string>()
-      for (const file of readdirSync(blogDir)) {
-        if (file.endsWith('.ts') && file !== 'index.ts') {
-          const content = readFileSync(join(blogDir, file), 'utf-8')
-          const slug = parseStringField(content, 'slug')
-          const date = parseStringField(content, 'date')
-          if (slug && !slugs.includes(slug)) slugs.push(slug)
-          if (slug && date) blogDates.set(slug, date)
-        }
-      }
+      const posts = collectBlogSourceMetadata()
+      if (!posts.length) return
 
       const today = new Date().toISOString().split('T')[0]
       const urls: SitemapUrl[] = [
         { loc: `${BASE_URL}/landing`, priority: '1.0', changefreq: 'weekly' },
         { loc: `${BASE_URL}/blog`, priority: '0.9', changefreq: 'daily' },
-        ...slugs.map(slug => ({
-          loc: `${BASE_URL}/blog/${slug}`,
-          lastmod: blogDates.get(slug) || today,
+        ...posts.map(post => ({
+          loc: `${BASE_URL}/blog/${post.slug}`,
+          lastmod: post.date,
           priority: '0.7',
           changefreq: 'monthly',
         })),
@@ -119,7 +143,6 @@ interface PrerenderedRoute {
 function buildHeadHtml(route: PrerenderedRoute): string {
   const { title, description, canonical, ogType, jsonLd } = route
   const lines = [
-    `<title>${title}</title>`,
     `<meta name="description" content="${description}" />`,
     `<link rel="canonical" href="${canonical}" />`,
     `<meta property="og:title" content="${title}" />`,
@@ -153,31 +176,15 @@ function prerenderPlugin() {
 
       const baseHtml = readFileSync(indexHtmlPath, 'utf-8')
 
-      // Collect blog post metadata from content files
-      const blogDir = resolve(import.meta.dirname, 'src/content/blog')
       const blogRoutes: PrerenderedRoute[] = []
-
-      for (const file of readdirSync(blogDir)) {
-        if (!file.endsWith('.ts') || file === 'index.ts') continue
-        const content = readFileSync(join(blogDir, file), 'utf-8')
-        const slug = parseStringField(content, 'slug')
-        if (!slug) continue
-
-        const seoTitle =
-          parseStringField(content, 'seo_title') ||
-          parseStringField(content, 'title') ||
-          'Atlas Intelligence Blog'
-        const seoDesc =
-          parseStringField(content, 'seo_description') ||
-          parseStringField(content, 'description') ||
-          'Amazon seller intelligence and competitive analysis insights.'
-        const date = parseStringField(content, 'date')
-
+      for (const post of collectBlogSourceMetadata()) {
+        const seoTitle = post.seoTitle || post.title
+        const seoDesc = post.seoDescription || post.description
         blogRoutes.push({
-          path: `/blog/${slug}`,
+          path: `/blog/${post.slug}`,
           title: `${seoTitle} | Atlas Intelligence`,
           description: seoDesc,
-          canonical: `${BASE_URL}/blog/${slug}`,
+          canonical: `${BASE_URL}/blog/${post.slug}`,
           ogType: 'article',
           jsonLd: {
             '@context': 'https://schema.org',
@@ -186,8 +193,8 @@ function prerenderPlugin() {
                 '@type': 'BlogPosting',
                 headline: seoTitle,
                 description: seoDesc,
-                datePublished: date || undefined,
-                dateModified: date || undefined,
+                datePublished: post.date,
+                dateModified: post.date,
                 image: DEFAULT_OG_IMAGE,
                 author: {
                   '@type': 'Organization',
@@ -201,14 +208,14 @@ function prerenderPlugin() {
                   sameAs: ATLAS_SAME_AS,
                   logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
                 },
-                mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${slug}` },
+                mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${post.slug}` },
               },
               {
                 '@type': 'BreadcrumbList',
                 itemListElement: [
                   { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/landing` },
                   { '@type': 'ListItem', position: 2, name: 'Blog', item: `${BASE_URL}/blog` },
-                  { '@type': 'ListItem', position: 3, name: seoTitle, item: `${BASE_URL}/blog/${slug}` },
+                  { '@type': 'ListItem', position: 3, name: seoTitle, item: `${BASE_URL}/blog/${post.slug}` },
                 ],
               },
             ],

--- a/plans/PR-Blog-Sitemap-Source-Lastmod.md
+++ b/plans/PR-Blog-Sitemap-Source-Lastmod.md
@@ -17,25 +17,28 @@ Rebuilding the site should not make every blog post look newly modified.
 2. Keep non-blog sitemap entries on the build date.
 3. Extend `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` to assert each
    blog sitemap `lastmod` matches the source post date.
-4. Keep route rendering, blog content, and generated metadata unchanged.
+4. Keep blog content unchanged while tightening the source metadata path used
+   by sitemap and prerender generation.
 
 ### Files touched
 
 | File | Change |
 |---|---|
 | `plans/PR-Blog-Sitemap-Source-Lastmod.md` | Plan doc for this slice. |
-| `atlas-intel-ui/vite.config.ts` | Use source post dates for blog sitemap lastmod. |
-| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify sitemap lastmod against source post dates. |
+| `atlas-intel-ui/vite.config.ts` | Use required source post metadata for blog sitemap lastmod and prerender output. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify sitemap lastmod against source post dates and reject duplicate title tags. |
 
 ## Mechanism
 
-The sitemap plugin already scans each blog source file. It now records the
-source `date` alongside each slug and writes that date into the blog URL
-`lastmod` field.
+The Vite build now collects blog metadata from the actual source post files and
+requires `slug`, `title`, `description`, and `date` before emitting crawler
+metadata. The sitemap and prerender plugins share that collection path, so the
+blog URLs, sitemap `lastmod`, title metadata, and BlogPosting JSON-LD all come
+from the same source fields.
 
 The publish verifier already parses the same source date for BlogPosting checks.
 It now also reads each sitemap URL block and compares `lastmod` to the source
-date.
+date. It also rejects duplicate title tags in prerendered blog pages.
 
 ## Intentional
 
@@ -61,7 +64,7 @@ date.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | ~60 |
-| Sitemap plugin | ~25 |
-| Publish verifier | ~20 |
-| Total | ~105 |
+| Plan | ~25 |
+| Sitemap and prerender source metadata path | ~95 |
+| Publish verifier | ~25 |
+| Total | ~145 |


### PR DESCRIPTION
## Summary
- collect required blog metadata from source post files for both sitemap and prerender generation
- stop seeding sitemap blog URLs from index.ts regex parsing
- remove duplicate prerendered title tags and add verifier coverage for exactly one blog title tag

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- bash scripts/local_pr_review.sh