### PR TITLE
Prerender crawler-visible blog article bodies

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -27,6 +27,12 @@ function parseStringField(content, field) {
   return match[1].replace(/\\'/g, "'")
 }
 
+function parseTemplateField(content, field) {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\`([\\s\\S]*?)\`\\s*,`, 'm')
+  const match = content.match(pattern)
+  return match ? match[1] : ''
+}
+
 function collectBlogPosts() {
   const posts = []
   for (const file of readdirSync(blogDir)) {
@@ -36,19 +42,25 @@ function collectBlogPosts() {
     const title = parseStringField(content, 'title')
     const description = parseStringField(content, 'description')
     const date = parseStringField(content, 'date')
+    const author = parseStringField(content, 'author')
     const seoTitle = parseStringField(content, 'seo_title')
     const seoDescription = parseStringField(content, 'seo_description')
+    const body = parseTemplateField(content, 'content')
     if (!slug) fail(`Missing slug in ${file}`)
     if (!title) fail(`Missing title in ${file}`)
     if (!description) fail(`Missing description in ${file}`)
     if (!date) fail(`Missing date in ${file}`)
+    if (!author) fail(`Missing author in ${file}`)
+    if (!body.trim()) fail(`Missing content in ${file}`)
     posts.push({
       slug,
       title,
       description,
       date,
+      author,
       seoTitle,
       seoDescription,
+      body,
     })
   }
   if (!posts.length) fail('No blog posts found')
@@ -79,6 +91,14 @@ function findTitle(html, slug) {
   return decodeHtml(matches[0][1].trim())
 }
 
+function findH1(html, slug) {
+  const matches = [...html.matchAll(/<h1\b[^>]*>([\s\S]*?)<\/h1>/gi)]
+  if (matches.length !== 1) {
+    fail(`/blog/${slug} must have exactly one crawler-visible h1`)
+  }
+  return normalizedText(matches[0][1])
+}
+
 function decodeHtml(value) {
   return value
     .replace(/&amp;/g, '&')
@@ -86,6 +106,35 @@ function decodeHtml(value) {
     .replace(/&#39;/g, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+}
+
+function normalizedText(value) {
+  return decodeHtml(value)
+    .replace(/<script\b[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function sourceBodyText(value) {
+  return normalizedText(
+    value
+      .replace(/<p>\s*\{\{chart:[^}]+\}\}\s*<\/p>|\{\{chart:[^}]+\}\}/g, ' ')
+      .replace(/<h[1-6]\b[\s\S]*?<\/h[1-6]>/gi, ' ')
+      .replace(/^#{1,6}\s+.*$/gm, ' ')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      .replace(/[#*_`|]+/g, ' '),
+  )
+}
+
+function expectedBodyPhrase(post) {
+  const text = sourceBodyText(post.body)
+  const sentence = text
+    .split(/(?<=[.!?])\s+/)
+    .find(item => item.length >= 60 && /[A-Za-z]/.test(item))
+  if (!sentence) fail(`/blog/${post.slug} source body needs a verifier phrase`)
+  return sentence.slice(0, 80).trim()
 }
 
 function parseJsonLd(html, slug) {
@@ -207,6 +256,33 @@ function assertSeoMeta(html, post) {
   }
 }
 
+function assertCrawlerVisibleArticle(html, post) {
+  if (!html.includes('data-prerendered-blog-article="true"')) {
+    fail(`/blog/${post.slug} missing prerendered article body`)
+  }
+  if (!html.includes('data-prerendered-blog-content="true"')) {
+    fail(`/blog/${post.slug} missing prerendered article content`)
+  }
+
+  const visibleText = normalizedText(html)
+  const h1 = findH1(html, post.slug)
+  if (h1 !== post.title) {
+    fail(`/blog/${post.slug} h1 must be ${post.title}`)
+  }
+  if (!visibleText.includes(post.author)) {
+    fail(`/blog/${post.slug} prerendered body missing source author`)
+  }
+
+  const phrase = expectedBodyPhrase(post)
+  if (!visibleText.includes(phrase)) {
+    fail(`/blog/${post.slug} prerendered body missing source phrase: ${phrase}`)
+  }
+
+  if (visibleText.length < 1000) {
+    fail(`/blog/${post.slug} prerendered body is too short for crawler-visible article content`)
+  }
+}
+
 function assertBreadcrumbs(node, canonical, slug) {
   const items = Array.isArray(node.itemListElement) ? node.itemListElement : []
   if (items.length < 3) fail(`/blog/${slug} breadcrumb list is incomplete`)
@@ -231,6 +307,7 @@ function verifyBlogPage(post, sitemap) {
   const html = readText(htmlPath)
 
   assertSeoMeta(html, post)
+  assertCrawlerVisibleArticle(html, post)
 
   const canonicalLink = findLink(html, 'canonical')
   if (attrValue(canonicalLink, 'href') !== canonical) {

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { marked } from 'marked'
 import {
   existsSync,
   mkdirSync,
@@ -29,8 +30,10 @@ interface BlogSourceMetadata {
   title: string
   description: string
   date: string
+  author: string
   seoTitle: string
   seoDescription: string
+  content: string
 }
 
 function escapeRegExp(value: string): string {
@@ -41,6 +44,12 @@ function parseStringField(content: string, field: string): string {
   const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
   const match = content.match(pattern)
   return match ? match[1].replace(/\\'/g, "'") : ''
+}
+
+function parseTemplateField(content: string, field: string): string {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\`([\\s\\S]*?)\`\\s*,`, 'm')
+  const match = content.match(pattern)
+  return match ? match[1] : ''
 }
 
 function collectBlogSourceMetadata(): BlogSourceMetadata[] {
@@ -55,13 +64,17 @@ function collectBlogSourceMetadata(): BlogSourceMetadata[] {
     const title = parseStringField(content, 'title')
     const description = parseStringField(content, 'description')
     const date = parseStringField(content, 'date')
+    const author = parseStringField(content, 'author')
     const seoTitle = parseStringField(content, 'seo_title')
     const seoDescription = parseStringField(content, 'seo_description')
+    const postContent = parseTemplateField(content, 'content')
 
     if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
     if (!title) throw new Error(`Missing title in blog source: ${file}`)
     if (!description) throw new Error(`Missing description in blog source: ${file}`)
     if (!date) throw new Error(`Missing date in blog source: ${file}`)
+    if (!author) throw new Error(`Missing author in blog source: ${file}`)
+    if (!postContent.trim()) throw new Error(`Missing content in blog source: ${file}`)
 
     posts.push({
       file,
@@ -69,8 +82,10 @@ function collectBlogSourceMetadata(): BlogSourceMetadata[] {
       title,
       description,
       date,
+      author,
       seoTitle,
       seoDescription,
+      content: postContent,
     })
   }
 
@@ -137,6 +152,37 @@ interface PrerenderedRoute {
   canonical: string
   ogType: string
   jsonLd?: object
+  bodyHtml?: string
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function stripChartPlaceholders(content: string): string {
+  return content.replace(/<p>\s*\{\{chart:[^}]+\}\}\s*<\/p>|\{\{chart:[^}]+\}\}/g, '')
+}
+
+function buildBlogBodyHtml(post: BlogSourceMetadata): string {
+  const articleHtml = marked.parse(stripChartPlaceholders(post.content), { async: false }) as string
+  return `
+    <article data-prerendered-blog-article="true">
+      <header>
+        <h1>${escapeHtml(post.title)}</h1>
+        <p>
+          <time datetime="${escapeHtml(post.date)}">${escapeHtml(post.date)}</time>
+          <span>${escapeHtml(post.author)}</span>
+        </p>
+      </header>
+      <section data-prerendered-blog-content="true">
+        ${articleHtml}
+      </section>
+    </article>`
 }
 
 function buildHeadHtml(route: PrerenderedRoute): string {
@@ -185,6 +231,7 @@ function prerenderPlugin() {
           description: seoDesc,
           canonical: `${BASE_URL}/blog/${post.slug}`,
           ogType: 'article',
+          bodyHtml: buildBlogBodyHtml(post),
           jsonLd: {
             '@context': 'https://schema.org',
             '@graph': [
@@ -290,6 +337,7 @@ function prerenderPlugin() {
             `<title>${route.title}</title>`,
           )
           .replace('</head>', `${headHtml}\n  </head>`)
+          .replace('<div id="root"></div>', `<div id="root">${route.bodyHtml || ''}</div>`)
 
         // Write to dist/<path>/index.html
         const outDir = join(distDir, ...route.path.split('/').filter(Boolean))

--- a/plans/PR-Blog-GEO-Visible-Article-HTML.md
+++ b/plans/PR-Blog-GEO-Visible-Article-HTML.md
@@ -1,0 +1,84 @@
+# PR-Blog-GEO-Visible-Article-HTML
+
+## Why this slice exists
+
+The Atlas Intel UI now verifies blog SEO metadata, BlogPosting JSON-LD,
+breadcrumbs, sitemap inclusion, and source-date `lastmod`. It also runs the
+publish verifier in CI.
+
+The remaining publish-level GEO gap is crawler-visible article content. A blog
+page can expose a correct `<head>` and schema while still serving an empty SPA
+root to crawlers that do not execute JavaScript. GEO and AEO need the article
+body to be visible in the returned HTML.
+
+## Scope (this PR)
+
+1. Add static blog article HTML to the prerendered `/blog/:slug/index.html`
+   output.
+2. Keep the React runtime route behavior unchanged.
+3. Use the existing blog source file collector as the source of truth.
+4. Extend the blog GEO prerender verifier to assert crawler-visible article
+   content.
+5. Keep landing, blog index, sitemap, and frontend component rendering
+   behavior unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Visible-Article-HTML.md` | Plan doc for this slice. |
+| `atlas-intel-ui/vite.config.ts` | Render source blog content into prerendered blog route HTML. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify crawler-visible blog article body output. |
+
+## Mechanism
+
+The Vite prerender plugin already scans each blog source file for required
+metadata. This slice extends that source collector to require the post `content`
+field. For blog routes only, the plugin renders the markdown content into static
+HTML and inserts it into the `#root` element in the prerendered route file.
+
+The generated static body includes a blog article marker, one `h1`, date/author
+context, and the rendered source body. Chart placeholders are removed from the
+static HTML because the interactive chart components still belong to the React
+runtime.
+
+The verifier now reads the built blog HTML and checks that each post has:
+
+- one crawler-visible `h1`
+- a prerendered article marker
+- a prerendered content marker
+- source title visible in the `h1`
+- source body text visible in the returned HTML
+- enough body text to prove it is not an empty shell
+
+## Intentional
+
+- No React component changes.
+- No generated blog content changes.
+- No static chart rendering in this slice.
+- No FAQ schema changes.
+- No claim that GEO guarantees AI-engine placement.
+
+## Deferred
+
+- Static chart summaries for no-JavaScript crawlers.
+- Full static FAQ rendering checks when the Atlas Intel source posts include
+  FAQ entries.
+- Sharing the source parsing helper between the Vite plugin and verifier.
+
+## Verification
+
+- Atlas UI lint.
+- Atlas UI production build.
+- Blog GEO prerender verification.
+- Whitespace diff check.
+- Local PR review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Vite prerender body output | ~65 |
+| Publish verifier | ~75 |
+| Total | ~215 |


### PR DESCRIPTION
## Summary
- render static blog article body HTML into prerendered /blog/:slug pages
- require source post content/author in the Vite blog source collector
- extend the blog GEO verifier to assert visible article markers, one h1, source author, and source body prose

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh