### PR TITLE
Use source context for FAQ intent policy

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -213,3 +213,15 @@ needed financial complaint action policy before SaaS-style reporting/account
 rules. PR-Content-Ops-FAQ-Complaint-Source-Policy owns that source-level fix.
 Future FAQ/source work should be driven by a real customer help desk export,
 hosted UI need, or another real dataset exposing a generic policy gap.
+
+**Real CFPB output-quality update:** A follow-up run against three 150-row
+samples from the same local CFPB export (`Debt collection`, `Credit reporting,
+credit repair services, or other personal consumer reports`, and `Mortgage`)
+showed that the source adapter preserved provider context such as `Product`,
+`Issue`, and `Sub-issue`, but the FAQ classifier did not read that context
+when choosing intent/action policy. That caused financial complaint rows to
+fall into generic SaaS reporting/account workflows.
+PR-Content-Ops-FAQ-Source-Context-Policy owns the generic fix: include
+normalized source-context fields in FAQ intent classification and add
+mortgage-servicing policy. This is still not a CFPB-specific branch; CFPB is
+the real public fixture that exposed the generic source-context gap.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -6,6 +6,6 @@ Add a row before opening a PR (session protocol step 2). Drop the row when the P
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| PR-Content-Ops-FAQ-Complaint-Source-Policy | Generic complaint source aliases and FAQ financial complaint actions | `extracted_content_pipeline/campaign_source_adapters.py`, `extracted_content_pipeline/ticket_faq_markdown.py`, `tests/test_extracted_campaign_source_adapters.py`, `tests/test_extracted_ticket_faq_markdown.py` | codex-2026-05-20 | open PR #691 blog publish metadata |
+| PR-Content-Ops-FAQ-Source-Context-Policy | Use preserved source context for FAQ intent/action policy | `extracted_content_pipeline/ticket_faq_markdown.py`, `tests/test_extracted_ticket_faq_markdown.py`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-20 | blog PR #697 owns blog content only |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -40,6 +40,24 @@ _GENERIC_QUESTION_TEXTS = {
     "what should i do?",
     "what can i do?",
 }
+_GENERIC_QUESTION_PHRASES = (
+    "submitted several complaints",
+    "filed several complaints",
+    "submitted a complaint",
+    "filing this complaint",
+    "this complaint is about",
+)
+_MORTGAGE_INTENT_TERMS = (
+    "mortgage",
+    "home loan",
+    "foreclosure",
+    "reverse mortgage",
+    "mortgage servicer",
+)
+_MORTGAGE_ACTION_STEPS = (
+    "Gather the mortgage statement, payment history, escrow record, payoff quote, or loss-mitigation notice tied to the issue.",
+    "Send the servicer a written request or dispute with the dates, amounts, account number, and copies of the records you want reviewed.",
+)
 DEFAULT_INTENT_RULES = (
     ("credit report disputes", (
         "credit report",
@@ -64,6 +82,7 @@ DEFAULT_INTENT_RULES = (
         "medical debt",
         "settled the debt",
     )),
+    ("mortgage servicing issues", _MORTGAGE_INTENT_TERMS),
     ("reporting friction", ("export", "report", "dashboard", "attribution")),
     ("manual follow-up", ("handoff", "follow-up", "workflow", "automation", "manual")),
     ("login reset", ("login reset", "password reset", "reset password", "reset my password")),
@@ -100,6 +119,13 @@ _DATE_KEYS = (
     "date",
     "timestamp",
 )
+_SOURCE_CONTEXT_KEYS = (
+    "product",
+    "category",
+    "sub_product",
+    "issue",
+    "sub_issue",
+)
 _ACTION_RULES = (
     (("credit report", "credit file", "credit bureau", "credit bureaus", "credit reporting", "incorrect information"), (
         "Get your latest credit reports and mark the account, date, balance, or status that looks wrong.",
@@ -109,6 +135,7 @@ _ACTION_RULES = (
         "Ask the collector in writing to identify the original creditor, the amount, the account, and why they say you owe it.",
         "Compare the notice with your payment, settlement, insurance, or provider records before you pay or share more information.",
     )),
+    (_MORTGAGE_INTENT_TERMS, _MORTGAGE_ACTION_STEPS),
     (("export", "report", "dashboard", "attribution"), (
         "Open the reporting or analytics area and choose the date range you need.",
         "Look for an Export or Download option, then ask an admin to check your role and plan access if it is missing.",
@@ -403,6 +430,7 @@ def _intent_topic(
     intent_rules: Sequence[tuple[str, Sequence[str]]],
 ) -> str:
     text = " ".join((
+        _source_context_text(opportunity, evidence),
         _compact(evidence.get("source_title") or opportunity.get("source_title")),
         _compact(evidence.get("text")),
         _compact(opportunity.get("text") or opportunity.get("description")),
@@ -414,6 +442,16 @@ def _intent_topic(
         if any(_keyword_matches(text, keyword) for keyword in keywords):
             return _clean(topic).lower()
     return ""
+
+
+def _source_context_text(*rows: Mapping[str, Any]) -> str:
+    values: list[str] = []
+    for row in rows:
+        for key in _SOURCE_CONTEXT_KEYS:
+            text = _compact(_field_value(row, key))
+            if text:
+                values.append(text)
+    return " ".join(values)
 
 
 def _keyword_matches(text: str, keyword: Any) -> bool:
@@ -596,7 +634,12 @@ def _first_sentence(text: str) -> str:
 
 def _usable_question(value: str) -> bool:
     lowered = _compact(value).lower()
-    return bool(value) and len(value) <= MAX_EXTRACTED_QUESTION_CHARS and lowered not in _GENERIC_QUESTION_TEXTS
+    return (
+        bool(value)
+        and len(value) <= MAX_EXTRACTED_QUESTION_CHARS
+        and lowered not in _GENERIC_QUESTION_TEXTS
+        and not any(phrase in lowered for phrase in _GENERIC_QUESTION_PHRASES)
+    )
 
 
 def _normalize_question_text(value: str) -> str:
@@ -612,6 +655,8 @@ def _policy_question(topic: str) -> str:
         return "What should I do if information on my credit report is wrong?"
     if normalized == "debt collection disputes":
         return "What should I do if a collector says I owe a debt I do not recognize?"
+    if normalized == "mortgage servicing issues":
+        return "What should I do if my mortgage servicer will not fix a payment, payoff, foreclosure, or modification issue?"
     return ""
 
 
@@ -701,6 +746,11 @@ def _escalation_guidance(topic: str, evidence_text: str, *, support_contact: str
         return (
             f"{_support_sentence(support_contact)} if the collector will not validate "
             "the debt, keeps contacting you about a debt you do not recognize, or reports it again."
+        )
+    if topic == "mortgage servicing issues" or any(term in text for term in _MORTGAGE_INTENT_TERMS):
+        return (
+            f"{_support_sentence(support_contact)} if the servicer will not explain "
+            "the payment, payoff, foreclosure, modification, escrow, or insurance issue in writing."
         )
     if any(term in text for term in ("export", "report", "dashboard", "attribution")):
         return (
@@ -863,6 +913,8 @@ def _support_contact_metadata(support_contact: str | None) -> dict[str, str]:
 
 
 def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:
+    if topic == "mortgage servicing issues":
+        return _MORTGAGE_ACTION_STEPS
     text = f"{topic} {evidence_text}".lower()
     for terms, steps in _ACTION_RULES:
         if any(term in text for term in terms):

--- a/plans/PR-Content-Ops-FAQ-Source-Context-Policy.md
+++ b/plans/PR-Content-Ops-FAQ-Source-Context-Policy.md
@@ -1,0 +1,105 @@
+# PR-Content-Ops-FAQ-Source-Context-Policy
+
+## Why this slice exists
+
+Running real CFPB complaint rows from
+`/home/juan-canfield/Downloads/archive (1)/rows.csv` through the generic FAQ
+Markdown path exposed a source-context loss. The source adapter preserves raw
+provider fields such as `Product`, `Issue`, and `Sub-issue`, but the FAQ intent
+classifier only uses source titles, evidence text, and pain points. That lets
+generic SaaS rules fire on consumer complaint narratives:
+
+- credit-report rows can become `reporting friction`;
+- debt-collection rows can become account/profile or reporting topics;
+- mortgage rows fall to generic billing or workflow guidance.
+
+The fix belongs in the generic FAQ classifier, not in a CFPB-only exporter or
+dataset-specific script.
+
+## Scope (this PR)
+
+1. Include generic source-context fields in FAQ intent classification.
+2. Add mortgage-servicing FAQ policy alongside the existing credit-report,
+   debt-collection, and billing policies.
+3. Reject complaint-process boilerplate as FAQ questions so rows such as
+   "submitted several complaints through the CFPB" fall back to the applicable
+   source policy instead of becoming the rendered FAQ heading.
+4. Add regression coverage using CFPB-shaped CSV rows through the real source
+   adapter plus direct FAQ builder tests for the new mortgage policy.
+5. Update the AI Content Ops backlog with the real-output finding and closeout.
+6. Replace the stale in-flight FAQ complaint-source row with this slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Source-Context-Policy.md` | Plan doc for this slice. |
+| `docs/extraction/coordination/inflight.md` | Claim this AI Content Ops slice and remove the merged stale FAQ row. |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | Record the real CFPB output-quality follow-up. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Use source-context fields in intent classification and add mortgage policy. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Regression tests for source-context classification and mortgage actions. |
+
+## Mechanism
+
+The FAQ classifier will build intent text from the existing evidence text,
+source title, pain points, and generic source-context fields such as `product`,
+`category`, `issue`, and `sub_issue`. The lookup uses the existing tolerant
+field normalization helper, so provider exports with `Product`, `Sub-product`,
+`Sub Issue`, or snake_case variants work without dataset-specific branches.
+
+Mortgage servicing gets the same treatment as credit reports and debt
+collection: a policy question, domain-specific action steps, and escalation
+guidance. Mortgage intent classification requires mortgage-specific anchors
+such as `mortgage`, `home loan`, `foreclosure`, or `mortgage servicer`; broader
+servicing language such as `loan modification` appears in the mortgage guidance
+only after a row is already classified as mortgage. Complaint-process
+boilerplate is treated the same way as vague openers like "Need help?" so the
+renderer does not turn filing-channel text into the FAQ question. The source
+adapter remains generic and unchanged.
+
+## Intentional
+
+- No LLM calls. FAQ output stays deterministic and audit-friendly.
+- No CFPB-only branch. CFPB is the real public fixture that exposed the gap,
+  but the implementation reads generic source-context fields.
+- No full-corpus CSV import in tests. Tests use small CFPB-shaped fixtures so
+  CI stays fast and independent of local downloads.
+
+## Deferred
+
+- Better representative-evidence ranking for very long complaint narratives.
+  Current output uses the first evidence row in each topic; this slice fixes
+  wrong topic/action policy first.
+- Larger source-specific policy packs for other financial products such as
+  student loans, credit cards, or bank accounts. Add only when real output
+  samples show the need.
+
+## Verification
+
+Passed locally:
+
+```bash
+pytest tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py -q
+# 58 passed
+
+python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py
+
+python scripts/build_extracted_ticket_faq_markdown.py /tmp/atlas_cfpb_samples/debt_collection_150.csv --source-format csv --title "Debt Collection Complaint FAQ" --max-items 8 --max-evidence-per-item 3 --support-contact https://example.com/support --require-output-checks --output /tmp/atlas_cfpb_samples/debt_collection_150_after.md
+python scripts/build_extracted_ticket_faq_markdown.py /tmp/atlas_cfpb_samples/credit_reporting_150.csv --source-format csv --title "Credit Reporting Complaint FAQ" --max-items 8 --max-evidence-per-item 3 --support-contact https://example.com/support --require-output-checks --output /tmp/atlas_cfpb_samples/credit_reporting_150_after.md
+python scripts/build_extracted_ticket_faq_markdown.py /tmp/atlas_cfpb_samples/mortgage_150.csv --source-format csv --title "Mortgage Complaint FAQ" --max-items 8 --max-evidence-per-item 3 --support-contact https://example.com/support --require-output-checks --output /tmp/atlas_cfpb_samples/mortgage_150_after.md
+
+bash scripts/run_extracted_pipeline_checks.sh
+# 1560 passed, 1 existing torch/pynvml warning
+```
+
+`bash scripts/local_pr_review.sh` runs after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| FAQ classifier/policy | ~45 |
+| Tests | ~110 |
+| Docs/coordination | ~20 |
+| Total | ~260 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 from html.parser import HTMLParser
 import json
 import subprocess
@@ -92,6 +93,16 @@ def _write_ticket_csv(tmp_path: Path, *rows: str) -> Path:
         )),
         encoding="utf-8",
     )
+    return source
+
+
+def _write_source_csv(tmp_path: Path, name: str, rows: list[dict[str, str]]) -> Path:
+    source = tmp_path / name
+    fieldnames = tuple(dict.fromkeys(key for row in rows for key in row))
+    with source.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
     return source
 
 
@@ -978,6 +989,141 @@ def test_build_ticket_faq_markdown_does_not_classify_generic_investigation_as_cr
     assert result.items[0]["question"] == "How do I export the investigation dashboard report?"
     assert "Open the reporting or analytics area" in result.markdown
     assert "credit bureau" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_credit_report_rows(tmp_path: Path) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "credit_reporting.csv",
+        [{
+            "Complaint ID": "3181474",
+            "Product": "Credit reporting, credit repair services, or other personal consumer reports",
+            "Issue": "Improper use of your report",
+            "Consumer complaint narrative": (
+                "The inquiries are a result of identity theft and should not remain on my report."
+            ),
+            "Company": "Example Bureau",
+        }],
+    )
+    loaded = load_source_campaign_opportunities_from_file(source, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities, support_contact="https://example.com/support")
+
+    assert result.items[0]["topic"] == "credit report disputes"
+    assert result.items[0]["question_source"] == "source_policy"
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+    assert "Get your latest credit reports and mark the account" in result.markdown
+    assert "Open the reporting or analytics area" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_debt_collection_rows(tmp_path: Path) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "debt_collection.csv",
+        [{
+            "Complaint ID": "3177182",
+            "Product": "Debt collection",
+            "Issue": "Communication tactics",
+            "Consumer complaint narrative": (
+                "The collector keeps calling and asking me to confirm my email address for a debt I do not owe."
+            ),
+            "Company": "Example Collector",
+        }],
+    )
+    loaded = load_source_campaign_opportunities_from_file(source, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities, support_contact="https://example.com/support")
+
+    assert result.items[0]["topic"] == "debt collection disputes"
+    assert result.output_checks["uses_user_vocabulary"] is True
+    assert "Ask the collector in writing to identify the original creditor" in result.markdown
+    assert "Open your profile, account settings, or login settings" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_mortgage_rows(tmp_path: Path) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "mortgage.csv",
+        [{
+            "Complaint ID": "3178554",
+            "Product": "Mortgage",
+            "Issue": "Struggling to pay mortgage",
+            "Consumer complaint narrative": (
+                "The servicer posted a foreclosure notice even though the modification documents were submitted."
+            ),
+            "Company": "Example Servicer",
+        }],
+    )
+    loaded = load_source_campaign_opportunities_from_file(source, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities, support_contact="https://example.com/support")
+
+    assert result.items[0]["topic"] == "mortgage servicing issues"
+    assert result.items[0]["question"] == (
+        "What should I do if my mortgage servicer will not fix a payment, payoff, foreclosure, or modification issue?"
+    )
+    assert result.items[0]["question_source"] == "source_policy"
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+    assert "Gather the mortgage statement, payment history, escrow record" in result.markdown
+    assert "Open the bill, statement, payment history, or dispute record" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_does_not_treat_generic_loan_modification_as_mortgage(
+    tmp_path: Path,
+) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "vehicle_loan.csv",
+        [{
+            "Complaint ID": "vehicle-1",
+            "Product": "Vehicle loan or lease",
+            "Issue": "Managing the loan or lease",
+            "Consumer complaint narrative": (
+                "I need help with a loan modification and payment dispute on my auto loan."
+            ),
+            "Company": "Example Auto Lender",
+        }],
+    )
+    loaded = load_source_campaign_opportunities_from_file(source, file_format="csv")
+
+    result = build_ticket_faq_markdown(loaded.opportunities, support_contact="https://example.com/support")
+
+    assert result.items[0]["topic"] == "billing and payments"
+    assert "mortgage servicer" not in result.markdown
+    assert "Gather the mortgage statement" not in result.markdown
+    assert "Open the bill, statement, payment history, or dispute record" in result.markdown
+
+
+def test_build_ticket_faq_markdown_rejects_complaint_process_boilerplate_question() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "complaint",
+        "Product": "Mortgage",
+        "Issue": "Struggling to pay mortgage",
+        "evidence": [{
+            "text": (
+                "My husband and I have submitted several complaints through the CFPB. "
+                "The servicer still has not reviewed the modification documents."
+            ),
+            "source_id": "cfpb:3178270",
+            "source_type": "complaint",
+        }],
+    }])
+
+    assert result.items[0]["topic"] == "mortgage servicing issues"
+    assert result.items[0]["question"] == (
+        "What should I do if my mortgage servicer will not fix a payment, payoff, foreclosure, or modification issue?"
+    )
+    assert result.items[0]["question_source"] == "source_policy"
+    assert "## 1. What should I do if my mortgage servicer" in result.markdown
+    assert "## 1. What should I do if my husband" not in result.markdown
 
 
 def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified_rows() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Source-Context-Policy.md

Real CFPB complaint rows showed that the source adapter preserved provider context such as Product, Issue, and Sub-issue, but the FAQ classifier did not read that context when selecting intent/action policy. That caused consumer-finance complaints to fall into generic SaaS reporting/account workflows. This PR fixes the generic classifier path rather than adding a CFPB-specific branch.

## Intentional
- Keep the implementation generic: CFPB is the real public fixture that exposed the issue, but the classifier reads normalized product/category/issue/sub-issue context.
- Keep FAQ generation deterministic; no LLM calls or generated-copy retry path.
- Reject complaint-process boilerplate as FAQ questions so filing-channel text does not become the rendered heading.

## Deferred
- Representative evidence ranking for very long complaint narratives.
- Additional financial product policy packs when real samples expose the need.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py -q` -> 58 passed.
- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` -> passed.
- Real CFPB 150-row samples for credit reporting, debt collection, and mortgage all pass `--require-output-checks`.
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1560 passed, 1 existing torch/pynvml warning.
- `bash scripts/local_pr_review.sh` -> passed.

## Diff size
5 files, +288 / -2.
