### PR TITLE
Add prerendered blog chart fallbacks

### DIFF
--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -33,6 +33,17 @@ function parseTemplateField(content, field) {
   return match ? match[1] : ''
 }
 
+function parseChartsField(content, file) {
+  const match = content.match(/^\s*charts:\s*(\[[\s\S]*?\])\s*,\s*content:/m)
+  if (!match) return []
+
+  try {
+    return JSON.parse(match[1])
+  } catch (error) {
+    fail(`Invalid charts JSON in ${file}: ${error.message}`)
+  }
+}
+
 function collectBlogPosts() {
   const posts = []
   for (const file of readdirSync(blogDir)) {
@@ -46,6 +57,7 @@ function collectBlogPosts() {
     const seoTitle = parseStringField(content, 'seo_title')
     const seoDescription = parseStringField(content, 'seo_description')
     const body = parseTemplateField(content, 'content')
+    const charts = parseChartsField(content, file)
     if (!slug) fail(`Missing slug in ${file}`)
     if (!title) fail(`Missing title in ${file}`)
     if (!description) fail(`Missing description in ${file}`)
@@ -61,6 +73,7 @@ function collectBlogPosts() {
       seoTitle,
       seoDescription,
       body,
+      charts,
     })
   }
   if (!posts.length) fail('No blog posts found')
@@ -271,6 +284,18 @@ function assertCrawlerVisibleArticle(html, post) {
   }
   if (!visibleText.includes(post.author)) {
     fail(`/blog/${post.slug} prerendered body missing source author`)
+  }
+  if (html.includes('{{chart:')) {
+    fail(`/blog/${post.slug} prerendered body still contains chart placeholders`)
+  }
+
+  for (const chart of post.charts) {
+    if (!html.includes(`data-prerendered-chart="${chart.chart_id}"`)) {
+      fail(`/blog/${post.slug} missing prerendered chart fallback for ${chart.chart_id}`)
+    }
+    if (!visibleText.includes(chart.title)) {
+      fail(`/blog/${post.slug} prerendered chart fallback missing title ${chart.title}`)
+    }
   }
 
   const phrase = expectedBodyPhrase(post)

--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -33,14 +33,67 @@ function parseTemplateField(content, field) {
   return match ? match[1] : ''
 }
 
+function parseArrayField(content, field) {
+  const fieldMatch = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\\[`, 'm').exec(content)
+  if (!fieldMatch) return ''
+
+  const start = fieldMatch.index + fieldMatch[0].lastIndexOf('[')
+  let depth = 0
+  let quote = ''
+  let escaped = false
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index]
+
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === quote) {
+        quote = ''
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+
+    if (char === '[') depth += 1
+    if (char === ']') depth -= 1
+
+    if (depth === 0) {
+      return content.slice(start, index + 1)
+    }
+  }
+
+  fail(`Unclosed array field in blog source: ${field}`)
+}
+
 function parseChartsField(content, file) {
-  const match = content.match(/^\s*charts:\s*(\[[\s\S]*?\])\s*,\s*content:/m)
-  if (!match) return []
+  const chartsLiteral = parseArrayField(content, 'charts')
+  if (!chartsLiteral) return []
 
   try {
-    return JSON.parse(match[1])
+    return JSON.parse(chartsLiteral)
   } catch (error) {
     fail(`Invalid charts JSON in ${file}: ${error.message}`)
+  }
+}
+
+function chartPlaceholderIds(content) {
+  return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
+    .map(match => (match[1] || match[2] || '').trim())
+    .filter(Boolean)
+}
+
+function assertKnownChartPlaceholders(body, charts, slug) {
+  const chartIds = new Set(charts.map(chart => chart.chart_id))
+  const unknownChartIds = [...new Set(chartPlaceholderIds(body).filter(chartId => !chartIds.has(chartId)))]
+  if (unknownChartIds.length) {
+    fail(`/blog/${slug} source references missing chart fallback data: ${unknownChartIds.join(', ')}`)
   }
 }
 
@@ -64,6 +117,7 @@ function collectBlogPosts() {
     if (!date) fail(`Missing date in ${file}`)
     if (!author) fail(`Missing author in ${file}`)
     if (!body.trim()) fail(`Missing content in ${file}`)
+    assertKnownChartPlaceholders(body, charts, slug)
     posts.push({
       slug,
       title,

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -70,12 +70,51 @@ function parseTemplateField(content: string, field: string): string {
   return match ? match[1] : ''
 }
 
+function parseArrayField(content: string, field: string): string {
+  const fieldMatch = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\\[`, 'm').exec(content)
+  if (!fieldMatch) return ''
+
+  const start = fieldMatch.index + fieldMatch[0].lastIndexOf('[')
+  let depth = 0
+  let quote = ''
+  let escaped = false
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index]
+
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === quote) {
+        quote = ''
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+
+    if (char === '[') depth += 1
+    if (char === ']') depth -= 1
+
+    if (depth === 0) {
+      return content.slice(start, index + 1)
+    }
+  }
+
+  throw new Error(`Unclosed array field in blog source: ${field}`)
+}
+
 function parseChartsField(content: string, file: string): ChartSpec[] {
-  const match = content.match(/^\s*charts:\s*(\[[\s\S]*?\])\s*,\s*content:/m)
-  if (!match) return []
+  const chartsLiteral = parseArrayField(content, 'charts')
+  if (!chartsLiteral) return []
 
   try {
-    return JSON.parse(match[1]) as ChartSpec[]
+    return JSON.parse(chartsLiteral) as ChartSpec[]
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Invalid charts JSON in blog source ${file}: ${message}`)
@@ -222,14 +261,28 @@ ${rows}
       </figure>`
 }
 
+function chartPlaceholderIds(content: string): string[] {
+  return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
+    .map(match => (match[1] || match[2] || '').trim())
+    .filter(Boolean)
+}
+
 function renderChartFallbacks(content: string, charts: ChartSpec[]): string {
   const chartMap = new Map(charts.map(chart => [chart.chart_id, chart]))
+  const unknownChartIds = [...new Set(chartPlaceholderIds(content).filter(chartId => !chartMap.has(chartId)))]
+  if (unknownChartIds.length) {
+    throw new Error(`Missing chart fallback data for: ${unknownChartIds.join(', ')}`)
+  }
+
   return content.replace(
     /<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g,
     (_match, htmlId: string | undefined, markdownId: string | undefined) => {
-      const chartId = htmlId || markdownId || ''
+      const chartId = (htmlId || markdownId || '').trim()
       const chart = chartMap.get(chartId)
-      return chart ? buildChartFallbackHtml(chart) : ''
+      if (!chart) {
+        throw new Error(`Missing chart fallback data for: ${chartId}`)
+      }
+      return buildChartFallbackHtml(chart)
     },
   )
 }

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -34,6 +34,24 @@ interface BlogSourceMetadata {
   seoTitle: string
   seoDescription: string
   content: string
+  charts: ChartSpec[]
+}
+
+type ChartValue = string | number | null | undefined
+type ChartDatum = Record<string, ChartValue>
+
+interface ChartSeries {
+  dataKey: string
+}
+
+interface ChartSpec {
+  chart_id: string
+  title: string
+  data: ChartDatum[]
+  config: {
+    bars?: ChartSeries[]
+    x_key?: string
+  }
 }
 
 function escapeRegExp(value: string): string {
@@ -52,6 +70,18 @@ function parseTemplateField(content: string, field: string): string {
   return match ? match[1] : ''
 }
 
+function parseChartsField(content: string, file: string): ChartSpec[] {
+  const match = content.match(/^\s*charts:\s*(\[[\s\S]*?\])\s*,\s*content:/m)
+  if (!match) return []
+
+  try {
+    return JSON.parse(match[1]) as ChartSpec[]
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid charts JSON in blog source ${file}: ${message}`)
+  }
+}
+
 function collectBlogSourceMetadata(): BlogSourceMetadata[] {
   const blogDir = resolve(import.meta.dirname, 'src/content/blog')
   if (!existsSync(blogDir)) return []
@@ -68,6 +98,7 @@ function collectBlogSourceMetadata(): BlogSourceMetadata[] {
     const seoTitle = parseStringField(content, 'seo_title')
     const seoDescription = parseStringField(content, 'seo_description')
     const postContent = parseTemplateField(content, 'content')
+    const charts = parseChartsField(content, file)
 
     if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
     if (!title) throw new Error(`Missing title in blog source: ${file}`)
@@ -86,6 +117,7 @@ function collectBlogSourceMetadata(): BlogSourceMetadata[] {
       seoTitle,
       seoDescription,
       content: postContent,
+      charts,
     })
   }
 
@@ -164,12 +196,46 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;')
 }
 
-function stripChartPlaceholders(content: string): string {
-  return content.replace(/<p>\s*\{\{chart:[^}]+\}\}\s*<\/p>|\{\{chart:[^}]+\}\}/g, '')
+function chartValue(value: ChartValue): string {
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+function buildChartFallbackHtml(chart: ChartSpec): string {
+  const xKey = chart.config.x_key || 'name'
+  const series = chart.config.bars?.map(item => item.dataKey) || []
+  const headers = [xKey, ...series]
+  const rows = chart.data
+    .map(row => `          <tr>${headers
+      .map(header => `<td>${escapeHtml(chartValue(row[header]))}</td>`)
+      .join('')}</tr>`)
+    .join('\n')
+
+  return `<figure data-prerendered-chart="${escapeHtml(chart.chart_id)}">
+        <figcaption>${escapeHtml(chart.title)}</figcaption>
+        <table>
+          <thead><tr>${headers.map(header => `<th>${escapeHtml(header)}</th>`).join('')}</tr></thead>
+          <tbody>
+${rows}
+          </tbody>
+        </table>
+      </figure>`
+}
+
+function renderChartFallbacks(content: string, charts: ChartSpec[]): string {
+  const chartMap = new Map(charts.map(chart => [chart.chart_id, chart]))
+  return content.replace(
+    /<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g,
+    (_match, htmlId: string | undefined, markdownId: string | undefined) => {
+      const chartId = htmlId || markdownId || ''
+      const chart = chartMap.get(chartId)
+      return chart ? buildChartFallbackHtml(chart) : ''
+    },
+  )
 }
 
 function buildBlogBodyHtml(post: BlogSourceMetadata): string {
-  const articleHtml = marked.parse(stripChartPlaceholders(post.content), { async: false }) as string
+  const articleHtml = marked.parse(renderChartFallbacks(post.content, post.charts), { async: false }) as string
   return `
     <article data-prerendered-blog-article="true">
       <header>

--- a/plans/PR-Blog-Prerender-Chart-Fallbacks.md
+++ b/plans/PR-Blog-Prerender-Chart-Fallbacks.md
@@ -1,0 +1,75 @@
+# PR-Blog-Prerender-Chart-Fallbacks
+
+## Why this slice exists
+
+PR-Blog-GEO-Visible-Article-HTML made blog article bodies visible in the
+prerendered Atlas Intel HTML. That closed the empty-shell crawler issue, but
+the first implementation removed chart placeholders from the static body.
+
+Several public blog posts use charts to expose evidence such as migration
+destinations, brands losing customers, and safety consequence counts. For GEO
+and AEO, no-JavaScript crawlers should see a readable evidence fallback instead
+of losing those chart-backed facts.
+
+## Scope (this PR)
+
+1. Parse source post chart specs during the existing Vite blog source scan.
+2. Replace `{{chart:id}}` placeholders with static chart fallback figures in
+   prerendered blog route HTML.
+3. Render each fallback as a `figcaption` plus table using the chart source data.
+4. Extend the blog GEO prerender verifier to reject leftover chart placeholders.
+5. Extend the verifier to assert each source chart has a visible fallback.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-Prerender-Chart-Fallbacks.md` | Plan doc for this slice. |
+| `atlas-intel-ui/vite.config.ts` | Render static chart fallback figures into prerendered blog bodies. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Verify chart placeholders are removed and chart fallback titles are visible. |
+
+## Mechanism
+
+The source post files already contain JSON-shaped `charts` arrays. The Vite
+prerender plugin now parses that field alongside `slug`, `title`, `date`,
+`author`, and `content`. When rendering the static article body, each
+`{{chart:id}}` placeholder is replaced with:
+
+- `figure[data-prerendered-chart]`
+- a visible `figcaption` using the chart title
+- a simple HTML table using the chart's `x_key` and configured bar series
+
+Interactive chart rendering remains owned by the React runtime. This slice only
+adds no-JavaScript HTML fallbacks for crawlers.
+
+## Intentional
+
+- No React component changes.
+- No generated blog content changes.
+- No changes to chart interactivity.
+- No attempt to render SVG/canvas charts at build time.
+- No claim that GEO guarantees AI-engine placement.
+
+## Deferred
+
+- Replacing regex source parsing with a shared manifest or build-time source
+  module import.
+- Richer chart fallback prose summaries.
+- FAQ fallback verification when Atlas Intel blog sources include FAQ entries.
+
+## Verification
+
+- Atlas UI lint.
+- Atlas UI production build.
+- Blog GEO prerender verification.
+- Whitespace diff check.
+- Local PR review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Vite chart fallback rendering | ~75 |
+| Publish verifier | ~30 |
+| Total | ~175 |

--- a/plans/PR-Blog-Prerender-Chart-Fallbacks.md
+++ b/plans/PR-Blog-Prerender-Chart-Fallbacks.md
@@ -19,6 +19,8 @@ of losing those chart-backed facts.
 3. Render each fallback as a `figcaption` plus table using the chart source data.
 4. Extend the blog GEO prerender verifier to reject leftover chart placeholders.
 5. Extend the verifier to assert each source chart has a visible fallback.
+6. Reject source chart placeholders that do not have matching chart data instead
+   of silently dropping evidence from prerendered HTML.
 
 ### Files touched
 
@@ -31,16 +33,19 @@ of losing those chart-backed facts.
 ## Mechanism
 
 The source post files already contain JSON-shaped `charts` arrays. The Vite
-prerender plugin now parses that field alongside `slug`, `title`, `date`,
-`author`, and `content`. When rendering the static article body, each
-`{{chart:id}}` placeholder is replaced with:
+prerender plugin now parses that field with a bracket-balanced field reader
+alongside `slug`, `title`, `date`, `author`, and `content`. That keeps chart
+extraction stable when other top-level fields sit between `charts` and
+`content`. When rendering the static article body, each `{{chart:id}}`
+placeholder is replaced with:
 
 - `figure[data-prerendered-chart]`
 - a visible `figcaption` using the chart title
 - a simple HTML table using the chart's `x_key` and configured bar series
 
 Interactive chart rendering remains owned by the React runtime. This slice only
-adds no-JavaScript HTML fallbacks for crawlers.
+adds no-JavaScript HTML fallbacks for crawlers. Unknown chart placeholder IDs now
+fail the build/verifier instead of being removed from the article body.
 
 ## Intentional
 
@@ -52,7 +57,7 @@ adds no-JavaScript HTML fallbacks for crawlers.
 
 ## Deferred
 
-- Replacing regex source parsing with a shared manifest or build-time source
+- Replacing field-level source parsing with a shared manifest or build-time source
   module import.
 - Richer chart fallback prose summaries.
 - FAQ fallback verification when Atlas Intel blog sources include FAQ entries.
@@ -69,7 +74,7 @@ adds no-JavaScript HTML fallbacks for crawlers.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | ~70 |
-| Vite chart fallback rendering | ~75 |
-| Publish verifier | ~30 |
-| Total | ~175 |
+| Plan | ~80 |
+| Vite chart fallback rendering | ~120 |
+| Publish verifier | ~80 |
+| Total | ~280 |


### PR DESCRIPTION
## Summary
- parse source blog chart specs during Atlas Intel UI prerendering
- replace chart placeholders in prerendered blog bodies with static figure/table fallbacks
- extend the blog GEO verifier to reject leftover chart placeholders and require chart fallback titles

## Verification
- npm run lint
- npm run build
- npm run verify:blog-geo
- git diff --check
- bash scripts/local_pr_review.sh