### PR TITLE
Close AI Content Ops blog SEO/GEO audit guidance

### DIFF
--- a/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
+++ b/docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md
@@ -5,20 +5,38 @@
 
 ## Short Answer
 
-Atlas partially generates SEO and AEO-ready blog drafts today.
+Atlas can generate, persist, review, and publish blog drafts with SEO/AEO/GEO
+readiness checks on the current AI Content Ops path.
 
-It now has a first-pass GEO contract in
-`docs/audits/ai_content_ops_blog_geo_contract_2026-05-20.md`, but the contract
-is not fully implemented as a validator yet. At the time of the original audit,
-at least one AI Content Ops persistence path did not appear to write the
-generated SEO fields into the public `blog_posts` columns that the public API
-and frontend read.
+This audit originally found that the extracted AI Content Ops blog path could
+generate SEO fields but did not prove they survived into public/publishable
+surfaces. That gap is now closed by the merged PR chain listed below.
 
 The safest current claim is:
 
-> The blog generator can produce SEO and answer-engine-ready drafts when the run uses the SEO/AEO prompt and the publishing path preserves the generated metadata.
+> Blog drafts include SEO metadata, FAQ answers, answer-engine-friendly
+> structure, and GEO readiness checks. Published blog pages are covered by
+> crawler-visible SEO/GEO verification.
 
-Avoid claiming fully automated SEO, AEO, and GEO optimization until the gaps below are closed.
+Still avoid claiming guaranteed AI-engine placement or "fully optimized" SEO,
+AEO, and GEO outcomes.
+
+## Closeout Status
+
+The follow-up chain that closed this audit:
+
+- PR #665: persisted extracted blog SEO fields into first-class `blog_posts`
+  columns and hydrated them back into `BlogPostDraft.metadata`.
+- PR #669: added SEO/AEO readiness to generated blog draft export rows.
+- PR #671: made missing SEO/AEO fields block generated blog saves.
+- PR #672: defined the first-class GEO draft/publish contract.
+- PR #674: added GEO readiness to generated blog draft export rows.
+- PR #676: made missing GEO draft structure block generated blog saves.
+- PR #678: added a targeted GEO repair loop.
+- PR #682 and PR #683: added local and CI publish-level GEO verification.
+- PR #688 and PR #690: surfaced readiness in the Atlas Intel review UI.
+- PR #691 and PR #693: verified publish metadata, FAQ schema, and JSON-LD.
+- PR #698: prerendered crawler-visible article bodies.
 
 ## What Exists
 
@@ -98,7 +116,7 @@ This path also has fallback logic for missing SEO title, SEO description, and ta
 
 ### Gap 1: GEO Is Not a First-Class Contract
 
-Status: definition added, implementation still pending.
+Status: closed for the current product contract.
 
 The prompts mention AI answer engines and include AEO patterns that overlap with GEO. A first-class product definition now exists in:
 
@@ -106,16 +124,20 @@ The prompts mention AI answer engines and include AEO patterns that overlap with
 
 That contract defines GEO as Generative Engine Optimization: structuring a blog post so AI answer engines can understand the topic, extract a useful answer, identify the entities involved, and cite or summarize the page without needing hidden context.
 
-The system can produce GEO-friendly content, but the repo does not yet fully
-prove or enforce "GEO-ready" as a distinct output.
+The repo now exposes GEO readiness in generated-asset export/review output,
+blocks generated drafts that miss the draft-level GEO contract, and verifies
+publish-level crawler-visible output in the Atlas Intel UI build path.
 
-Needed:
+Implemented:
 
-- add `geo_readiness` to generated-asset review/export output
-- add draft-level GEO checks to the blog quality gate
-- add publish-level checks for crawler-visible HTML and structured data
+- `geo_readiness` in generated-asset review/export output
+- draft-level GEO checks in the blog quality gate
+- publish-level checks for crawler-visible HTML, SEO metadata, JSON-LD, and
+  article body content
 
 ### Gap 2: AI Content Ops Blog Persistence May Bury SEO Fields
+
+Status: closed by PR #665.
 
 The newer extracted AI Content Ops blog service builds a `BlogPostDraft` with SEO fields in `draft.metadata`.
 
@@ -123,7 +145,9 @@ Relevant file:
 
 - `extracted_content_pipeline/blog_generation.py`
 
-But `PostgresBlogPostRepository.save_drafts()` writes only core draft fields and stores metadata under `data_context["_metadata"]`.
+`PostgresBlogPostRepository.save_drafts()` now writes the generated SEO fields
+into the first-class `blog_posts` columns while still preserving the metadata
+bag under `data_context["_metadata"]`.
 
 Relevant file:
 
@@ -146,23 +170,23 @@ Those columns exist in:
 
 - `atlas_brain/storage/migrations/120_blog_seo.sql`
 
-Risk:
-
-Generated SEO/AEO metadata from the extracted AI Content Ops Station path may be saved in `data_context["_metadata"]` but not exposed to the public API or frontend as SEO fields.
+Risk status: closed for the extracted Content Ops blog-post repository.
 
 ### Gap 3: Quality Gate Does Not Validate SEO/AEO/GEO Metadata
 
-`extracted_quality_gate.blog_pack.evaluate_blog_post()` validates long-form blog quality, word count, chart placeholders, internal links, quote use, unsupported data claims, and related content quality issues.
+Status: closed for the extracted Content Ops blog generator.
 
-It does not appear to validate:
+`extracted_quality_gate.blog_pack.evaluate_blog_post()` now validates long-form blog quality, word count, chart placeholders, internal links, quote use, unsupported data claims, SEO/AEO metadata, and GEO draft structure when the caller opts into those checks.
 
-- `seo_title` length or keyword placement
-- `seo_description` length or keyword inclusion
+The extracted blog generator opts into checks for:
+
+- `seo_title` presence and length
+- `seo_description` presence and length
 - target keyword presence
-- FAQ count or answer quality
+- secondary keyword presence
+- FAQ count
 - answer-first section format
 - question-style H2 usage
-- BlogPosting/FAQ schema readiness
 - GEO/AEO citable-section requirements as a named score
 
 Relevant files:
@@ -170,53 +194,66 @@ Relevant files:
 - `extracted_quality_gate/blog_pack.py`
 - `extracted_content_pipeline/blog_generation.py`
 
-Risk:
-
-The prompt asks for SEO/AEO, but the quality gate does not independently enforce it before a draft is saved.
+Risk status: closed for save-time draft validation. Publish-time schema and
+crawler-visible checks are handled by the Atlas Intel publish verifier.
 
 ### Gap 4: Two Blog Generation Paths Are Easy to Confuse
+
+Status: mitigated for the current AI Content Ops path.
 
 There are at least two relevant paths:
 
 1. Legacy/autonomous blog generation, which writes SEO fields directly.
 2. Extracted AI Content Ops `BlogPostGenerationService`, which stores SEO fields in draft metadata and relies on a repository that does not write the first-class SEO columns.
 
-Risk:
-
-We may be looking at a working SEO implementation in one path while the actual AI Content Ops Station path used by the product has a weaker contract.
+Risk status: the extracted AI Content Ops path now has its own persistence,
+quality, export, review UI, and publish verification contracts. The legacy
+autonomous path remains separate and should not be used as evidence for future
+extracted-path claims unless a PR explicitly wires or tests both.
 
 ### Gap 5: Current Product Claim Needs Careful Wording
 
-The repo supports this claim:
+The repo now supports this claim:
 
-> Generates data-backed blog drafts with SEO fields, FAQ output, and AEO-style structure.
+> Generates data-backed blog drafts with SEO metadata, FAQ output,
+> answer-engine-friendly structure, GEO readiness checks, and publish-surface
+> verification.
 
-The repo does not yet fully support this stronger claim:
+The repo still should not claim:
 
 > Automatically generates, validates, and publishes fully SEO/GEO/AEO optimized blog posts.
 
-## Discovery Questions
+## Resolved Discovery Questions
 
-1. Which blog path powers the AI Content Ops Station experience we want to sell: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` or `extracted_content_pipeline/blog_generation.py`?
-2. When a customer generates a blog post from the Station, does the draft get published through the DB/API path or exported to static frontend `.ts` content?
-3. Which GEO checks should block draft save versus only show in review output?
-4. What should the report show the customer: raw generated article, SEO fields, AEO checklist, GEO checklist, or all of those?
-5. What proof do we need before saying the output is SEO/GEO/AEO-ready?
+1. The AI Content Ops Station path is `extracted_content_pipeline/blog_generation.py`
+   with host-injected blueprint, LLM, skill, and repository ports.
+2. Generated blog drafts persist through `PostgresBlogPostRepository`; public
+   static/frontend publishing remains a separate route with its own verifier.
+3. SEO/AEO and draft-level GEO blockers run before save on the extracted blog
+   generator. Export/review rows also show readiness summaries for operators.
+4. Review/export output shows the raw generated article plus SEO/AEO and GEO
+   readiness summaries. The Atlas Intel UI renders both compact labels and a
+   readiness breakdown.
+5. The current proof is test and CI coverage for first-class SEO persistence,
+   save-time quality gates, review/export readiness, review UI visibility,
+   and publish-level crawler-visible verification.
 
 ## Recommended Next Slice
 
-Before changing copy or selling this as SEO/GEO/AEO generation, tighten the product contract:
+No active follow-up remains from this audit. The next Content Ops blog
+SEO/GEO slice should require a new concrete trigger, such as:
 
-1. Add first-class SEO fields to the extracted AI Content Ops `BlogPostDraft` persistence path, or map `metadata` into the existing public SEO columns.
-2. Add a small GEO readiness summary to blog draft export/review output.
-3. Add tests proving that a generated blog draft persists `seo_title`, `seo_description`, `target_keyword`, `secondary_keywords`, and `faq` into the fields read by the public API.
-4. Add publish-level GEO checks before claiming fully SEO/GEO/AEO-ready pages.
+1. A live generated blog draft fails a readiness check for a reason operators
+   cannot understand or fix.
+2. A public publish verifier misses a crawler-visible SEO/GEO regression.
+3. The product changes the public claim beyond the safe wording below.
 
 ## Suggested Customer-Facing Language For Now
 
 Use:
 
-> Blog drafts include SEO metadata, FAQ answers, and answer-engine-friendly article structure.
+> Blog drafts include SEO metadata, FAQ answers, answer-engine-friendly article
+> structure, and GEO readiness checks.
 
 Avoid until validated:
 

--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -58,6 +58,12 @@ The following items appear in older plan docs but are no longer active backlog:
 - Operator-facing strict validation telemetry in Content Ops execution results.
 - Strict validation blocked-event logging in Content Ops execution.
 - Blog-specific packaged narrative pack for structured reasoning.
+- Extracted blog SEO field persistence into first-class `blog_posts` columns.
+- Blog SEO/AEO and GEO readiness summaries in generated-asset export/review
+  output.
+- Blog SEO/AEO and GEO save-time quality gates plus GEO repair loop.
+- Blog publish-level SEO/GEO/JSON-LD/crawler-visible article verification.
+- Atlas Intel blog readiness review and breakdown UI.
 
 ## Active Backlog
 
@@ -168,6 +174,14 @@ highest-leverage code should come from either a real source export fixture
 future slice touches reasoning policy, it should name the concrete trigger from
 the list above in its plan doc.
 
+The blog SEO/AEO/GEO arc is also closed for the current product contract.
+The original discovery audit now records the merged closeout chain:
+
+- `docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md`
+
+Do not take another Content Ops blog SEO/GEO slice unless it is driven by a
+new live-output failure, a UI/operator need, or a publish verifier regression.
+
 The review-source readiness and Postgres smoke closeouts do not create a new
 active Content Ops implementation backlog. G2 can use the existing exporter,
 source-row import, DB-backed draft persistence, optional live-provider
@@ -210,9 +224,9 @@ has 1,282,355 rows, 383,564 with usable complaint narratives. A 50-row debt
 collection sample exposed generic gaps: provider-style complaint narrative
 fields needed direct source-row aliases, and debt/credit-report complaints
 needed financial complaint action policy before SaaS-style reporting/account
-rules. PR-Content-Ops-FAQ-Complaint-Source-Policy owns that source-level fix.
-Future FAQ/source work should be driven by a real customer help desk export,
-hosted UI need, or another real dataset exposing a generic policy gap.
+rules. Those source-level fixes landed in the FAQ complaint/source-policy
+chain. Future FAQ/source work should be driven by a real customer help desk
+export, hosted UI need, or another real dataset exposing a generic policy gap.
 
 **Real CFPB output-quality update:** A follow-up run against three 150-row
 samples from the same local CFPB export (`Debt collection`, `Credit reporting,
@@ -221,7 +235,8 @@ showed that the source adapter preserved provider context such as `Product`,
 `Issue`, and `Sub-issue`, but the FAQ classifier did not read that context
 when choosing intent/action policy. That caused financial complaint rows to
 fall into generic SaaS reporting/account workflows.
-PR-Content-Ops-FAQ-Source-Context-Policy owns the generic fix: include
-normalized source-context fields in FAQ intent classification and add
-mortgage-servicing policy. This is still not a CFPB-specific branch; CFPB is
-the real public fixture that exposed the generic source-context gap.
+PR #699 landed the generic fix: include normalized source-context fields in FAQ
+intent classification, add mortgage-servicing policy, and keep mortgage
+classification anchored to mortgage-specific source language. This is still
+not a CFPB-specific branch; CFPB is the real public fixture that exposed the
+generic source-context gap.

--- a/docs/extraction/coordination/inflight.md
+++ b/docs/extraction/coordination/inflight.md
@@ -1,11 +1,11 @@
 # In-Flight PRs
 
-Last updated: 2026-05-20T17:08Z by codex-2026-05-20
+Last updated: 2026-05-20T19:20Z by codex-2026-05-20
 
 Add a row before opening a PR (session protocol step 2). Drop the row when the PR merges (step 4). See [`../COORDINATION.md`](../COORDINATION.md) for protocol details.
 
 | PR | Title | Touches | Owner | Don't conflict with |
 |---|---|---|---|---|
-| PR-Content-Ops-FAQ-Source-Context-Policy | Use preserved source context for FAQ intent/action policy | `extracted_content_pipeline/ticket_faq_markdown.py`, `tests/test_extracted_ticket_faq_markdown.py`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | codex-2026-05-20 | blog PR #697 owns blog content only |
+| PR-Content-Ops-Blog-SEO-Closeout | Close stale AI Content Ops blog SEO/GEO audit recommendations | `docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md`, `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`, `plans/PR-Content-Ops-Blog-SEO-Closeout.md` | codex-2026-05-20 | open blog content PRs #697/#700 own generated blog data/UI content only |
 
 This table is for PRs we need to coordinate around, not a mirror of `gh pr list`. Use `gh pr list --state open` for the full inventory.

--- a/plans/PR-Content-Ops-Blog-SEO-Closeout.md
+++ b/plans/PR-Content-Ops-Blog-SEO-Closeout.md
@@ -1,0 +1,79 @@
+# Content Ops Blog SEO Closeout
+
+## Why this slice exists
+
+The AI Content Ops blog SEO/AEO/GEO audit still describes several gaps as
+open even though the follow-up PR chain has now landed:
+
+- PR #665 persists extracted blog SEO fields into first-class `blog_posts`
+  columns.
+- PR #669 and PR #674 expose SEO/AEO and GEO readiness in generated-asset
+  export rows.
+- PR #671 and PR #676 block incomplete SEO/AEO and GEO drafts before save.
+- PR #682, PR #683, PR #691, PR #693, and PR #698 cover publish-level blog
+  GEO/SEO/JSON-LD/crawler-visible checks.
+- PR #688 and PR #690 surface readiness in the review UI.
+
+The stale audit text caused the next-slice picker to re-select completed SEO
+persistence work. This PR closes that coordination gap so future sessions do
+not spend time rediscovering already-merged work.
+
+## Scope (this PR)
+
+1. Update the blog SEO/AEO/GEO discovery audit with the merged closeout status.
+2. Update the AI Content Ops deferred backlog so blog SEO/GEO and the merged
+   FAQ source-context slice are no longer presented as active work.
+3. Clean the in-flight coordination row for the merged FAQ PR and claim this
+   doc-only closeout slice.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Blog-SEO-Closeout.md` | Plan doc for this slice. |
+| `docs/audits/ai_content_ops_blog_seo_aeo_geo_discovery_2026-05-20.md` | Mark merged SEO/AEO/GEO follow-up work as closed and update safe claim language. |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | Retire the merged blog SEO/GEO and FAQ source-context follow-ups from active selection. |
+| `docs/extraction/coordination/inflight.md` | Remove stale FAQ in-flight row and claim this closeout. |
+
+## Mechanism
+
+This is a documentation and coordination update only. It records the actual
+merged PR sequence next to the stale audit findings, then restates the current
+selection rule: do not take another AI Content Ops blog SEO/GEO slice unless a
+new live output, UI need, or publish verifier regression exposes a concrete
+gap.
+
+## Intentional
+
+- No runtime code changes. The runtime paths are already covered by the merged
+  PRs listed above.
+- No new product claim beyond the verified wording. The docs still avoid
+  guaranteeing AI-engine placement or "fully optimized" outcomes.
+- No cleanup of unrelated blog content PRs. Open blog content work remains
+  separate from this AI Content Ops closeout.
+
+## Deferred
+
+- Remove this in-flight coordination row after the PR merges.
+- Future Content Ops blog SEO/GEO work should start from a new concrete
+  failure, not from this now-closed audit.
+
+## Verification
+
+Planned commands:
+
+```bash
+bash scripts/local_pr_review.sh
+git diff --check
+```
+
+No package tests are required because this slice changes Markdown docs only.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Audit/backlog docs | ~165 |
+| Coordination ledger | ~5 |
+| Total | ~250 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-SEO-Closeout.md

Close stale AI Content Ops blog SEO/AEO/GEO audit guidance now that the follow-up chain has landed: SEO field persistence, SEO/AEO and GEO readiness, save-time gates, repair loop, review UI, and publish-level verification are all represented as closed for the current product contract.

## Intentional
- Doc-only closeout; no runtime code changes.
- Keeps customer-facing language bounded to verified readiness and publish-verification claims.
- Leaves unrelated open blog content PRs separate.

## Deferred
- Remove this coordination in-flight row after the PR merges.
- Future Content Ops blog SEO/GEO work should start from a concrete live-output, UI, or verifier regression.

## Verification
- bash scripts/local_pr_review.sh
- git diff --check

## Diff size
4 files, +188 / -57