### PR TITLE
Harden orphan-disclaimer patterns for off-topic keyword-match quotes

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1583,9 +1583,18 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
 # Disclaimer-prose patterns. When a blockquote block is stripped, an
 # adjacent paragraph matching one of these patterns is itself orphaned
 # (it references content that no longer exists) and stripped along
-# with the block. These match the seo-geo-aeo-blog-post skill's v1.4.0
+# with the block. These match the seo-geo-aeo-blog-post skill's
 # detection patterns -- the audit catches the same shapes post-publish,
-# and this stripper catches them upstream during generation.
+# and this stripper catches them upstream during generation. Keep this
+# tuple in sync with the skill's detectAcknowledgedMisattribution patterns.
+#
+# The second group was added after a corpus audit found off-topic
+# keyword-match quotes (copper-the-metal, audio gear, an ISP complaint, a
+# financial-planning note) shipped with disclaimers whose wording the
+# original four patterns missed -- e.g. "references X rather than CRM
+# software", "does not directly reference Copper CRM", "may reflect data
+# noise". Validated against the published corpus: the additions match only
+# the genuine disclaimers, with zero false positives on legitimate prose.
 _ORPHAN_DISCLAIMER_RES = (
     re.compile(r"that quote is from a .{0,60}? discussion, not a", re.IGNORECASE),
     re.compile(r"misattributed in the source data", re.IGNORECASE),
@@ -1595,6 +1604,16 @@ _ORPHAN_DISCLAIMER_RES = (
         re.IGNORECASE,
     ),
     re.compile(r"(?:quote|review) is misattributed", re.IGNORECASE),
+    # Off-topic keyword-match disclaimers (corpus-audit additions).
+    re.compile(
+        r"references?\s+.{0,60}?\s+rather than\s+.{0,40}?"
+        r"(?:crm|software|the (?:software )?product|the platform)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?:does not|doesn't|do not|did not)\s+(?:directly\s+)?reference\b", re.IGNORECASE),
+    re.compile(r"\bdata noise\b", re.IGNORECASE),
+    re.compile(r"lacked?\s+(?:crm|product|vendor|software)[- ]specific context", re.IGNORECASE),
+    re.compile(r"not every mention of\s+.{0,40}?\s+refers to", re.IGNORECASE),
 )
 
 

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1583,9 +1583,18 @@ def _quote_matches_source(quote_text: str, source_quotes: list[str]) -> bool:
 # Disclaimer-prose patterns. When a blockquote block is stripped, an
 # adjacent paragraph matching one of these patterns is itself orphaned
 # (it references content that no longer exists) and stripped along
-# with the block. These match the seo-geo-aeo-blog-post skill's v1.4.0
+# with the block. These match the seo-geo-aeo-blog-post skill's
 # detection patterns -- the audit catches the same shapes post-publish,
-# and this stripper catches them upstream during generation.
+# and this stripper catches them upstream during generation. Keep this
+# tuple in sync with the skill's detectAcknowledgedMisattribution patterns.
+#
+# The second group was added after a corpus audit found off-topic
+# keyword-match quotes (copper-the-metal, audio gear, an ISP complaint, a
+# financial-planning note) shipped with disclaimers whose wording the
+# original four patterns missed -- e.g. "references X rather than CRM
+# software", "does not directly reference Copper CRM", "may reflect data
+# noise". Validated against the published corpus: the additions match only
+# the genuine disclaimers, with zero false positives on legitimate prose.
 _ORPHAN_DISCLAIMER_RES = (
     re.compile(r"that quote is from a .{0,60}? discussion, not a", re.IGNORECASE),
     re.compile(r"misattributed in the source data", re.IGNORECASE),
@@ -1595,6 +1604,16 @@ _ORPHAN_DISCLAIMER_RES = (
         re.IGNORECASE,
     ),
     re.compile(r"(?:quote|review) is misattributed", re.IGNORECASE),
+    # Off-topic keyword-match disclaimers (corpus-audit additions).
+    re.compile(
+        r"references?\s+.{0,60}?\s+rather than\s+.{0,40}?"
+        r"(?:crm|software|the (?:software )?product|the platform)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?:does not|doesn't|do not|did not)\s+(?:directly\s+)?reference\b", re.IGNORECASE),
+    re.compile(r"\bdata noise\b", re.IGNORECASE),
+    re.compile(r"lacked?\s+(?:crm|product|vendor|software)[- ]specific context", re.IGNORECASE),
+    re.compile(r"not every mention of\s+.{0,40}?\s+refers to", re.IGNORECASE),
 )
 
 

--- a/plans/PR-Blog-Harden-Orphan-Disclaimer-Patterns.md
+++ b/plans/PR-Blog-Harden-Orphan-Disclaimer-Patterns.md
@@ -1,0 +1,109 @@
+# PR-Blog-Harden-Orphan-Disclaimer-Patterns
+
+## Why this slice exists
+
+The blog generator strips a disclaimer paragraph that sits next to an
+ungrounded/stripped blockquote (`_remove_unmatched_quote_lines` ->
+`_looks_like_orphan_disclaimer` -> `_ORPHAN_DISCLAIMER_RES`). The same four
+patterns are mirrored by the `seo-geo-aeo-blog-post` skill's audit so the
+two stay in sync.
+
+A corpus audit found those four patterns were too narrow. Posts shipped with
+disclaimers admitting an off-topic keyword-match quote -- "copper" matched
+copper-the-metal, audio cables, an ISP complaint, a financial-planning note --
+in wording the patterns missed:
+
+- *"While the quote references internet service providers rather than CRM
+  software ..."*
+- *"This quote does not directly reference Copper CRM ..."*
+- *"... appears to reference audio equipment rather than the software product,
+  indicating data noise in the corpus."*
+- *"Two complaints ... lacked CRM-specific context."*
+- *"Not every mention of 'Copper' and 'pricing' refers to the software
+  product."*
+
+Because the generator stripper and the audit share the pattern set, these
+escaped **both** upstream stripping (so they shipped) and post-publish
+detection (so the first audit pass missed them). This widens both.
+
+## Scope (this PR)
+
+1. Add five patterns to `_ORPHAN_DISCLAIMER_RES` covering the
+   "references X rather than CRM/software", "does not (directly) reference",
+   "data noise", "lacked <X>-specific context", and "not every mention of ...
+   refers to" disclaimer shapes.
+2. Add two regression tests: one asserting the new variants are swept with
+   their stripped block, one false-positive guard that non-disclaimer prose
+   containing "rather than" adjacent to a stripped block is preserved.
+3. Sync the change into the `extracted_content_pipeline` mirror.
+
+The skill-side audit patterns (`detectAcknowledgedMisattribution` in
+`scripts/audit-published-posts.js`) are widened in tandem so the two stay in
+sync; that change lives in the skill repo, not this PR.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+- `plans/PR-Blog-Harden-Orphan-Disclaimer-Patterns.md`
+
+## Mechanism
+
+The new patterns are appended to the existing tuple, so the
+`_looks_like_orphan_disclaimer` guard (skip lines starting with `>`, `#`,
+`-`, `*`, `+`, or an ordered-list marker) still applies -- the additions only
+change *which* prose lines count as disclaimers, not the structural safety
+rails. They fire only on a paragraph adjacent to an already-stripped block, so
+their blast radius is bounded by the existing block-strip logic.
+
+Pattern tightness was validated against the published corpus (79 posts): the
+five additions match only the genuine disclaimers (the repaired
+`real-cost-of-copper` spots and the one remaining `close-deep-dive`
+occurrence) with zero false positives on legitimate prose. The
+`references ... rather than ...` pattern is anchored to a trailing
+`crm|software|the product|the platform`, and `data noise` is a specific
+two-word phrase, so ordinary "X rather than Y" prose is not swept.
+
+## Intentional
+
+- **Patterns appended, not rewritten.** The original four stay verbatim; the
+  additions are a clearly-commented second group, so the diff is auditable and
+  the existing behavior is unchanged.
+- **`does not (directly) reference` left fairly broad.** It is a strong
+  disclaimer signal and only fires adjacent to a stripped block; the corpus
+  validation showed no false positives.
+- **Skill audit widened separately.** The generator (this PR) and the skill
+  audit must carry the same patterns, but they live in different repos. This
+  PR notes the dependency; the skill edit ships alongside.
+
+## Deferred
+
+- **`close-deep-dive` data repair.** The hardened audit now flags its one
+  remaining off-topic financial-planning quote; repairing that post is a
+  data-side follow-up (same surgical approach as `real-cost-of-copper`).
+
+## Verification
+
+- `python -m pytest tests/test_b2b_blog_post_generation_quote_gate.py -q` ->
+  `83 passed` (was 81; +2 new tests).
+- Corpus scan with the five candidate patterns over all 79 published posts ->
+  matched only `close-deep-dive` (the one unrepaired disclaimer), zero matches
+  on the other 78, confirming no false positives.
+- `extracted_content_pipeline` re-synced via
+  `extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`
+  (`refreshed from atlas_brain sources (43 files)`); mirror carries the new
+  patterns.
+- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape,
+  extracted manifest sync, ASCII Python policy, plan/code consistency,
+  `git diff --check`).
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `b2b_blog_post_generation.py` (5 patterns + comment) | ~23 |
+| `extracted_content_pipeline` mirror | ~23 |
+| `test_b2b_blog_post_generation_quote_gate.py` (2 tests) | ~41 |
+| Plan doc | ~120 |
+| **Total** | **~207** |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -555,6 +555,47 @@ def test_orphan_disclaimer_alone_stripped_when_no_intro():
     assert "Some normal prose without a colon ending." in out
 
 
+def test_orphan_disclaimer_offtopic_keyword_match_variants_stripped():
+    """Off-topic keyword-match disclaimers (corpus-audit additions) are
+    swept along with their stripped blockquote, the same as the original
+    acknowledged-misattribution patterns. These wordings shipped in
+    production posts (copper-the-metal, audio gear, an ISP complaint, a
+    financial-planning note) before the pattern set was widened."""
+    variants = [
+        "While the quote references internet service providers rather than CRM software, the sentiment mirrors hidden-fee complaints.",
+        "This quote does not directly reference Copper CRM, but the erosion of trust is similar.",
+        "This appears to reference audio equipment rather than the software product, indicating data noise in the corpus.",
+        "Two complaints came from community platforms but lacked CRM-specific context.",
+        'Not every mention of "Copper" and "pricing" refers to the software product.',
+    ]
+    for disclaimer in variants:
+        markdown = (
+            "## Section\n\n"
+            "> an off-topic quote that does not ground\n\n"
+            f"{disclaimer}\n"
+        )
+        out, _removed = _remove_unmatched_quote_lines(markdown, [])
+        assert "off-topic quote" not in out, disclaimer
+        assert disclaimer not in out, f"disclaimer survived: {disclaimer}"
+        assert "## Section" in out
+
+
+def test_offtopic_pattern_does_not_sweep_nondisclaimer_following_prose():
+    """False-positive guard: prose adjacent to a STRIPPED block that merely
+    contains 'rather than' (without the 'reference ... CRM/software' shape)
+    is NOT treated as a disclaimer. Only disclaimer-shaped wording is swept;
+    legitimate analysis survives."""
+    markdown = (
+        "## Section\n\n"
+        "> ungrounded quote\n\n"
+        "Buyers value simplicity rather than feature depth, a recurring theme.\n"
+    )
+    out, _removed = _remove_unmatched_quote_lines(markdown, [])
+    assert "ungrounded quote" not in out  # block stripped (fail-closed)
+    # Not disclaimer-shaped -> preserved.
+    assert "Buyers value simplicity rather than feature depth" in out
+
+
 def test_orphan_prose_preserved_for_kept_blocks():
     """When a block is KEPT (its quotes ground), the surrounding intro
     and prose are also preserved. The orphan-prose cleanup only fires


### PR DESCRIPTION
Plan: plans/PR-Blog-Harden-Orphan-Disclaimer-Patterns.md

The generator strips a disclaimer paragraph next to an ungrounded/stripped blockquote (`_ORPHAN_DISCLAIMER_RES`), and the seo-geo-aeo-blog-post audit mirrors the same patterns. A corpus audit found those four patterns too narrow: posts shipped with disclaimers admitting an off-topic keyword-match quote ("copper" matched copper-the-metal, audio cables, an ISP complaint, a financial-planning note) in wording the patterns missed. Because the generator stripper and the audit share the set, these escaped **both** upstream stripping and post-publish detection.

## Intentional
- **Patterns appended, not rewritten** — the original four stay verbatim; the five additions are a commented second group. Existing behavior unchanged.
- **Structural guards intact** — additions flow through `_looks_like_orphan_disclaimer`, which still skips `>`/`#`/`-`/`*`/`+`/ordered-list lines, and only fire on prose adjacent to an already-stripped block.
- **Validated for false positives** — scanned all 79 published posts: the five additions match only genuine disclaimers (the repaired `real-cost-of-copper` spots + the one remaining `close-deep-dive` occurrence), zero matches on the other 78. `references … rather than …` is anchored to a trailing `crm|software|the product|the platform`; `data noise` is a specific phrase.
- **Skill audit widened in tandem** — the generator (this PR) and the skill's `detectAcknowledgedMisattribution` must carry the same patterns; the skill edit ships alongside (different repo).

## Deferred
- `close-deep-dive` data repair — the hardened audit now flags its one off-topic financial-planning quote; surgical fix is a data-side follow-up (same as `real-cost-of-copper`).

## Verification
- `python -m pytest tests/test_b2b_blog_post_generation_quote_gate.py -q` -> `83 passed` (+2: variants-stripped + false-positive guard).
- Corpus scan with the five candidate patterns over 79 posts -> only `close-deep-dive` matched; zero false positives on the other 78.
- `extracted_content_pipeline` re-synced (`refreshed from atlas_brain sources (43 files)`); mirror carries the new patterns.
- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape, extracted manifest sync, ASCII policy, plan/code consistency 5/5 path claims, diff drift 5.3%, `git diff --check`).

## Diff size
~196 LOC (generator +23, mirror +23, tests +41, plan ~110).