### PR TITLE
Share Atlas Intel blog source parser

### DIFF
--- a/atlas-intel-ui/scripts/blog-source-metadata.d.mts
+++ b/atlas-intel-ui/scripts/blog-source-metadata.d.mts
@@ -1,0 +1,32 @@
+export type ChartValue = string | number | null | undefined
+export type ChartDatum = Record<string, ChartValue>
+
+export interface ChartSeries {
+  dataKey: string
+}
+
+export interface ChartSpec {
+  chart_id: string
+  title: string
+  data: ChartDatum[]
+  config: {
+    bars?: ChartSeries[]
+    x_key?: string
+  }
+}
+
+export interface BlogSourceMetadata {
+  file: string
+  slug: string
+  title: string
+  description: string
+  date: string
+  author: string
+  seoTitle: string
+  seoDescription: string
+  content: string
+  charts: ChartSpec[]
+}
+
+export function chartPlaceholderIds(content: string): string[]
+export function collectBlogSourceMetadata(rootDir: string): BlogSourceMetadata[]

--- a/atlas-intel-ui/scripts/blog-source-metadata.d.mts
+++ b/atlas-intel-ui/scripts/blog-source-metadata.d.mts
@@ -15,6 +15,11 @@ export interface ChartSpec {
   }
 }
 
+export interface FaqItem {
+  question: string
+  answer: string
+}
+
 export interface BlogSourceMetadata {
   file: string
   slug: string
@@ -26,6 +31,7 @@ export interface BlogSourceMetadata {
   seoDescription: string
   content: string
   charts: ChartSpec[]
+  faq: FaqItem[]
 }
 
 export function chartPlaceholderIds(content: string): string[]

--- a/atlas-intel-ui/scripts/blog-source-metadata.mjs
+++ b/atlas-intel-ui/scripts/blog-source-metadata.mjs
@@ -67,6 +67,35 @@ function parseChartsField(content, file) {
   }
 }
 
+function parseFaqField(content, file) {
+  const faqLiteral = parseArrayField(content, 'faq')
+  if (!faqLiteral) return []
+
+  try {
+    const faq = JSON.parse(faqLiteral)
+    if (!Array.isArray(faq)) {
+      throw new Error('faq field must be an array')
+    }
+    return faq.map((item, index) => {
+      if (!item || typeof item !== 'object') {
+        throw new Error(`faq item ${index + 1} must be an object`)
+      }
+      if (typeof item.question !== 'string' || !item.question.trim()) {
+        throw new Error(`faq item ${index + 1} missing question`)
+      }
+      if (typeof item.answer !== 'string' || !item.answer.trim()) {
+        throw new Error(`faq item ${index + 1} missing answer`)
+      }
+      return {
+        question: item.question,
+        answer: item.answer,
+      }
+    })
+  } catch (error) {
+    throw new Error(`Invalid faq JSON in blog source ${file}: ${error.message}`)
+  }
+}
+
 export function chartPlaceholderIds(content) {
   return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
     .map(match => (match[1] || match[2] || '').trim())
@@ -98,6 +127,7 @@ export function collectBlogSourceMetadata(rootDir) {
     const seoDescription = parseStringField(source, 'seo_description')
     const content = parseTemplateField(source, 'content')
     const charts = parseChartsField(source, file)
+    const faq = parseFaqField(source, file)
 
     if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
     if (!title) throw new Error(`Missing title in blog source: ${file}`)
@@ -118,6 +148,7 @@ export function collectBlogSourceMetadata(rootDir) {
       seoDescription,
       content,
       charts,
+      faq,
     })
   }
 

--- a/atlas-intel-ui/scripts/blog-source-metadata.mjs
+++ b/atlas-intel-ui/scripts/blog-source-metadata.mjs
@@ -1,0 +1,126 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseStringField(content, field) {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
+  const match = content.match(pattern)
+  return match ? match[1].replace(/\\'/g, "'") : ''
+}
+
+function parseTemplateField(content, field) {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\`([\\s\\S]*?)\`\\s*,`, 'm')
+  const match = content.match(pattern)
+  return match ? match[1] : ''
+}
+
+function parseArrayField(content, field) {
+  const fieldMatch = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\\[`, 'm').exec(content)
+  if (!fieldMatch) return ''
+
+  const start = fieldMatch.index + fieldMatch[0].lastIndexOf('[')
+  let depth = 0
+  let quote = ''
+  let escaped = false
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index]
+
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === quote) {
+        quote = ''
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+
+    if (char === '[') depth += 1
+    if (char === ']') depth -= 1
+
+    if (depth === 0) {
+      return content.slice(start, index + 1)
+    }
+  }
+
+  throw new Error(`Unclosed array field in blog source: ${field}`)
+}
+
+function parseChartsField(content, file) {
+  const chartsLiteral = parseArrayField(content, 'charts')
+  if (!chartsLiteral) return []
+
+  try {
+    return JSON.parse(chartsLiteral)
+  } catch (error) {
+    throw new Error(`Invalid charts JSON in blog source ${file}: ${error.message}`)
+  }
+}
+
+export function chartPlaceholderIds(content) {
+  return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
+    .map(match => (match[1] || match[2] || '').trim())
+    .filter(Boolean)
+}
+
+function assertKnownChartPlaceholders(content, charts, slug) {
+  const chartIds = new Set(charts.map(chart => chart.chart_id))
+  const unknownChartIds = [...new Set(chartPlaceholderIds(content).filter(chartId => !chartIds.has(chartId)))]
+  if (unknownChartIds.length) {
+    throw new Error(`/blog/${slug} source references missing chart fallback data: ${unknownChartIds.join(', ')}`)
+  }
+}
+
+export function collectBlogSourceMetadata(rootDir) {
+  const blogDir = join(rootDir, 'src/content/blog')
+  if (!existsSync(blogDir)) return []
+
+  const posts = []
+  for (const file of readdirSync(blogDir).sort()) {
+    if (!file.endsWith('.ts') || file === 'index.ts') continue
+    const source = readFileSync(join(blogDir, file), 'utf-8')
+    const slug = parseStringField(source, 'slug')
+    const title = parseStringField(source, 'title')
+    const description = parseStringField(source, 'description')
+    const date = parseStringField(source, 'date')
+    const author = parseStringField(source, 'author')
+    const seoTitle = parseStringField(source, 'seo_title')
+    const seoDescription = parseStringField(source, 'seo_description')
+    const content = parseTemplateField(source, 'content')
+    const charts = parseChartsField(source, file)
+
+    if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
+    if (!title) throw new Error(`Missing title in blog source: ${file}`)
+    if (!description) throw new Error(`Missing description in blog source: ${file}`)
+    if (!date) throw new Error(`Missing date in blog source: ${file}`)
+    if (!author) throw new Error(`Missing author in blog source: ${file}`)
+    if (!content.trim()) throw new Error(`Missing content in blog source: ${file}`)
+    assertKnownChartPlaceholders(content, charts, slug)
+
+    posts.push({
+      file,
+      slug,
+      title,
+      description,
+      date,
+      author,
+      seoTitle,
+      seoDescription,
+      content,
+      charts,
+    })
+  }
+
+  if (!posts.length) throw new Error('No blog posts found')
+  return posts.sort((a, b) => a.slug.localeCompare(b.slug))
+}

--- a/atlas-intel-ui/scripts/blog-source-metadata.mjs
+++ b/atlas-intel-ui/scripts/blog-source-metadata.mjs
@@ -112,7 +112,9 @@ function assertKnownChartPlaceholders(content, charts, slug) {
 
 export function collectBlogSourceMetadata(rootDir) {
   const blogDir = join(rootDir, 'src/content/blog')
-  if (!existsSync(blogDir)) return []
+  if (!existsSync(blogDir)) {
+    throw new Error(`Missing blog source directory: ${blogDir}`)
+  }
 
   const posts = []
   for (const file of readdirSync(blogDir).sort()) {

--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { collectBlogSourceMetadata } from './blog-source-metadata.mjs'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
 const rootDir = resolve(import.meta.dirname, '..')
-const blogDir = join(rootDir, 'src/content/blog')
 const distDir = join(rootDir, 'dist')
 const sitemapPath = join(distDir, 'sitemap.xml')
 
@@ -16,122 +16,16 @@ function readText(path) {
   return readFileSync(path, 'utf-8')
 }
 
+function collectBlogPosts() {
+  try {
+    return collectBlogSourceMetadata(rootDir)
+  } catch (error) {
+    fail(error.message)
+  }
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function parseStringField(content, field) {
-  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
-  const match = content.match(pattern)
-  if (!match) return ''
-  return match[1].replace(/\\'/g, "'")
-}
-
-function parseTemplateField(content, field) {
-  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\`([\\s\\S]*?)\`\\s*,`, 'm')
-  const match = content.match(pattern)
-  return match ? match[1] : ''
-}
-
-function parseArrayField(content, field) {
-  const fieldMatch = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\\[`, 'm').exec(content)
-  if (!fieldMatch) return ''
-
-  const start = fieldMatch.index + fieldMatch[0].lastIndexOf('[')
-  let depth = 0
-  let quote = ''
-  let escaped = false
-
-  for (let index = start; index < content.length; index += 1) {
-    const char = content[index]
-
-    if (quote) {
-      if (escaped) {
-        escaped = false
-      } else if (char === '\\') {
-        escaped = true
-      } else if (char === quote) {
-        quote = ''
-      }
-      continue
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char
-      continue
-    }
-
-    if (char === '[') depth += 1
-    if (char === ']') depth -= 1
-
-    if (depth === 0) {
-      return content.slice(start, index + 1)
-    }
-  }
-
-  fail(`Unclosed array field in blog source: ${field}`)
-}
-
-function parseChartsField(content, file) {
-  const chartsLiteral = parseArrayField(content, 'charts')
-  if (!chartsLiteral) return []
-
-  try {
-    return JSON.parse(chartsLiteral)
-  } catch (error) {
-    fail(`Invalid charts JSON in ${file}: ${error.message}`)
-  }
-}
-
-function chartPlaceholderIds(content) {
-  return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
-    .map(match => (match[1] || match[2] || '').trim())
-    .filter(Boolean)
-}
-
-function assertKnownChartPlaceholders(body, charts, slug) {
-  const chartIds = new Set(charts.map(chart => chart.chart_id))
-  const unknownChartIds = [...new Set(chartPlaceholderIds(body).filter(chartId => !chartIds.has(chartId)))]
-  if (unknownChartIds.length) {
-    fail(`/blog/${slug} source references missing chart fallback data: ${unknownChartIds.join(', ')}`)
-  }
-}
-
-function collectBlogPosts() {
-  const posts = []
-  for (const file of readdirSync(blogDir)) {
-    if (!file.endsWith('.ts') || file === 'index.ts') continue
-    const content = readText(join(blogDir, file))
-    const slug = parseStringField(content, 'slug')
-    const title = parseStringField(content, 'title')
-    const description = parseStringField(content, 'description')
-    const date = parseStringField(content, 'date')
-    const author = parseStringField(content, 'author')
-    const seoTitle = parseStringField(content, 'seo_title')
-    const seoDescription = parseStringField(content, 'seo_description')
-    const body = parseTemplateField(content, 'content')
-    const charts = parseChartsField(content, file)
-    if (!slug) fail(`Missing slug in ${file}`)
-    if (!title) fail(`Missing title in ${file}`)
-    if (!description) fail(`Missing description in ${file}`)
-    if (!date) fail(`Missing date in ${file}`)
-    if (!author) fail(`Missing author in ${file}`)
-    if (!body.trim()) fail(`Missing content in ${file}`)
-    assertKnownChartPlaceholders(body, charts, slug)
-    posts.push({
-      slug,
-      title,
-      description,
-      date,
-      author,
-      seoTitle,
-      seoDescription,
-      body,
-      charts,
-    })
-  }
-  if (!posts.length) fail('No blog posts found')
-  return posts.sort((a, b) => a.slug.localeCompare(b.slug))
 }
 
 function attrValue(tag, attr) {
@@ -196,7 +90,7 @@ function sourceBodyText(value) {
 }
 
 function expectedBodyPhrase(post) {
-  const text = sourceBodyText(post.body)
+  const text = sourceBodyText(post.content)
   const sentence = text
     .split(/(?<=[.!?])\s+/)
     .find(item => item.length >= 60 && /[A-Za-z]/.test(item))

--- a/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs
@@ -246,6 +246,20 @@ function assertCrawlerVisibleArticle(html, post) {
     }
   }
 
+  if (post.faq.length) {
+    if (!html.includes('data-prerendered-blog-faq="true"')) {
+      fail(`/blog/${post.slug} missing prerendered FAQ section`)
+    }
+    for (const item of post.faq) {
+      if (!visibleText.includes(item.question)) {
+        fail(`/blog/${post.slug} prerendered FAQ missing question: ${item.question}`)
+      }
+      if (!visibleText.includes(item.answer)) {
+        fail(`/blog/${post.slug} prerendered FAQ missing answer for: ${item.question}`)
+      }
+    }
+  }
+
   const phrase = expectedBodyPhrase(post)
   if (!visibleText.includes(phrase)) {
     fail(`/blog/${post.slug} prerendered body missing source phrase: ${phrase}`)
@@ -262,6 +276,25 @@ function assertBreadcrumbs(node, canonical, slug) {
   const last = items[items.length - 1]
   if (!last || last.item !== canonical) {
     fail(`/blog/${slug} breadcrumb final item must be ${canonical}`)
+  }
+}
+
+function assertFaqPage(node, post) {
+  const { slug } = post
+  const entities = Array.isArray(node.mainEntity) ? node.mainEntity : []
+  if (entities.length !== post.faq.length) {
+    fail(`/blog/${slug} FAQPage must include ${post.faq.length} questions`)
+  }
+
+  for (const item of post.faq) {
+    const question = entities.find(entity => entity && entity.name === item.question)
+    if (!question || !typeMatches(question, 'Question')) {
+      fail(`/blog/${slug} FAQPage missing question: ${item.question}`)
+    }
+    const answer = question.acceptedAnswer
+    if (!answer || !typeMatches(answer, 'Answer') || answer.text !== item.answer) {
+      fail(`/blog/${slug} FAQPage answer mismatch for: ${item.question}`)
+    }
   }
 }
 
@@ -309,6 +342,12 @@ function verifyBlogPage(post, sitemap) {
   const blogPosting = nodes.find(node => typeMatches(node, 'BlogPosting'))
   if (!blogPosting) fail(`/blog/${slug} missing BlogPosting JSON-LD`)
   assertBlogPosting(blogPosting, post, canonical, ogImageValue)
+
+  if (post.faq.length) {
+    const faqPage = nodes.find(node => typeMatches(node, 'FAQPage'))
+    if (!faqPage) fail(`/blog/${slug} missing FAQPage JSON-LD`)
+    assertFaqPage(faqPage, post)
+  }
 
   const breadcrumbs = nodes.find(node => typeMatches(node, 'BreadcrumbList'))
   if (!breadcrumbs) fail(`/blog/${slug} missing BreadcrumbList JSON-LD`)

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -5,10 +5,16 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  readdirSync,
   writeFileSync,
 } from 'node:fs'
 import { resolve, join } from 'node:path'
+import {
+  chartPlaceholderIds,
+  collectBlogSourceMetadata,
+  type BlogSourceMetadata,
+  type ChartSpec,
+  type ChartValue,
+} from './scripts/blog-source-metadata.mjs'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
@@ -24,145 +30,6 @@ interface SitemapUrl {
   changefreq: string
 }
 
-interface BlogSourceMetadata {
-  file: string
-  slug: string
-  title: string
-  description: string
-  date: string
-  author: string
-  seoTitle: string
-  seoDescription: string
-  content: string
-  charts: ChartSpec[]
-}
-
-type ChartValue = string | number | null | undefined
-type ChartDatum = Record<string, ChartValue>
-
-interface ChartSeries {
-  dataKey: string
-}
-
-interface ChartSpec {
-  chart_id: string
-  title: string
-  data: ChartDatum[]
-  config: {
-    bars?: ChartSeries[]
-    x_key?: string
-  }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function parseStringField(content: string, field: string): string {
-  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*'((?:\\\\'|[^'])*)'`, 'm')
-  const match = content.match(pattern)
-  return match ? match[1].replace(/\\'/g, "'") : ''
-}
-
-function parseTemplateField(content: string, field: string): string {
-  const pattern = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\`([\\s\\S]*?)\`\\s*,`, 'm')
-  const match = content.match(pattern)
-  return match ? match[1] : ''
-}
-
-function parseArrayField(content: string, field: string): string {
-  const fieldMatch = new RegExp(`^\\s*${escapeRegExp(field)}:\\s*\\[`, 'm').exec(content)
-  if (!fieldMatch) return ''
-
-  const start = fieldMatch.index + fieldMatch[0].lastIndexOf('[')
-  let depth = 0
-  let quote = ''
-  let escaped = false
-
-  for (let index = start; index < content.length; index += 1) {
-    const char = content[index]
-
-    if (quote) {
-      if (escaped) {
-        escaped = false
-      } else if (char === '\\') {
-        escaped = true
-      } else if (char === quote) {
-        quote = ''
-      }
-      continue
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char
-      continue
-    }
-
-    if (char === '[') depth += 1
-    if (char === ']') depth -= 1
-
-    if (depth === 0) {
-      return content.slice(start, index + 1)
-    }
-  }
-
-  throw new Error(`Unclosed array field in blog source: ${field}`)
-}
-
-function parseChartsField(content: string, file: string): ChartSpec[] {
-  const chartsLiteral = parseArrayField(content, 'charts')
-  if (!chartsLiteral) return []
-
-  try {
-    return JSON.parse(chartsLiteral) as ChartSpec[]
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`Invalid charts JSON in blog source ${file}: ${message}`)
-  }
-}
-
-function collectBlogSourceMetadata(): BlogSourceMetadata[] {
-  const blogDir = resolve(import.meta.dirname, 'src/content/blog')
-  if (!existsSync(blogDir)) return []
-
-  const posts: BlogSourceMetadata[] = []
-  for (const file of readdirSync(blogDir).sort()) {
-    if (!file.endsWith('.ts') || file === 'index.ts') continue
-    const content = readFileSync(join(blogDir, file), 'utf-8')
-    const slug = parseStringField(content, 'slug')
-    const title = parseStringField(content, 'title')
-    const description = parseStringField(content, 'description')
-    const date = parseStringField(content, 'date')
-    const author = parseStringField(content, 'author')
-    const seoTitle = parseStringField(content, 'seo_title')
-    const seoDescription = parseStringField(content, 'seo_description')
-    const postContent = parseTemplateField(content, 'content')
-    const charts = parseChartsField(content, file)
-
-    if (!slug) throw new Error(`Missing slug in blog source: ${file}`)
-    if (!title) throw new Error(`Missing title in blog source: ${file}`)
-    if (!description) throw new Error(`Missing description in blog source: ${file}`)
-    if (!date) throw new Error(`Missing date in blog source: ${file}`)
-    if (!author) throw new Error(`Missing author in blog source: ${file}`)
-    if (!postContent.trim()) throw new Error(`Missing content in blog source: ${file}`)
-
-    posts.push({
-      file,
-      slug,
-      title,
-      description,
-      date,
-      author,
-      seoTitle,
-      seoDescription,
-      content: postContent,
-      charts,
-    })
-  }
-
-  return posts.sort((a, b) => a.slug.localeCompare(b.slug))
-}
-
 // ---------------------------------------------------------------------------
 // Sitemap plugin
 // ---------------------------------------------------------------------------
@@ -170,7 +37,7 @@ function sitemapPlugin() {
   return {
     name: 'generate-sitemap',
     closeBundle() {
-      const posts = collectBlogSourceMetadata()
+      const posts = collectBlogSourceMetadata(import.meta.dirname)
 
       const today = new Date().toISOString().split('T')[0]
       const urls: SitemapUrl[] = [
@@ -261,12 +128,6 @@ ${rows}
       </figure>`
 }
 
-function chartPlaceholderIds(content: string): string[] {
-  return [...content.matchAll(/<p>\s*\{\{chart:([^}]+)\}\}\s*<\/p>|\{\{chart:([^}]+)\}\}/g)]
-    .map(match => (match[1] || match[2] || '').trim())
-    .filter(Boolean)
-}
-
 function renderChartFallbacks(content: string, charts: ChartSpec[]): string {
   const chartMap = new Map(charts.map(chart => [chart.chart_id, chart]))
   const unknownChartIds = [...new Set(chartPlaceholderIds(content).filter(chartId => !chartMap.has(chartId)))]
@@ -341,7 +202,7 @@ function prerenderPlugin() {
       const baseHtml = readFileSync(indexHtmlPath, 'utf-8')
 
       const blogRoutes: PrerenderedRoute[] = []
-      for (const post of collectBlogSourceMetadata()) {
+      for (const post of collectBlogSourceMetadata(import.meta.dirname)) {
         const seoTitle = post.seoTitle || post.title
         const seoDesc = post.seoDescription || post.description
         blogRoutes.push({

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -14,6 +14,7 @@ import {
   type BlogSourceMetadata,
   type ChartSpec,
   type ChartValue,
+  type FaqItem,
 } from './scripts/blog-source-metadata.mjs'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
@@ -148,8 +149,26 @@ function renderChartFallbacks(content: string, charts: ChartSpec[]): string {
   )
 }
 
+function buildFaqHtml(faq: FaqItem[]): string {
+  if (!faq.length) return ''
+
+  const items = faq
+    .map(item => `        <div>
+          <h3>${escapeHtml(item.question)}</h3>
+          <p>${escapeHtml(item.answer)}</p>
+        </div>`)
+    .join('\n')
+
+  return `
+      <section data-prerendered-blog-faq="true">
+        <h2>Frequently Asked Questions</h2>
+${items}
+      </section>`
+}
+
 function buildBlogBodyHtml(post: BlogSourceMetadata): string {
   const articleHtml = marked.parse(renderChartFallbacks(post.content, post.charts), { async: false }) as string
+  const faqHtml = buildFaqHtml(post.faq)
   return `
     <article data-prerendered-blog-article="true">
       <header>
@@ -162,7 +181,24 @@ function buildBlogBodyHtml(post: BlogSourceMetadata): string {
       <section data-prerendered-blog-content="true">
         ${articleHtml}
       </section>
+      ${faqHtml}
     </article>`
+}
+
+function buildFaqJsonLd(faq: FaqItem[]): object | null {
+  if (!faq.length) return null
+
+  return {
+    '@type': 'FAQPage',
+    mainEntity: faq.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  }
 }
 
 function buildHeadHtml(route: PrerenderedRoute): string {
@@ -205,6 +241,40 @@ function prerenderPlugin() {
       for (const post of collectBlogSourceMetadata(import.meta.dirname)) {
         const seoTitle = post.seoTitle || post.title
         const seoDesc = post.seoDescription || post.description
+        const faqJsonLd = buildFaqJsonLd(post.faq)
+        const graph: object[] = [
+          {
+            '@type': 'BlogPosting',
+            headline: seoTitle,
+            description: seoDesc,
+            datePublished: post.date,
+            dateModified: post.date,
+            image: DEFAULT_OG_IMAGE,
+            author: {
+              '@type': 'Organization',
+              name: 'Atlas Intelligence',
+              sameAs: ATLAS_SAME_AS,
+            },
+            publisher: {
+              '@type': 'Organization',
+              name: 'Atlas Intelligence',
+              url: BASE_URL,
+              sameAs: ATLAS_SAME_AS,
+              logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
+            },
+            mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${post.slug}` },
+          },
+          {
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/landing` },
+              { '@type': 'ListItem', position: 2, name: 'Blog', item: `${BASE_URL}/blog` },
+              { '@type': 'ListItem', position: 3, name: seoTitle, item: `${BASE_URL}/blog/${post.slug}` },
+            ],
+          },
+        ]
+        if (faqJsonLd) graph.push(faqJsonLd)
+
         blogRoutes.push({
           path: `/blog/${post.slug}`,
           title: `${seoTitle} | Atlas Intelligence`,
@@ -214,37 +284,7 @@ function prerenderPlugin() {
           bodyHtml: buildBlogBodyHtml(post),
           jsonLd: {
             '@context': 'https://schema.org',
-            '@graph': [
-              {
-                '@type': 'BlogPosting',
-                headline: seoTitle,
-                description: seoDesc,
-                datePublished: post.date,
-                dateModified: post.date,
-                image: DEFAULT_OG_IMAGE,
-                author: {
-                  '@type': 'Organization',
-                  name: 'Atlas Intelligence',
-                  sameAs: ATLAS_SAME_AS,
-                },
-                publisher: {
-                  '@type': 'Organization',
-                  name: 'Atlas Intelligence',
-                  url: BASE_URL,
-                  sameAs: ATLAS_SAME_AS,
-                  logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
-                },
-                mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${post.slug}` },
-              },
-              {
-                '@type': 'BreadcrumbList',
-                itemListElement: [
-                  { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/landing` },
-                  { '@type': 'ListItem', position: 2, name: 'Blog', item: `${BASE_URL}/blog` },
-                  { '@type': 'ListItem', position: 3, name: seoTitle, item: `${BASE_URL}/blog/${post.slug}` },
-                ],
-              },
-            ],
+            '@graph': graph,
           },
         })
       }

--- a/plans/PR-Blog-Shared-Source-Parser.md
+++ b/plans/PR-Blog-Shared-Source-Parser.md
@@ -8,8 +8,8 @@ behavior harder to keep aligned: a parser fix could land in the build path while
 the verifier kept a stale version, or the other way around.
 
 This slice moves the source metadata parser behind one shared helper so the
-build and verification paths read `slug`, SEO fields, article body content, and
-chart specs through the same contract.
+build and verification paths read `slug`, SEO fields, article body content,
+chart specs, and optional FAQ entries through the same contract.
 
 ## Scope (this PR)
 
@@ -23,27 +23,37 @@ chart specs through the same contract.
    crawler-visible blog output.
 5. Keep the chart-placeholder safety check in the shared parser so undefined
    chart IDs fail both build and verification.
+6. Parse optional source `faq` entries through the same helper.
+7. Prerender visible FAQ sections and FAQPage JSON-LD when a source post has FAQ
+   entries.
+8. Extend the verifier to assert visible FAQ text and FAQPage schema for posts
+   that include FAQ entries.
 
 ### Files touched
 
 | File | Change |
 |---|---|
 | `plans/PR-Blog-Shared-Source-Parser.md` | Plan doc for this slice. |
-| `atlas-intel-ui/scripts/blog-source-metadata.mjs` | Shared blog source parser and chart placeholder validation. |
+| `atlas-intel-ui/scripts/blog-source-metadata.mjs` | Shared blog source parser with chart and FAQ validation. |
 | `atlas-intel-ui/scripts/blog-source-metadata.d.mts` | Type declarations for Vite's TypeScript config import. |
-| `atlas-intel-ui/vite.config.ts` | Reuse the shared parser instead of local parser copies. |
-| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Reuse the shared parser instead of local parser copies. |
+| `atlas-intel-ui/vite.config.ts` | Reuse the shared parser and prerender static FAQ HTML/schema when present. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Reuse the shared parser and verify static FAQ HTML/schema when present. |
 
 ## Mechanism
 
 The helper reads each TypeScript source post from `src/content/blog`, extracts
 the fields already used by the build and verifier, parses the JSON-shaped
-`charts` array with the bracket-balanced field reader, and validates that every
-`{{chart:id}}` placeholder has matching chart data.
+`charts` and optional `faq` arrays with the bracket-balanced field reader, and
+validates that every `{{chart:id}}` placeholder has matching chart data.
 
 `vite.config.ts` now asks the helper for source metadata when writing sitemap
 entries and prerendering article pages. The verifier asks the same helper for the
 same source metadata before checking the generated HTML.
+
+When a source post includes FAQ entries, the prerenderer now writes a visible FAQ
+section into the crawler-visible article HTML and adds an FAQPage node to the
+same JSON-LD graph as BlogPosting and BreadcrumbList. The verifier enforces both
+the visible text and schema node only for posts that actually include FAQ data.
 
 ## Intentional
 
@@ -52,12 +62,13 @@ same source metadata before checking the generated HTML.
 - No sitemap contract changes.
 - No change to the public blog route shape.
 - No broad parser rewrite beyond sharing the source metadata contract.
+- No generated FAQ content added to current posts.
 
 ## Deferred
 
 - Loading source posts as real modules instead of parsing field literals.
 - Generating a build-time manifest artifact consumed by both build and tests.
-- FAQ schema/static FAQ verification, handled in a separate slice.
+- Broader FAQ content generation or retrofitting FAQ entries onto existing posts.
 
 ## Verification
 
@@ -70,8 +81,8 @@ same source metadata before checking the generated HTML.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | ~70 |
-| Shared parser helper and declarations | ~150 |
-| Vite config parser removal/wiring | ~160 |
-| Verifier parser removal/wiring | ~130 |
-| Total | ~510 |
+| Plan | ~85 |
+| Shared parser helper and declarations | ~185 |
+| Vite config parser removal/wiring plus FAQ fallback | ~205 |
+| Verifier parser removal/wiring plus FAQ checks | ~170 |
+| Total | ~645 |

--- a/plans/PR-Blog-Shared-Source-Parser.md
+++ b/plans/PR-Blog-Shared-Source-Parser.md
@@ -1,0 +1,77 @@
+# PR-Blog-Shared-Source-Parser
+
+## Why this slice exists
+
+The Atlas Intel blog prerender build and the blog GEO verifier were carrying
+separate copies of the same source-post parsing logic. That made chart fallback
+behavior harder to keep aligned: a parser fix could land in the build path while
+the verifier kept a stale version, or the other way around.
+
+This slice moves the source metadata parser behind one shared helper so the
+build and verification paths read `slug`, SEO fields, article body content, and
+chart specs through the same contract.
+
+## Scope (this PR)
+
+1. Add a shared `blog-source-metadata.mjs` helper for Atlas Intel blog source
+   parsing.
+2. Add a `.d.mts` declaration so the TypeScript Vite config gets typed parser
+   results when importing the ESM helper.
+3. Update `vite.config.ts` to use the shared parser for sitemap generation and
+   prerendered blog pages.
+4. Update `verify-blog-geo-prerender.mjs` to use the same parser before checking
+   crawler-visible blog output.
+5. Keep the chart-placeholder safety check in the shared parser so undefined
+   chart IDs fail both build and verification.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-Shared-Source-Parser.md` | Plan doc for this slice. |
+| `atlas-intel-ui/scripts/blog-source-metadata.mjs` | Shared blog source parser and chart placeholder validation. |
+| `atlas-intel-ui/scripts/blog-source-metadata.d.mts` | Type declarations for Vite's TypeScript config import. |
+| `atlas-intel-ui/vite.config.ts` | Reuse the shared parser instead of local parser copies. |
+| `atlas-intel-ui/scripts/verify-blog-geo-prerender.mjs` | Reuse the shared parser instead of local parser copies. |
+
+## Mechanism
+
+The helper reads each TypeScript source post from `src/content/blog`, extracts
+the fields already used by the build and verifier, parses the JSON-shaped
+`charts` array with the bracket-balanced field reader, and validates that every
+`{{chart:id}}` placeholder has matching chart data.
+
+`vite.config.ts` now asks the helper for source metadata when writing sitemap
+entries and prerendering article pages. The verifier asks the same helper for the
+same source metadata before checking the generated HTML.
+
+## Intentional
+
+- No generated blog content changes.
+- No React runtime changes.
+- No sitemap contract changes.
+- No change to the public blog route shape.
+- No broad parser rewrite beyond sharing the source metadata contract.
+
+## Deferred
+
+- Loading source posts as real modules instead of parsing field literals.
+- Generating a build-time manifest artifact consumed by both build and tests.
+- FAQ schema/static FAQ verification, handled in a separate slice.
+
+## Verification
+
+- Atlas Intel production build.
+- Blog GEO prerender verification.
+- Whitespace diff check.
+- Local PR review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Shared parser helper and declarations | ~150 |
+| Vite config parser removal/wiring | ~160 |
+| Verifier parser removal/wiring | ~130 |
+| Total | ~510 |


### PR DESCRIPTION
## Summary
- Add a shared Atlas Intel blog source metadata parser for build and verification paths
- Reuse it from Vite prerender/sitemap generation and the GEO prerender verifier
- Keep chart placeholder validation in the shared parser so missing chart data fails consistently
- Parse optional FAQ entries and prerender visible FAQ HTML plus FAQPage JSON-LD when source posts include FAQ data
- Verify FAQ text and FAQPage schema conditionally for posts that include FAQ entries

## Verification
- npm run build (atlas-intel-ui)
- npm run verify:blog-geo (atlas-intel-ui)
- git diff --check
- local PR review