### PR TITLE
Add landing page readiness export summaries

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -7,6 +7,7 @@ import csv
 from dataclasses import dataclass
 from io import StringIO
 import json
+import re
 from typing import Any
 
 from .campaign_ports import TenantScope
@@ -31,6 +32,10 @@ _EXPORT_COLUMNS = (
     "reasoning_context_used",
     "reasoning_wedge",
     "reasoning_confidence",
+    "passed_output_checks",
+    "output_checks",
+    "seo_aeo_readiness",
+    "geo_readiness",
     "hero",
     "sections",
     "cta",
@@ -109,6 +114,11 @@ def _draft_row(draft: LandingPageDraft) -> JsonDict:
     row["section_count"] = len(draft.sections)
     row["reference_count"] = len(draft.reference_ids)
     row.update(_metadata_summary(draft.metadata))
+    readiness = _seo_aeo_readiness(draft)
+    row["output_checks"] = readiness["checks"]
+    row["passed_output_checks"] = readiness["passed"]
+    row["seo_aeo_readiness"] = readiness
+    row["geo_readiness"] = _geo_readiness(draft)
     return row
 
 
@@ -138,6 +148,309 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
+
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_UNRESOLVED_TOKEN_RE = re.compile(
+    r"\{\{[^{}]+\}\}|\b(?:todo|tbd|lorem ipsum)\b",
+    re.IGNORECASE,
+)
+_NUMERIC_CLAIM_RE = re.compile(r"\b\d+(?:[\d,]*|\.\d+)?%?\b")
+_EVIDENCE_RE = re.compile(
+    r"\b(?:case stud(?:y|ies)|customer(?:s)?|testimonial(?:s)?|review(?:s)?|"
+    r"source(?:s)?|data|survey(?:s)?|benchmark(?:s)?|ticket(?:s)?|"
+    r"last\s+\d+\s+(?:days?|weeks?|months?|years?))\b",
+    re.IGNORECASE,
+)
+_OBJECTION_SECTION_RE = re.compile(
+    r"\b(?:faq|question(?:s)?|objection(?:s)?|concern(?:s)?|how it works|"
+    r"pricing|compare|comparison|proof|risk|security|implementation)\b",
+    re.IGNORECASE,
+)
+_PROBLEM_RE = re.compile(r"\b(?:problem|pain|challenge|risk|stuck|friction)\b", re.IGNORECASE)
+_SOLUTION_RE = re.compile(r"\b(?:solution|solve|fix|how it works|approach|workflow|way)\b", re.IGNORECASE)
+_GENERIC_SLUGS = frozenset({"landing-page", "campaign", "demo", "offer", "page"})
+_GENERIC_AUDIENCES = frozenset({
+    "business",
+    "businesses",
+    "companies",
+    "company",
+    "customers",
+    "people",
+    "teams",
+    "users",
+})
+_GENERIC_SECTION_TITLES = frozenset({
+    "benefits",
+    "conclusion",
+    "features",
+    "introduction",
+    "overview",
+    "summary",
+})
+_STOPWORDS = frozenset({
+    "about",
+    "after",
+    "again",
+    "also",
+    "and",
+    "are",
+    "before",
+    "business",
+    "can",
+    "company",
+    "customer",
+    "customers",
+    "for",
+    "from",
+    "have",
+    "into",
+    "landing",
+    "page",
+    "problem",
+    "problems",
+    "same",
+    "that",
+    "the",
+    "their",
+    "this",
+    "turn",
+    "use",
+    "with",
+    "your",
+})
+
+
+def _seo_aeo_readiness(draft: LandingPageDraft) -> JsonDict:
+    meta = _metadata_mapping(draft.meta)
+    text = _visible_text(draft)
+    hero_text = _mapping_text(draft.hero)
+    checks = {
+        "title_tag": _text_len_between(meta.get("title_tag"), min_len=8, max_len=70),
+        "meta_description": _text_len_between(
+            meta.get("description"),
+            min_len=50,
+            max_len=180,
+        ),
+        "slug_quality": _slug_quality(draft.slug),
+        "metadata_consistency": _metadata_consistency(draft, meta),
+        "answer_first_hero": _answer_first_hero(draft, hero_text),
+        "problem_solution_clarity": _problem_solution_clarity(draft),
+        "audience_specificity": _audience_specificity(draft, text),
+        "objection_coverage": _objection_coverage(draft),
+    }
+    return _readiness_summary(checks)
+
+
+def _geo_readiness(draft: LandingPageDraft) -> JsonDict:
+    text = _visible_text(draft)
+    checks = {
+        "offer_entity_clarity": _offer_entity_clarity(draft, text),
+        "audience_entity_clarity": _audience_specificity(draft, text),
+        "answer_extractability": _answer_extractability(draft),
+        "section_semantics": _section_semantics(draft),
+        "trust_signal_visibility": _trust_signal_visibility(draft, text),
+        "conversion_path_clarity": _conversion_path_clarity(draft),
+        "claim_safety": _claim_safety(draft, text),
+    }
+    return _readiness_summary(checks)
+
+
+def _readiness_summary(checks: Mapping[str, bool]) -> JsonDict:
+    missing = [key for key, value in checks.items() if not value]
+    passed = sum(1 for value in checks.values() if value)
+    return {
+        "status": "ready" if not missing else "needs_review",
+        "passed": passed,
+        "total": len(checks),
+        "missing": missing,
+        "checks": dict(checks),
+    }
+
+
+def _text_len_between(value: Any, *, min_len: int, max_len: int) -> bool:
+    text = _clean_text(value)
+    return min_len <= len(text) <= max_len and not _UNRESOLVED_TOKEN_RE.search(text)
+
+
+def _slug_quality(value: Any) -> bool:
+    slug = _clean_text(value)
+    return bool(_SLUG_RE.fullmatch(slug)) and slug not in _GENERIC_SLUGS
+
+
+def _metadata_consistency(draft: LandingPageDraft, meta: Mapping[str, Any]) -> bool:
+    metadata_text = _normalize_text(" ".join((
+        _clean_text(meta.get("title_tag")),
+        _clean_text(meta.get("description")),
+        _clean_text(meta.get("og_title")),
+    )))
+    if not metadata_text:
+        return False
+    return _contains_any(metadata_text, _key_terms(
+        draft.campaign_name,
+        draft.title,
+        draft.value_prop,
+        _mapping_text(draft.hero),
+    ))
+
+
+def _answer_first_hero(draft: LandingPageDraft, hero_text: str) -> bool:
+    headline = _clean_text(_metadata_mapping(draft.hero).get("headline"))
+    subheadline = _clean_text(_metadata_mapping(draft.hero).get("subheadline"))
+    if not headline or not subheadline:
+        return False
+    normalized = _normalize_text(hero_text)
+    return _contains_any(normalized, _key_terms(draft.persona, draft.value_prop))
+
+
+def _problem_solution_clarity(draft: LandingPageDraft) -> bool:
+    section_text = " ".join(
+        f"{section.id} {section.title} {section.body_markdown}"
+        for section in draft.sections
+    )
+    has_problem = bool(_PROBLEM_RE.search(section_text))
+    has_solution = bool(_SOLUTION_RE.search(section_text))
+    value_terms = _key_terms(draft.value_prop)
+    return (
+        has_problem
+        and has_solution
+        and _contains_any(_normalize_text(section_text), value_terms)
+    )
+
+
+def _audience_specificity(draft: LandingPageDraft, text: str) -> bool:
+    persona = _clean_text(draft.persona)
+    if len(persona) < 4 or persona.lower() in _GENERIC_AUDIENCES:
+        return False
+    return _contains_any(_normalize_text(text), _key_terms(persona))
+
+
+def _objection_coverage(draft: LandingPageDraft) -> bool:
+    for section in draft.sections:
+        if _OBJECTION_SECTION_RE.search(f"{section.id} {section.title}"):
+            return True
+    return False
+
+
+def _offer_entity_clarity(draft: LandingPageDraft, text: str) -> bool:
+    if not _clean_text(draft.campaign_name) and not _clean_text(draft.title):
+        return False
+    return _contains_any(_normalize_text(text), _key_terms(
+        draft.campaign_name,
+        draft.title,
+        draft.value_prop,
+    ))
+
+
+def _answer_extractability(draft: LandingPageDraft) -> bool:
+    hero_text = _mapping_text(draft.hero)
+    words = hero_text.split()
+    if len(words) < 12 or len(words) > 90:
+        return False
+    return _answer_first_hero(draft, hero_text)
+
+
+def _section_semantics(draft: LandingPageDraft) -> bool:
+    if not draft.sections:
+        return False
+    for section in draft.sections:
+        title = _clean_text(section.title)
+        if len(title) < 4 or title.lower() in _GENERIC_SECTION_TITLES:
+            return False
+    return True
+
+
+def _trust_signal_visibility(draft: LandingPageDraft, text: str) -> bool:
+    return bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
+
+
+def _conversion_path_clarity(draft: LandingPageDraft) -> bool:
+    cta = _metadata_mapping(draft.cta)
+    label = _clean_text(cta.get("label"))
+    url = _clean_text(cta.get("url"))
+    if not label or not url or url in {"#", "/#", "javascript:void(0)"}:
+        return False
+    hero = _metadata_mapping(draft.hero)
+    hero_label = _clean_text(hero.get("cta_label"))
+    if hero_label and not _shared_terms(label, hero_label):
+        return False
+    return True
+
+
+def _claim_safety(draft: LandingPageDraft, text: str) -> bool:
+    if _UNRESOLVED_TOKEN_RE.search(text):
+        return False
+    has_evidence = bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
+    if _NUMERIC_CLAIM_RE.search(text) and not has_evidence:
+        return False
+    return True
+
+
+def _visible_text(draft: LandingPageDraft) -> str:
+    parts = [
+        draft.title,
+        _mapping_text(draft.hero),
+        _mapping_text(draft.cta),
+    ]
+    for section in draft.sections:
+        parts.extend((
+            section.id,
+            section.title,
+            section.body_markdown,
+            _mapping_text(section.metadata),
+        ))
+    return " ".join(_clean_text(part) for part in parts if _clean_text(part))
+
+
+def _mapping_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(_mapping_text(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return " ".join(_mapping_text(item) for item in value)
+    return _clean_text(value)
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", _clean_text(value).lower()).strip()
+
+
+def _key_terms(*values: Any) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = _normalize_text(value)
+        if not normalized:
+            continue
+        words = [
+            word for word in normalized.split()
+            if len(word) >= 4 and word not in _STOPWORDS
+        ]
+        if len(words) > 1:
+            phrase = " ".join(words)
+            if phrase not in seen:
+                seen.add(phrase)
+                terms.append(phrase)
+        for word in words:
+            if word not in seen:
+                seen.add(word)
+                terms.append(word)
+    return tuple(terms)
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    if not terms:
+        return False
+    return any(term in text for term in terms)
+
+
+def _shared_terms(left: str, right: str) -> bool:
+    left_terms = set(_key_terms(left))
+    right_terms = set(_key_terms(right))
+    return bool(left_terms and right_terms and left_terms.intersection(right_terms))
 
 
 def _csv_value(value: Any) -> Any:

--- a/plans/PR-Landing-Page-Readiness-Helper.md
+++ b/plans/PR-Landing-Page-Readiness-Helper.md
@@ -1,0 +1,105 @@
+# PR-Landing-Page-Readiness-Helper
+
+## Why this slice exists
+
+PR #709 defined the landing-page SEO/AEO/GEO contract, but generated
+landing-page review rows still do not expose the readiness fields that the
+review UI already knows how to render.
+
+This slice adds draft-level readiness output at the export/API boundary. It
+does not change the generator prompt, block saves, change the database schema,
+or claim publish-level SEO/GEO support. Operators get a deterministic review
+signal first, then later slices can decide which checks should become quality
+gate blockers.
+
+## Scope (this PR)
+
+1. Add landing-page `seo_aeo_readiness` and `geo_readiness` summaries to draft
+   export rows.
+2. Expose `output_checks` and `passed_output_checks` for landing pages using
+   the same generated-asset row convention as blog posts.
+3. Include readiness fields in landing-page CSV exports.
+4. Cover ready, incomplete, CSV, and generated-asset API visibility paths.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Readiness-Helper.md` | Plan doc for this implementation slice. |
+| `extracted_content_pipeline/landing_page_export.py` | Add deterministic landing-page readiness helpers and export fields. |
+| `tests/test_extracted_landing_page_export.py` | Cover ready/incomplete readiness output and CSV columns. |
+| `tests/test_extracted_content_asset_api.py` | Prove generated-asset API rows expose landing-page readiness fields. |
+
+## Mechanism
+
+`_draft_row` now computes landing-page readiness summaries before returning the
+review/export row.
+
+The SEO/AEO summary checks:
+
+- `title_tag`
+- `meta_description`
+- `slug_quality`
+- `metadata_consistency`
+- `answer_first_hero`
+- `problem_solution_clarity`
+- `audience_specificity`
+- `objection_coverage`
+
+The GEO summary checks:
+
+- `offer_entity_clarity`
+- `audience_entity_clarity`
+- `answer_extractability`
+- `section_semantics`
+- `trust_signal_visibility`
+- `conversion_path_clarity`
+- `claim_safety`
+
+The helper uses deterministic text, metadata, slug, section, CTA, evidence, and
+placeholder checks. It treats the row as a draft review surface, so placeholder
+or missing fields produce `needs_review` rather than blocking persistence.
+
+## Intentional
+
+- No prompt changes.
+- No quality-gate blockers.
+- No database schema changes.
+- No frontend code changes; the review UI already has landing-page readiness
+  labels/panels when rows include the fields.
+- No publish-level crawler, structured-data, canonical, or rendered HTML
+  verification.
+
+## Deferred
+
+- Extend `extracted_quality_gate/landing_page_pack.py` with selected blocking
+  checks.
+- Update `digest/landing_page_generation.md` so generated drafts are more
+  likely to satisfy the readiness contract.
+- Add public renderer/publish verification once generated landing pages have a
+  concrete hosted route.
+
+## Verification
+
+- `pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q`
+  -> passed 34/34 tests.
+- Python compile command over `extracted_content_pipeline/landing_page_export.py`,
+  `tests/test_extracted_landing_page_export.py`, and
+  `tests/test_extracted_content_asset_api.py` -> passed 3/3 files.
+- `git diff --check` -> passed with 0 whitespace errors.
+- `bash scripts/local_pr_review.sh origin/main` -> passed 3/3 top-level
+  checks: pre-push audit wrapper, plan/code consistency, and `git diff
+  --check`.
+- The pre-push audit wrapper inside local review reported all 8 internal checks
+  passed: MCP tool counts, MCP port assignments, MCP tool-name inventories,
+  extracted manifest sync, plan shape, plan files touched, plan diff size, and
+  ASCII Python policy.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~105 |
+| Landing-page export helper | ~315 |
+| Tests | ~200 |
+| Total | ~620 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -236,6 +236,30 @@ def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     assert args == ("acct_1", "draft", "vendor_alternative", 5)
 
 
+def test_generated_asset_router_lists_landing_page_drafts_with_readiness() -> None:
+    pool = _Pool(rows=[_landing_page_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/landing_page/drafts"
+        "?campaign_name=acme-launch&slug=acme-launch&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    row = body["rows"][0]
+    assert row["id"] == "landing-page-uuid-1"
+    assert row["passed_output_checks"] == 3
+    assert row["seo_aeo_readiness"]["status"] == "needs_review"
+    assert row["geo_readiness"]["status"] == "needs_review"
+    assert row["geo_readiness"]["checks"]["trust_signal_visibility"] is True
+    query, args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in query
+    assert args == ("acct_1", "draft", "acme-launch", "acme-launch", 5)
+
+
 def test_generated_asset_router_exports_landing_page_csv() -> None:
     pool = _Pool(rows=[_landing_page_row()])
 

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -145,6 +145,84 @@ def _draft(**overrides) -> LandingPageDraft:
     )
 
 
+def _ready_draft(**overrides) -> LandingPageDraft:
+    sections = (
+        LandingPageSection(
+            id="problem",
+            title="Support problems that keep coming back",
+            body_markdown=(
+                "Support problems keep coming back when VP Engineering teams "
+                "cannot see where customers get stuck before renewal pressure "
+                "builds."
+            ),
+        ),
+        LandingPageSection(
+            id="solution",
+            title="A workflow for catching pressure early",
+            body_markdown=(
+                "The solution helps teams catch pressure early by turning the "
+                "same repeated support signals into a clear page and follow-up "
+                "workflow."
+            ),
+        ),
+        LandingPageSection(
+            id="faq",
+            title="Questions buyers ask before rollout",
+            body_markdown=(
+                "This section answers implementation, pricing, and security "
+                "questions before the buyer has to email the team."
+            ),
+        ),
+    )
+    draft = LandingPageDraft(
+        campaign_name="acme-support-retention",
+        persona="VP Engineering",
+        value_prop="Catch pressure early",
+        title="Acme support retention page",
+        slug="acme-support-retention",
+        hero={
+            "headline": "Catch support pressure before renewal risk builds",
+            "subheadline": (
+                "A landing page for VP Engineering teams that turns repeat "
+                "support signals into clearer answers before customers drift."
+            ),
+            "cta_label": "Book a demo",
+            "cta_url": "/demo",
+        },
+        sections=sections,
+        cta={"label": "Book a demo", "url": "/demo"},
+        meta={
+            "title_tag": "Acme Support Retention for VP Engineering",
+            "description": (
+                "See how VP Engineering teams catch support pressure early and "
+                "turn repeated customer questions into clearer retention pages."
+            ),
+            "og_title": "Acme Support Retention",
+        },
+        reference_ids=("r1",),
+        metadata={
+            "generation_usage": {
+                "input_tokens": 12,
+                "output_tokens": 6,
+                "total_tokens": 18,
+            },
+        },
+    )
+    return LandingPageDraft(
+        campaign_name=overrides.get("campaign_name", draft.campaign_name),
+        persona=overrides.get("persona", draft.persona),
+        value_prop=overrides.get("value_prop", draft.value_prop),
+        title=overrides.get("title", draft.title),
+        slug=overrides.get("slug", draft.slug),
+        hero=overrides.get("hero", draft.hero),
+        sections=overrides.get("sections", draft.sections),
+        cta=overrides.get("cta", draft.cta),
+        meta=overrides.get("meta", draft.meta),
+        reference_ids=overrides.get("reference_ids", draft.reference_ids),
+        metadata=overrides.get("metadata", draft.metadata),
+    )
+
+
 @pytest.mark.asyncio
 async def test_export_landing_page_drafts_passes_filters_to_repository() -> None:
     repo = _Repository(drafts=[_draft()])
@@ -193,6 +271,98 @@ async def test_export_landing_page_drafts_derives_review_summary_fields() -> Non
     assert row["reasoning_context_used"] is True
     assert row["reasoning_wedge"] == "price_squeeze"
     assert row["reasoning_confidence"] == "high"
+    assert row["passed_output_checks"] == 3
+    assert row["seo_aeo_readiness"]["status"] == "needs_review"
+    assert row["geo_readiness"]["status"] == "needs_review"
+
+
+@pytest.mark.asyncio
+async def test_export_landing_page_drafts_surfaces_ready_readiness() -> None:
+    result = await export_landing_page_drafts(
+        _Repository(drafts=[_ready_draft()]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["passed_output_checks"] == 8
+    assert row["output_checks"] == {
+        "title_tag": True,
+        "meta_description": True,
+        "slug_quality": True,
+        "metadata_consistency": True,
+        "answer_first_hero": True,
+        "problem_solution_clarity": True,
+        "audience_specificity": True,
+        "objection_coverage": True,
+    }
+    assert row["seo_aeo_readiness"] == {
+        "status": "ready",
+        "passed": 8,
+        "total": 8,
+        "missing": [],
+        "checks": row["output_checks"],
+    }
+    assert row["geo_readiness"] == {
+        "status": "ready",
+        "passed": 7,
+        "total": 7,
+        "missing": [],
+        "checks": {
+            "offer_entity_clarity": True,
+            "audience_entity_clarity": True,
+            "answer_extractability": True,
+            "section_semantics": True,
+            "trust_signal_visibility": True,
+            "conversion_path_clarity": True,
+            "claim_safety": True,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_export_landing_page_drafts_surfaces_incomplete_readiness() -> None:
+    result = await export_landing_page_drafts(
+        _Repository(drafts=[
+            _ready_draft(
+                persona="teams",
+                slug="landing-page",
+                hero={"headline": "Launch faster"},
+                sections=(
+                    LandingPageSection(
+                        id="overview",
+                        title="Overview",
+                        body_markdown="TODO {{claim}} 42% faster",
+                    ),
+                ),
+                cta={"label": "Book a demo", "url": "#"},
+                meta={"title_tag": "Launch"},
+                reference_ids=(),
+            )
+        ]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["passed_output_checks"] == 1
+    assert row["seo_aeo_readiness"]["status"] == "needs_review"
+    assert row["seo_aeo_readiness"]["missing"] == [
+        "title_tag",
+        "meta_description",
+        "slug_quality",
+        "answer_first_hero",
+        "problem_solution_clarity",
+        "audience_specificity",
+        "objection_coverage",
+    ]
+    assert row["geo_readiness"]["status"] == "needs_review"
+    assert row["geo_readiness"]["missing"] == [
+        "audience_entity_clarity",
+        "answer_extractability",
+        "section_semantics",
+        "trust_signal_visibility",
+        "conversion_path_clarity",
+        "claim_safety",
+    ]
 
 
 @pytest.mark.asyncio
@@ -267,6 +437,10 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
                 "reasoning_context_used": True,
                 "reasoning_wedge": "price_squeeze",
                 "reasoning_confidence": "high",
+                "passed_output_checks": 8,
+                "output_checks": {"title_tag": True},
+                "seo_aeo_readiness": {"status": "ready"},
+                "geo_readiness": {"status": "ready"},
                 "hero": {"headline": "Stop surprises"},
                 "sections": [{"id": "problem"}],
                 "cta": {"label": "Book a demo"},
@@ -287,4 +461,5 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
     assert "campaign_name,persona,value_prop" in csv_text
     assert "generation_input_tokens,generation_output_tokens" in csv_text
     assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in csv_text
+    assert "passed_output_checks,output_checks,seo_aeo_readiness,geo_readiness" in csv_text
     assert "price_squeeze" in csv_text


### PR DESCRIPTION
## Summary
- add deterministic SEO/AEO and GEO readiness summaries to landing-page draft export rows
- expose `output_checks`, `passed_output_checks`, `seo_aeo_readiness`, and `geo_readiness` for landing pages
- include readiness fields in landing-page CSV exports
- add ready/incomplete export coverage and generated-asset API visibility coverage

## Validation
- `pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q` -> 34/34 passed
- `python -m py_compile extracted_content_pipeline/landing_page_export.py tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py` -> 3/3 files passed
- `git diff --check` -> 0 whitespace errors
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Notes
- No prompt changes, quality-gate blockers, DB schema changes, or publish-level checks in this slice.
- Opened ready for review, not draft.