### PR TITLE
Add landing page readiness quality gates

### DIFF
--- a/extracted_quality_gate/landing_page_pack.py
+++ b/extracted_quality_gate/landing_page_pack.py
@@ -54,6 +54,54 @@ from .types import (
 )
 
 
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_GENERIC_SLUGS = frozenset({"landing-page", "campaign", "demo", "offer", "page"})
+_PLACEHOLDER_URLS = frozenset({"#", "/#", "javascript:void(0)", "javascript:;"})
+_UNRESOLVED_TOKEN_RE = re.compile(
+    r"\{\{[^{}]+\}\}|\{\{[^{}]+\}|\b(?:todo|tbd|lorem ipsum)\b",
+    re.IGNORECASE,
+)
+_GENERIC_SECTION_TITLES = frozenset({
+    "benefits",
+    "conclusion",
+    "features",
+    "introduction",
+    "overview",
+    "summary",
+})
+_STOPWORDS = frozenset({
+    "about",
+    "after",
+    "again",
+    "also",
+    "and",
+    "are",
+    "before",
+    "business",
+    "can",
+    "company",
+    "customer",
+    "customers",
+    "for",
+    "from",
+    "have",
+    "into",
+    "landing",
+    "page",
+    "problem",
+    "problems",
+    "same",
+    "that",
+    "the",
+    "their",
+    "this",
+    "turn",
+    "use",
+    "with",
+    "your",
+})
+
+
 _DEFAULT_THRESHOLDS: Mapping[str, Any] = {
     "min_sections": 1,
     "min_meta_description_chars": 0,
@@ -113,6 +161,15 @@ def evaluate_landing_page(
         findings.append(GateFinding(code="no_title", message="no_title", severity=GateSeverity.BLOCKER))
     if not slug:
         findings.append(GateFinding(code="no_slug", message="no_slug", severity=GateSeverity.BLOCKER))
+    elif not _slug_quality(slug):
+        findings.append(
+            GateFinding(
+                code="invalid_slug",
+                message=f"invalid_slug:{slug}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"slug": slug},
+            )
+        )
 
     # ---- Hero ----
     headline = str(hero.get("headline") or "").strip()
@@ -146,6 +203,15 @@ def evaluate_landing_page(
                 metadata={"has_label": bool(cta_label), "has_url": bool(cta_url)},
             )
         )
+    elif _placeholder_url(cta_url):
+        findings.append(
+            GateFinding(
+                code="placeholder_cta_url",
+                message=f"placeholder_cta_url:{cta_url}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"url": cta_url},
+            )
+        )
 
     # ---- Sections ----
     min_sections = _threshold_int(policy, "min_sections")
@@ -169,6 +235,15 @@ def evaluate_landing_page(
                     metadata={"section_index": index},
                 )
             )
+        elif section_title.lower() in _GENERIC_SECTION_TITLES:
+            findings.append(
+                GateFinding(
+                    code="generic_section_title",
+                    message=f"generic_section_title:{index}:{section_title}",
+                    severity=GateSeverity.WARNING,
+                    metadata={"section_index": index, "title": section_title},
+                )
+            )
         section_body = str(section.get("body_markdown") or "").strip()
         if not section_body:
             findings.append(
@@ -180,7 +255,25 @@ def evaluate_landing_page(
                 )
             )
 
-    # ---- SEO meta description ----
+    # ---- SEO metadata ----
+    title_tag = str(meta.get("title_tag") or "").strip()
+    if not title_tag:
+        findings.append(
+            GateFinding(
+                code="missing_meta_title_tag",
+                message="missing_meta_title_tag",
+                severity=GateSeverity.WARNING,
+            )
+        )
+    elif len(title_tag) > 70:
+        findings.append(
+            GateFinding(
+                code="meta_title_tag_too_long",
+                message=f"meta_title_tag_too_long:{len(title_tag)}>70",
+                severity=GateSeverity.WARNING,
+                metadata={"length": len(title_tag), "max": 70},
+            )
+        )
     min_meta_chars = _threshold_int(policy, "min_meta_description_chars")
     description = str(meta.get("description") or "").strip()
     if min_meta_chars > 0:
@@ -201,6 +294,32 @@ def evaluate_landing_page(
                     metadata={"length": len(description), "min": min_meta_chars},
                 )
             )
+    if not _metadata_consistent(title=title, hero=hero, sections=sections, meta=meta):
+        findings.append(
+            GateFinding(
+                code="metadata_inconsistent",
+                message="metadata_inconsistent",
+                severity=GateSeverity.WARNING,
+            )
+        )
+
+    # ---- Placeholder/template safety ----
+    unresolved_tokens = _unresolved_tokens(
+        title=title,
+        hero=hero,
+        cta=cta,
+        meta=meta,
+        sections=sections,
+    )
+    for token in unresolved_tokens:
+        findings.append(
+            GateFinding(
+                code="unresolved_placeholder",
+                message=f"unresolved_placeholder:{token}",
+                severity=GateSeverity.BLOCKER,
+                metadata={"token": token},
+            )
+        )
 
     # ---- Blocked phrasing (case-insensitive word-boundary) ----
     phrases = _blocked_phrases(policy)
@@ -250,6 +369,98 @@ def evaluate_landing_page(
                 )
 
     return _build_report(findings=findings, sections=sections, policy=policy)
+
+
+def _slug_quality(value: str) -> bool:
+    slug = str(value or "").strip()
+    return bool(_SLUG_RE.fullmatch(slug)) and slug not in _GENERIC_SLUGS
+
+
+def _placeholder_url(value: str) -> bool:
+    url = str(value or "").strip().lower()
+    return url in _PLACEHOLDER_URLS or url.startswith("javascript:")
+
+
+def _metadata_consistent(
+    *,
+    title: str,
+    hero: Mapping[str, Any],
+    sections: Sequence[Mapping[str, Any]],
+    meta: Mapping[str, Any],
+) -> bool:
+    metadata_text = _normalize_text(" ".join((
+        str(meta.get("title_tag") or ""),
+        str(meta.get("description") or ""),
+        str(meta.get("og_title") or ""),
+    )))
+    if not metadata_text:
+        return False
+    visible_text = _normalize_text(" ".join((
+        title,
+        _mapping_text(hero),
+        " ".join(
+            f"{section.get('title') or ''} {section.get('body_markdown') or ''}"
+            for section in sections
+        ),
+    )))
+    return _contains_any(metadata_text, _key_terms(visible_text))
+
+
+def _unresolved_tokens(
+    *,
+    title: str,
+    hero: Mapping[str, Any],
+    cta: Mapping[str, Any],
+    meta: Mapping[str, Any],
+    sections: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    haystack_parts = [title, _mapping_text(hero), _mapping_text(cta), _mapping_text(meta)]
+    for section in sections:
+        haystack_parts.append(_mapping_text(section))
+    haystack = "\n".join(part for part in haystack_parts if part)
+    tokens: list[str] = []
+    for match in _UNRESOLVED_TOKEN_RE.finditer(haystack):
+        token = match.group(0).strip()
+        if token and token not in tokens:
+            tokens.append(token)
+    return tuple(tokens)
+
+
+def _mapping_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(_mapping_text(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return " ".join(_mapping_text(item) for item in value)
+    return str(value or "").strip()
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(value or "").lower()).strip()
+
+
+def _key_terms(value: Any) -> tuple[str, ...]:
+    normalized = _normalize_text(value)
+    if not normalized:
+        return ()
+    words = [
+        word for word in normalized.split()
+        if len(word) >= 4 and word not in _STOPWORDS
+    ]
+    terms: list[str] = []
+    seen: set[str] = set()
+    if len(words) > 1:
+        phrase = " ".join(words)
+        terms.append(phrase)
+        seen.add(phrase)
+    for word in words:
+        if word not in seen:
+            terms.append(word)
+            seen.add(word)
+    return tuple(terms)
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in text for term in terms)
 
 
 def _build_report(

--- a/plans/PR-Landing-Page-Quality-Gate-Readiness.md
+++ b/plans/PR-Landing-Page-Quality-Gate-Readiness.md
@@ -1,0 +1,104 @@
+# PR-Landing-Page-Quality-Gate-Readiness
+
+## Why this slice exists
+
+PR #710 added landing-page SEO/AEO/GEO readiness summaries to review/export
+rows. That gives operators visibility, but the generator can still persist
+drafts with malformed slugs, placeholder CTA URLs, unresolved template tokens,
+or metadata that clearly does not match the visible page.
+
+This slice moves the safest draft-level checks into the landing-page quality
+pack. The goal is not to make every readiness issue a blocker. The quality gate
+should block structural or unsafe draft defects and warn on weaker SEO/GEO
+signals that a reviewer can still fix.
+
+## Scope (this PR)
+
+1. Block malformed or generic landing-page slugs.
+2. Block placeholder or JavaScript primary CTA URLs.
+3. Block unresolved template placeholders across visible page surfaces.
+4. Warn when SEO title metadata is missing or too long.
+5. Warn when section titles are too generic to describe the offer.
+6. Warn when metadata does not share meaningful terms with visible page copy.
+7. Add focused quality-pack tests and run landing-page generation/export
+   integration coverage.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Quality-Gate-Readiness.md` | Plan doc for this implementation slice. |
+| `extracted_quality_gate/landing_page_pack.py` | Add selected landing-page readiness validators to the quality gate. |
+| `tests/test_extracted_quality_gate_landing_page_pack.py` | Cover new blocker and warning behavior. |
+
+## Mechanism
+
+The pack remains a pure deterministic validator. It still receives the
+structured landing-page payload through `QualityInput.context` and returns a
+`QualityReport` with blockers, warnings, score, and decision metadata.
+
+New blockers:
+
+- `invalid_slug`
+- `placeholder_cta_url`
+- `unresolved_placeholder`
+
+New warnings:
+
+- `generic_section_title`
+- `missing_meta_title_tag`
+- `meta_title_tag_too_long`
+- `metadata_inconsistent`
+
+These checks are intentionally narrower than the full review/export readiness
+summary. They cover defects that are clearly detectable before save without
+requiring publish-time context, public URL routing, structured data, analytics,
+or evidence-store lookups.
+
+## Intentional
+
+- No prompt changes.
+- No export/API changes.
+- No generated-asset UI changes.
+- No database schema changes.
+- No publish-level crawler, structured-data, canonical, or rendered HTML
+  verification.
+- No hard block for every SEO/AEO/GEO readiness miss. Drafts can still save
+  with warnings when the issue is reviewable copy quality rather than a broken
+  artifact.
+
+## Deferred
+
+- Prompt alignment so generated landing pages naturally satisfy the stricter
+  quality pack more often.
+- Public renderer/publish verification once generated landing pages have a
+  concrete hosted route.
+- Evidence-aware claim validation that can distinguish supported numeric claims
+  from unsupported ones.
+
+## Verification
+
+- `pytest tests/test_extracted_quality_gate_landing_page_pack.py -q` -> passed
+  30/30 tests.
+- `pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_landing_page_export.py tests/test_extracted_quality_gate_landing_page_pack.py -q`
+  -> passed 60/60 tests.
+- Python compile command over `extracted_quality_gate/landing_page_pack.py` and
+  `tests/test_extracted_quality_gate_landing_page_pack.py` -> passed 2/2
+  files.
+- `git diff --check` -> passed with 0 whitespace errors.
+- `bash scripts/local_pr_review.sh origin/main` -> passed 3/3 top-level
+  checks: pre-push audit wrapper, plan/code consistency, and `git diff
+  --check`.
+- The pre-push audit wrapper inside local review reported all 8 internal checks
+  passed: MCP tool counts, MCP port assignments, MCP tool-name inventories,
+  extracted manifest sync, plan shape, plan files touched, plan diff size, and
+  ASCII Python policy.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~100 |
+| Landing-page quality pack | ~215 |
+| Tests | ~90 |
+| Total | ~405 |

--- a/tests/test_extracted_quality_gate_landing_page_pack.py
+++ b/tests/test_extracted_quality_gate_landing_page_pack.py
@@ -57,6 +57,18 @@ def test_evaluate_landing_page_no_slug_blocks() -> None:
     assert "no_slug" in codes
 
 
+def test_evaluate_landing_page_invalid_slug_blocks() -> None:
+    report = evaluate_landing_page(_input(slug="Landing Page"))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "invalid_slug:Landing Page" in blocker_msgs
+
+
+def test_evaluate_landing_page_generic_slug_blocks() -> None:
+    report = evaluate_landing_page(_input(slug="landing-page"))
+    codes = {f.code for f in report.blockers}
+    assert "invalid_slug" in codes
+
+
 def test_evaluate_landing_page_no_hero_headline_blocks() -> None:
     report = evaluate_landing_page(_input(hero={"subheadline": "x", "cta_label": "y", "cta_url": "/z"}))
     codes = {f.code for f in report.blockers}
@@ -86,6 +98,20 @@ def test_evaluate_landing_page_partial_cta_still_blocks() -> None:
     assert any(f.code == "no_cta" for f in report.blockers)
 
 
+def test_evaluate_landing_page_placeholder_cta_url_blocks() -> None:
+    report = evaluate_landing_page(_input(cta={"label": "Demo", "url": "#"}))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "placeholder_cta_url:#" in blocker_msgs
+
+
+def test_evaluate_landing_page_javascript_cta_url_blocks() -> None:
+    report = evaluate_landing_page(
+        _input(cta={"label": "Demo", "url": "javascript:void(0)"})
+    )
+    codes = {f.code for f in report.blockers}
+    assert "placeholder_cta_url" in codes
+
+
 def test_evaluate_landing_page_no_sections_blocks() -> None:
     report = evaluate_landing_page(_input(sections=()))
     codes = {f.code for f in report.blockers}
@@ -107,6 +133,57 @@ def test_evaluate_landing_page_section_missing_body_blocks_per_section() -> None
     assert "section_missing_body:1" in blocker_msgs
 
 
+def test_evaluate_landing_page_generic_section_title_warns() -> None:
+    sections = (_section(title="Overview"),)
+    report = evaluate_landing_page(_input(sections=sections))
+    warning_msgs = {f.message for f in report.warnings}
+    assert "generic_section_title:0:Overview" in warning_msgs
+
+
+def test_evaluate_landing_page_missing_meta_title_tag_warns() -> None:
+    report = evaluate_landing_page(
+        _input(
+            meta={
+                "description": (
+                    "Acme catches renewal pressure 90 days early so you can "
+                    "prevent unplanned churn at scale."
+                ),
+            },
+        )
+    )
+    codes = {f.code for f in report.warnings}
+    assert "missing_meta_title_tag" in codes
+
+
+def test_evaluate_landing_page_long_meta_title_tag_warns() -> None:
+    report = evaluate_landing_page(
+        _input(
+            meta={
+                "title_tag": "A" * 71,
+                "description": (
+                    "Acme catches renewal pressure 90 days early so you can "
+                    "prevent unplanned churn at scale."
+                ),
+            },
+        )
+    )
+    codes = {f.code for f in report.warnings}
+    assert "meta_title_tag_too_long" in codes
+
+
+def test_evaluate_landing_page_metadata_inconsistent_warns() -> None:
+    report = evaluate_landing_page(
+        _input(
+            meta={
+                "title_tag": "Unrelated Payroll Workflow",
+                "description": "Payroll approvals for finance teams and accountants.",
+            },
+        )
+    )
+    codes = {f.code for f in report.warnings}
+    assert "metadata_inconsistent" in codes
+
+
 def test_evaluate_landing_page_meta_description_too_short_warns() -> None:
     """Below the configured min for SEO."""
     policy = QualityPolicy(name="lp_policy", thresholds={"min_meta_description_chars": 200})
@@ -120,6 +197,19 @@ def test_evaluate_landing_page_meta_description_missing_warns() -> None:
     report = evaluate_landing_page(_input(meta={}), policy=policy)
     codes = {f.code for f in report.warnings}
     assert "missing_meta_description" in codes
+
+
+def test_evaluate_landing_page_unresolved_placeholders_block_across_surfaces() -> None:
+    sections = (_section(body="Use {{missing_claim}} before launch."),)
+    report = evaluate_landing_page(_input(sections=sections))
+    blocker_msgs = {f.message for f in report.blockers}
+    assert "unresolved_placeholder:{{missing_claim}}" in blocker_msgs
+
+
+def test_evaluate_landing_page_todo_placeholder_blocks() -> None:
+    report = evaluate_landing_page(_input(hero={"headline": "TODO", "subheadline": "x"}))
+    codes = {f.code for f in report.blockers}
+    assert "unresolved_placeholder" in codes
 
 
 def test_evaluate_landing_page_blocked_phrasing_word_boundary_does_not_match_substring() -> None:


### PR DESCRIPTION
## Summary
- block invalid/generic landing-page slugs before save
- block placeholder or JavaScript primary CTA URLs
- block unresolved template placeholders across landing-page surfaces
- warn on weak SEO title metadata, generic section titles, and inconsistent metadata
- add focused quality-pack tests

## Validation
- `pytest tests/test_extracted_quality_gate_landing_page_pack.py -q` -> 30/30 passed
- `pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_landing_page_export.py tests/test_extracted_quality_gate_landing_page_pack.py -q` -> 60/60 passed
- `python -m py_compile extracted_quality_gate/landing_page_pack.py tests/test_extracted_quality_gate_landing_page_pack.py` -> 2/2 files passed
- `git diff --check` -> 0 whitespace errors
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Notes
- No prompt changes, export/API changes, DB schema changes, or publish-level checks in this slice.
- Opened ready for review, not draft.