### PR TITLE
Align landing page prompt with readiness gates

### DIFF
--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -38,13 +38,22 @@ Output ONLY a single JSON object with this exact shape. No prose outside the JSO
 
 Field rules:
 - `title`: descriptive H1; reflects the campaign's value_prop; do NOT include date stamps.
-- `slug`: lowercase, hyphenated, derived from `campaign.name`. URL-safe ASCII only.
-- `hero.headline`: punchy, persona-aware. Subheadline reinforces the value prop in one sentence.
+- `slug`: lowercase, hyphenated, derived from `campaign.name`. URL-safe ASCII only. Do not use generic slugs such as `landing-page`, `campaign`, `demo`, `offer`, or `page`.
+- `hero.headline`: punchy, persona-aware. Subheadline reinforces the value prop in one sentence and makes the offer clear without hidden context.
 - `hero.cta_label` / `hero.cta_url`: the hero's primary CTA. Reuse for the page-level `cta` block unless the page uses a hero-CTA + sticky-footer-CTA pattern.
-- `sections`: 3-6 ordered sections. Common shapes: problem / solution / social-proof / how-it-works / pricing / FAQ. Each section needs a non-empty `title` and `body_markdown`.
-- `cta`: page-level primary CTA (label + url required). Optional `secondary_label` / `secondary_url`.
-- `meta.description`: SEO meta description, 120-160 characters. Skip the title tag if it's identical to `title`.
-- `reference_ids`: customer logos, case studies, testimonials, or other social-proof source ids the page cites. Empty when none.
+- `sections`: 3-6 ordered sections. Common shapes: problem / solution / how-it-works / proof / pricing / FAQ. Each section needs a non-empty `title` and `body_markdown`.
+- `sections.title`: use specific headings that describe the offer, audience, problem, or buyer question. Do not use generic headings such as "Overview", "Features", "Benefits", "Summary", "Introduction", or "Conclusion".
+- `cta`: page-level primary CTA (label + url required). Optional `secondary_label` / `secondary_url`. Do not output placeholder URLs such as `#`, `/#`, `javascript:void(0)`, or `javascript:;`.
+- `meta.title_tag`: always include a concrete SEO title tag, ideally 50-60 characters and no more than 70 characters.
+- `meta.description`: SEO meta description, 120-160 characters. Keep the title tag and description aligned with visible page copy.
+- `reference_ids`: customer logos, case studies, testimonials, or other social-proof source ids the page cites. Empty when none. Do not invent reference ids.
+
+Readiness rules:
+- The first viewport must make it clear what the offer is, who it is for, and why that reader should care.
+- Include a clear problem section and a clear solution or how-it-works section tied to `campaign.value_prop`.
+- Include objection coverage when the campaign gives enough context. This can be a FAQ, pricing, implementation, risk-reversal, comparison, security, or proof section.
+- If the campaign does not provide proof, testimonials, case studies, customer names, customer logos, or source ids, do not invent them. Use honest copy without fake social proof.
+- Do not leave unresolved placeholders or draft notes such as `{{claim}}`, `TODO`, `TBD`, or `lorem ipsum`.
 
 When the reasoning context provides a `narrative_plan`, copy each plan section's `id`/`title` verbatim and write prose grounded in the plan's `claim_ids`. Persona-tailor the headline + subheadline for `campaign.persona`.
 

--- a/plans/PR-Landing-Page-Prompt-Readiness.md
+++ b/plans/PR-Landing-Page-Prompt-Readiness.md
@@ -1,0 +1,90 @@
+# PR-Landing-Page-Prompt-Readiness
+
+## Why this slice exists
+
+PR #711 tightened the landing-page quality gate, but the landing-page
+generation prompt still allowed output that the gate now warns on or blocks.
+The most direct mismatch was `meta.title_tag`: the old prompt told the model to
+skip the title tag if it matched the page title, while the quality gate now
+warns when the title tag is missing.
+
+This slice aligns the bundled landing-page prompt with the readiness contract
+and quality gate so generation is asked for the same structure that review and
+validation expect.
+
+## Scope (this PR)
+
+1. Require valid lowercase hyphenated slugs and call out generic slug values to
+   avoid.
+2. Require concrete CTA URLs and prohibit placeholder or JavaScript URLs.
+3. Require `meta.title_tag` and keep metadata aligned with visible page copy.
+4. Ask for specific section headings instead of generic labels.
+5. Add readiness instructions for first-viewport clarity, problem/solution
+   coverage, and objection coverage when context supports it.
+6. Add explicit no-fake-proof and no-placeholder instructions.
+7. Add prompt-regression tests for the new contract language.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Prompt-Readiness.md` | Plan doc for this prompt-alignment slice. |
+| `extracted_content_pipeline/skills/digest/landing_page_generation.md` | Align the bundled landing-page generation prompt with readiness and quality-gate expectations. |
+| `tests/test_extracted_campaign_skill_registry.py` | Add prompt-regression tests for readiness language and fake-proof guardrails. |
+
+## Mechanism
+
+The prompt update keeps the same JSON contract and does not change runtime
+parsing, persistence, or quality-gate code. It only narrows field guidance:
+
+- `slug` must be URL-safe and non-generic.
+- `cta.url` must be real enough for draft review, not a placeholder.
+- `meta.title_tag` must always be present.
+- `sections.title` should describe the offer, audience, problem, or buyer
+  question.
+- proof, reference ids, testimonials, logos, and source ids must not be
+  invented when the campaign does not provide them.
+
+The registry tests assert that the packaged prompt keeps these instructions in
+place.
+
+## Intentional
+
+- No generator code changes.
+- No quality-gate changes.
+- No export/API changes.
+- No frontend review UI changes.
+- No publish-level checks.
+
+## Deferred
+
+- Add repair-loop behavior that feeds quality-gate blocker details back into
+  the model for regeneration.
+- Add public-renderer publish verification for crawler-visible HTML, metadata,
+  canonical URL, structured data, and CTA routes.
+- Evaluate whether future prompts should emit a richer FAQ/objection structure
+  when campaign context is strong enough.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py tests/test_extracted_quality_gate_landing_page_pack.py -q`
+  -> passed 66/66 tests.
+- Python compile command over `tests/test_extracted_campaign_skill_registry.py`
+  -> passed 1/1 file.
+- `git diff --check` -> passed with 0 whitespace errors.
+- `bash scripts/local_pr_review.sh origin/main` -> passed 3/3 top-level
+  checks: pre-push audit wrapper, plan/code consistency, and `git diff
+  --check`.
+- The pre-push audit wrapper inside local review reported all 8 internal checks
+  passed: MCP tool counts, MCP port assignments, MCP tool-name inventories,
+  extracted manifest sync, plan shape, plan files touched, plan diff size, and
+  ASCII Python policy.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~95 |
+| Prompt | ~20 |
+| Tests | ~20 |
+| Total | ~135 |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -72,6 +72,29 @@ def test_packaged_landing_page_prompt_frames_support_tickets_as_service_evidence
     assert "evaluating, buying, switching, or considering" in prompt
 
 
+def test_packaged_landing_page_prompt_matches_readiness_gate_contract() -> None:
+    prompt = get_skill_registry().get_prompt("digest/landing_page_generation")
+
+    assert prompt is not None
+    assert "Do not use generic slugs" in prompt
+    assert "`meta.title_tag`: always include" in prompt
+    assert "Do not output placeholder URLs" in prompt
+    assert "Do not use generic headings" in prompt
+    assert "first viewport must make it clear" in prompt
+    assert "Include a clear problem section" in prompt
+    assert "Include objection coverage" in prompt
+    assert "Do not leave unresolved placeholders" in prompt
+
+
+def test_packaged_landing_page_prompt_prevents_fake_proof() -> None:
+    prompt = get_skill_registry().get_prompt("digest/landing_page_generation")
+
+    assert prompt is not None
+    assert "Do not invent reference ids" in prompt
+    assert "If the campaign does not provide proof" in prompt
+    assert "fake social proof" in prompt
+
+
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:
     skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
     skill_path.parent.mkdir()


### PR DESCRIPTION
## Summary
- align the bundled landing-page prompt with the readiness contract and quality gate
- require concrete SEO title tags, non-generic slugs/headings, and non-placeholder CTA URLs
- add no-fake-proof and no-unresolved-placeholder prompt rules
- add prompt-regression tests for readiness language

## Validation
- `pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py tests/test_extracted_quality_gate_landing_page_pack.py -q` -> 66/66 passed
- `python -m py_compile tests/test_extracted_campaign_skill_registry.py` -> 1/1 file passed
- `git diff --check` -> 0 whitespace errors
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Notes
- No generator code, quality-gate, export/API, frontend, or publish-level changes in this slice.
- Opened ready for review, not draft.