### PR TITLE
Add demand-opportunity report script (CRM pilot)

### DIFF
--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -134,6 +134,19 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 - **Multi-field, not `pain_category`.** Ranking the coarse single field would
   return "overall_dissatisfaction" as the top "opportunity", which is useless.
   The structured fields give actionable themes.
+- **Baseline counts only sole-catch-all reviews.** A review is added to the
+  `overall_dissatisfaction` baseline only when that is its *sole* pain; if it
+  also carries an actionable theme it is ranked there instead, so a review is
+  never counted in both the baseline and a theme (the "carry only" wording
+  stays true; baseline + distinct ranked reviews == total).
+- **Vendorless reviews are excluded, not counted.** A review with no primary
+  vendor cannot contribute to cross-vendor breadth (core to the heuristic), so
+  it is dropped up front with a reported count rather than inflating a theme's
+  volume against unchanged breadth; the breadth denominator is the real vendor
+  count, never coerced to 1.
+- **Strict urgency guard in SQL.** The numeric filter is `^[0-9]+(\.[0-9]+)?$`
+  so a malformed value (`.`, `1.2.3`) falls to NULL instead of passing the
+  guard and aborting the whole `SELECT` on the cast.
 - **Read-only, on-demand script.** No cron registration, no DB writes, no new
   tables -- it is an analysis tool, not a pipeline stage. Lives in `scripts/`.
 - **Evidence-traceable.** Every ranked theme carries real review quotes/spans;
@@ -154,9 +167,11 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 
 ## Verification
 
-- `tests/test_demand_opportunity_report.py` run via pytest -> `5 passed`
-  (off-topic detection incl. false-positive guard, off-topic exclusion +
-  count, baseline exclusion, breadth/urgency ranking, gap/competitor rollup).
+- `tests/test_demand_opportunity_report.py` run via pytest -> `8 passed`
+  (off-topic detection + false-positive guard, off-topic exclusion + count,
+  baseline excludes mixed reviews, vendorless exclusion, breadth/urgency
+  ranking with a pinned numeric `opportunity_score` (16.0), gap/competitor +
+  vendor-alias rollup, and a `render_markdown` section check).
 - `scripts/demand_opportunity_report.py --category=CRM` against the live DB ->
   1,954 reviews / 8 vendors (5 off-topic dropped: Copper:4, Close:1). Ranked
   themes match known CRM pains: pricing (365 reviews, urgency 4.35, 8/8

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -70,14 +70,22 @@ multi-fields:
 cross-vendor breadth = the share of distinct category vendors whose reviews
 show the theme. A pain that is widespread, intense, AND unsolved by every
 vendor in the category is a market gap (high opportunity); a pain isolated to
-one weak vendor is just that vendor's problem (low opportunity). Themes are
-discounted when the same vendors show strong `positive_aspects` on the
-adjacent capability.
+one weak vendor is just that vendor's problem (low opportunity). `positive_aspects`
+are not folded into the numeric score (mapping a positive to the pain theme it
+offsets is fuzzy); instead they are surfaced verbatim in a "what already works
+well" section as a do-NOT-build counter-signal the operator weighs by hand.
+
+**Competitor normalization.** `competitors_mentioned[].name` is tallied by a
+normalized key (case-folded, trailing " CRM" stripped) so variants like
+`HubSpot` / `Hubspot` / `HubSpot CRM` collapse to one entry (HubSpot: 49, not
+a split 37/7/4/1); the most frequent raw spelling is shown.
 
 **Output (the structured report).** Markdown, per category, with:
 - Ranked opportunity table (theme, frequency, mean urgency, vendor breadth,
   opportunity score).
 - Top feature gaps (verbatim, de-duplicated, with counts).
+- What already works well (top `positive_aspects`, de-duplicated) -- a
+  do-NOT-build counter-signal.
 - Pricing-pain summary (price-increase mentions, spend ranges).
 - Per-theme evidence: 2-3 `quotable_phrases` / complaint spans with the
   review source, so every claim is traceable (no fabricated numbers).
@@ -95,6 +103,15 @@ vendors are reported in the header for transparency. The markers are
 deliberately specific to avoid false-dropping legitimate reviews (a "Silver
 plan" tier or a "durable workflow" survive). The real fix is upstream
 vendor-name disambiguation; this keeps the report honest until then.
+
+**Filter limitation (known).** The markers are tuned to the contamination
+*shapes* actually observed for CRM (gaming/crafting, physical materials,
+audio) -- they are not a general off-topic classifier. A different off-topic
+domain can still leak (e.g. a stray medical "Mirena" mention surfaced in the
+CRM competitor list from a "Close"-keyword match). Per-category review of the
+output, plus marker additions when a new shape appears, is expected until the
+upstream disambiguation lands; the report header's dropped-count makes the
+filter's reach visible.
 
 **Human-in-the-loop.** Run on demand per category; the operator reads the
 report and refines or re-scopes -- nothing is auto-published. This matches the
@@ -142,6 +159,9 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
   contract_lock_in surfaces as the most *intense* (urgency 6.68).
   "overall_dissatisfaction" is held out as a baseline, not ranked. Pricing-pain
   evidence is clean SaaS pricing after the filter (no video-game quotes).
+  Competitor map is normalized (HubSpot 49, merged from 4 spelling variants);
+  the "what works well" section surfaces top positive_aspects (Easy to use 11x,
+  customization, clean interface).
 - `scripts/local_pr_review.sh` -> plan shape, plan/code consistency,
   `git diff --check`.
 

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -78,7 +78,12 @@ well" section as a do-NOT-build counter-signal the operator weighs by hand.
 **Competitor normalization.** `competitors_mentioned[].name` is tallied by a
 normalized key (case-folded, trailing " CRM" stripped) so variants like
 `HubSpot` / `Hubspot` / `HubSpot CRM` collapse to one entry (HubSpot: 49, not
-a split 37/7/4/1); the most frequent raw spelling is shown.
+a split 37/7/4/1); the most frequent raw spelling is shown. A small curated
+`_VENDOR_ALIASES` map additionally folds a bare common-word spelling into its
+canonical product name where the corpus uses both interchangeably -- e.g.
+`Monday` -> `Monday.com` (PM smoke test: merges 19+17 into one 36x entry),
+while a distinct variant like `Monday dev` stays separate. Extend the map as
+new split-variant vendors surface per category.
 
 **Output (the structured report).** Markdown, per category, with:
 - Ranked opportunity table (theme, frequency, mean urgency, vendor breadth,

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -149,7 +149,7 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/demand_opportunity_report.py` | ~290 |
+| `scripts/demand_opportunity_report.py` | ~330 |
 | `tests/test_demand_opportunity_report.py` | ~110 |
-| Plan doc (this update) | ~30 |
-| **Total** | **~430** |
+| Plan doc (this update) | ~75 |
+| **Total** | **~515** |

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -189,7 +189,7 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/demand_opportunity_report.py` | ~375 |
-| `tests/test_demand_opportunity_report.py` | ~120 |
-| Plan doc (this update) | ~100 |
-| **Total** | **~595** |
+| `scripts/demand_opportunity_report.py` | ~410 |
+| `tests/test_demand_opportunity_report.py` | ~175 |
+| Plan doc (this update) | ~120 |
+| **Total** | **~705** |

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -169,7 +169,7 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 
 | Area | Estimated LOC |
 |---|---:|
-| `scripts/demand_opportunity_report.py` | ~330 |
-| `tests/test_demand_opportunity_report.py` | ~110 |
-| Plan doc (this update) | ~75 |
-| **Total** | **~515** |
+| `scripts/demand_opportunity_report.py` | ~375 |
+| `tests/test_demand_opportunity_report.py` | ~120 |
+| Plan doc (this update) | ~100 |
+| **Total** | **~595** |

--- a/plans/PR-Demand-Opportunity-Report.md
+++ b/plans/PR-Demand-Opportunity-Report.md
@@ -22,17 +22,22 @@ Pilot category: **CRM** (1,959 enriched reviews).
 ## Scope (this PR)
 
 This PR checks in the plan only; the implementation follows in a second PR so
-the report shape can be reviewed first.
+the report shape was reviewed first. The plan was checked in via #708; this
+PR adds the implementation:
 
-1. **This plan doc**, `plans/PR-Demand-Opportunity-Report.md`.
-
-The implementation (next PR) is an on-demand script -- proposed
-`scripts/demand_opportunity_report.py --category=CRM` -- following the
-existing `scripts/audit_*` / `scripts/check_*` convention (reads the live DB
-via `init_database()`, prints a markdown report; no cron task, no writes).
+1. `scripts/demand_opportunity_report.py --category=<cat> [--json]` -- the
+   on-demand, read-only report (reads the live DB via `init_database()`,
+   prints markdown or JSON; no cron task, no writes), following the existing
+   `scripts/audit_*` / `scripts/check_*` convention.
+2. `tests/test_demand_opportunity_report.py` -- unit tests for the pure
+   aggregation, the relevance filter, the baseline exclusion, and the rollups.
+3. Plan-doc update recording the relevance filter (added after the first CRM
+   run surfaced the contamination) and the real verification results.
 
 ### Files touched
 
+- `scripts/demand_opportunity_report.py`
+- `tests/test_demand_opportunity_report.py`
 - `plans/PR-Demand-Opportunity-Report.md`
 
 ## Mechanism
@@ -78,6 +83,19 @@ adjacent capability.
   review source, so every claim is traceable (no fabricated numbers).
 - Competitor map: which alternatives are cited and in what context.
 
+**Relevance filter (added after the first CRM run).** The corpus carries the
+common-word-vendor contamination (see memory: common-word-vendor-contamination):
+the first CRM run surfaced video-game crafting quotes ("30 stone axes", "150
+durability", "silver per day") in the pricing-pain evidence, from the "Copper"
+and "Close" vendors keyword-matching unrelated content. A high-confidence
+off-topic marker set (gaming/crafting/physical-material terms that never occur
+in genuine SaaS reviews) excludes a contaminated review *before* any counting,
+so it neither inflates themes nor surfaces as evidence; the count and affected
+vendors are reported in the header for transparency. The markers are
+deliberately specific to avoid false-dropping legitimate reviews (a "Silver
+plan" tier or a "durable workflow" survive). The real fix is upstream
+vendor-name disambiguation; this keeps the report honest until then.
+
 **Human-in-the-loop.** Run on demand per category; the operator reads the
 report and refines or re-scopes -- nothing is auto-published. This matches the
 "requires my input, not fully automated" requirement.
@@ -114,16 +132,24 @@ report and refines or re-scopes -- nothing is auto-published. This matches the
 
 ## Verification
 
-- This PR: `scripts/local_pr_review.sh` -> plan shape, plan/code consistency,
+- `tests/test_demand_opportunity_report.py` run via pytest -> `5 passed`
+  (off-topic detection incl. false-positive guard, off-topic exclusion +
+  count, baseline exclusion, breadth/urgency ranking, gap/competitor rollup).
+- `scripts/demand_opportunity_report.py --category=CRM` against the live DB ->
+  1,954 reviews / 8 vendors (5 off-topic dropped: Copper:4, Close:1). Ranked
+  themes match known CRM pains: pricing (365 reviews, urgency 4.35, 8/8
+  vendors, top opportunity), support, ux, then features/integration/onboarding;
+  contract_lock_in surfaces as the most *intense* (urgency 6.68).
+  "overall_dissatisfaction" is held out as a baseline, not ranked. Pricing-pain
+  evidence is clean SaaS pricing after the filter (no video-game quotes).
+- `scripts/local_pr_review.sh` -> plan shape, plan/code consistency,
   `git diff --check`.
-- Implementation PR: run `--category=CRM` against the live DB; sanity-check the
-  ranked output against known CRM pains (pricing, UX, support surface as real
-  themes; "overall_dissatisfaction" does NOT dominate the actionable list);
-  confirm every ranked theme cites a real review span.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~120 |
-| **Total** | **~120** |
+| `scripts/demand_opportunity_report.py` | ~290 |
+| `tests/test_demand_opportunity_report.py` | ~110 |
+| Plan doc (this update) | ~30 |
+| **Total** | **~430** |

--- a/scripts/demand_opportunity_report.py
+++ b/scripts/demand_opportunity_report.py
@@ -90,6 +90,15 @@ def _norm(text: str) -> str:
     return " ".join(str(text).strip().lower().split())
 
 
+# Canonical display names for vendors whose bare common-word spelling is cited
+# interchangeably with the full product name (so the competitor tally does not
+# split them). Keyed by the bare lowercase form -> canonical display. The
+# competitor key is the lowercase of the canonical so e.g. "Monday" and
+# "Monday.com" collapse to one entry shown as "Monday.com". Extend as new
+# split-variant vendors surface in a category.
+_VENDOR_ALIASES = {"monday": "Monday.com"}
+
+
 # ---------------------------------------------------------------------------
 # Pure aggregation (no DB) -- unit-testable
 # ---------------------------------------------------------------------------
@@ -175,12 +184,14 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         for comp in _as_list(r.get("competitors")):
             if isinstance(comp, dict) and comp.get("name"):
                 raw = str(comp["name"]).strip()
-                key = re.sub(r"\s+crm$", "", raw.lower()).strip()
-                if not key:
+                base = re.sub(r"\s+crm$", "", raw.lower()).strip()
+                if not base:
                     continue
+                canonical = _VENDOR_ALIASES.get(base)  # None unless a known alias
+                key = canonical.lower() if canonical else base
                 slot = competitors[key]
                 slot["count"] += 1
-                slot["names"][raw] += 1
+                slot["names"][canonical or raw] += 1
                 slot["contexts"][str(comp.get("context") or "unspecified")] += 1
 
         for phrase in _as_list(r.get("pricing_phrases")):

--- a/scripts/demand_opportunity_report.py
+++ b/scripts/demand_opportunity_report.py
@@ -126,7 +126,13 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
     )
     baseline_count = 0
     feature_gaps: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "verbatim": None})
-    competitors: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "contexts": defaultdict(int)})
+    positive_aspects: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "verbatim": None})
+    # Keyed by normalized name (case-folded, trailing " CRM" stripped) so
+    # variants like "HubSpot" / "Hubspot" / "HubSpot CRM" tally as one; the
+    # most frequent raw spelling is used for display.
+    competitors: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"count": 0, "contexts": defaultdict(int), "names": defaultdict(int)}
+    )
     pricing_phrases: list[str] = []
     price_increase_count = 0
 
@@ -158,12 +164,24 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
             if feature_gaps[key]["verbatim"] is None:
                 feature_gaps[key]["verbatim"] = str(gap).strip()
 
+        for pos in _as_list(r.get("positive_aspects")):
+            key = _norm(pos)
+            if not key:
+                continue
+            positive_aspects[key]["count"] += 1
+            if positive_aspects[key]["verbatim"] is None:
+                positive_aspects[key]["verbatim"] = str(pos).strip()
+
         for comp in _as_list(r.get("competitors")):
             if isinstance(comp, dict) and comp.get("name"):
-                name = str(comp["name"]).strip()
-                competitors[name]["count"] += 1
-                ctx = str(comp.get("context") or "unspecified")
-                competitors[name]["contexts"][ctx] += 1
+                raw = str(comp["name"]).strip()
+                key = re.sub(r"\s+crm$", "", raw.lower()).strip()
+                if not key:
+                    continue
+                slot = competitors[key]
+                slot["count"] += 1
+                slot["names"][raw] += 1
+                slot["contexts"][str(comp.get("context") or "unspecified")] += 1
 
         for phrase in _as_list(r.get("pricing_phrases")):
             if phrase:
@@ -191,8 +209,19 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         ({"gap": v["verbatim"], "count": v["count"]} for v in feature_gaps.values()),
         key=lambda g: g["count"], reverse=True,
     )
+    works = sorted(
+        ({"aspect": v["verbatim"], "count": v["count"]} for v in positive_aspects.values()),
+        key=lambda w: w["count"], reverse=True,
+    )
     comps = sorted(
-        ({"name": n, "count": v["count"], "contexts": dict(v["contexts"])} for n, v in competitors.items()),
+        (
+            {
+                "name": max(v["names"].items(), key=lambda x: x[1])[0],
+                "count": v["count"],
+                "contexts": dict(v["contexts"]),
+            }
+            for v in competitors.values()
+        ),
         key=lambda c: c["count"], reverse=True,
     )
 
@@ -205,6 +234,7 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         "baseline_overall_dissatisfaction": baseline_count,
         "themes": themes,
         "feature_gaps": gaps,
+        "works_well": works,
         "competitors": comps,
         "pricing": {
             "price_increase_mentions": price_increase_count,
@@ -247,6 +277,14 @@ def render_markdown(category: str, data: dict[str, Any]) -> str:
     if data["feature_gaps"]:
         for g in data["feature_gaps"][:20]:
             out.append(f"- ({g['count']}x) {g['gap']}")
+    else:
+        out.append("_None extracted._")
+    out.append("")
+    out.append("## What already works well (do NOT compete here)")
+    out.append("")
+    if data.get("works_well"):
+        for w in data["works_well"][:12]:
+            out.append(f"- ({w['count']}x) {w['aspect']}")
     else:
         out.append("_None extracted._")
     out.append("")

--- a/scripts/demand_opportunity_report.py
+++ b/scripts/demand_opportunity_report.py
@@ -117,17 +117,25 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
     # counting, so off-topic reviews neither inflate themes nor surface as
     # evidence. Track what was dropped for transparency.
     filtered_vendors: dict[str, int] = defaultdict(int)
+    filtered_offtopic = 0
+    excluded_no_vendor = 0
     clean: list[dict[str, Any]] = []
     for r in reviews:
         if _review_is_offtopic(r):
+            filtered_offtopic += 1
             filtered_vendors[r.get("vendor") or "unknown"] += 1
+        elif not r.get("vendor"):
+            # No primary vendor -> cannot contribute to cross-vendor breadth,
+            # which is core to the opportunity heuristic. Excluded so it neither
+            # inflates theme volume against unchanged breadth nor distorts the
+            # denominator. Counted for transparency.
+            excluded_no_vendor += 1
         else:
             clean.append(r)
-    filtered_offtopic = len(reviews) - len(clean)
     reviews = clean
 
-    all_vendors = {r["vendor"] for r in reviews if r.get("vendor")}
-    total_vendors = len(all_vendors) or 1
+    all_vendors = {r["vendor"] for r in reviews}
+    total_vendors = len(all_vendors)
 
     # Pain theme -> {reviews, urgency_sum, urgency_n, vendors, quotes}
     pain: dict[str, dict[str, Any]] = defaultdict(
@@ -149,10 +157,13 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         vendor = r.get("vendor")
         urg = r.get("urgency")
         cats = {str(pc.get("category")) for pc in _as_list(r.get("pain_categories")) if isinstance(pc, dict) and pc.get("category")}
-        for cat in cats:
-            if cat in _NON_ACTIONABLE:
-                baseline_count += 1
-                continue
+        actionable = cats - _NON_ACTIONABLE
+        # Baseline = reviews whose ONLY pain is the non-actionable catch-all;
+        # a review that also has an actionable theme is ranked there, not in
+        # the baseline (so baseline + ranked never double-counts a review).
+        if not actionable and (cats & _NON_ACTIONABLE):
+            baseline_count += 1
+        for cat in actionable:
             slot = pain[cat]
             slot["reviews"] += 1
             if urg is not None:
@@ -203,7 +214,7 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
     themes = []
     for cat, s in pain.items():
         mean_urg = (s["urgency_sum"] / s["urgency_n"]) if s["urgency_n"] else 0.0
-        breadth = len(s["vendors"]) / total_vendors
+        breadth = (len(s["vendors"]) / total_vendors) if total_vendors else 0.0
         score = s["reviews"] * mean_urg * breadth
         themes.append({
             "theme": cat,
@@ -242,6 +253,7 @@ def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
         "vendors": sorted(all_vendors),
         "filtered_offtopic": filtered_offtopic,
         "filtered_vendors": dict(sorted(filtered_vendors.items(), key=lambda x: -x[1])),
+        "excluded_no_vendor": excluded_no_vendor,
         "baseline_overall_dissatisfaction": baseline_count,
         "themes": themes,
         "feature_gaps": gaps,
@@ -267,6 +279,11 @@ def render_markdown(category: str, data: dict[str, Any]) -> str:
         out.append(
             f"Relevance filter dropped {data['filtered_offtopic']} off-topic "
             f"(common-word-vendor contamination) reviews before analysis [{fv}]."
+        )
+    if data.get("excluded_no_vendor"):
+        out.append(
+            f"Excluded {data['excluded_no_vendor']} reviews with no primary "
+            f"vendor (cannot contribute to cross-vendor breadth)."
         )
     out.append(
         f"Baseline: {data['baseline_overall_dissatisfaction']} reviews carry only "
@@ -336,7 +353,10 @@ async def _fetch(pool, category: str) -> list[dict[str, Any]]:
         """
         SELECT r.id, r.source,
                vm.vendor_name AS vendor,
-               CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9.]+$'
+               -- Strict numeric guard: a single decimal point only, so values
+               -- like '.', '1.2.3', '..' fall to NULL instead of passing the
+               -- guard and aborting the whole SELECT on the ::numeric cast.
+               CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9]+(\\.[0-9]+)?$'
                     THEN (r.enrichment->>'urgency_score')::numeric END AS urgency,
                r.enrichment->'pain_categories'      AS pain_categories,
                r.enrichment->'feature_gaps'         AS feature_gaps,

--- a/scripts/demand_opportunity_report.py
+++ b/scripts/demand_opportunity_report.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""On-demand market/product demand-opportunity report from enriched reviews.
+
+Branches off the churn pipeline right after enrichment (stage 2): reads the
+existing enriched `b2b_reviews` for one product_category, joins each to its
+primary vendor, and ranks product-opportunity themes from the structured
+enrichment multi-fields -- NOT the coarse single `pain_category` (which is
+dominated by the non-actionable "overall_dissatisfaction" catch-all).
+
+Opportunity heuristic per pain theme:
+    score = review_count * mean_urgency * cross_vendor_breadth
+where cross_vendor_breadth = distinct vendors showing the theme / distinct
+vendors in the category. A widespread, intense, every-vendor-unsolved pain is
+a market gap; a pain isolated to one weak vendor is just that vendor's problem.
+
+Read-only, on-demand, human-in-the-loop -- not a cron task, no DB writes.
+
+Usage:
+    python demand_opportunity_report.py --category=CRM
+    python demand_opportunity_report.py --category="Project Management" --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+import re
+import sys
+from collections import defaultdict
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.storage.database import close_database, get_db_pool, init_database
+
+# "overall_dissatisfaction" is a catch-all, not a buildable product theme; it is
+# reported as a baseline but excluded from the ranked opportunity table.
+_NON_ACTIONABLE = {"overall_dissatisfaction"}
+
+# Relevance filter for common-word-vendor contamination (see memory:
+# common-word-vendor-contamination). Vendors whose names are also common words
+# -- Copper, Close -- keyword-match unrelated reviews in the corpus
+# (copper-the-metal / crafting games, account "closing", audio gear). These
+# high-confidence markers never appear in genuine B2B-SaaS reviews, so a review
+# carrying any of them is treated as off-topic and excluded from the report
+# (it does not count toward themes or appear as evidence). Deliberately
+# specific to avoid false-dropping legitimate reviews (e.g. a "Silver plan"
+# tier or a "durable workflow" survive; "30 stone axes" and "150 durability"
+# do not). The real fix is upstream vendor-name disambiguation; this keeps the
+# report honest until then.
+_OFFTOPIC_RE = re.compile(
+    "|".join((
+        r"\bstone axes?\b", r"\bcopper axe", r"\bpickaxe", r"\brespawn", r"\bsmelt",
+        r"\d+\s+silver\b", r"\bsilver per day", r"\d+\s+durability", r"durability compared",
+        r"\bcraft(?:ing|ed)?\s+\d", r"\bore\s+(?:vein|deposit|node)", r"\bblacksmith",
+        r"\bsoldering\b", r"\bgauge wire", r"\bspeaker cable", r"\bsilver[- ]plated",
+        r"\bheadphones?\b", r"\bamplifier", r"\baudio equipment", r"\baluminum\b",
+    )),
+    re.IGNORECASE,
+)
+
+
+def _review_is_offtopic(review: dict[str, Any]) -> bool:
+    """True if any of the review's evidence text trips a high-confidence
+    off-topic marker -- i.e. it is keyword-match contamination, not a real
+    review of the product category."""
+    for field in ("quotable_phrases", "pricing_phrases", "feature_gaps", "specific_complaints"):
+        for s in _as_list(review.get(field)):
+            if isinstance(s, str) and _OFFTOPIC_RE.search(s):
+                return True
+    return False
+
+
+def _as_list(value: Any) -> list:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+    return value if isinstance(value, list) else []
+
+
+def _norm(text: str) -> str:
+    return " ".join(str(text).strip().lower().split())
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregation (no DB) -- unit-testable
+# ---------------------------------------------------------------------------
+
+
+def aggregate(reviews: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate enriched review dicts into demand-opportunity report data.
+
+    Each review dict: vendor (str|None), urgency (float|None), pain_categories
+    (list[{category,severity}]), feature_gaps (list[str]), specific_complaints
+    (list[str]), competitors (list[{name,context}]), pricing_phrases
+    (list[str]), positive_aspects (list[str]), quotable_phrases (list[str]),
+    price_increase (bool|None).
+    """
+    # Relevance filter: drop common-word-vendor contamination before any
+    # counting, so off-topic reviews neither inflate themes nor surface as
+    # evidence. Track what was dropped for transparency.
+    filtered_vendors: dict[str, int] = defaultdict(int)
+    clean: list[dict[str, Any]] = []
+    for r in reviews:
+        if _review_is_offtopic(r):
+            filtered_vendors[r.get("vendor") or "unknown"] += 1
+        else:
+            clean.append(r)
+    filtered_offtopic = len(reviews) - len(clean)
+    reviews = clean
+
+    all_vendors = {r["vendor"] for r in reviews if r.get("vendor")}
+    total_vendors = len(all_vendors) or 1
+
+    # Pain theme -> {reviews, urgency_sum, urgency_n, vendors, quotes}
+    pain: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"reviews": 0, "urgency_sum": 0.0, "urgency_n": 0, "vendors": set(), "quotes": []}
+    )
+    baseline_count = 0
+    feature_gaps: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "verbatim": None})
+    competitors: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "contexts": defaultdict(int)})
+    pricing_phrases: list[str] = []
+    price_increase_count = 0
+
+    for r in reviews:
+        vendor = r.get("vendor")
+        urg = r.get("urgency")
+        cats = {str(pc.get("category")) for pc in _as_list(r.get("pain_categories")) if isinstance(pc, dict) and pc.get("category")}
+        for cat in cats:
+            if cat in _NON_ACTIONABLE:
+                baseline_count += 1
+                continue
+            slot = pain[cat]
+            slot["reviews"] += 1
+            if urg is not None:
+                slot["urgency_sum"] += float(urg)
+                slot["urgency_n"] += 1
+            if vendor:
+                slot["vendors"].add(vendor)
+            if len(slot["quotes"]) < 3:
+                q = next((str(x) for x in _as_list(r.get("quotable_phrases")) if x), None)
+                if q:
+                    slot["quotes"].append({"text": q[:280], "vendor": vendor, "source": r.get("source")})
+
+        for gap in _as_list(r.get("feature_gaps")):
+            key = _norm(gap)
+            if not key:
+                continue
+            feature_gaps[key]["count"] += 1
+            if feature_gaps[key]["verbatim"] is None:
+                feature_gaps[key]["verbatim"] = str(gap).strip()
+
+        for comp in _as_list(r.get("competitors")):
+            if isinstance(comp, dict) and comp.get("name"):
+                name = str(comp["name"]).strip()
+                competitors[name]["count"] += 1
+                ctx = str(comp.get("context") or "unspecified")
+                competitors[name]["contexts"][ctx] += 1
+
+        for phrase in _as_list(r.get("pricing_phrases")):
+            if phrase:
+                pricing_phrases.append(str(phrase).strip())
+        if r.get("price_increase"):
+            price_increase_count += 1
+
+    themes = []
+    for cat, s in pain.items():
+        mean_urg = (s["urgency_sum"] / s["urgency_n"]) if s["urgency_n"] else 0.0
+        breadth = len(s["vendors"]) / total_vendors
+        score = s["reviews"] * mean_urg * breadth
+        themes.append({
+            "theme": cat,
+            "reviews": s["reviews"],
+            "mean_urgency": round(mean_urg, 2),
+            "vendor_breadth": f"{len(s['vendors'])}/{total_vendors}",
+            "breadth_pct": round(breadth, 2),
+            "opportunity_score": round(score, 1),
+            "quotes": s["quotes"],
+        })
+    themes.sort(key=lambda t: t["opportunity_score"], reverse=True)
+
+    gaps = sorted(
+        ({"gap": v["verbatim"], "count": v["count"]} for v in feature_gaps.values()),
+        key=lambda g: g["count"], reverse=True,
+    )
+    comps = sorted(
+        ({"name": n, "count": v["count"], "contexts": dict(v["contexts"])} for n, v in competitors.items()),
+        key=lambda c: c["count"], reverse=True,
+    )
+
+    return {
+        "total_reviews": len(reviews),
+        "total_vendors": total_vendors,
+        "vendors": sorted(all_vendors),
+        "filtered_offtopic": filtered_offtopic,
+        "filtered_vendors": dict(sorted(filtered_vendors.items(), key=lambda x: -x[1])),
+        "baseline_overall_dissatisfaction": baseline_count,
+        "themes": themes,
+        "feature_gaps": gaps,
+        "competitors": comps,
+        "pricing": {
+            "price_increase_mentions": price_increase_count,
+            "sample_phrases": pricing_phrases[:8],
+        },
+    }
+
+
+def render_markdown(category: str, data: dict[str, Any]) -> str:
+    out: list[str] = []
+    out.append(f"# Demand-Opportunity Report: {category}")
+    out.append("")
+    out.append(
+        f"{data['total_reviews']} enriched reviews across {data['total_vendors']} "
+        f"primary vendors ({', '.join(data['vendors'])})."
+    )
+    if data.get("filtered_offtopic"):
+        fv = ", ".join(f"{v}:{n}" for v, n in data["filtered_vendors"].items())
+        out.append(
+            f"Relevance filter dropped {data['filtered_offtopic']} off-topic "
+            f"(common-word-vendor contamination) reviews before analysis [{fv}]."
+        )
+    out.append(
+        f"Baseline: {data['baseline_overall_dissatisfaction']} reviews carry only "
+        f"non-specific \"overall dissatisfaction\" (excluded from ranked themes below)."
+    )
+    out.append("")
+    out.append("## Ranked opportunity themes")
+    out.append("")
+    out.append("| Theme | Reviews | Mean urgency | Vendor breadth | Opportunity |")
+    out.append("|---|--:|--:|:--:|--:|")
+    for t in data["themes"]:
+        out.append(
+            f"| {t['theme']} | {t['reviews']} | {t['mean_urgency']} | "
+            f"{t['vendor_breadth']} | {t['opportunity_score']} |"
+        )
+    out.append("")
+    out.append("## Top unmet needs / feature gaps (verbatim)")
+    out.append("")
+    if data["feature_gaps"]:
+        for g in data["feature_gaps"][:20]:
+            out.append(f"- ({g['count']}x) {g['gap']}")
+    else:
+        out.append("_None extracted._")
+    out.append("")
+    out.append("## Pricing pain")
+    out.append("")
+    out.append(f"- Price-increase mentions: {data['pricing']['price_increase_mentions']}")
+    for p in data["pricing"]["sample_phrases"]:
+        out.append(f"- \"{p}\"")
+    out.append("")
+    out.append("## Competitors cited (alternatives buyers mention)")
+    out.append("")
+    if data["competitors"]:
+        for c in data["competitors"][:15]:
+            ctx = ", ".join(f"{k}:{v}" for k, v in sorted(c["contexts"].items(), key=lambda x: -x[1]))
+            out.append(f"- {c['name']} ({c['count']}x) -- {ctx}")
+    else:
+        out.append("_None._")
+    out.append("")
+    out.append("## Evidence (sample quotes per top theme)")
+    out.append("")
+    for t in data["themes"][:6]:
+        if not t["quotes"]:
+            continue
+        out.append(f"**{t['theme']}**")
+        for q in t["quotes"]:
+            out.append(f"> {q['text']}  \n> -- {q['vendor'] or 'unknown'} ({q['source'] or 'n/a'})")
+        out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# DB I/O
+# ---------------------------------------------------------------------------
+
+
+async def _fetch(pool, category: str) -> list[dict[str, Any]]:
+    rows = await pool.fetch(
+        """
+        SELECT r.id, r.source,
+               vm.vendor_name AS vendor,
+               CASE WHEN r.enrichment->>'urgency_score' ~ '^[0-9.]+$'
+                    THEN (r.enrichment->>'urgency_score')::numeric END AS urgency,
+               r.enrichment->'pain_categories'      AS pain_categories,
+               r.enrichment->'feature_gaps'         AS feature_gaps,
+               r.enrichment->'specific_complaints'  AS specific_complaints,
+               r.enrichment->'competitors_mentioned' AS competitors,
+               r.enrichment->'pricing_phrases'      AS pricing_phrases,
+               r.enrichment->'positive_aspects'     AS positive_aspects,
+               r.enrichment->'quotable_phrases'     AS quotable_phrases,
+               (r.enrichment->'budget_signals'->>'price_increase_mentioned')::boolean AS price_increase
+        FROM b2b_reviews r
+        LEFT JOIN b2b_review_vendor_mentions vm
+            ON vm.review_id = r.id AND vm.is_primary
+        WHERE r.enrichment_status = 'enriched'
+          AND r.product_category = $1
+        """,
+        category,
+    )
+    return [
+        {
+            "vendor": r["vendor"],
+            "urgency": float(r["urgency"]) if r["urgency"] is not None else None,
+            "pain_categories": r["pain_categories"],
+            "feature_gaps": r["feature_gaps"],
+            "specific_complaints": r["specific_complaints"],
+            "competitors": r["competitors"],
+            "pricing_phrases": r["pricing_phrases"],
+            "positive_aspects": r["positive_aspects"],
+            "quotable_phrases": r["quotable_phrases"],
+            "price_increase": r["price_increase"],
+            "source": r["source"],
+        }
+        for r in rows
+    ]
+
+
+async def _run(category: str) -> dict[str, Any]:
+    await init_database()
+    pool = get_db_pool()
+    reviews = await _fetch(pool, category)
+    return aggregate(reviews)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--category", required=True, help="product_category, e.g. CRM")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    args = parser.parse_args()
+
+    async def _main() -> int:
+        try:
+            data = await _run(args.category)
+        finally:
+            await close_database()
+        if not data["total_reviews"]:
+            print(f"No enriched reviews found for category: {args.category}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(data, indent=2, sort_keys=True, default=str))
+        else:
+            print(render_markdown(args.category, data))
+        return 0
+
+    raise SystemExit(asyncio.run(_main()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demand_opportunity_report.py
+++ b/tests/test_demand_opportunity_report.py
@@ -115,3 +115,21 @@ def test_feature_gaps_and_competitors_rollup():
     # positive_aspects surfaced + case-normalized.
     assert data["works_well"][0]["count"] == 2
     assert "intuitive ui" in data["works_well"][0]["aspect"].lower()
+
+
+def test_vendor_alias_merges_bare_name_to_canonical():
+    # "Monday" / "monday" must collapse into "Monday.com" (not split entries).
+    reviews = [
+        _review("Asana", 5, ["features"], competitors=[{"name": "Monday", "context": "considering"}]),
+        _review("Trello", 5, ["features"], competitors=[{"name": "Monday.com", "context": "compared"}]),
+        _review("Jira", 5, ["features"], competitors=[{"name": "monday", "context": "considering"}]),
+    ]
+    data = dor.aggregate(reviews)
+    monday = [c for c in data["competitors"] if c["name"] == "Monday.com"]
+    assert len(monday) == 1
+    assert monday[0]["count"] == 3
+    assert monday[0]["contexts"] == {"considering": 2, "compared": 1}
+    # "Monday dev" is a distinct product variant -- must NOT merge.
+    reviews2 = [_review("Asana", 5, ["features"], competitors=[{"name": "Monday dev", "context": "compared"}])]
+    data2 = dor.aggregate(reviews2)
+    assert data2["competitors"][0]["name"] == "Monday dev"

--- a/tests/test_demand_opportunity_report.py
+++ b/tests/test_demand_opportunity_report.py
@@ -92,15 +92,26 @@ def test_opportunity_ranking_rewards_breadth_and_urgency():
 
 def test_feature_gaps_and_competitors_rollup():
     reviews = [
-        _review("Close", 5, ["features"], feature_gaps=["deeper reporting", "Deeper Reporting"],
+        _review("Close", 5, ["features"],
+                feature_gaps=["deeper reporting", "Deeper Reporting"],
+                positive_aspects=["clean, intuitive UI"],
                 competitors=[{"name": "HubSpot", "context": "compared"}]),
-        _review("Pipedrive", 5, ["features"], feature_gaps=["deeper reporting"],
-                competitors=[{"name": "HubSpot", "context": "considering"}]),
+        _review("Pipedrive", 5, ["features"],
+                feature_gaps=["deeper reporting"],
+                positive_aspects=["Clean, intuitive UI"],
+                # name variants must merge into one competitor
+                competitors=[{"name": "Hubspot", "context": "considering"},
+                             {"name": "HubSpot CRM", "context": "compared"}]),
     ]
     data = dor.aggregate(reviews)
     top_gap = data["feature_gaps"][0]
     assert top_gap["count"] == 3  # case-normalized dedup across reviews
     assert "reporting" in top_gap["gap"].lower()
-    hubspot = next(c for c in data["competitors"] if c["name"] == "HubSpot")
-    assert hubspot["count"] == 2
-    assert hubspot["contexts"] == {"compared": 1, "considering": 1}
+    # HubSpot / Hubspot / HubSpot CRM collapse to one entry, count 3.
+    hub = [c for c in data["competitors"] if c["count"] == 3]
+    assert len(hub) == 1
+    assert hub[0]["name"].lower().startswith("hubspot")
+    assert hub[0]["contexts"] == {"compared": 2, "considering": 1}
+    # positive_aspects surfaced + case-normalized.
+    assert data["works_well"][0]["count"] == 2
+    assert "intuitive ui" in data["works_well"][0]["aspect"].lower()

--- a/tests/test_demand_opportunity_report.py
+++ b/tests/test_demand_opportunity_report.py
@@ -63,17 +63,56 @@ def test_aggregate_excludes_offtopic_and_counts_them():
     assert pricing["reviews"] == 2  # only the two clean reviews counted
 
 
-def test_overall_dissatisfaction_is_baseline_not_a_theme():
+def test_overall_dissatisfaction_baseline_excludes_mixed_reviews():
+    # Baseline counts ONLY reviews whose sole pain is the catch-all. A review
+    # that also carries an actionable theme is ranked there, not double-counted
+    # in the baseline (so baseline + ranked never exceeds total).
     reviews = [
-        _review("Close", 3, ["overall_dissatisfaction"]),
-        _review("Close", 3, ["overall_dissatisfaction"]),
+        _review("Close", 3, ["overall_dissatisfaction"]),                  # baseline-only
+        _review("Close", 3, ["overall_dissatisfaction", "pricing"]),       # mixed -> NOT baseline
         _review("Pipedrive", 5, ["support"]),
     ]
     data = dor.aggregate(reviews)
-    assert data["baseline_overall_dissatisfaction"] == 2
-    themes = {t["theme"] for t in data["themes"]}
+    assert data["baseline_overall_dissatisfaction"] == 1
+    themes = {t["theme"]: t for t in data["themes"]}
     assert "overall_dissatisfaction" not in themes
+    assert themes["pricing"]["reviews"] == 1   # the mixed review ranked here
     assert "support" in themes
+    # baseline (1) + distinct ranked reviews (pricing:1 + support:1) == total (3)
+    assert data["baseline_overall_dissatisfaction"] + sum(
+        t["reviews"] for t in data["themes"]) == data["total_reviews"]
+
+
+def test_vendorless_reviews_excluded_from_scoring():
+    reviews = [
+        _review("Salesforce", 8, ["pricing"]),
+        _review(None, 9, ["pricing"]),  # no primary vendor -> excluded
+    ]
+    data = dor.aggregate(reviews)
+    assert data["excluded_no_vendor"] == 1
+    assert data["total_reviews"] == 1
+    pricing = next(t for t in data["themes"] if t["theme"] == "pricing")
+    assert pricing["reviews"] == 1  # vendorless review did not inflate volume
+
+
+def test_render_markdown_has_key_sections():
+    reviews = [
+        _review("Salesforce", 8, ["pricing"], feature_gaps=["deeper reporting"],
+                positive_aspects=["easy to use"], quotable_phrases=["pricing is brutal"],
+                competitors=[{"name": "HubSpot", "context": "compared"}]),
+    ]
+    md = dor.render_markdown("CRM", dor.aggregate(reviews))
+    for needle in (
+        "# Demand-Opportunity Report: CRM",
+        "## Ranked opportunity themes",
+        "| pricing |",
+        "## Top unmet needs / feature gaps",
+        "deeper reporting",
+        "## What already works well",
+        "## Competitors cited",
+        "HubSpot",
+    ):
+        assert needle in md, needle
 
 
 def test_opportunity_ranking_rewards_breadth_and_urgency():
@@ -88,6 +127,9 @@ def test_opportunity_ranking_rewards_breadth_and_urgency():
     assert ranked[0] == "pricing"  # broader + more urgent -> higher score
     pricing = next(t for t in data["themes"] if t["theme"] == "pricing")
     assert pricing["vendor_breadth"] == "2/2"
+    # Pin the formula: 2 reviews x mean urgency 8 x breadth (2/2) = 16.0.
+    # Guards against a regression that drops a factor or flips x -> +.
+    assert pricing["opportunity_score"] == 16.0
 
 
 def test_feature_gaps_and_competitors_rollup():

--- a/tests/test_demand_opportunity_report.py
+++ b/tests/test_demand_opportunity_report.py
@@ -1,0 +1,106 @@
+"""Unit tests for the demand-opportunity report's pure aggregation + filter.
+
+No database required -- covers the relevance filter, the
+overall_dissatisfaction baseline exclusion, the opportunity ranking, and the
+feature-gap / competitor rollups, which is the logic that determines the
+report's correctness.
+"""
+
+import importlib.util
+import pathlib
+
+_SPEC = importlib.util.spec_from_file_location(
+    "demand_opportunity_report",
+    pathlib.Path(__file__).resolve().parents[1] / "scripts" / "demand_opportunity_report.py",
+)
+dor = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(dor)
+
+
+def _review(vendor, urgency, pains, **kw):
+    return {
+        "vendor": vendor,
+        "urgency": urgency,
+        "pain_categories": [{"category": c, "severity": "primary"} for c in pains],
+        "feature_gaps": kw.get("feature_gaps", []),
+        "specific_complaints": kw.get("specific_complaints", []),
+        "competitors": kw.get("competitors", []),
+        "pricing_phrases": kw.get("pricing_phrases", []),
+        "positive_aspects": kw.get("positive_aspects", []),
+        "quotable_phrases": kw.get("quotable_phrases", []),
+        "price_increase": kw.get("price_increase", False),
+        "source": kw.get("source", "G2"),
+    }
+
+
+def test_offtopic_detection_high_confidence_only():
+    # Common-word-vendor contamination -> off-topic.
+    assert dor._review_is_offtopic(_review("Copper", 5, ["pricing"],
+        pricing_phrases=["craft 30 stone axes vs the copper axe"]))
+    assert dor._review_is_offtopic(_review("Copper", 5, ["pricing"],
+        quotable_phrases=["1500 durability compared to 150"]))
+    assert dor._review_is_offtopic(_review("Close", 5, ["features"],
+        feature_gaps=["silver plated copper cable is flexible"]))
+    # Legitimate SaaS reviews must NOT be dropped (no false positives on plan
+    # names or ordinary words).
+    assert not dor._review_is_offtopic(_review("Zoho CRM", 5, ["pricing"],
+        pricing_phrases=["the Silver plan is $12/user/month"]))
+    assert not dor._review_is_offtopic(_review("Salesforce", 5, ["ux"],
+        feature_gaps=["needs a more durable workflow audit trail"]))
+
+
+def test_aggregate_excludes_offtopic_and_counts_them():
+    reviews = [
+        _review("Copper", 8, ["pricing"], pricing_phrases=["110 silver per day for wood"]),
+        _review("Zoho CRM", 6, ["pricing"], pricing_phrases=["$15/user/mo too high"]),
+        _review("Salesforce", 4, ["pricing"]),
+    ]
+    data = dor.aggregate(reviews)
+    assert data["filtered_offtopic"] == 1
+    assert data["filtered_vendors"] == {"Copper": 1}
+    assert data["total_reviews"] == 2  # off-topic Copper review excluded
+    pricing = next(t for t in data["themes"] if t["theme"] == "pricing")
+    assert pricing["reviews"] == 2  # only the two clean reviews counted
+
+
+def test_overall_dissatisfaction_is_baseline_not_a_theme():
+    reviews = [
+        _review("Close", 3, ["overall_dissatisfaction"]),
+        _review("Close", 3, ["overall_dissatisfaction"]),
+        _review("Pipedrive", 5, ["support"]),
+    ]
+    data = dor.aggregate(reviews)
+    assert data["baseline_overall_dissatisfaction"] == 2
+    themes = {t["theme"] for t in data["themes"]}
+    assert "overall_dissatisfaction" not in themes
+    assert "support" in themes
+
+
+def test_opportunity_ranking_rewards_breadth_and_urgency():
+    # Theme A: 2 vendors, high urgency. Theme B: 1 vendor, low urgency.
+    reviews = [
+        _review("Salesforce", 8, ["pricing"]),
+        _review("Zoho CRM", 8, ["pricing"]),
+        _review("Salesforce", 2, ["api_limitations"]),
+    ]
+    data = dor.aggregate(reviews)
+    ranked = [t["theme"] for t in data["themes"]]
+    assert ranked[0] == "pricing"  # broader + more urgent -> higher score
+    pricing = next(t for t in data["themes"] if t["theme"] == "pricing")
+    assert pricing["vendor_breadth"] == "2/2"
+
+
+def test_feature_gaps_and_competitors_rollup():
+    reviews = [
+        _review("Close", 5, ["features"], feature_gaps=["deeper reporting", "Deeper Reporting"],
+                competitors=[{"name": "HubSpot", "context": "compared"}]),
+        _review("Pipedrive", 5, ["features"], feature_gaps=["deeper reporting"],
+                competitors=[{"name": "HubSpot", "context": "considering"}]),
+    ]
+    data = dor.aggregate(reviews)
+    top_gap = data["feature_gaps"][0]
+    assert top_gap["count"] == 3  # case-normalized dedup across reviews
+    assert "reporting" in top_gap["gap"].lower()
+    hubspot = next(c for c in data["competitors"] if c["name"] == "HubSpot")
+    assert hubspot["count"] == 2
+    assert hubspot["contexts"] == {"compared": 1, "considering": 1}


### PR DESCRIPTION
Plan: plans/PR-Demand-Opportunity-Report.md (plan checked in via #708)

Implements the demand/opportunity report: an on-demand, read-only script that branches off the churn pipeline **after enrichment** and ranks product-opportunity themes from the structured enrichment multi-fields — for market/product research, not the churn reports. Runs over the existing 22k-review corpus (no scraping needed).

## Intentional
- **Branches off after enrichment** — parallel consumer of enriched rows; never touches `b2b_churn_intelligence`+ (wrong lens for demand research).
- **Opportunity = frequency × urgency × cross-vendor breadth** — widespread + intense + every-vendor-unsolved = market gap. `overall_dissatisfaction` is held out as a baseline (it's a non-actionable catch-all), not ranked.
- **Relevance filter (added after the first CRM run).** The run surfaced common-word-vendor contamination — "Copper"/"Close" pulled video-game crafting + audio quotes into the evidence. A high-confidence off-topic marker set excludes contaminated reviews *before* counting (so they neither inflate themes nor surface as evidence) and reports the dropped count/vendors. Markers are specific to avoid false-dropping legit reviews (a "Silver plan" tier, a "durable workflow" survive). Real fix is upstream vendor-name disambiguation (tracked).
- **Read-only, on-demand, human-in-the-loop** — no cron, no DB writes, no new tables; `scripts/` convention.

## Verification
- `tests/test_demand_opportunity_report.py` -> `5 passed` (off-topic detection + false-positive guard, off-topic exclusion + count, baseline exclusion, breadth/urgency ranking, gap/competitor rollup).
- `scripts/demand_opportunity_report.py --category=CRM` (live DB) -> 1,954 reviews / 8 vendors (5 off-topic dropped: Copper:4, Close:1). Top themes: **pricing** (365 reviews, urgency 4.35, 8/8 vendors), support, ux; **contract_lock_in** most intense (urgency 6.68). Pricing evidence clean of video-game noise after the filter.
- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape, plan/code 4/4 path claims, diff drift 0.8%, `git diff --check`).

## Diff size
~519 LOC (script ~330, tests ~110, plan-doc update ~75).