### PR TITLE
PR-Content-Ops-FAQ-Result-Output

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Result-Output.md
+++ b/plans/PR-Content-Ops-FAQ-Result-Output.md
@@ -1,0 +1,70 @@
+# PR-Content-Ops-FAQ-Result-Output
+
+## Why this slice exists
+
+The 1,000-row CFPB FAQ run proved the generator can process large uploads, but
+the failure evidence was collected manually after reruns. Future 500-row,
+1,000-row, or larger uploads should leave a structured result artifact even when
+`--require-output-checks` exits nonzero, so operators can see which check failed
+and where to inspect first.
+
+## Scope (this PR)
+
+1. Add a `--result-output` option to the standalone FAQ Markdown CLI.
+2. Write a compact JSON run artifact on both successful and fail-closed runs.
+3. Include small diagnostics for failed checks, item distribution, question
+   source distribution, warnings, and output paths.
+4. Add focused CLI tests for success and failure result artifacts.
+
+### Files touched
+
+- `scripts/build_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `plans/PR-Content-Ops-FAQ-Result-Output.md`
+
+## Mechanism
+
+The CLI already receives a `TicketFAQMarkdownResult` before it decides whether
+`--require-output-checks` should fail. This slice serializes a compact run
+summary immediately after generation and before raising `SystemExit` for failed
+checks.
+
+The artifact intentionally excludes full Markdown body text. It records counts,
+output checks, failed checks, warning summaries, item summaries, question source
+counts, ticket-count distribution, CLI config, input path, and output path.
+
+## Intentional
+
+- No FAQ generation behavior changes.
+- No new runtime dependency or persistence dependency.
+- The result artifact is compact by default so very large uploads do not produce
+  duplicate Markdown-sized JSON.
+- The CLI still exits nonzero when `--require-output-checks` fails.
+
+## Deferred
+
+- A later slice can add a dedicated scale-smoke wrapper that extracts source
+  rows and calls this CLI with a standard artifact directory.
+- A later slice can surface these diagnostics in a hosted review UI if operators
+  need browser access to run artifacts.
+
+## Verification
+
+- Focused FAQ Markdown pytest - passed, 62 tests.
+- Manual 1,000-row CFPB CLI check with `--result-output` - passed. Result JSON
+  reported `source_count=1000`, `ticket_source_count=1000`, `generated=12`,
+  no failed output checks, and `rendered_ticket_source_count=1000`.
+- Extracted gauntlet passed: manifest sync, reasoning import guard,
+  standalone audit with 0 Atlas runtime import findings, and ASCII Python check.
+- Full extracted pipeline wrapper - passed, including 1,581 extracted Content
+  Ops tests and 295 reasoning-core tests.
+- Local PR review - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 72 |
+| FAQ CLI | 132 |
+| Tests | 49 |
+| **Total** | **251** |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 from datetime import date
+import json
 from pathlib import Path
 import sys
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -71,6 +73,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Write FAQ Markdown to this path instead of stdout.",
     )
     parser.add_argument(
+        "--result-output",
+        type=Path,
+        help="Write compact JSON run diagnostics to this path.",
+    )
+    parser.add_argument(
         "--support-contact",
         help="Phone, email, or URL shown when the FAQ tells users to contact support.",
     )
@@ -116,6 +123,16 @@ def main(argv: list[str] | None = None) -> int:
         support_contact=args.support_contact,
     )
     failed_checks = _failed_output_checks(result.output_checks)
+    if args.result_output:
+        args.result_output.write_text(
+            json.dumps(
+                _result_payload(args, result, loaded.warning_dicts(), failed_checks),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     if args.require_output_checks and failed_checks:
         raise SystemExit(f"FAQ output checks failed: {', '.join(failed_checks)}")
     if args.output:
@@ -127,6 +144,121 @@ def main(argv: list[str] | None = None) -> int:
 
 def _failed_output_checks(output_checks: dict[str, bool]) -> list[str]:
     return [name for name, passed in sorted(output_checks.items()) if passed is not True]
+
+
+def _result_payload(
+    args: argparse.Namespace,
+    result: Any,
+    load_warnings: list[dict[str, Any]],
+    failed_checks: list[str],
+) -> dict[str, Any]:
+    items = [dict(item) for item in result.items]
+    ticket_counts = [int(item.get("ticket_count") or 0) for item in items]
+    question_source_counts = _count_by(items, "question_source")
+    rendered_ticket_source_count = _rendered_ticket_source_count(items)
+    warnings = load_warnings + [dict(warning) for warning in result.warnings]
+    return {
+        "status": "failed_output_checks" if failed_checks else "ok",
+        "input": {
+            "path": str(args.path),
+            "source_format": args.source_format,
+        },
+        "output": {
+            "markdown_path": str(args.output) if args.output else None,
+            "result_path": str(args.result_output) if args.result_output else None,
+        },
+        "config": {
+            "title": args.title,
+            "max_items": args.max_items,
+            "max_evidence_per_item": args.max_evidence_per_item,
+            "max_text_chars": args.max_text_chars,
+            "window_days": args.window_days,
+            "as_of_date": args.as_of_date,
+            "require_output_checks": bool(args.require_output_checks),
+            "support_contact": args.support_contact,
+        },
+        "source_count": result.source_count,
+        "ticket_source_count": result.ticket_source_count,
+        "generated": len(items),
+        "output_checks": dict(result.output_checks),
+        "failed_output_checks": list(failed_checks),
+        "diagnostics": {
+            "output_check_details": _output_check_details(result, failed_checks, rendered_ticket_source_count),
+            "question_source_counts": question_source_counts,
+            "ticket_counts": ticket_counts,
+            "rendered_ticket_source_count": rendered_ticket_source_count,
+            "unrepresented_ticket_sources": max(result.ticket_source_count - rendered_ticket_source_count, 0),
+            "warning_count": len(warnings),
+            "warnings": warnings[:50],
+            "warnings_truncated": len(warnings) > 50,
+            "items": [_item_summary(index, item) for index, item in enumerate(items, start=1)],
+        },
+    }
+
+
+def _output_check_details(
+    result: Any,
+    failed_checks: list[str],
+    rendered_ticket_source_count: int,
+) -> list[dict[str, Any]]:
+    details = []
+    for name, passed in sorted(result.output_checks.items()):
+        detail: dict[str, Any] = {"check": name, "passed": bool(passed)}
+        if name in failed_checks:
+            detail["why"] = _output_check_hint(name, result, rendered_ticket_source_count)
+        details.append(detail)
+    return details
+
+
+def _output_check_hint(name: str, result: Any, rendered_ticket_source_count: int) -> str:
+    if name == "condensed":
+        if rendered_ticket_source_count != result.ticket_source_count:
+            return (
+                "Some ticket sources were not represented in generated FAQ items. "
+                f"ticket_source_count={result.ticket_source_count}, "
+                f"rendered_ticket_source_count={rendered_ticket_source_count}."
+            )
+        return (
+            "The FAQ produced one item per ticket source, so the output was not condensed. "
+            f"ticket_source_count={result.ticket_source_count}, generated={len(result.items)}."
+        )
+    if name == "uses_user_vocabulary":
+        return "One or more FAQ questions did not come from customer wording or source policy."
+    if name == "has_action_items":
+        return "One or more FAQ items did not include actionable next steps."
+    return "Output check failed."
+
+
+def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
+    source_ids = item.get("source_ids") or ()
+    steps = item.get("steps") or ()
+    return {
+        "rank": index,
+        "topic": item.get("topic"),
+        "question": item.get("question"),
+        "question_source": item.get("question_source"),
+        "ticket_count": item.get("ticket_count"),
+        "evidence_count": item.get("evidence_count"),
+        "source_id_count": len(source_ids),
+        "first_source_id": source_ids[0] if source_ids else None,
+        "step_count": len(steps),
+    }
+
+
+def _count_by(items: list[dict[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        value = str(item.get(key) or "unknown")
+        counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _rendered_ticket_source_count(items: list[dict[str, Any]]) -> int:
+    source_ids: set[str] = set()
+    for item in items:
+        values = item.get("source_ids") or ()
+        source_ids.update(str(value) for value in values if str(value))
+    return len(source_ids)
 
 
 if __name__ == "__main__":

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1509,6 +1509,7 @@ def test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncat
 
 def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     output = tmp_path / "ticket_faq.md"
+    result_output = tmp_path / "ticket_faq_result.json"
 
     completed = subprocess.run(
         [
@@ -1523,6 +1524,8 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
             "1-800-555-0100",
             "--output",
             str(output),
+            "--result-output",
+            str(result_output),
         ],
         check=True,
         capture_output=True,
@@ -1535,6 +1538,27 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert "Ticket sources used: 4" in markdown
     assert "ticket-acme-1" in markdown
     assert "contact support at 1-800-555-0100" in markdown
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["status"] == "ok"
+    assert result["source_count"] == 4
+    assert result["ticket_source_count"] == 4
+    assert result["failed_output_checks"] == []
+    assert result["output"]["markdown_path"] == str(output)
+    assert result["diagnostics"]["question_source_counts"] == {
+        "customer_wording": 2,
+    }
+    assert result["diagnostics"]["ticket_counts"] == [2, 2]
+    assert result["diagnostics"]["items"][0] == {
+        "rank": 1,
+        "topic": "email and profile updates",
+        "question": "How do I change my login email?",
+        "question_source": "customer_wording",
+        "ticket_count": 2,
+        "evidence_count": 2,
+        "source_id_count": 2,
+        "first_source_id": "ticket-acme-1",
+        "step_count": 3,
+    }
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:
@@ -1626,13 +1650,36 @@ def test_ticket_faq_cli_fails_required_output_checks_for_weak_rows(tmp_path: Pat
             "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
             "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
     )
+    result_output = tmp_path / "failed_result.json"
 
-    completed = _run_ticket_faq_cli(source, "--require-output-checks")
+    completed = _run_ticket_faq_cli(
+        source,
+        "--require-output-checks",
+        "--result-output",
+        str(result_output),
+    )
 
     assert completed.returncode == 1
     assert "FAQ output checks failed" in completed.stderr
     assert "condensed" in completed.stderr
     assert "uses_user_vocabulary" not in completed.stderr
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["status"] == "failed_output_checks"
+    assert result["failed_output_checks"] == ["condensed"]
+    assert result["diagnostics"]["rendered_ticket_source_count"] == 2
+    assert result["diagnostics"]["unrepresented_ticket_sources"] == 0
+    assert result["diagnostics"]["output_check_details"] == [
+        {
+            "check": "condensed",
+            "passed": False,
+            "why": (
+                "The FAQ produced one item per ticket source, so the output was not condensed. "
+                "ticket_source_count=2, generated=2."
+            ),
+        },
+        {"check": "has_action_items", "passed": True},
+        {"check": "uses_user_vocabulary", "passed": True},
+    ]
 
 
 def test_ticket_faq_cli_rejects_as_of_date_without_window(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Result-Output.md

Adds compact structured result artifacts to the standalone FAQ Markdown CLI so large uploads leave machine-readable diagnostics on both successful and fail-closed runs.

## Intentional
- No FAQ generation behavior changes.
- No new runtime dependency or persistence dependency.
- Result JSON excludes the full Markdown body to stay compact for larger uploads.
- `--require-output-checks` still exits nonzero when checks fail.

## Deferred
- Add a dedicated scale-smoke wrapper in a later slice.
- Surface diagnostics in a hosted review UI only if operators need it.

## Verification
- Focused FAQ Markdown pytest: 62 passed.
- Manual 1,000-row CFPB CLI check with `--result-output`: passed with source_count=1000, ticket_source_count=1000, generated=12, failed_output_checks=[].
- Extracted gauntlet: passed.
- Full extracted pipeline wrapper: passed, including 1,581 extracted Content Ops tests and 295 reasoning-core tests.
- Local PR review: passed.

## Diff size
3 files, +250 / -1