### PR TITLE
PR-Content-Ops-FAQ-Scale-Smoke

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Smoke.md
@@ -1,0 +1,70 @@
+# PR-Content-Ops-FAQ-Scale-Smoke
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Result-Output made the FAQ CLI write structured diagnostics,
+but operators still need to assemble output paths, stderr capture, and exit-code
+metadata by hand for each 500-row, 1,000-row, or larger upload. A small wrapper
+should make scale runs repeatable without changing FAQ generation behavior.
+
+## Scope (this PR)
+
+1. Add a standalone FAQ scale-smoke wrapper that calls the existing Markdown
+   builder with `--result-output`.
+2. Write a standard artifact directory containing Markdown, result JSON,
+   stdout, stderr, and a run summary.
+3. Preserve fail-closed exit behavior while still leaving diagnostics on disk.
+4. Add focused tests for successful, failed, format, and default smoke runs.
+
+### Files touched
+
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+- `plans/PR-Content-Ops-FAQ-Scale-Smoke.md`
+
+## Mechanism
+
+The new wrapper is intentionally thin. It shells out to
+`scripts/build_extracted_ticket_faq_markdown.py`, passes through the common FAQ
+size/configuration flags, and always writes:
+
+Markdown, result JSON, stdout text, stderr text, and run-summary JSON artifacts.
+
+The summary records the command, exit code, artifact paths, source path, and the
+compact result JSON when present.
+
+## Intentional
+
+- No FAQ generation behavior changes.
+- No CFPB-specific branch. The wrapper accepts any JSON, JSONL, or CSV source
+  upload the FAQ CLI can already load.
+- The wrapper uses the existing CLI as the source of truth instead of importing
+  generator internals again.
+
+## Deferred
+
+- A later slice can add archive-specific extraction helpers if we want one
+  command from raw CFPB archive to FAQ artifacts.
+- A hosted UI for smoke artifacts remains separate from this CLI utility.
+
+## Verification
+
+- Focused scale-smoke + FAQ Markdown CLI tests passed, 75 tests.
+- Manual 1,000-row CFPB scale-smoke run passed. Standard artifacts were written
+  under `/tmp/content_ops_faq_scale_smoke_1000`, with `exit_code=0`,
+  `source_count=1000`, `ticket_source_count=1000`, `generated=12`, and no
+  failed output checks.
+- Extracted gauntlet passed: manifest sync, reasoning import guard,
+  standalone audit with 0 Atlas runtime import findings, and ASCII Python check.
+- Full extracted pipeline wrapper passed, including 1,583 extracted Content Ops
+  tests and 295 reasoning-core tests.
+- Local PR review passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 70 |
+| Scale-smoke wrapper | 154 |
+| Tests | 175 |
+| **Total** | **399** |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Run a repeatable FAQ Markdown scale smoke with standard artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FAQ_CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run FAQ Markdown generation and capture scale-smoke artifacts."
+    )
+    parser.add_argument("path", type=Path, help="Source JSON, JSONL, or CSV file.")
+    parser.add_argument("--source-format", choices=("auto", "json", "jsonl", "csv"), default="auto")
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--title", default="Customer Ticket FAQ Scale Smoke")
+    parser.add_argument("--max-items", type=int, default=12)
+    parser.add_argument("--max-evidence-per-item", type=int, default=5)
+    parser.add_argument("--max-text-chars", type=int, default=1200)
+    parser.add_argument("--window-days", type=int)
+    parser.add_argument("--as-of-date")
+    parser.add_argument("--support-contact")
+    parser.add_argument("--default-field", action="append", default=[])
+    parser.add_argument("--allow-output-check-failures", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, _summary = run_scale_smoke(args)
+    return code
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.max_items < 1:
+        raise SystemExit("--max-items must be positive")
+    if args.max_evidence_per_item < 1:
+        raise SystemExit("--max-evidence-per-item must be positive")
+    if args.max_text_chars < 1:
+        raise SystemExit("--max-text-chars must be positive")
+    if args.window_days is not None and args.window_days < 1:
+        raise SystemExit("--window-days must be positive")
+    if args.as_of_date and args.window_days is None:
+        raise SystemExit("--as-of-date requires --window-days")
+
+
+def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    artifact_dir = Path(args.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    markdown_path = artifact_dir / "faq.md"
+    result_path = artifact_dir / "faq_result.json"
+    stdout_path = artifact_dir / "stdout.txt"
+    stderr_path = artifact_dir / "stderr.txt"
+    summary_path = artifact_dir / "run_summary.json"
+    command = _build_command(args, markdown_path=markdown_path, result_path=result_path)
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    stdout_path.write_text(completed.stdout, encoding="utf-8")
+    stderr_path.write_text(completed.stderr, encoding="utf-8")
+    result_payload = _read_json(result_path)
+    summary = {
+        "ok": completed.returncode == 0,
+        "exit_code": completed.returncode,
+        "source": str(args.path),
+        "source_format": args.source_format,
+        "command": command,
+        "artifacts": {
+            "markdown": _artifact_path(markdown_path),
+            "result": _artifact_path(result_path),
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "summary": str(summary_path),
+        },
+        "result": result_payload,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if (
+        completed.returncode != 0
+        and bool(args.allow_output_check_failures)
+        and _is_output_check_failure(result_payload)
+    ):
+        return 0, summary
+    return completed.returncode, summary
+
+
+def _build_command(
+    args: argparse.Namespace,
+    *,
+    markdown_path: Path,
+    result_path: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(FAQ_CLI),
+        str(args.path),
+        "--source-format",
+        str(args.source_format),
+        "--title",
+        str(args.title),
+        "--max-items",
+        str(args.max_items),
+        "--max-evidence-per-item",
+        str(args.max_evidence_per_item),
+        "--max-text-chars",
+        str(args.max_text_chars),
+        "--output",
+        str(markdown_path),
+        "--result-output",
+        str(result_path),
+        "--require-output-checks",
+    ]
+    if args.window_days is not None:
+        command.extend(["--window-days", str(args.window_days)])
+    if args.as_of_date:
+        command.extend(["--as-of-date", str(args.as_of_date)])
+    if args.support_contact:
+        command.extend(["--support-contact", str(args.support_contact)])
+    for value in args.default_field:
+        command.extend(["--default-field", str(value)])
+    return command
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _artifact_path(path: Path) -> str | None:
+    return str(path) if path.exists() else None
+
+
+def _is_output_check_failure(result_payload: dict[str, Any] | None) -> bool:
+    return bool(
+        isinstance(result_payload, dict)
+        and result_payload.get("status") == "failed_output_checks"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_scale_run.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_scale_run", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+TICKET_ROWS = (
+    ("ticket-acme-1", "Change login email", "How do I change my login email?", "email and profile updates"),
+    ("ticket-acme-2", "Update account email", "I need to update the email on my account.", "email and profile updates"),
+    ("ticket-northstar-1", "Export campaign reports", "How do we export campaign attribution data before renewal?", "reporting friction"),
+    ("ticket-northstar-2", "Reporting dashboard export", "We cannot export the reporting dashboard for analysts.", "reporting friction"),
+)
+
+
+def _args(tmp_path: Path, **overrides):
+    values = {
+        "path": SUPPORT_TICKET_CSV,
+        "source_format": "auto",
+        "artifact_dir": tmp_path / "artifacts",
+        "title": "Customer Ticket FAQ Scale Smoke",
+        "max_items": 12,
+        "max_evidence_per_item": 5,
+        "max_text_chars": 1200,
+        "window_days": None,
+        "as_of_date": None,
+        "support_contact": None,
+        "default_field": [],
+        "allow_output_check_failures": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _write_ticket_csv(tmp_path: Path, *rows: str) -> Path:
+    source = tmp_path / "tickets.csv"
+    source.write_text(
+        "Ticket ID,Created At,Subject,Description,Pain Category\n"
+        + "\n".join(rows)
+        + "\n",
+        encoding="utf-8",
+    )
+    return source
+
+
+def _write_source(tmp_path: Path, fmt: str) -> Path:
+    dict_rows = [
+        dict(zip(("Ticket ID", "Subject", "Description", "Pain Category"), row))
+        for row in TICKET_ROWS
+    ]
+    if fmt == "jsonl":
+        source = tmp_path / "tickets.jsonl"
+        source.write_text(
+            "\n".join(json.dumps(row) for row in dict_rows) + "\n",
+            encoding="utf-8",
+        )
+        return source
+    if fmt in {"auto", "json"}:
+        source = tmp_path / "tickets.json"
+        source.write_text(json.dumps(dict_rows) + "\n", encoding="utf-8")
+        return source
+    return _write_ticket_csv(
+        tmp_path,
+        *(",".join((ticket_id, "2026-05-01", subject, description, pain_category))
+          for ticket_id, subject, description, pain_category in TICKET_ROWS),
+    )
+
+
+@pytest.mark.parametrize("fmt", ["auto", "csv", "json", "jsonl"])
+def test_faq_scale_smoke_writes_standard_artifacts(tmp_path: Path, fmt: str) -> None:
+    source = _write_source(tmp_path, fmt)
+    code, summary = smoke.run_scale_smoke(_args(tmp_path, path=source, source_format=fmt))
+
+    artifact_dir = tmp_path / "artifacts"
+    assert code == 0
+    assert summary["ok"] is True
+    for name in ("faq.md", "faq_result.json", "stdout.txt", "stderr.txt", "run_summary.json"):
+        assert (artifact_dir / name).exists()
+    result = json.loads((artifact_dir / "faq_result.json").read_text(encoding="utf-8"))
+    saved_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
+    assert result["status"] == "ok"
+    assert result["ticket_source_count"] == 4
+    assert result["failed_output_checks"] == []
+    assert saved_summary["exit_code"] == 0
+    assert saved_summary["result"]["generated"] == result["generated"]
+    assert saved_summary["source_format"] == fmt
+    assert (artifact_dir / "faq.md").read_text(encoding="utf-8").startswith(
+        "# Customer Ticket FAQ Scale Smoke"
+    )
+
+
+def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
+        "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
+    )
+
+    code, summary = smoke.run_scale_smoke(_args(tmp_path, path=source))
+
+    artifact_dir = tmp_path / "artifacts"
+    assert code == 1
+    assert summary["ok"] is False
+    result = json.loads((artifact_dir / "faq_result.json").read_text(encoding="utf-8"))
+    stderr = (artifact_dir / "stderr.txt").read_text(encoding="utf-8")
+    assert result["status"] == "failed_output_checks"
+    assert result["failed_output_checks"] == ["condensed"]
+    assert "FAQ output checks failed: condensed" in stderr
+    assert not (artifact_dir / "faq.md").exists()
+    assert summary["artifacts"]["markdown"] is None
+    assert summary["result"]["diagnostics"]["rendered_ticket_source_count"] == 2
+
+
+def test_faq_scale_smoke_can_allow_output_check_failures(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
+        "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
+    )
+
+    code, summary = smoke.run_scale_smoke(
+        _args(tmp_path, path=source, allow_output_check_failures=True)
+    )
+
+    assert code == 0
+    assert summary["ok"] is False
+    assert summary["exit_code"] == 1
+
+
+def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> None:
+    code, summary = smoke.run_scale_smoke(
+        _args(tmp_path, path=tmp_path / "missing.csv", allow_output_check_failures=True)
+    )
+
+    assert code != 0
+    assert summary["ok"] is False
+    assert summary["result"] is None
+    assert "No such file or directory" in (
+        tmp_path / "artifacts" / "stderr.txt"
+    ).read_text(encoding="utf-8")
+
+
+def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path) -> None:
+    code = smoke.main([str(SUPPORT_TICKET_CSV), "--artifact-dir", str(tmp_path / "artifacts")])
+
+    result = json.loads((tmp_path / "artifacts" / "faq_result.json").read_text(encoding="utf-8"))
+    assert code == 0
+    assert result["input"]["source_format"] == "auto"
+    assert result["config"]["max_items"] == 12
+
+
+@pytest.mark.parametrize("overrides,message", [
+    ({"max_items": 0}, "--max-items must be positive"),
+    ({"max_evidence_per_item": 0}, "--max-evidence-per-item must be positive"),
+    ({"max_text_chars": 0}, "--max-text-chars must be positive"),
+    ({"window_days": 0}, "--window-days must be positive"),
+    ({"as_of_date": "2026-05-01"}, "--as-of-date requires --window-days"),
+])
+def test_faq_scale_smoke_rejects_invalid_args(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(SystemExit, match=message):
+        smoke._validate_args(_args(tmp_path, **overrides))


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Smoke.md

Adds a repeatable FAQ scale-smoke wrapper that delegates to the existing FAQ Markdown CLI and writes a standard artifact directory for any JSON, JSONL, or CSV upload.

## Intentional
- No FAQ generation behavior changes.
- No CFPB-specific branch.
- The wrapper uses the existing FAQ CLI as the source of truth.

## Deferred
- Add raw archive extraction helpers later if one command from CFPB archive to FAQ artifacts becomes necessary.
- Hosted artifact UI remains separate.

## Verification
- Focused scale-smoke + FAQ Markdown CLI tests: 75 passed.
- Manual 1,000-row CFPB scale-smoke run: passed, exit_code=0, source_count=1000, ticket_source_count=1000, generated=12, failed_output_checks=[].
- Extracted gauntlet: passed.
- Full extracted pipeline wrapper: passed, including 1,583 extracted Content Ops tests and 295 reasoning-core tests.
- Local PR review: passed.

## Diff size
3 files, +399 / -0