### PR TITLE
Add landing page quality repair retry

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -17,7 +17,7 @@ plan + claims that the LLM consumes when structuring the page.
 
 Quality gating runs through ``extracted_quality_gate.landing_page_pack``
 -- pure deterministic, no LLM. Failures skip persistence and surface
-in the result's ``errors`` payload.
+in the result's ``errors`` payload after one targeted repair attempt.
 """
 
 from __future__ import annotations
@@ -69,6 +69,7 @@ class LandingPageGenerationConfig:
     temperature: float = 0.3
     quality_policy: QualityPolicy | None = None
     quality_gates_enabled: bool = True
+    quality_repair_attempts: int = 1
     parse_retry_attempts: int = 1
     parse_retry_response_excerpt_chars: int = 800
 
@@ -166,8 +167,21 @@ def _has_prompt_reasoning_context(payload: Mapping[str, Any]) -> bool:
     return isinstance(payload.get("campaign_reasoning_context"), Mapping)
 
 
-def _landing_page_user_prompt(prior_invalid_response: str = "") -> str:
+def _landing_page_user_prompt(
+    prior_invalid_response: str = "",
+    *,
+    quality_blockers: Sequence[str] = (),
+) -> str:
     prompt = "Generate one landing page from the marketing campaign above."
+    if quality_blockers:
+        blockers = "\n".join(f"- {str(item)}" for item in quality_blockers)
+        prompt = (
+            f"{prompt}\n\n"
+            "The previous landing-page JSON parsed, but it failed the "
+            "deterministic quality gate. Fix these issues and return one "
+            "corrected JSON object only:\n"
+            f"{blockers}"
+        )
     return retry_prompt_with_invalid_response(
         prompt,
         prior_invalid_response=prior_invalid_response,
@@ -219,6 +233,7 @@ class LandingPageGenerationService:
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        quality_repair_attempts: int | None = None,
     ) -> LandingPageGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -250,6 +265,11 @@ class LandingPageGenerationService:
             if quality_gates_enabled is None
             else bool(quality_gates_enabled)
         )
+        resolved_quality_repair_attempts = (
+            self._config.quality_repair_attempts
+            if quality_repair_attempts is None
+            else int(quality_repair_attempts)
+        )
 
         if not str(campaign.name or "").strip():
             return LandingPageGenerationResult(
@@ -272,36 +292,67 @@ class LandingPageGenerationService:
                 errors=({"campaign_name": campaign.name, "reason": str(exc)},),
             )
 
-        try:
-            parsed = await self._generate_one(
-                prompt_template,
-                campaign_payload=campaign_payload,
-                temperature=resolved_temperature,
-                max_tokens=resolved_max_tokens,
-                parse_retry_attempts=resolved_parse_retry_attempts,
-                parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
-            )
-        except Exception as exc:
-            return LandingPageGenerationResult(
-                requested=1,
-                generated=0,
-                skipped=1,
-                errors=({"campaign_name": campaign.name, "reason": str(exc)},),
-            )
-
-        if not parsed:
-            return LandingPageGenerationResult(
-                requested=1,
-                generated=0,
-                skipped=1,
-                errors=({"campaign_name": campaign.name, "reason": "unparseable_response"},),
-            )
-
-        quality = self._quality_check(
-            parsed,
-            quality_gates_enabled=resolved_quality_gates_enabled,
+        parsed: dict[str, Any] | None = None
+        quality: dict[str, Any] = {"passed": False, "blockers": (), "repair_issues": ()}
+        quality_blockers: tuple[str, ...] = ()
+        total_usage: dict[str, Any] = {}
+        total_parse_attempts = 0
+        repair_limit = (
+            max(0, int(resolved_quality_repair_attempts or 0))
+            if resolved_quality_gates_enabled
+            else 0
         )
-        if not quality["passed"]:
+        for repair_attempt_no in range(0, repair_limit + 1):
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    campaign_payload=campaign_payload,
+                    temperature=resolved_temperature,
+                    max_tokens=resolved_max_tokens,
+                    parse_retry_attempts=resolved_parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
+                    quality_blockers=quality_blockers,
+                    quality_repair_attempt_no=repair_attempt_no,
+                )
+            except Exception as exc:
+                return LandingPageGenerationResult(
+                    requested=1,
+                    generated=0,
+                    skipped=1,
+                    errors=({"campaign_name": campaign.name, "reason": str(exc)},),
+                )
+
+            if not parsed:
+                error: dict[str, Any] = {
+                    "campaign_name": campaign.name,
+                    "reason": "unparseable_response",
+                }
+                if quality_blockers:
+                    error["quality_blockers"] = quality_blockers
+                return LandingPageGenerationResult(
+                    requested=1,
+                    generated=0,
+                    skipped=1,
+                    errors=(error,),
+                )
+
+            total_usage = accumulate_usage(total_usage, parsed.get("_usage"))
+            total_parse_attempts += int(parsed.get("_parse_attempts") or 0)
+            parsed = {
+                **parsed,
+                "_usage": total_usage,
+                "_parse_attempts": total_parse_attempts,
+                "_quality_repair_attempts": repair_attempt_no,
+            }
+            quality = self._quality_check(
+                parsed,
+                quality_gates_enabled=resolved_quality_gates_enabled,
+            )
+            if quality["passed"]:
+                break
+            quality_blockers = tuple(str(item) for item in quality["repair_issues"])
+
+        if not quality["passed"] or parsed is None:
             return LandingPageGenerationResult(
                 requested=1,
                 generated=0,
@@ -309,7 +360,8 @@ class LandingPageGenerationService:
                 errors=({
                     "campaign_name": campaign.name,
                     "reason": "quality_blocked",
-                    "blockers": quality["blockers"],
+                    "blockers": tuple(str(item) for item in quality["blockers"]),
+                    "quality_repair_attempts": repair_limit,
                 },),
             )
 
@@ -376,6 +428,8 @@ class LandingPageGenerationService:
         max_tokens: int,
         parse_retry_attempts: int,
         parse_retry_response_excerpt_chars: int,
+        quality_blockers: Sequence[str] = (),
+        quality_repair_attempt_no: int = 0,
     ) -> dict[str, Any] | None:
         campaign_json = json.dumps(dict(campaign_payload), separators=(",", ":"), default=str)
         # Single source for the campaign payload: in the system prompt
@@ -391,7 +445,10 @@ class LandingPageGenerationService:
                     LLMMessage(role="system", content=system_prompt),
                     LLMMessage(
                         role="user",
-                        content=_landing_page_user_prompt(last_response),
+                        content=_landing_page_user_prompt(
+                            last_response,
+                            quality_blockers=quality_blockers,
+                        ),
                     ),
                 ],
                 max_tokens=max_tokens,
@@ -402,6 +459,7 @@ class LandingPageGenerationService:
                     "asset_type": "landing_page",
                     "target_mode": _TARGET_MODE,
                     "attempt_no": attempt_no,
+                    "quality_repair_attempt_no": quality_repair_attempt_no,
                 },
             )
             total_usage = accumulate_usage(total_usage, response.usage)
@@ -430,7 +488,7 @@ class LandingPageGenerationService:
         # can route the operator's choice to the service. False short-
         # circuits the gate; True (the default) preserves prior behavior.
         if not quality_gates_enabled:
-            return {"passed": True, "blockers": ()}
+            return {"passed": True, "blockers": (), "repair_issues": ()}
         report_input = QualityInput(
             artifact_type="landing_page",
             context={
@@ -443,9 +501,12 @@ class LandingPageGenerationService:
             },
         )
         report = evaluate_landing_page(report_input, policy=self._config.quality_policy)
+        blockers = tuple(f.message for f in report.blockers)
+        warnings = tuple(f.message for f in report.warnings)
         return {
             "passed": report.passed,
-            "blockers": tuple(f.message for f in report.blockers),
+            "blockers": blockers,
+            "repair_issues": blockers or warnings,
         }
 
     def _build_draft(
@@ -484,6 +545,7 @@ class LandingPageGenerationService:
             "generation_model": parsed.get("_model"),
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
+            "generation_quality_repair_attempts": parsed.get("_quality_repair_attempts"),
         }
         if campaign_payload is not None:
             context = normalize_campaign_reasoning_context(campaign_payload)

--- a/plans/PR-Landing-Page-Quality-Repair.md
+++ b/plans/PR-Landing-Page-Quality-Repair.md
@@ -1,0 +1,93 @@
+# PR-Landing-Page-Quality-Repair
+
+## Why this slice exists
+
+The landing-page generator now has a readiness contract, export/readiness
+summaries, quality-gate validators, and a prompt aligned to those validators.
+The remaining source gap is generation behavior: when the LLM returns valid
+JSON that fails the deterministic quality gate, the service currently stops
+immediately and skips persistence.
+
+That is wasteful for repairable defects like a missing CTA block or invalid
+slug. This slice adds one targeted quality-repair pass that feeds the gate
+issues back to the model and persists only if the repaired draft passes.
+
+## Scope (this PR)
+
+1. Add a landing-page `quality_repair_attempts` config default of 1.
+2. Let callers override `quality_repair_attempts` per generation call.
+3. Retry parsed-but-quality-blocked landing-page JSON with the quality issues
+   in the user prompt.
+4. Keep parse retry and quality repair separate.
+5. Accumulate token usage and parse-attempt counts across repair passes.
+6. Persist only the passing repaired draft.
+7. Add tests for successful repair, failed repair, and legacy block behavior
+   with repair disabled.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Quality-Repair.md` | Plan doc for this implementation slice. |
+| `extracted_content_pipeline/landing_page_generation.py` | Add quality-repair retry flow and repair metadata. |
+| `tests/test_extracted_landing_page_generation.py` | Cover repair success, repair failure, and disabled-repair blocking. |
+
+## Mechanism
+
+The generator still calls `_generate_one(...)` for JSON generation and parse
+retry. The new outer loop runs around that parsed output:
+
+1. Generate and parse a landing-page JSON candidate.
+2. Run the deterministic landing-page quality gate.
+3. If it passes, build and save the draft.
+4. If it fails and repair attempts remain, call the LLM again with the quality
+   issues included in the user prompt.
+5. If the repaired candidate still fails, return `quality_blocked` and do not
+   save.
+
+Usage metadata is accumulated across all LLM calls. The saved draft stores the
+final model, total usage, total parse attempts, and
+`generation_quality_repair_attempts`.
+
+## Intentional
+
+- No prompt-file changes.
+- No quality-pack changes.
+- No export/API changes.
+- No frontend changes.
+- No persistence of failed intermediate drafts.
+- No repair loop for unparseable responses beyond the existing parse retry
+  mechanism.
+
+## Deferred
+
+- Threading `quality_repair_attempts` through the Content Ops run-plan/control
+  surface.
+- Adding the same quality-repair behavior to other generated asset services.
+- Adding richer operator telemetry for every failed intermediate candidate.
+
+## Verification
+
+- `pytest tests/test_extracted_landing_page_generation.py -q` -> passed 24/24
+  tests.
+- `pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_landing_page_export.py tests/test_extracted_quality_gate_landing_page_pack.py -q`
+  -> passed 62/62 tests.
+- Python compile command over `extracted_content_pipeline/landing_page_generation.py`
+  and `tests/test_extracted_landing_page_generation.py` -> passed 2/2 files.
+- `git diff --check` -> passed with 0 whitespace errors.
+- `bash scripts/local_pr_review.sh origin/main` -> passed 3/3 top-level
+  checks: pre-push audit wrapper, plan/code consistency, and `git diff
+  --check`.
+- The pre-push audit wrapper inside local review reported all 8 internal checks
+  passed: MCP tool counts, MCP port assignments, MCP tool-name inventories,
+  extracted manifest sync, plan shape, plan files touched, plan diff size, and
+  ASCII Python policy.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~95 |
+| Landing-page generation | ~135 |
+| Tests | ~95 |
+| Total | ~325 |

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -230,7 +230,10 @@ async def test_generate_blocks_with_no_hero_headline_when_response_omits_hero() 
         "cta": {"label": "L", "url": "/u"},
         "meta": {},
     })
-    service, landing_pages, _llm, _skills, _rp = _service(responses=[response])
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
 
     result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
 
@@ -373,7 +376,10 @@ async def test_generate_skips_when_quality_pack_blocks() -> None:
         "meta": {},
         "reference_ids": [],
     })
-    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[bad_response],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
 
     result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
 
@@ -383,6 +389,101 @@ async def test_generate_skips_when_quality_pack_blocks() -> None:
     assert any(err.get("reason") == "quality_blocked" for err in result.errors)
     blockers = result.errors[0]["blockers"]
     assert any("no_cta" in b for b in blockers)
+
+
+@pytest.mark.asyncio
+async def test_generate_repairs_quality_blocked_response_once_and_persists() -> None:
+    """Parsed JSON that fails the quality gate gets one targeted repair pass."""
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},  # missing CTA -> no_cta blocker
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[
+            {
+                "content": bad_response,
+                "model": "first-model",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+            },
+            {
+                "content": _valid_response(),
+                "model": "final-model",
+                "usage": {"input_tokens": 7, "output_tokens": 3},
+            },
+        ],
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 1
+    assert result.saved_ids == ("lp-1",)
+    assert len(llm.calls) == 2
+    assert llm.calls[0]["metadata"]["quality_repair_attempt_no"] == 0
+    assert llm.calls[1]["metadata"]["quality_repair_attempt_no"] == 1
+    repair_prompt = llm.calls[1]["messages"][1].content
+    assert "failed the deterministic quality gate" in repair_prompt
+    assert "no_cta" in repair_prompt
+    draft = landing_pages.saved[0]["drafts"][0]
+    assert draft.metadata["generation_model"] == "final-model"
+    assert draft.metadata["generation_usage"] == {"input_tokens": 12, "output_tokens": 5}
+    assert draft.metadata["generation_parse_attempts"] == 2
+    assert draft.metadata["generation_quality_repair_attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_reports_quality_blockers_after_repair_attempt_fails() -> None:
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[bad_response, bad_response],
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert landing_pages.saved == []
+    assert len(llm.calls) == 2
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert result.errors[0]["quality_repair_attempts"] == 1
+    assert any("no_cta" in blocker for blocker in result.errors[0]["blockers"])
+
+
+@pytest.mark.asyncio
+async def test_generate_reports_quality_blockers_when_repair_response_will_not_parse() -> None:
+    bad_response = json.dumps({
+        "title": "ok",
+        "slug": "ok",
+        "hero": {"headline": "h", "subheadline": "s", "cta_label": "L", "cta_url": "/u"},
+        "sections": [{"id": "s1", "title": "T", "body_markdown": "b"}],
+        "cta": {},
+        "meta": {},
+        "reference_ids": [],
+    })
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[bad_response, "not valid json"],
+        config=LandingPageGenerationConfig(parse_retry_attempts=0),
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    assert len(llm.calls) == 2
+    assert result.errors[0]["reason"] == "unparseable_response"
+    assert any("no_cta" in blocker for blocker in result.errors[0]["quality_blockers"])
 
 
 @pytest.mark.asyncio
@@ -439,7 +540,10 @@ async def test_generate_raises_value_error_when_skill_prompt_missing() -> None:
 async def test_generate_blocks_when_llm_omits_slug() -> None:
     """Empty slug from the LLM hits the quality pack's no_slug blocker."""
     response = _valid_response(slug="")
-    service, landing_pages, _llm, _skills, _rp = _service(responses=[response])
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[response],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
 
     result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
 
@@ -551,7 +655,10 @@ async def test_generate_per_call_quality_gates_enabled_false_skips_quality_gate(
         "meta": {},
         "reference_ids": [],
     })
-    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[bad_response],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
 
     result = await service.generate(
         scope=TenantScope(account_id="acct-1"),
@@ -578,7 +685,10 @@ async def test_generate_per_call_quality_gates_enabled_true_still_blocks() -> No
         "meta": {},
         "reference_ids": [],
     })
-    service, landing_pages, _llm, _skills, _rp = _service(responses=[bad_response])
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[bad_response],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
 
     result = await service.generate(
         scope=TenantScope(account_id="acct-1"),


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Quality-Repair.md

## Summary
- add one targeted quality-repair pass for parsed landing-page JSON that fails the quality gate
- keep parse retry separate from quality repair
- accumulate usage and parse-attempt metadata across repair passes
- persist only repaired drafts that pass quality gates
- add tests for successful repair, failed repair, unparseable repair, and disabled repair behavior

## Validation
- `pytest tests/test_extracted_landing_page_generation.py -q` -> 25/25 passed
- `pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_landing_page_export.py tests/test_extracted_quality_gate_landing_page_pack.py -q` -> 63/63 passed
- `python -m py_compile extracted_content_pipeline/landing_page_generation.py tests/test_extracted_landing_page_generation.py` -> 2/2 files passed
- `git diff --check` -> 0 whitespace errors
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Notes
- No prompt-file, quality-pack, export/API, frontend, or DB changes in this slice.
- Opened ready for review, not draft.