### PR TITLE
PR-Content-Ops-FAQ-Scale-Smoke-Observability

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Smoke-Observability.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Smoke-Observability.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-FAQ-Scale-Smoke-Observability
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Scale-Smoke made FAQ scale runs repeatable for any JSON,
+JSONL, or CSV upload, but operators still have to inspect multiple artifacts to
+answer the first debugging questions: how long did the run take, which files
+were actually written, and whether a failure came from output checks or a hard
+CLI error. Large uploads need that visibility in the summary artifact itself.
+
+This slice adds a compact observability layer to the existing scale-smoke
+wrapper so failure capture scales with upload size without changing FAQ
+generation behavior.
+
+## Scope (this PR)
+
+1. Add elapsed-time metadata to the summary artifact.
+2. Add artifact existence and byte-size metadata without removing the existing
+   artifact path fields.
+3. Add a compact failure summary that distinguishes output-check failures from
+   hard CLI errors.
+4. Extend focused scale-smoke tests for success, fail-closed, and hard-failure
+   observability.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Smoke-Observability.md`
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+The wrapper will time the subprocess call with `time.monotonic()`, write stdout
+and stderr as it does today, then build a summary with two additional fields:
+
+- `timing`: elapsed seconds for the subprocess run.
+- `artifact_details`: per-artifact path, existence, and byte count.
+- `failure`: `null` on success, otherwise a compact object with the exit code,
+  result status, failed output checks when available, and a bounded stderr tail.
+
+The existing `artifacts` path/null map stays in place so callers that already
+read those fields do not need to change.
+
+## Intentional
+
+- No FAQ generator behavior changes.
+- No source-row counting is added for arbitrary CSV/JSON/JSONL here; the result
+  JSON remains the source of truth for loaded ticket/source counts.
+- The stderr copy in `failure` is bounded so a large upload cannot duplicate an
+  unbounded log into the summary JSON.
+
+## Deferred
+
+- Raw-archive source-density reporting remains CFPB/exporter-specific work.
+- A hosted artifact viewer remains separate from this CLI summary enrichment.
+
+## Verification
+
+- Focused scale-smoke + FAQ Markdown CLI tests passed, 76 tests.
+- Full extracted pipeline wrapper passed, including 1,583 extracted Content Ops
+  tests and 295 reasoning-core tests.
+- Local PR review passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 71 |
+| Scale-smoke wrapper | 90 |
+| Tests | 22 |
+| **Total** | **183** |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import Any
 
 
@@ -63,16 +64,26 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     stderr_path = artifact_dir / "stderr.txt"
     summary_path = artifact_dir / "run_summary.json"
     command = _build_command(args, markdown_path=markdown_path, result_path=result_path)
+    started = time.monotonic()
     completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    elapsed_seconds = time.monotonic() - started
     stdout_path.write_text(completed.stdout, encoding="utf-8")
     stderr_path.write_text(completed.stderr, encoding="utf-8")
     result_payload = _read_json(result_path)
+    artifact_paths = {
+        "markdown": markdown_path,
+        "result": result_path,
+        "stdout": stdout_path,
+        "stderr": stderr_path,
+        "summary": summary_path,
+    }
     summary = {
         "ok": completed.returncode == 0,
         "exit_code": completed.returncode,
         "source": str(args.path),
         "source_format": args.source_format,
         "command": command,
+        "timing": {"elapsed_seconds": round(elapsed_seconds, 6)},
         "artifacts": {
             "markdown": _artifact_path(markdown_path),
             "result": _artifact_path(result_path),
@@ -80,9 +91,15 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "stderr": str(stderr_path),
             "summary": str(summary_path),
         },
+        "artifact_details": _artifact_details(artifact_paths),
+        "failure": _failure_summary(
+            returncode=completed.returncode,
+            result_payload=result_payload,
+            stderr=completed.stderr,
+        ),
         "result": result_payload,
     }
-    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_summary(summary_path, summary, artifact_paths)
     if (
         completed.returncode != 0
         and bool(args.allow_output_check_failures)
@@ -141,6 +158,77 @@ def _read_json(path: Path) -> dict[str, Any] | None:
 
 def _artifact_path(path: Path) -> str | None:
     return str(path) if path.exists() else None
+
+
+def _artifact_details(paths: dict[str, Path]) -> dict[str, dict[str, Any]]:
+    details = {}
+    for name, path in paths.items():
+        exists = path.exists()
+        details[name] = {
+            "path": str(path),
+            "exists": exists,
+            "bytes": path.stat().st_size if exists else None,
+        }
+    return details
+
+
+def _write_summary(
+    summary_path: Path,
+    summary: dict[str, Any],
+    artifact_paths: dict[str, Path],
+) -> None:
+    details = _artifact_details(artifact_paths)
+    if "summary" in details:
+        details["summary"]["exists"] = True
+        details["summary"]["bytes"] = None
+    summary["artifact_details"] = details
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _failure_summary(
+    *,
+    returncode: int,
+    result_payload: dict[str, Any] | None,
+    stderr: str,
+) -> dict[str, Any] | None:
+    if returncode == 0:
+        return None
+    failed_checks: list[str] = []
+    result_status = None
+    output_check_details: list[dict[str, Any]] = []
+    if isinstance(result_payload, dict):
+        result_status = result_payload.get("status")
+        failed_checks = [
+            str(check)
+            for check in result_payload.get("failed_output_checks") or []
+        ]
+        diagnostics = result_payload.get("diagnostics")
+        if isinstance(diagnostics, dict):
+            details = diagnostics.get("output_check_details")
+            if isinstance(details, list):
+                output_check_details = [
+                    dict(detail)
+                    for detail in details
+                    if isinstance(detail, dict) and detail.get("passed") is not True
+                ]
+    return {
+        "type": "output_checks" if failed_checks else "cli_error",
+        "exit_code": returncode,
+        "result_status": result_status,
+        "failed_output_checks": failed_checks,
+        "output_check_details": output_check_details,
+        "stderr_tail": _text_tail(stderr),
+    }
+
+
+def _text_tail(text: str, *, max_lines: int = 20, max_chars: int = 4000) -> str:
+    tail = "\n".join(text.splitlines()[-max_lines:])
+    if len(tail) > max_chars:
+        return tail[-max_chars:]
+    return tail
 
 
 def _is_output_check_failure(result_payload: dict[str, Any] | None) -> bool:

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -94,6 +94,12 @@ def test_faq_scale_smoke_writes_standard_artifacts(tmp_path: Path, fmt: str) -> 
     assert saved_summary["exit_code"] == 0
     assert saved_summary["result"]["generated"] == result["generated"]
     assert saved_summary["source_format"] == fmt
+    assert saved_summary["timing"]["elapsed_seconds"] >= 0
+    assert saved_summary["failure"] is None
+    assert saved_summary["artifact_details"]["markdown"]["exists"] is True
+    assert saved_summary["artifact_details"]["markdown"]["bytes"] > 0
+    assert saved_summary["artifact_details"]["summary"]["exists"] is True
+    assert saved_summary["artifact_details"]["summary"]["bytes"] is None
     assert (artifact_dir / "faq.md").read_text(encoding="utf-8").startswith(
         "# Customer Ticket FAQ Scale Smoke"
     )
@@ -118,6 +124,11 @@ def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path
     assert "FAQ output checks failed: condensed" in stderr
     assert not (artifact_dir / "faq.md").exists()
     assert summary["artifacts"]["markdown"] is None
+    assert summary["artifact_details"]["markdown"]["exists"] is False
+    assert summary["artifact_details"]["result"]["bytes"] > 0
+    assert summary["failure"]["type"] == "output_checks"
+    assert summary["failure"]["failed_output_checks"] == ["condensed"]
+    assert "FAQ output checks failed: condensed" in summary["failure"]["stderr_tail"]
     assert summary["result"]["diagnostics"]["rendered_ticket_source_count"] == 2
 
 
@@ -145,6 +156,10 @@ def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> Non
     assert code != 0
     assert summary["ok"] is False
     assert summary["result"] is None
+    assert summary["failure"]["type"] == "cli_error"
+    assert summary["failure"]["result_status"] is None
+    assert summary["artifact_details"]["result"]["exists"] is False
+    assert "No such file or directory" in summary["failure"]["stderr_tail"]
     assert "No such file or directory" in (
         tmp_path / "artifacts" / "stderr.txt"
     ).read_text(encoding="utf-8")
@@ -157,6 +172,13 @@ def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path) -> None:
     assert code == 0
     assert result["input"]["source_format"] == "auto"
     assert result["config"]["max_items"] == 12
+
+
+def test_text_tail_bounds_long_stderr() -> None:
+    assert smoke._text_tail("\n".join(f"line{i}" for i in range(50))).splitlines() == [
+        f"line{i}" for i in range(30, 50)
+    ]
+    assert len(smoke._text_tail("x" * 5000)) == 4000
 
 
 @pytest.mark.parametrize("overrides,message", [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Smoke-Observability.md

Adds compact observability to the FAQ scale-smoke summary so operators can see elapsed time, written artifact sizes, and whether a failure came from output checks or a hard CLI error without opening every artifact first.

## Intentional
- No FAQ generator behavior changes.
- Keep the existing artifacts path/null map for compatibility.
- Bound stderr copied into failure summaries.

## Deferred
- Raw-archive source-density reporting remains CFPB/exporter-specific work.
- Hosted artifact viewer remains separate.

## Verification
- Focused scale-smoke + FAQ Markdown CLI tests: 76 passed.
- Full extracted pipeline wrapper: passed, including 1,583 extracted Content Ops tests and 295 reasoning-core tests.
- Local PR review: passed.

## Diff size
3 files, +182 / -1