### PR TITLE
Show landing page readiness in review UI

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -552,7 +552,7 @@ function AssetDetailDrawer({
   const sections = sectionList(row.sections)
   const references = valueList(row.reference_ids)
   const faqItems = asset === 'faq_markdown' ? faqItemList(row.items) : []
-  const readinessPanels = asset === 'blog_post' ? blogReadinessPanels(row) : []
+  const readinessPanels = assetReadinessPanels(row, asset)
   const drawerRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
 
@@ -673,7 +673,7 @@ function AssetDetailDrawer({
         )}
 
         {readinessPanels.length > 0 && (
-          <BlogReadinessBreakdown panels={readinessPanels} />
+          <ReadinessBreakdown panels={readinessPanels} />
         )}
 
         {sections.length > 0 && (
@@ -781,7 +781,7 @@ function AssetDetailDrawer({
   )
 }
 
-function BlogReadinessBreakdown({ panels }: { panels: ReadinessPanel[] }) {
+function ReadinessBreakdown({ panels }: { panels: ReadinessPanel[] }) {
   return (
     <section className="mt-6">
       <h3 className="text-sm font-semibold text-slate-200">Readiness</h3>
@@ -936,6 +936,8 @@ function addAssetSpecificFacts(
   if (asset === 'landing_page') {
     addFact(facts, 'campaign', row.campaign_name)
     addFact(facts, 'persona', row.persona)
+    addFact(facts, 'SEO/AEO', readinessLabel(row.seo_aeo_readiness))
+    addFact(facts, 'GEO', readinessLabel(row.geo_readiness))
     return
   }
   if (asset === 'faq_markdown') {
@@ -1148,7 +1150,11 @@ function readinessSummary(value: unknown): ReadinessSummary | null {
   }
 }
 
-function blogReadinessPanels(row: GeneratedAssetDraft): ReadinessPanel[] {
+function assetReadinessPanels(
+  row: GeneratedAssetDraft,
+  asset: GeneratedAssetType,
+): ReadinessPanel[] {
+  if (asset !== 'blog_post' && asset !== 'landing_page') return []
   return [
     readinessPanel('SEO/AEO', row.seo_aeo_readiness),
     readinessPanel('GEO', row.geo_readiness),

--- a/plans/PR-Landing-Page-Readiness-Review-UI.md
+++ b/plans/PR-Landing-Page-Readiness-Review-UI.md
@@ -1,0 +1,73 @@
+# PR-Landing-Page-Readiness-Review-UI
+
+## Why this slice exists
+
+PR #710 added landing-page SEO/AEO and GEO readiness summaries to generated
+asset rows, and PRs #711, #712, and #717 made the generator respect those
+checks more directly. The review UI still only renders the full readiness
+breakdown for blog posts, so landing-page reviewers can see compact facts but
+must inspect the raw JSON to understand which checks passed or failed.
+
+This slice closes that UI gap without changing generation, persistence, export,
+or review behavior.
+
+## Scope (this PR)
+
+1. Reuse the existing readiness breakdown drawer section for landing pages.
+2. Keep blog-post readiness rendering unchanged.
+3. Add landing-page SEO/AEO and GEO compact facts beside campaign and persona
+   facts.
+4. Rename the blog-specific helper/component names so the UI reflects the shared
+   readiness surface.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Readiness-Review-UI.md` | Plan doc for this UI slice. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Render readiness panels for landing pages as well as blog posts. |
+
+## Mechanism
+
+The detail drawer already parses `seo_aeo_readiness` and `geo_readiness` into
+`ReadinessPanel` objects for blog posts. This PR promotes that helper from a
+blog-only function to an asset-aware function and returns panels for both
+`blog_post` and `landing_page` rows.
+
+The rendered card markup stays the same: status, pass count, missing checks,
+and per-check pass/fail rows. Landing pages also show SEO/AEO and GEO facts in
+the compact Facts block so operators can scan the queue and inspect the detail
+drawer without opening Raw Row.
+
+## Intentional
+
+- No backend or API changes; the required fields already ship on generated
+  asset rows.
+- No new generator, quality-gate, export, approval, or rejection behavior.
+- No readiness panels for reports, sales briefs, or FAQ Markdown until those
+  asset types have first-class readiness contracts.
+- No UI component tests because the Atlas Intel UI does not currently include a
+  component test runner.
+
+## Deferred
+
+- PR-Landing-Page-Publish-Verification should add public-rendered URL checks
+  once generated landing pages have a concrete hosted publish route.
+- PR-Generated-Asset-Readiness-Shared-Component can extract the readiness
+  breakdown if more generated asset types adopt the same contract.
+
+## Verification
+
+- `npm ci` in `atlas-intel-ui` -> completed; existing dependency audit reported
+  6 vulnerabilities.
+- `npm run lint` in `atlas-intel-ui` -> passed.
+- `npm run build` in `atlas-intel-ui` -> passed.
+- `git diff --check` -> passed with 0 whitespace errors.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Review UI | ~20 |
+| Total | ~90 |


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Readiness-Review-UI.md

Landing-page generated-asset rows now expose SEO/AEO and GEO readiness, but the detail drawer only showed the full readiness breakdown for blog posts. This PR reuses that existing drawer section for landing pages and adds compact landing-page readiness facts.

## Intentional
- No backend, API, generation, quality-gate, export, approval, or rejection behavior changes.
- Readiness panels stay limited to blog posts and landing pages because those are the generated asset types with first-class readiness fields.
- No UI component tests because the Atlas Intel UI does not currently include a component test runner.

## Deferred
- PR-Landing-Page-Publish-Verification should add public rendered-page checks when a hosted route exists.
- PR-Generated-Asset-Readiness-Shared-Component can extract this if more asset types adopt the readiness contract.

## Verification
- `npm ci` in `atlas-intel-ui` -> completed; existing dependency audit reported 6 vulnerabilities.
- `npm run lint` in `atlas-intel-ui` -> passed.
- `npm run build` in `atlas-intel-ui` -> passed.
- `git diff --check` -> passed with 0 whitespace errors.
- `bash scripts/local_pr_review.sh origin/main` -> passed.

## Diff size
2 files, +83 / -4