### PR TITLE
Thread landing page quality repair through execution

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -478,6 +478,7 @@ async def _dispatch_landing_page(
             step.config, "parse_retry_response_excerpt_chars"
         ),
         quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
+        quality_repair_attempts=_step_config_int(step.config, "quality_repair_attempts"),
     )
 
 

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -316,6 +316,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "max_tokens": config.max_tokens,
                 "temperature": config.temperature,
                 "quality_gates_enabled": request.require_quality_gates,
+                "quality_repair_attempts": config.quality_repair_attempts,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 **_reasoning_config_for_output(output, request),

--- a/plans/PR-Landing-Page-Quality-Repair-Execution.md
+++ b/plans/PR-Landing-Page-Quality-Repair-Execution.md
@@ -1,0 +1,89 @@
+# PR-Landing-Page-Quality-Repair-Execution
+
+## Why this slice exists
+
+PR #717 added quality repair attempts to
+`LandingPageGenerationService.generate(...)`, but the Content Ops plan and
+execution dispatcher still do not carry that value through. A direct caller can
+use the repair loop, while an operator running landing pages through Content Ops
+only sees the service construction default.
+
+That is an integration gap at the source of the execution path: the generated
+plan should expose the landing-page repair default, and the executor should
+pass the planned value into the service call just like it already does for
+temperature, max tokens, parse retry, and quality gates.
+
+## Scope (this PR)
+
+1. Add quality repair attempts to the landing-page generation plan step
+   config.
+2. Thread quality repair attempts from the landing-page step config into
+   `LandingPageGenerationService.generate(...)`.
+3. Update focused plan and execution tests so this integration point cannot
+   silently regress.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Quality-Repair-Execution.md` | Plan doc for this execution wiring slice. |
+| `extracted_content_pipeline/generation_plan.py` | Emit the landing-page quality repair attempt default in step config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Pass the planned repair attempt count into the landing-page service call. |
+| `tests/test_extracted_content_generation_plan.py` | Assert landing-page plan config includes the repair attempt count. |
+| `tests/test_extracted_content_ops_execution.py` | Assert landing-page execution dispatch passes the repair attempt count. |
+
+## Mechanism
+
+`_landing_page_config_for_request(...)` already returns a
+`LandingPageGenerationConfig`, which now owns the repair-attempt default. The
+landing-page branch in `_step_for_output(...)` includes that value in
+`step.config`.
+
+`_dispatch_landing_page(...)` reads the integer from `step.config` with the
+same typed helper used for other numeric controls and passes it to
+`service.generate(...)`.
+
+## Intentional
+
+- No new request input override in this slice. This only closes the default
+  plan-to-execution wiring gap.
+- No behavior change for direct `LandingPageGenerationService` callers.
+- No quality-gate or prompt changes.
+- No UI or API control-surface schema changes.
+- No equivalent repair loop added to other asset generators.
+
+## Deferred
+
+- PR-Landing-Page-Quality-Repair-Input-Override can add a validated operator
+  input if we want users to tune repair attempts per run.
+- PR-Generated-Asset-Repair-Telemetry can expose intermediate repair failures
+  in operator-facing diagnostics.
+- PR-Other-Asset-Quality-Repair can evaluate whether reports, sales briefs, or
+  blog posts should get the same repair-loop behavior.
+
+## Verification
+
+- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q`
+  -> passed 84/84 tests.
+- Python compile command over `extracted_content_pipeline/generation_plan.py`,
+  `extracted_content_pipeline/content_ops_execution.py`,
+  `tests/test_extracted_content_generation_plan.py`, and
+  `tests/test_extracted_content_ops_execution.py` -> passed 4/4 files.
+- `git diff --check` -> passed with 0 whitespace errors.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed mapped-file
+  and hard-import checks.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  -> passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed with
+  0 Atlas runtime import findings.
+- bash scripts/check_ascii_python.sh -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Generation plan wiring | ~5 |
+| Execution dispatcher wiring | ~5 |
+| Tests | ~15 |
+| Total | ~105 |

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -343,6 +343,7 @@ def test_plan_maps_landing_page_to_landing_page_generation_service():
         "max_tokens": 4096,
         "temperature": 0.3,
         "quality_gates_enabled": True,
+        "quality_repair_attempts": 1,
         "parse_retry_attempts": 1,
         "parse_retry_response_excerpt_chars": 800,
     }

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -260,6 +260,7 @@ class _LandingPageService:
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        quality_repair_attempts: int | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -270,6 +271,7 @@ class _LandingPageService:
             "parse_retry_attempts": parse_retry_attempts,
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
             "quality_gates_enabled": quality_gates_enabled,
+            "quality_repair_attempts": quality_repair_attempts,
             "extras": dict(extras),
         })
         return _Result()
@@ -1004,6 +1006,22 @@ async def test_execute_threads_quality_gates_enabled_into_landing_page() -> None
 
     call = landing.calls[0]
     assert call["quality_gates_enabled"] is True
+    assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_quality_repair_attempts_into_landing_page() -> None:
+    landing = _LandingPageService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {"campaign_name": "Q3", "offer": "Audit", "audience": "VPs"},
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    call = landing.calls[0]
+    assert call["quality_repair_attempts"] == 1
     assert call["extras"] == {}
 
 


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Quality-Repair-Execution.md

PR #717 added landing-page quality repair attempts at the generator, but the Content Ops plan and execution dispatcher did not carry that value into generated runs. This PR closes that integration gap so the planned landing-page service call receives the same repair-attempt default the generator exposes.

## Intentional
- No new request-level override; this only carries the generator default through plan and dispatch.
- No prompt, quality-gate, API, UI, or other asset-generator changes.
- No equivalent repair loop added to reports, sales briefs, or blog posts.

## Deferred
- PR-Landing-Page-Quality-Repair-Input-Override can add a validated operator override later.
- PR-Generated-Asset-Repair-Telemetry can expose intermediate repair diagnostics later.
- PR-Other-Asset-Quality-Repair can evaluate repair loops for other asset generators.

## Verification
- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q` -> 84/84 passed
- Python compile over the touched Python modules/tests -> passed
- `git diff --check` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Diff size
5 files, +110 / -0