### PR TITLE
Add landing page repair attempt input override

### DIFF
--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -8,7 +8,7 @@ call. Thrilling bureaucracy, but the useful kind.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date
 from typing import Any, Mapping, Sequence
 
@@ -31,6 +31,9 @@ from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
 from .ticket_faq_markdown import TicketFAQMarkdownConfig
+
+
+_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
 
 
 @dataclass(frozen=True)
@@ -159,20 +162,23 @@ def _validate_reasoning_runtime_request(
 
 
 def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageGenerationConfig:
-    """Return defaults; the request is intentionally not consumed.
+    """Return landing-page generation config for a control-surface request.
 
-    Other ``_*_config_for_request`` helpers thread ``request.inputs``
-    or ``request.limit`` into their config. Landing pages are
-    per-campaign single-shot (one MarketingCampaign in, one draft
-    out) so ``limit`` doesn't apply, and per-call inputs land on the
+    Landing pages are per-campaign single-shot (one MarketingCampaign in, one
+    draft out) so ``limit`` doesn't apply, and per-call copy inputs land on the
     ``MarketingCampaign`` payload built by
     ``content_ops_execution._marketing_campaign_from_inputs`` rather
-    than on the config dataclass. Discarding the request here is
-    deliberate -- documented to close the audit-trail gap on the
-    helper-shape asymmetry (PR-Audit-MINOR-Batch-3).
+    than on the config dataclass.
     """
-    del request  # intentional; see docstring
-    return LandingPageGenerationConfig()
+    defaults = LandingPageGenerationConfig()
+    repair_attempts = _nonnegative_int_input(
+        request.inputs,
+        "landing_page_quality_repair_attempts",
+        max_value=_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
+    )
+    if repair_attempts is None:
+        return defaults
+    return replace(defaults, quality_repair_attempts=repair_attempts)
 
 
 def _sales_brief_config_for_request(request: ContentOpsRequest) -> SalesBriefGenerationConfig:
@@ -246,6 +252,28 @@ def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
         raise ValueError(f"{key} must be an integer") from None
     if value < 1:
         raise ValueError(f"{key} must be at least 1; got {value}")
+    return value
+
+
+def _nonnegative_int_input(
+    inputs: Mapping[str, Any],
+    key: str,
+    *,
+    max_value: int | None = None,
+) -> int | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, (bool, float)):
+        raise ValueError(f"{key} must be an integer")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be an integer") from None
+    if value < 0:
+        raise ValueError(f"{key} must be at least 0; got {value}")
+    if max_value is not None and value > max_value:
+        raise ValueError(f"{key} must be at most {max_value}; got {value}")
     return value
 
 

--- a/plans/PR-Landing-Page-Quality-Repair-Input-Override.md
+++ b/plans/PR-Landing-Page-Quality-Repair-Input-Override.md
@@ -1,0 +1,89 @@
+# PR-Landing-Page-Quality-Repair-Input-Override
+
+## Why this slice exists
+
+PR #717 added the landing-page quality repair loop, and PR #720 threaded the
+default repair-attempt count through Content Ops planning and execution. The
+remaining operator gap is control: Content Ops runs still cannot tune that
+count per request.
+
+Operators need a small validated input for cost control and debugging. Setting
+the value to 0 should disable the repair pass for a run; setting a positive
+integer should allow more repair attempts without changing the service default
+for every caller.
+
+## Scope (this PR)
+
+1. Add a landing-page-only landing_page_quality_repair_attempts input.
+2. Allow non-negative integers, including 0.
+3. Reject booleans, floats, negative values, values above 10, and non-integer
+   strings.
+4. Keep all other landing-page generation inputs and defaults unchanged.
+5. Add focused plan and execution coverage for the override.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Quality-Repair-Input-Override.md` | Plan doc for this operator override slice. |
+| `extracted_content_pipeline/generation_plan.py` | Read and validate the landing-page repair-attempt override from request inputs. |
+| `tests/test_extracted_content_generation_plan.py` | Cover default, explicit zero, positive string, and invalid override behavior. |
+| `tests/test_extracted_content_ops_execution.py` | Prove the override reaches the landing-page service call. |
+
+## Mechanism
+
+_landing_page_config_for_request stops discarding the request. It reads
+landing_page_quality_repair_attempts from request inputs and returns a
+LandingPageGenerationConfig with the default repair-attempt count unless the
+input is present.
+
+A new non-negative integer input helper mirrors the existing positive-integer
+helper but accepts 0, because disabling repair is a valid operator choice. The
+landing-page override also caps the value at 10 so a typo cannot queue a runaway
+repair loop. The generated plan already emits quality_repair_attempts, and the
+executor already dispatches that value, so the override only needs to change
+the planned config.
+
+## Intentional
+
+- No UI form field in this slice; the New Run screen already supports raw
+  inputs JSON.
+- No change to the default repair count.
+- No generic quality_repair_attempts input shared by other assets.
+- No cost-estimate change; repair attempts are a quality fallback, while the
+  current preview budget is still parse-retry based.
+- No repair-loop changes for reports, sales briefs, or blog posts.
+
+## Deferred
+
+- PR-Landing-Page-Quality-Repair-UI-Control can add a first-class UI control if
+  operators use this frequently enough.
+- PR-Generated-Asset-Repair-Telemetry can expose intermediate repair failures
+  in operator-facing diagnostics.
+- PR-Content-Ops-Quality-Cost-Model can revisit budget estimation if repair
+  attempts should become part of preflight cost limits.
+
+## Verification
+
+- pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q
+  -> passed 93/93 tests.
+- Python compile command over `extracted_content_pipeline/generation_plan.py`,
+  `tests/test_extracted_content_generation_plan.py`, and
+  `tests/test_extracted_content_ops_execution.py` -> passed 3/3 files.
+- git diff --check -> passed with 0 whitespace errors.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed mapped-file
+  and hard-import checks.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed with
+  0 Atlas runtime import findings.
+- bash scripts/check_ascii_python.sh -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Generation plan override | ~45 |
+| Tests | ~75 |
+| Total | ~230 |

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -349,6 +349,75 @@ def test_plan_maps_landing_page_to_landing_page_generation_service():
     }
 
 
+def test_plan_threads_landing_page_quality_repair_attempt_override_zero():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 0,
+            },
+        }
+    )
+
+    assert plan["steps"][0]["config"]["quality_repair_attempts"] == 0
+
+
+def test_plan_threads_landing_page_quality_repair_attempt_override_string():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": "2",
+            },
+        }
+    )
+
+    assert plan["steps"][0]["config"]["quality_repair_attempts"] == 2
+
+
+def test_plan_threads_landing_page_quality_repair_attempt_override_max():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 10,
+            },
+        }
+    )
+
+    assert plan["steps"][0]["config"]["quality_repair_attempts"] == 10
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (-1, "landing_page_quality_repair_attempts must be at least 0"),
+        (11, "landing_page_quality_repair_attempts must be at most 10"),
+        (True, "landing_page_quality_repair_attempts must be an integer"),
+        (1.5, "landing_page_quality_repair_attempts must be an integer"),
+        ("many", "landing_page_quality_repair_attempts must be an integer"),
+    ],
+)
+def test_plan_rejects_invalid_landing_page_quality_repair_attempt_override(value, message):
+    with pytest.raises(ValueError, match=message):
+        build_generation_plan_from_mapping(
+            {
+                "outputs": ["landing_page"],
+                "inputs": {
+                    "offer": "Churn audit",
+                    "audience": "B2B SaaS founders",
+                    "landing_page_quality_repair_attempts": value,
+                },
+            }
+        )
+
+
 def test_plan_maps_sales_brief_to_sales_brief_generation_service():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -1026,6 +1026,27 @@ async def test_execute_threads_quality_repair_attempts_into_landing_page() -> No
 
 
 @pytest.mark.asyncio
+async def test_execute_threads_quality_repair_attempt_override_into_landing_page() -> None:
+    landing = _LandingPageService()
+    await execute_content_ops_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "campaign_name": "Q3",
+                "offer": "Audit",
+                "audience": "VPs",
+                "landing_page_quality_repair_attempts": 0,
+            },
+        },
+        services=ContentOpsExecutionServices(landing_page=landing),
+    )
+
+    call = landing.calls[0]
+    assert call["quality_repair_attempts"] == 0
+    assert call["extras"] == {}
+
+
+@pytest.mark.asyncio
 async def test_marketing_campaign_context_does_not_leak_unrelated_inputs() -> None:
     """Audit MAJOR fix: prior shape dumped every non-{name, persona,
     value_prop, vendors, categories, tags} input field into


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Quality-Repair-Input-Override.md

This PR lets Content Ops operators tune landing-page quality repair attempts per run through the raw inputs JSON. The new landing_page_quality_repair_attempts input accepts non-negative integers, including 0 to disable repair for a run, rejects values above 10 to prevent runaway repair loops, and keeps the default repair count unchanged.

## Intentional
- No UI form field in this slice; the New Run screen already supports raw inputs JSON.
- No default repair-count change.
- No generic quality_repair_attempts input shared by other assets.
- No cost-estimate change; repair attempts remain a quality fallback while preview budget is parse-retry based.

## Deferred
- PR-Landing-Page-Quality-Repair-UI-Control can add a first-class UI control later.
- PR-Generated-Asset-Repair-Telemetry can expose intermediate repair diagnostics later.
- PR-Content-Ops-Quality-Cost-Model can revisit budget estimation if repair attempts should affect preflight costs.

## Verification
- `pytest tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q` -> 93/93 passed
- Python compile over touched Python module/tests -> passed
- `git diff --check` -> passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/local_pr_review.sh origin/main` -> passed

## Diff size
4 files, +218 / -11