### PR TITLE
PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile.md
@@ -1,0 +1,73 @@
+# PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile
+
+## Why this slice exists
+
+The 1,000-row FAQ run proved the generator can process large batches quickly,
+but it also showed that source density matters: a raw archive can scan many
+rows before finding enough usable ticket narratives. PR-Content-Ops-FAQ-Scale-
+Smoke-Observability made failures visible after generation. Operators still
+need a quick preflight profile that says how many upload rows were seen, how
+many normalized into usable source opportunities, and which adapter warnings
+explain skipped rows.
+
+This keeps large-upload confidence grounded in the actual source file instead
+of only the generated FAQ result.
+
+## Scope (this PR)
+
+1. Add an `input_profile` block to the FAQ scale-smoke summary.
+2. Count raw rows for common CSV, JSONL, JSON array, and common JSON bundle
+   shapes where available.
+3. Use the public source adapter to report normalized usable row count and
+   warning counts by code.
+4. Preserve existing smoke exit behavior and FAQ generation behavior.
+5. Extend focused scale-smoke tests for source-profile success and hard-failure
+   visibility.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile.md`
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+The wrapper will compute a bounded preflight profile before launching the FAQ
+Markdown CLI. The profile uses standard parsing only for raw-row counts, then
+calls `load_source_campaign_opportunities_from_file` with the same source
+format, text limit, and default fields the CLI receives. Adapter warnings are
+summarized by code with a small sample for debugging.
+
+If preflight parsing fails, the wrapper records `input_profile.status="error"`
+and still runs the existing CLI so the CLI remains the source of truth for exit
+behavior and stderr artifacts.
+
+## Intentional
+
+- No FAQ generator behavior changes.
+- No fail-closed gate is added for density. This is visibility only.
+- Raw-row counting is best-effort for arbitrary JSON objects; unsupported bundle
+  shapes report `raw_row_count=null` instead of guessing.
+- The full warning list is not duplicated into the summary; the profile keeps a
+  bounded sample and counts by code.
+
+## Deferred
+
+- CFPB raw-archive scan count reporting remains exporter-specific work.
+- Hosted UI display for source-profile diagnostics remains separate.
+
+## Verification
+
+- Focused scale-smoke + FAQ Markdown CLI tests passed, 78 tests.
+- Full extracted pipeline wrapper passed, including 1,587 extracted Content Ops
+  tests and 295 reasoning-core tests.
+- Local PR review passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 73 |
+| Scale-smoke wrapper | 117 |
+| Tests | 50 |
+| **Total** | **240** |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
+from collections.abc import Mapping, Sequence
+import csv
 import json
 from pathlib import Path
 import subprocess
@@ -13,7 +16,29 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 FAQ_CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
+
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+
+
+_JSON_ROW_KEYS = (
+    "support_tickets",
+    "tickets",
+    "cases",
+    "conversations",
+    "complaints",
+    "reviews",
+    "feedback",
+    "sources",
+    "rows",
+    "data",
+)
+_SKIP_WARNING_CODES = {"empty_row", "missing_source_text", "row_not_object"}
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -64,6 +89,7 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     stderr_path = artifact_dir / "stderr.txt"
     summary_path = artifact_dir / "run_summary.json"
     command = _build_command(args, markdown_path=markdown_path, result_path=result_path)
+    input_profile = _input_profile(args)
     started = time.monotonic()
     completed = subprocess.run(command, check=False, capture_output=True, text=True)
     elapsed_seconds = time.monotonic() - started
@@ -83,6 +109,7 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "source": str(args.path),
         "source_format": args.source_format,
         "command": command,
+        "input_profile": input_profile,
         "timing": {"elapsed_seconds": round(elapsed_seconds, 6)},
         "artifacts": {
             "markdown": _artifact_path(markdown_path),
@@ -154,6 +181,96 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return data if isinstance(data, dict) else None
+
+
+def _input_profile(args: argparse.Namespace) -> dict[str, Any]:
+    profile = {
+        "status": "ok",
+        "raw_row_count": None,
+        "raw_row_count_source": None,
+        "usable_source_count": None,
+        "warning_count": None,
+        "warnings_by_code": {},
+        "skipped_row_count": None,
+        "missing_source_text_count": None,
+        "warning_sample": [],
+    }
+    try:
+        profile.update(_raw_row_profile(Path(args.path), str(args.source_format)))
+    except Exception as exc:  # pragma: no cover - exact host filesystem errors vary.
+        profile["raw_row_count_error"] = f"{type(exc).__name__}: {exc}"
+    try:
+        loaded = load_source_campaign_opportunities_from_file(
+            args.path,
+            file_format=args.source_format,
+            max_text_chars=args.max_text_chars,
+            default_fields=parse_default_fields_or_exit(args.default_field),
+        )
+    except (Exception, SystemExit) as exc:
+        profile["status"] = "error"
+        profile["error"] = f"{type(exc).__name__}: {exc}"
+        return profile
+    warnings = loaded.warning_dicts()
+    warnings_by_code = Counter(str(warning.get("code") or "unknown") for warning in warnings)
+    skipped_rows = {
+        int(warning["row_index"])
+        for warning in warnings
+        if warning.get("code") in _SKIP_WARNING_CODES and isinstance(warning.get("row_index"), int)
+    }
+    raw_count = profile.get("raw_row_count")
+    usable_count = len(loaded.opportunities)
+    profile.update({
+        "usable_source_count": usable_count,
+        "warning_count": len(warnings),
+        "warnings_by_code": dict(sorted(warnings_by_code.items())),
+        "skipped_row_count": len(skipped_rows),
+        "missing_source_text_count": warnings_by_code.get("missing_source_text", 0),
+        "warning_sample": warnings[:10],
+    })
+    if isinstance(raw_count, int) and raw_count > 0:
+        profile["usable_source_ratio"] = round(usable_count / raw_count, 6)
+    return profile
+
+
+def _raw_row_profile(path: Path, source_format: str) -> dict[str, Any]:
+    resolved = _resolve_source_format(path, source_format)
+    if resolved == "csv":
+        with path.open(newline="", encoding="utf-8") as handle:
+            return {
+                "raw_row_count": sum(1 for _row in csv.DictReader(handle)),
+                "raw_row_count_source": "csv_rows",
+            }
+    if resolved == "jsonl":
+        return {
+            "raw_row_count": sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip()),
+            "raw_row_count_source": "jsonl_lines",
+        }
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return {"raw_row_count": len(data), "raw_row_count_source": "json_array"}
+    if isinstance(data, Mapping):
+        bundle_counts = []
+        for key in _JSON_ROW_KEYS:
+            value = data.get(key)
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                bundle_counts.append((key, len(value)))
+        if bundle_counts:
+            keys = ",".join(key for key, _count in bundle_counts)
+            return {
+                "raw_row_count": sum(count for _key, count in bundle_counts),
+                "raw_row_count_source": f"json_bundle.{keys}",
+            }
+    return {"raw_row_count": None, "raw_row_count_source": None}
+
+
+def _resolve_source_format(path: Path, source_format: str) -> str:
+    if source_format != "auto":
+        return source_format
+    if path.suffix.lower() == ".csv":
+        return "csv"
+    if path.suffix.lower() == ".jsonl":
+        return "jsonl"
+    return "json"
 
 
 def _artifact_path(path: Path) -> str | None:

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -76,8 +76,17 @@ def _write_source(tmp_path: Path, fmt: str) -> Path:
     )
 
 
-@pytest.mark.parametrize("fmt", ["auto", "csv", "json", "jsonl"])
-def test_faq_scale_smoke_writes_standard_artifacts(tmp_path: Path, fmt: str) -> None:
+@pytest.mark.parametrize(("fmt", "raw_row_count_source"), [
+    ("auto", "json_array"),
+    ("csv", "csv_rows"),
+    ("json", "json_array"),
+    ("jsonl", "jsonl_lines"),
+])
+def test_faq_scale_smoke_writes_standard_artifacts(
+    tmp_path: Path,
+    fmt: str,
+    raw_row_count_source: str,
+) -> None:
     source = _write_source(tmp_path, fmt)
     code, summary = smoke.run_scale_smoke(_args(tmp_path, path=source, source_format=fmt))
 
@@ -94,6 +103,12 @@ def test_faq_scale_smoke_writes_standard_artifacts(tmp_path: Path, fmt: str) -> 
     assert saved_summary["exit_code"] == 0
     assert saved_summary["result"]["generated"] == result["generated"]
     assert saved_summary["source_format"] == fmt
+    assert saved_summary["input_profile"]["status"] == "ok"
+    assert saved_summary["input_profile"]["raw_row_count"] == 4
+    assert saved_summary["input_profile"]["raw_row_count_source"] == raw_row_count_source
+    assert saved_summary["input_profile"]["usable_source_count"] == 4
+    assert saved_summary["input_profile"]["missing_source_text_count"] == 0
+    assert saved_summary["input_profile"]["usable_source_ratio"] == 1.0
     assert saved_summary["timing"]["elapsed_seconds"] >= 0
     assert saved_summary["failure"] is None
     assert saved_summary["artifact_details"]["markdown"]["exists"] is True
@@ -110,6 +125,7 @@ def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path
         tmp_path,
         "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
         "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
+        "ticket-3,2026-05-01,Empty text,,billing",
     )
 
     code, summary = smoke.run_scale_smoke(_args(tmp_path, path=source))
@@ -129,6 +145,11 @@ def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path
     assert summary["failure"]["type"] == "output_checks"
     assert summary["failure"]["failed_output_checks"] == ["condensed"]
     assert "FAQ output checks failed: condensed" in summary["failure"]["stderr_tail"]
+    assert summary["input_profile"]["raw_row_count"] == 3
+    assert summary["input_profile"]["usable_source_count"] == 2
+    assert summary["input_profile"]["warnings_by_code"]["missing_source_text"] == 1
+    assert summary["input_profile"]["missing_source_text_count"] == 1
+    assert summary["input_profile"]["skipped_row_count"] == 1
     assert summary["result"]["diagnostics"]["rendered_ticket_source_count"] == 2
 
 
@@ -156,6 +177,8 @@ def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> Non
     assert code != 0
     assert summary["ok"] is False
     assert summary["result"] is None
+    assert summary["input_profile"]["status"] == "error"
+    assert "No such file or directory" in summary["input_profile"]["error"]
     assert summary["failure"]["type"] == "cli_error"
     assert summary["failure"]["result_status"] is None
     assert summary["artifact_details"]["result"]["exists"] is False
@@ -179,6 +202,29 @@ def test_text_tail_bounds_long_stderr() -> None:
         f"line{i}" for i in range(30, 50)
     ]
     assert len(smoke._text_tail("x" * 5000)) == 4000
+
+
+def test_raw_row_profile_counts_json_bundle_rows(tmp_path: Path) -> None:
+    source = tmp_path / "bundle.json"
+    source.write_text(
+        json.dumps({"support_tickets": [{}, {}, {}], "reviews": [{}, {}]}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert smoke._raw_row_profile(source, "auto") == {
+        "raw_row_count": 5,
+        "raw_row_count_source": "json_bundle.support_tickets,reviews",
+    }
+
+
+def test_raw_row_profile_returns_none_for_unrecognized_shape(tmp_path: Path) -> None:
+    source = tmp_path / "odd.json"
+    source.write_text(json.dumps({"items": [{}, {}]}) + "\n", encoding="utf-8")
+
+    assert smoke._raw_row_profile(source, "auto") == {
+        "raw_row_count": None,
+        "raw_row_count_source": None,
+    }
 
 
 @pytest.mark.parametrize("overrides,message", [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Smoke-Source-Profile.md

Adds an input_profile preflight block to FAQ scale-smoke summaries so operators can see raw rows, usable adapter rows, warning counts, skipped text rows, and warning samples before opening every artifact.

## Intentional
- No FAQ generator behavior changes.
- Source density is visibility only, not a new fail-closed gate.
- Raw row counts are best-effort for arbitrary JSON objects.
- The full warning list is not duplicated into the summary.

## Deferred
- CFPB raw-archive scan counts remain exporter-specific work.
- Hosted UI display for source-profile diagnostics remains separate.

## Verification
- Focused scale-smoke + FAQ Markdown CLI tests: 78 passed.
- Full extracted pipeline wrapper: passed, including 1,587 extracted Content Ops tests and 295 reasoning-core tests.
- Local PR review: passed.

## Diff size
3 files, +238 / -2