### PR TITLE
PR-Content-Ops-FAQ-CFPB-Archive-Profile

### DIFF
--- a/plans/PR-Content-Ops-FAQ-CFPB-Archive-Profile.md
+++ b/plans/PR-Content-Ops-FAQ-CFPB-Archive-Profile.md
@@ -1,0 +1,69 @@
+# PR-Content-Ops-FAQ-CFPB-Archive-Profile
+
+## Why this slice exists
+
+The FAQ generator scale smoke now reports generic input profiles, but the CFPB support-ticket demo still hides the source-prep shape for its public complaint archive fetch. That makes it harder to see whether a CFPB run produced too few FAQ-ready rows because the upstream archive returned sparse rows, missing narratives, missing complaint IDs, or because the FAQ generator itself failed.
+
+This slice adds CFPB-specific source profiling so archive extraction failures are acknowledged in the smoke artifact before the data enters the FAQ generator.
+
+## Scope (this PR)
+
+1. Add a profiled CFPB fetch helper that preserves the existing `fetch_cfpb_source_rows(...)` list-returning API.
+2. Count scanned rows, usable rows, rows skipped for missing narratives, rows skipped for missing complaint IDs, and the fetch stop reason.
+3. Include the CFPB source profile in the CFPB FAQ smoke JSON payload.
+4. Add focused tests for the exporter profile and smoke payload.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-CFPB-Archive-Profile.md`
+- `scripts/export_content_ops_cfpb_sources.py`
+- `scripts/smoke_content_ops_cfpb_faq_markdown.py`
+- `tests/test_export_content_ops_cfpb_sources.py`
+- `tests/test_smoke_content_ops_cfpb_faq_markdown.py`
+
+## Mechanism
+
+`fetch_cfpb_source_rows_with_profile(...)` will share the same CFPB request parameters as `fetch_cfpb_source_rows(...)`, stream CSV rows once, and return `(rows, profile)`. The existing `fetch_cfpb_source_rows(...)` becomes a wrapper that returns only `rows`, so existing callers do not change.
+
+The profile is derived from the raw CFPB row before conversion:
+
+```python
+if not complaint_id:
+    skipped_without_id_count += 1
+elif not narrative:
+    skipped_without_narrative_count += 1
+elif source_row:
+    rows.append(source_row)
+else:
+    skipped_other_count += 1
+```
+
+The CFPB FAQ smoke uses the profiled helper and writes `source_profile` beside `source_rows`, `source_rows_path`, and the FAQ result.
+
+## Intentional
+
+- The FAQ generator is unchanged; this slice only makes the CFPB archive extraction stage observable.
+- The existing `fetch_cfpb_source_rows(...)` API remains list-returning to avoid breaking current callers and tests.
+- No live CFPB network dependency is added to tests; fixtures stay as tiny fake CSV payloads.
+- The exporter CLI still emits JSONL rows only. The source profile is for programmatic smoke payloads, not a mixed stdout format.
+
+## Deferred
+
+- A future `PR-Content-Ops-FAQ-Archive-Runbook` can document how to interpret CFPB source profiles during large local archive runs.
+- A future UI slice can surface source-profile counts on hosted artifacts if the portfolio app needs user-facing diagnostics.
+
+## Verification
+
+- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_faq_markdown.py` passed, 16 tests.
+- `bash scripts/run_extracted_pipeline_checks.sh` passed, including 295 reasoning-core tests and 1,597 extracted Content Ops tests.
+- `bash scripts/local_pr_review.sh origin/main` passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 69 |
+| CFPB exporter | 76 |
+| CFPB smoke wrapper | 7 |
+| Tests | 109 |
+| **Total** | **261** |

--- a/scripts/export_content_ops_cfpb_sources.py
+++ b/scripts/export_content_ops_cfpb_sources.py
@@ -199,6 +199,48 @@ def fetch_cfpb_source_rows(
 ) -> list[dict[str, Any]]:
     """Fetch CFPB complaint rows and return Content Ops source rows."""
 
+    rows, _profile = fetch_cfpb_source_rows_with_profile(
+        api_url=api_url,
+        company=company,
+        product=product,
+        issue=issue,
+        search_term=search_term,
+        date_received_min=date_received_min,
+        date_received_max=date_received_max,
+        limit=limit,
+        max_rows_scanned=max_rows_scanned,
+        timeout=timeout,
+        source_system=source_system,
+        source_type=source_type,
+        detail_url_base=detail_url_base,
+        user_agent=user_agent,
+        referer=referer,
+        require_narrative=require_narrative,
+    )
+    return rows
+
+
+def fetch_cfpb_source_rows_with_profile(
+    *,
+    api_url: str = DEFAULT_API_URL,
+    company: str | None = None,
+    product: str | None = None,
+    issue: str | None = None,
+    search_term: str | None = None,
+    date_received_min: str | None = None,
+    date_received_max: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    max_rows_scanned: int = DEFAULT_MAX_ROWS_SCANNED,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    source_system: str = DEFAULT_SOURCE_SYSTEM,
+    source_type: str = DEFAULT_SOURCE_TYPE,
+    detail_url_base: str = DEFAULT_DETAIL_URL_BASE,
+    user_agent: str = DEFAULT_USER_AGENT,
+    referer: str = DEFAULT_REFERER,
+    require_narrative: bool = True,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Fetch CFPB source rows and return extraction visibility metadata."""
+
     params = build_cfpb_query(
         company=company,
         product=product,
@@ -214,21 +256,51 @@ def fetch_cfpb_source_rows(
         headers=build_cfpb_headers(user_agent=user_agent, referer=referer),
     )
     rows: list[dict[str, Any]] = []
+    scanned = 0
+    skipped_without_id = 0
+    skipped_without_narrative = 0
+    skipped_other = 0
+    stop_reason = "exhausted"
     with urlopen(request, timeout=timeout) as response:
         stream = io.TextIOWrapper(response, encoding="utf-8-sig", newline="")
         reader = csv.DictReader(stream)
         for scanned, row in enumerate(reader, start=1):
+            complaint_id = _clean_text(row.get(FIELD_COMPLAINT_ID))
+            narrative = _clean_text(row.get(FIELD_NARRATIVE))
             source_row = cfpb_row_to_source_row(
                 row,
                 source_system=source_system,
                 source_type=source_type,
                 detail_url_base=detail_url_base,
             )
-            if source_row:
+            if not complaint_id:
+                skipped_without_id += 1
+            elif not narrative:
+                skipped_without_narrative += 1
+            elif source_row:
                 rows.append(source_row)
+            else:
+                skipped_other += 1
             if len(rows) >= limit or scanned >= max_rows_scanned:
+                stop_reason = "limit" if len(rows) >= limit else "max_rows_scanned"
                 break
-    return rows
+    skipped_rows = skipped_without_id + skipped_without_narrative + skipped_other
+    profile: dict[str, Any] = {
+        "status": "ok",
+        "raw_row_count": scanned,
+        "raw_row_count_source": "cfpb_csv_rows_scanned",
+        "usable_source_count": len(rows),
+        "skipped_row_count": skipped_rows,
+        "missing_complaint_id_count": skipped_without_id,
+        "missing_narrative_count": skipped_without_narrative,
+        "skipped_other_count": skipped_other,
+        "usable_source_ratio": round(len(rows) / scanned, 6) if scanned else None,
+        "requested_source_count": int(limit),
+        "max_rows_scanned": int(max_rows_scanned),
+        "stop_reason": stop_reason,
+        "require_narrative": bool(require_narrative),
+    }
+    return rows, profile
 
 
 def render_jsonl(rows: Sequence[Mapping[str, Any]]) -> str:

--- a/scripts/smoke_content_ops_cfpb_faq_markdown.py
+++ b/scripts/smoke_content_ops_cfpb_faq_markdown.py
@@ -31,6 +31,7 @@ def _load_cfpb_exporter_module():
 
 _cfpb = _load_cfpb_exporter_module()
 fetch_cfpb_source_rows = _cfpb.fetch_cfpb_source_rows
+fetch_cfpb_source_rows_with_profile = _cfpb.fetch_cfpb_source_rows_with_profile
 render_jsonl = _cfpb.render_jsonl
 
 
@@ -78,9 +79,10 @@ def run_cfpb_faq_markdown_smoke(
 ) -> tuple[int, dict[str, Any]]:
     errors: list[str] = []
     rows: list[dict[str, Any]] = []
+    source_profile: dict[str, Any] = {"status": "not_started"}
     faq: dict[str, Any] | None = None
     try:
-        rows = fetch_cfpb_source_rows(
+        rows, source_profile = fetch_cfpb_source_rows_with_profile(
             api_url=str(args.api_url),
             company=args.company,
             product=args.product,
@@ -121,11 +123,14 @@ def run_cfpb_faq_markdown_smoke(
                 args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
                 args.output_markdown.write_text(result.markdown, encoding="utf-8")
     except Exception as exc:  # pragma: no cover - exercised by live hosts
+        if source_profile.get("status") == "not_started":
+            source_profile = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
         errors.append(f"{type(exc).__name__}: {exc}")
     return (0 if not errors else 1), {
         "ok": not errors,
         "source": "cfpb",
         "source_rows": len(rows),
+        "source_profile": source_profile,
         "source_rows_path": str(source_rows_path),
         "markdown_path": str(args.output_markdown) if args.output_markdown else None,
         "faq": faq,

--- a/tests/test_export_content_ops_cfpb_sources.py
+++ b/tests/test_export_content_ops_cfpb_sources.py
@@ -164,6 +164,46 @@ def test_fetch_cfpb_source_rows_streams_until_limit(monkeypatch):
     assert calls[0]["headers"]["Accept"] == "text/csv,*/*"
 
 
+def test_fetch_cfpb_source_rows_with_profile_counts_skipped_rows(monkeypatch):
+    csv_payload = (
+        "Complaint ID,Company,Product,Issue,Consumer complaint narrative\n"
+        ",Example Bank,Checking,Fees,Missing id complaint.\n"
+        "2,Example Bank,Checking,Fees,\n"
+        "3,Example Bank,Checking,Fees,First usable complaint.\n"
+        "4,Example Bank,Checking,Access,Second usable complaint.\n"
+        "5,Example Bank,Checking,Access,Third usable complaint.\n"
+    ).encode("utf-8")
+
+    def fake_urlopen(_request, timeout):
+        assert timeout == exporter.DEFAULT_TIMEOUT_SECONDS
+        return _Response(csv_payload)
+
+    monkeypatch.setattr(exporter, "urlopen", fake_urlopen)
+
+    rows, profile = exporter.fetch_cfpb_source_rows_with_profile(
+        api_url="https://example.test/cfpb",
+        limit=2,
+        max_rows_scanned=5,
+    )
+
+    assert [row["id"] for row in rows] == ["cfpb:3", "cfpb:4"]
+    assert profile == {
+        "status": "ok",
+        "raw_row_count": 4,
+        "raw_row_count_source": "cfpb_csv_rows_scanned",
+        "usable_source_count": 2,
+        "skipped_row_count": 2,
+        "missing_complaint_id_count": 1,
+        "missing_narrative_count": 1,
+        "skipped_other_count": 0,
+        "usable_source_ratio": 0.5,
+        "requested_source_count": 2,
+        "max_rows_scanned": 5,
+        "stop_reason": "limit",
+        "require_narrative": True,
+    }
+
+
 def test_fetch_cfpb_source_rows_threads_request_overrides(monkeypatch):
     csv_payload = (
         "Complaint ID,Company,Product,Issue,Consumer complaint narrative\n"

--- a/tests/test_smoke_content_ops_cfpb_faq_markdown.py
+++ b/tests/test_smoke_content_ops_cfpb_faq_markdown.py
@@ -29,6 +29,25 @@ def _row(row_id: str, text: str) -> dict[str, str]:
     }
 
 
+def _profile(*, source_count: int, scanned_count: int | None = None) -> dict[str, object]:
+    scanned = scanned_count if scanned_count is not None else source_count
+    return {
+        "status": "ok",
+        "raw_row_count": scanned,
+        "raw_row_count_source": "cfpb_csv_rows_scanned",
+        "usable_source_count": source_count,
+        "skipped_row_count": scanned - source_count,
+        "missing_complaint_id_count": 0,
+        "missing_narrative_count": scanned - source_count,
+        "skipped_other_count": 0,
+        "usable_source_ratio": round(source_count / scanned, 6) if scanned else None,
+        "requested_source_count": 2,
+        "max_rows_scanned": 5,
+        "stop_reason": "limit" if source_count >= 2 else "exhausted",
+        "require_narrative": True,
+    }
+
+
 def _args(**overrides):
     values = {
         "company": "Example Bank",
@@ -60,11 +79,15 @@ def test_cfpb_faq_smoke_builds_grounded_markdown(monkeypatch, tmp_path: Path) ->
     calls = []
     monkeypatch.setattr(
         smoke,
-        "fetch_cfpb_source_rows",
-        lambda **kwargs: calls.append(kwargs) or [
-            _row("1", "I was charged overdraft fees after I closed the account."),
-            _row("2", "My payment was applied to the wrong loan balance."),
-        ],
+        "fetch_cfpb_source_rows_with_profile",
+        lambda **kwargs: calls.append(kwargs)
+        or (
+            [
+                _row("1", "I was charged overdraft fees after I closed the account."),
+                _row("2", "My payment was applied to the wrong loan balance."),
+            ],
+            _profile(source_count=2, scanned_count=4),
+        ),
     )
 
     code, payload = smoke.run_cfpb_faq_markdown_smoke(
@@ -79,28 +102,52 @@ def test_cfpb_faq_smoke_builds_grounded_markdown(monkeypatch, tmp_path: Path) ->
         "has_action_items": True,
     }
     assert calls[0]["require_narrative"] is True
+    assert payload["source_profile"]["raw_row_count"] == 4
+    assert payload["source_profile"]["usable_source_count"] == 2
+    assert payload["source_profile"]["missing_narrative_count"] == 2
     markdown = (tmp_path / "cfpb_faq.md").read_text(encoding="utf-8")
     assert "What should I do if I was charged overdraft fees" in markdown
     assert "Open the bill, statement, payment history, or dispute record" in markdown
 
 
 def test_cfpb_faq_smoke_fails_when_fetch_returns_too_few_rows(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(smoke, "fetch_cfpb_source_rows", lambda **_kwargs: [_row("1", "I was charged a fee.")])
+    monkeypatch.setattr(
+        smoke,
+        "fetch_cfpb_source_rows_with_profile",
+        lambda **_kwargs: (
+            [_row("1", "I was charged a fee.")],
+            _profile(source_count=1, scanned_count=3),
+        ),
+    )
 
-    code, payload = smoke.run_cfpb_faq_markdown_smoke(_args(limit=2), source_rows_path=tmp_path / "rows.jsonl")
+    code, payload = smoke.run_cfpb_faq_markdown_smoke(
+        _args(limit=2),
+        source_rows_path=tmp_path / "rows.jsonl",
+    )
 
     assert code == 1
     assert payload["errors"] == ["expected 2 CFPB source row(s), got 1"]
+    assert payload["source_profile"]["raw_row_count"] == 3
+    assert payload["source_profile"]["usable_source_count"] == 1
 
 
-def test_cfpb_faq_smoke_accepts_source_policy_questions_for_weak_rows(monkeypatch, tmp_path: Path) -> None:
+def test_cfpb_faq_smoke_accepts_source_policy_questions_for_weak_rows(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.setattr(
         smoke,
-        "fetch_cfpb_source_rows",
-        lambda **_kwargs: [_row("1", "Fee appeared after closure."), _row("2", "Fees changed.")],
+        "fetch_cfpb_source_rows_with_profile",
+        lambda **_kwargs: (
+            [_row("1", "Fee appeared after closure."), _row("2", "Fees changed.")],
+            _profile(source_count=2),
+        ),
     )
 
-    code, payload = smoke.run_cfpb_faq_markdown_smoke(_args(), source_rows_path=tmp_path / "rows.jsonl")
+    code, payload = smoke.run_cfpb_faq_markdown_smoke(
+        _args(),
+        source_rows_path=tmp_path / "rows.jsonl",
+    )
 
     assert code == 0
     assert payload["faq"]["output_checks"] == {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-CFPB-Archive-Profile.md

The FAQ generator scale smoke already reports generic input profiles, but the CFPB support-ticket demo still hid the archive extraction shape. This adds CFPB-specific source profiling so smoke artifacts show scanned rows, usable rows, skipped rows, missing narratives, missing complaint IDs, and stop reason before data enters FAQ generation.

## Intentional
- Preserve `fetch_cfpb_source_rows(...)` as the existing list-returning API.
- Keep the exporter CLI JSONL-only; `source_profile` is emitted by the CFPB FAQ smoke payload.
- Avoid live CFPB dependencies in tests; fake CSV fixtures cover the profile behavior.

## Deferred
- `PR-Content-Ops-FAQ-Archive-Runbook` can document how to interpret CFPB source profiles during large local archive runs.
- Hosted UI surfacing remains separate if the portfolio app needs user-facing diagnostics.

## Verification
- `pytest tests/test_export_content_ops_cfpb_sources.py tests/test_smoke_content_ops_cfpb_faq_markdown.py` passed, 16 tests.
- `bash scripts/run_extracted_pipeline_checks.sh` passed, including 295 reasoning-core tests and 1,597 extracted Content Ops tests.
- `bash scripts/local_pr_review.sh origin/main` passed.

## Diff size
5 files, +247 / -14
