### PR TITLE
PR-Content-Ops-FAQ-Archive-Runbook

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -308,6 +308,30 @@ python scripts/smoke_content_ops_cfpb_faq_markdown.py \
   --json
 ```
 
+For a larger confidence run, raise both the requested source count and the scan
+cap, and write every artifact to disk:
+
+```bash
+python scripts/smoke_content_ops_cfpb_faq_markdown.py \
+  --search-term fees \
+  --limit 1000 \
+  --max-rows-scanned 5000 \
+  --max-items 20 \
+  --support-contact "https://support.example.com" \
+  --output-source-rows cfpb_sources_1000.jsonl \
+  --output-markdown cfpb_faq_1000.md \
+  --json > cfpb_faq_1000.summary.json
+```
+
+The JSON summary includes `source_profile` so operators can separate source
+prep from FAQ generation. Check `usable_source_count` against the requested
+limit first. If it is low while `raw_row_count` is high, inspect
+`missing_narrative_count`, `missing_complaint_id_count`, and
+`skipped_row_count` before changing the generator. If
+`stop_reason="max_rows_scanned"`, increase `--max-rows-scanned` or narrow the
+CFPB filters. If `usable_source_count` is healthy but FAQ output checks fail,
+investigate the FAQ grouping/output path.
+
 ```bash
 python scripts/smoke_content_ops_cfpb_source_postgres.py \
   --company "Example Bank" \

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -560,6 +560,29 @@ python scripts/export_content_ops_cfpb_sources.py \
   --output cfpb_sources.jsonl
 ```
 
+To prove large FAQ generation before importing into a database, run the CFPB FAQ
+smoke with a production-sized request and keep the summary payload:
+
+```bash
+python scripts/smoke_content_ops_cfpb_faq_markdown.py \
+  --search-term fees \
+  --limit 1000 \
+  --max-rows-scanned 5000 \
+  --max-items 20 \
+  --support-contact "https://support.example.com" \
+  --output-source-rows cfpb_sources_1000.jsonl \
+  --output-markdown cfpb_faq_1000.md \
+  --json > cfpb_faq_1000.summary.json
+```
+
+Read `source_profile` in the summary before debugging the FAQ generator.
+`raw_row_count` is the number of CFPB CSV rows scanned,
+`usable_source_count` is the number that became source rows, and
+`skipped_row_count` is explained by `missing_narrative_count`,
+`missing_complaint_id_count`, and `skipped_other_count`. A
+`stop_reason` of `max_rows_scanned` means the scan cap stopped extraction before
+enough usable rows were found.
+
 The DB smoke fetches CFPB rows, inspects source-row ingestion, imports them
 under the provided account id, and persists generated drafts through the
 Postgres runner. It defaults to offline generation; pass `--llm pipeline` to

--- a/plans/PR-Content-Ops-FAQ-Archive-Runbook.md
+++ b/plans/PR-Content-Ops-FAQ-Archive-Runbook.md
@@ -1,0 +1,65 @@
+# PR-Content-Ops-FAQ-Archive-Runbook
+
+## Why this slice exists
+
+The CFPB FAQ smoke now reports source-profile counts, but the operator docs
+still show only a tiny three-row demo and do not explain how to read those
+counts during larger runs. That leaves the same confidence gap the FAQ scale
+work is meant to close: a weak run should show whether the source archive was
+sparse or whether FAQ generation failed after enough usable rows were loaded.
+
+This slice documents the 1,000-row CFPB FAQ smoke and the `source_profile`
+fields that identify source-density issues.
+
+## Scope (this PR)
+
+1. Update the extracted package README with a 1,000-row CFPB FAQ smoke command.
+2. Document how to interpret `source_profile` counts and stop reasons.
+3. Mirror the same operator guidance in the host install runbook.
+4. Keep this docs-only; no runtime behavior changes.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Archive-Runbook.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+
+## Mechanism
+
+The docs will show the large-run command with `--limit 1000`,
+`--max-rows-scanned 5000`, `--output-source-rows`, `--output-markdown`, and
+`--json` so operators get the FAQ artifact, source rows, and summary payload in
+one run.
+
+The interpretation notes will map source-profile fields to next actions:
+`usable_source_count` below the requested limit means source prep failed early,
+`missing_narrative_count` and `missing_complaint_id_count` point at skipped CFPB
+rows, and `stop_reason="max_rows_scanned"` means the scan cap, not the FAQ
+generator, limited the run.
+
+## Intentional
+
+- No code changes. PR #725 already added the CFPB source-profile payload.
+- No live CFPB command is run as verification; docs changes should not depend on
+  external API availability.
+- The command writes local artifacts instead of implying hosted storage.
+
+## Deferred
+
+- Hosted UI surfacing for source-profile counts remains a separate portfolio or
+  host-dashboard slice.
+- A local static CFPB archive reader remains separate if operators need fully
+  offline CFPB extraction beyond generic source-file scale smoke runs.
+
+## Verification
+
+- `bash scripts/local_pr_review.sh origin/main` passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 65 |
+| README | 24 |
+| Host runbook | 23 |
+| **Total** | **112** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Archive-Runbook.md

The CFPB FAQ smoke now reports source-profile counts, but the operator docs still showed only a tiny three-row demo. This documents the 1,000-row CFPB FAQ smoke and explains how to read `source_profile` so operators can separate source-density issues from FAQ generation issues.

## Intentional
- Keep this docs-only; PR #725 added the runtime profile payload.
- Do not run a live CFPB smoke as verification because docs changes should not depend on external API availability.
- Keep the documented artifacts local: source rows, Markdown, and JSON summary.

## Deferred
- Hosted UI surfacing for source-profile counts remains separate.
- Fully offline CFPB archive extraction remains separate from this runbook slice.

## Verification
- `bash scripts/local_pr_review.sh origin/main` passed.

## Diff size
3 files, +112 / -0
