### PR TITLE
PR-Content-Ops-FAQ-Scale-Console-Profile

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Console-Profile.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Console-Profile.md
@@ -1,0 +1,63 @@
+# PR-Content-Ops-FAQ-Scale-Console-Profile
+
+## Why this slice exists
+
+The FAQ scale smoke writes a detailed `run_summary.json`, but the CLI itself
+returns silently. During large upload testing, that forces operators to open the
+JSON artifact before they can tell whether a failure was caused by sparse input
+rows, source adapter warnings, or FAQ output checks.
+
+This slice adds a compact console summary so failures are acknowledged at the
+command line while keeping the JSON artifact as the source of truth.
+
+## Scope (this PR)
+
+1. Print a one-line pass/fail summary from `smoke_content_ops_faq_scale_run.py`.
+2. Include source-density fields from `input_profile` in that line.
+3. Include failure type and summary artifact path when the run fails.
+4. Add focused tests for the console output.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Console-Profile.md`
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+`main(...)` will keep calling `run_scale_smoke(...)`, then pass the returned
+summary into a small printer. The printer derives a compact profile string from
+`input_profile`, such as `source_rows=2/3 skipped_rows=1
+missing_source_text=1`, and writes success summaries to stdout and failure
+summaries to stderr.
+
+The JSON summary, artifact paths, exit-code behavior, and
+`--allow-output-check-failures` semantics remain unchanged.
+
+## Intentional
+
+- This is visibility only; no new fail-closed rule is added.
+- The console line is compact and does not duplicate the full JSON summary.
+- Programmatic callers of `run_scale_smoke(...)` still receive the same tuple
+  and do not print.
+
+## Deferred
+
+- Rich terminal formatting remains out of scope.
+- Hosted UI surfacing for input profiles remains a separate UI/dashboard slice.
+
+## Verification
+
+- Focused pytest passed, 17 tests: pytest tests/test_smoke_content_ops_faq_scale_run.py
+- Full extracted pipeline checks passed, including 295 reasoning-core tests and
+  1,597 extracted Content Ops tests: bash scripts/run_extracted_pipeline_checks.sh
+- Local PR review passed: bash scripts/local_pr_review.sh origin/main
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 63 |
+| Scale-smoke wrapper | 45 |
+| Tests | 28 |
+| **Total** | **136** |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -63,7 +63,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     _validate_args(args)
-    code, _summary = run_scale_smoke(args)
+    code, summary = run_scale_smoke(args)
+    _print_scale_summary(summary)
     return code
 
 
@@ -303,6 +304,48 @@ def _write_summary(
         json.dumps(summary, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _print_scale_summary(summary: Mapping[str, Any]) -> None:
+    artifacts = summary.get("artifacts") if isinstance(summary.get("artifacts"), Mapping) else {}
+    summary_path = artifacts.get("summary") if isinstance(artifacts, Mapping) else None
+    profile = _console_input_profile(summary.get("input_profile"))
+    if summary.get("ok") is True:
+        print(
+            "Content Ops FAQ scale smoke passed: "
+            f"{profile} summary={summary_path}"
+        )
+        return
+    failure = summary.get("failure") if isinstance(summary.get("failure"), Mapping) else {}
+    failure_type = failure.get("type") if isinstance(failure, Mapping) else None
+    print(
+        "Content Ops FAQ scale smoke failed: "
+        f"{profile} failure={failure_type or 'unknown'} summary={summary_path}",
+        file=sys.stderr,
+    )
+
+
+def _console_input_profile(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return "source_rows=unknown"
+    parts = [f"input_status={value.get('status') or 'unknown'}"]
+    usable = value.get("usable_source_count")
+    raw = value.get("raw_row_count")
+    if usable is not None or raw is not None:
+        parts.append(f"source_rows={_console_value(usable)}/{_console_value(raw)}")
+    for key, label in (
+        ("skipped_row_count", "skipped_rows"),
+        ("missing_source_text_count", "missing_source_text"),
+        ("warning_count", "warnings"),
+    ):
+        item = value.get(key)
+        if item not in (None, 0):
+            parts.append(f"{label}={item}")
+    return " ".join(parts)
+
+
+def _console_value(value: Any) -> str:
+    return str(value) if value is not None else "unknown"
 
 
 def _failure_summary(

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -188,13 +188,39 @@ def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> Non
     ).read_text(encoding="utf-8")
 
 
-def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path) -> None:
+def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path, capsys) -> None:
     code = smoke.main([str(SUPPORT_TICKET_CSV), "--artifact-dir", str(tmp_path / "artifacts")])
 
     result = json.loads((tmp_path / "artifacts" / "faq_result.json").read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
     assert code == 0
+    assert "Content Ops FAQ scale smoke passed:" in captured.out
+    assert "source_rows=4/4" in captured.out
+    assert "summary=" in captured.out
+    assert captured.err == ""
     assert result["input"]["source_format"] == "auto"
     assert result["config"]["max_items"] == 12
+
+
+def test_faq_scale_smoke_main_prints_profile_on_failure(tmp_path: Path, capsys) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Unique one,The export button moved.,exports",
+        "ticket-2,2026-05-01,Unique two,Billing receipt is missing.,billing",
+        "ticket-3,2026-05-01,Empty text,,billing",
+    )
+
+    code = smoke.main([str(source), "--artifact-dir", str(tmp_path / "artifacts")])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "Content Ops FAQ scale smoke failed:" in captured.err
+    assert "source_rows=2/3" in captured.err
+    assert "skipped_rows=1" in captured.err
+    assert "missing_source_text=1" in captured.err
+    assert "failure=output_checks" in captured.err
+    assert "summary=" in captured.err
 
 
 def test_text_tail_bounds_long_stderr() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Console-Profile.md

The FAQ scale smoke writes a detailed `run_summary.json`, but the CLI returned silently. This adds a compact pass/fail console summary with source-density fields so operators can immediately see whether a large-upload failure came from sparse input rows, adapter warnings, or FAQ output checks.

## Intentional
- Visibility only; no new fail-closed rule.
- Keep the console line compact and leave `run_summary.json` as the detailed artifact.
- Preserve `run_scale_smoke(...)` programmatic behavior.

## Deferred
- Rich terminal formatting remains out of scope.
- Hosted UI surfacing for input profiles remains separate.

## Verification
- Focused pytest passed, 17 tests: pytest tests/test_smoke_content_ops_faq_scale_run.py
- Full extracted pipeline checks passed, including 295 reasoning-core tests and 1,597 extracted Content Ops tests: bash scripts/run_extracted_pipeline_checks.sh
- Local PR review passed: bash scripts/local_pr_review.sh origin/main

## Diff size
3 files, +134 / -2
