### PR TITLE
Generator: sweep orphan quote-reference follow-ons (#706 prevention)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1695,7 +1695,16 @@ def _looks_like_orphan_quote_reference(line: str) -> bool:
         return False
     if re.match(r"^\d+\.\s", stripped):  # ordered list item
         return False
-    if re.match(r"^the witness\b", stripped, re.IGNORECASE):
+    # Exclude only AGGREGATE witness references ("the witness evidence/data/
+    # highlights ..."), which cite aggregate data, not a quote. A genuine
+    # orphan ref like "The witness quoted earlier ..." must still be caught
+    # (Codex review on #728), so the guard is the aggregate-noun form rather
+    # than a bare "the witness" prefix.
+    if re.match(
+        r"^the witness\s+(?:evidence|data|highlights?|packet|signals?)\b",
+        stripped,
+        re.IGNORECASE,
+    ):
         return False
     return bool(_ORPHAN_QUOTE_REF_RE.match(stripped) or _QUOTED_EARLIER_RE.search(line))
 

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1668,6 +1668,38 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
     return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
 
 
+# Quote back-reference patterns. A paragraph that points at a specific quote
+# ("That/This quote", "This/The excerpt", or "quoted earlier") is orphaned when
+# the quote it references was stripped, leaving a dangling non-sequitur. Kept
+# in sync with the seo-geo-aeo-blog-post skill's orphaned_quote_reference
+# detector. Aggregate "the witness ..." references and generic follow-ons
+# ("This pattern recurs ...") are deliberately NOT matched.
+_ORPHAN_QUOTE_REF_RE = re.compile(
+    r"^(?:that quote|this quote|the quote\b|this excerpt|the excerpt)\b",
+    re.IGNORECASE,
+)
+_QUOTED_EARLIER_RE = re.compile(r"\bquoted earlier\b", re.IGNORECASE)
+
+
+def _looks_like_orphan_quote_reference(line: str) -> bool:
+    """True if ``line`` explicitly back-references a quote that no longer
+    exists (its block was stripped), leaving a dangling reference. When a
+    stripped blockquote is followed by such a paragraph, the paragraph is
+    orphaned and should be swept with the block. Same structural guards as
+    ``_looks_like_orphan_disclaimer``; aggregate "the witness ..." references
+    and generic follow-ons are not matched."""
+    if not line or not line.strip():
+        return False
+    stripped = line.lstrip()
+    if stripped.startswith((">", "#", "-", "*", "+")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
+        return False
+    if re.match(r"^the witness\b", stripped, re.IGNORECASE):
+        return False
+    return bool(_ORPHAN_QUOTE_REF_RE.match(stripped) or _QUOTED_EARLIER_RE.search(line))
+
+
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool, AND the orphan prose adjacent to them.
@@ -1770,13 +1802,17 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
                 # the block.
                 span_start = cursor
 
-        # Widen the span forward to swallow blank separators + an
-        # orphan disclaimer paragraph.
+        # Widen the span forward to swallow blank separators + an orphan
+        # disclaimer OR an orphan quote back-reference paragraph (both
+        # reference the stripped quote and dangle without it).
         span_end = block_end
         cursor = block_end
         while cursor < n and not lines[cursor].strip():
             cursor += 1
-        if cursor < n and _looks_like_orphan_disclaimer(lines[cursor]):
+        if cursor < n and (
+            _looks_like_orphan_disclaimer(lines[cursor])
+            or _looks_like_orphan_quote_reference(lines[cursor])
+        ):
             span_end = cursor + 1
 
         strip_spans.append((span_start, span_end))

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1695,7 +1695,16 @@ def _looks_like_orphan_quote_reference(line: str) -> bool:
         return False
     if re.match(r"^\d+\.\s", stripped):  # ordered list item
         return False
-    if re.match(r"^the witness\b", stripped, re.IGNORECASE):
+    # Exclude only AGGREGATE witness references ("the witness evidence/data/
+    # highlights ..."), which cite aggregate data, not a quote. A genuine
+    # orphan ref like "The witness quoted earlier ..." must still be caught
+    # (Codex review on #728), so the guard is the aggregate-noun form rather
+    # than a bare "the witness" prefix.
+    if re.match(
+        r"^the witness\s+(?:evidence|data|highlights?|packet|signals?)\b",
+        stripped,
+        re.IGNORECASE,
+    ):
         return False
     return bool(_ORPHAN_QUOTE_REF_RE.match(stripped) or _QUOTED_EARLIER_RE.search(line))
 

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1668,6 +1668,38 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
     return any(p.search(line) for p in _ORPHAN_DISCLAIMER_RES)
 
 
+# Quote back-reference patterns. A paragraph that points at a specific quote
+# ("That/This quote", "This/The excerpt", or "quoted earlier") is orphaned when
+# the quote it references was stripped, leaving a dangling non-sequitur. Kept
+# in sync with the seo-geo-aeo-blog-post skill's orphaned_quote_reference
+# detector. Aggregate "the witness ..." references and generic follow-ons
+# ("This pattern recurs ...") are deliberately NOT matched.
+_ORPHAN_QUOTE_REF_RE = re.compile(
+    r"^(?:that quote|this quote|the quote\b|this excerpt|the excerpt)\b",
+    re.IGNORECASE,
+)
+_QUOTED_EARLIER_RE = re.compile(r"\bquoted earlier\b", re.IGNORECASE)
+
+
+def _looks_like_orphan_quote_reference(line: str) -> bool:
+    """True if ``line`` explicitly back-references a quote that no longer
+    exists (its block was stripped), leaving a dangling reference. When a
+    stripped blockquote is followed by such a paragraph, the paragraph is
+    orphaned and should be swept with the block. Same structural guards as
+    ``_looks_like_orphan_disclaimer``; aggregate "the witness ..." references
+    and generic follow-ons are not matched."""
+    if not line or not line.strip():
+        return False
+    stripped = line.lstrip()
+    if stripped.startswith((">", "#", "-", "*", "+")):
+        return False
+    if re.match(r"^\d+\.\s", stripped):  # ordered list item
+        return False
+    if re.match(r"^the witness\b", stripped, re.IGNORECASE):
+        return False
+    return bool(_ORPHAN_QUOTE_REF_RE.match(stripped) or _QUOTED_EARLIER_RE.search(line))
+
+
 def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tuple[str, int]:
     """Strip LLM-generated blockquote BLOCKS that do not ground in a
     quote-grade source pool, AND the orphan prose adjacent to them.
@@ -1770,13 +1802,17 @@ def _remove_unmatched_quote_lines(markdown: str, source_quotes: list[str]) -> tu
                 # the block.
                 span_start = cursor
 
-        # Widen the span forward to swallow blank separators + an
-        # orphan disclaimer paragraph.
+        # Widen the span forward to swallow blank separators + an orphan
+        # disclaimer OR an orphan quote back-reference paragraph (both
+        # reference the stripped quote and dangle without it).
         span_end = block_end
         cursor = block_end
         while cursor < n and not lines[cursor].strip():
             cursor += 1
-        if cursor < n and _looks_like_orphan_disclaimer(lines[cursor]):
+        if cursor < n and (
+            _looks_like_orphan_disclaimer(lines[cursor])
+            or _looks_like_orphan_quote_reference(lines[cursor])
+        ):
             span_end = cursor + 1
 
         strip_spans.append((span_start, span_end))

--- a/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
+++ b/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
@@ -19,15 +19,19 @@ in sync.
 
 1. Add `_looks_like_orphan_quote_reference(line)` -- mirrors the skill
    detector: matches a line starting with "That/This quote", "This/The
-   excerpt", or containing "quoted earlier"; excludes aggregate "the witness
-   ..." references, generic follow-ons, and markdown structural lines (`>`,
-   `#`, `-`, `*`, `+`, ordered list), same guards as
-   `_looks_like_orphan_disclaimer`.
+   excerpt", or containing "quoted earlier"; same structural guards as
+   `_looks_like_orphan_disclaimer`. The witness guard excludes only the
+   AGGREGATE-noun forms ("the witness evidence/data/highlights/..."), so a
+   genuine orphan ref like "The witness quoted earlier ..." is still caught
+   (per Codex review on #728).
 2. Extend the forward-sweep in `_remove_unmatched_quote_lines` to widen across
    an orphan quote-reference paragraph as well as a disclaimer.
-3. Add two tests: the sweep fires on the back-reference shapes; a
-   false-positive guard that a generic follow-on ("This pattern recurs ...")
-   and an aggregate "The witness evidence ..." reference are preserved.
+3. Tests: the sweep fires on the back-reference shapes (incl. "The witness
+   quoted earlier ..."); a false-positive guard that a generic follow-on and
+   an aggregate "The witness evidence ..." reference are preserved; and a
+   quote-reference-shaped follow-on after a KEPT (grounded) block survives
+   (the legitimate #723 case -- the line matches the matcher, so the
+   stripped-block gate is the only protection, and this pins it).
 4. Sync the change into the `extracted_content_pipeline` mirror.
 
 ### Files touched
@@ -66,8 +70,9 @@ configurable values. `_remove_unmatched_quote_lines`'s signature is unchanged.
 ## Verification
 
 - `tests/test_b2b_blog_post_generation_quote_gate.py` run via pytest ->
-  `85 passed` (was 83; +2: orphan-quote-reference swept, and the
-  generic/witness false-positive guard).
+  `86 passed` (orphan-quote-reference swept incl. "The witness quoted
+  earlier ..."; generic/aggregate-witness false-positive guard; and the
+  kept-block-survives case from the #728 review).
 - `extracted_content_pipeline` re-synced via
   `extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`
   (`refreshed from atlas_brain sources (43 files)`); mirror carries the new

--- a/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
+++ b/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
@@ -1,0 +1,86 @@
+# PR-Blog-Generator-Orphan-Quote-Ref
+
+## Why this slice exists
+
+The generator-prevention phase of #706. The data fix (#723) cleaned the 7
+orphaned quote references already live in `main`; this closes the upstream so
+future generations cannot reintroduce them.
+
+When `_remove_unmatched_quote_lines` strips an ungrounded/empty blockquote it
+already sweeps an adjacent orphan **intro** (lead-in ending ":") and orphan
+**disclaimer** paragraph. It did NOT sweep a following paragraph that
+back-references the stripped quote ("This quote captures...", "The excerpt
+cuts off...", "quoted earlier") -- exactly the shape that shipped into the 5
+posts the data fix repaired. This widens the forward-sweep to catch that shape
+too, keeping the generator and the skill's `orphaned_quote_reference` detector
+in sync.
+
+## Scope (this PR)
+
+1. Add `_looks_like_orphan_quote_reference(line)` -- mirrors the skill
+   detector: matches a line starting with "That/This quote", "This/The
+   excerpt", or containing "quoted earlier"; excludes aggregate "the witness
+   ..." references, generic follow-ons, and markdown structural lines (`>`,
+   `#`, `-`, `*`, `+`, ordered list), same guards as
+   `_looks_like_orphan_disclaimer`.
+2. Extend the forward-sweep in `_remove_unmatched_quote_lines` to widen across
+   an orphan quote-reference paragraph as well as a disclaimer.
+3. Add two tests: the sweep fires on the back-reference shapes; a
+   false-positive guard that a generic follow-on ("This pattern recurs ...")
+   and an aggregate "The witness evidence ..." reference are preserved.
+4. Sync the change into the `extracted_content_pipeline` mirror.
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+- `plans/PR-Blog-Generator-Orphan-Quote-Ref.md`
+
+## Mechanism
+
+The forward-sweep only fires on a STRIPPED block, so the blast radius is
+bounded by the existing block-strip logic. The new matcher reuses the
+disclaimer guards, so a fresh blockquote / heading / list item that happens to
+start with "this quote" is not swept. Patterns are ASCII-only (Python Unicode
+policy) and are pattern definitions (like `_ORPHAN_DISCLAIMER_RES`), not
+configurable values. `_remove_unmatched_quote_lines`'s signature is unchanged.
+
+## Intentional
+
+- **Explicit back-reference only.** Generic follow-ons ("This pattern recurs")
+  are accepted behavior and carry real analysis -- they are NOT swept. Only
+  paragraphs that name "this/that quote", "this/the excerpt", or "quoted
+  earlier" are.
+- **Whole-paragraph sweep (generator), surgical edit (data fix).** New
+  generation removes the dangling follow-on outright (the quote it cites is
+  gone); the published-data fix (#723) was surgical to preserve already-shipped
+  analysis. Different tools, different appropriate behavior.
+- **Kept in sync with the skill detector**, as with the disclaimer patterns
+  (#703).
+
+## Deferred
+
+- None; this completes #706 alongside #723.
+
+## Verification
+
+- `tests/test_b2b_blog_post_generation_quote_gate.py` run via pytest ->
+  `85 passed` (was 83; +2: orphan-quote-reference swept, and the
+  generic/witness false-positive guard).
+- `extracted_content_pipeline` re-synced via
+  `extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`
+  (`refreshed from atlas_brain sources (43 files)`); mirror carries the new
+  function.
+- `scripts/local_pr_review.sh` -> plan shape, plan/code consistency, extracted
+  manifest sync, ASCII Python policy, `git diff --check`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `b2b_blog_post_generation.py` (matcher + sweep) | ~45 |
+| `extracted_content_pipeline` mirror | ~45 |
+| `test_b2b_blog_post_generation_quote_gate.py` (2 tests) | ~40 |
+| Plan doc | ~95 |
+| **Total** | **~225** |

--- a/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
+++ b/plans/PR-Blog-Generator-Orphan-Quote-Ref.md
@@ -84,8 +84,8 @@ configurable values. `_remove_unmatched_quote_lines`'s signature is unchanged.
 
 | Area | Estimated LOC |
 |---|---:|
-| `b2b_blog_post_generation.py` (matcher + sweep) | ~45 |
-| `extracted_content_pipeline` mirror | ~45 |
-| `test_b2b_blog_post_generation_quote_gate.py` (2 tests) | ~40 |
-| Plan doc | ~95 |
-| **Total** | **~225** |
+| `b2b_blog_post_generation.py` (matcher + sweep) | ~55 |
+| `extracted_content_pipeline` mirror | ~55 |
+| `test_b2b_blog_post_generation_quote_gate.py` (tests) | ~55 |
+| Plan doc | ~90 |
+| **Total** | **~255** |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -596,6 +596,44 @@ def test_offtopic_pattern_does_not_sweep_nondisclaimer_following_prose():
     assert "Buyers value simplicity rather than feature depth" in out
 
 
+def test_orphan_quote_reference_swept_with_block():
+    """A stripped blockquote followed by a paragraph that back-references the
+    quote ("This quote ...", "The excerpt ...", "quoted earlier") is swept
+    with the block -- the reference dangles once the quote is gone."""
+    for follow in (
+        "This quote shows an active evaluation in progress.",
+        "The excerpt cuts off, but the signal is clear: teams compare costs.",
+        "The Reddit reviewer quoted earlier described it as the worst so far.",
+    ):
+        markdown = (
+            "## Section\n\n"
+            "> a quote that gets stripped (empty source pool)\n\n"
+            f"{follow}\n"
+        )
+        out, _removed = _remove_unmatched_quote_lines(markdown, [])
+        assert "gets stripped" not in out
+        assert follow not in out, follow
+        assert "## Section" in out
+
+
+def test_quote_reference_does_not_sweep_generic_or_witness_followon():
+    """False-positive guard: a generic follow-on or an aggregate
+    "The witness evidence ..." reference after a stripped block is preserved
+    -- neither is an orphaned quote back-reference."""
+    for follow in (
+        "This pattern recurs across the dataset.",
+        "The witness evidence shows workflow migration at the team level.",
+    ):
+        markdown = (
+            "## Section\n\n"
+            "> an ungrounded quote\n\n"
+            f"{follow}\n"
+        )
+        out, _removed = _remove_unmatched_quote_lines(markdown, [])
+        assert "ungrounded quote" not in out  # block still stripped
+        assert follow in out, follow          # follow-on preserved
+
+
 def test_orphan_prose_preserved_for_kept_blocks():
     """When a block is KEPT (its quotes ground), the surrounding intro
     and prose are also preserved. The orphan-prose cleanup only fires

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -36,6 +36,7 @@ from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (  # noqa: E40
     _blueprint_pricing_reality_check,
     _blueprint_vendor_showdown,
     _is_placeholder_partner,
+    _looks_like_orphan_quote_reference,
     _pick_affiliate_partner_for_vendors,
     _quote_grade_blueprint_phrases,
     _remove_unmatched_quote_lines,
@@ -604,6 +605,9 @@ def test_orphan_quote_reference_swept_with_block():
         "This quote shows an active evaluation in progress.",
         "The excerpt cuts off, but the signal is clear: teams compare costs.",
         "The Reddit reviewer quoted earlier described it as the worst so far.",
+        # "the witness" prefix must NOT suppress a genuine orphan ref -- the
+        # guard only excludes the aggregate-noun forms (Codex review on #728).
+        "The witness quoted earlier described the rollout as a disaster.",
     ):
         markdown = (
             "## Section\n\n"
@@ -614,6 +618,26 @@ def test_orphan_quote_reference_swept_with_block():
         assert "gets stripped" not in out
         assert follow not in out, follow
         assert "## Section" in out
+
+
+def test_quote_reference_after_kept_block_survives():
+    """A quote-reference-shaped follow-on after a KEPT (grounded) block must
+    survive -- the quote it references is present, so the reference is
+    legitimate (the #723 close-vs-zoho 176/205 / slack 67/110 case). The line
+    DOES match the matcher, so the only thing protecting it is the sweep
+    firing on STRIPPED blocks alone; this pins that protection."""
+    follow = "This quote reflects the evaluation fatigue common in a high-churn category."
+    assert _looks_like_orphan_quote_reference(follow)  # matcher would flag it...
+    source = ["evaluation fatigue is common in this high-churn category"]
+    markdown = (
+        "## Section\n\n"
+        "> evaluation fatigue is common in this high-churn category\n\n"
+        f"{follow}\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 0                       # block grounds -> nothing stripped
+    assert "evaluation fatigue is common" in out  # the quote is kept
+    assert follow in out                      # ...but the reference legitimately survives
 
 
 def test_quote_reference_does_not_sweep_generic_or_witness_followon():


### PR DESCRIPTION
Plan: plans/PR-Blog-Generator-Orphan-Quote-Ref.md (generator-prevention phase of #706)

The data fix (#723) cleaned the 7 orphaned quote references live in `main`; this closes the upstream so future generations can't reintroduce them.

`_remove_unmatched_quote_lines` already swept an adjacent orphan **intro** (lead-in ending ":") + **disclaimer** when stripping a blockquote, but not a following paragraph that back-references the stripped quote ("This quote captures…", "The excerpt cuts off…", "quoted earlier") — the exact shape that shipped into the 5 posts.

## Intentional
- **Mirrors the skill detector** — `_looks_like_orphan_quote_reference` matches the same shapes as the skill's `orphaned_quote_reference` detector, kept in sync as with the disclaimer patterns (#703).
- **Same structural guards** as `_looks_like_orphan_disclaimer` (`>`/`#`/`-`/`*`/`+`/ordered-list skipped), and excludes aggregate "The witness …" references + generic follow-ons ("This pattern recurs …" preserved).
- **Fires only on a stripped block** — blast radius bounded by the existing block-strip logic. Signature unchanged. ASCII-only (Python Unicode policy).
- **Whole-paragraph sweep here vs surgical edit in #723** — new generation removes the dangling follow-on outright (the quote it cites is gone); the published-data fix preserved already-shipped analysis. Different tools, different appropriate behavior.

## Verification
- `tests/test_b2b_blog_post_generation_quote_gate.py` → `85 passed` (was 83; +2: orphan-quote-reference swept, generic/witness false-positive guard preserved).
- `extracted_content_pipeline` re-synced (`refreshed from atlas_brain sources (43 files)`); mirror carries the new function.
- `scripts/local_pr_review.sh` → `local PR review passed` (4/4 files, 5/5 path claims, ASCII Python policy, extracted manifest sync, diff drift 7.6%, `git diff --check`).

## Diff size
~208 LOC (generator + mirror + 2 tests; plan ~95).