### PR TITLE
PR-Content-Ops-FAQ-Scale-Failure-Examples

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -190,6 +190,21 @@ show a support phone number, email, or help URL; the builder never invents one.
 Pass `--require-output-checks` in host smoke runs when weak FAQ output should
 fail the command instead of producing a reviewable draft.
 
+For large-upload validation, compare the scale smoke `run_summary.json` against
+the checked-in failure profiles:
+
+- `examples/faq_scale_density_limited_summary.json` shows a 1,000-row upload
+  where most rows were skipped before FAQ generation. Fix source export fields,
+  text columns, or filters before tuning the FAQ generator.
+- `examples/faq_scale_output_check_failure_summary.json` shows healthy input
+  density with failed FAQ output checks. In that case, investigate grouping,
+  question wording, or action-step generation.
+
+The first pass is `input_profile.usable_source_count` divided by
+`input_profile.raw_row_count`. If that ratio is poor, treat the run as a source
+prep problem. If the ratio is healthy and `failure.type` is `output_checks`,
+debug the FAQ generator path.
+
 The same artifact can run through the Content Ops execution seam by selecting
 `faq_markdown` and passing inline `source_material`. It remains zero-provider.
 When the host wires `PostgresTicketFAQRepository`, execution also persists the

--- a/extracted_content_pipeline/examples/faq_scale_density_limited_summary.json
+++ b/extracted_content_pipeline/examples/faq_scale_density_limited_summary.json
@@ -1,0 +1,39 @@
+{
+  "ok": false,
+  "exit_code": 1,
+  "source": "customer_tickets_1000.csv",
+  "source_format": "csv",
+  "input_profile": {
+    "status": "ok",
+    "raw_row_count": 1000,
+    "raw_row_count_source": "csv_rows",
+    "usable_source_count": 46,
+    "warning_count": 954,
+    "warnings_by_code": {
+      "missing_source_text": 954
+    },
+    "skipped_row_count": 954,
+    "missing_source_text_count": 954,
+    "warning_sample": [],
+    "usable_source_ratio": 0.046
+  },
+  "failure": {
+    "type": "output_checks",
+    "exit_code": 1,
+    "result_status": "failed_output_checks",
+    "failed_output_checks": [
+      "condensed"
+    ],
+    "output_check_details": [
+      {
+        "name": "condensed",
+        "passed": false,
+        "hint": "Most raw rows were skipped before FAQ generation; inspect source text columns or export filters first."
+      }
+    ],
+    "stderr_tail": "FAQ output checks failed: condensed"
+  },
+  "artifacts": {
+    "summary": "artifacts/run_summary.json"
+  }
+}

--- a/extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json
+++ b/extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json
@@ -1,0 +1,43 @@
+{
+  "ok": false,
+  "exit_code": 1,
+  "source": "customer_tickets_1000.csv",
+  "source_format": "csv",
+  "input_profile": {
+    "status": "ok",
+    "raw_row_count": 1000,
+    "raw_row_count_source": "csv_rows",
+    "usable_source_count": 1000,
+    "warning_count": 0,
+    "warnings_by_code": {},
+    "skipped_row_count": 0,
+    "missing_source_text_count": 0,
+    "warning_sample": [],
+    "usable_source_ratio": 1.0
+  },
+  "failure": {
+    "type": "output_checks",
+    "exit_code": 1,
+    "result_status": "failed_output_checks",
+    "failed_output_checks": [
+      "uses_user_vocabulary",
+      "has_action_items"
+    ],
+    "output_check_details": [
+      {
+        "name": "uses_user_vocabulary",
+        "passed": false,
+        "hint": "Generated FAQ questions did not preserve customer wording or source-policy question wording."
+      },
+      {
+        "name": "has_action_items",
+        "passed": false,
+        "hint": "Generated FAQ items did not include actionable next steps."
+      }
+    ],
+    "stderr_tail": "FAQ output checks failed: has_action_items, uses_user_vocabulary"
+  },
+  "artifacts": {
+    "summary": "artifacts/run_summary.json"
+  }
+}

--- a/plans/PR-Content-Ops-FAQ-Scale-Failure-Examples.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Failure-Examples.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-FAQ-Scale-Failure-Examples
+
+## Why this slice exists
+
+The FAQ scale smoke now reports input density in JSON and on the console, but
+operators still need concrete examples for the two failure modes we care about
+in 1,000-row validation: sparse source material versus FAQ output checks
+failing after enough usable rows were loaded.
+
+This slice adds static run-summary examples so the next large-row investigation
+can compare its summary artifact against known shapes instead of treating every failure
+as a generic generator problem.
+
+## Scope (this PR)
+
+1. Add a density-limited run-summary example.
+2. Add a healthy-input output-check failure example.
+3. Document how to compare a real 1,000-row run summary against the
+   examples.
+4. Add a fixture test that keeps the examples valid JSON with the expected
+   failure-profile fields.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Failure-Examples.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/examples/faq_scale_density_limited_summary.json`
+- `extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+The two example JSON files are compact run-summary-shaped payloads. The
+density-limited example shows a high raw row count but low
+`usable_source_count`, high `skipped_row_count`, and missing source text. The
+output-check example shows healthy input density with
+`failure.type="output_checks"` and failed checks in the FAQ result.
+
+The README points operators at both files after running the large scale smoke.
+The test loads the checked-in examples and asserts the distinction that matters:
+source-density examples have poor usable-source ratio, while output-check
+examples have healthy source density and failed output checks.
+
+## Intentional
+
+- No runtime behavior changes; this slice only adds reference artifacts and
+  documentation.
+- The examples are compact summaries, not full generated Markdown bodies.
+- Counts are illustrative, not claims about a specific live CFPB run.
+
+## Deferred
+
+- Running and archiving a fresh live 1,000-row CFPB artifact remains a separate
+  operator action because CFPB availability is external.
+- Additional source-specific examples can be added when another real upload
+  exposes a new failure mode.
+
+## Verification
+
+- Focused pytest passed, 18 tests: pytest tests/test_smoke_content_ops_faq_scale_run.py
+- Local PR review passed: bash scripts/local_pr_review.sh origin/main
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 71 |
+| README | 15 |
+| Example JSON | 82 |
+| Tests | 24 |
+| **Total** | **192** |

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -15,6 +15,10 @@ assert SPEC is not None and SPEC.loader is not None
 smoke = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(smoke)
 SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+FAILURE_EXAMPLES = {
+    "density": ROOT / "extracted_content_pipeline/examples/faq_scale_density_limited_summary.json",
+    "output_checks": ROOT / "extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json",
+}
 TICKET_ROWS = (
     ("ticket-acme-1", "Change login email", "How do I change my login email?", "email and profile updates"),
     ("ticket-acme-2", "Update account email", "I need to update the email on my account.", "email and profile updates"),
@@ -251,6 +255,26 @@ def test_raw_row_profile_returns_none_for_unrecognized_shape(tmp_path: Path) -> 
         "raw_row_count": None,
         "raw_row_count_source": None,
     }
+
+
+def test_faq_scale_failure_examples_separate_density_from_output_checks() -> None:
+    density = json.loads(FAILURE_EXAMPLES["density"].read_text(encoding="utf-8"))
+    output_checks = json.loads(FAILURE_EXAMPLES["output_checks"].read_text(encoding="utf-8"))
+
+    assert density["ok"] is False
+    assert density["input_profile"]["raw_row_count"] == 1000
+    assert density["input_profile"]["usable_source_count"] == 46
+    assert density["input_profile"]["usable_source_ratio"] < 0.1
+    assert density["input_profile"]["skipped_row_count"] == 954
+    assert density["input_profile"]["warnings_by_code"]["missing_source_text"] == 954
+
+    assert output_checks["ok"] is False
+    assert output_checks["input_profile"]["raw_row_count"] == 1000
+    assert output_checks["input_profile"]["usable_source_count"] == 1000
+    assert output_checks["input_profile"]["usable_source_ratio"] == 1.0
+    assert output_checks["input_profile"]["skipped_row_count"] == 0
+    assert output_checks["failure"]["type"] == "output_checks"
+    assert output_checks["failure"]["failed_output_checks"]
 
 
 @pytest.mark.parametrize("overrides,message", [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Failure-Examples.md

The FAQ scale smoke now reports input density, but the 1,000-row validation lane still needed concrete examples for the two failure modes we care about: sparse source material versus FAQ output checks failing after enough usable rows were loaded. This adds compact run-summary examples and a fixture test that keeps that distinction explicit.

## Intentional
- Docs and fixtures only; no runtime behavior changes.
- Compact examples instead of full generated Markdown artifacts.
- Counts are illustrative and are not claims about a specific live CFPB run.

## Deferred
- Archiving a fresh live 1,000-row CFPB artifact remains a separate operator action because CFPB availability is external.
- Additional source-specific examples wait for real upload failure modes.

## Verification
- Focused pytest passed, 18 tests: pytest tests/test_smoke_content_ops_faq_scale_run.py
- Local PR review passed: bash scripts/local_pr_review.sh origin/main

## Diff size
5 files, +192 / -0
