### PR TITLE
Account for landing page repair attempts in cost preview

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -7,6 +7,7 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.18,
       "default_parse_retry_attempts": 1,
+      "default_quality_repair_attempts": 0,
       "estimated_retry_adjusted_unit_cost_usd": 0.36,
       "required_inputs": [
         "target_account",
@@ -24,6 +25,7 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.45,
       "default_parse_retry_attempts": 1,
+      "default_quality_repair_attempts": 0,
       "estimated_retry_adjusted_unit_cost_usd": 0.9,
       "required_inputs": [
         "topic"
@@ -40,6 +42,7 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.55,
       "default_parse_retry_attempts": 1,
+      "default_quality_repair_attempts": 0,
       "estimated_retry_adjusted_unit_cost_usd": 1.1,
       "required_inputs": [
         "opportunity_id"
@@ -56,7 +59,8 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.65,
       "default_parse_retry_attempts": 1,
-      "estimated_retry_adjusted_unit_cost_usd": 1.3,
+      "default_quality_repair_attempts": 1,
+      "estimated_retry_adjusted_unit_cost_usd": 2.6,
       "required_inputs": [
         "offer",
         "audience"
@@ -73,6 +77,7 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.35,
       "default_parse_retry_attempts": 1,
+      "default_quality_repair_attempts": 0,
       "estimated_retry_adjusted_unit_cost_usd": 0.7,
       "required_inputs": [
         "target_account"
@@ -89,6 +94,7 @@
       "implemented": true,
       "estimated_unit_cost_usd": 0.0,
       "default_parse_retry_attempts": 0,
+      "default_quality_repair_attempts": 0,
       "estimated_retry_adjusted_unit_cost_usd": 0.0,
       "required_inputs": [
         "source_material"

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -49,6 +49,7 @@ export interface ContentOpsOutputDefinition {
   implemented: boolean
   estimated_unit_cost_usd: number
   default_parse_retry_attempts: number
+  default_quality_repair_attempts: number
   estimated_retry_adjusted_unit_cost_usd: number
   required_inputs: string[]
   default_max_items: number

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -57,6 +57,7 @@ export function fromWireOutputDefinition(
     implemented: wire.implemented,
     estimatedUnitCostUsd: wire.estimated_unit_cost_usd,
     defaultParseRetryAttempts: wire.default_parse_retry_attempts,
+    defaultQualityRepairAttempts: wire.default_quality_repair_attempts,
     estimatedRetryAdjustedUnitCostUsd: wire.estimated_retry_adjusted_unit_cost_usd,
     requiredInputs: [...wire.required_inputs],
     defaultMaxItems: wire.default_max_items,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -26,6 +26,7 @@ export interface OutputDefinitionView {
   implemented: boolean
   estimatedUnitCostUsd: number
   defaultParseRetryAttempts: number
+  defaultQualityRepairAttempts: number
   estimatedRetryAdjustedUnitCostUsd: number
   requiredInputs: string[]
   defaultMaxItems: number

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -98,6 +98,7 @@ def _build_static_catalog_payload() -> Mapping[str, Any]:
                 "implemented": item.implemented,
                 "estimated_unit_cost_usd": item.estimated_unit_cost_usd,
                 "default_parse_retry_attempts": item.default_parse_retry_attempts,
+                "default_quality_repair_attempts": item.default_quality_repair_attempts,
                 "estimated_retry_adjusted_unit_cost_usd": round(
                     retry_adjusted_unit_cost_usd(item),
                     4,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
+_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
+_LANDING_PAGE_QUALITY_REPAIR_INPUT = "landing_page_quality_repair_attempts"
+
 
 @dataclass(frozen=True)
 class OutputDefinition:
@@ -28,6 +31,9 @@ class OutputDefinition:
     # Must mirror each *GenerationConfig.parse_retry_attempts default used in
     # generation_plan.py. If a service raises retries, update this field too.
     default_parse_retry_attempts: int = 1
+    # Must mirror each GenerationConfig quality-repair default. Only landing
+    # pages currently have a quality-repair LLM loop.
+    default_quality_repair_attempts: int = 0
 
 
 @dataclass(frozen=True)
@@ -134,6 +140,7 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         estimated_unit_cost_usd=0.65,
         required_inputs=("offer", "audience"),
         reasoning_requirement="optional_host_context",
+        default_quality_repair_attempts=1,
     ),
     "sales_brief": OutputDefinition(
         id="sales_brief",
@@ -277,27 +284,102 @@ def resolve_outputs(request: ContentOpsRequest) -> tuple[str, ...]:
     return PRESETS["email_only"].outputs
 
 
-def retry_adjusted_unit_cost_usd(definition: OutputDefinition) -> float:
-    """Return the per-item preview budget including default parse retries."""
+def _nonnegative_int_input(
+    inputs: Mapping[str, Any],
+    key: str,
+    *,
+    max_value: int | None = None,
+) -> int | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, (bool, float)):
+        raise ValueError(f"{key} must be an integer")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be an integer") from None
+    if value < 0:
+        raise ValueError(f"{key} must be at least 0; got {value}")
+    if max_value is not None and value > max_value:
+        raise ValueError(f"{key} must be at most {max_value}; got {value}")
+    return value
 
-    attempts = max(1, int(definition.default_parse_retry_attempts) + 1)
-    return definition.estimated_unit_cost_usd * attempts
+
+def _quality_repair_attempts_for_output(
+    output_id: str,
+    definition: OutputDefinition,
+    *,
+    inputs: Mapping[str, Any],
+    require_quality_gates: bool,
+) -> int:
+    """Return preview quality-repair attempts for one selected output."""
+
+    if not require_quality_gates:
+        return 0
+    repair_attempts = definition.default_quality_repair_attempts
+    if output_id == "landing_page":
+        override = _nonnegative_int_input(
+            inputs,
+            _LANDING_PAGE_QUALITY_REPAIR_INPUT,
+            max_value=_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
+        )
+        if override is not None:
+            repair_attempts = override
+    return max(0, int(repair_attempts))
 
 
-def estimate_cost_usd(outputs: Sequence[str], *, limit: int) -> float:
+def retry_adjusted_unit_cost_usd(
+    definition: OutputDefinition,
+    *,
+    quality_repair_attempts: int | None = None,
+) -> float:
+    """Return the per-item preview budget including parse and repair attempts."""
+
+    parse_attempts = max(1, int(definition.default_parse_retry_attempts) + 1)
+    repair_attempts = (
+        definition.default_quality_repair_attempts
+        if quality_repair_attempts is None
+        else quality_repair_attempts
+    )
+    repair_attempts = max(0, int(repair_attempts))
+    return definition.estimated_unit_cost_usd * parse_attempts * (repair_attempts + 1)
+
+
+def estimate_cost_usd(
+    outputs: Sequence[str],
+    *,
+    limit: int,
+    inputs: Mapping[str, Any] | None = None,
+    require_quality_gates: bool = True,
+) -> float:
     """Estimate cost from selected outputs and opportunity limit.
 
     The estimates are intentionally conservative placeholders. Generated
-    assets default to one parse retry, so preview budgets use the worst-case
-    attempt count instead of the first-call cost.
+    assets default to one parse retry, and landing pages can add quality repair
+    attempts. Preview budgets use the worst-case attempt count instead of the
+    first-call cost.
     """
 
     total = 0.0
+    provided_inputs = inputs or {}
     for output_id in outputs:
         definition = OUTPUT_CATALOG.get(output_id)
         if not definition:
             continue
-        total += retry_adjusted_unit_cost_usd(definition) * max(1, limit)
+        repair_attempts = _quality_repair_attempts_for_output(
+            output_id,
+            definition,
+            inputs=provided_inputs,
+            require_quality_gates=require_quality_gates,
+        )
+        total += (
+            retry_adjusted_unit_cost_usd(
+                definition,
+                quality_repair_attempts=repair_attempts,
+            )
+            * max(1, limit)
+        )
     return total
 
 
@@ -351,7 +433,12 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
 
     selected_outputs = tuple(output for output in outputs if output not in blocked)
     missing = missing_required_inputs(selected_outputs, request.inputs)
-    estimated_cost = estimate_cost_usd(selected_outputs, limit=request.limit)
+    estimated_cost = estimate_cost_usd(
+        selected_outputs,
+        limit=request.limit,
+        inputs=request.inputs,
+        require_quality_gates=request.require_quality_gates,
+    )
 
     if request.max_cost_usd is not None and estimated_cost > request.max_cost_usd:
         warnings.append(

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -99,7 +99,9 @@ Current preset ids:
 
 The catalog endpoint exposes both `estimated_unit_cost_usd` and
 `estimated_retry_adjusted_unit_cost_usd`. Use the retry-adjusted value for
-budget UI and the preview response as the authoritative run estimate.
+budget UI and the preview response as the authoritative run estimate. The
+retry-adjusted catalog value includes default parse retry attempts and, for
+landing pages, the default quality-repair attempt.
 
 ## Preview Payload
 
@@ -148,13 +150,21 @@ Treat `can_run=false` as a hard stop for generation controls. The UI can still
 show the selected plan, but it should not enable the generate button until
 `missing_inputs`, `blocked_outputs`, and budget warnings are resolved.
 `estimated_cost_usd` is conservative: generated assets default to one parse
-retry, so preview budgets include the worst-case retry attempt count.
+retry, so preview budgets include the worst-case retry attempt count. Landing
+pages also include the quality-repair loop when quality gates are enabled:
+`landing_page_quality_repair_attempts` can raise, lower, or disable that repair
+multiplier for the request.
 
 > **Upgrade note (breaking):** Prior to 2026-05-08, `estimated_cost_usd`
 > reflected a single LLM call per output. It now reflects worst-case retry
 > attempts (default: 2 calls per generated asset). Operators with existing
 > `max_cost_usd` budgets should multiply their previous limit by
 > `default_parse_retry_attempts + 1` (default: x2).
+>
+> Landing pages can cost more than the generic x2 default when quality gates
+> are enabled because quality repair can trigger another parsed-generation
+> pass. With the default landing-page settings, preview uses
+> `(parse_retry_attempts + 1) * (quality_repair_attempts + 1)`.
 
 ## Plan Payload
 

--- a/plans/PR-Content-Ops-Quality-Cost-Model.md
+++ b/plans/PR-Content-Ops-Quality-Cost-Model.md
@@ -1,0 +1,100 @@
+# PR-Content-Ops-Quality-Cost-Model
+
+## Why this slice exists
+
+PR #721 added a capped landing-page repair-attempt override, and PR #724 added
+a first-class New Run control for it. The remaining cost gap is in preview
+planning: Content Ops estimates still count parse retries but do not count the
+landing-page quality-repair loop.
+
+That can make a run look cheaper than the worst-case number of LLM calls the
+operator has selected. Cost preview and budget gating should reflect the same
+repair-attempt setting that execution will use.
+
+## Scope (this PR)
+
+1. Add quality-repair attempt metadata to the output catalog.
+2. Include landing-page quality-repair attempts in retry-adjusted unit costs.
+3. Let preview cost estimation read landing_page_quality_repair_attempts from
+   request inputs.
+4. Ignore landing-page repair attempts when quality gates are disabled.
+5. Keep the existing 0 to 10 validation bound aligned with generation planning.
+6. Update preview tests and control-surface docs for the new estimate behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Quality-Cost-Model.md` | Plan doc for this cost-model slice. |
+| `extracted_content_pipeline/control_surfaces.py` | Include quality-repair attempts in preview cost estimation. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Expose default quality-repair attempts in the catalog payload. |
+| `extracted_content_pipeline/docs/control_surface_preview_api.md` | Document that landing-page estimates include quality repairs. |
+| `tests/test_extracted_content_control_surfaces.py` | Cover default, override, disabled-gate, and invalid repair cost behavior. |
+| `tests/test_extracted_content_control_surface_api.py` | Cover the catalog's default quality-repair metadata. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Add the catalog wire field for default quality-repair attempts. |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | Add the domain field for default quality-repair attempts. |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | Map the catalog field into the domain model. |
+| `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json` | Keep the local catalog fixture aligned with the backend contract. |
+
+## Mechanism
+
+The existing preview estimate multiplies unit cost by
+default_parse_retry_attempts + 1. Landing pages now have an additional
+quality-repair loop that can call the LLM again after parsed output fails the
+quality gate.
+
+This slice keeps cost math deterministic by deriving a per-output attempt
+multiplier:
+
+- parse multiplier: default_parse_retry_attempts + 1
+- landing-page repair multiplier: quality_repair_attempts + 1 when quality
+  gates are enabled
+- all other outputs: repair multiplier 1
+
+The landing-page repair count defaults to the service default and can be
+overridden by landing_page_quality_repair_attempts in request inputs. Invalid
+override values raise before preview returns a runnable plan, matching the
+planning and execution validation path.
+
+## Intentional
+
+- No change to actual execution behavior.
+- No change to landing-page repair defaults.
+- No UI changes in this slice; PR #724 already added the operator control.
+- No repair cost model for reports, sales briefs, FAQ, or email campaigns.
+- No live provider pricing integration; these remain placeholder unit-cost
+  estimates.
+
+## Deferred
+
+- Provider-specific token/cost estimates based on observed usage.
+- Operator-facing telemetry for failed intermediate repair candidates.
+- A shared repair-attempt model if other generated assets gain repair loops.
+
+## Verification
+
+- pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q
+  -> passed 99/99 tests.
+- Python compile command over changed control-surface Python files and focused
+  tests -> passed 4/4 files.
+- atlas-intel-ui npm run lint -> passed.
+- atlas-intel-ui npm run build -> passed.
+- git diff --check -> passed.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed mapped-file
+  and hard-import checks.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed with
+  0 Atlas runtime import findings.
+- bash scripts/check_ascii_python.sh -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| Control-surface cost model | ~95 |
+| API/docs | ~35 |
+| Tests | ~105 |
+| Frontend contract fixture/types | ~35 |
+| Total | ~350 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -123,7 +123,10 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["email_campaign"]["can_execute"] is False
     assert outputs["email_campaign"]["estimated_unit_cost_usd"] == 0.18
     assert outputs["email_campaign"]["default_parse_retry_attempts"] == 1
+    assert outputs["email_campaign"]["default_quality_repair_attempts"] == 0
     assert outputs["email_campaign"]["estimated_retry_adjusted_unit_cost_usd"] == 0.36
+    assert outputs["landing_page"]["default_quality_repair_attempts"] == 1
+    assert outputs["landing_page"]["estimated_retry_adjusted_unit_cost_usd"] == 2.6
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -161,6 +161,147 @@ def test_preview_budget_gate_uses_retry_adjusted_cost():
     assert "Estimated cost exceeds max_cost_usd: 2.20 > 1.10" in preview["warnings"]
 
 
+def test_preview_landing_page_cost_includes_default_quality_repair_attempt():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 2.6
+
+
+def test_preview_landing_page_cost_uses_quality_repair_attempt_override_zero():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 0,
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 1.3
+
+
+def test_preview_landing_page_cost_uses_quality_repair_attempt_override_string():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": "3",
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 5.2
+
+
+def test_preview_landing_page_cost_accepts_quality_repair_attempt_override_max():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 10,
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 14.3
+
+
+def test_preview_landing_page_repair_cost_can_block_budget():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "max_cost_usd": 2.5,
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+            },
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["estimated_cost_usd"] == 2.6
+    assert "Estimated cost exceeds max_cost_usd: 2.60 > 2.50" in preview["warnings"]
+
+
+def test_preview_landing_page_cost_ignores_quality_repair_when_gates_disabled():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "require_quality_gates": False,
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 3,
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 1.3
+
+
+def test_preview_landing_page_repair_override_is_not_validated_when_gates_disabled():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["landing_page"],
+            "require_quality_gates": False,
+            "inputs": {
+                "offer": "Churn audit",
+                "audience": "B2B SaaS founders",
+                "landing_page_quality_repair_attempts": 50,
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["estimated_cost_usd"] == 1.3
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (-1, "landing_page_quality_repair_attempts must be at least 0"),
+        (11, "landing_page_quality_repair_attempts must be at most 10"),
+        (True, "landing_page_quality_repair_attempts must be an integer"),
+        (1.5, "landing_page_quality_repair_attempts must be an integer"),
+        ("many", "landing_page_quality_repair_attempts must be an integer"),
+    ],
+)
+def test_preview_rejects_invalid_landing_page_quality_repair_attempt_override(
+    value,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        preview_from_mapping(
+            {
+                "outputs": ["landing_page"],
+                "inputs": {
+                    "offer": "Churn audit",
+                    "audience": "B2B SaaS founders",
+                    "landing_page_quality_repair_attempts": value,
+                },
+            }
+        )
+
+
 def test_preview_keeps_signal_extraction_blocked_without_source_material():
     preview = preview_from_mapping(
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Quality-Cost-Model.md

## Summary

- Includes landing-page quality-repair attempts in Content Ops preview cost estimation and budget gating.
- Exposes default quality-repair attempts in the control-surface catalog and keeps Intel UI wire/domain types plus fixtures aligned.
- Documents the landing-page parse-retry and quality-repair multiplier behavior.

## Verification

- pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q
- python -m py_compile extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py
- atlas-intel-ui npm run lint
- atlas-intel-ui npm run build
- git diff --check
- bash scripts/validate_extracted_content_pipeline.sh
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh origin/main
