### PR TITLE
Add landing page repair telemetry

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -83,6 +83,7 @@ class LandingPageGenerationResult:
     consumed_reasoning_contexts: tuple[Mapping[str, Any], ...] = ()
     saved_ids: tuple[str, ...] = ()
     errors: tuple[Mapping[str, Any], ...] = ()
+    quality_repair_history: tuple[Mapping[str, Any], ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         data = {
@@ -93,6 +94,10 @@ class LandingPageGenerationResult:
             "saved_ids": list(self.saved_ids),
             "errors": list(self.errors),
         }
+        if self.quality_repair_history:
+            data["quality_repair_history"] = [
+                dict(item) for item in self.quality_repair_history
+            ]
         if self.consumed_reasoning_contexts:
             data["consumed_reasoning_contexts"] = [
                 dict(item) for item in self.consumed_reasoning_contexts
@@ -295,6 +300,7 @@ class LandingPageGenerationService:
         parsed: dict[str, Any] | None = None
         quality: dict[str, Any] = {"passed": False, "blockers": (), "repair_issues": ()}
         quality_blockers: tuple[str, ...] = ()
+        quality_repair_history: list[dict[str, Any]] = []
         total_usage: dict[str, Any] = {}
         total_parse_attempts = 0
         repair_limit = (
@@ -329,11 +335,14 @@ class LandingPageGenerationService:
                 }
                 if quality_blockers:
                     error["quality_blockers"] = quality_blockers
+                if quality_repair_history:
+                    error["quality_repair_history"] = tuple(quality_repair_history)
                 return LandingPageGenerationResult(
                     requested=1,
                     generated=0,
                     skipped=1,
                     errors=(error,),
+                    quality_repair_history=tuple(quality_repair_history),
                 )
 
             total_usage = accumulate_usage(total_usage, parsed.get("_usage"))
@@ -348,6 +357,13 @@ class LandingPageGenerationService:
                 parsed,
                 quality_gates_enabled=resolved_quality_gates_enabled,
             )
+            quality_repair_history.append(
+                _quality_repair_history_row(repair_attempt_no, quality)
+            )
+            parsed = {
+                **parsed,
+                "_quality_repair_history": tuple(quality_repair_history),
+            }
             if quality["passed"]:
                 break
             quality_blockers = tuple(str(item) for item in quality["repair_issues"])
@@ -362,7 +378,9 @@ class LandingPageGenerationService:
                     "reason": "quality_blocked",
                     "blockers": tuple(str(item) for item in quality["blockers"]),
                     "quality_repair_attempts": repair_limit,
+                    "quality_repair_history": tuple(quality_repair_history),
                 },),
+                quality_repair_history=tuple(quality_repair_history),
             )
 
         draft = self._build_draft(
@@ -384,6 +402,7 @@ class LandingPageGenerationService:
                 campaign_payload
             ),
             saved_ids=saved_ids,
+            quality_repair_history=tuple(quality_repair_history),
         )
 
     async def _campaign_with_reasoning_context(
@@ -546,6 +565,8 @@ class LandingPageGenerationService:
             "generation_usage": parsed.get("_usage") or {},
             "generation_parse_attempts": parsed.get("_parse_attempts"),
             "generation_quality_repair_attempts": parsed.get("_quality_repair_attempts"),
+            "generation_quality_repair_history": parsed.get("_quality_repair_history")
+            or (),
         }
         if campaign_payload is not None:
             context = normalize_campaign_reasoning_context(campaign_payload)
@@ -563,6 +584,20 @@ class LandingPageGenerationService:
             reference_ids=reference_ids,
             metadata=metadata,
         )
+
+
+def _quality_repair_history_row(
+    attempt_no: int,
+    quality: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "attempt": int(attempt_no),
+        "passed": bool(quality.get("passed")),
+        "blockers": tuple(str(item) for item in quality.get("blockers") or ()),
+        "repair_issues": tuple(
+            str(item) for item in quality.get("repair_issues") or ()
+        ),
+    }
 
 
 __all__ = [

--- a/plans/PR-Generated-Asset-Repair-Telemetry.md
+++ b/plans/PR-Generated-Asset-Repair-Telemetry.md
@@ -1,0 +1,88 @@
+# PR-Generated-Asset-Repair-Telemetry
+
+## Why this slice exists
+
+The landing-page repair-attempt chain is now wired end to end: generator,
+dispatch, input override, UI control, and cost preview. Operators can choose
+repair attempts and see the cost impact, but the generated output still does
+not explain what happened inside the repair loop.
+
+When a landing-page draft repairs successfully, reviewers should be able to see
+which earlier candidate failed the quality gate. When repair still fails,
+operators should see the sequence of quality issues that were fed back to the
+model.
+
+## Scope (this PR)
+
+1. Record a compact landing-page quality-repair history per generation run.
+2. Include each parsed candidate's repair attempt number, pass/fail state,
+   blockers, and repair issues.
+3. Expose the repair history in `LandingPageGenerationResult.as_dict()`.
+4. Persist the repair history in saved landing-page draft metadata.
+5. Attach the repair history to quality-blocked and repair-unparseable errors.
+6. Add focused landing-page generation tests.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Generated-Asset-Repair-Telemetry.md` | Plan doc for this telemetry slice. |
+| `extracted_content_pipeline/landing_page_generation.py` | Record and expose landing-page quality-repair history. |
+| `tests/test_extracted_landing_page_generation.py` | Cover success, quality-blocked, and repair-unparseable telemetry. |
+
+## Mechanism
+
+The landing-page generator already evaluates each parsed candidate through the
+deterministic quality pack before deciding whether to repair or persist. This
+slice records that decision as a small serializable row:
+
+- `attempt`
+- `passed`
+- `blockers`
+- `repair_issues`
+
+The row is appended only after a candidate parses and receives a quality
+report. Parse failures after a previous quality block include the history from
+the earlier parsed candidate so operators can still see what drove the repair
+prompt.
+
+## Intentional
+
+- No changes to repair behavior, prompts, quality-gate decisions, or cost
+  estimates.
+- No new database columns; draft metadata already carries generation
+  diagnostics.
+- No separate UI renderer; the existing execution result JSON and generated
+  asset metadata can carry the field.
+- No repair telemetry for blog posts or other generated assets in this slice.
+
+## Deferred
+
+- A polished generated-asset UI panel for repair history.
+- Shared repair telemetry if other generated assets adopt the same repair-loop
+  contract.
+- Token-level or provider-cost telemetry per repair attempt.
+
+## Verification
+
+- pytest tests/test_extracted_landing_page_generation.py -q
+  -> passed 25/25 tests.
+- Python compile command over `extracted_content_pipeline/landing_page_generation.py`
+  and `tests/test_extracted_landing_page_generation.py` -> passed 2/2 files.
+- git diff --check -> passed.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed mapped-file
+  and hard-import checks.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed with
+  0 Atlas runtime import findings.
+- bash scripts/check_ascii_python.sh -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Landing-page generation | ~45 |
+| Tests | ~70 |
+| Total | ~190 |

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -433,6 +433,25 @@ async def test_generate_repairs_quality_blocked_response_once_and_persists() -> 
     assert draft.metadata["generation_usage"] == {"input_tokens": 12, "output_tokens": 5}
     assert draft.metadata["generation_parse_attempts"] == 2
     assert draft.metadata["generation_quality_repair_attempts"] == 1
+    assert result.quality_repair_history[0]["attempt"] == 0
+    assert result.quality_repair_history[0]["passed"] is False
+    assert any(
+        "no_cta" in blocker
+        for blocker in result.quality_repair_history[0]["blockers"]
+    )
+    assert result.quality_repair_history[1] == {
+        "attempt": 1,
+        "passed": True,
+        "blockers": (),
+        "repair_issues": (),
+    }
+    assert result.as_dict()["quality_repair_history"] == [
+        dict(item) for item in result.quality_repair_history
+    ]
+    assert (
+        draft.metadata["generation_quality_repair_history"]
+        == result.quality_repair_history
+    )
 
 
 @pytest.mark.asyncio
@@ -458,6 +477,9 @@ async def test_generate_reports_quality_blockers_after_repair_attempt_fails() ->
     assert result.errors[0]["reason"] == "quality_blocked"
     assert result.errors[0]["quality_repair_attempts"] == 1
     assert any("no_cta" in blocker for blocker in result.errors[0]["blockers"])
+    assert result.errors[0]["quality_repair_history"] == result.quality_repair_history
+    assert [row["attempt"] for row in result.quality_repair_history] == [0, 1]
+    assert all(row["passed"] is False for row in result.quality_repair_history)
 
 
 @pytest.mark.asyncio
@@ -484,6 +506,10 @@ async def test_generate_reports_quality_blockers_when_repair_response_will_not_p
     assert len(llm.calls) == 2
     assert result.errors[0]["reason"] == "unparseable_response"
     assert any("no_cta" in blocker for blocker in result.errors[0]["quality_blockers"])
+    assert result.errors[0]["quality_repair_history"] == result.quality_repair_history
+    assert len(result.quality_repair_history) == 1
+    assert result.quality_repair_history[0]["attempt"] == 0
+    assert result.quality_repair_history[0]["passed"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Generated-Asset-Repair-Telemetry.md

## Summary

- Records compact landing-page quality repair history for each parsed candidate.
- Exposes repair history in LandingPageGenerationResult.as_dict(), saved draft metadata, and quality-blocked / repair-unparseable errors.
- Covers successful repair, failed repair, and repair response parse failure paths.

## Verification

- pytest tests/test_extracted_landing_page_generation.py -q
- python -m py_compile extracted_content_pipeline/landing_page_generation.py tests/test_extracted_landing_page_generation.py
- git diff --check
- bash scripts/validate_extracted_content_pipeline.sh
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh origin/main
