### PR TITLE
PR-Content-Ops-FAQ-Zero-Result-Risk

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -398,7 +398,12 @@ def build_ticket_faq_markdown(
                 "text": text,
                 "source_id": source_id or "unknown",
                 "source_key": source_key,
+                "source_type": source_type,
                 "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
+                "results_count": _first_present(evidence, opportunity, key="results_count"),
+                "result_count": _first_present(evidence, opportunity, key="result_count"),
+                "zero_results": _first_present(evidence, opportunity, key="zero_results"),
+                "zero_result": _first_present(evidence, opportunity, key="zero_result"),
             })
 
     sorted_groups = sorted(groups.items(), key=_group_sort_key)
@@ -599,7 +604,48 @@ def _failure_risk_signals(topic: str, rows: Sequence[Mapping[str, str]]) -> tupl
     for signal, terms in _FAILURE_RISK_RULES:
         if any(_keyword_matches(text, term) for term in terms):
             signals.append(signal)
+    if any(_is_zero_result_search_row(row) for row in rows):
+        signals.append("zero_result_search")
     return tuple(signals)
+
+
+def _is_zero_result_search_row(row: Mapping[str, Any]) -> bool:
+    source_type = _source_type_key(row.get("source_type"))
+    if source_type not in {"search_log", "search_query"}:
+        return False
+    for key in ("zero_results", "zero_result"):
+        value = row.get(key)
+        if _truthy(value):
+            return True
+    for key in ("results_count", "result_count"):
+        count = _integer_or_none(row.get(key))
+        if count == 0:
+            return True
+    return False
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = _clean(value).lower()
+    return text in {"1", "true", "yes", "y"}
+
+
+def _integer_or_none(value: Any) -> int | None:
+    if value in (None, "", [], {}):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_present(*rows: Mapping[str, Any], key: str) -> Any:
+    for row in rows:
+        value = row.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return ""
 
 
 def _question(topic: str, rows: Sequence[Mapping[str, str]]) -> tuple[str, str]:

--- a/plans/PR-Content-Ops-FAQ-Zero-Result-Risk.md
+++ b/plans/PR-Content-Ops-FAQ-Zero-Result-Risk.md
@@ -1,0 +1,67 @@
+# PR-Content-Ops-FAQ-Zero-Result-Risk
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Search-Log-Sources made search-log rows first-class FAQ evidence, but zero-result searches are still scored the same as any other query unless their text happens to match an existing failure keyword. For an FAQ product wedge, a zero-result search is a direct failure signal: the customer asked in their own words and the help surface returned nothing useful.
+
+This slice closes that gap by making zero-result search rows contribute to FAQ opportunity risk.
+
+## Scope (this PR)
+
+1. Preserve search-result metadata from opportunities/evidence on grouped FAQ rows.
+2. Add a deterministic `zero_result_search` failure-risk signal for search-log rows with zero-result metadata.
+3. Let zero-result search signals affect existing `opportunity_score = frequency * (1 + failure_risk_score)` ranking.
+4. Add focused regression tests for metadata preservation, signal output, and ranking.
+
+### Files touched
+
+| File | Intent |
+|---|---|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Carry search metadata into scoring and add the zero-result risk signal. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Cover zero-result scoring/ranking behavior. |
+| `plans/PR-Content-Ops-FAQ-Zero-Result-Risk.md` | Plan contract for this slice. |
+
+## Mechanism
+
+The existing grouping loop builds compact row dictionaries for each FAQ topic. This PR adds source type and search-result fields to those grouped rows, using evidence values first and opportunity values as fallback. The failure-risk signal pass then appends `zero_result_search` when any grouped row is search-log/search-query evidence with zero-result metadata such as `zero_results=true`, `results_count=0`, or `result_count=0`.
+
+The scoring formula remains unchanged:
+
+```python
+opportunity_score = frequency * (1 + failure_risk_score)
+```
+
+Zero-result searches increase `failure_risk_score` through the new signal.
+
+## Intentional
+
+- This is still deterministic and provider-free.
+- Zero-result searches count once per FAQ topic as a signal category, not once per row. Frequency already captures repeated searches.
+- This does not yet produce vocabulary-gap term mappings; it only makes zero-result search demand visible in the intent ranking.
+
+## Deferred
+
+- `PR-Content-Ops-FAQ-Vocabulary-Gaps`: compare customer/search terms against documentation terms and emit term-mapping suggestions.
+- `PR-Content-Ops-FAQ-Sales-Objection-Sources`: add explicit sales-objection source aliases.
+
+## Verification
+
+Local verification:
+
+```bash
+pytest tests/test_extracted_ticket_faq_markdown.py -q
+# 67 passed
+
+bash scripts/run_extracted_pipeline_checks.sh
+# extracted_reasoning_core: 295 passed
+# extracted_content_pipeline: 1616 passed, 1 warning
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | 46 |
+| `tests/test_extracted_ticket_faq_markdown.py` | 67 |
+| `plans/PR-Content-Ops-FAQ-Zero-Result-Risk.md` | 67 |
+| **Total** | **180** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -329,6 +329,73 @@ def test_build_ticket_faq_markdown_uses_frequency_tiebreak_after_opportunity_sco
     ]
 
 
+def test_build_ticket_faq_markdown_ranks_zero_result_searches_as_failure_risk() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "search_log",
+            "query_id": "search-export-1",
+            "search_query": "How do I export attribution report?",
+            "results_count": 0,
+            "zero_results": True,
+            "evidence": [{
+                "text": "How do I export attribution report?",
+                "source_id": "search-export-1",
+                "source_type": "search_log",
+            }],
+        },
+        {
+            "source_type": "search_log",
+            "query_id": "search-export-2",
+            "search_query": "export dashboard attribution",
+            "result_count": "0",
+            "evidence": [{
+                "text": "export dashboard attribution",
+                "source_id": "search-export-2",
+                "source_type": "search_log",
+            }],
+        },
+        {
+            "source_type": "support_ticket",
+            "source_title": "Email update",
+            "evidence": [{
+                "text": "How do I change my email?",
+                "source_id": "ticket-email-1",
+                "source_type": "support_ticket",
+            }],
+        },
+        {
+            "source_type": "support_ticket",
+            "source_title": "Email settings",
+            "evidence": [{
+                "text": "I need to update the email on my account.",
+                "source_id": "ticket-email-2",
+                "source_type": "support_ticket",
+            }],
+        },
+        {
+            "source_type": "support_ticket",
+            "source_title": "Email profile",
+            "evidence": [{
+                "text": "Where can I edit the email address?",
+                "source_id": "ticket-email-3",
+                "source_type": "support_ticket",
+            }],
+        },
+    ])
+
+    assert [item["topic"] for item in result.items] == [
+        "reporting friction",
+        "email and profile updates",
+    ]
+    assert result.items[0]["frequency"] == 2
+    assert result.items[0]["failure_risk_signals"] == ("zero_result_search",)
+    assert result.items[0]["failure_risk_score"] == 1
+    assert result.items[0]["opportunity_score"] == 4
+    assert result.items[1]["frequency"] == 3
+    assert result.items[1]["failure_risk_score"] == 0
+    assert result.items[1]["opportunity_score"] == 3
+
+
 def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -> None:
     result = build_ticket_faq_markdown(
         [


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Zero-Result-Risk.md

Search-log rows are now first-class FAQ evidence, but zero-result searches still needed to affect prioritization. This slice preserves search-result metadata on grouped FAQ rows and adds `zero_result_search` as a deterministic failure-risk signal.

## Intentional
- Count zero-result search as one risk category per FAQ topic; frequency already captures repeated demand.
- Keep the scoring path deterministic and provider-free.
- Keep the existing `opportunity_score = frequency * (1 + failure_risk_score)` formula.

## Deferred
- Vocabulary gap detection against documentation terms.
- Explicit sales-objection source aliases.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py -q` — 67 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — extracted_reasoning_core: 295 passed; extracted_content_pipeline: 1616 passed, 1 warning.
- `bash scripts/local_pr_review.sh origin/main` — passed.

## Diff size
3 files, +180 / -0