### PR TITLE
PR-Landing-Page-Repair-Attempt-Contract

### DIFF
--- a/atlas-intel-ui/src/domain/contentOps/repairAttempts.ts
+++ b/atlas-intel-ui/src/domain/contentOps/repairAttempts.ts
@@ -1,0 +1,42 @@
+export const LANDING_PAGE_QUALITY_REPAIR_INPUT =
+  'landing_page_quality_repair_attempts'
+
+export const MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
+
+export const INVALID_LANDING_PAGE_QUALITY_REPAIR_VALUE = '__invalid__'
+
+export const LANDING_PAGE_QUALITY_REPAIR_OPTIONS = Array.from(
+  { length: MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS + 1 },
+  (_, index) => String(index),
+)
+
+export function normalizeLandingPageRepairAttemptValue(
+  value: unknown,
+): { ok: true; value: number } | { ok: false } {
+  if (
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && !Number.isInteger(value))
+  ) {
+    return { ok: false }
+  }
+
+  let normalized: number
+  if (typeof value === 'number') {
+    normalized = value
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!/^\d+$/.test(trimmed)) return { ok: false }
+    normalized = Number(trimmed)
+  } else {
+    return { ok: false }
+  }
+
+  if (
+    !Number.isSafeInteger(normalized) ||
+    normalized < 0 ||
+    normalized > MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS
+  ) {
+    return { ok: false }
+  }
+  return { ok: true, value: normalized }
+}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -39,6 +39,13 @@ import {
   type GenerationPlan,
   type GenerationPlanStep,
 } from '../domain/contentOps'
+import {
+  INVALID_LANDING_PAGE_QUALITY_REPAIR_VALUE,
+  LANDING_PAGE_QUALITY_REPAIR_INPUT,
+  LANDING_PAGE_QUALITY_REPAIR_OPTIONS,
+  MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
+  normalizeLandingPageRepairAttemptValue,
+} from '../domain/contentOps/repairAttempts'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
 
@@ -92,15 +99,6 @@ const DEFAULT_INGESTION_DEFAULT_FIELDS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_SOURCE = 'manual'
 const INGESTION_SAMPLE_LIMIT = 5
 const INGESTION_MAX_SOURCE_TEXT_CHARS = 1200
-const LANDING_PAGE_QUALITY_REPAIR_INPUT =
-  'landing_page_quality_repair_attempts'
-const MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
-const INVALID_LANDING_PAGE_QUALITY_REPAIR_VALUE = '__invalid__'
-const LANDING_PAGE_QUALITY_REPAIR_OPTIONS = Array.from(
-  { length: MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS + 1 },
-  (_, index) => String(index),
-)
-
 export default function ContentOpsNewRun() {
   const {
     data: wireCatalog,
@@ -1457,37 +1455,6 @@ function updateLandingPageRepairAttemptsInputJson(
   }
 
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
-}
-
-function normalizeLandingPageRepairAttemptValue(
-  value: unknown,
-): { ok: true; value: number } | { ok: false } {
-  if (
-    typeof value === 'boolean' ||
-    (typeof value === 'number' && !Number.isInteger(value))
-  ) {
-    return { ok: false }
-  }
-
-  let normalized: number
-  if (typeof value === 'number') {
-    normalized = value
-  } else if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!/^\d+$/.test(trimmed)) return { ok: false }
-    normalized = Number(trimmed)
-  } else {
-    return { ok: false }
-  }
-
-  if (
-    !Number.isSafeInteger(normalized) ||
-    normalized < 0 ||
-    normalized > MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS
-  ) {
-    return { ok: false }
-  }
-  return { ok: true, value: normalized }
 }
 
 function parseIngestionRowsJson(value: string): ParsedIngestionRows {

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
-_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
-_LANDING_PAGE_QUALITY_REPAIR_INPUT = "landing_page_quality_repair_attempts"
+LANDING_PAGE_QUALITY_REPAIR_INPUT = "landing_page_quality_repair_attempts"
+MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
 
 
 @dataclass(frozen=True)
@@ -31,8 +31,8 @@ class OutputDefinition:
     # Must mirror each *GenerationConfig.parse_retry_attempts default used in
     # generation_plan.py. If a service raises retries, update this field too.
     default_parse_retry_attempts: int = 1
-    # Must mirror each GenerationConfig quality-repair default. Only landing
-    # pages currently have a quality-repair LLM loop.
+    # Contract-tested against the landing-page generation config default.
+    # Only landing pages currently have a quality-repair LLM loop.
     default_quality_repair_attempts: int = 0
 
 
@@ -306,6 +306,16 @@ def _nonnegative_int_input(
     return value
 
 
+def landing_page_quality_repair_attempt_input(inputs: Mapping[str, Any]) -> int | None:
+    """Return the landing-page quality repair-attempt override, if present."""
+
+    return _nonnegative_int_input(
+        inputs,
+        LANDING_PAGE_QUALITY_REPAIR_INPUT,
+        max_value=MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
+    )
+
+
 def _quality_repair_attempts_for_output(
     output_id: str,
     definition: OutputDefinition,
@@ -319,11 +329,7 @@ def _quality_repair_attempts_for_output(
         return 0
     repair_attempts = definition.default_quality_repair_attempts
     if output_id == "landing_page":
-        override = _nonnegative_int_input(
-            inputs,
-            _LANDING_PAGE_QUALITY_REPAIR_INPUT,
-            max_value=_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
-        )
+        override = landing_page_quality_repair_attempt_input(inputs)
         if override is not None:
             repair_attempts = override
     return max(0, int(repair_attempts))

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -17,6 +17,7 @@ from .campaign_generation import CampaignGenerationConfig
 from .control_surfaces import (
     ContentOpsRequest,
     ControlSurfacePreview,
+    landing_page_quality_repair_attempt_input,
     preview_control_surface,
     request_from_mapping,
 )
@@ -31,9 +32,6 @@ from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
 from .ticket_faq_markdown import TicketFAQMarkdownConfig
-
-
-_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS = 10
 
 
 @dataclass(frozen=True)
@@ -171,11 +169,7 @@ def _landing_page_config_for_request(request: ContentOpsRequest) -> LandingPageG
     than on the config dataclass.
     """
     defaults = LandingPageGenerationConfig()
-    repair_attempts = _nonnegative_int_input(
-        request.inputs,
-        "landing_page_quality_repair_attempts",
-        max_value=_MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
-    )
+    repair_attempts = landing_page_quality_repair_attempt_input(request.inputs)
     if repair_attempts is None:
         return defaults
     return replace(defaults, quality_repair_attempts=repair_attempts)
@@ -252,28 +246,6 @@ def _positive_int_input(inputs: Mapping[str, Any], key: str) -> int | None:
         raise ValueError(f"{key} must be an integer") from None
     if value < 1:
         raise ValueError(f"{key} must be at least 1; got {value}")
-    return value
-
-
-def _nonnegative_int_input(
-    inputs: Mapping[str, Any],
-    key: str,
-    *,
-    max_value: int | None = None,
-) -> int | None:
-    raw = inputs.get(key)
-    if raw is None:
-        return None
-    if isinstance(raw, (bool, float)):
-        raise ValueError(f"{key} must be an integer")
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        raise ValueError(f"{key} must be an integer") from None
-    if value < 0:
-        raise ValueError(f"{key} must be at least 0; got {value}")
-    if max_value is not None and value > max_value:
-        raise ValueError(f"{key} must be at most {max_value}; got {value}")
     return value
 
 

--- a/plans/PR-Landing-Page-Repair-Attempt-Contract.md
+++ b/plans/PR-Landing-Page-Repair-Attempt-Contract.md
@@ -1,0 +1,79 @@
+# PR-Landing-Page-Repair-Attempt-Contract
+
+## Why this slice exists
+
+Landing-page quality repair attempt validation drifted across layers. The same integer range and max cap were duplicated in generation planning, preview cost estimation, and the Intel UI page. That caused a window where backend-valid values could be shown as invalid in the UI, and future changes would require manual edits in multiple places.
+
+This slice closes the drift path with one backend validator, one frontend validator module, and a contract test that pins the shared max/default expectations across those layers.
+
+## Scope (this PR)
+
+1. Promote landing-page repair attempt input name, max value, and validation to a shared backend control-surface helper.
+2. Make generation planning call the shared backend helper instead of reimplementing nonnegative integer validation.
+3. Move the Intel UI repair-attempt constant/options/normalizer out of the page into a small content-ops domain module.
+4. Add contract tests that assert backend preview, backend generation planning, landing-page generation defaults, catalog defaults, and UI max constant agree.
+
+### Files touched
+
+| File | Intent |
+|---|---|
+| `extracted_content_pipeline/control_surfaces.py` | Own the backend repair-attempt input constant, max constant, and validator helper. |
+| `extracted_content_pipeline/generation_plan.py` | Reuse the backend repair-attempt validator. |
+| `tests/test_extracted_content_control_surfaces.py` | Add backend/UI contract coverage for repair-attempt max/default agreement. |
+| `atlas-intel-ui/src/domain/contentOps/repairAttempts.ts` | Own the frontend repair-attempt constants/options/normalizer. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Use the frontend repair-attempt domain helper instead of local literals. |
+| `plans/PR-Landing-Page-Repair-Attempt-Contract.md` | Plan contract for this slice. |
+
+## Mechanism
+
+Backend code calls:
+
+```python
+landing_page_quality_repair_attempt_input(inputs)
+```
+
+for both preview and generation planning. That helper enforces integer-only values from `0` through `MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS`.
+
+Frontend code imports the same-shaped UI contract from `domain/contentOps/repairAttempts.ts`, so the page no longer owns the max literal or normalizer. A Python contract test reads the UI max export and asserts it matches the backend max, while also asserting the catalog default mirrors `LandingPageGenerationConfig().quality_repair_attempts`.
+
+## Intentional
+
+- The backend and frontend cannot share one runtime module without a larger generated contract. This slice uses shared helpers inside each runtime plus a cross-language contract test.
+- The UI still validates client-side for fast feedback, but the test prevents the UI cap from drifting from backend validation.
+- This does not change the allowed range; valid values remain `0..10`.
+
+## Deferred
+
+- Generated frontend constants from backend catalog/schema. That would remove the final cross-language manual mirror but is larger than this slice.
+- Parse-retry default mirror cleanup. This slice focuses only on landing-page quality repair attempts.
+
+## Verification
+
+Local verification:
+
+```bash
+pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py -q
+# 72 passed
+
+bash scripts/run_extracted_pipeline_checks.sh
+# extracted_reasoning_core: 295 passed
+# extracted_content_pipeline: 1616 passed, 1 warning
+
+npm --prefix atlas-intel-ui run build
+# passed
+
+bash scripts/local_pr_review.sh origin/main
+# passed
+```
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/control_surfaces.py` | 24 |
+| `extracted_content_pipeline/generation_plan.py` | 32 |
+| `tests/test_extracted_content_control_surfaces.py` | 35 |
+| `atlas-intel-ui/src/domain/contentOps/repairAttempts.ts` | 42 |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | 47 |
+| `plans/PR-Landing-Page-Repair-Attempt-Contract.md` | 79 |
+| **Total** | **259** |

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -1,9 +1,23 @@
+from pathlib import Path
+import re
+
 import pytest
 
 from extracted_content_pipeline.control_surfaces import (
+    LANDING_PAGE_QUALITY_REPAIR_INPUT,
+    MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS,
+    OUTPUT_CATALOG,
+    landing_page_quality_repair_attempt_input,
     normalize_outputs,
     preview_from_mapping,
     request_from_mapping,
+)
+from extracted_content_pipeline.landing_page_generation import LandingPageGenerationConfig
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_REPAIR_ATTEMPTS_CONTRACT = (
+    ROOT / "atlas-intel-ui/src/domain/contentOps/repairAttempts.ts"
 )
 
 
@@ -222,6 +236,27 @@ def test_preview_landing_page_cost_accepts_quality_repair_attempt_override_max()
 
     assert preview["can_run"] is True
     assert preview["estimated_cost_usd"] == 14.3
+
+
+def test_landing_page_repair_attempt_contract_matches_generation_and_ui():
+    ui_contract = UI_REPAIR_ATTEMPTS_CONTRACT.read_text(encoding="utf-8")
+    match = re.search(
+        r"MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS\s*=\s*(\d+)",
+        ui_contract,
+    )
+    assert match is not None
+    assert int(match.group(1)) == MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS
+    assert LANDING_PAGE_QUALITY_REPAIR_INPUT in ui_contract
+    assert (
+        landing_page_quality_repair_attempt_input({
+            LANDING_PAGE_QUALITY_REPAIR_INPUT: str(MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS)
+        })
+        == MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS
+    )
+    assert (
+        OUTPUT_CATALOG["landing_page"].default_quality_repair_attempts
+        == LandingPageGenerationConfig().quality_repair_attempts
+    )
 
 
 def test_preview_landing_page_repair_cost_can_block_budget():

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -259,6 +259,56 @@ def test_landing_page_repair_attempt_contract_matches_generation_and_ui():
     )
 
 
+# The cross-language scrape above pins the MAX/key/default constants. These pin
+# the shared backend validator's accept/reject LOGIC, so a regression that drops
+# the cap, the negative check, or the bool/float guards is also caught -- not
+# just a changed constant. The UI normalizer is expected to mirror this; that
+# mirror is asserted at the constant level (scrape) until a JS test runner exists.
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, 0),
+        (5, 5),
+        (MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS, MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS),
+        ("0", 0),
+        ("7", 7),
+        (str(MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS), MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS),
+    ],
+)
+def test_landing_page_repair_attempt_input_accepts_in_range(raw, expected):
+    assert (
+        landing_page_quality_repair_attempt_input({LANDING_PAGE_QUALITY_REPAIR_INPUT: raw})
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        -1,
+        MAX_LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS + 1,
+        100,
+        True,
+        1.5,
+        "many",
+        "-1",
+        "1.5",
+        "",
+    ],
+)
+def test_landing_page_repair_attempt_input_rejects_out_of_contract(raw):
+    with pytest.raises(ValueError):
+        landing_page_quality_repair_attempt_input({LANDING_PAGE_QUALITY_REPAIR_INPUT: raw})
+
+
+def test_landing_page_repair_attempt_input_treats_missing_as_none():
+    assert landing_page_quality_repair_attempt_input({}) is None
+    assert (
+        landing_page_quality_repair_attempt_input({LANDING_PAGE_QUALITY_REPAIR_INPUT: None})
+        is None
+    )
+
+
 def test_preview_landing_page_repair_cost_can_block_budget():
     preview = preview_from_mapping(
         {


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Repair-Attempt-Contract.md

Landing-page quality repair attempt validation had drifted across generation planning, preview cost estimation, and the Intel UI. This slice consolidates the backend validator, moves the UI validator into a domain helper, and adds a cross-runtime contract test for the max/default expectations.

## Intentional
- Keep backend and frontend runtime helpers separate but contract-tested because there is no generated cross-language schema in this slice.
- Preserve the existing allowed range: 0..10.
- Leave parse-retry default mirror cleanup for a separate slice.

## Deferred
- Generated frontend constants from backend schema/catalog.
- Parse-retry default mirror cleanup.

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py -q` — 72 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — extracted_reasoning_core: 295 passed; extracted_content_pipeline: 1616 passed, 1 warning.
- `npm --prefix atlas-intel-ui run build` — passed.
- `bash scripts/local_pr_review.sh origin/main` — passed.

## Diff size
6 files, +180 / -79