### PR TITLE
Add generated asset repair summary badge

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -282,6 +282,14 @@ export type GeneratedAssetType =
   | 'sales_brief'
   | 'faq_markdown'
 
+export interface GeneratedAssetRepairHistoryEntry {
+  attempt?: number
+  passed?: boolean
+  blockers?: string[] | string
+  repair_issues?: string[] | string
+  [key: string]: unknown
+}
+
 export interface GeneratedAssetDraft {
   id?: string
   title?: string
@@ -303,11 +311,15 @@ export interface GeneratedAssetDraft {
   hero?: Record<string, unknown>
   sections?: Array<Record<string, unknown>> | string
   cta?: Record<string, unknown>
+  metadata?: Record<string, unknown> | string
   reference_ids?: string[] | string
   generation_total_tokens?: number
   generation_input_tokens?: number
   generation_output_tokens?: number
   generation_parse_attempts?: number
+  generation_quality_repair_attempts?: number
+  generation_quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+  quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
   reasoning_context_used?: boolean
   reasoning_wedge?: string
   reasoning_confidence?: number | string

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -426,6 +426,8 @@ function AssetRow({
   const canReview = Boolean(id)
   const preview = assetPreview(row, asset)
   const facts = assetFacts(row, asset)
+  const repairHistory = assetRepairHistory(row)
+  const repairSummary = repairHistorySummary(repairHistory)
 
   return (
     <article className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
@@ -448,6 +450,16 @@ function AssetRow({
               {row.reasoning_context_used && (
                 <span className="rounded bg-violet-500/10 px-2 py-0.5 text-xs text-violet-200">
                   reasoning
+                </span>
+              )}
+              {repairSummary && (
+                <span className={clsx(
+                  'rounded px-2 py-0.5 text-xs',
+                  repairSummary.passed
+                    ? 'bg-emerald-500/10 text-emerald-200'
+                    : 'bg-amber-500/10 text-amber-200',
+                )}>
+                  {repairSummary.label}
                 </span>
               )}
             </div>
@@ -882,6 +894,24 @@ function RepairHistoryList({
       </ul>
     </div>
   )
+}
+
+function repairHistorySummary(
+  history: RepairHistoryEntry[],
+): { label: string; passed: boolean } | null {
+  if (history.length === 0) return null
+  const latest = history[history.length - 1]
+  const repairCount = Math.max(0, history.length - 1)
+  const repairLabel =
+    repairCount === 0
+      ? 'without repair'
+      : `after ${repairCount} repair${repairCount === 1 ? '' : 's'}`
+  return {
+    label: latest.passed
+      ? `quality passed ${repairLabel}`
+      : `quality blocked ${repairLabel}`,
+    passed: latest.passed,
+  }
 }
 
 function ReadinessBreakdown({ panels }: { panels: ReadinessPanel[] }) {

--- a/plans/PR-Generated-Asset-Repair-Summary.md
+++ b/plans/PR-Generated-Asset-Repair-Summary.md
@@ -1,0 +1,68 @@
+# PR-Generated-Asset-Repair-Summary
+
+## Why this slice exists
+
+PR #736 made landing-page repair history readable in the generated asset drawer,
+but the queue row still hides that signal. Review also noted that the
+repair-history fields compile only through `GeneratedAssetDraft`'s index
+signature, so a field-name typo would silently render an empty panel.
+
+This slice tightens the generated-asset wire type and adds a row-level repair
+summary.
+
+## Scope (this PR)
+
+1. Declare generated asset repair-history fields on the TypeScript wire type.
+2. Reuse the drawer repair-history parser for a compact row badge.
+3. Keep the detailed per-attempt display in the drawer unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Generated-Asset-Repair-Summary.md` | Plan doc for this UI contract/readability slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Adds explicit generated-asset repair telemetry fields. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Adds row-level repair summary derived from parsed repair history. |
+
+## Mechanism
+
+`GeneratedAssetDraft` now declares the top-level repair telemetry fields emitted
+by the backend:
+
+- `generation_quality_repair_attempts`
+- `generation_quality_repair_history`
+- `quality_repair_history`
+- `metadata`
+
+The asset row calls the existing `assetRepairHistory(row)` helper and renders a
+small status badge only when usable repair history is present. The badge reports
+whether the final attempt passed or remained blocked, and whether repairs were
+needed.
+
+## Intentional
+
+- No backend changes; the merged telemetry persistence already emits the data.
+- No new filtering/export behavior; this is queue readability only.
+- The drawer remains the source for detailed blockers and repair issues.
+
+## Deferred
+
+- A future generated-asset filtering/export slice can add repair-history CSV
+  columns or filters if operators need queue-wide triage.
+
+## Verification
+
+- `npm run lint` from `atlas-intel-ui` -> passed.
+- `npm run build` from `atlas-intel-ui` -> passed; Vite built successfully,
+  generated the sitemap, and pre-rendered public routes.
+- `git diff --check` -> passed with 0 whitespace errors.
+- `bash scripts/local_pr_review.sh origin/main` -> passed all wrapper checks:
+  pre-push audit wrapper, plan/code consistency, and `git diff --check`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~55 |
+| Type/UI | ~70 |
+| Total | ~125 |


### PR DESCRIPTION
Plan: plans/PR-Generated-Asset-Repair-Summary.md

## Why this slice exists

PR #736 made landing-page repair history readable in the generated asset drawer, but queue rows still hid that signal. Review also noted that the repair-history fields compiled only through the generated asset draft index signature.

## Scope (this PR)

1. Declare generated asset repair-history fields on the TypeScript wire type.
2. Reuse the drawer repair-history parser for a compact row badge.
3. Keep the detailed per-attempt drawer display unchanged.

## Mechanism

`GeneratedAssetDraft` now explicitly declares the top-level repair telemetry fields emitted by the backend. `AssetRow` calls the existing `assetRepairHistory(row)` parser and renders a badge only when usable repair history exists, showing whether quality passed or remained blocked and whether repairs were needed.

## Intentional

- No backend changes.
- No export/filter changes.
- Drawer detail remains the source for blockers and repair issues.

## Deferred

- Queue-level repair-history filters/export columns can be added later if operators need them.

## Verification

- `npm run lint` from `atlas-intel-ui` -> passed.
- `npm run build` from `atlas-intel-ui` -> passed.
- `git diff --check` -> passed.
- `bash scripts/local_pr_review.sh origin/main` -> passed.