### PR TITLE
PR-Generated-Asset-Repair-History-Type-Contract

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -290,6 +290,12 @@ export interface GeneratedAssetRepairHistoryEntry {
   [key: string]: unknown
 }
 
+export interface GeneratedAssetDraftMetadata {
+  generation_quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+  quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+  [key: string]: unknown
+}
+
 export interface GeneratedAssetDraft {
   id?: string
   title?: string
@@ -311,7 +317,7 @@ export interface GeneratedAssetDraft {
   hero?: Record<string, unknown>
   sections?: Array<Record<string, unknown>> | string
   cta?: Record<string, unknown>
-  metadata?: Record<string, unknown> | string
+  metadata?: GeneratedAssetDraftMetadata | string
   reference_ids?: string[] | string
   generation_total_tokens?: number
   generation_input_tokens?: number

--- a/plans/PR-Generated-Asset-Repair-History-Type-Contract.md
+++ b/plans/PR-Generated-Asset-Repair-History-Type-Contract.md
@@ -1,0 +1,71 @@
+# PR-Generated-Asset-Repair-History-Type-Contract
+
+## Why this slice exists
+
+PR #736 surfaced landing-page repair history in the generated asset review
+drawer. Reviewer feedback noted that the drawer reads
+`generation_quality_repair_history` and `quality_repair_history` through the
+`GeneratedAssetDraft` catch-all index signature, so a field-name typo would
+compile and fail closed to an empty panel.
+
+This slice makes the repair-history telemetry keys explicit on the generated
+asset API type.
+
+## Scope (this PR)
+
+1. Declare the generated asset repair-history entry shape used by the review
+   drawer.
+2. Declare the top-level and metadata fallback repair-history fields on
+   `GeneratedAssetDraft`.
+3. Keep the existing drawer parser and backend payloads unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Generated-Asset-Repair-History-Type-Contract.md` | Plan doc for this review-follow-up slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Adds explicit generated asset repair-history telemetry fields. |
+
+## Mechanism
+
+`GeneratedAssetDraft` gains two explicit optional telemetry fields:
+
+```ts
+generation_quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+```
+
+The same keys are declared on a `GeneratedAssetDraftMetadata` shape because the
+review drawer also accepts metadata-nested values. The fields continue to allow
+either arrays or JSON-stringified payloads, matching the fail-soft parser shipped
+in #736.
+
+## Intentional
+
+- No drawer rendering changes; this is a contract tightening follow-up to #736.
+- No backend migration or payload rename; the UI type now names the fields the
+  backend already emits.
+- The draft row catch-all index signature stays because generated assets still
+  carry asset-specific fields beyond this telemetry.
+
+## Deferred
+
+- Queue-level repair-history filters and export columns remain deferred to a
+  future generated-asset triage slice.
+- A broader generated-asset response-schema contract can follow if more
+  review-drawer fields become cross-layer drift risks.
+
+## Verification
+
+- `npm run lint` from `atlas-intel-ui`.
+- `npm run build` from `atlas-intel-ui`.
+- `git diff --check`.
+- `bash scripts/local_pr_review.sh origin/main`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| API type | ~15 |
+| Total | ~75 |


### PR DESCRIPTION
Plan: plans/PR-Generated-Asset-Repair-History-Type-Contract.md

PR #736 surfaced repair history in the generated asset review drawer, but reviewer feedback caught that the UI field names still relied on `GeneratedAssetDraft`'s catch-all index signature. This follow-up makes those repair-history telemetry keys explicit in the API client type so UI/backend field-name drift is compiler-visible. Rebased after #739 and kept #740's stronger typed metadata shape while preserving #739's repair-attempt count field.

## Intentional
- No drawer rendering changes; this is a contract tightening follow-up to #736.
- No backend migration or payload rename; the UI type now names the fields the backend already emits.
- The draft row catch-all index signature stays because generated assets still carry asset-specific fields beyond this telemetry.

## Deferred
- Queue-level repair-history filters and export columns remain deferred to a future generated-asset triage slice.
- A broader generated-asset response-schema contract can follow if more review-drawer fields become cross-layer drift risks.

## Verification
- `npm run lint` from `atlas-intel-ui` -> passed after rebase.
- `npm run build` from `atlas-intel-ui` -> passed after rebase.
- `bash scripts/local_pr_review.sh origin/main` -> passed after rebase.

## Diff size
2 files, +79 / -1
