### PR TITLE
Fix 61 markdown bullet-lists rendering as literal text (D9, 10 posts)

### DIFF
--- a/atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts
@@ -200,16 +200,20 @@ const post: BlogPost = {
 <p><strong>Technical debt signals are newly emerging</strong>, with all 4 mentions appearing in the recent review period (prior count was zero). Support complaints are accelerating. These are early-stage compounding signals that typically precede broader churn acceleration. The data suggests that engaging accounts before these issues become entrenched increases displacement probability, particularly given the 61 active evaluation signals visible in the current dataset.</p>
 <p>Economic buyer churn rate is 0.0%, meaning none of the decision-makers in this dataset show switching intent. This is a strong retention signal at the budget-holder level. However, the declining sentiment trajectory (0.0% declining vs. 0.0% improving) suggests stability rather than momentum. The platform is not losing ground, but it is not gaining either.</p>
 <p>The strongest current pressure surfaces with <strong>economic buyers and evaluators, especially in SMB accounts</strong>. This segment is actively comparing Copper to alternatives and weighing the Google integration benefit against feature and UX trade-offs. For teams where Google Workspace is central to operations, Copper's integration advantage is defensible. For teams with lighter Google usage or stronger automation needs, the feature gaps become harder to justify.</p>
-<p><strong>Who should buy Copper:</strong>
-- Small to mid-market sales teams (under 50 users) embedded in Google Workspace
-- Teams prioritizing seamless Gmail and Calendar integration over advanced automation
-- Organizations with straightforward sales processes that do not require complex workflow customization
-- Buyers who value simplicity and are willing to trade feature depth for ease of deployment</p>
-<p><strong>Who should evaluate alternatives:</strong>
-- Teams using Microsoft 365 or other non-Google productivity suites
-- Organizations needing enterprise-grade reporting, automation, or AI-powered insights
-- Sales teams with complex, multi-stage pipelines requiring advanced customization
-- Buyers who have outgrown Copper's feature set and are experiencing UX friction at scale</p>
+<p><strong>Who should buy Copper:</strong></p>
+<ul>
+<li>Small to mid-market sales teams (under 50 users) embedded in Google Workspace</li>
+<li>Teams prioritizing seamless Gmail and Calendar integration over advanced automation</li>
+<li>Organizations with straightforward sales processes that do not require complex workflow customization</li>
+<li>Buyers who value simplicity and are willing to trade feature depth for ease of deployment</li>
+</ul>
+<p><strong>Who should evaluate alternatives:</strong></p>
+<ul>
+<li>Teams using Microsoft 365 or other non-Google productivity suites</li>
+<li>Organizations needing enterprise-grade reporting, automation, or AI-powered insights</li>
+<li>Sales teams with complex, multi-stage pipelines requiring advanced customization</li>
+<li>Buyers who have outgrown Copper's feature set and are experiencing UX friction at scale</li>
+</ul>
 <p>The market regime is <strong>stable</strong>, indicating no category-wide disruption or churn acceleration. Copper operates in a mature CRM market where buyer expectations are high and feature parity with leaders like Salesforce and HubSpot is an ongoing challenge.</p>
 <p>The data suggests Copper is a defensible choice for its target segment (Google-native SMB teams) but faces pressure as customers scale and demand more sophisticated capabilities. The platform's future competitiveness depends on closing feature gaps without sacrificing the simplicity that defines its positioning.</p>
 <p>For teams evaluating Copper today, the decision hinges on one question: Is seamless Google integration worth the trade-offs in automation, reporting, and UX polish? If yes, Copper delivers on its core promise. If no, Salesforce and HubSpot offer richer feature sets at the cost of complexity.</p>`,

--- a/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
@@ -191,80 +191,110 @@ const post: BlogPost = {
 <p>These patterns suggest that CRM buyers are actively evaluating multiple options and that no single vendor fully resolves the category's recurring pain points.</p>
 <h2 id="close-strengths-weaknesses">Close: Strengths &amp; Weaknesses</h2>
 <p>Close has 12 reviews in scope with an average rating of 4.5 stars. The sample is small, so treat these findings as preliminary sentiment evidence.</p>
-<p><strong>Top pain points:</strong>
-- Overall dissatisfaction
-- Pricing
-- User experience</p>
-<p><strong>Strengths:</strong>
-- Pricing (despite also appearing as a weakness, some reviewers find the pricing model acceptable)
-- User experience (reviewers who praise Close often highlight its clean interface)
-- Reliability</p>
-<p><strong>Weaknesses:</strong>
-- Contract lock-in
-- Technical debt
-- Support</p>
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Overall dissatisfaction</li>
+<li>Pricing</li>
+<li>User experience</li>
+</ul>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Pricing (despite also appearing as a weakness, some reviewers find the pricing model acceptable)</li>
+<li>User experience (reviewers who praise Close often highlight its clean interface)</li>
+<li>Reliability</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Contract lock-in</li>
+<li>Technical debt</li>
+<li>Support</li>
+</ul>
 <p>Close's positioning is interesting. Pricing appears in both the strength and weakness lists, suggesting segmentation. Some reviewers find the pricing fair, while others report frustration with cost increases or seat-based models.</p>
 <p>The small sample size limits confidence. If you are evaluating Close, supplement this analysis with direct vendor conversations and trial usage.</p>
 <h2 id="copper-strengths-weaknesses">Copper: Strengths &amp; Weaknesses</h2>
 <p>Copper has 24 reviews in scope with an average rating of 4.7 stars. Despite the high rating, Copper shows elevated churn urgency.</p>
-<p><strong>Top pain points:</strong>
-- Overall dissatisfaction (appears twice in the top three, indicating concentrated frustration)
-- Pricing</p>
-<p><strong>Strengths:</strong>
-- Security
-- Overall dissatisfaction (counterintuitively, some reviewers report satisfaction despite the category's high pain frequency)
-- Onboarding</p>
-<p><strong>Weaknesses:</strong>
-- Data migration
-- Technical debt
-- Contract lock-in</p>
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Overall dissatisfaction (appears twice in the top three, indicating concentrated frustration)</li>
+<li>Pricing</li>
+</ul>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Security</li>
+<li>Overall dissatisfaction (counterintuitively, some reviewers report satisfaction despite the category's high pain frequency)</li>
+<li>Onboarding</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Data migration</li>
+<li>Technical debt</li>
+<li>Contract lock-in</li>
+</ul>
 <p>Copper's high rating combined with elevated churn urgency suggests a polarized user base. Satisfied users rate it highly, but frustrated users express strong switching intent.</p>
 <p>Data migration appears as a weakness. Reviewers report friction moving data into or out of Copper, which can create lock-in effects even when satisfaction declines.</p>
 <h2 id="freshsales-strengths-weaknesses">Freshsales: Strengths &amp; Weaknesses</h2>
 <p>Freshsales has 31 reviews in scope with an average rating of 4.2 stars. It shows elevated churn urgency alongside Copper.</p>
-<p><strong>Top pain points:</strong>
-- Features
-- Overall dissatisfaction
-- User experience</p>
-<p><strong>Strengths:</strong>
-- Performance
-- User experience (again, appears in both lists)
-- Features (also appears in both lists)</p>
-<p><strong>Weaknesses:</strong>
-- Contract lock-in
-- Reliability
-- Pricing</p>
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Features</li>
+<li>Overall dissatisfaction</li>
+<li>User experience</li>
+</ul>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Performance</li>
+<li>User experience (again, appears in both lists)</li>
+<li>Features (also appears in both lists)</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Contract lock-in</li>
+<li>Reliability</li>
+<li>Pricing</li>
+</ul>
 <p>Freshsales' pain profile is broad. Features, UX, and overall dissatisfaction all appear in the top three, suggesting that frustration is not concentrated in one area.</p>
 <p>The dual appearance of features and UX in both strength and weakness lists indicates segmentation. Some users find the feature set and interface strong, while others report gaps and friction.</p>
 <p>Reliability appears as a weakness. Reviewers mention bugs, downtime, and performance issues that undermine trust.</p>
 <h2 id="insightly-strengths-weaknesses">Insightly: Strengths &amp; Weaknesses</h2>
 <p>Insightly has 26 reviews in scope with an average rating of 4.1 stars.</p>
-<p><strong>Top pain points:</strong>
-- Features
-- Support
-- Pricing</p>
-<p><strong>Strengths:</strong>
-- Data migration
-- Onboarding
-- User experience</p>
-<p><strong>Weaknesses:</strong>
-- Support (appears in both lists)
-- Features (appears in both lists)</p>
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Features</li>
+<li>Support</li>
+<li>Pricing</li>
+</ul>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Data migration</li>
+<li>Onboarding</li>
+<li>User experience</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Support (appears in both lists)</li>
+<li>Features (appears in both lists)</li>
+</ul>
 <p>Insightly's pain profile is notable for the prominence of support. Reviewers report frustration with response time, resolution quality, and the support team's ability to address complex issues.</p>
 <p>Features also appear in both lists. Some reviewers praise Insightly's project management and pipeline features, while others report gaps in reporting, automation, and customization.</p>
 <p>Data migration appears as a strength. Reviewers who switched to Insightly report relatively smooth onboarding and data import processes.</p>
 <h2 id="nutshell-strengths-weaknesses">Nutshell: Strengths &amp; Weaknesses</h2>
 <p>Nutshell has 26 reviews in scope with an average rating of 4.4 stars. It shows the lowest churn urgency among the vendors profiled.</p>
-<p><strong>Top pain points:</strong>
-- Data migration
-- Integration
-- Pricing</p>
-<p><strong>Strengths:</strong>
-- Integration (appears in both lists)
-- Data migration (appears in both lists)
-- Onboarding</p>
-<p><strong>Weaknesses:</strong>
-- None listed in the supplied data</p>
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Data migration</li>
+<li>Integration</li>
+<li>Pricing</li>
+</ul>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Integration (appears in both lists)</li>
+<li>Data migration (appears in both lists)</li>
+<li>Onboarding</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>None listed in the supplied data</li>
+</ul>
 <p>Nutshell's profile is the most balanced. Data migration and integration appear in both the pain and strength lists, suggesting that experiences vary by use case or implementation quality.</p>
 <p>The absence of weaknesses in the supplied data does not mean Nutshell is flawless. It may indicate that the sample size is too small to surface a clear weakness pattern, or that Nutshell's pain points are more evenly distributed across categories.</p>
 <p>Nutshell's low churn urgency and high rating suggest relatively stable satisfaction, but the pricing pain point indicates that cost pressure is still a factor.</p>

--- a/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
@@ -171,55 +171,75 @@ While most vendors deliver functional interfaces, reviewers report that onboardi
 This is the most volatile pain point. Reviewers report that initial pricing is competitive, but renewal increases are steep. The phrase "pricing backlash" captures the pattern: teams choose a vendor based on cost, then face significant increases 12–24 months in. This creates renewal-window vulnerability—a key moment when competitors can win deals.</p>
 <p>Secondary pain patterns include integration lag (Freshdesk's third-party integrations, Zendesk's API complexity), contract lock-in (both Freshdesk and Zendesk), and performance issues during high-volume periods (Zendesk cited by small businesses handling rapid ticket growth).</p>
 <h2 id="freshdesk-strengths-weaknesses">Freshdesk: Strengths &amp; Weaknesses</h2>
-<p><strong>Strengths:</strong>
-- Data migration capabilities are cited as a competitive advantage. Reviewers moving from other platforms report smooth data transfer.
-- User experience is generally positive. The interface is intuitive enough that new team members ramp quickly.
-- Feature breadth at mid-market price points appeals to growing teams.</p>
-<p><strong>Weaknesses:</strong>
-- Integration maintenance is a pain point. Third-party integrations (especially WooCommerce) are community-maintained and lag behind official updates.
-- Contract cancellation is difficult. Multiple reviewers report that the cancellation process is opaque and time-consuming.
-- Pricing increases at renewal are steep. Teams report 30–50% increases when renewing, particularly at the 3-year mark.</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Data migration capabilities are cited as a competitive advantage. Reviewers moving from other platforms report smooth data transfer.</li>
+<li>User experience is generally positive. The interface is intuitive enough that new team members ramp quickly.</li>
+<li>Feature breadth at mid-market price points appeals to growing teams.</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Integration maintenance is a pain point. Third-party integrations (especially WooCommerce) are community-maintained and lag behind official updates.</li>
+<li>Contract cancellation is difficult. Multiple reviewers report that the cancellation process is opaque and time-consuming.</li>
+<li>Pricing increases at renewal are steep. Teams report 30–50% increases when renewing, particularly at the 3-year mark.</li>
+</ul>
 <p><strong>Verdict:</strong> Freshdesk is a strong cost alternative to Zendesk, but integration depth and renewal pricing are friction points. Best for teams prioritizing cost and comfortable managing integration lag.</p>
 <h2 id="happyfox-strengths-weaknesses">HappyFox: Strengths &amp; Weaknesses</h2>
-<p><strong>Strengths:</strong>
-- User experience is praised for simplicity. HappyFox reviewers note that the platform is easy to learn and configure without heavy customization.
-- Support responsiveness is stronger than larger competitors. Smaller team size means faster resolution on support tickets.
-- Overall satisfaction is high relative to sample size (11 reviews, 4.5 rating).</p>
-<p><strong>Weaknesses:</strong>
-- Limited data on major pain points. The smaller review sample makes it harder to identify systematic issues.
-- Feature breadth may lag larger competitors. HappyFox is positioned as a simpler, lighter alternative, which appeals to small teams but limits enterprise use cases.</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>User experience is praised for simplicity. HappyFox reviewers note that the platform is easy to learn and configure without heavy customization.</li>
+<li>Support responsiveness is stronger than larger competitors. Smaller team size means faster resolution on support tickets.</li>
+<li>Overall satisfaction is high relative to sample size (11 reviews, 4.5 rating).</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Limited data on major pain points. The smaller review sample makes it harder to identify systematic issues.</li>
+<li>Feature breadth may lag larger competitors. HappyFox is positioned as a simpler, lighter alternative, which appeals to small teams but limits enterprise use cases.</li>
+</ul>
 <p><strong>Verdict:</strong> HappyFox is best for small teams (under 50 people) prioritizing ease of use and responsive support. Not recommended for teams needing deep integrations or multi-channel support at scale.</p>
 <h2 id="help-scout-strengths-weaknesses">Help Scout: Strengths &amp; Weaknesses</h2>
-<p><strong>Strengths:</strong>
-- Support quality is a differentiator. Help Scout reviewers explicitly praise responsive, helpful support.
-- User experience is clean and approachable. The platform avoids the complexity of larger competitors.
-- Overall satisfaction is solid (4.4 rating across 11 reviews).</p>
-<p><strong>Weaknesses:</strong>
-- Pricing complaints are consistent. Help Scout is positioned as premium for its size, and reviewers note that cost is a barrier for growing teams.
-- Data migration from other platforms is cited as difficult. Reviewers report that switching to Help Scout requires manual effort.
-- Feature limitations emerge as teams scale. Reviewers note that advanced automation and reporting are weaker than Zendesk or Freshdesk.</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Support quality is a differentiator. Help Scout reviewers explicitly praise responsive, helpful support.</li>
+<li>User experience is clean and approachable. The platform avoids the complexity of larger competitors.</li>
+<li>Overall satisfaction is solid (4.4 rating across 11 reviews).</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing complaints are consistent. Help Scout is positioned as premium for its size, and reviewers note that cost is a barrier for growing teams.</li>
+<li>Data migration from other platforms is cited as difficult. Reviewers report that switching to Help Scout requires manual effort.</li>
+<li>Feature limitations emerge as teams scale. Reviewers note that advanced automation and reporting are weaker than Zendesk or Freshdesk.</li>
+</ul>
 <p><strong>Verdict:</strong> Help Scout works well for small, support-focused teams (under 100 people) willing to pay premium pricing for responsive support. Not ideal for teams needing broad feature depth or cost efficiency.</p>
 <h2 id="zendesk-strengths-weaknesses">Zendesk: Strengths &amp; Weaknesses</h2>
-<p><strong>Strengths:</strong>
-- Feature breadth is unmatched. Zendesk offers extensive automation, reporting, and multi-channel support (email, chat, phone, social).
-- Reliability at scale is strong. Reviewers managing high ticket volumes (small businesses with 200+ daily tickets) report that Zendesk handles load well.
-- Integration ecosystem is mature. Official integrations with CRMs, e-commerce platforms, and communication tools are robust.</p>
-<p><strong>Weaknesses:</strong>
-- Support quality is inconsistent. Reviewers report slow response times and difficulty escalating issues. One reviewer noted being "drowning in support tickets" without adequate vendor support.
-- Pricing is aggressive. Zendesk is the most expensive option on a per-seat basis, and reviewers cite this as the primary reason for evaluating competitors.
-- Contract lock-in is frustrating. Zendesk's multi-year contracts with steep renewal increases create friction at decision windows.
-- Onboarding complexity is steep. Reviewers note that implementation requires significant internal effort, particularly for custom workflows.</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Feature breadth is unmatched. Zendesk offers extensive automation, reporting, and multi-channel support (email, chat, phone, social).</li>
+<li>Reliability at scale is strong. Reviewers managing high ticket volumes (small businesses with 200+ daily tickets) report that Zendesk handles load well.</li>
+<li>Integration ecosystem is mature. Official integrations with CRMs, e-commerce platforms, and communication tools are robust.</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Support quality is inconsistent. Reviewers report slow response times and difficulty escalating issues. One reviewer noted being "drowning in support tickets" without adequate vendor support.</li>
+<li>Pricing is aggressive. Zendesk is the most expensive option on a per-seat basis, and reviewers cite this as the primary reason for evaluating competitors.</li>
+<li>Contract lock-in is frustrating. Zendesk's multi-year contracts with steep renewal increases create friction at decision windows.</li>
+<li>Onboarding complexity is steep. Reviewers note that implementation requires significant internal effort, particularly for custom workflows.</li>
+</ul>
 <p><strong>Verdict:</strong> Zendesk is best for large teams (200+ people) or enterprises needing extensive feature depth and multi-channel support. Avoid if cost is a primary concern or if your team lacks implementation bandwidth.</p>
 <h2 id="zoho-desk-strengths-weaknesses">Zoho Desk: Strengths &amp; Weaknesses</h2>
-<p><strong>Strengths:</strong>
-- Ecosystem integration is powerful. Teams already using Zoho CRM, Zoho Analytics, or other Zoho products report seamless workflows.
-- Support quality is praised. Zoho Desk reviewers note responsive support and helpful documentation.
-- Performance is reliable. Reviewers report fast response times and stability, even under load.
-- Pricing is competitive, especially for teams using other Zoho products.</p>
-<p><strong>Weaknesses:</strong>
-- Onboarding friction is notable. Reviewers report that initial setup is complex, particularly for teams unfamiliar with Zoho's ecosystem.
-- Integration outside the Zoho ecosystem is limited. Teams needing to connect to non-Zoho tools report friction.
-- User experience can feel dated. Reviewers note that the interface is functional but less polished than Zendesk or Freshdesk.</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Ecosystem integration is powerful. Teams already using Zoho CRM, Zoho Analytics, or other Zoho products report seamless workflows.</li>
+<li>Support quality is praised. Zoho Desk reviewers note responsive support and helpful documentation.</li>
+<li>Performance is reliable. Reviewers report fast response times and stability, even under load.</li>
+<li>Pricing is competitive, especially for teams using other Zoho products.</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Onboarding friction is notable. Reviewers report that initial setup is complex, particularly for teams unfamiliar with Zoho's ecosystem.</li>
+<li>Integration outside the Zoho ecosystem is limited. Teams needing to connect to non-Zoho tools report friction.</li>
+<li>User experience can feel dated. Reviewers note that the interface is functional but less polished than Zendesk or Freshdesk.</li>
+</ul>
 <p><strong>Verdict:</strong> Zoho Desk is ideal for teams already invested in the Zoho ecosystem or those prioritizing cost and support quality. Not recommended for teams needing broad third-party integrations or premium UI/UX.</p>
 <h2 id="choosing-the-right-helpdesk-platform">Choosing the Right Helpdesk Platform</h2>
 <p>The helpdesk market offers five viable options, each with distinct positioning:</p>

--- a/atlas-churn-ui/src/content/blog/jira-vs-trello-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/jira-vs-trello-2026-03.ts
@@ -128,18 +128,22 @@ const post: BlogPost = {
 <h2 id="jira-vs-trello-by-the-numbers">Jira vs Trello: By the Numbers</h2>
 <p>The core metrics reveal divergent reviewer experiences. Jira's 886 reviews show elevated urgency across multiple pain categories, while Trello's 1016 reviews cluster around a narrower set of scaling-related complaints.</p>
 <p>{{chart:head2head-bar}}</p>
-<p><strong>Jira's profile:</strong>
-- 886 reviews analyzed, 2.3/10 average urgency
-- Decision-maker churn rate: 10%
-- Top complaint category: UX complexity and forced cloud migrations
-- 58 evaluator-role reviews, 30 economic buyer reviews
-- 7 displacement signals (reviewers describing switches to Trello)</p>
-<p><strong>Trello's profile:</strong>
-- 1016 reviews analyzed, 1.7/10 average urgency
-- Decision-maker churn rate: 0%
-- Top complaint category: Scaling limitations beyond 50 cards
-- 48 evaluator-role reviews, 24 economic buyer reviews
-- 6 displacement signals (reviewers describing switches to Jira)</p>
+<p><strong>Jira's profile:</strong></p>
+<ul>
+<li>886 reviews analyzed, 2.3/10 average urgency</li>
+<li>Decision-maker churn rate: 10%</li>
+<li>Top complaint category: UX complexity and forced cloud migrations</li>
+<li>58 evaluator-role reviews, 30 economic buyer reviews</li>
+<li>7 displacement signals (reviewers describing switches to Trello)</li>
+</ul>
+<p><strong>Trello's profile:</strong></p>
+<ul>
+<li>1016 reviews analyzed, 1.7/10 average urgency</li>
+<li>Decision-maker churn rate: 0%</li>
+<li>Top complaint category: Scaling limitations beyond 50 cards</li>
+<li>48 evaluator-role reviews, 24 economic buyer reviews</li>
+<li>6 displacement signals (reviewers describing switches to Jira)</li>
+</ul>
 <p>The 0.6-point urgency gap is meaningful but not extreme. For context, urgency scores above 5.0 indicate acute pain requiring immediate intervention. Both vendors sit well below that threshold, suggesting most reviewers experience manageable friction rather than crisis-level problems.</p>
 <p>Source distribution matters for interpretation. Reddit accounts for 708 reviews (37% of total), skewing toward technical users and teams with strong opinions. Verified review platforms (G2, Capterra, Gartner, TrustRadius) contribute 294 reviews, representing a more balanced mix of buyer roles. Trustpilot adds 173 reviews, often from smaller teams and individual users.</p>
 <h2 id="where-each-vendor-falls-short">Where Each Vendor Falls Short</h2>
@@ -165,18 +169,22 @@ const post: BlogPost = {
 <h2 id="who-is-actually-switching">Who Is Actually Switching?</h2>
 <p>Displacement patterns reveal bidirectional movement between the two vendors, with moderate signal strength and distinct switching triggers.</p>
 <p>Among 1002 enriched reviews, <strong>7 describe switching from Jira to Trello</strong> and <strong>6 describe switching from Trello to Jira</strong>. This near-parity suggests the vendors serve different segments rather than competing head-to-head for the same buyers. The displacement flows are driven by different pain points:</p>
-<p><strong>Jira → Trello switches:</strong>
-- Primary driver: <strong>Integration challenges and UX complexity</strong>
-- Signal strength: Moderate (based on 7 mentions)
-- Active evaluations: 5 reviewers actively comparing alternatives
-- Explicit switches: 0 reviewers report completed migrations in this sample</p>
+<p><strong>Jira → Trello switches:</strong></p>
+<ul>
+<li>Primary driver: <strong>Integration challenges and UX complexity</strong></li>
+<li>Signal strength: Moderate (based on 7 mentions)</li>
+<li>Active evaluations: 5 reviewers actively comparing alternatives</li>
+<li>Explicit switches: 0 reviewers report completed migrations in this sample</li>
+</ul>
 <p>Reviewers considering moves from Jira to Trello cite the desire for simpler workflows and easier onboarding. These are typically smaller teams (under 20 people) or teams using Jira for use cases simpler than software development. They describe Jira as "overkill" for their needs.</p>
 <p>The integration complaint appears counterintuitive—Jira has a larger ecosystem than Trello. But reviewers describe friction connecting Jira to non-Atlassian tools, particularly in marketing, design, and operations workflows where Atlassian's ecosystem has less coverage.</p>
-<p><strong>Trello → Jira switches:</strong>
-- Primary driver: <strong>Scaling limitations and feature gaps</strong>
-- Signal strength: Moderate (based on 6 mentions)
-- Active evaluations: Included in the 5 total active evaluations
-- Explicit switches: 0 reviewers report completed migrations in this sample</p>
+<p><strong>Trello → Jira switches:</strong></p>
+<ul>
+<li>Primary driver: <strong>Scaling limitations and feature gaps</strong></li>
+<li>Signal strength: Moderate (based on 6 mentions)</li>
+<li>Active evaluations: Included in the 5 total active evaluations</li>
+<li>Explicit switches: 0 reviewers report completed migrations in this sample</li>
+</ul>
 <p>Reviewers considering moves from Trello to Jira describe hitting the 50-card wall or needing capabilities Trello lacks (time tracking, advanced reporting, dependency management). These are typically growing teams (20-50 people) or teams with increasingly complex workflows.</p>
 <p>One reviewer cites <strong>support issues</strong> as a switching trigger, though this appears only once and may reflect an isolated incident rather than a systemic pattern.</p>
 <p><strong>Displacement velocity:</strong></p>
@@ -324,11 +332,13 @@ const post: BlogPost = {
 <p>The pricing pain patterns reinforce the positioning difference. Jira reviewers complain about forced increases from a higher baseline. Trello reviewers complain about add-on costs from a lower baseline. Neither pattern suggests the vendor is overpriced for its target segment—they suggest friction at the boundaries of those segments.</p>
 <h2 id="the-verdict">The Verdict</h2>
 <p>Based on 1902 reviews analyzed between March 4 and March 29, 2026, the data leans toward Trello showing stronger reviewer sentiment, but with critical caveats.</p>
-<p><strong>By the numbers:</strong>
-- Trello shows 26% lower complaint urgency (1.7 vs 2.3)
-- Trello shows 0% decision-maker churn vs 10% for Jira
-- Displacement flows are bidirectional and moderate (7 Jira → Trello, 6 Trello → Jira)
-- Both vendors show 0% churn among evaluators, champions, and end-users</p>
+<p><strong>By the numbers:</strong></p>
+<ul>
+<li>Trello shows 26% lower complaint urgency (1.7 vs 2.3)</li>
+<li>Trello shows 0% decision-maker churn vs 10% for Jira</li>
+<li>Displacement flows are bidirectional and moderate (7 Jira → Trello, 6 Trello → Jira)</li>
+<li>Both vendors show 0% churn among evaluators, champions, and end-users</li>
+</ul>
 <p><strong>The decisive factor:</strong></p>
 <p>Jira's elevated urgency and decision-maker churn stem from a specific catalyst: <strong>forced Server edition sunset compounding existing UX and pricing frustrations</strong>. This is a temporal trigger, not a permanent product weakness. The data shows UX complaints accelerated 36% and pricing complaints surged 86% in the recent window, creating simultaneous friction on usability and cost.</p>
 <p>Reviewers caught in this migration mandate face acute pressure. Teams in regulated industries (financial services, healthcare, government) describe being trapped between compliance requirements and discontinued products. This cohort drives Jira's elevated urgency.</p>
@@ -341,23 +351,29 @@ const post: BlogPost = {
 <p>In this stable context, Jira's UX regression and Server sunset represent a localized disruption, not a category-wide shift. Trello's scaling limitations represent a persistent constraint, not an emerging crisis.</p>
 <p><strong>Buyer guidance:</strong></p>
 <p>The data suggests which vendor fits which buyer profile:</p>
-<p><strong>Consider Trello if:</strong>
-- Your team is under 20 people
-- Your workflows are simple and visual
-- You need fast onboarding and minimal training
-- You won't exceed 50 cards per board
-- You don't need advanced reporting or time tracking</p>
-<p><strong>Consider Jira if:</strong>
-- Your team is over 50 people
-- Your workflows are complex with dependencies
-- You need advanced reporting and sprint planning
-- You can invest in training and configuration
-- You don't have regulatory barriers to cloud deployment</p>
-<p><strong>Reconsider both if:</strong>
-- You're in a regulated industry requiring on-premise deployment (Jira Server sunset affects you)
-- You're a small team that might scale quickly (Trello's limits will constrain you)
-- You need deep integration with non-Atlassian tools (Jira's ecosystem has gaps)
-- You want database-backed flexibility (both are workflow-centric, not data-centric)</p>
+<p><strong>Consider Trello if:</strong></p>
+<ul>
+<li>Your team is under 20 people</li>
+<li>Your workflows are simple and visual</li>
+<li>You need fast onboarding and minimal training</li>
+<li>You won't exceed 50 cards per board</li>
+<li>You don't need advanced reporting or time tracking</li>
+</ul>
+<p><strong>Consider Jira if:</strong></p>
+<ul>
+<li>Your team is over 50 people</li>
+<li>Your workflows are complex with dependencies</li>
+<li>You need advanced reporting and sprint planning</li>
+<li>You can invest in training and configuration</li>
+<li>You don't have regulatory barriers to cloud deployment</li>
+</ul>
+<p><strong>Reconsider both if:</strong></p>
+<ul>
+<li>You're in a regulated industry requiring on-premise deployment (Jira Server sunset affects you)</li>
+<li>You're a small team that might scale quickly (Trello's limits will constrain you)</li>
+<li>You need deep integration with non-Atlassian tools (Jira's ecosystem has gaps)</li>
+<li>You want database-backed flexibility (both are workflow-centric, not data-centric)</li>
+</ul>
 <p>The "winner" depends entirely on where you sit on the complexity-simplicity spectrum and whether you're affected by Jira's migration mandates. Neither vendor dominates across all buyer segments.</p>
 <p><strong>Looking forward:</strong></p>
 <p>The causal trigger (Server sunset) is a one-time event. As affected teams complete migrations or switch to alternatives, Jira's elevated urgency should normalize. The UX complexity complaints will persist—they predate the Server sunset and reflect fundamental design choices—but without the migration catalyst, they're less likely to drive active churn.</p>

--- a/atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts
@@ -216,18 +216,22 @@ const post: BlogPost = {
 <hr />
 <h2 id="who-reviews-mailchimp-buyer-personas">Who Reviews Mailchimp: Buyer Personas</h2>
 <p>Mailchimp reviewers span multiple roles and purchase stages:</p>
-<p><strong>Top reviewer roles:</strong>
-- Unknown/unspecified (13 reviews in post-purchase stage)
-- End users / individual contributors (5 reviews in post-purchase)
-- Evaluators / decision-makers in active assessment (4 reviews)
-- Economic buyers / budget holders (2 reviews)</p>
+<p><strong>Top reviewer roles:</strong></p>
+<ul>
+<li>Unknown/unspecified (13 reviews in post-purchase stage)</li>
+<li>End users / individual contributors (5 reviews in post-purchase)</li>
+<li>Evaluators / decision-makers in active assessment (4 reviews)</li>
+<li>Economic buyers / budget holders (2 reviews)</li>
+</ul>
 <p><strong>Purchase stage distribution:</strong>
 - <strong>Post-purchase.</strong> The vast majority of reviews come from existing customers reflecting on their experience. This skews sentiment toward frustration with price increases and feature gaps.
 - <strong>Evaluation stage.</strong> A smaller but vocal segment of reviewers are actively comparing Mailchimp to competitors (Brevo, Klaviyo, ActiveCampaign) and documenting switching intent.</p>
-<p><strong>Company size and use case:</strong>
-- Small businesses (1–50 employees) dominate the review base, particularly solopreneurs and small marketing teams.
-- Mid-market companies (51–1,000 employees) also appear, often frustrated by feature limitations.
-- Enterprise adoption is minimal; Mailchimp lacks the depth and compliance features needed at scale.</p>
+<p><strong>Company size and use case:</strong></p>
+<ul>
+<li>Small businesses (1–50 employees) dominate the review base, particularly solopreneurs and small marketing teams.</li>
+<li>Mid-market companies (51–1,000 employees) also appear, often frustrated by feature limitations.</li>
+<li>Enterprise adoption is minimal; Mailchimp lacks the depth and compliance features needed at scale.</li>
+</ul>
 <p><strong>Decision timeline:</strong> Reviewers explicitly reference "few weeks" evaluation windows, often triggered by price increase notices or contract renewal cycles.</p>
 <hr />
 <h2 id="how-mailchimp-stacks-up-against-competitors">How Mailchimp Stacks Up Against Competitors</h2>
@@ -254,10 +258,12 @@ const post: BlogPost = {
 <p><strong>Specific price points cited:</strong>
 - $126/month for 1,000 contacts
 - $308/month for 7,000 contacts</p>
-<p><strong>Triggering events:</strong>
-- Free plan cuts in early 2026
-- Retroactive price increases on existing plans
-- Contact-based pricing model that penalizes growth</p>
+<p><strong>Triggering events:</strong></p>
+<ul>
+<li>Free plan cuts in early 2026</li>
+<li>Retroactive price increases on existing plans</li>
+<li>Contact-based pricing model that penalizes growth</li>
+</ul>
 <p><strong>Reviewer sentiment on pricing:</strong></p>
 <blockquote>
 <p>"I stopped paying hundreds per month for Mailchimp &amp; Instantly and built a self-hosted cold email system in n8n." -- reviewer on Reddit</p>
@@ -267,19 +273,23 @@ const post: BlogPost = {
 <p><strong>The counterevidence:</strong> Despite pricing frustration, reviewers acknowledge that the basic platform works well. One reviewer noted: "Despite the many price increases, we do like the basic platform. This may be our goodbye to Mailchimp." This suggests that if Mailchimp were to address pricing or introduce tiered feature improvements, some churn could be arrested. However, the "few weeks" evaluation timeline indicates that the window to act is narrow.</p>
 <hr />
 <h2 id="key-takeaways-for-potential-buyers">Key Takeaways for Potential Buyers</h2>
-<p><strong>Choose Mailchimp if:</strong>
-- You need a simple, intuitive email marketing platform with minimal learning curve.
-- You operate an e-commerce store and want seamless Shopify or WooCommerce integration.
-- You have fewer than 5,000 contacts and plan to stay small.
-- You value template quality and drag-and-drop simplicity over advanced automation.
-- You are willing to accept limited support on lower-tier plans.</p>
-<p><strong>Evaluate alternatives if:</strong>
-- You have more than 5,000 contacts or expect rapid growth. Cost per contact will become prohibitive.
-- You need advanced automation, conditional logic, or multi-channel orchestration.
-- You require tight CRM integration or API depth for custom workflows.
-- You want unlimited contacts at a fixed price (Brevo is a strong alternative).
-- You prioritize responsive support and transparent pricing without recent increases.
-- You are evaluating Mailchimp during a contract renewal or price increase notice.</p>
+<p><strong>Choose Mailchimp if:</strong></p>
+<ul>
+<li>You need a simple, intuitive email marketing platform with minimal learning curve.</li>
+<li>You operate an e-commerce store and want seamless Shopify or WooCommerce integration.</li>
+<li>You have fewer than 5,000 contacts and plan to stay small.</li>
+<li>You value template quality and drag-and-drop simplicity over advanced automation.</li>
+<li>You are willing to accept limited support on lower-tier plans.</li>
+</ul>
+<p><strong>Evaluate alternatives if:</strong></p>
+<ul>
+<li>You have more than 5,000 contacts or expect rapid growth. Cost per contact will become prohibitive.</li>
+<li>You need advanced automation, conditional logic, or multi-channel orchestration.</li>
+<li>You require tight CRM integration or API depth for custom workflows.</li>
+<li>You want unlimited contacts at a fixed price (Brevo is a strong alternative).</li>
+<li>You prioritize responsive support and transparent pricing without recent increases.</li>
+<li>You are evaluating Mailchimp during a contract renewal or price increase notice.</li>
+</ul>
 <p><strong>Market context:</strong> Mailchimp operates in an entrenchment regime where the incumbent has raised prices on the existing base while feature development has slowed relative to competitors. This creates a window for challengers (Brevo, Klaviyo, ActiveCampaign) to capture switchers. The timing is immediate: free plan cuts and price increases in early 2026 are actively triggering evaluation cycles with few-week decision windows.</p>
 <hr />
 <h2 id="the-bottom-line">The Bottom Line</h2>

--- a/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
@@ -144,12 +144,14 @@ const post: BlogPost = {
 <p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-28 to 2026-04-06. It captures reviewer perception, not a census of all users.</em></p>
 <p>The marketing automation category has become a crowded, price-sensitive market where feature parity is high and cost differentiation drives switching behavior. This analysis examines 1,568 enriched reviews of five major vendors—ActiveCampaign, Brevo, GetResponse, Klaviyo, and Mailchimp—collected between February 28 and April 6, 2026.</p>
 <p>Our data comes from verified review platforms (G2, Gartner Peer Insights, PeerSpot) and community platforms (Reddit, Software Advice, TrustPilot), giving us both structured ratings and unfiltered switching intent signals. The goal is not to declare a winner, but to show you where the churn pressure lies, which vendors face the highest replacement risk, and what patterns repeat across the category.</p>
-<p><strong>Key facts:</strong>
-- 5 vendors analyzed
-- 57 total churn signals identified
-- Average urgency score: 4.1 (on a 10-point scale)
-- Market regime: fragmented
-- Confidence level: high (based on 1,568 enriched reviews)</p>
+<p><strong>Key facts:</strong></p>
+<ul>
+<li>5 vendors analyzed</li>
+<li>57 total churn signals identified</li>
+<li>Average urgency score: 4.1 (on a 10-point scale)</li>
+<li>Market regime: fragmented</li>
+<li>Confidence level: high (based on 1,568 enriched reviews)</li>
+</ul>
 <h2 id="what-market-regime-are-we-in">What Market Regime Are We In?</h2>
 <p>The marketing automation market is fragmented. No single vendor dominates; instead, we see clear displacement flows where teams switch based on cost and perceived feature gaps. This fragmentation creates opportunity for specialists (Klaviyo for e-commerce, GetResponse for small business) and pressure on generalists (ActiveCampaign, Mailchimp) to justify premium pricing.</p>
 <p>In a fragmented regime, switching costs are moderate, contract lock-in is real but not absolute, and pricing becomes the tiebreaker. When two platforms offer similar features, the cheaper one wins—especially at renewal time when frustration peaks.</p>
@@ -165,76 +167,96 @@ const post: BlogPost = {
 <h2 id="activecampaign-strengths-weaknesses">ActiveCampaign: Strengths &amp; Weaknesses</h2>
 <p><strong>Rating:</strong> 4.3 | <strong>Reviews analyzed:</strong> 28 | <strong>Churn urgency:</strong> High</p>
 <p>ActiveC ampaign is a full-featured CRM and marketing automation platform that excels at workflow automation and integration breadth. Reviewers consistently praise its feature depth and customization options.</p>
-<p><strong>Strengths:</strong>
-- Feature richness and automation depth
-- Strong UX for power users
-- Extensive integration ecosystem</p>
-<p><strong>Weaknesses:</strong>
-- Pricing pressure: Premium plans run $500–$800 more per month than Mailchimp equivalents
-- Overall dissatisfaction: Reviewers report frustration with pricing-to-value ratio
-- Competitive inferiority: Losing ground to HubSpot on all-in-one appeal and to Klaviyo on e-commerce focus
-- Technical debt and performance issues cited by some users
-- Contract lock-in concerns, especially at higher tiers</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Feature richness and automation depth</li>
+<li>Strong UX for power users</li>
+<li>Extensive integration ecosystem</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing pressure: Premium plans run $500–$800 more per month than Mailchimp equivalents</li>
+<li>Overall dissatisfaction: Reviewers report frustration with pricing-to-value ratio</li>
+<li>Competitive inferiority: Losing ground to HubSpot on all-in-one appeal and to Klaviyo on e-commerce focus</li>
+<li>Technical debt and performance issues cited by some users</li>
+<li>Contract lock-in concerns, especially at higher tiers</li>
+</ul>
 <p><strong>Churn signal:</strong> Reviewers report evaluating Mailchimp, HubSpot, and Klaviyo as cost-conscious alternatives. Pricing renewal conversations often trigger evaluations.</p>
 <h2 id="brevo-strengths-weaknesses">Brevo: Strengths &amp; Weaknesses</h2>
 <p><strong>Rating:</strong> 4.4 | <strong>Reviews analyzed:</strong> 20 | <strong>Churn urgency:</strong> Moderate</p>
 <p>Brevo (formerly Sendinblue) positions itself as a budget-friendly alternative with strong email and SMS capabilities. It appeals to cost-conscious SMBs and mid-market teams.</p>
-<p><strong>Strengths:</strong>
-- Competitive pricing, especially for email-first workflows
-- Smooth data migration from legacy platforms
-- Strong onboarding experience
-- Reasonable feature set for the price</p>
-<p><strong>Weaknesses:</strong>
-- Pricing still a friction point for some; UX complexity for advanced automation
-- Competitive inferiority: Losing to Klaviyo on e-commerce and HubSpot on all-in-one appeal
-- Performance and reliability concerns cited by some reviewers
-- Contract lock-in on longer commitments</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Competitive pricing, especially for email-first workflows</li>
+<li>Smooth data migration from legacy platforms</li>
+<li>Strong onboarding experience</li>
+<li>Reasonable feature set for the price</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing still a friction point for some; UX complexity for advanced automation</li>
+<li>Competitive inferiority: Losing to Klaviyo on e-commerce and HubSpot on all-in-one appeal</li>
+<li>Performance and reliability concerns cited by some reviewers</li>
+<li>Contract lock-in on longer commitments</li>
+</ul>
 <p><strong>Churn signal:</strong> Reviewers often evaluate Brevo as a cost-down move, then reconsider when they need deeper automation or e-commerce features. Retention is strongest among email-first teams.</p>
 <h2 id="getresponse-strengths-weaknesses">GetResponse: Strengths &amp; Weaknesses</h2>
 <p><strong>Rating:</strong> 4.6 | <strong>Reviews analyzed:</strong> 12 | <strong>Churn urgency:</strong> Low-Moderate</p>
 <p>GetResponse targets small business and solopreneur segments with an affordable, integrated platform. It combines email, landing pages, and webinars in one toolset.</p>
-<p><strong>Strengths:</strong>
-- Strong integration ecosystem
-- Clean, intuitive UX
-- Smooth onboarding for non-technical users
-- Good value for small teams</p>
-<p><strong>Weaknesses:</strong>
-- Pricing complaints despite affordability—reviewers want lower entry points
-- Support responsiveness cited as a gap
-- Competitive inferiority: Losing to HubSpot and Klaviyo on feature depth
-- Contract lock-in for annual commitments</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Strong integration ecosystem</li>
+<li>Clean, intuitive UX</li>
+<li>Smooth onboarding for non-technical users</li>
+<li>Good value for small teams</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing complaints despite affordability—reviewers want lower entry points</li>
+<li>Support responsiveness cited as a gap</li>
+<li>Competitive inferiority: Losing to HubSpot and Klaviyo on feature depth</li>
+<li>Contract lock-in for annual commitments</li>
+</ul>
 <p><strong>Churn signal:</strong> GetResponse loses teams when they outgrow the platform's feature set or when they consolidate around HubSpot for all-in-one CRM + marketing. Churn is less price-driven than feature-driven.</p>
 <h2 id="klaviyo-strengths-weaknesses">Klaviyo: Strengths &amp; Weaknesses</h2>
 <p><strong>Rating:</strong> 4.6 | <strong>Reviews analyzed:</strong> 45 | <strong>Churn urgency:</strong> Low</p>
 <p>Klaviyo has become the dominant e-commerce marketing automation platform, with deep Shopify, WooCommerce, and BigCommerce integration. It attracts high-growth online retailers and DTC brands.</p>
-<p><strong>Strengths:</strong>
-- Industry-leading e-commerce integrations
-- Powerful segmentation and personalization
-- Strong feature depth and onboarding
-- High satisfaction among target segment</p>
-<p><strong>Weaknesses:</strong>
-- Pricing: Premium plans are expensive; reviewers cite $500+ monthly costs for mid-scale campaigns
-- UX complexity: Advanced features have a learning curve
-- Overall dissatisfaction: Some reviewers feel price does not justify feature gaps vs. competitors
-- Data migration challenges from legacy platforms
-- Performance issues at scale reported by some users
-- Security concerns cited in a small number of reviews</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Industry-leading e-commerce integrations</li>
+<li>Powerful segmentation and personalization</li>
+<li>Strong feature depth and onboarding</li>
+<li>High satisfaction among target segment</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing: Premium plans are expensive; reviewers cite $500+ monthly costs for mid-scale campaigns</li>
+<li>UX complexity: Advanced features have a learning curve</li>
+<li>Overall dissatisfaction: Some reviewers feel price does not justify feature gaps vs. competitors</li>
+<li>Data migration challenges from legacy platforms</li>
+<li>Performance issues at scale reported by some users</li>
+<li>Security concerns cited in a small number of reviews</li>
+</ul>
 <p><strong>Churn signal:</strong> Klaviyo loses cost-conscious teams to Omnisend and Brevo, but retention is strong among high-growth e-commerce teams that see clear ROI. Pricing renewal is the key churn moment.</p>
 <h2 id="mailchimp-strengths-weaknesses">Mailchimp: Strengths &amp; Weaknesses</h2>
 <p><strong>Rating:</strong> 4.3 | <strong>Reviews analyzed:</strong> 45 | <strong>Churn urgency:</strong> High</p>
 <p>Mailchimp is the incumbent email marketing platform, known for ease of use and free tier accessibility. It remains the entry point for many small businesses, but faces intense competition at scale.</p>
-<p><strong>Strengths:</strong>
-- Intuitive UX, especially for email-first workflows
-- Robust feature set for the price
-- Strong overall satisfaction among small business users
-- Free tier enables low-friction adoption</p>
-<p><strong>Weaknesses:</strong>
-- Pricing: Teams report significant cost jumps at higher tiers and list sizes
-- UX: Advanced automation and segmentation feel clunky compared to Klaviyo or ActiveCampaign
-- Feature gaps: Missing advanced CRM, e-commerce, and workflow capabilities
-- Technical debt: Platform feels dated in places
-- Contract lock-in: Annual commitments with limited flexibility
-- Reliability: Some users report deliverability and API stability issues</p>
+<p><strong>Strengths:</strong></p>
+<ul>
+<li>Intuitive UX, especially for email-first workflows</li>
+<li>Robust feature set for the price</li>
+<li>Strong overall satisfaction among small business users</li>
+<li>Free tier enables low-friction adoption</li>
+</ul>
+<p><strong>Weaknesses:</strong></p>
+<ul>
+<li>Pricing: Teams report significant cost jumps at higher tiers and list sizes</li>
+<li>UX: Advanced automation and segmentation feel clunky compared to Klaviyo or ActiveCampaign</li>
+<li>Feature gaps: Missing advanced CRM, e-commerce, and workflow capabilities</li>
+<li>Technical debt: Platform feels dated in places</li>
+<li>Contract lock-in: Annual commitments with limited flexibility</li>
+<li>Reliability: Some users report deliverability and API stability issues</li>
+</ul>
 <p><strong>Churn signal:</strong> Mailchimp loses teams to Klaviyo (e-commerce focus), HubSpot (all-in-one CRM), and Brevo (cost). The churn moment typically arrives at renewal when teams realize they have outgrown email-only capabilities.</p>
 <h2 id="choosing-the-right-marketing-automation-platform">Choosing the Right Marketing Automation Platform</h2>
 <p>The marketing automation landscape offers no universal winner. Instead, the right choice depends on your use case, budget, and growth stage.</p>

--- a/atlas-churn-ui/src/content/blog/microsoft-defender-for-endpoint-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/microsoft-defender-for-endpoint-deep-dive-2026-04.ts
@@ -185,10 +185,12 @@ const post: BlogPost = {
 <p>Organizations should supplement this review analysis with direct account intelligence—contract end dates, renewal discussions, competitive RFP activity, and feature request patterns—to identify which customers are at elevated risk of switching.</p>
 <h2 id="how-microsoft-defender-for-endpoint-stacks-up-against-competitors">How Microsoft Defender for Endpoint Stacks Up Against Competitors</h2>
 <p>Reviewers frequently compare Microsoft Defender for Endpoint to CrowdStrike, Cisco Secure Endpoint, Microsoft Defender (the consumer product), Rapid7, and Tenable. The competitive landscape reveals clear differentiation points:</p>
-<p><strong>Microsoft Defender for Endpoint strengths in comparison:</strong>
-- Native Windows and Microsoft 365 integration
-- Lower cost of ownership for organizations already on Microsoft licensing
-- Unified security posture across endpoints and cloud workloads</p>
+<p><strong>Microsoft Defender for Endpoint strengths in comparison:</strong></p>
+<ul>
+<li>Native Windows and Microsoft 365 integration</li>
+<li>Lower cost of ownership for organizations already on Microsoft licensing</li>
+<li>Unified security posture across endpoints and cloud workloads</li>
+</ul>
 <p><strong>Competitor advantages cited by reviewers:</strong>
 - <strong>CrowdStrike</strong>: Superior visibility into non-Windows and cloud-native environments; better integration with modern development tooling
 - <strong>Cisco Secure Endpoint</strong>: Stronger support for heterogeneous infrastructure; better multi-cloud visibility

--- a/atlas-churn-ui/src/content/blog/salesforce-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/salesforce-deep-dive-2026-04.ts
@@ -239,27 +239,33 @@ const post: BlogPost = {
 <p>Timing matters here. The analysis identifies May 1 as a timing anchor, corresponding to the Agentforce launch window. Reviewers are actively calculating ROI in the context of new product announcements and pricing changes. Setup cost transparency creates immediate evaluation pressure before teams commit to deeper organizational integration. This isn't a long-simmering issue -- it's fresh, and buyers are responding now.</p>
 <p>Two active evaluation signals are visible in the current dataset, indicating teams actively weighing alternatives. That's a small number in absolute terms, but meaningful given the dataset's 73 total churn intent signals. When 2.7% of switching-intent reviewers are in active evaluation (versus considering a future switch), it suggests urgency.</p>
 <p><strong>Economic buyers show zero public churn rate.</strong> This is a critical data point: once economic decision-makers commit to Salesforce, they don't publicly reverse that decision. The 0.0% churn rate among economic buyers suggests either strong satisfaction post-purchase, or that switching costs (data migration complexity, organizational dependencies) create effective lock-in. The data can't distinguish between these explanations, but the pattern is clear.</p>
-<p><strong>The platform works best for well-resourced organizations.</strong> Reviewer sentiment consistently shows that Salesforce delivers value when teams have:
-- Dedicated Salesforce administrators to manage the platform
-- Budget for proper implementation (not just licensing)
-- Complex business processes that justify customization investment
-- Enterprise-scale user bases where per-seat costs distribute across larger teams</p>
+<p><strong>The platform works best for well-resourced organizations.</strong> Reviewer sentiment consistently shows that Salesforce delivers value when teams have:</p>
+<ul>
+<li>Dedicated Salesforce administrators to manage the platform</li>
+<li>Budget for proper implementation (not just licensing)</li>
+<li>Complex business processes that justify customization investment</li>
+<li>Enterprise-scale user bases where per-seat costs distribute across larger teams</li>
+</ul>
 <p>Teams without these resources report frustration with complexity, implementation timelines, and cost-benefit ratios that don't justify the investment.</p>
 <p><strong>Support quality remains a persistent weakness.</strong> Despite Salesforce's market dominance and enterprise focus, reviewers consistently cite support issues. Response times, knowledge gaps, and the need for premium support tiers to access competent help create friction. This pattern appears across company sizes, though enterprise reviewers report better experiences with dedicated account teams.</p>
 <p><strong>The ecosystem is both strength and liability.</strong> Reviewers value Salesforce's integration breadth and AppExchange marketplace while simultaneously reporting that making integrations work reliably requires ongoing effort. Pre-built connectors don't always deliver seamless data flow. Custom development or middleware becomes necessary for integrations that should theoretically work out-of-box. The maintenance burden of keeping integrations functional through platform updates creates ongoing operational cost.</p>
 <p><strong>Market regime remains stable.</strong> Despite pricing pressure and active evaluation signals, Salesforce operates in a "stable" market regime according to category assessment. This suggests the current churn patterns are elevated but not catastrophic. Competitors are applying pressure, but no single alternative is displacing Salesforce at scale. The platform's market position remains defensible, even as specific buyer segments (particularly smaller teams) increasingly question the value proposition.</p>
-<p><strong>Who should consider Salesforce in 2026:</strong>
-- Mid-market to enterprise B2B companies with complex sales processes
-- Organizations with existing Salesforce investments seeking to expand usage
-- Teams with dedicated resources for implementation and ongoing administration
-- Companies requiring deep customization and extensive third-party integrations
-- Buyers prioritizing ecosystem breadth over setup simplicity</p>
-<p><strong>Who should evaluate alternatives:</strong>
-- Small teams (sub-50 employees) without dedicated admin resources
-- Organizations with straightforward CRM requirements that don't justify customization investment
-- Budget-constrained buyers where total cost of ownership is a primary concern
-- Teams prioritizing quick setup and intuitive UX over customization depth
-- Companies seeking modern interface design and user experience</p>
+<p><strong>Who should consider Salesforce in 2026:</strong></p>
+<ul>
+<li>Mid-market to enterprise B2B companies with complex sales processes</li>
+<li>Organizations with existing Salesforce investments seeking to expand usage</li>
+<li>Teams with dedicated resources for implementation and ongoing administration</li>
+<li>Companies requiring deep customization and extensive third-party integrations</li>
+<li>Buyers prioritizing ecosystem breadth over setup simplicity</li>
+</ul>
+<p><strong>Who should evaluate alternatives:</strong></p>
+<ul>
+<li>Small teams (sub-50 employees) without dedicated admin resources</li>
+<li>Organizations with straightforward CRM requirements that don't justify customization investment</li>
+<li>Budget-constrained buyers where total cost of ownership is a primary concern</li>
+<li>Teams prioritizing quick setup and intuitive UX over customization depth</li>
+<li>Companies seeking modern interface design and user experience</li>
+</ul>
 <p>The data suggests Salesforce isn't failing -- it's succeeding at what it was designed to do while struggling to justify its complexity and cost for buyers outside its core market. The platform's challenges are primarily economic (pricing pressure) and operational (implementation complexity) rather than technical capability gaps.</p>
 <p>For decision-makers evaluating Salesforce in 2026, the key question isn't "Is Salesforce good?" but rather "Do we have the resources and requirements that make Salesforce the right fit?" The reviewer data provides clear signals on both sides of that question.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts
@@ -192,16 +192,20 @@ const post: BlogPost = {
 <p><strong>Integration priorities</strong>: Payment processing (PayPal), shipping logistics (FedEx), dropshipping (Printful), WordPress ecosystem dependencies, and social commerce (Facebook) define the plugin landscape. Reviewers report that integration quality varies and requires active management.</p>
 <p><strong>Migration trade-offs</strong>: Cost control and customization flexibility versus operational simplicity and vendor-managed infrastructure. Reviewers who successfully migrate describe 1-2 weeks of intensive setup and ongoing responsibility for hosting, security, and updates. Those who prioritize simplicity report switching <em>away from</em> WooCommerce to SaaS alternatives.</p>
 <p><strong>Market context</strong>: The category regime is <strong>fragmented comparison</strong> — buyers are actively weighing trade-offs across multiple platforms rather than defaulting to a single dominant solution. This creates opportunity for WooCommerce's cost-control positioning but also means buyers must evaluate performance, ecosystem maturity, and operational complexity alongside price.</p>
-<p><strong>Who this migration pattern fits</strong>:
-- Teams with technical competence or developer support
-- Businesses prioritizing cost control over operational simplicity
-- Stores requiring deep customization beyond SaaS platform constraints
-- Buyers willing to manage hosting, security, and plugin ecosystem</p>
-<p><strong>Who should reconsider</strong>:
-- Teams without technical resources or budget for developer support
-- Businesses prioritizing operational simplicity and vendor-managed infrastructure
-- Stores needing out-of-the-box performance comparable to hosted SaaS platforms
-- Buyers seeking bundled features without plugin dependency management</p>
+<p><strong>Who this migration pattern fits</strong>:</p>
+<ul>
+<li>Teams with technical competence or developer support</li>
+<li>Businesses prioritizing cost control over operational simplicity</li>
+<li>Stores requiring deep customization beyond SaaS platform constraints</li>
+<li>Buyers willing to manage hosting, security, and plugin ecosystem</li>
+</ul>
+<p><strong>Who should reconsider</strong>:</p>
+<ul>
+<li>Teams without technical resources or budget for developer support</li>
+<li>Businesses prioritizing operational simplicity and vendor-managed infrastructure</li>
+<li>Stores needing out-of-the-box performance comparable to hosted SaaS platforms</li>
+<li>Buyers seeking bundled features without plugin dependency management</li>
+</ul>
 <p>The data suggests WooCommerce migration is a strategic choice, not a universal solution. The right decision depends on whether cost control and customization flexibility justify the operational complexity reviewers describe.</p>
 <p>For additional context on CRM migration patterns, see the <a href="/blog/copper-deep-dive-2026-04">Copper deep dive</a>, which shows reviewer sentiment across a different category with distinct switching triggers.</p>`,
 }

--- a/atlas-churn-ui/src/content/blog/tableau-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/tableau-deep-dive-2026-04.ts
@@ -230,28 +230,36 @@ const post: BlogPost = {
 <p>For a broader view of how other platforms fare in reviewer sentiment, see our <a href="https://churnsignals.co/blog/hubspot-deep-dive-2026-03">HubSpot Deep Dive</a> and <a href="https://churnsignals.co/blog/zoom-deep-dive-2026-04">Zoom Deep Dive</a> analyses.</p>
 <h2 id="the-bottom-line-on-tableau">The Bottom Line on Tableau</h2>
 <p>Tableau's reviewer data reveals a platform with strong technical capabilities and a loyal power-user base, but persistent friction around cost, complexity, and broad user adoption. The synthesis wedge identified in the data -- <strong>segment mismatch</strong> -- captures the core tension: Tableau delivers exceptional value for technical analytics teams, but struggles to achieve the broad, self-service adoption many organizations seek.</p>
-<p><strong>What the data suggests Tableau does exceptionally well:</strong>
-- Advanced visualization capabilities that power users describe as unmatched
-- Deep integration with modern data stacks (Snowflake, Python, dbt)
-- Enterprise deployment options (Server, Cloud) with governance features
-- Strong community resources and documentation</p>
-<p><strong>Where reviewers consistently report friction:</strong>
-- Pricing that scales poorly for broad deployment (per-user licensing)
-- Performance issues with large datasets and real-time dashboards
-- UX complexity that limits self-service adoption among non-technical users
-- Tableau Prep gaps that force third-party ETL tool adoption</p>
+<p><strong>What the data suggests Tableau does exceptionally well:</strong></p>
+<ul>
+<li>Advanced visualization capabilities that power users describe as unmatched</li>
+<li>Deep integration with modern data stacks (Snowflake, Python, dbt)</li>
+<li>Enterprise deployment options (Server, Cloud) with governance features</li>
+<li>Strong community resources and documentation</li>
+</ul>
+<p><strong>Where reviewers consistently report friction:</strong></p>
+<ul>
+<li>Pricing that scales poorly for broad deployment (per-user licensing)</li>
+<li>Performance issues with large datasets and real-time dashboards</li>
+<li>UX complexity that limits self-service adoption among non-technical users</li>
+<li>Tableau Prep gaps that force third-party ETL tool adoption</li>
+</ul>
 <p><strong>Timing context:</strong> One 140-seat account is in active evaluation stage right now, with pricing pain driving consideration of Lightdash and Quicksight alternatives. This represents meaningful near-term churn risk, though the overall churn signal rate (5% of enriched reviews) remains relatively low compared to other data and analytics platforms.</p>
 <p><strong>Market regime context:</strong> In a platform consolidation market, Tableau competes on ecosystem depth and enterprise integration, not disruptive innovation. This favors incumbents with established user bases, but creates vulnerability to pricing pressure and cloud-native challengers.</p>
-<p><strong>Who should consider Tableau:</strong>
-- Organizations with dedicated analytics teams and technical user bases
-- Buyers prioritizing visualization flexibility and advanced analytics over ease of use
-- Enterprises with complex data governance and deployment requirements
-- Teams already invested in Salesforce or cloud data warehouses (Snowflake, BigQuery)</p>
-<p><strong>Who should proceed cautiously:</strong>
-- Organizations seeking broad, self-service BI adoption across non-technical users
-- Small to mid-market buyers with limited budgets for per-user licensing
-- Teams without dedicated analytics resources to manage deployment and training
-- Buyers prioritizing Microsoft ecosystem integration (Power BI may fit better)</p>
+<p><strong>Who should consider Tableau:</strong></p>
+<ul>
+<li>Organizations with dedicated analytics teams and technical user bases</li>
+<li>Buyers prioritizing visualization flexibility and advanced analytics over ease of use</li>
+<li>Enterprises with complex data governance and deployment requirements</li>
+<li>Teams already invested in Salesforce or cloud data warehouses (Snowflake, BigQuery)</li>
+</ul>
+<p><strong>Who should proceed cautiously:</strong></p>
+<ul>
+<li>Organizations seeking broad, self-service BI adoption across non-technical users</li>
+<li>Small to mid-market buyers with limited budgets for per-user licensing</li>
+<li>Teams without dedicated analytics resources to manage deployment and training</li>
+<li>Buyers prioritizing Microsoft ecosystem integration (Power BI may fit better)</li>
+</ul>
 <p>The data does not suggest Tableau is failing or losing ground dramatically. The 5% churn signal rate and low end-user churn rate indicate a stable, satisfied core user base. The friction appears in deployment breadth and cost scaling, not core product capability.</p>
 <p>For organizations where Tableau's strengths align with their needs -- technical teams, complex visualization requirements, enterprise scale -- reviewer sentiment remains positive. For organizations seeking lower-cost, easier-to-adopt alternatives for broad user populations, the competitive pressure from Power BI and cloud-native options is real and growing.</p>
 <p>To see how other enterprise platforms navigate similar challenges, explore our <a href="https://churnsignals.co/blog/copper-deep-dive-2026-04">Copper Deep Dive</a> analysis.</p>

--- a/plans/PR-Blog-Fix-Markdown-Lists.md
+++ b/plans/PR-Blog-Fix-Markdown-Lists.md
@@ -1,0 +1,99 @@
+# PR-Blog-Fix-Markdown-Lists
+
+## Why this slice exists
+
+A per-post correctness audit (logged in `reports/blog-audit-findings.md`,
+defect class **D9**) found markdown bullet lists emitted *inside* `<p>` blocks:
+
+```
+<p><strong>Top pain points:</strong>
+- Overall dissatisfaction
+- Pricing
+- User experience</p>
+```
+
+The markdown->HTML build step treats `<p>...</p>` as a raw HTML block and does
+not convert the inner list, so it renders as literal "- item" text instead of
+a bulleted list -- visibly broken on the page.
+
+This shape was invisible to the SEO analyzer: the old `detectMarkdownInHtml`
+regex (`<p>[^<]*?\n\s*[-*]`) stopped at the first inner tag, so a list after a
+`<strong>label:</strong>` never matched (it reported 0). The analyzer was
+hardened to scan the whole `<p>` block, which surfaced **61 occurrences across
+10 posts**. This PR fixes those 10 posts.
+
+## Scope (this PR)
+
+Convert each markdown-in-`<p>` block into a label paragraph plus a real list:
+
+```
+<p><strong>Top pain points:</strong></p>
+<ul>
+<li>Overall dissatisfaction</li>
+<li>Pricing</li>
+<li>User experience</li>
+</ul>
+```
+
+### Files touched
+
+- `plans/PR-Blog-Fix-Markdown-Lists.md`
+- `atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts` (15)
+- `atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts` (11)
+- `atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts` (10)
+- `atlas-churn-ui/src/content/blog/jira-vs-trello-2026-03.ts` (8)
+- `atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts` (5)
+- `atlas-churn-ui/src/content/blog/tableau-deep-dive-2026-04.ts` (4)
+- `atlas-churn-ui/src/content/blog/salesforce-deep-dive-2026-04.ts` (3)
+- `atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts` (2)
+- `atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts` (2)
+- `atlas-churn-ui/src/content/blog/microsoft-defender-for-endpoint-deep-dive-2026-04.ts` (1)
+
+## Mechanism
+
+A one-off transform (`/tmp/fix_markdown_lists.py`, not committed) mirrors the
+detector: for each `<p>` block containing a `\n- ` / `\n* ` bullet line, it
+splits the pre-bullet prefix into its own `<p>` (kept verbatim, e.g. the
+`<strong>label:</strong>`) and renders the bullet items as `<ul><li>`. Item
+text is preserved verbatim (no rewording, no fabrication). Content-field only
+-- no `affiliate_url` / `seo` / `faq` / metadata touched, so prerender,
+sitemap, and disclosure wiring are unaffected.
+
+The analyzer-side detector change (extended `markdown_in_html`, plus a new
+`form_prompt_quote` detector for the related D1 class) lives in the
+`seo-geo-aeo-blog-post` skill, not in this PR.
+
+## Intentional
+
+- **Real `<ul><li>`, not a re-flattened paragraph.** These are genuine lists;
+  rendering them as proper HTML lists is the correct fix and improves
+  AEO/snippet eligibility.
+- **Verbatim items.** The transform only restructures; it does not change item
+  text, so no evidence or numbers are altered.
+- **Content-field only**, one transform applied uniformly to the 10 flagged
+  posts.
+
+## Deferred
+
+- **D1 (form-prompt quotes)** -- 31 posts, separate cleanup.
+- **Generator fix** -- emit real `<ul>` rather than markdown-in-`<p>` so the
+  shape cannot recur (the root cause).
+- D2/D3/D4/D7/D8 -- catalogued, not yet addressed.
+
+## Verification
+
+- `seo-geo-aeo-blog-post` analyzer across the corpus -> `Markdown in <p>
+  tags 0 / 0` (was `10 / 61`); `0 CRITICAL`.
+- HTML well-formedness validator on all 10 edited posts -> 0 issues
+  (balanced `<ul>`/`<li>`).
+- `npm run build` (atlas-churn-ui) -> `built in 4.47s`, `Pre-rendered 82
+  public routes`, no TS errors.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| 10 blog `.ts` posts (61 markdown blocks -> `<ul><li>`) | ~245 |
+| Plan doc | ~90 |
+| **Total** | **~335** |

--- a/plans/PR-Blog-Fix-Markdown-Lists.md
+++ b/plans/PR-Blog-Fix-Markdown-Lists.md
@@ -94,6 +94,6 @@ The analyzer-side detector change (extended `markdown_in_html`, plus a new
 
 | Area | Estimated LOC |
 |---|---:|
-| 10 blog `.ts` posts (61 markdown blocks -> `<ul><li>`) | ~245 |
-| Plan doc | ~90 |
-| **Total** | **~335** |
+| 10 blog `.ts` posts (61 markdown blocks -> `<ul><li>`, line-expanding) | ~705 |
+| Plan doc | ~92 |
+| **Total** | **~797** |


### PR DESCRIPTION
Plan: plans/PR-Blog-Fix-Markdown-Lists.md

A per-post correctness audit + a hardened analyzer found **61 markdown bullet-lists inside `<p>` blocks across 10 posts** — e.g. `<p><strong>Top pain points:</strong>\n- X\n- Y</p>`. The md→html build step leaves `<p>` contents raw, so they rendered as **literal "- item" text** (visibly broken).

This shape was invisible to the SEO analyzer: the old `detectMarkdownInHtml` regex stopped at the first inner tag, so a list after a `<strong>label:</strong>` never matched (reported 0). The analyzer was extended to scan the whole `<p>` block, which surfaced these.

## Intentional
- Converts each block to a label `<p>` + a real `<ul><li>` list. **Item text preserved verbatim** — restructure only, no rewording/fabrication.
- **Content-field only** — no affiliate/seo/faq/metadata touched; prerender/sitemap/disclosure unaffected.
- One transform applied uniformly to the 10 flagged posts (counts: crm-landscape 15, marketing-automation-landscape 11, helpdesk-landscape 10, jira-vs-trello 8, mailchimp 5, tableau 4, salesforce 3, copper 2, switch-to-woocommerce 2, ms-defender 1).

## Deferred
- D1 (form-prompt quotes) — 31 posts, separate cleanup.
- Generator fix — emit real `<ul>` instead of markdown-in-`<p>` (root cause).

## Verification
- Analyzer across corpus → `Markdown in <p> tags 0 / 0` (was `10 / 61`); `0 CRITICAL`.
- HTML well-formedness validator on all 10 → 0 issues (balanced `<ul>`/`<li>`).
- `npm run build` → `Pre-rendered 82 public routes`, no TS errors.
- `scripts/local_pr_review.sh` → `local PR review passed` (11/11 files, drift 0.0%, `git diff --check`).

## Diff size
~797 LOC (10 posts; markdown blocks expand into `<li>` lines; plan ~92).