### PR TITLE
PR-Cross-Session-PR-Drift-Guard

### DIFF
--- a/plans/PR-Cross-Session-PR-Drift-Guard.md
+++ b/plans/PR-Cross-Session-PR-Drift-Guard.md
@@ -1,0 +1,96 @@
+# PR-Cross-Session-PR-Drift-Guard
+
+## Why this slice exists
+
+Multiple sessions are now working around AI Content Ops at the same time. The
+existing local PR review catches plan shape, diff size, manifest sync, and
+whitespace issues, but it does not warn when a branch overlaps another open PR
+or when `main` has landed changes to the same files since the branch forked.
+
+That gap let the landing-page repair-attempt contract work drift across
+sessions until a later PR superseded an earlier one. This slice adds a cheap
+mechanical guard before PR open/update and a lightweight lane contract so
+parallel sessions can stay scoped.
+
+## Scope (this PR)
+
+Ownership lane: workflow/pr-drift-guard
+
+1. Add a local audit that compares the current branch's changed files with
+   changes already landed on the base branch since the merge-base.
+2. Add an optional GitHub-backed open-PR overlap check when `gh` is available.
+3. Require newly added PR plan docs to declare an ownership lane.
+4. Compare the current branch's ownership lane against open PR bodies when
+   GitHub metadata is available.
+5. Keep open-PR file overlap advisory while blocking stale-base file overlap and
+   same-lane overlap.
+6. Wire the audit into `scripts/local_pr_review.sh`.
+7. Cover the audit behavior with fixture tests.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Cross-Session-PR-Drift-Guard.md` | Plan doc for this guard slice. |
+| `scripts/audit_pr_session_drift.py` | Adds the cross-session branch/open-PR overlap audit. |
+| `scripts/local_pr_review.sh` | Runs the new audit as part of local PR review. |
+| `tests/test_audit_pr_session_drift.py` | Fixture tests for the audit CLI contract. |
+| `tests/test_local_pr_review.py` | Confirms local review invokes the audit when present. |
+
+## Mechanism
+
+The audit resolves `merge-base(HEAD, base-ref)` and compares:
+
+- current branch changed files: `git diff --name-only <base>...HEAD`
+- base changes since the branch forked: `git diff --name-only <base>..<base-ref>`
+- open PR files from `gh pr list` / `gh pr view` when GitHub metadata is
+  available
+- ownership lanes declared as `Ownership lane: <lane>` in changed PR plan docs
+  and mirrored PR bodies
+
+Exact file-path overlap with base changes exits nonzero and tells the builder to
+rebase. File overlap with another open PR is advisory because parallel slices can
+legitimately touch different regions of the same file. Any open PR with the same
+ownership lane exits nonzero, even when the files differ.
+
+If `gh` is unavailable, unauthenticated, or cannot read one open PR's metadata,
+that GitHub metadata is explicitly skipped while local base-overlap and local
+ownership-lane checks still run. Self-PR detection uses branch name first and
+falls back to head SHA for detached checkouts.
+
+## Intentional
+
+- This is stale-base file detection plus explicit lane detection, not semantic
+  duplicate-constant analysis. Open-PR file overlap is printed as a warning
+  because same-file edits can still be legitimate.
+- The GitHub PR sweep is fail-open when `gh` is unavailable so CI and offline
+  local work do not block on network/auth state.
+- The guard is repo-wide instead of Content-Ops-only because exact changed-file
+  overlap is a general conflict signal and cheap to compute.
+
+## Deferred
+
+- A later semantic-contract slice can add targeted checks for duplicated
+  business constants such as repair attempt caps.
+- A later workflow slice can add a separate command that comments the overlap
+  report on PRs if reviewers want GitHub-visible drift diagnostics.
+
+## Verification
+
+- Focused pytest: tests/test_audit_pr_session_drift.py and
+  tests/test_local_pr_review.py.
+- Local PR wrapper: `bash scripts/local_pr_review.sh origin/main`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| Audit script | ~335 |
+| Local review hook | ~10 |
+| Tests | ~390 |
+| Total | ~800 |
+
+This is over the soft 400 LOC target because new audit scripts require fixture
+tests for the CLI contract, and the GitHub/lane fixture paths are the bulk of
+the size.

--- a/scripts/audit_pr_session_drift.py
+++ b/scripts/audit_pr_session_drift.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Detect changed-file drift across concurrent PR sessions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Sequence
+
+LANE_RE = re.compile(r"^\s*Ownership lane:\s*`?([^`\n]+?)`?\s*$", re.IGNORECASE | re.MULTILINE)
+LANE_VALUE_RE = re.compile(r"^[a-z0-9][a-z0-9._/-]*[a-z0-9]$")
+
+
+@dataclass(frozen=True)
+class OpenPullRequest:
+    number: int
+    title: str
+    head_ref: str
+    head_oid: str
+    url: str
+    files: frozenset[str]
+    ownership_lanes: frozenset[str]
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    branch_files: frozenset[str]
+    base_files: frozenset[str]
+    base_overlap: frozenset[str]
+    open_pr_overlaps: tuple[tuple[OpenPullRequest, frozenset[str]], ...]
+    branch_ownership_lanes: frozenset[str]
+    open_pr_lane_overlaps: tuple[tuple[OpenPullRequest, frozenset[str]], ...]
+    github_status: str
+    github_warnings: tuple[str, ...]
+    path_errors: tuple[str, ...]
+    ownership_errors: tuple[str, ...]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect changed-file overlap with base updates and open PRs.",
+    )
+    parser.add_argument(
+        "base_ref",
+        nargs="?",
+        default="origin/main",
+        help="base ref to compare against (default: origin/main)",
+    )
+    parser.add_argument(
+        "--skip-github",
+        action="store_true",
+        help="skip GitHub open-PR overlap checks",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = build_report(args.base_ref, skip_github=args.skip_github)
+    except AuditError as exc:
+        print(f"DRIFT audit error: {exc}", file=sys.stderr)
+        return 2
+
+    render_report(args.base_ref, report)
+    if (
+        report.path_errors
+        or report.ownership_errors
+        or report.base_overlap
+        or report.open_pr_lane_overlaps
+    ):
+        return 1
+    return 0
+
+
+def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
+    ensure_git_ref(base_ref)
+    base = git_stdout(["merge-base", "HEAD", base_ref])
+    branch_files = changed_files([base, "HEAD"], triple_dot=True)
+    base_files = changed_files([base, base_ref], triple_dot=False)
+    branch_ownership_lanes, ownership_errors = branch_ownership(added_plan_docs(base))
+
+    path_errors: list[str] = []
+    path_errors.extend(validate_paths(branch_files, "branch diff"))
+    path_errors.extend(validate_paths(base_files, f"{base_ref} diff"))
+
+    base_overlap = frozenset(branch_files & base_files)
+    open_pr_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
+    open_pr_lane_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
+    github_status = "skipped (--skip-github)"
+    github_warnings: list[str] = []
+
+    if not skip_github and os.environ.get("ATLAS_SKIP_PR_SESSION_DRIFT_GITHUB") != "1":
+        github_status, prs, loaded_github_warnings = load_open_pull_requests(base_ref)
+        github_warnings.extend(loaded_github_warnings)
+        current_branch = current_head_ref()
+        current_oid = current_head_oid()
+        for pr in prs:
+            if pr.head_ref == current_branch or (pr.head_oid and pr.head_oid == current_oid):
+                continue
+            overlap = frozenset(branch_files & pr.files)
+            if overlap:
+                open_pr_overlaps.append((pr, overlap))
+            lane_overlap = frozenset(branch_ownership_lanes & pr.ownership_lanes)
+            if lane_overlap:
+                open_pr_lane_overlaps.append((pr, lane_overlap))
+
+    return DriftReport(
+        branch_files=frozenset(branch_files),
+        base_files=frozenset(base_files),
+        base_overlap=base_overlap,
+        open_pr_overlaps=tuple(open_pr_overlaps),
+        branch_ownership_lanes=branch_ownership_lanes,
+        open_pr_lane_overlaps=tuple(open_pr_lane_overlaps),
+        github_status=github_status,
+        github_warnings=tuple(github_warnings),
+        path_errors=tuple(path_errors),
+        ownership_errors=tuple(ownership_errors),
+    )
+
+
+def ensure_git_ref(ref: str) -> None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", ref],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AuditError(f"base ref not found: {ref}")
+
+
+def changed_files(revs: Sequence[str], *, triple_dot: bool) -> set[str]:
+    separator = "..." if triple_dot else ".."
+    diff_ref = f"{revs[0]}{separator}{revs[1]}"
+    output = git_stdout(["diff", "--name-only", diff_ref])
+    return {line for line in output.splitlines() if line.strip()}
+
+
+def added_plan_docs(base: str) -> set[str]:
+    output = git_stdout([
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{base}...HEAD",
+        "--",
+        "plans/PR-*.md",
+    ])
+    return {line for line in output.splitlines() if line.strip()}
+
+
+def branch_ownership(plan_docs: set[str]) -> tuple[frozenset[str], tuple[str, ...]]:
+    lanes: set[str] = set()
+    errors: list[str] = []
+    if not plan_docs:
+        return frozenset(), tuple()
+
+    for plan_doc in plan_docs:
+        text = git_stdout(["show", f"HEAD:{plan_doc}"])
+        doc_lanes, doc_errors = extract_ownership_lanes(text, source=plan_doc)
+        lanes.update(doc_lanes)
+        errors.extend(doc_errors)
+        if not doc_lanes and not doc_errors:
+            errors.append(f"{plan_doc}: missing Ownership lane")
+
+    if not lanes and plan_docs:
+        errors.append("changed PR plan docs must declare an Ownership lane")
+    return frozenset(lanes), tuple(errors)
+
+
+def extract_ownership_lanes(text: str, *, source: str) -> tuple[frozenset[str], tuple[str, ...]]:
+    lanes: set[str] = set()
+    errors: list[str] = []
+    for raw_lane in LANE_RE.findall(text):
+        lane = raw_lane.strip().lower()
+        if not LANE_VALUE_RE.match(lane):
+            errors.append(
+                f"{source}: invalid Ownership lane {raw_lane!r}; "
+                "use lowercase letters, numbers, dots, dashes, slashes, or underscores"
+            )
+            continue
+        lanes.add(lane)
+    return frozenset(lanes), tuple(errors)
+
+
+def load_open_pull_requests(base_ref: str) -> tuple[str, tuple[OpenPullRequest, ...], tuple[str, ...]]:
+    if shutil.which("gh") is None:
+        return "skipped (gh not found)", (), ()
+
+    base_branch = github_base_branch_name(base_ref)
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--base",
+            base_branch,
+            "--limit",
+            "100",
+            "--json",
+            "number,title,headRefName,headRefOid,url",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = one_line(result.stderr) or one_line(result.stdout) or "gh pr list failed"
+        return f"skipped ({message})", (), ()
+
+    try:
+        rows = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return f"skipped (gh pr list returned invalid JSON: {exc})", (), ()
+
+    prs: list[OpenPullRequest] = []
+    warnings: list[str] = []
+    for row in rows:
+        pr_number = integer_value(row.get("number"))
+        if pr_number is None:
+            warnings.append(f"open PR row missing numeric number: {row!r}")
+            continue
+        pr, metadata_warnings = load_open_pull_request_files(pr_number, row)
+        prs.append(pr)
+        warnings.extend(metadata_warnings)
+        for error in validate_paths(pr.files, f"PR #{pr.number}"):
+            warnings.append(error)
+
+    return f"checked {len(prs)} open PR(s)", tuple(prs), tuple(warnings)
+
+
+def load_open_pull_request_files(number: int, row: dict[str, Any]) -> tuple[OpenPullRequest, tuple[str, ...]]:
+    fallback = open_pr_from_row(number, row, files=frozenset(), ownership_lanes=frozenset())
+    result = subprocess.run(
+        ["gh", "pr", "view", str(number), "--json", "files,body"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = one_line(result.stderr) or one_line(result.stdout) or "gh pr view failed"
+        return fallback, (f"skipped PR #{number}: could not read files/body: {message}",)
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        return fallback, (f"skipped PR #{number}: files/body JSON is invalid: {exc}",)
+
+    files = {
+        str(item.get("path", "")).strip()
+        for item in payload.get("files", [])
+        if isinstance(item, dict)
+    }
+    body = str(payload.get("body", "") or "")
+    lanes, lane_errors = extract_ownership_lanes(body, source=f"PR #{number} body")
+    warnings = tuple(lane_errors)
+    return open_pr_from_row(
+        number,
+        row,
+        files=frozenset(path for path in files if path),
+        ownership_lanes=lanes if not lane_errors else frozenset(),
+    ), warnings
+
+
+def open_pr_from_row(
+    number: int,
+    row: dict[str, Any],
+    *,
+    files: frozenset[str],
+    ownership_lanes: frozenset[str],
+) -> OpenPullRequest:
+    return OpenPullRequest(
+        number=number,
+        title=str(row.get("title", "")).strip(),
+        head_ref=str(row.get("headRefName", "")).strip(),
+        head_oid=str(row.get("headRefOid", "")).strip(),
+        url=str(row.get("url", "")).strip(),
+        files=files,
+        ownership_lanes=ownership_lanes,
+    )
+
+
+def github_base_branch_name(base_ref: str) -> str:
+    for prefix in ("refs/remotes/origin/", "origin/", "refs/heads/"):
+        if base_ref.startswith(prefix):
+            return base_ref[len(prefix):]
+    return base_ref
+
+
+def validate_paths(paths: Iterable[str], source: str) -> list[str]:
+    errors: list[str] = []
+    for path in sorted(paths):
+        posix = PurePosixPath(path)
+        if not path or posix.is_absolute() or ".." in posix.parts:
+            errors.append(f"{source}: unsafe path {path!r}")
+    return errors
+
+
+def render_report(base_ref: str, report: DriftReport) -> None:
+    print("cross-session PR drift audit")
+    print(f"base ref: {base_ref}")
+    print(f"branch changed files: {len(report.branch_files)}")
+    print(f"base changed files since branch point: {len(report.base_files)}")
+    print(f"branch ownership lanes: {', '.join(sorted(report.branch_ownership_lanes)) or 'none'}")
+    print(f"GitHub open PR check: {report.github_status}")
+    if report.github_warnings:
+        print()
+        print("WARN: GitHub metadata skipped or malformed")
+        for warning in report.github_warnings:
+            print(f"- {warning}")
+
+    if report.path_errors:
+        print()
+        print("DRIFT: unsafe or malformed file paths detected")
+        for error in report.path_errors:
+            print(f"- {error}")
+
+    if report.ownership_errors:
+        print()
+        print("DRIFT: ownership lane contract failed")
+        for error in report.ownership_errors:
+            print(f"- {error}")
+
+    if report.base_overlap:
+        print()
+        print("DRIFT: base branch changed files that this branch also changes")
+        for path in sorted(report.base_overlap):
+            print(f"- {path}")
+
+    if report.open_pr_overlaps:
+        print()
+        print("WARN: open PRs change files that this branch also changes")
+        for pr, files in report.open_pr_overlaps:
+            label = f"#{pr.number}"
+            if pr.title:
+                label = f"{label} {pr.title}"
+            if pr.url:
+                label = f"{label} ({pr.url})"
+            print(f"- {label}")
+            for path in sorted(files):
+                print(f"  - {path}")
+
+    if report.open_pr_lane_overlaps:
+        print()
+        print("DRIFT: open PRs claim the same ownership lane")
+        for pr, lanes in report.open_pr_lane_overlaps:
+            label = f"#{pr.number}"
+            if pr.title:
+                label = f"{label} {pr.title}"
+            if pr.url:
+                label = f"{label} ({pr.url})"
+            print(f"- {label}")
+            for lane in sorted(lanes):
+                print(f"  - {lane}")
+
+    if (
+        not report.path_errors
+        and not report.ownership_errors
+        and not report.base_overlap
+        and not report.open_pr_lane_overlaps
+    ):
+        print("OK: no blocking drift detected")
+
+
+def current_head_ref() -> str:
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def current_head_oid() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def git_stdout(args: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AuditError(one_line(result.stderr) or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def integer_value(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def one_line(value: str) -> str:
+    return " ".join(value.split())
+
+
+class AuditError(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -81,6 +81,14 @@ git diff --name-status "$base"...HEAD || true
 
 run_check "Pre-push audit wrapper" bash scripts/pre_push_audit.sh
 
+if [ -f scripts/audit_pr_session_drift.py ]; then
+    run_check "Cross-session PR drift" python scripts/audit_pr_session_drift.py "$base_ref"
+else
+    echo
+    echo "==> Cross-session PR drift"
+    echo "    SKIP (scripts/audit_pr_session_drift.py not found)"
+fi
+
 committed_plan_docs=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null |
         sort -u |

--- a/tests/test_audit_pr_session_drift.py
+++ b/tests/test_audit_pr_session_drift.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cli_passes_when_base_moved_without_file_overlap(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(repo, "atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx", "branch\n")
+    _advance_origin_main(repo, "README.md", "main moved\n")
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "base changed files since branch point: 1" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_fails_when_base_changed_same_file_since_branch_point(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    path = "atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx"
+    _commit(repo, path, "branch\n")
+    _advance_origin_main(repo, path, "main\n")
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 1
+    assert "DRIFT: base branch changed files" in result.stdout
+    assert path in result.stdout
+
+
+def test_cli_warns_when_open_pr_changes_same_file(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    path = "extracted_content_pipeline/services/faq.py"
+    _commit(repo, path, "branch\n")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 12,
+                "title": "Content Ops overlap",
+                "headRefName": "claude/other",
+                "url": "https://github.test/pr/12",
+            }
+        ],
+        files={12: [path]},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: open PRs change files" in result.stdout
+    assert "#12 Content Ops overlap" in result.stdout
+    assert path in result.stdout
+
+
+def test_cli_ignores_open_pr_for_current_branch(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "atlas-intel-ui/src/api/contentOps.ts"
+    _commit(repo, path, "branch\n")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 13,
+                "title": "Self PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/13",
+            }
+        ],
+        files={13: [path]},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "checked 1 open PR(s)" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_warns_for_unsafe_open_pr_file_path(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(repo, "README.md", "branch\n")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 14,
+                "title": "Bad path",
+                "headRefName": "claude/bad-path",
+                "url": "https://github.test/pr/14",
+            }
+        ],
+        files={14: ["../outside.txt"]},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: GitHub metadata skipped or malformed" in result.stdout
+    assert "../outside.txt" in result.stdout
+
+
+def test_cli_fails_when_changed_plan_doc_missing_ownership_lane(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-No-Lane.md",
+        "# PR-No-Lane\n\n## Why this slice exists\n\nTest.\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 1
+    assert "ownership lane contract failed" in result.stdout
+    assert "plans/PR-No-Lane.md: missing Ownership lane" in result.stdout
+
+
+def test_cli_allows_modified_legacy_plan_doc_without_ownership_lane(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Legacy.md",
+        "# PR-Legacy\n\n## Why this slice exists\n\nOld plan.\n",
+    )
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--ff-only", "feature")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", "-b", "legacy-edit")
+    _commit(
+        repo,
+        "plans/PR-Legacy.md",
+        "# PR-Legacy\n\n## Why this slice exists\n\nOld plan edited.\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ownership lane contract failed" not in result.stdout
+
+
+def test_cli_fails_when_open_pr_claims_same_ownership_lane(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 15,
+                "title": "Other FAQ slice",
+                "headRefName": "claude/other-faq",
+                "url": "https://github.test/pr/15",
+            }
+        ],
+        files={15: ["README.md"]},
+        bodies={15: "Plan: plans/PR-Other.md\n\nOwnership lane: content-ops/faq-generator\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 1
+    assert "DRIFT: open PRs claim the same ownership lane" in result.stdout
+    assert "#15 Other FAQ slice" in result.stdout
+    assert "content-ops/faq-generator" in result.stdout
+
+
+def test_cli_allows_open_pr_with_different_ownership_lane(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 16,
+                "title": "Landing SEO slice",
+                "headRefName": "claude/landing-seo",
+                "url": "https://github.test/pr/16",
+            }
+        ],
+        files={16: ["atlas-intel-ui/src/pages/Landing.tsx"]},
+        bodies={16: "Ownership lane: content-ops/landing-seo-geo\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "branch ownership lanes: content-ops/faq-generator" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_warns_when_pr_view_fails_mid_sweep(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(repo, "README.md", "branch\n")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 17,
+                "title": "Transient failure",
+                "headRefName": "claude/transient",
+                "url": "https://github.test/pr/17",
+            }
+        ],
+        files={},
+        fail_views={17: "api timed out"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: GitHub metadata skipped or malformed" in result.stdout
+    assert "skipped PR #17" in result.stdout
+    assert "api timed out" in result.stdout
+
+
+def test_cli_warns_for_malformed_lane_in_other_pr_body(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 18,
+                "title": "Malformed lane",
+                "headRefName": "claude/bad-lane",
+                "url": "https://github.test/pr/18",
+            }
+        ],
+        files={18: ["README.md"]},
+        bodies={18: "Ownership lane: Content Ops!\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: GitHub metadata skipped or malformed" in result.stdout
+    assert "PR #18 body: invalid Ownership lane" in result.stdout
+
+
+def test_cli_ignores_current_pr_by_head_oid_when_detached(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+    )
+    head_oid = _git_stdout(repo, "rev-parse", "HEAD")
+    _git(repo, "checkout", "--detach", "HEAD")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 19,
+                "title": "Self detached",
+                "headRefName": "claude/current",
+                "headRefOid": head_oid,
+                "url": "https://github.test/pr/19",
+            }
+        ],
+        files={19: [path]},
+        bodies={19: "Ownership lane: content-ops/faq-generator\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def _write_fixture_repo(tmp_path: Path, *, branch: str = "feature") -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "atlas-intel-ui/src/pages").mkdir(parents=True)
+    (repo / "scripts" / "audit_pr_session_drift.py").write_text(
+        (REPO_ROOT / "scripts" / "audit_pr_session_drift.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    (repo / "atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx").write_text(
+        "base\n",
+        encoding="utf-8",
+    )
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", "-b", branch)
+    return repo
+
+
+def _advance_origin_main(repo: Path, path: str, text: str) -> None:
+    current = _git_stdout(repo, "branch", "--show-current")
+    _git(repo, "checkout", "main")
+    _commit(repo, path, text)
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", current)
+
+
+def _commit(repo: Path, path: str, text: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", f"change {path}")
+
+
+def _write_fake_gh(
+    tmp_path: Path,
+    *,
+    prs: list[dict[str, object]],
+    files: dict[int, list[str]],
+    bodies: dict[int, str] | None = None,
+    fail_views: dict[int, str] | None = None,
+) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    script = f"""#!/usr/bin/env python3
+import json
+import sys
+
+PRS = {json.dumps(prs)}
+FILES = {json.dumps({str(key): value for key, value in files.items()})}
+BODIES = {json.dumps({str(key): value for key, value in (bodies or {}).items()})}
+FAIL_VIEWS = {json.dumps({str(key): value for key, value in (fail_views or {}).items()})}
+
+args = sys.argv[1:]
+if args[:2] == ["pr", "list"]:
+    print(json.dumps(PRS))
+    raise SystemExit(0)
+if args[:2] == ["pr", "view"]:
+    number = args[2]
+    if number in FAIL_VIEWS:
+        print(FAIL_VIEWS[number], file=sys.stderr)
+        raise SystemExit(1)
+    print(json.dumps({{
+        "body": BODIES.get(number, ""),
+        "files": [{{"path": path}} for path in FILES.get(number, [])],
+    }}))
+    raise SystemExit(0)
+print("unexpected gh args: " + " ".join(args), file=sys.stderr)
+raise SystemExit(2)
+"""
+    gh.write_text(script, encoding="utf-8")
+    gh.chmod(gh.stat().st_mode | stat.S_IXUSR)
+    return bin_dir
+
+
+def _run(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=repo, check=False, capture_output=True, text=True)
+
+
+def _run_with_path(
+    repo: Path,
+    bin_dir: Path,
+    args: list[str],
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    return subprocess.run(
+        args,
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _git_stdout(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()

--- a/tests/test_local_pr_review.py
+++ b/tests/test_local_pr_review.py
@@ -80,6 +80,23 @@ def test_local_pr_review_rejects_multiple_base_refs(tmp_path: Path) -> None:
     assert "multiple base refs supplied" in result.stderr
 
 
+def test_local_pr_review_runs_cross_session_drift_audit_when_present(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_fixture_repo(repo)
+    _write_executable(
+        repo / "scripts" / "audit_pr_session_drift.py",
+        "#!/usr/bin/env python3\nprint('drift guard ran')\n",
+    )
+    _git(repo, "add", "scripts/audit_pr_session_drift.py")
+    _git(repo, "commit", "-m", "add drift guard")
+
+    result = _run(repo, ["bash", "scripts/local_pr_review.sh"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Cross-session PR drift" in result.stdout
+    assert "drift guard ran" in result.stdout
+
+
 def _write_fixture_repo(repo: Path) -> None:
     (repo / "scripts").mkdir(parents=True)
     _write_executable(


### PR DESCRIPTION
Plan: plans/PR-Cross-Session-PR-Drift-Guard.md

Ownership lane: workflow/pr-drift-guard

Multiple sessions are now working around AI Content Ops at the same time. The existing local PR review catches plan shape, diff size, manifest sync, and whitespace issues, but it did not warn when a branch overlaps another open PR, when `main` has landed changes to the same files since the branch forked, or when two PRs claim the same work lane. This adds a mechanical guard plus a lightweight ownership-lane contract before PR open/update.

## Intentional
- Stale-base same-file overlap remains blocking because the branch needs a rebase.
- Same-file overlap with another open PR is advisory only; siblings can legitimately touch different regions of the same file.
- Same ownership-lane overlap remains blocking because it means two sessions explicitly claimed the same work lane.
- GitHub PR metadata failures are fail-open warnings; local git/base failures still return audit errors.
- Newly added PR plan docs need an `Ownership lane:` line. Modified legacy plan docs without a lane are allowed to avoid retroactive surprise blocks.

## Deferred
- A later semantic-contract slice can add targeted checks for duplicated business constants such as repair attempt caps.
- A later workflow slice can add a separate command that comments the overlap report on PRs if reviewers want GitHub-visible drift diagnostics.

## Verification
- `pytest tests/test_audit_pr_session_drift.py tests/test_local_pr_review.py` -> 19 passed.
- `bash scripts/local_pr_review.sh origin/main` -> passed, including live open-PR drift sweep against 4 open PRs and lane `workflow/pr-drift-guard`.

## Diff size
5 files, +944 / -0
