### PR TITLE
Add landing page repair telemetry export

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -29,6 +29,8 @@ _EXPORT_COLUMNS = (
     "generation_output_tokens",
     "generation_total_tokens",
     "generation_parse_attempts",
+    "generation_quality_repair_attempts",
+    "generation_quality_repair_history",
     "reasoning_context_used",
     "reasoning_wedge",
     "reasoning_confidence",
@@ -131,6 +133,12 @@ def _metadata_summary(value: Any) -> JsonDict:
         "generation_output_tokens": usage.get("output_tokens"),
         "generation_total_tokens": usage.get("total_tokens"),
         "generation_parse_attempts": metadata.get("generation_parse_attempts"),
+        "generation_quality_repair_attempts": metadata.get(
+            "generation_quality_repair_attempts"
+        ),
+        "generation_quality_repair_history": metadata.get(
+            "generation_quality_repair_history"
+        ),
         "reasoning_context_used": bool(reasoning),
         "reasoning_wedge": reasoning.get("wedge"),
         "reasoning_confidence": reasoning.get("confidence"),

--- a/plans/PR-Landing-Page-Repair-Export.md
+++ b/plans/PR-Landing-Page-Repair-Export.md
@@ -1,0 +1,63 @@
+# PR-Landing-Page-Repair-Export
+
+## Why this slice exists
+
+Landing page generation now records quality repair telemetry in draft metadata,
+but the host export path still omits that telemetry from the review/export
+contract. That leaves operators able to see parse attempts and readiness fields
+without seeing whether the landing page passed only after a quality repair.
+
+## Scope (this PR)
+
+1. Add landing page quality repair attempts to exported landing page rows.
+2. Add landing page quality repair history to exported landing page rows.
+3. Cover JSON and CSV export behavior with focused regression tests.
+
+### Files touched
+
+- `extracted_content_pipeline/landing_page_export.py`
+- `tests/test_extracted_landing_page_export.py`
+- `plans/PR-Landing-Page-Repair-Export.md`
+
+## Mechanism
+
+The metadata summary helper already flattens generated metadata into review columns.
+This slice extends that same summary with:
+
+```python
+"generation_quality_repair_attempts": metadata.get("generation_quality_repair_attempts")
+"generation_quality_repair_history": metadata.get("generation_quality_repair_history")
+```
+
+The export column list adds both fields beside the existing generation attempt
+metadata. CSV rendering already serializes list and mapping values through the
+shared `_csv_value()` helper, so nested repair history can be exported without a
+new serializer.
+
+## Intentional
+
+- No generation changes: the telemetry is already written by the landing page
+  generator.
+- No UI changes: generated asset review surfaces were handled by earlier slices.
+- The export keeps missing metadata as `None`, matching existing token and parse
+  attempt export behavior.
+
+## Deferred
+
+- `PR-Landing-Page-Repair-Analytics` can decide whether these export fields need
+  aggregate reporting across generated assets.
+
+## Verification
+
+- `pytest tests/test_extracted_landing_page_export.py -q` - 8 passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Export contract | ~8 |
+| Export tests | ~46 |
+| Plan doc | ~58 |
+| **Total** | **~112** |

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -124,6 +124,21 @@ def _draft(**overrides) -> LandingPageDraft:
                 "total_tokens": 18,
             },
             "generation_parse_attempts": 2,
+            "generation_quality_repair_attempts": 1,
+            "generation_quality_repair_history": [
+                {
+                    "attempt": 0,
+                    "passed": False,
+                    "blockers": ["missing proof"],
+                    "repair_issues": ["add evidence"],
+                },
+                {
+                    "attempt": 1,
+                    "passed": True,
+                    "blockers": [],
+                    "repair_issues": [],
+                },
+            ],
             "reasoning_context": {
                 "wedge": "price_squeeze",
                 "confidence": "high",
@@ -268,6 +283,21 @@ async def test_export_landing_page_drafts_derives_review_summary_fields() -> Non
     assert row["generation_output_tokens"] == 6
     assert row["generation_total_tokens"] == 18
     assert row["generation_parse_attempts"] == 2
+    assert row["generation_quality_repair_attempts"] == 1
+    assert row["generation_quality_repair_history"] == [
+        {
+            "attempt": 0,
+            "passed": False,
+            "blockers": ["missing proof"],
+            "repair_issues": ["add evidence"],
+        },
+        {
+            "attempt": 1,
+            "passed": True,
+            "blockers": [],
+            "repair_issues": [],
+        },
+    ]
     assert row["reasoning_context_used"] is True
     assert row["reasoning_wedge"] == "price_squeeze"
     assert row["reasoning_confidence"] == "high"
@@ -377,6 +407,8 @@ async def test_export_landing_page_drafts_defaults_summary_fields_without_metada
     assert row["generation_output_tokens"] is None
     assert row["generation_total_tokens"] is None
     assert row["generation_parse_attempts"] is None
+    assert row["generation_quality_repair_attempts"] is None
+    assert row["generation_quality_repair_history"] is None
     assert row["reasoning_context_used"] is False
     assert row["reasoning_wedge"] is None
     assert row["reasoning_confidence"] is None
@@ -434,6 +466,15 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
                 "generation_output_tokens": 6,
                 "generation_total_tokens": 18,
                 "generation_parse_attempts": 1,
+                "generation_quality_repair_attempts": 1,
+                "generation_quality_repair_history": [
+                    {
+                        "attempt": 1,
+                        "passed": True,
+                        "blockers": [],
+                        "repair_issues": [],
+                    },
+                ],
                 "reasoning_context_used": True,
                 "reasoning_wedge": "price_squeeze",
                 "reasoning_confidence": "high",
@@ -460,6 +501,11 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
     assert as_dict["rows"][0]["reasoning_wedge"] == "price_squeeze"
     assert "campaign_name,persona,value_prop" in csv_text
     assert "generation_input_tokens,generation_output_tokens" in csv_text
+    assert (
+        "generation_quality_repair_attempts,generation_quality_repair_history"
+        in csv_text
+    )
     assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in csv_text
     assert "passed_output_checks,output_checks,seo_aeo_readiness,geo_readiness" in csv_text
+    assert '"[{""attempt"":1,""passed"":true' in csv_text
     assert "price_squeeze" in csv_text


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Repair-Export.md

Expose landing page quality repair telemetry in the draft export so host review workflows can see repair attempts and repair history alongside parse attempts and readiness fields.

## Intentional
- No generation changes; the landing page generator already writes the telemetry.
- No UI changes; generated asset review surfaces were handled by earlier slices.
- Missing repair metadata exports as null, matching existing summary metadata behavior.

## Deferred
- PR-Landing-Page-Repair-Analytics can decide whether aggregate reporting is needed.

## Verification
- pytest tests/test_extracted_landing_page_export.py -q
- git diff --check
- bash scripts/local_pr_review.sh origin/main

## Diff size
3 files, +117 / -0