### PR TITLE
Add landing page AEO/GEO section source contract

### DIFF
--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -19,7 +19,12 @@ Output ONLY a single JSON object with this exact shape. No prose outside the JSO
       "id": "snake_case_section_id",
       "title": "Section heading",
       "body_markdown": "Section body in markdown",
-      "metadata": {"order": 1}
+      "metadata": {
+        "order": 1,
+        "kind": "problem | solution | how_it_works | proof | pricing | faq | objection | conversion",
+        "primary_question": "Buyer/search question this section answers, or empty string",
+        "answer_summary": "35-60 word direct answer that also appears as the first paragraph of body_markdown"
+      }
     }
   ],
   "cta": {
@@ -43,6 +48,9 @@ Field rules:
 - `hero.cta_label` / `hero.cta_url`: the hero's primary CTA. Reuse for the page-level `cta` block unless the page uses a hero-CTA + sticky-footer-CTA pattern.
 - `sections`: 3-6 ordered sections. Common shapes: problem / solution / how-it-works / proof / pricing / FAQ. Each section needs a non-empty `title` and `body_markdown`.
 - `sections.title`: use specific headings that describe the offer, audience, problem, or buyer question. Do not use generic headings such as "Overview", "Features", "Benefits", "Summary", "Introduction", or "Conclusion".
+- `sections.metadata.kind`: choose the section role from problem, solution, how_it_works, proof, pricing, faq, objection, or conversion.
+- `sections.metadata.primary_question`: include the plain-language buyer or search question the section answers when one is natural. Use an empty string when the section is not question-shaped.
+- `sections.metadata.answer_summary`: write a 35-60 word direct answer for problem, solution, how-it-works, FAQ, and objection sections. Put the same answer at the start of `body_markdown` so the answer is visible on the page, not hidden in metadata.
 - `cta`: page-level primary CTA (label + url required). Optional `secondary_label` / `secondary_url`. Do not output placeholder URLs such as `#`, `/#`, `javascript:void(0)`, or `javascript:;`.
 - `meta.title_tag`: always include a concrete SEO title tag, ideally 50-60 characters and no more than 70 characters.
 - `meta.description`: SEO meta description, 120-160 characters. Keep the title tag and description aligned with visible page copy.
@@ -52,6 +60,8 @@ Readiness rules:
 - The first viewport must make it clear what the offer is, who it is for, and why that reader should care.
 - Include a clear problem section and a clear solution or how-it-works section tied to `campaign.value_prop`.
 - Include objection coverage when the campaign gives enough context. This can be a FAQ, pricing, implementation, risk-reversal, comparison, security, or proof section.
+- Do not force a FAQ section when the campaign does not give enough real buyer questions. A useful how-it-works or objection section is better than fake FAQ content.
+- Start each section that poses or implies a buyer question with the direct answer in the first paragraph, then expand. This supports answer extraction without making the page read like a blog post.
 - If the campaign does not provide proof, testimonials, case studies, customer names, customer logos, or source ids, do not invent them. Use honest copy without fake social proof.
 - Do not leave unresolved placeholders or draft notes such as `{{claim}}`, `TODO`, `TBD`, or `lorem ipsum`.
 

--- a/plans/PR-Landing-Page-AEO-GEO-Section-Source.md
+++ b/plans/PR-Landing-Page-AEO-GEO-Section-Source.md
@@ -1,0 +1,79 @@
+# PR-Landing-Page-AEO-GEO-Section-Source
+
+## Why this slice exists
+
+The landing-page generator already has SEO/AEO/GEO readiness checks, prompt
+guardrails, quality repair, UI visibility, and export telemetry. The remaining
+source-level gap is that generated sections are still only generic markdown
+blocks with optional `order` metadata.
+
+That makes AEO/GEO quality depend too much on the model happening to write
+answer-first prose. This slice tightens the generation source contract so each
+landing-page section can carry buyer-question and answer-summary metadata while
+still rendering normal visible copy.
+
+## Scope (this PR)
+
+1. Extend the bundled landing-page prompt's section metadata contract.
+2. Ask for answer-first section bodies that match the metadata summary.
+3. Preserve the no-fake-proof and no-forced-FAQ policy.
+4. Add prompt-regression coverage for the AEO/GEO source language.
+5. Add a generation regression proving the section metadata survives parsing
+   and draft construction.
+
+### Files touched
+
+- `plans/PR-Landing-Page-AEO-GEO-Section-Source.md`
+- `extracted_content_pipeline/skills/digest/landing_page_generation.md`
+- `tests/test_extracted_campaign_skill_registry.py`
+- `tests/test_extracted_landing_page_generation.py`
+
+## Mechanism
+
+The landing-page prompt already allows arbitrary per-section metadata, and
+`LandingPageSection` already persists that metadata through draft construction.
+This slice uses that existing contract instead of adding a new schema.
+
+The prompt now asks each section for:
+
+- `kind`: the role of the section, such as problem, solution, how-it-works,
+  proof, pricing, FAQ, objection, or conversion.
+- `primary_question`: the buyer/search question the section answers when one is
+  natural.
+- `answer_summary`: a short direct answer that must also appear in the first
+  paragraph of `body_markdown`.
+
+This gives future renderers and reviewers a stable source signal without hiding
+important answer copy outside the visible page.
+
+## Intentional
+
+- No storage change: section metadata is already part of the persisted landing
+  page shape.
+- No parser change: the parser already accepts mapped section metadata.
+- No quality-gate hard block: this prompt slice asks for better source
+  structure without making older generated drafts invalid.
+- No forced FAQ: FAQ/objection content should appear only when campaign context
+  supports it.
+
+## Deferred
+
+- `PR-Landing-Page-AEO-GEO-Section-Readiness` can decide whether readiness
+  helpers should score this metadata directly.
+- `PR-Landing-Page-Publish-Structured-Data` can map FAQ/objection sections into
+  public JSON-LD once a generated landing-page renderer exists.
+
+## Verification
+
+- `pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py -q` - 41 passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Prompt | ~18 |
+| Tests | ~30 |
+| **Total** | **~123** |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -95,6 +95,18 @@ def test_packaged_landing_page_prompt_prevents_fake_proof() -> None:
     assert "fake social proof" in prompt
 
 
+def test_packaged_landing_page_prompt_requests_aeo_geo_section_metadata() -> None:
+    prompt = get_skill_registry().get_prompt("digest/landing_page_generation")
+
+    assert prompt is not None
+    assert "sections.metadata.kind" in prompt
+    assert "sections.metadata.primary_question" in prompt
+    assert "sections.metadata.answer_summary" in prompt
+    assert "same answer at the start of `body_markdown`" in prompt
+    assert "Do not force a FAQ section" in prompt
+    assert "supports answer extraction" in prompt
+
+
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:
     skill_path = tmp_path / "digest" / "b2b_campaign_generation.md"
     skill_path.parent.mkdir()

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -117,13 +117,29 @@ def _valid_response(*, slug="acme-q3-launch") -> str:
                 "id": "problem",
                 "title": "The Problem",
                 "body_markdown": "Renewal pricing is the #1 churn driver.",
-                "metadata": {"order": 1},
+                "metadata": {
+                    "order": 1,
+                    "kind": "problem",
+                    "primary_question": "Why do renewal surprises cause churn?",
+                    "answer_summary": (
+                        "Renewal surprises create preventable churn because "
+                        "teams see pricing pressure too late."
+                    ),
+                },
             },
             {
                 "id": "solution",
                 "title": "The Solution",
                 "body_markdown": "Acme surfaces pressure signals in the first 30 days.",
-                "metadata": {"order": 2},
+                "metadata": {
+                    "order": 2,
+                    "kind": "solution",
+                    "primary_question": "How does Acme catch renewal pressure?",
+                    "answer_summary": (
+                        "Acme catches renewal pressure early by surfacing "
+                        "risk signals during the first 30 days."
+                    ),
+                },
             },
         ],
         "cta": {"label": "Book a 15-min demo", "url": "/demo", "variant": "primary"},
@@ -165,6 +181,7 @@ def test_parse_landing_page_response_strips_code_fences_and_extracts_first_objec
     assert parsed is not None
     assert parsed["title"] == "Acme Q3: Stop Renewal Surprises"
     assert parsed["sections"][0]["id"] == "problem"
+    assert parsed["sections"][0]["metadata"]["kind"] == "problem"
 
 
 def test_parse_landing_page_response_returns_none_when_required_fields_missing() -> None:
@@ -288,6 +305,12 @@ async def test_generate_persists_one_landing_page_per_call_via_save_drafts() -> 
     assert draft.hero["headline"] == "Stop renewal surprises"
     assert draft.cta["label"] == "Book a 15-min demo"
     assert draft.sections[0].id == "problem"
+    assert draft.sections[0].metadata["kind"] == "problem"
+    assert (
+        draft.sections[0].metadata["primary_question"]
+        == "Why do renewal surprises cause churn?"
+    )
+    assert "preventable churn" in draft.sections[0].metadata["answer_summary"]
     assert draft.metadata["generation_model"] == "test-model"
 
 


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-AEO-GEO-Section-Source.md

Tighten the landing-page source prompt so generated sections carry AEO/GEO-friendly role, buyer-question, and answer-summary metadata while keeping the answer visible in body copy.

## Intentional
- No schema or parser change; section metadata already persists through LandingPageSection.
- No hard quality-gate block yet, so older drafts remain valid.
- No forced FAQ or fake proof.

## Deferred
- PR-Landing-Page-AEO-GEO-Section-Readiness can score the new metadata directly.
- PR-Landing-Page-Publish-Structured-Data can map FAQ/objection sections into JSON-LD once a renderer exists.

## Verification
- pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py -q
- git diff --check
- bash scripts/local_pr_review.sh origin/main

## Diff size
4 files, +127 / -3