### PR TITLE
Score landing page AEO/GEO section metadata

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -196,6 +196,32 @@ _GENERIC_SECTION_TITLES = frozenset({
     "overview",
     "summary",
 })
+_SECTION_KINDS = frozenset({
+    "problem",
+    "solution",
+    "how_it_works",
+    "proof",
+    "pricing",
+    "faq",
+    "objection",
+    "conversion",
+})
+_QUESTION_SECTION_KINDS = frozenset({
+    "problem",
+    "solution",
+    "how_it_works",
+    "faq",
+    "objection",
+})
+_PROBLEM_SECTION_KINDS = frozenset({"problem"})
+_SOLUTION_SECTION_KINDS = frozenset({"solution", "how_it_works"})
+_OBJECTION_SECTION_KINDS = frozenset({
+    "faq",
+    "objection",
+    "pricing",
+    "proof",
+    "how_it_works",
+})
 _STOPWORDS = frozenset({
     "about",
     "after",
@@ -313,11 +339,17 @@ def _answer_first_hero(draft: LandingPageDraft, hero_text: str) -> bool:
 
 def _problem_solution_clarity(draft: LandingPageDraft) -> bool:
     section_text = " ".join(
-        f"{section.id} {section.title} {section.body_markdown}"
+        f"{section.id} {section.title} {section.body_markdown} "
+        f"{_mapping_text(section.metadata)}"
         for section in draft.sections
     )
-    has_problem = bool(_PROBLEM_RE.search(section_text))
-    has_solution = bool(_SOLUTION_RE.search(section_text))
+    section_kinds = {_section_kind(section) for section in draft.sections}
+    has_problem = bool(_PROBLEM_RE.search(section_text)) or bool(
+        section_kinds.intersection(_PROBLEM_SECTION_KINDS)
+    )
+    has_solution = bool(_SOLUTION_RE.search(section_text)) or bool(
+        section_kinds.intersection(_SOLUTION_SECTION_KINDS)
+    )
     value_terms = _key_terms(draft.value_prop)
     return (
         has_problem
@@ -335,6 +367,8 @@ def _audience_specificity(draft: LandingPageDraft, text: str) -> bool:
 
 def _objection_coverage(draft: LandingPageDraft) -> bool:
     for section in draft.sections:
+        if _section_kind(section) in _OBJECTION_SECTION_KINDS:
+            return True
         if _OBJECTION_SECTION_RE.search(f"{section.id} {section.title}"):
             return True
     return False
@@ -353,9 +387,17 @@ def _offer_entity_clarity(draft: LandingPageDraft, text: str) -> bool:
 def _answer_extractability(draft: LandingPageDraft) -> bool:
     hero_text = _mapping_text(draft.hero)
     words = hero_text.split()
-    if len(words) < 12 or len(words) > 90:
+    if 12 <= len(words) <= 90 and _answer_first_hero(draft, hero_text):
+        return True
+    if not draft.sections:
         return False
-    return _answer_first_hero(draft, hero_text)
+    summary = _section_answer_summary(draft.sections[0])
+    if not _section_answer_summary_visible(draft.sections[0]):
+        return False
+    return _contains_any(
+        _normalize_text(summary),
+        _key_terms(draft.persona, draft.value_prop, draft.title),
+    )
 
 
 def _section_semantics(draft: LandingPageDraft) -> bool:
@@ -365,7 +407,45 @@ def _section_semantics(draft: LandingPageDraft) -> bool:
         title = _clean_text(section.title)
         if len(title) < 4 or title.lower() in _GENERIC_SECTION_TITLES:
             return False
+        kind = _section_kind(section)
+        if kind not in _SECTION_KINDS:
+            return False
+        if _section_requires_visible_answer(section) and not _section_answer_summary_visible(section):
+            return False
     return True
+
+
+def _section_kind(section: LandingPageSection) -> str:
+    return _normalize_kind(_metadata_mapping(section.metadata).get("kind"))
+
+
+def _normalize_kind(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", _clean_text(value).lower()).strip("_")
+
+
+def _section_primary_question(section: LandingPageSection) -> str:
+    return _clean_text(_metadata_mapping(section.metadata).get("primary_question"))
+
+
+def _section_answer_summary(section: LandingPageSection) -> str:
+    return _clean_text(_metadata_mapping(section.metadata).get("answer_summary"))
+
+
+def _section_requires_visible_answer(section: LandingPageSection) -> bool:
+    return bool(_section_primary_question(section)) or (
+        _section_kind(section) in _QUESTION_SECTION_KINDS
+    )
+
+
+def _section_answer_summary_visible(section: LandingPageSection) -> bool:
+    summary = _section_answer_summary(section)
+    body = _clean_text(section.body_markdown)
+    words = summary.split()
+    if len(words) < 6 or len(words) > 90:
+        return False
+    normalized_summary = _normalize_text(summary)
+    normalized_body = _normalize_text(body)
+    return bool(normalized_summary and normalized_body.startswith(normalized_summary))
 
 
 def _trust_signal_visibility(draft: LandingPageDraft, text: str) -> bool:

--- a/plans/PR-Landing-Page-AEO-GEO-Section-Readiness.md
+++ b/plans/PR-Landing-Page-AEO-GEO-Section-Readiness.md
@@ -1,0 +1,71 @@
+# PR-Landing-Page-AEO-GEO-Section-Readiness
+
+## Why this slice exists
+
+PR #744 made the landing-page prompt ask for AEO/GEO section metadata:
+`kind`, `primary_question`, and `answer_summary`. The review/export readiness
+helpers still score only visible text, section titles, and regex matches.
+
+This slice makes readiness use that new source metadata directly while keeping
+the output contract stable.
+
+## Scope (this PR)
+
+1. Let problem/solution clarity read section `metadata.kind`.
+2. Let objection coverage read section `metadata.kind`.
+3. Let answer extractability pass from a visible first-section answer summary.
+4. Let section semantics require valid section kind metadata and visible
+   answer summaries for question-shaped sections.
+5. Add focused export tests for the metadata scoring behavior.
+
+### Files touched
+
+- `plans/PR-Landing-Page-AEO-GEO-Section-Readiness.md`
+- `extracted_content_pipeline/landing_page_export.py`
+- `tests/test_extracted_landing_page_export.py`
+
+## Mechanism
+
+The export readiness helpers already own read-only `seo_aeo_readiness` and
+`geo_readiness` summaries. This slice extends those helpers to inspect
+`LandingPageSection.metadata`:
+
+- `kind` must be one of the section roles requested by the prompt.
+- `primary_question` marks a question-shaped section.
+- `answer_summary` must be present at the start of visible `body_markdown`
+  when the section is question-shaped.
+
+The readiness output shape, check names, and totals stay the same. This is a
+scoring improvement, not a new API contract.
+
+## Intentional
+
+- No generator prompt changes; #744 already changed the prompt.
+- No parser or persistence changes; section metadata already round-trips.
+- No quality-gate blocker. Older drafts can still persist; they may simply
+  score lower on review readiness until regenerated or edited.
+- No publish-level structured-data work.
+
+## Deferred
+
+- `PR-Landing-Page-Publish-Structured-Data` can map FAQ/objection sections into
+  public JSON-LD once a generated landing-page renderer exists.
+- `PR-Landing-Page-Section-Metadata-Quality-Gate` can decide whether missing
+  or invalid section metadata should become a warning in the quality pack.
+
+## Verification
+
+- `pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q` - 35 passed.
+- Python compile command over `extracted_content_pipeline/landing_page_export.py`
+  and `tests/test_extracted_landing_page_export.py` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Readiness helpers | ~90 |
+| Tests | ~140 |
+| **Total** | **~300** |

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -166,27 +166,59 @@ def _ready_draft(**overrides) -> LandingPageDraft:
             id="problem",
             title="Support problems that keep coming back",
             body_markdown=(
-                "Support problems keep coming back when VP Engineering teams "
-                "cannot see where customers get stuck before renewal pressure "
-                "builds."
+                "VP Engineering teams catch pressure early when repeated "
+                "support issues are turned into visible answers before "
+                "renewal risk builds. Support problems keep coming back when "
+                "teams cannot see where customers get stuck."
             ),
+            metadata={
+                "order": 1,
+                "kind": "problem",
+                "primary_question": "Why do support problems become renewal risk?",
+                "answer_summary": (
+                    "VP Engineering teams catch pressure early when repeated "
+                    "support issues are turned into visible answers before "
+                    "renewal risk builds."
+                ),
+            },
         ),
         LandingPageSection(
             id="solution",
             title="A workflow for catching pressure early",
             body_markdown=(
-                "The solution helps teams catch pressure early by turning the "
-                "same repeated support signals into a clear page and follow-up "
-                "workflow."
+                "The solution helps VP Engineering teams catch pressure early "
+                "by turning repeated support signals into a clear page and "
+                "follow-up workflow."
             ),
+            metadata={
+                "order": 2,
+                "kind": "solution",
+                "primary_question": "How does the workflow catch pressure early?",
+                "answer_summary": (
+                    "The solution helps VP Engineering teams catch pressure "
+                    "early by turning repeated support signals into a clear "
+                    "page and follow-up workflow."
+                ),
+            },
         ),
         LandingPageSection(
-            id="faq",
+            id="buyer_questions",
             title="Questions buyers ask before rollout",
             body_markdown=(
-                "This section answers implementation, pricing, and security "
-                "questions before the buyer has to email the team."
+                "VP Engineering buyers can answer implementation, pricing, "
+                "and security questions before they have to email the team. "
+                "This keeps the conversion path clear during rollout review."
             ),
+            metadata={
+                "order": 3,
+                "kind": "objection",
+                "primary_question": "What should buyers know before rollout?",
+                "answer_summary": (
+                    "VP Engineering buyers can answer implementation, "
+                    "pricing, and security questions before they have to "
+                    "email the team."
+                ),
+            },
         ),
     )
     draft = LandingPageDraft(
@@ -393,6 +425,92 @@ async def test_export_landing_page_drafts_surfaces_incomplete_readiness() -> Non
         "conversion_path_clarity",
         "claim_safety",
     ]
+
+
+@pytest.mark.asyncio
+async def test_export_landing_page_drafts_scores_section_metadata_readiness() -> None:
+    result = await export_landing_page_drafts(
+        _Repository(drafts=[
+            _ready_draft(
+                hero={
+                    "headline": "Start the review",
+                    "subheadline": "For busy operators.",
+                    "cta_label": "Book a demo",
+                    "cta_url": "/demo",
+                },
+                sections=(
+                    LandingPageSection(
+                        id="customer_friction",
+                        title="Customer friction before renewal",
+                        body_markdown=(
+                            "VP Engineering teams catch pressure early by "
+                            "turning repeated support issues into visible "
+                            "answers before renewal risk builds. Customers "
+                            "stop waiting for the same basic answer."
+                        ),
+                        metadata={
+                            "kind": "problem",
+                            "primary_question": (
+                                "Why does repeated customer friction matter?"
+                            ),
+                            "answer_summary": (
+                                "VP Engineering teams catch pressure early by "
+                                "turning repeated support issues into visible "
+                                "answers before renewal risk builds."
+                            ),
+                        },
+                    ),
+                    LandingPageSection(
+                        id="clearer_answers",
+                        title="Clearer answers before customers wait",
+                        body_markdown=(
+                            "VP Engineering teams use a workflow to turn "
+                            "repeated support signals into clearer answers "
+                            "before customers wait on another reply."
+                        ),
+                        metadata={
+                            "kind": "solution",
+                            "primary_question": (
+                                "How do teams turn repeat tickets into answers?"
+                            ),
+                            "answer_summary": (
+                                "VP Engineering teams use a workflow to turn "
+                                "repeated support signals into clearer answers "
+                                "before customers wait on another reply."
+                            ),
+                        },
+                    ),
+                    LandingPageSection(
+                        id="before_rollout",
+                        title="Before rollout questions",
+                        body_markdown=(
+                            "VP Engineering buyers can answer implementation "
+                            "and pricing concerns before they book time with "
+                            "the team. That keeps review moving without "
+                            "another support handoff."
+                        ),
+                        metadata={
+                            "kind": "objection",
+                            "primary_question": "What should buyers know first?",
+                            "answer_summary": (
+                                "VP Engineering buyers can answer "
+                                "implementation and pricing concerns before "
+                                "they book time with the team."
+                            ),
+                        },
+                    ),
+                ),
+            )
+        ]),
+        scope=TenantScope(account_id="acct_1"),
+    )
+
+    row = result.rows[0]
+    assert row["seo_aeo_readiness"]["checks"]["answer_first_hero"] is False
+    assert row["seo_aeo_readiness"]["checks"]["problem_solution_clarity"] is True
+    assert row["seo_aeo_readiness"]["checks"]["objection_coverage"] is True
+    assert row["geo_readiness"]["checks"]["answer_extractability"] is True
+    assert row["geo_readiness"]["checks"]["section_semantics"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-AEO-GEO-Section-Readiness.md

Score landing-page AEO/GEO section metadata in review readiness without changing the exported readiness shape or adding quality-gate blockers.

## Intentional
- No generator, parser, persistence, or quality-gate change.
- Older drafts can still persist, but may score lower until regenerated or edited with section metadata.
- Readiness output shape, check names, and totals stay stable.

## Deferred
- PR-Landing-Page-Publish-Structured-Data can map FAQ and objection sections into JSON-LD once a renderer exists.
- PR-Landing-Page-Section-Metadata-Quality-Gate can decide whether metadata gaps become quality-pack warnings.

## Verification
- pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q
- python -m py_compile extracted_content_pipeline/landing_page_export.py tests/test_extracted_landing_page_export.py
- git diff --check
- bash scripts/local_pr_review.sh origin/main

## Diff size
3 files, +283 / -14