### PR TITLE
Centralize landing page section kind contract

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -12,6 +12,14 @@ from typing import Any
 
 from .campaign_ports import TenantScope
 from .landing_page_ports import LandingPageDraft, LandingPageRepository
+from .landing_page_section_contract import (
+    LANDING_PAGE_OBJECTION_SECTION_KINDS,
+    LANDING_PAGE_PROBLEM_SECTION_KINDS,
+    LANDING_PAGE_QUESTION_SECTION_KINDS,
+    LANDING_PAGE_SECTION_KINDS,
+    LANDING_PAGE_SOLUTION_SECTION_KINDS,
+    normalize_landing_page_section_kind,
+)
 
 
 JsonDict = dict[str, Any]
@@ -196,32 +204,6 @@ _GENERIC_SECTION_TITLES = frozenset({
     "overview",
     "summary",
 })
-_SECTION_KINDS = frozenset({
-    "problem",
-    "solution",
-    "how_it_works",
-    "proof",
-    "pricing",
-    "faq",
-    "objection",
-    "conversion",
-})
-_QUESTION_SECTION_KINDS = frozenset({
-    "problem",
-    "solution",
-    "how_it_works",
-    "faq",
-    "objection",
-})
-_PROBLEM_SECTION_KINDS = frozenset({"problem"})
-_SOLUTION_SECTION_KINDS = frozenset({"solution", "how_it_works"})
-_OBJECTION_SECTION_KINDS = frozenset({
-    "faq",
-    "objection",
-    "pricing",
-    "proof",
-    "how_it_works",
-})
 _STOPWORDS = frozenset({
     "about",
     "after",
@@ -345,10 +327,10 @@ def _problem_solution_clarity(draft: LandingPageDraft) -> bool:
     )
     section_kinds = {_section_kind(section) for section in draft.sections}
     has_problem = bool(_PROBLEM_RE.search(section_text)) or bool(
-        section_kinds.intersection(_PROBLEM_SECTION_KINDS)
+        section_kinds.intersection(LANDING_PAGE_PROBLEM_SECTION_KINDS)
     )
     has_solution = bool(_SOLUTION_RE.search(section_text)) or bool(
-        section_kinds.intersection(_SOLUTION_SECTION_KINDS)
+        section_kinds.intersection(LANDING_PAGE_SOLUTION_SECTION_KINDS)
     )
     value_terms = _key_terms(draft.value_prop)
     return (
@@ -367,7 +349,7 @@ def _audience_specificity(draft: LandingPageDraft, text: str) -> bool:
 
 def _objection_coverage(draft: LandingPageDraft) -> bool:
     for section in draft.sections:
-        if _section_kind(section) in _OBJECTION_SECTION_KINDS:
+        if _section_kind(section) in LANDING_PAGE_OBJECTION_SECTION_KINDS:
             return True
         if _OBJECTION_SECTION_RE.search(f"{section.id} {section.title}"):
             return True
@@ -408,7 +390,7 @@ def _section_semantics(draft: LandingPageDraft) -> bool:
         if len(title) < 4 or title.lower() in _GENERIC_SECTION_TITLES:
             return False
         kind = _section_kind(section)
-        if kind not in _SECTION_KINDS:
+        if kind not in LANDING_PAGE_SECTION_KINDS:
             return False
         if _section_requires_visible_answer(section) and not _section_answer_summary_visible(section):
             return False
@@ -416,11 +398,9 @@ def _section_semantics(draft: LandingPageDraft) -> bool:
 
 
 def _section_kind(section: LandingPageSection) -> str:
-    return _normalize_kind(_metadata_mapping(section.metadata).get("kind"))
-
-
-def _normalize_kind(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", _clean_text(value).lower()).strip("_")
+    return normalize_landing_page_section_kind(
+        _metadata_mapping(section.metadata).get("kind")
+    )
 
 
 def _section_primary_question(section: LandingPageSection) -> str:
@@ -433,7 +413,7 @@ def _section_answer_summary(section: LandingPageSection) -> str:
 
 def _section_requires_visible_answer(section: LandingPageSection) -> bool:
     return bool(_section_primary_question(section)) or (
-        _section_kind(section) in _QUESTION_SECTION_KINDS
+        _section_kind(section) in LANDING_PAGE_QUESTION_SECTION_KINDS
     )
 
 

--- a/extracted_content_pipeline/landing_page_section_contract.py
+++ b/extracted_content_pipeline/landing_page_section_contract.py
@@ -1,0 +1,52 @@
+"""Canonical landing-page section metadata contract."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+LANDING_PAGE_SECTION_KINDS = (
+    "problem",
+    "solution",
+    "how_it_works",
+    "proof",
+    "pricing",
+    "faq",
+    "objection",
+    "conversion",
+)
+
+LANDING_PAGE_QUESTION_SECTION_KINDS = (
+    "problem",
+    "solution",
+    "how_it_works",
+    "faq",
+    "objection",
+)
+
+LANDING_PAGE_PROBLEM_SECTION_KINDS = ("problem",)
+LANDING_PAGE_SOLUTION_SECTION_KINDS = ("solution", "how_it_works")
+LANDING_PAGE_OBJECTION_SECTION_KINDS = (
+    "faq",
+    "objection",
+    "pricing",
+    "proof",
+    "how_it_works",
+)
+
+
+def normalize_landing_page_section_kind(value: Any) -> str:
+    """Normalize a landing-page section kind for readiness scoring."""
+
+    return re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower()).strip("_")
+
+
+__all__ = [
+    "LANDING_PAGE_OBJECTION_SECTION_KINDS",
+    "LANDING_PAGE_PROBLEM_SECTION_KINDS",
+    "LANDING_PAGE_QUESTION_SECTION_KINDS",
+    "LANDING_PAGE_SECTION_KINDS",
+    "LANDING_PAGE_SOLUTION_SECTION_KINDS",
+    "normalize_landing_page_section_kind",
+]

--- a/plans/PR-Landing-Page-Section-Kind-Contract.md
+++ b/plans/PR-Landing-Page-Section-Kind-Contract.md
@@ -1,0 +1,76 @@
+# PR-Landing-Page-Section-Kind-Contract
+
+## Why this slice exists
+
+PR #746 made landing-page readiness score `sections.metadata.kind`, but the
+valid section-kind enum now lives as a manual mirror in the readiness helper and
+the bundled prompt. That is the same drift pattern we already corrected for
+landing-page repair attempts.
+
+This slice creates one small source of truth for landing-page section kind
+values and makes the scorer and prompt regression tests use it.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-section-kind-contract
+
+1. Add a canonical landing-page section-kind contract module.
+2. Replace readiness-helper local section-kind constants with the shared
+   contract.
+3. Add tests that validate kind normalization and prompt enum coverage.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Section-Kind-Contract.md`
+- `extracted_content_pipeline/landing_page_section_contract.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `tests/test_landing_page_section_contract.py`
+- `tests/test_extracted_campaign_skill_registry.py`
+
+## Mechanism
+
+`landing_page_section_contract.py` owns:
+
+- `LANDING_PAGE_SECTION_KINDS`
+- `LANDING_PAGE_QUESTION_SECTION_KINDS`
+- `LANDING_PAGE_PROBLEM_SECTION_KINDS`
+- `LANDING_PAGE_SOLUTION_SECTION_KINDS`
+- `LANDING_PAGE_OBJECTION_SECTION_KINDS`
+- `normalize_landing_page_section_kind(...)`
+
+The export readiness helper imports those constants instead of carrying a local
+copy. The prompt remains static markdown, but the packaged-prompt regression
+test now loops over the canonical kind list and fails if any canonical value is
+missing from the prompt's section-kind instruction.
+
+## Intentional
+
+- No prompt copy change. This slice verifies the existing prompt against the
+  backend contract.
+- No API output change.
+- No quality-gate blocker. This only removes a manual mirror.
+
+## Deferred
+
+- `PR-Landing-Page-Section-Metadata-Quality-Gate` can decide whether invalid
+  section kinds should become quality-pack warnings.
+
+## Verification
+
+- `pytest tests/test_landing_page_section_contract.py tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_export.py -q` - 30 passed.
+- Python compile command over `extracted_content_pipeline/landing_page_section_contract.py`,
+  `extracted_content_pipeline/landing_page_export.py`,
+  `tests/test_landing_page_section_contract.py`, and
+  `tests/test_extracted_campaign_skill_registry.py` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Contract module | ~52 |
+| Export import swap | ~55 |
+| Tests | ~40 |
+| **Total** | **~220** |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -4,6 +4,9 @@ from extracted_content_pipeline.skills.registry import (
     LocalSkillRegistry,
     get_skill_registry,
 )
+from extracted_content_pipeline.landing_page_section_contract import (
+    LANDING_PAGE_SECTION_KINDS,
+)
 
 
 def test_local_skill_registry_reads_packaged_campaign_prompt() -> None:
@@ -105,6 +108,8 @@ def test_packaged_landing_page_prompt_requests_aeo_geo_section_metadata() -> Non
     assert "same answer at the start of `body_markdown`" in prompt
     assert "Do not force a FAQ section" in prompt
     assert "supports answer extraction" in prompt
+    for kind in LANDING_PAGE_SECTION_KINDS:
+        assert kind in prompt
 
 
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:

--- a/tests/test_landing_page_section_contract.py
+++ b/tests/test_landing_page_section_contract.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.landing_page_section_contract import (
+    LANDING_PAGE_OBJECTION_SECTION_KINDS,
+    LANDING_PAGE_PROBLEM_SECTION_KINDS,
+    LANDING_PAGE_QUESTION_SECTION_KINDS,
+    LANDING_PAGE_SECTION_KINDS,
+    LANDING_PAGE_SOLUTION_SECTION_KINDS,
+    normalize_landing_page_section_kind,
+)
+
+
+def test_landing_page_section_kind_groups_are_subsets_of_canonical_kinds() -> None:
+    kinds = set(LANDING_PAGE_SECTION_KINDS)
+
+    assert set(LANDING_PAGE_QUESTION_SECTION_KINDS).issubset(kinds)
+    assert set(LANDING_PAGE_PROBLEM_SECTION_KINDS).issubset(kinds)
+    assert set(LANDING_PAGE_SOLUTION_SECTION_KINDS).issubset(kinds)
+    assert set(LANDING_PAGE_OBJECTION_SECTION_KINDS).issubset(kinds)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("How It Works", "how_it_works"),
+        (" how-it-works ", "how_it_works"),
+        ("FAQ", "faq"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_normalize_landing_page_section_kind(raw, expected) -> None:
+    assert normalize_landing_page_section_kind(raw) == expected


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Section-Kind-Contract.md

Ownership lane: content-ops/landing-page-section-kind-contract

Centralize the landing-page section-kind contract so readiness scoring and packaged prompt regression tests share one canonical enum.

## Intentional
- No prompt copy, API output, parser, or quality-gate behavior change.
- This removes a manual mirror before extending section metadata further.

## Deferred
- PR-Landing-Page-Section-Metadata-Quality-Gate can decide whether invalid section kinds become quality-pack warnings.

## Verification
- pytest tests/test_landing_page_section_contract.py tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_export.py -q
- python -m py_compile extracted_content_pipeline/landing_page_section_contract.py extracted_content_pipeline/landing_page_export.py tests/test_landing_page_section_contract.py tests/test_extracted_campaign_skill_registry.py
- git diff --check
- bash scripts/local_pr_review.sh origin/main

## Diff size
5 files, +184 / -36