### PR TITLE
Expand FAQ intent source coverage

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -21,8 +21,11 @@ SourceDataFormat = Literal["auto", "json", "jsonl", "csv"]
 
 _ROW_LIST_KEYS = (
     "sources",
+    "opportunities",
     "documents",
     "reviews",
+    "chats",
+    "chat_transcripts",
     "transcripts",
     "calls",
     "call_transcripts",
@@ -42,6 +45,8 @@ _ROW_LIST_KEYS = (
     "renewal_notes",
     "subscriptions",
     "subscription_notes",
+    "sales_objections",
+    "objections",
     "complaints",
     "search_logs",
     "site_searches",
@@ -63,6 +68,9 @@ _ROW_LIST_KEYS = (
 _SOURCE_ID_KEYS = (
     "source_id",
     "id",
+    "chat_id",
+    "sales_objection_id",
+    "objection_id",
     "review_id",
     "transcript_id",
     "call_id",
@@ -89,12 +97,14 @@ _SOURCE_ID_KEYS = (
     "conversation_id",
     "conversation_number",
     "request_id",
+    "message_id",
     "survey_id",
     "response_id",
     "feedback_id",
 )
 _TEXT_KEYS = (
     "text",
+    "chat_transcript",
     "review_text",
     "transcript",
     "content",
@@ -107,6 +117,10 @@ _TEXT_KEYS = (
     "search_terms",
     "search_phrase",
     "zero_result_query",
+    "objection",
+    "objection_text",
+    "buyer_objection",
+    "sales_objection",
     "complaint",
     "complaint_narrative",
     "consumer_complaint_narrative",
@@ -235,6 +249,14 @@ _CANONICAL_VALUE_ALIAS_KEYS = (
 # travel as context on notes without changing the evidence row type.
 _SOURCE_TYPE_PRECEDENCE = (
     (("review_text",), "review"),
+    ((
+        "objection",
+        "objection_text",
+        "buyer_objection",
+        "sales_objection",
+        "sales_objection_id",
+        "objection_id",
+    ), "sales_objection"),
     (("transcript",), "transcript"),
     ((
         "search_query",
@@ -250,6 +272,7 @@ _SOURCE_TYPE_PRECEDENCE = (
         "query_id",
         "zero_result_query_id",
     ), "search_log"),
+    (("chat_id",), "chat"),
     (("call_id", "recording_id"), "sales_call"),
     (("meeting_id",), "meeting"),
     (("deal_id", "opportunity_id"), "crm_deal"),
@@ -386,6 +409,19 @@ def source_rows_to_campaign_opportunities(
         opportunities=normalized.opportunities,
         warnings=tuple(warnings) + normalized.warnings,
     )
+
+
+def source_material_to_source_rows(source_material: Any) -> list[Any]:
+    """Expand a source-material object, bundle, or row list into source rows."""
+
+    if isinstance(source_material, Mapping):
+        return _source_rows_from_bundle(source_material)
+    if isinstance(source_material, Sequence) and not isinstance(
+        source_material,
+        (str, bytes, bytearray),
+    ):
+        return list(source_material)
+    return []
 
 
 def parse_default_fields(values: Sequence[str] | None) -> dict[str, str]:
@@ -853,6 +889,7 @@ __all__ = [
     "parse_default_fields",
     "parse_default_fields_with_booking_url_or_exit",
     "parse_default_fields_or_exit",
+    "source_material_to_source_rows",
     "source_row_to_campaign_opportunity",
     "source_rows_to_campaign_opportunities",
 ]

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -10,7 +10,10 @@ import re
 from typing import Any
 
 from .campaign_ports import TenantScope
-from .campaign_source_adapters import source_rows_to_campaign_opportunities
+from .campaign_source_adapters import (
+    source_material_to_source_rows,
+    source_rows_to_campaign_opportunities,
+)
 from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
@@ -18,7 +21,14 @@ DEFAULT_TICKET_SOURCE_TYPES = (
     "ticket",
     "support_ticket",
     "case",
+    "chat",
+    "chat_transcript",
     "conversation",
+    "transcript",
+    "sales_call",
+    "meeting",
+    "sales_objection",
+    "objection",
     "complaint",
     "search_log",
     "search_query",
@@ -850,7 +860,10 @@ def _render(
         lines.extend([
             "No ticket FAQ items were generated.",
             "",
-            "Provide source rows with support-ticket, case, conversation, or complaint evidence.",
+            (
+                "Provide source rows with support-ticket, case, conversation, "
+                "chat, transcript, objection, search, or complaint evidence."
+            ),
             "",
         ])
         return "\n".join(lines)
@@ -1181,32 +1194,7 @@ def _rows_from_source_material(source_material: Any) -> list[Any]:
     if isinstance(source_material, str):
         text = source_material.strip()
         return [{"text": text, "source_type": "support_ticket"}] if text else []
-    if isinstance(source_material, Mapping):
-        for key in (
-            "support_tickets",
-            "tickets",
-            "cases",
-            "conversations",
-            "complaints",
-            "search_logs",
-            "site_searches",
-            "search_queries",
-            "zero_result_searches",
-            "zero_result_queries",
-            "sources",
-            "rows",
-            "data",
-            "opportunities",
-        ):
-            value = source_material.get(key)
-            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-                rows = list(value)
-                if rows:
-                    return rows
-        return [dict(source_material)]
-    if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
-        return list(source_material)
-    return []
+    return source_material_to_source_rows(source_material)
 
 
 __all__ = [

--- a/plans/PR-Content-Ops-FAQ-Intent-Source-Coverage.md
+++ b/plans/PR-Content-Ops-FAQ-Intent-Source-Coverage.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-FAQ-Intent-Source-Coverage
+
+## Why this slice exists
+
+The FAQ product wedge promises intent-to-FAQ mapping from real queries across
+search logs, chat transcripts, tickets, and sales objections. Search logs and
+support tickets are already accepted by the FAQ generator, but source rows that
+normalize as transcripts, sales calls, meetings, chats, or sales objections can
+be filtered out by the default FAQ source-type allowlist.
+
+That makes the feature look narrower than the source adapter already supports.
+This slice closes the first-class source coverage gap without changing the FAQ
+Markdown shape or adding vocabulary-gap detection.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add FAQ default source coverage for transcript, chat, sales-call, meeting,
+   and sales-objection evidence.
+2. Teach the source adapter common chat and sales-objection row labels so
+   bundled uploads normalize to FAQ-eligible source types.
+3. Add focused tests proving chat transcript and sales-objection inputs flow
+   through the service and cluster into FAQ items.
+4. Keep review/document source rows excluded from default FAQ generation.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Intent-Source-Coverage.md` | Plan doc for this FAQ source coverage slice. |
+| `extracted_content_pipeline/campaign_source_adapters.py` | Recognize common chat and sales-objection bundle, id, text, and type labels. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Expand the default FAQ source-type allowlist to source types emitted for chats, transcripts, calls, meetings, and objections. |
+| `tests/test_extracted_campaign_source_adapters.py` | Cover bundled chat and sales-objection source normalization. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Cover FAQ service ingestion for chat transcript and sales-objection sources. |
+
+## Mechanism
+
+TicketFAQMarkdownService.generate already normalizes arbitrary source material
+through the campaign source adapter before calling the FAQ Markdown builder. The
+generator then filters evidence rows by DEFAULT_TICKET_SOURCE_TYPES.
+
+This slice keeps that flow and broadens the default allowlist to include the
+customer-support and buyer-intent source types the adapter can emit for
+conversation-shaped evidence. Source-material bundle expansion is centralized in
+the adapter so the FAQ service does not need its own copy of bundle key names.
+The adapter receives small alias additions so common bundle labels such as
+`chats`, `chat_transcripts`, `sales_objections`, and row fields such as
+`chat_id`, `objection_id`, and `objection_text` normalize without callers
+needing to force `source_type` manually.
+
+## Intentional
+
+- No change to ranking, output checks, Markdown rendering, persistence, or the
+  result JSON artifact.
+- No vocabulary-gap detection in this slice; this is source coverage for the
+  already-partial intent-to-FAQ mapping work.
+- Review, survey, CRM, contract, renewal, and subscription evidence remain
+  outside the default FAQ source filter unless a caller explicitly passes
+  `source_types=()`.
+
+## Deferred
+
+- A later vocabulary-gap slice can compare customer terms against existing
+  documentation terms and emit synonym/heading suggestions.
+- A later intent-ranking slice can expose frequency x failure-risk summaries in
+  a dedicated product artifact instead of only Markdown items and metadata.
+- A later hosted upload slice can surface these accepted source families in the
+  UI copy and examples.
+
+## Verification
+
+- Py compile for affected Python files - passed.
+- Focused source-coverage pytest - passed, 9 tests.
+- `pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py -q` - passed, 138 tests.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 89 |
+| Source adapter aliases/helper | 37 |
+| FAQ source allowlist/service routing | 44 |
+| Tests | 162 |
+| **Total** | **~335** |

--- a/tests/test_extracted_campaign_source_adapters.py
+++ b/tests/test_extracted_campaign_source_adapters.py
@@ -13,6 +13,7 @@ from extracted_content_pipeline.campaign_source_adapters import (
     parse_default_fields,
     parse_default_fields_with_booking_url_or_exit,
     parse_default_fields_or_exit,
+    source_material_to_source_rows,
     source_row_to_campaign_opportunity,
     source_rows_to_campaign_opportunities,
 )
@@ -38,6 +39,14 @@ def test_source_type_precedence_table_matches_current_contract() -> None:
     # This intentionally locks a private table: source-type order is product behavior.
     assert adapters._SOURCE_TYPE_PRECEDENCE == (
         (("review_text",), "review"),
+        ((
+            "objection",
+            "objection_text",
+            "buyer_objection",
+            "sales_objection",
+            "sales_objection_id",
+            "objection_id",
+        ), "sales_objection"),
         (("transcript",), "transcript"),
         ((
             "search_query",
@@ -53,6 +62,7 @@ def test_source_type_precedence_table_matches_current_contract() -> None:
             "query_id",
             "zero_result_query_id",
         ), "search_log"),
+        (("chat_id",), "chat"),
         (("call_id", "recording_id"), "sales_call"),
         (("meeting_id",), "meeting"),
         (("deal_id", "opportunity_id"), "crm_deal"),
@@ -81,7 +91,19 @@ def test_source_type_precedence_table_controls_ambiguous_rows() -> None:
 
     assert warnings == ()
     assert opportunity["source_type"] == "review"
-    assert opportunity["target_id"] == "sales_call-value"
+    assert opportunity["target_id"] == "chat-value"
+
+
+def test_message_id_does_not_relabel_support_ticket_as_chat() -> None:
+    opportunity, warnings = source_row_to_campaign_opportunity({
+        "request_id": "ticket-1",
+        "message_id": "message-1",
+        "message": "The attribution export is not working.",
+    })
+
+    assert warnings == ()
+    assert opportunity["source_type"] == "support_ticket"
+    assert opportunity["target_id"] == "ticket-1"
 
 
 def test_source_field_lookup_preserves_exact_key_precedence() -> None:
@@ -127,6 +149,31 @@ def test_source_field_lookup_reuses_cached_alias_results(monkeypatch) -> None:
     assert adapters._field_value(lookup, "missing_key") is None
     assert adapters._field_value(lookup, "missing_key") is None
     assert calls == 5
+
+
+def test_source_material_to_source_rows_expands_bundle_keys() -> None:
+    rows = source_material_to_source_rows({
+        "support_tickets": [],
+        "sales_objections": [{
+            "objection_id": "obj-1",
+            "objection_text": "Exports are blocked.",
+        }],
+        "opportunities": [{
+            "source_id": "opp-1",
+            "text": "Opportunity row stays in the bundle.",
+        }],
+    })
+
+    assert rows == [
+        {
+            "source_id": "opp-1",
+            "text": "Opportunity row stays in the bundle.",
+        },
+        {
+            "objection_id": "obj-1",
+            "objection_text": "Exports are blocked.",
+        },
+    ]
 
 
 def test_source_row_maps_review_text_to_campaign_opportunity() -> None:
@@ -1230,6 +1277,52 @@ def test_load_source_campaign_opportunities_from_meeting_bundle(tmp_path: Path) 
         "source_id": "meeting-1",
         "source_type": "meeting",
         "source_title": "Renewal checkpoint",
+    }
+
+
+def test_load_source_campaign_opportunities_from_chat_and_objection_bundle(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "chat_objection_bundle.json"
+    path.write_text(
+        json.dumps({
+            "company": "Acme Logistics",
+            "vendor": "HubSpot",
+            "chats": [
+                {
+                    "chat_id": "chat-1",
+                    "subject": "Dashboard export",
+                    "messages": [
+                        {
+                            "speaker": "customer",
+                            "message": "How do I export the attribution dashboard?",
+                        },
+                        {"speaker": "agent", "message": "I can send the export steps."},
+                    ],
+                }
+            ],
+            "sales_objections": [
+                {
+                    "objection_id": "obj-1",
+                    "objection_text": "We cannot export attribution reports before renewal.",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    loaded = load_source_campaign_opportunities_from_file(path)
+
+    assert [row["target_id"] for row in loaded.opportunities] == ["chat-1", "obj-1"]
+    assert [row["source_type"] for row in loaded.opportunities] == ["chat", "sales_objection"]
+    assert loaded.opportunities[0]["evidence"][0]["text"] == (
+        "customer: How do I export the attribution dashboard?\n"
+        "agent: I can send the export steps."
+    )
+    assert loaded.opportunities[1]["evidence"][0] == {
+        "text": "We cannot export attribution reports before renewal.",
+        "source_id": "obj-1",
+        "source_type": "sales_objection",
     }
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1262,6 +1262,66 @@ async def test_ticket_faq_service_accepts_search_log_source_material() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ticket_faq_service_accepts_chat_transcript_source_material() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "chats": [
+                {
+                    "chat_id": "chat-1",
+                    "subject": "Attribution export",
+                    "messages": [
+                        {
+                            "speaker": "customer",
+                            "message": "How do I export the attribution dashboard?",
+                        },
+                        {
+                            "speaker": "agent",
+                            "message": "I can send the export steps.",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert result.ticket_source_count == 1
+    assert result.items[0]["topic"] == "reporting friction"
+    assert result.items[0]["source_ids"] == ("chat-1",)
+    assert result.items[0]["question"] == "How do I export the attribution dashboard?"
+    assert "`chat-1` - Attribution export" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_ticket_faq_service_accepts_sales_objection_source_material() -> None:
+    service = TicketFAQMarkdownService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "sales_objections": [
+                {
+                    "objection_id": "obj-1",
+                    "objection_text": "We cannot export attribution reports before renewal.",
+                }
+            ]
+        },
+    )
+
+    assert result.as_dict()["generated"] == 1
+    assert result.ticket_source_count == 1
+    assert result.items[0]["topic"] == "reporting friction"
+    assert result.items[0]["source_ids"] == ("obj-1",)
+    assert result.items[0]["question"] == "How do we export attribution reports before renewal?"
+    assert "`obj-1`" in result.markdown
+
+
+@pytest.mark.asyncio
 async def test_ticket_faq_service_saves_generated_markdown_when_repository_configured() -> None:
     repository = _FAQRepository()
     service = TicketFAQMarkdownService(ticket_faqs=repository)
@@ -1292,7 +1352,14 @@ async def test_ticket_faq_service_saves_generated_markdown_when_repository_confi
         "ticket",
         "support_ticket",
         "case",
+        "chat",
+        "chat_transcript",
         "conversation",
+        "transcript",
+        "sales_call",
+        "meeting",
+        "sales_objection",
+        "objection",
         "complaint",
         "search_log",
         "search_query",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Intent-Source-Coverage.md

Ownership lane: content-ops/faq-generator

The FAQ product wedge promises intent-to-FAQ mapping from search logs, chat transcripts, tickets, and sales objections. This slice closes the source coverage gap by accepting transcript/chat/sales-call/meeting/sales-objection evidence in default FAQ generation and centralizing source-material bundle expansion in the adapter.

## Intentional
- No ranking, output-check, Markdown rendering, persistence, or result JSON behavior changes.
- No vocabulary-gap detection in this slice; this only expands source coverage for the already-partial intent-to-FAQ mapping work.
- Review, survey, CRM, contract, renewal, and subscription evidence remain excluded by default unless a caller explicitly disables the source-type filter.

## Deferred
- A later vocabulary-gap slice can compare customer terms against existing documentation terms and emit synonym/heading suggestions.
- A later intent-ranking slice can expose frequency x failure-risk summaries in a dedicated product artifact.
- A later hosted upload slice can surface accepted source families in UI copy and examples.

## Verification
- Py compile for affected Python files - passed.
- Focused source-coverage pytest - passed, 9 tests.
- pytest tests/test_extracted_campaign_source_adapters.py tests/test_extracted_ticket_faq_markdown.py -q - passed, 137 tests.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 Atlas runtime import findings.
- bash scripts/check_ascii_python.sh - passed.
- git diff --check - passed.
- bash scripts/local_pr_review.sh origin/main - passed after rebase.

## Diff size
5 files, +293 / -29