### PR TITLE
Add FAQ vocabulary gap term mappings

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -160,6 +160,34 @@ _SOURCE_CONTEXT_KEYS = (
     "issue",
     "sub_issue",
 )
+_DOCUMENTATION_SOURCE_TYPES = {
+    "article",
+    "document",
+    "documentation",
+    "docs",
+    "help_article",
+    "kb_article",
+    "knowledge_base",
+}
+_DOCUMENTATION_TERM_KEYS = (
+    "source_title",
+    "title",
+    "name",
+    "heading",
+    "topic",
+    "category",
+    "text",
+    "description",
+)
+_VOCABULARY_GAP_RULES = (
+    ("export", "download", "download report", "report download"),
+    ("dashboard", "analytics", "reporting", "reports"),
+    ("bill", "billing", "invoice", "statement"),
+    ("login", "log in", "sign in", "authentication"),
+    ("password", "credentials", "authentication"),
+    ("connect", "connection", "integration", "sync"),
+    ("cancel", "cancellation", "renewal"),
+)
 _ACTION_RULES = (
     (("credit report", "credit file", "credit bureau", "credit bureaus", "credit reporting", "incorrect information"), (
         "Get your latest credit reports and mark the account, date, balance, or status that looks wrong.",
@@ -235,6 +263,7 @@ class TicketFAQMarkdownConfig:
     as_of_date: str | None = None
     support_contact: str | None = None
     intent_rules: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_INTENT_RULES
+    documentation_terms: tuple[str, ...] = ()
 
 
 class TicketFAQMarkdownService:
@@ -264,6 +293,7 @@ class TicketFAQMarkdownService:
         as_of_date: Any = None,
         support_contact: str | None = None,
         intent_rules: Sequence[tuple[str, Sequence[str]]] | None = None,
+        documentation_terms: Sequence[str] | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
@@ -306,6 +336,11 @@ class TicketFAQMarkdownService:
             if intent_rules is not None
             else self.config.intent_rules
         )
+        resolved_documentation_terms = (
+            tuple(_clean(term) for term in documentation_terms if _clean(term))
+            if documentation_terms is not None
+            else self.config.documentation_terms
+        )
         title_text = title or self.config.title
         result = build_ticket_faq_markdown(
             normalized.opportunities,
@@ -317,6 +352,7 @@ class TicketFAQMarkdownService:
             as_of_date=resolved_as_of_date,
             support_contact=resolved_support_contact,
             intent_rules=resolved_intent_rules,
+            documentation_terms=resolved_documentation_terms,
         )
         result = replace(
             result,
@@ -343,6 +379,7 @@ class TicketFAQMarkdownService:
                             window_days=resolved_window_days,
                             as_of_date=resolved_as_of_date,
                         ),
+                        **_documentation_term_metadata(resolved_documentation_terms),
                     },
                 )
             ],
@@ -362,6 +399,7 @@ def build_ticket_faq_markdown(
     as_of_date: Any = None,
     support_contact: str | None = None,
     intent_rules: Sequence[tuple[str, Sequence[str]]] = DEFAULT_INTENT_RULES,
+    documentation_terms: Sequence[str] = (),
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -372,6 +410,7 @@ def build_ticket_faq_markdown(
 
     allowed = {_source_type_key(item) for item in source_types if _source_type_key(item)}
     date_window = _date_window(window_days=window_days, as_of_date=as_of_date)
+    resolved_documentation_terms = _documentation_terms(opportunities, documentation_terms)
     groups: dict[str, list[dict[str, str]]] = defaultdict(list)
     seen: set[tuple[str, str]] = set()
     source_keys: set[str] = set()
@@ -436,6 +475,7 @@ def build_ticket_faq_markdown(
             rows,
             max_evidence_per_item=max_evidence_per_item,
             support_contact=support_contact,
+            documentation_terms=resolved_documentation_terms,
         )
         for topic, rows in selected_groups
     )
@@ -547,6 +587,7 @@ def _item(
     *,
     max_evidence_per_item: int,
     support_contact: str | None,
+    documentation_terms: Sequence[str],
 ) -> dict[str, Any]:
     display_rows = rows[:max_evidence_per_item]
     sources = tuple(_source_label(row) for row in display_rows)
@@ -563,6 +604,7 @@ def _item(
     escalation = _escalation_guidance(topic, action_context, support_contact=support_contact)
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     opportunity = _opportunity_score(topic, rows)
+    term_mappings = _term_mappings(rows, documentation_terms)
     return {
         "topic": topic,
         "question": question,
@@ -577,6 +619,7 @@ def _item(
         "steps": steps,
         "when_to_contact_support": escalation,
         "evidence_quotes": evidence_quotes,
+        "term_mappings": term_mappings,
         "source_ids": source_ids,
         "source_labels": sources,
         "evidence_count": len(display_rows),
@@ -600,6 +643,116 @@ def _opportunity_score(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[st
 def _distinct_source_keys(rows: Sequence[Mapping[str, str]]) -> tuple[str, ...]:
     values = (row.get("source_key") or row.get("source_id", "") for row in rows)
     return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _term_mappings(
+    rows: Sequence[Mapping[str, str]],
+    documentation_terms: Sequence[str],
+) -> tuple[dict[str, Any], ...]:
+    doc_terms = _clean_terms(documentation_terms)
+    if not rows or not doc_terms:
+        return ()
+    customer_text = " ".join((
+        " ".join(_clean(row.get("source_title")) for row in rows),
+        " ".join(_clean(row.get("text")) for row in rows),
+    )).lower()
+    if not customer_text:
+        return ()
+    source_ids = _distinct_source_keys(rows)
+    mappings: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for aliases in _VOCABULARY_GAP_RULES:
+        for customer_term in aliases:
+            if not _keyword_matches(customer_text, customer_term):
+                continue
+            if any(_keyword_matches(term.lower(), customer_term) for term in doc_terms):
+                continue
+            documentation_term = _matching_documentation_term(
+                doc_terms,
+                aliases=aliases,
+                customer_term=customer_term,
+            )
+            if not documentation_term:
+                continue
+            key = (customer_term, documentation_term.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            mappings.append({
+                "customer_term": customer_term,
+                "documentation_term": documentation_term,
+                "suggestion": (
+                    f'Add "{customer_term}" as alternate phrasing for '
+                    f'"{documentation_term}" in FAQ headings and answer text.'
+                ),
+                "source_id_count": len(source_ids),
+                "first_source_id": source_ids[0] if source_ids else None,
+            })
+            break
+        if len(mappings) >= 3:
+            break
+    return tuple(mappings)
+
+
+def _matching_documentation_term(
+    documentation_terms: Sequence[str],
+    *,
+    aliases: Sequence[str],
+    customer_term: str,
+) -> str:
+    for term in documentation_terms:
+        lowered = term.lower()
+        if _keyword_matches(lowered, customer_term):
+            continue
+        if any(_keyword_matches(lowered, alias) for alias in aliases if alias != customer_term):
+            return term
+    return ""
+
+
+def _documentation_terms(
+    opportunities: Sequence[Mapping[str, Any]],
+    explicit_terms: Sequence[str],
+) -> tuple[str, ...]:
+    terms: list[str] = []
+    terms.extend(_clean(term) for term in explicit_terms if _clean(term))
+    for opportunity in opportunities:
+        opportunity_type = _source_type_key(opportunity.get("source_type"))
+        if opportunity_type in _DOCUMENTATION_SOURCE_TYPES:
+            terms.extend(_documentation_terms_from_row(opportunity))
+        for evidence in _evidence_rows(opportunity):
+            evidence_type = _source_type_key(evidence.get("source_type") or opportunity_type)
+            if evidence_type in _DOCUMENTATION_SOURCE_TYPES:
+                terms.extend(_documentation_terms_from_row(evidence))
+    return _clean_terms(terms)
+
+
+def _documentation_terms_from_row(row: Mapping[str, Any]) -> tuple[str, ...]:
+    terms: list[str] = []
+    for key in _DOCUMENTATION_TERM_KEYS:
+        text = _compact(_field_value(row, key))
+        if text:
+            terms.append(_term_excerpt(text))
+    return tuple(terms)
+
+
+def _clean_terms(terms: Sequence[str]) -> tuple[str, ...]:
+    out: dict[str, str] = {}
+    for term in terms:
+        text = _compact(term)
+        if not text:
+            continue
+        out.setdefault(text.lower(), text)
+    return tuple(out.values())
+
+
+def _term_excerpt(value: str, *, limit: int = 90) -> str:
+    text = _compact(value)
+    if len(text) <= limit:
+        return text
+    sentence = _first_sentence(text)
+    if sentence and len(sentence) <= limit:
+        return sentence
+    return f"{text[:limit].rstrip()}..."
 
 
 def _failure_risk_signals(topic: str, rows: Sequence[Mapping[str, str]]) -> tuple[str, ...]:
@@ -873,6 +1026,16 @@ def _render(
             "",
             _md(item.get("summary") or item["answer"]),
             "",
+        ])
+        term_mappings = _list(item.get("term_mappings"))
+        if term_mappings:
+            lines.extend([
+                "**Vocabulary gaps:**",
+                "",
+                *[f"- {_md(_term_mapping_line(mapping))}" for mapping in term_mappings],
+                "",
+            ])
+        lines.extend([
             "**What to do next:**",
             "",
             *[f"{step_index}. {_md(step)}" for step_index, step in enumerate(_list(item.get("steps") or item["action_items"]), start=1)],
@@ -895,6 +1058,20 @@ def _source_label(row: Mapping[str, str]) -> str:
     if source_id and title:
         return f"`{source_id}` - {title}"
     return f"`{source_id or 'unknown'}`"
+
+
+def _term_mapping_line(mapping: Any) -> str:
+    if not isinstance(mapping, Mapping):
+        return ""
+    customer_term = _clean(mapping.get("customer_term"))
+    documentation_term = _clean(mapping.get("documentation_term"))
+    suggestion = _clean(mapping.get("suggestion"))
+    if customer_term and documentation_term and suggestion:
+        return (
+            f'Customers say "{customer_term}"; documentation says '
+            f'"{documentation_term}". {suggestion}'
+        )
+    return suggestion or ""
 
 
 def _summary(*, topic: str, rows: Sequence[Mapping[str, str]], source_count: int) -> str:
@@ -1116,6 +1293,13 @@ def _support_contact_metadata(support_contact: str | None) -> dict[str, str]:
     if not contact:
         return {}
     return {"support_contact": contact}
+
+
+def _documentation_term_metadata(documentation_terms: Sequence[str]) -> dict[str, Any]:
+    terms = _clean_terms(documentation_terms)
+    if not terms:
+        return {}
+    return {"documentation_terms": list(terms)}
 
 
 def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping.md
@@ -1,0 +1,97 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping
+
+## Why this slice exists
+
+The FAQ product wedge still needs first-pass Vocabulary Gap Detection. The
+generator can rank FAQ opportunities from customer language, but it does not yet
+show when customers use one term and the existing documentation uses another.
+
+That gap matters for SMB and mid-market teams because zero-result searches and
+support tickets often come from wording mismatch, not missing functionality.
+This slice adds deterministic term-mapping suggestions to the FAQ artifact so a
+generated FAQ can say which customer terms should be added as synonyms or
+alternate headings.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add optional documentation-term input to the FAQ service, core builder, and
+   CLI.
+2. Extract documentation terms from explicit configuration and documentation-like
+   source rows without using those rows as FAQ evidence by default.
+3. Add per-FAQ-item vocabulary-gap suggestions when customer evidence uses a
+   known customer term and documentation terms use a different known term.
+4. Render compact "Vocabulary gaps" Markdown bullets and expose compact counts
+   in the CLI result JSON.
+5. Add focused tests for explicit documentation terms, documentation source
+   rows, CLI result diagnostics, and no-gap behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping.md` | Plan doc for this vocabulary-gap slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds documentation-term input, term mapping detection, item metadata, and Markdown rendering. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds repeatable CLI documentation-term input and compact term-mapping diagnostics. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers generator, service, and CLI vocabulary-gap behavior. |
+
+## Mechanism
+
+The core builder receives optional documentation terms. It also scans
+documentation-like rows already present in normalized source opportunities, such
+as document/help-article rows, for source titles and evidence text. Those rows
+continue to be excluded from default FAQ evidence because the existing
+source-type filter still controls which rows can produce FAQ items.
+
+For each generated FAQ item, the builder compares customer evidence against a
+small deterministic synonym-rule table. When customer evidence contains a
+customer term and the documentation terms contain a different term from the same
+rule, the item gets a compact term-mapping suggestion. The Markdown renderer
+prints these under "Vocabulary gaps", and the CLI result JSON records counts and
+compact mapping summaries without duplicating the full Markdown body.
+
+## Intentional
+
+- No LLM call, embedding dependency, search index dependency, or hosted UI
+  change.
+- No new output check gate; missing documentation terms should not make FAQ
+  generation fail.
+- Documentation rows can inform term mapping, but they do not become FAQ
+  evidence unless callers explicitly change the source-type filter.
+- The synonym table is deliberately small and deterministic. It covers common
+  support/doc mismatches first and can grow in later slices.
+
+## Deferred
+
+- A later hosted upload slice can expose documentation-term inputs in the UI.
+- A later search-log slice can import zero-result search terms directly from a
+  site-search export and rank mappings by zero-result frequency.
+- A later semantic slice can replace or supplement deterministic synonym rules
+  with embeddings or a customer-provided glossary.
+
+## Verification
+
+- Focused vocabulary-gap pytest for builder, service, and CLI behavior - passed, 6 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 74 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review wrapper against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 97 |
+| FAQ generator | 184 |
+| CLI result diagnostics | 39 |
+| Tests | 147 |
+| **Total** | **~470** |
+
+This intentionally exceeds the soft 400 LOC target because the slice needs the
+generator behavior, service/CLI entry points, and tests together to make the
+feature usable and reviewable.

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -28,8 +28,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Convert support-ticket, case, conversation, or complaint source "
-            "rows into a grounded Markdown FAQ."
+            "Convert ticket-like source rows into a grounded Markdown FAQ."
         )
     )
     parser.add_argument("path", type=Path, help="Source JSON, JSONL, or CSV file.")
@@ -82,6 +81,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Phone, email, or URL shown when the FAQ tells users to contact support.",
     )
     parser.add_argument(
+        "--documentation-term",
+        action="append",
+        default=[],
+        help=(
+            "Existing documentation term or heading used for vocabulary-gap "
+            "suggestions. Repeat to provide multiple terms."
+        ),
+    )
+    parser.add_argument(
         "--require-output-checks",
         action="store_true",
         help="Fail when generated FAQ output checks are not all true.",
@@ -121,6 +129,7 @@ def main(argv: list[str] | None = None) -> int:
         window_days=args.window_days,
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
+        documentation_terms=args.documentation_term,
     )
     failed_checks = _failed_output_checks(result.output_checks)
     if args.result_output:
@@ -176,6 +185,7 @@ def _result_payload(
             "as_of_date": args.as_of_date,
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
+            "documentation_terms": list(args.documentation_term),
         },
         "source_count": result.source_count,
         "ticket_source_count": result.ticket_source_count,
@@ -188,6 +198,8 @@ def _result_payload(
             "ticket_counts": ticket_counts,
             "rendered_ticket_source_count": rendered_ticket_source_count,
             "unrepresented_ticket_sources": max(result.ticket_source_count - rendered_ticket_source_count, 0),
+            "term_mapping_count": _term_mapping_count(items),
+            "term_mappings": _term_mapping_summaries(items),
             "warning_count": len(warnings),
             "warnings": warnings[:50],
             "warnings_truncated": len(warnings) > 50,
@@ -232,6 +244,7 @@ def _output_check_hint(name: str, result: Any, rendered_ticket_source_count: int
 def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
     source_ids = item.get("source_ids") or ()
     steps = item.get("steps") or ()
+    term_mappings = item.get("term_mappings") or ()
     return {
         "rank": index,
         "topic": item.get("topic"),
@@ -246,7 +259,29 @@ def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
         "source_id_count": len(source_ids),
         "first_source_id": source_ids[0] if source_ids else None,
         "step_count": len(steps),
+        "term_mapping_count": len(term_mappings),
     }
+
+
+def _term_mapping_count(items: list[dict[str, Any]]) -> int:
+    return sum(len(item.get("term_mappings") or ()) for item in items)
+
+
+def _term_mapping_summaries(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for index, item in enumerate(items, start=1):
+        for mapping in item.get("term_mappings") or ():
+            if not isinstance(mapping, dict):
+                continue
+            out.append({
+                "rank": index,
+                "topic": item.get("topic"),
+                "customer_term": mapping.get("customer_term"),
+                "documentation_term": mapping.get("documentation_term"),
+                "source_id_count": mapping.get("source_id_count"),
+                "first_source_id": mapping.get("first_source_id"),
+            })
+    return out
 
 
 def _count_by(items: list[dict[str, Any]], key: str) -> dict[str, int]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -396,6 +396,95 @@ def test_build_ticket_faq_markdown_ranks_zero_result_searches_as_failure_risk() 
     assert result.items[1]["opportunity_score"] == 3
 
 
+def test_build_ticket_faq_markdown_adds_vocabulary_gap_from_documentation_terms() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Attribution dashboard",
+            "evidence": [{
+                "text": "How do I export the attribution dashboard?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        }],
+        documentation_terms=("Download report", "Analytics"),
+    )
+
+    assert result.items[0]["term_mappings"] == (
+        {
+            "customer_term": "export",
+            "documentation_term": "Download report",
+            "suggestion": (
+                'Add "export" as alternate phrasing for "Download report" '
+                "in FAQ headings and answer text."
+            ),
+            "source_id_count": 1,
+            "first_source_id": "ticket-1",
+        },
+        {
+            "customer_term": "dashboard",
+            "documentation_term": "Analytics",
+            "suggestion": (
+                'Add "dashboard" as alternate phrasing for "Analytics" '
+                "in FAQ headings and answer text."
+            ),
+            "source_id_count": 1,
+            "first_source_id": "ticket-1",
+        },
+    )
+    assert "**Vocabulary gaps:**" in result.markdown
+    assert 'Customers say "export"; documentation says "Download report".' in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_document_rows_for_vocabulary_gap_only() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "support_ticket",
+            "source_title": "Billing confusion",
+            "evidence": [{
+                "text": "Where can I find my bill?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        },
+        {
+            "source_type": "document",
+            "source_title": "Invoice settings",
+            "evidence": [{
+                "text": "Open invoice settings to download your statement.",
+                "source_id": "doc-1",
+                "source_type": "document",
+                "source_title": "Invoice settings",
+            }],
+        },
+    ])
+
+    assert result.source_count == 2
+    assert result.ticket_source_count == 1
+    assert result.items[0]["source_ids"] == ("ticket-1",)
+    assert result.items[0]["term_mappings"][0]["customer_term"] == "bill"
+    assert result.items[0]["term_mappings"][0]["documentation_term"] == "Invoice settings"
+    assert "`doc-1`" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_skips_vocabulary_gap_when_docs_match_customer_term() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export report",
+            "evidence": [{
+                "text": "How do I export the attribution dashboard?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        }],
+        documentation_terms=("Export reports", "Dashboard analytics"),
+    )
+
+    assert result.items[0]["term_mappings"] == ()
+    assert "**Vocabulary gaps:**" not in result.markdown
+
+
 def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -> None:
     result = build_ticket_faq_markdown(
         [
@@ -1322,6 +1411,30 @@ async def test_ticket_faq_service_accepts_sales_objection_source_material() -> N
 
 
 @pytest.mark.asyncio
+async def test_ticket_faq_service_accepts_documentation_terms() -> None:
+    service = TicketFAQMarkdownService(
+        TicketFAQMarkdownConfig(documentation_terms=("Download report",))
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "message": "How do I export attribution data?",
+                    "pain_category": "exports",
+                }
+            ]
+        },
+    )
+
+    assert result.items[0]["term_mappings"][0]["customer_term"] == "export"
+    assert result.items[0]["term_mappings"][0]["documentation_term"] == "Download report"
+
+
+@pytest.mark.asyncio
 async def test_ticket_faq_service_saves_generated_markdown_when_repository_configured() -> None:
     repository = _FAQRepository()
     service = TicketFAQMarkdownService(ticket_faqs=repository)
@@ -1865,6 +1978,8 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "customer_wording": 2,
     }
     assert result["diagnostics"]["ticket_counts"] == [2, 2]
+    assert result["diagnostics"]["term_mapping_count"] == 0
+    assert result["diagnostics"]["term_mappings"] == []
     assert result["diagnostics"]["items"][0] == {
         "rank": 1,
         "topic": "reporting friction",
@@ -1879,7 +1994,39 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "source_id_count": 2,
         "first_source_id": "ticket-northstar-1",
         "step_count": 3,
+        "term_mapping_count": 0,
     }
+
+
+def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Download report",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    assert "**Vocabulary gaps:**" in completed.stdout
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == ["Download report"]
+    assert result["diagnostics"]["term_mapping_count"] == 1
+    assert result["diagnostics"]["term_mappings"] == [{
+        "rank": 1,
+        "topic": "reporting friction",
+        "customer_term": "export",
+        "documentation_term": "Download report",
+        "source_id_count": 1,
+        "first_source_id": "ticket-1",
+    }]
+    assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping.md

Ownership lane: content-ops/faq-generator

The FAQ generator can rank customer questions, but it did not yet show when customer wording and documentation wording diverge. This slice adds deterministic vocabulary-gap term mappings from explicit documentation terms or documentation-like source rows, renders compact Markdown suggestions, and exposes compact CLI diagnostics.

## Intentional
- No LLM call, embedding dependency, search-index dependency, hosted UI change, or output-check gate.
- Documentation rows can inform term mapping, but they do not become FAQ evidence unless callers explicitly change the source-type filter.
- The synonym table is deliberately small and deterministic so this is reviewable and cheap to operate.

## Deferred
- Hosted upload controls for documentation-term inputs.
- Search-log ranked vocabulary gaps from site-search exports.
- Semantic glossary or embedding-backed matching.

## Verification
- Focused vocabulary-gap pytest for builder, service, and CLI behavior - passed, 6 tests.
- pytest tests/test_extracted_ticket_faq_markdown.py -q - passed, 74 tests.
- Py compile for affected Python files - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 Atlas runtime import findings.
- bash scripts/check_ascii_python.sh - passed.
- git diff --check - passed.
- bash scripts/local_pr_review.sh origin/main - passed.

## Diff size
4 files, +465 / -2