### PR TITLE
Export landing page structured data

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -339,6 +339,7 @@ export interface GeneratedAssetDraft {
   passed_output_checks?: number
   seo_aeo_readiness?: GeneratedAssetReadiness | string
   geo_readiness?: GeneratedAssetReadiness | string
+  structured_data?: Record<string, unknown> | string
   persona?: string
   value_prop?: string
   [key: string]: unknown

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .campaign_ports import TenantScope
 from .landing_page_ports import LandingPageDraft, LandingPageRepository
+from .landing_page_structured_data import build_landing_page_structured_data
 from extracted_quality_gate.landing_page_section_contract import (
     LANDING_PAGE_OBJECTION_SECTION_KINDS,
     LANDING_PAGE_PROBLEM_SECTION_KINDS,
@@ -46,6 +47,7 @@ _EXPORT_COLUMNS = (
     "output_checks",
     "seo_aeo_readiness",
     "geo_readiness",
+    "structured_data",
     "hero",
     "sections",
     "cta",
@@ -129,6 +131,7 @@ def _draft_row(draft: LandingPageDraft) -> JsonDict:
     row["passed_output_checks"] = readiness["passed"]
     row["seo_aeo_readiness"] = readiness
     row["geo_readiness"] = _geo_readiness(draft)
+    row["structured_data"] = build_landing_page_structured_data(draft)
     return row
 
 

--- a/extracted_content_pipeline/landing_page_structured_data.py
+++ b/extracted_content_pipeline/landing_page_structured_data.py
@@ -1,0 +1,181 @@
+"""Schema.org structured-data builder for generated landing pages."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+from typing import Any
+
+from extracted_quality_gate.landing_page_section_contract import (
+    LANDING_PAGE_QUESTION_SECTION_KINDS,
+    normalize_landing_page_section_kind,
+)
+
+from .landing_page_ports import LandingPageDraft, LandingPageSection
+
+
+JsonDict = dict[str, Any]
+
+
+def build_landing_page_structured_data(draft: LandingPageDraft) -> JsonDict:
+    """Return renderer-ready JSON-LD for a generated landing-page draft.
+
+    The builder only emits facts already present in the draft. It avoids
+    inventing a public URL, organization, pricing, or proof claim that the
+    generator did not provide.
+    """
+
+    graph: list[JsonDict] = [_web_page_node(draft)]
+    faq_page = _faq_page_node(draft)
+    if faq_page:
+        graph.append(faq_page)
+    return {
+        "@context": "https://schema.org",
+        "@graph": graph,
+    }
+
+
+def _web_page_node(draft: LandingPageDraft) -> JsonDict:
+    meta = _mapping(draft.meta)
+    canonical_url = _text(
+        meta.get("canonical_url") or meta.get("public_url") or meta.get("url")
+    )
+    description = _text(meta.get("description"))
+    node: JsonDict = {
+        "@type": "WebPage",
+        "name": _text(meta.get("title_tag")) or _text(draft.title),
+    }
+    if canonical_url:
+        node["@id"] = f"{canonical_url}#webpage"
+        node["url"] = canonical_url
+    if description:
+        node["description"] = description
+    audience = _text(draft.persona)
+    if audience:
+        node["audience"] = {
+            "@type": "Audience",
+            "audienceType": audience,
+        }
+    value_prop = _text(draft.value_prop)
+    if value_prop:
+        node["about"] = {
+            "@type": "Thing",
+            "name": value_prop,
+        }
+    cta = _action_node(draft.cta)
+    if cta:
+        node["potentialAction"] = cta
+    parts = _section_part_nodes(draft.sections)
+    if parts:
+        node["hasPart"] = parts
+    return node
+
+
+def _faq_page_node(draft: LandingPageDraft) -> JsonDict | None:
+    questions = [
+        question
+        for section in draft.sections
+        if (question := _question_node(section))
+    ]
+    if not questions:
+        return None
+    meta = _mapping(draft.meta)
+    canonical_url = _text(
+        meta.get("canonical_url") or meta.get("public_url") or meta.get("url")
+    )
+    node: JsonDict = {
+        "@type": "FAQPage",
+        "name": f"{_text(draft.title) or _text(draft.campaign_name)} FAQs",
+        "mainEntity": questions,
+    }
+    if canonical_url:
+        node["@id"] = f"{canonical_url}#faq"
+        node["mainEntityOfPage"] = {"@id": f"{canonical_url}#webpage"}
+    return node
+
+
+def _section_part_nodes(sections: Any) -> list[JsonDict]:
+    nodes: list[JsonDict] = []
+    for index, section in enumerate(sections or (), start=1):
+        title = _text(getattr(section, "title", ""))
+        body = _text(getattr(section, "body_markdown", ""))
+        if not title and not body:
+            continue
+        metadata = _mapping(getattr(section, "metadata", {}))
+        node: JsonDict = {
+            "@type": "WebPageElement",
+            "position": _position(metadata.get("order"), index),
+        }
+        if title:
+            node["name"] = title
+        if body:
+            node["text"] = body
+        kind = normalize_landing_page_section_kind(metadata.get("kind"))
+        if kind:
+            node["additionalType"] = kind
+        nodes.append(node)
+    return nodes
+
+
+def _question_node(section: LandingPageSection) -> JsonDict | None:
+    metadata = _mapping(section.metadata)
+    question = _text(metadata.get("primary_question"))
+    answer = _text(metadata.get("answer_summary"))
+    kind = normalize_landing_page_section_kind(metadata.get("kind"))
+    if not question or not answer:
+        return None
+    if kind and kind not in LANDING_PAGE_QUESTION_SECTION_KINDS:
+        return None
+    if not _answer_visible(answer, section.body_markdown):
+        return None
+    return {
+        "@type": "Question",
+        "name": question,
+        "acceptedAnswer": {
+            "@type": "Answer",
+            "text": answer,
+        },
+    }
+
+
+def _action_node(value: Any) -> JsonDict | None:
+    cta = _mapping(value)
+    label = _text(cta.get("label"))
+    url = _text(cta.get("url"))
+    if not label and not url:
+        return None
+    node: JsonDict = {"@type": "Action"}
+    if label:
+        node["name"] = label
+    if url:
+        node["target"] = url
+    return node
+
+
+def _mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    return {}
+
+
+def _position(value: Any, fallback: int) -> int:
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int) and value > 0:
+        return value
+    return fallback
+
+
+def _answer_visible(answer: str, body: str) -> bool:
+    return bool(answer and _normalize(body).startswith(_normalize(answer)))
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", _text(value).lower()).strip()
+
+
+__all__ = ["build_landing_page_structured_data"]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -217,6 +217,9 @@
       "target": "extracted_content_pipeline/landing_page_export.py"
     },
     {
+      "target": "extracted_content_pipeline/landing_page_structured_data.py"
+    },
+    {
       "target": "extracted_content_pipeline/sales_brief_export.py"
     },
     {

--- a/plans/PR-Landing-Page-Structured-Data-Export.md
+++ b/plans/PR-Landing-Page-Structured-Data-Export.md
@@ -1,0 +1,79 @@
+# PR-Landing-Page-Structured-Data-Export
+
+## Why this slice exists
+
+Landing-page generation now produces SEO/AEO/GEO section metadata and the
+export path scores readiness, but hosts still do not get renderer-ready
+structured data back from the generated asset export. There is no clear public
+generated landing-page renderer in this repo yet, so publishing JSON-LD inside
+the export contract is the next production step before wiring a live route.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-structured-data-export
+
+1. Add a reusable landing-page Schema.org structured-data builder.
+2. Export structured data alongside existing SEO/AEO and GEO readiness fields.
+3. Type the new export field in the Intel UI content-assets API model.
+4. Cover WebPage and FAQPage output with focused tests.
+5. Keep the builder conservative: no invented public URL, organization,
+   pricing, or proof claim.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Structured-Data-Export.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/landing_page_structured_data.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `tests/test_landing_page_structured_data.py`
+- `tests/test_extracted_landing_page_export.py`
+
+## Mechanism
+
+The structured-data builder returns a JSON-LD object with
+`@context: https://schema.org` and an `@graph`.
+
+The builder always emits a `WebPage` node from the draft title, meta
+description, persona, value proposition, CTA, and ordered sections. It adds
+`@id` / `url` only when the draft meta already provides `canonical_url`,
+`public_url`, or `url`.
+
+The builder emits an additional `FAQPage` node only from section metadata where
+`primary_question` and a visible `answer_summary` are present. This keeps the
+published structured data aligned with the same answer-first metadata contract
+used by readiness scoring.
+
+## Intentional
+
+- No live route or renderer changes in this PR.
+- No database migration. The structured data is derived at export time from
+  existing draft fields.
+- No generated organization, offer, pricing, aggregate rating, or proof schema.
+  Those require source data that is not guaranteed in a landing-page draft.
+
+## Deferred
+
+- `PR-Landing-Page-Public-Renderer` can consume the exported structured data
+  once a public generated landing-page route exists.
+- `PR-Landing-Page-Structured-Data-Preview-UI` can add an explicit review panel
+  for JSON-LD inspection if the asset review screen needs it.
+
+## Verification
+
+- `pytest tests/test_landing_page_structured_data.py tests/test_extracted_landing_page_export.py -q` - 12 passed.
+- Python compile over `extracted_content_pipeline/landing_page_structured_data.py` and `extracted_content_pipeline/landing_page_export.py` - passed.
+- `scripts/run_extracted_pipeline_checks.sh` - 1628 passed.
+- `npm run build` in `atlas-intel-ui` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| Structured-data builder | ~170 |
+| Export/API wiring | ~15 |
+| Tests | ~170 |
+| **Total** | **~420** |

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -379,6 +379,12 @@ async def test_export_landing_page_drafts_surfaces_ready_readiness() -> None:
             "claim_safety": True,
         },
     }
+    assert row["structured_data"]["@context"] == "https://schema.org"
+    assert [node["@type"] for node in row["structured_data"]["@graph"]] == [
+        "WebPage",
+        "FAQPage",
+    ]
+    assert len(row["structured_data"]["@graph"][1]["mainEntity"]) == 3
 
 
 @pytest.mark.asyncio
@@ -600,6 +606,10 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
                 "output_checks": {"title_tag": True},
                 "seo_aeo_readiness": {"status": "ready"},
                 "geo_readiness": {"status": "ready"},
+                "structured_data": {
+                    "@context": "https://schema.org",
+                    "@graph": [{"@type": "WebPage", "name": "Acme page"}],
+                },
                 "hero": {"headline": "Stop surprises"},
                 "sections": [{"id": "problem"}],
                 "cta": {"label": "Book a demo"},
@@ -624,6 +634,10 @@ def test_landing_page_draft_export_result_renders_dict_and_csv() -> None:
         in csv_text
     )
     assert "reasoning_context_used,reasoning_wedge,reasoning_confidence" in csv_text
-    assert "passed_output_checks,output_checks,seo_aeo_readiness,geo_readiness" in csv_text
+    assert (
+        "passed_output_checks,output_checks,seo_aeo_readiness,geo_readiness,"
+        "structured_data"
+    ) in csv_text
     assert '"[{""attempt"":1,""passed"":true' in csv_text
+    assert '""@context"":""https://schema.org"",""@graph""' in csv_text
     assert "price_squeeze" in csv_text

--- a/tests/test_landing_page_structured_data.py
+++ b/tests/test_landing_page_structured_data.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.landing_page_ports import (
+    LandingPageDraft,
+    LandingPageSection,
+)
+from extracted_content_pipeline.landing_page_structured_data import (
+    build_landing_page_structured_data,
+)
+
+
+def _draft(**overrides) -> LandingPageDraft:
+    sections = (
+        LandingPageSection(
+            id="problem",
+            title="Support questions keep repeating",
+            body_markdown=(
+                "Teams reduce repeat support pressure by turning old tickets "
+                "into answers customers can find before they email. Customers "
+                "stop waiting on the same basic answer."
+            ),
+            metadata={
+                "order": 1,
+                "kind": "problem",
+                "primary_question": (
+                    "Why do repeat support questions create retention risk?"
+                ),
+                "answer_summary": (
+                    "Teams reduce repeat support pressure by turning old "
+                    "tickets into answers customers can find before they email."
+                ),
+            },
+        ),
+        LandingPageSection(
+            id="proof",
+            title="Internal proof",
+            body_markdown=(
+                "This section is not a customer question, so it should remain "
+                "a WebPageElement instead of becoming FAQPage schema."
+            ),
+            metadata={
+                "order": 2,
+                "kind": "proof",
+                "primary_question": "What proof exists?",
+                "answer_summary": (
+                    "This hidden summary does not match the visible body start."
+                ),
+            },
+        ),
+    )
+    draft = LandingPageDraft(
+        campaign_name="faq-report",
+        persona="Small SaaS operator",
+        value_prop="Turn repeat support tickets into clearer FAQ answers",
+        title="FAQ Report",
+        slug="faq-report",
+        hero={"headline": "Stop answering the same support questions"},
+        sections=sections,
+        cta={"label": "Upload ticket CSV", "url": "/intake"},
+        meta={
+            "title_tag": "FAQ Report for Small SaaS Teams",
+            "description": (
+                "Turn repeat support tickets into FAQ answers customers can "
+                "find before they email again."
+            ),
+            "canonical_url": "https://example.com/faq-report",
+        },
+        reference_ids=("ticket-cluster-1",),
+    )
+    return LandingPageDraft(
+        campaign_name=overrides.get("campaign_name", draft.campaign_name),
+        persona=overrides.get("persona", draft.persona),
+        value_prop=overrides.get("value_prop", draft.value_prop),
+        title=overrides.get("title", draft.title),
+        slug=overrides.get("slug", draft.slug),
+        hero=overrides.get("hero", draft.hero),
+        sections=overrides.get("sections", draft.sections),
+        cta=overrides.get("cta", draft.cta),
+        meta=overrides.get("meta", draft.meta),
+        reference_ids=overrides.get("reference_ids", draft.reference_ids),
+        metadata=overrides.get("metadata", draft.metadata),
+        id=overrides.get("id", draft.id),
+        status=overrides.get("status", draft.status),
+    )
+
+
+def test_build_landing_page_structured_data_emits_webpage_and_faqpage() -> None:
+    structured_data = build_landing_page_structured_data(_draft())
+
+    assert structured_data["@context"] == "https://schema.org"
+    graph = structured_data["@graph"]
+    webpage = graph[0]
+    faq_page = graph[1]
+
+    assert webpage["@type"] == "WebPage"
+    assert webpage["@id"] == "https://example.com/faq-report#webpage"
+    assert webpage["url"] == "https://example.com/faq-report"
+    assert webpage["name"] == "FAQ Report for Small SaaS Teams"
+    assert webpage["description"].startswith("Turn repeat support tickets")
+    assert webpage["audience"] == {
+        "@type": "Audience",
+        "audienceType": "Small SaaS operator",
+    }
+    assert webpage["about"] == {
+        "@type": "Thing",
+        "name": "Turn repeat support tickets into clearer FAQ answers",
+    }
+    assert webpage["potentialAction"] == {
+        "@type": "Action",
+        "name": "Upload ticket CSV",
+        "target": "/intake",
+    }
+    assert webpage["hasPart"][0]["additionalType"] == "problem"
+
+    assert faq_page["@type"] == "FAQPage"
+    assert faq_page["@id"] == "https://example.com/faq-report#faq"
+    assert faq_page["mainEntityOfPage"] == {
+        "@id": "https://example.com/faq-report#webpage",
+    }
+    assert faq_page["mainEntity"] == [
+        {
+            "@type": "Question",
+            "name": "Why do repeat support questions create retention risk?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": (
+                    "Teams reduce repeat support pressure by turning old "
+                    "tickets into answers customers can find before they email."
+                ),
+            },
+        }
+    ]
+
+
+def test_build_landing_page_structured_data_omits_faqpage_without_questions() -> None:
+    structured_data = build_landing_page_structured_data(
+        _draft(sections=(
+            LandingPageSection(
+                id="overview",
+                title="Overview",
+                body_markdown="A plain section without question metadata.",
+                metadata={"order": 1, "kind": "proof"},
+            ),
+        ))
+    )
+
+    assert [node["@type"] for node in structured_data["@graph"]] == ["WebPage"]
+
+
+def test_build_landing_page_structured_data_does_not_invent_canonical_url() -> None:
+    structured_data = build_landing_page_structured_data(
+        _draft(meta={"title_tag": "FAQ Report"})
+    )
+
+    webpage = structured_data["@graph"][0]
+    assert webpage["@type"] == "WebPage"
+    assert "@id" not in webpage
+    assert "url" not in webpage


### PR DESCRIPTION
## Summary

- Adds a conservative Schema.org JSON-LD builder for generated landing-page drafts.
- Exports structured_data beside existing SEO/AEO and GEO readiness fields in landing-page asset exports.
- Types the new field in the Intel UI content-assets API model.
- Covers WebPage and FAQPage output, including the rule that FAQ schema only uses visible answer summaries from section metadata.

## Scope

Ownership lane: content-ops/landing-page-structured-data-export

Plan: plans/PR-Landing-Page-Structured-Data-Export.md

This is intentionally a broader but still bounded slice: backend builder, export contract, UI API type, manifest ownership, and tests. It does not add a public renderer because this repo does not yet expose a clear generated landing-page render route.

## Verification

- pytest tests/test_landing_page_structured_data.py tests/test_extracted_landing_page_export.py -q - 12 passed
- Python compile over structured-data/export modules - passed
- scripts/run_extracted_pipeline_checks.sh - 1628 passed
- npm run build in atlas-intel-ui - passed
- git diff --check - passed
- bash scripts/local_pr_review.sh origin/main - passed

## Deferred

- PR-Landing-Page-Public-Renderer can consume the exported JSON-LD once a public generated landing-page route exists.
- PR-Landing-Page-Structured-Data-Preview-UI can add an explicit review panel for JSON-LD inspection if needed.
