### PR TITLE
Generator: drop form-prompt quotes (D1) + fix tight markdown lists (D9)

### DIFF
--- a/atlas_brain/autonomous/tasks/_blog_ts.py
+++ b/atlas_brain/autonomous/tasks/_blog_ts.py
@@ -13,6 +13,30 @@ _md_converter = _md.Markdown(extensions=["tables", "fenced_code", "toc"])
 
 logger = logging.getLogger(__name__)
 
+_BULLET_LINE_RE = re.compile(r"^[ \t]*[-*][ \t]+\S")
+
+
+def _ensure_blank_line_before_lists(md: str) -> str:
+    """Insert a blank line before a bullet list that is tightly coupled to the
+    preceding paragraph.
+
+    python-markdown requires a blank line before a list; a bullet that
+    immediately follows a non-blank, non-list line (e.g.
+    ``**Top pain points:**\\n- Pricing``) is otherwise absorbed into the
+    paragraph and the converter emits ``<p>...\\n- Pricing</p>`` -- which
+    renders as literal "- Pricing" text. Adding the blank line lets the
+    converter produce a real ``<ul>``.
+    """
+    lines = md.split("\n")
+    out: list[str] = []
+    for line in lines:
+        if _BULLET_LINE_RE.match(line):
+            prev = out[-1] if out else ""
+            if prev.strip() and not _BULLET_LINE_RE.match(prev):
+                out.append("")
+        out.append(line)
+    return "\n".join(out)
+
 
 def escape_js_single(text: str) -> str:
     """Escape a string for use inside JS single quotes."""
@@ -139,7 +163,7 @@ def build_post_ts(
     charts_str = json.dumps(charts_json, indent=2, default=str)
     # Render markdown to HTML at deploy time so the frontend never parses markdown
     _md_converter.reset()
-    html_content = _md_converter.convert(content)
+    html_content = _md_converter.convert(_ensure_blank_line_before_lists(content))
     escaped_content = escape_template_literal(html_content)
     escaped_title = escape_js_single(title)
     escaped_desc = escape_js_single(description)

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1418,6 +1418,25 @@ def _quote_grade_blueprint_phrases(
     return out
 
 
+# G2-style review-FORM PROMPTS ("What do you like best about <X>?") get scraped
+# into review_text as boilerplate and otherwise surface as fake reviewer
+# quotes. Kept in sync with the seo-geo-aeo-blog-post skill's
+# form_prompt_quote detector.
+_FORM_PROMPT_RE = re.compile(
+    r"what do you (?:like best|dislike) about"
+    r"|what problems? (?:is|are) .{0,60}? solving"
+    r"|recommendations to others considering"
+    r"|what benefits have you realized",
+    re.IGNORECASE,
+)
+
+
+def _is_form_prompt(text: str) -> bool:
+    """True if ``text`` is a review-form prompt (boilerplate the form asks),
+    not a genuine reviewer quote."""
+    return bool(_FORM_PROMPT_RE.search(text or ""))
+
+
 def _split_and_gate_blog_quotes(
     rows: list[dict[str, Any]],
     *,
@@ -1483,6 +1502,11 @@ def _split_and_gate_blog_quotes(
             "phrase_verbatim": True,
         })
     combined = review_quotes + vault_quotes
+    # Drop review-form prompts that slipped through as verbatim phrases.
+    combined = [
+        q for q in combined
+        if not _is_form_prompt(str(q.get("phrase") or q.get("text") or ""))
+    ]
     if limit is not None:
         return combined[:limit]
     return combined

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1476,9 +1476,14 @@ def _split_and_gate_blog_quotes(
         elif origin == "vault":
             vault_rows.append(r)
         # Unmarked / unknown origin: dropped on purpose.
-    review_quotes = _quote_grade_blueprint_phrases(
-        review_rows, field=field, limit=limit,
-    )
+    # Do NOT pass `limit` here. Form-prompt rejection (below) runs after the
+    # pool is built, so capping collection at `limit` would let leading
+    # form-prompt boilerplate consume slots that never backfill -- small pools
+    # (limit=15) could end up with fewer genuine quotes than requested even
+    # when enough valid rows exist (Codex P2 on #752). Collect the full
+    # quote-grade pool; the post-filter `combined[:limit]` enforces the limit
+    # on ACCEPTED quotes.
+    review_quotes = _quote_grade_blueprint_phrases(review_rows, field=field)
     vault_quotes: list[dict[str, Any]] = []
     for r in vault_rows:
         # Phase 2.3 4i: vault rows must also carry phrase_verbatim=True.

--- a/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
+++ b/extracted_content_pipeline/autonomous/tasks/_blog_ts.py
@@ -60,8 +60,27 @@ def slug_to_var_name(slug: str) -> str:
     return var_name
 
 
+_BULLET_LINE_RE = re.compile(r"^[ \t]*[-*][ \t]+\S")
+
+
+def _ensure_blank_line_before_lists(md: str) -> str:
+    """Insert a blank line before a bullet list tightly coupled to the
+    preceding paragraph, so the converter emits a real <ul> instead of literal
+    "- item" text inside a <p>. Mirrors the atlas_brain _blog_ts fix."""
+    lines = md.split("\n")
+    out: list[str] = []
+    for line in lines:
+        if _BULLET_LINE_RE.match(line):
+            prev = out[-1] if out else ""
+            if prev.strip() and not _BULLET_LINE_RE.match(prev):
+                out.append("")
+        out.append(line)
+    return "\n".join(out)
+
+
 def _render_markdown(content: str) -> str:
     """Render markdown when available, otherwise emit safe minimal HTML."""
+    content = _ensure_blank_line_before_lists(content)
     if _md_converter is not None:
         _md_converter.reset()
         return _md_converter.convert(content)

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1418,6 +1418,25 @@ def _quote_grade_blueprint_phrases(
     return out
 
 
+# G2-style review-FORM PROMPTS ("What do you like best about <X>?") get scraped
+# into review_text as boilerplate and otherwise surface as fake reviewer
+# quotes. Kept in sync with the seo-geo-aeo-blog-post skill's
+# form_prompt_quote detector.
+_FORM_PROMPT_RE = re.compile(
+    r"what do you (?:like best|dislike) about"
+    r"|what problems? (?:is|are) .{0,60}? solving"
+    r"|recommendations to others considering"
+    r"|what benefits have you realized",
+    re.IGNORECASE,
+)
+
+
+def _is_form_prompt(text: str) -> bool:
+    """True if ``text`` is a review-form prompt (boilerplate the form asks),
+    not a genuine reviewer quote."""
+    return bool(_FORM_PROMPT_RE.search(text or ""))
+
+
 def _split_and_gate_blog_quotes(
     rows: list[dict[str, Any]],
     *,
@@ -1483,6 +1502,11 @@ def _split_and_gate_blog_quotes(
             "phrase_verbatim": True,
         })
     combined = review_quotes + vault_quotes
+    # Drop review-form prompts that slipped through as verbatim phrases.
+    combined = [
+        q for q in combined
+        if not _is_form_prompt(str(q.get("phrase") or q.get("text") or ""))
+    ]
     if limit is not None:
         return combined[:limit]
     return combined

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1476,9 +1476,14 @@ def _split_and_gate_blog_quotes(
         elif origin == "vault":
             vault_rows.append(r)
         # Unmarked / unknown origin: dropped on purpose.
-    review_quotes = _quote_grade_blueprint_phrases(
-        review_rows, field=field, limit=limit,
-    )
+    # Do NOT pass `limit` here. Form-prompt rejection (below) runs after the
+    # pool is built, so capping collection at `limit` would let leading
+    # form-prompt boilerplate consume slots that never backfill -- small pools
+    # (limit=15) could end up with fewer genuine quotes than requested even
+    # when enough valid rows exist (Codex P2 on #752). Collect the full
+    # quote-grade pool; the post-filter `combined[:limit]` enforces the limit
+    # on ACCEPTED quotes.
+    review_quotes = _quote_grade_blueprint_phrases(review_rows, field=field)
     vault_quotes: list[dict[str, Any]] = []
     for r in vault_rows:
         # Phase 2.3 4i: vault rows must also carry phrase_verbatim=True.

--- a/plans/PR-Blog-Generator-D1-D9.md
+++ b/plans/PR-Blog-Generator-D1-D9.md
@@ -1,5 +1,7 @@
 # PR-Blog-Generator-D1-D9
 
+Ownership lane: content-ops/blog-generator-d1-d9
+
 ## Why this slice exists
 
 A per-post correctness audit (catalogued in `reports/blog-audit-findings.md`)
@@ -93,8 +95,9 @@ the single md->html boundary so it covers every generation path. ASCII-only;
   renders `<ul><li>Pricing</li><li>Support</li></ul>`.
 - `extracted_content_pipeline` re-synced; manifest sync + ASCII Python policy
   PASS.
-- `scripts/local_pr_review.sh` -> expected pass (plan shape, plan/code
-  consistency, manifest sync, ASCII, `git diff --check`).
+- `scripts/local_pr_review.sh` -> `local PR review passed` (plan shape,
+  plan/code consistency 13/13 path claims, manifest sync, ASCII Python policy,
+  cross-session ownership lane, diff drift ~6%, `git diff --check`).
 
 ## Estimated diff size
 

--- a/plans/PR-Blog-Generator-D1-D9.md
+++ b/plans/PR-Blog-Generator-D1-D9.md
@@ -1,0 +1,108 @@
+# PR-Blog-Generator-D1-D9
+
+## Why this slice exists
+
+A per-post correctness audit (catalogued in `reports/blog-audit-findings.md`)
+found two defect classes that the data-cleanup PRs (#741, #745) removed from
+published posts but that the **generator still produces**, so they would
+recur:
+
+- **D1 -- form-prompt-as-quote.** G2 review-FORM PROMPTS ("What do you like
+  best about <X>?") get scraped into `review_text` as boilerplate and pass the
+  quote gate as verbatim phrases, surfacing as fake reviewer quotes. 47
+  occurrences across 31 posts before cleanup.
+- **D9 -- markdown-in-`<p>`.** A bullet list tightly coupled to a label (no
+  blank line, e.g. `**Top pain points:**\n- Pricing`) is left un-converted by
+  the markdown step, rendering as literal "- item" text. 61 occurrences across
+  10 posts before cleanup.
+
+This PR fixes both at the source so new posts are clean, and the skill's
+`form_prompt_quote` / `markdown_in_html` detectors stay at 0.
+
+## Scope (this PR)
+
+- **D1:** add `_is_form_prompt` + a reject filter in
+  `_split_and_gate_blog_quotes` (the gate every blueprint path uses to build
+  `quotable_phrases`), so form prompts are dropped from the quote pool.
+- **D9:** add `_ensure_blank_line_before_lists` and apply it just before the
+  markdown->HTML conversion in `_blog_ts.py` (`build_post_ts` /
+  `_render_markdown`), so tightly-coupled lists convert to a real `<ul>`.
+- Tests for both; sync the change into `extracted_content_pipeline`. The
+  `b2b_blog_post_generation.py` mirror is source-mapped (auto-synced); the
+  `_blog_ts.py` mirror is a target-only (divergent) copy with the same bug, so
+  the D9 fix is applied to it directly.
+- Includes the audit catalog `reports/blog-audit-findings.md` as the rationale
+  + remaining-work tracker (D2/D3/D4/D7/D8 still open).
+
+### Files touched
+
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `atlas_brain/autonomous/tasks/_blog_ts.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/_blog_ts.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+- `tests/test_blog_ts_publish.py`
+- `reports/blog-audit-findings.md`
+- `plans/PR-Blog-Generator-D1-D9.md`
+
+## Mechanism
+
+**D1.** `_FORM_PROMPT_RE` matches the G2 prompt shapes ("what do you like
+best/dislike about", "what problems ... solving", "recommendations to others
+considering", "what benefits have you realized"). After
+`_split_and_gate_blog_quotes` assembles `combined`, any phrase matching the
+pattern is dropped. Kept in sync with the skill's `form_prompt_quote`
+detector. ASCII-only.
+
+**D9.** `_ensure_blank_line_before_lists` inserts a blank line before a bullet
+line (`- `/`* `) that immediately follows a non-blank, non-bullet line.
+python-markdown requires that blank line to start a `<ul>`; without it the
+list is absorbed into the preceding `<p>` and emitted as raw text. Applied at
+the single md->html boundary so it covers every generation path. ASCII-only;
+`build_post_ts`'s signature is unchanged.
+
+## Intentional
+
+- **Filter at the shared gate, not per-blueprint.** `_split_and_gate_blog_quotes`
+  is called by every topic-type producer, so one filter covers all paths.
+- **Fix D9 at the conversion boundary**, not by rewriting LLM output -- the
+  blank-line normalization is deterministic and source-agnostic.
+- **Mirror D9 into the target-only extracted copy by hand**, since it is not
+  source-mapped but carries the same bug (and the extracted pipeline renders
+  blogs through it).
+- **No behavior change to real quotes / real lists** -- only form prompts are
+  dropped, only tightly-coupled lists get a blank line.
+
+## Deferred
+
+- **D2/D3/D4/D7/D8** (count-vs-list, prose-vs-chart, strength/weakness
+  mislabel, corpus-number overstatement, vendor-count) -- catalogued; need
+  blueprint/data-layer changes + DB cross-checks, not regex.
+- **Detector hardening** for "question"/stacked orphan-quote references (a
+  skill change, tracked from the #745 review).
+
+## Verification
+
+- `tests/test_b2b_blog_post_generation_quote_gate.py` + `tests/test_blog_ts_publish.py`
+  -> `91 passed` (added: form-prompt detection, gate-drops-form-prompt, and
+  tight-bullet-list -> `<ul>`).
+- `tests/test_extracted_blog_post_export.py` + `tests/test_extracted_blog_generation.py`
+  -> `36 passed` (mirror change safe).
+- Functional check: `_split_and_gate_blog_quotes` drops "What do you like best
+  about Zoho CRM", keeps "Support never responded for weeks"; a tight list
+  renders `<ul><li>Pricing</li><li>Support</li></ul>`.
+- `extracted_content_pipeline` re-synced; manifest sync + ASCII Python policy
+  PASS.
+- `scripts/local_pr_review.sh` -> expected pass (plan shape, plan/code
+  consistency, manifest sync, ASCII, `git diff --check`).
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `b2b_blog_post_generation.py` + mirror (D1) | ~55 |
+| `_blog_ts.py` + mirror (D9) | ~55 |
+| tests | ~50 |
+| `reports/blog-audit-findings.md` (audit catalog) | ~200 |
+| Plan doc | ~110 |
+| **Total** | **~470** |

--- a/reports/blog-audit-findings.md
+++ b/reports/blog-audit-findings.md
@@ -1,0 +1,252 @@
+# Blog correctness audit — findings & pattern log
+
+Per-post grounding audits (correctness, grounded data, contradictions,
+hallucinations) of published posts, logged by **defect class** so the
+recurring patterns can be fixed at the source (the generator,
+`atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`) rather than only
+patched per post.
+
+**Grounding method (verified on pipedrive):** headline counts reconcile to a
+**source-allowlisted** window (exclude `capterra`, `trustpilot`,
+`stackoverflow`, `twitter`; `imported_at` in the post's window;
+`is_primary` vendor; dedup). Quotes must exist verbatim in `b2b_reviews`
+(watch for G2 form-prompt boilerplate). Cross-check prose vs charts vs
+internal counts.
+
+---
+
+## Defect classes (root-cause candidates for the code fix)
+
+### D1 — Form-prompt-as-quote (evidence integrity)
+G2-style review-form prompts ("What do you like best about <vendor>?")
+presented as genuine reviewer quotes. They exist in the corpus as boilerplate
+(e.g. "What do you like best about Pipedrive?" appears 19x) but carry no
+opinion.
+- **Root cause:** quote extraction treats the G2 prompt boilerplate as
+  quotable text.
+- **Code fix target:** drop form-prompt patterns from quote candidates
+  (`What do you like best about`, `What do you dislike about`, etc.) in the
+  quote-grade / blueprint quote selection.
+- **Also a detector candidate** in the skill audit (same family as
+  empty-blockquote / orphaned-ref).
+- Instances: `pipedrive-deep-dive` (1); previously seen in
+  `top-complaint-every-crm`, `real-cost-of-copper`, `close-deep-dive`,
+  `marketing-automation-landscape`.
+
+### D2 — Count-vs-list mismatch + un-deduped vendor variants
+A stated count that disagrees with the rendered list, and/or vendor-name
+variants double-counted.
+- Example: "six primary alternatives: HubSpot, Salesforce, Zoho, Monday, and
+  Zoho CRM" — says **six**, lists **five**, and "Zoho"/"Zoho CRM" duplicate
+  (4 distinct).
+- **Root cause:** competitor count is stated independently of the deduped
+  list; vendor aliases not normalized (same family as the Monday/Monday.com
+  and HubSpot/HubSpot CRM merges).
+- **Code fix target:** derive the count from the deduped competitor list;
+  normalize vendor aliases before counting/listing.
+- Instances: `pipedrive-deep-dive`.
+
+### D3 — Prose vs chart contradiction (frequency vs urgency)
+Prose names a "dominant" pain by one metric while the chart ranks by another.
+- Example: "Pricing emerges as the dominant pain category" vs pain-radar chart
+  where UX urgency (10.0) > Pricing (7.2).
+- **Root cause:** prose conflates frequency-rank and urgency-rank.
+- **Code fix target:** make the "dominant pain" sentence state the metric it
+  means (frequency) and not contradict the urgency chart, or rank both
+  consistently.
+- Instances: `pipedrive-deep-dive`.
+
+### D4 — Strengths/weaknesses chart mislabeling
+The strengths-vs-weaknesses chart buckets complaint categories under
+"strengths."
+- Example: `pricing` (51) and `overall_dissatisfaction` (118) appear as
+  "strengths"; only `support` (22) is a "weakness."
+- **Root cause:** the chart-data builder mislabels pain-mention counts as
+  strengths (likely all positive-polarity mention counts dumped into
+  "strengths" regardless of category sentiment).
+- **Code fix target:** correct the strengths/weaknesses bucketing in the chart
+  builder.
+- Instances: `pipedrive-deep-dive`. (Suspected systemic across deep-dives.)
+
+### D8 — Vendor-count claim vs incomplete coverage
+A "compare N vendors" claim where the charts/profiles cover fewer than N.
+- Example (crm-landscape): title/desc say "**8 vendors** compared," but the
+  churn-urgency chart lists **7** (Salesforce missing) and only **5** get
+  strength/weakness profiles (Close, Copper, Freshsales, Insightly, Nutshell --
+  no Pipedrive/Salesforce/Zoho/HubSpot profile).
+- **Root cause:** the headline vendor count is stated independently of the
+  vendors actually charted/profiled.
+- **Code fix target:** derive "N vendors" from the set actually rendered, or
+  ensure all N are charted + profiled.
+- Instances: `crm-landscape`.
+
+### D9 — Markdown bullet lists inside `<p>` (broken rendering, ANALYZER-BLIND)
+Bare-hyphen markdown lists emitted inside an HTML `<p>` block, which the
+markdown converter leaves un-converted, so they render as literal "- item"
+text instead of a bulleted list.
+- Example (crm-landscape): `<p><strong>Top pain points:</strong>\n- Overall
+  dissatisfaction\n- Pricing\n- User experience</p>` -- **15 such blocks** in
+  one post (every vendor profile's pain/strength/weakness lists).
+- **The skill's `detectMarkdownInHtml` does NOT catch this** (returned 0;
+  analyzer flagged NOTHING on this post). High-priority detector gap.
+- **Root cause:** the generator wraps a strong-label + markdown list in a
+  single `<p>`, so md->html skips the inner list.
+- **Code fix targets:** (1) generator -- emit real `<ul><li>` (or don't wrap
+  the list in `<p>`); (2) skill detector -- flag `^\s*-\s` lines inside `<p>`.
+- Instances: `crm-landscape` (15).
+
+### D6 — Quote source attribution mismatch (prose vs blockquote/DB)
+The prose lead-in names a different platform than the blockquote attribution
+and the actual source in the corpus.
+- Example (zoho): prose says "One verified reviewer on **G2** describes...",
+  blockquote says "reviewer on **Slashdot**", and the DB confirms the quote is
+  from **slashdot** (1 occurrence). The prose "G2" is wrong.
+- **Root cause:** the prose lead-in's source label is generated independently
+  of the quote's real source field.
+- **Code fix target:** derive the prose source label from the quote's actual
+  `source`, or drop the platform claim from the lead-in.
+- Instances: `zoho-crm-deep-dive`.
+
+### D7 — Headline "total reviews" scope mismatch (overstated corpus)
+The headline "total reviews" uses a broader scope (all sources) than the
+"enriched" / analysis numbers (allowlist sources only), so the stated total
+overstates the base that was actually analyzed -- and it is computed
+inconsistently across posts.
+- Example (zoho): "940 reviews collected ... with 268 enriched" -- but "940"
+  matches all-source window primary (~915), while "268 enriched" matches the
+  **allowlist** window (DB: 262 enriched from 431 allowlist total). The 940
+  includes Capterra/Trustpilot/etc. that were excluded from the analysis.
+- **Contrast (pipedrive):** its "262 total" WAS the allowlist count (264) --
+  so the two posts disagree on what "total" means. Inconsistent generator
+  behavior.
+- **Root cause:** the "total reviews" stat is computed with a different
+  source/scope filter than the enriched/churn stats.
+- **Code fix target:** compute the headline total over the SAME
+  allowlist+window+primary scope as the enriched/churn numbers, so
+  "N reviews, M enriched" share a denominator.
+- Instances: `zoho-crm-deep-dive` (940 vs ~431 allowlist). NOT in pipedrive
+  (used allowlist total) -- the inconsistency itself is the bug.
+- **Stronger instance (crm-landscape):** "3,287 enriched reviews" is
+  **impossible** -- it exceeds the CRM category's all-time enriched ceiling
+  (1,959); window all-source enriched is 1,784, per-vendor-mention double-count
+  only 1,821. The "4,990 total" ~ all-source window total (4,609), so a
+  plausible total is paired with a fabricated-but-internally-consistent
+  enriched count (172 verified + 3,115 community = 3,287). This is the
+  headline corpus size, materially overstated.
+
+### D5 — Source-list incompleteness (minor accuracy)
+Prose names a partial source set that omits sources the post actually uses and
+quotes.
+- Example: states "G2, Gartner Peer Insights, PeerSpot... Reddit" but the
+  allowlist also includes Slashdot, Software Advice, SourceForge, HackerNews
+  (the post quotes a Slashdot analyst and a Software Advice reviewer).
+- **Root cause:** prose lists a hardcoded/partial source set, not the actual
+  allowlist.
+- **Code fix target:** state the real source set (or generalize the phrasing).
+- Instances: `pipedrive-deep-dive`.
+
+---
+
+## Per-post audit results
+
+### pipedrive-deep-dive-2026-04 (HubSpot affiliate)
+- **Grounded data: PASS.** 262/143/10 reconcile to the allowlisted window
+  (264/143/10 -- enriched + churn exact, total off by 2 dedup). "Bird's eye
+  view" quote verified (1 occurrence).
+- Issues: D1 (form-prompt quote "What do you like best about Pipedrive?"),
+  D2 (six-vs-five + Zoho dup), D3 (pricing-dominant vs UX-urgency),
+  D4 (pricing/overall_dissatisfaction as "strengths"), D5 (source list).
+
+### zoho-crm-deep-dive-2026-04 (HubSpot affiliate)
+- **Grounded data: PARTIAL.** churn 14 **exact**; enriched 268 ~ DB allowlist
+  262 (off 6); but **total 940 does NOT match** the same scope -- 940 is
+  all-source window (~915), while the analysis is allowlist-only (431 total ->
+  262 enriched). "28 verified + 240 community = 268" and "14/268 = 5.2%" are
+  internally consistent.
+- Issues: **D7** (940 overstates vs ~431 allowlist base; scope inconsistent
+  with pipedrive), **D6** (quote attributed to G2 in prose but is from
+  Slashdot), **D2** ("six alternatives" lists five + Zoho self-ref),
+  **D3** ("Pricing dominates"/"UX ranks second" but radar shows
+  contract_lock_in 6.2 > pricing 4.4 and UX only 1.5 -- near the bottom),
+  **D4** (overall_dissatisfaction 186 mislabeled "strengths").
+- D1 (form-prompt quote) NOT present here.
+- **Recurring (systemic -> generator):** D2, D3, D4 now seen in both deep-dives.
+
+### crm-landscape-2026-04 (market_landscape, HubSpot affiliate) -- WORST so far
+- **Analyzer flagged NOTHING**, yet 5 defect classes present -- shows the
+  analyzer's blind spots (D9, D1, D7, D8 all uncaught).
+- **D9 (NEW, major):** 15 markdown bullet-lists inside `<p>` -> render as
+  literal "- item" text. Broken formatting on a flagship category post.
+- **D7 (strong):** "3,287 enriched / 4,990 total" -- 3,287 exceeds the
+  category's all-time enriched ceiling (1,959); overstated ~2-3x. (4,990 ~
+  all-source window total 4,609.)
+- **D1 (recurs):** 2 G2 form-prompt quotes ("What do you like best about
+  Agentforce Sales...", "What do you like best about Zoho CRM") presented as
+  reviewer quotes -- the same prompts cleaned from other posts.
+- **D8 (NEW):** "8 vendors" but chart shows 7, only 5 profiled.
+- **D4 (recurs, in prose):** vendor profiles list `overall_dissatisfaction`
+  and `pricing` as "Strengths" (hand-waved as "counterintuitively").
+- D3: milder here (prose "top pain category" = frequency, matches chart freq).
+
+### best-crm-for-51-200-2026-04 (best_fit_guide, HubSpot affiliate)
+- **D7 (blatant INTERNAL contradiction):** headline says **"1,163 reviews"**
+  (title, seo_desc, body, FAQ) but the source breakdown says **"172 verified +
+  3,115 community"** = **3,287** -- the same post states two incompatible
+  totals. (1,163 was crm-landscape's "total churn signals" number, reused here
+  as a review count; 3,287 is the overstated enriched figure pasted from the
+  landscape.) Reader-visible factual contradiction.
+- **D8 (recurs):** "8 vendors" but the ratings chart omits Zoho's rating
+  ("chart does not display its exact rating") and Salesforce/HubSpot get no
+  profile; 6 profiled.
+- **D4 (milder):** strength/weakness segmentation (pricing/features in both
+  lists), hand-waved; reworded to "overall satisfaction" (not the
+  overall_dissatisfaction-as-strength mislabel).
+- **D9 NOT present** (this post uses prose, not markdown bullet lists) ->
+  confirms D9 is post/path-specific, not universal.
+- Minor: `<br />` artifact inside a blockquote; "reddit" lowercased in one
+  attribution.
+- Cross-post number drift: Pipedrive shows **88 reviews** here vs **262** in
+  its deep-dive vs **18** in top-complaint-every-crm -- three different
+  "in scope" counts for the same vendor across posts.
+
+## Corpus scan with hardened analyzer (D1 + D9 now detected)
+
+Added two detectors to `audit-published-posts.js`:
+- `form_prompt_quote` (high) -- G2 boilerplate ("What do you like best about
+  ...") presented as quotes.
+- extended `markdown_in_html` (critical) -- now scans the whole `<p>` block,
+  catching bullet lists that follow a `<strong>label:</strong>` (the old regex
+  stopped at the first inner tag and missed them entirely -> previously 0).
+
+Corpus result: **42 clean, 10 with CRITICAL** (was a false "78 clean / 0
+CRITICAL").
+
+**D9 -- markdown-in-`<p>` (10 posts, 61 occurrences, broken rendering):**
+crm-landscape (15), marketing-automation-landscape (11), helpdesk-landscape
+(10), jira-vs-trello (8), mailchimp-deep-dive (5), tableau-deep-dive (4),
+salesforce-deep-dive (3), copper-deep-dive (2), switch-to-woocommerce (2),
+microsoft-defender-for-endpoint-deep-dive (1).
+
+**D1 -- form-prompt quotes (31 posts, 47 occurrences):**
+hr-hcm-landscape (4), best-hr-hcm-for-51-200 (3),
+best-project-management-for-201-1000 (3), project-management-landscape (3),
+close-vs-zoho-crm (2), crm-landscape (2), insightly-vs-zoho-crm (2),
+power-bi-deep-dive (2), switch-to-salesforce (2), top-complaint-every-e-commerce
+(2), top-complaint-every-project-management (2), + 20 posts with 1 each
+(basecamp, best-crm-for-51-200, fortinet, gusto-vs-workday, intercom,
+jira-vs-mondaycom, looker, marketing-automation-landscape, metabase-vs-tableau,
+microsoft-defender, pipedrive, salesforce, shopify, slack, switch-to-asana,
+switch-to-clickup, switch-to-woocommerce, top-complaint-every-helpdesk,
+woocommerce, zoom).
+
+These two lists are the cleanup targets. D2/D3/D4/D7/D8 remain manual/DB-checks
+(not yet automated) -- candidates for the generator fix.
+
+## Pattern summary (after 4 posts)
+- **Systemic, every applicable post:** D4 (strength/weakness mislabel),
+  D7 (corpus-size scope/overstatement), D2/D8 (count vs rendered list).
+- **Recurs where quotes exist:** D1 (G2 form-prompt-as-quote).
+- **Analyzer-blind (need new/expanded detectors):** D1, D9, D7, D8 (the
+  structural detectors only catch D-form issues, not grounding/labeling).
+- **Highest publish-risk:** D9 (broken markdown rendering, visible to readers),
+  D7 (overstated/false corpus numbers, credibility + factual), D1 (fake quotes).

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -1621,3 +1621,33 @@ def test_split_and_gate_drops_form_prompt_quotes():
     kept = [q["phrase"] for q in _split_and_gate_blog_quotes(rows, limit=10)]
     assert "Support never responded for weeks" in kept
     assert not any(_is_form_prompt(p) for p in kept)
+
+
+def test_form_prompts_do_not_consume_limit_slots():
+    """Codex P2 on #752: the form-prompt filter must run BEFORE the limit
+    is enforced. If the first `limit` review candidates are form-prompt
+    boilerplate, dropping them must not shrink the result below `limit`
+    when enough genuine quotes exist further down the pool.
+
+    Regression: _split_and_gate_blog_quotes used to pass `limit` into
+    _quote_grade_blueprint_phrases, which early-returns after collecting
+    `limit` candidates -- so leading form prompts ate the slots and the
+    post-collection filter left fewer than `limit` quotes (here: zero).
+    """
+    rows = [
+        _v4_row(text="What do you like best about Pipedrive?", review_id="fp-1"),
+        _v4_row(text="What do you dislike about Pipedrive", review_id="fp-2"),
+        _v4_row(text="Pricing climbs at every renewal", review_id="real-1"),
+        _v4_row(text="Support never responded for weeks", review_id="real-2"),
+        _v4_row(text="Onboarding dragged on for months", review_id="real-3"),
+    ]
+    out = _split_and_gate_blog_quotes(rows, limit=2)
+    phrases = [q["phrase"] for q in out]
+    # Limit constrains ACCEPTED quotes, not pre-filter candidates.
+    assert len(out) == 2
+    assert not any(_is_form_prompt(p) for p in phrases)
+    # The genuine quotes backfill in pool order once the form prompts go.
+    assert phrases == [
+        "Pricing climbs at every renewal",
+        "Support never responded for weeks",
+    ]

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -35,6 +35,7 @@ from atlas_brain.autonomous.tasks.b2b_blog_post_generation import (  # noqa: E40
     _blueprint_pain_point_roundup,
     _blueprint_pricing_reality_check,
     _blueprint_vendor_showdown,
+    _is_form_prompt,
     _is_placeholder_partner,
     _looks_like_orphan_quote_reference,
     _pick_affiliate_partner_for_vendors,
@@ -1598,3 +1599,25 @@ def test_specificity_anchor_repair_no_op_when_no_anchor_and_no_issues():
     )
     assert did_repair is False
     assert repaired["content"] == content["content"]
+
+
+def test_form_prompt_detection():
+    # G2 review-form prompts are not genuine quotes.
+    assert _is_form_prompt("What do you like best about Pipedrive?")
+    assert _is_form_prompt("What do you dislike about Zoho CRM")
+    assert _is_form_prompt("Recommendations to others considering HubSpot")
+    # Real reviewer phrases survive.
+    assert not _is_form_prompt("Pricing is too high for what you get")
+    assert not _is_form_prompt("Support never responded for weeks")
+
+
+def test_split_and_gate_drops_form_prompt_quotes():
+    rows = [
+        {"quote_origin": "vault", "phrase_verbatim": True,
+         "phrase": "What do you like best about Zoho CRM"},
+        {"quote_origin": "vault", "phrase_verbatim": True,
+         "phrase": "Support never responded for weeks"},
+    ]
+    kept = [q["phrase"] for q in _split_and_gate_blog_quotes(rows, limit=10)]
+    assert "Support never responded for weeks" in kept
+    assert not any(_is_form_prompt(p) for p in kept)

--- a/tests/test_blog_ts_publish.py
+++ b/tests/test_blog_ts_publish.py
@@ -29,6 +29,28 @@ def test_build_post_ts_serializes_cta():
     assert "See the full migration brief" in ts_content
 
 
+def test_build_post_ts_converts_tight_bullet_list():
+    # A bullet list tightly coupled to a label (no blank line) must render as
+    # a real <ul>, not literal "- item" text inside a <p> (the D9 bug).
+    _, ts_content = build_post_ts(
+        slug="x-deep-dive-2026-04",
+        title="X Deep Dive",
+        description="d",
+        date_str="2026-04-01",
+        author="Churn Signals Team",
+        tags=["x"],
+        topic_type="vendor_deep_dive",
+        charts_json=[],
+        content="**Top pain points:**\n- Pricing\n- Support",
+        data_context={},
+    )
+    assert "<ul>" in ts_content
+    assert "<li>Pricing</li>" in ts_content
+    assert "<li>Support</li>" in ts_content
+    # The broken markdown-in-<p> shape must not appear.
+    assert "<p><strong>Top pain points:</strong>\n- Pricing" not in ts_content
+
+
 def test_write_blog_ts_file_uses_churn_signals_team_and_persists_cta(tmp_path):
     blog_dir = tmp_path / "blog"
     blog_dir.mkdir()


### PR DESCRIPTION
Plan: plans/PR-Blog-Generator-D1-D9.md

Fixes the **root cause** of the two analyzer-detectable defect classes the data PRs (#741, #745) cleaned from published posts but the generator still produced:

- **D1 — form-prompt-as-quote:** G2 prompts ("What do you like best about <X>?") pass the quote gate as verbatim phrases (47 occurrences / 31 posts before cleanup). Added `_is_form_prompt` + a reject filter in `_split_and_gate_blog_quotes` — the gate every blueprint uses.
- **D9 — markdown-in-`<p>`:** a bullet list tightly coupled to a label (`**Label:**\n- item`, no blank line) is left un-converted and renders as literal "- item" (61 occurrences / 10 posts before cleanup). Added `_ensure_blank_line_before_lists`, applied at the md→HTML boundary in `_blog_ts.py`.

## Intentional
- **One filter at the shared gate** (`_split_and_gate_blog_quotes`) covers all topic-type producers.
- **D9 fixed at the conversion boundary** (deterministic blank-line normalization), not by rewriting LLM output. `build_post_ts` signature unchanged.
- **Mirror parity:** `b2b_blog_post_generation.py` mirror auto-synced (source-mapped); the `_blog_ts.py` mirror is a target-only divergent copy with the same bug, so the D9 fix is applied to it directly.
- Kept in sync with the skill's `form_prompt_quote` / `markdown_in_html` detectors. ASCII-only.
- No behavior change to real quotes / real lists.

## Deferred
- D2/D3/D4/D7/D8 (count-vs-list, prose-vs-chart, strength mislabel, corpus-number overstatement, vendor-count) — catalogued in `reports/blog-audit-findings.md`; need data-layer changes, not regex.
- Detector hardening for "question"/stacked orphan-quote refs (skill change, from the #745 review).

## Verification
- `test_b2b_blog_post_generation_quote_gate.py` + `test_blog_ts_publish.py` → `91 passed` (+ form-prompt detection/drop, tight-list→`<ul>`).
- `test_extracted_blog_post_export.py` + `test_extracted_blog_generation.py` → `36 passed` (mirror change safe).
- `extracted_content_pipeline` re-synced; manifest sync + ASCII PASS.
- `scripts/local_pr_review.sh` → `local PR review passed` (13/13 path claims, ownership lane, cross-session drift OK, `git diff --check`).

## Diff size
~498 LOC (generator + mirror + tests; includes the audit catalog `reports/blog-audit-findings.md`; plan).