### PR TITLE
Show landing page structured data in review drawer

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import {
   ArrowRight,
   CheckCircle2,
+  Code2,
   Download,
   Eye,
   Loader2,
@@ -64,6 +65,13 @@ type FAQItemPreview = {
   answer: string
   actionItems: string[]
   sourceLabels: string[]
+}
+
+type StructuredDataSummary = {
+  raw: Record<string, unknown>
+  nodeTypes: string[]
+  questionCount: number
+  hasCanonical: boolean
 }
 
 const ASSETS: Array<{
@@ -573,6 +581,8 @@ function AssetDetailDrawer({
   const faqItems = asset === 'faq_markdown' ? faqItemList(row.items) : []
   const readinessPanels = assetReadinessPanels(row, asset)
   const repairHistory = assetRepairHistory(row)
+  const structuredData =
+    asset === 'landing_page' ? structuredDataSummary(row.structured_data) : null
   const drawerRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
 
@@ -700,6 +710,10 @@ function AssetDetailDrawer({
           <RepairHistory history={repairHistory} />
         )}
 
+        {structuredData && (
+          <StructuredDataPreview summary={structuredData} />
+        )}
+
         {sections.length > 0 && (
           <section className="mt-6">
             <h3 className="text-sm font-semibold text-slate-200">Sections</h3>
@@ -802,6 +816,41 @@ function AssetDetailDrawer({
         </section>
       </aside>
     </div>
+  )
+}
+
+function StructuredDataPreview({ summary }: { summary: StructuredDataSummary }) {
+  return (
+    <section className="mt-6">
+      <h3 className="text-sm font-semibold text-slate-200">Structured Data</h3>
+      <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/60 p-4">
+        <div className="flex flex-wrap gap-2 text-xs">
+          {summary.nodeTypes.map((type) => (
+            <span
+              key={type}
+              className="inline-flex items-center gap-1 rounded bg-slate-800 px-2 py-1 text-slate-300"
+            >
+              <Code2 className="h-3.5 w-3.5 text-cyan-300" />
+              {type}
+            </span>
+          ))}
+          <span className="rounded bg-slate-800 px-2 py-1 text-slate-300">
+            {summary.questionCount} FAQ question{summary.questionCount === 1 ? '' : 's'}
+          </span>
+          <span className={clsx(
+            'rounded px-2 py-1',
+            summary.hasCanonical
+              ? 'bg-emerald-500/10 text-emerald-200'
+              : 'bg-amber-500/10 text-amber-200',
+          )}>
+            {summary.hasCanonical ? 'canonical linked' : 'no canonical URL'}
+          </span>
+        </div>
+        <pre className="mt-3 max-h-80 overflow-auto rounded border border-slate-800 bg-slate-950/70 p-3 text-xs leading-5 text-slate-300">
+          {JSON.stringify(summary.raw, null, 2)}
+        </pre>
+      </div>
+    </section>
   )
 }
 
@@ -1341,6 +1390,29 @@ function readinessChecks(value: unknown): ReadinessCheck[] {
       label: fmtLabel(key),
       passed: passed === true,
     }))
+}
+
+function structuredDataSummary(value: unknown): StructuredDataSummary | null {
+  const raw = recordValue(value)
+  if (!raw) return null
+  const graph = recordList(raw['@graph'])
+  const nodes = graph.length > 0 ? graph : [raw]
+  const nodeTypes = Array.from(new Set(nodes.flatMap(schemaTypes))).filter(Boolean)
+  const questionCount = nodes
+    .filter((node) => schemaTypes(node).includes('FAQPage'))
+    .reduce((count, node) => count + recordList(node.mainEntity).length, 0)
+  return {
+    raw,
+    nodeTypes: nodeTypes.length > 0 ? nodeTypes : ['Schema.org'],
+    questionCount,
+    hasCanonical: nodes.some((node) => Boolean(textValue(node.url) || textValue(node['@id']))),
+  }
+}
+
+function schemaTypes(node: Record<string, unknown>): string[] {
+  const type = node['@type']
+  if (Array.isArray(type)) return type.map(textValue).filter(Boolean)
+  return textValue(type) ? [textValue(type)] : []
 }
 
 function readinessCountLabel(summary: ReadinessSummary): string {

--- a/plans/PR-Landing-Page-Structured-Data-Preview-UI.md
+++ b/plans/PR-Landing-Page-Structured-Data-Preview-UI.md
@@ -1,0 +1,66 @@
+# PR-Landing-Page-Structured-Data-Preview-UI
+
+## Why this slice exists
+
+PR #751 exports renderer-ready landing-page structured data, but operators
+reviewing generated landing pages still only see the raw row dump. The review
+drawer should surface the JSON-LD in a compact, scannable panel before approval
+or export.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-structured-data-preview-ui
+
+1. Add a landing-page-only structured-data panel to the generated asset detail
+   drawer.
+2. Summarize Schema.org node types, FAQ question count, and canonical-link
+   presence.
+3. Show the formatted JSON-LD without changing review, approval, export, or
+   generation behavior.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Structured-Data-Preview-UI.md`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+
+## Mechanism
+
+The detail drawer reads `row.structured_data` for landing-page assets only. The
+helper accepts either object or JSON-string wire shapes, mirrors the existing
+row parsing helpers, and derives:
+
+- schema node types from `@graph` / `@type`
+- FAQ count from `FAQPage.mainEntity`
+- canonical status from `url` or `@id`
+
+The panel is placed near readiness and repair history so reviewers can inspect
+whether SEO/AEO/GEO export metadata is usable before approving a generated
+landing page.
+
+## Intentional
+
+- No backend changes. PR #751 already added the export field.
+- No approval behavior change.
+- No public renderer. This is review visibility only.
+- No copy-to-clipboard interaction in this slice; raw JSON is already visible
+  and selectable.
+
+## Deferred
+
+- `PR-Landing-Page-Public-Renderer` can consume the structured data when a
+  public generated landing-page route exists.
+- A future UI slice can add copy/download controls if reviewers need them.
+
+## Verification
+
+- `npm run build` in `atlas-intel-ui` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~55 |
+| Review drawer panel | ~80 |
+| **Total** | **~135** |


### PR DESCRIPTION
## Summary

- Adds a landing-page-only Structured Data panel to the generated asset detail drawer.
- Summarizes Schema.org node types, FAQ question count, and canonical-link presence.
- Shows formatted JSON-LD so reviewers can inspect WebPage/FAQPage output before approval/export.

## Scope

Ownership lane: content-ops/landing-page-structured-data-preview-ui

Plan: plans/PR-Landing-Page-Structured-Data-Preview-UI.md

This is intentionally UI-only. PR #751 added the export field; this slice makes that field visible in the existing review workflow without changing approval, export, generation, or backend behavior.

## Verification

- npm run build in atlas-intel-ui - passed
- git diff --check - passed
- bash scripts/local_pr_review.sh origin/main - passed

## Deferred

- PR-Landing-Page-Public-Renderer can consume structured data when a public generated landing-page route exists.
- Copy/download controls can be added later if reviewers need them.
