### PR TITLE
Rank FAQ vocabulary gap diagnostics

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -659,6 +659,8 @@ def _term_mappings(
     if not customer_text:
         return ()
     source_ids = _distinct_source_keys(rows)
+    opportunity = _opportunity_score("", rows)
+    zero_result_source_count = _zero_result_source_count(rows)
     mappings: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
     for aliases in _VOCABULARY_GAP_RULES:
@@ -686,12 +688,23 @@ def _term_mappings(
                     f'"{documentation_term}" in FAQ headings and answer text.'
                 ),
                 "source_id_count": len(source_ids),
+                "zero_result_source_count": zero_result_source_count,
+                "failure_risk_score": opportunity["failure_risk_score"],
+                "failure_risk_signals": opportunity["failure_risk_signals"],
+                "opportunity_score": opportunity["opportunity_score"],
                 "first_source_id": source_ids[0] if source_ids else None,
             })
             break
         if len(mappings) >= 3:
             break
     return tuple(mappings)
+
+
+def _zero_result_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    source_ids = _distinct_source_keys([
+        row for row in rows if _is_zero_result_search_row(row)
+    ])
+    return len(source_ids)
 
 
 def _matching_documentation_term(
@@ -1067,11 +1080,29 @@ def _term_mapping_line(mapping: Any) -> str:
     documentation_term = _clean(mapping.get("documentation_term"))
     suggestion = _clean(mapping.get("suggestion"))
     if customer_term and documentation_term and suggestion:
-        return (
+        line = (
             f'Customers say "{customer_term}"; documentation says '
             f'"{documentation_term}". {suggestion}'
         )
+        impact = _term_mapping_impact_line(mapping)
+        return f"{line} {impact}" if impact else line
     return suggestion or ""
+
+
+def _term_mapping_impact_line(mapping: Mapping[str, Any]) -> str:
+    source_count = _integer_or_none(mapping.get("source_id_count")) or 0
+    zero_result_count = _integer_or_none(mapping.get("zero_result_source_count")) or 0
+    opportunity_score = _integer_or_none(mapping.get("opportunity_score")) or 0
+    if source_count < 1 and zero_result_count < 1 and opportunity_score < 1:
+        return ""
+    parts = []
+    if source_count:
+        parts.append(f"Seen in {source_count} source(s)")
+    if zero_result_count:
+        parts.append(f"{zero_result_count} zero-result search source(s)")
+    if opportunity_score:
+        parts.append(f"mapping score {opportunity_score}")
+    return f"({'; '.join(parts)}.)"
 
 
 def _summary(*, topic: str, rows: Sequence[Mapping[str, str]], source_count: int) -> str:

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Ranking.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Ranking.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Ranking
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Vocabulary-Gap-Term-Mapping added deterministic term-mapping
+suggestions, but each mapping only said which customer term differs from a
+documentation term. Operators still need to know which vocabulary gap is most
+urgent, especially when zero-result searches and tickets point at the same
+wording mismatch.
+
+This slice adds frequency and failure-risk context to each term mapping and
+sorts CLI mapping diagnostics by impact so the artifact can prioritize the
+phrasing gaps most likely to reduce support load or zero-result searches.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add per-mapping frequency, failure-risk, zero-result source count, and
+   opportunity score metadata.
+2. Render compact impact context in the Markdown vocabulary-gap bullets.
+3. Sort CLI term-mapping diagnostics by mapping opportunity score, frequency,
+   zero-result count, and FAQ rank.
+4. Add focused tests for zero-result ranking and unchanged no-gap behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Ranking.md` | Plan doc for this ranking slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds mapping impact metadata and Markdown impact text. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Sorts compact term-mapping diagnostics by impact and exposes impact fields. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers ranking metadata, CLI ordering, and no-gap stability. |
+
+## Mechanism
+
+The FAQ item already computes frequency, failure-risk signals, and opportunity
+score from the item rows. Vocabulary mappings are generated from the same row
+set, so this slice reuses that row context instead of adding a new scoring
+model.
+
+Each mapping records:
+
+- `source_id_count`
+- `zero_result_source_count`
+- `failure_risk_score`
+- `failure_risk_signals`
+- `opportunity_score`
+
+The Markdown renderer appends a short "Seen in ..." sentence to each mapping
+bullet. The CLI result JSON keeps the compact mapping summaries but sorts them
+by `opportunity_score`, then frequency, then zero-result count, then FAQ rank.
+
+## Intentional
+
+- No change to FAQ item ranking, grouping, output checks, or source filtering.
+- No new scoring model; mapping impact mirrors the existing FAQ opportunity
+  score for the rows that produced the mapping.
+- No long source-id lists in result JSON. The compact result keeps first source
+  id plus counts only.
+
+## Deferred
+
+- A later slice can add a dedicated vocabulary-gap artifact if operators need a
+  standalone report separate from FAQ Markdown.
+- A later search-log slice can weight mappings by search volume when uploaded
+  search exports include impression or count fields.
+- A later glossary slice can make the synonym table data-driven.
+
+## Verification
+
+- Focused vocabulary-gap ranking pytest for builder and CLI behavior - passed, 5 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 76 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review wrapper against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 90 |
+| FAQ generator | 33 |
+| CLI diagnostics | 17 |
+| Tests | 94 |
+| **Total** | **~235** |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -279,9 +279,24 @@ def _term_mapping_summaries(items: list[dict[str, Any]]) -> list[dict[str, Any]]
                 "customer_term": mapping.get("customer_term"),
                 "documentation_term": mapping.get("documentation_term"),
                 "source_id_count": mapping.get("source_id_count"),
+                "zero_result_source_count": mapping.get("zero_result_source_count"),
+                "failure_risk_score": mapping.get("failure_risk_score"),
+                "failure_risk_signals": list(mapping.get("failure_risk_signals") or ()),
+                "opportunity_score": mapping.get("opportunity_score"),
                 "first_source_id": mapping.get("first_source_id"),
             })
-    return out
+    return sorted(out, key=_term_mapping_sort_key)
+
+
+def _term_mapping_sort_key(mapping: dict[str, Any]) -> tuple[int, int, int, int, str, str]:
+    return (
+        -int(mapping.get("opportunity_score") or 0),
+        -int(mapping.get("source_id_count") or 0),
+        -int(mapping.get("zero_result_source_count") or 0),
+        int(mapping.get("rank") or 0),
+        str(mapping.get("topic") or ""),
+        str(mapping.get("customer_term") or ""),
+    )
 
 
 def _count_by(items: list[dict[str, Any]], key: str) -> dict[str, int]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -419,6 +419,10 @@ def test_build_ticket_faq_markdown_adds_vocabulary_gap_from_documentation_terms(
                 "in FAQ headings and answer text."
             ),
             "source_id_count": 1,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": (),
+            "opportunity_score": 1,
             "first_source_id": "ticket-1",
         },
         {
@@ -429,11 +433,16 @@ def test_build_ticket_faq_markdown_adds_vocabulary_gap_from_documentation_terms(
                 "in FAQ headings and answer text."
             ),
             "source_id_count": 1,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": (),
+            "opportunity_score": 1,
             "first_source_id": "ticket-1",
         },
     )
     assert "**Vocabulary gaps:**" in result.markdown
     assert 'Customers say "export"; documentation says "Download report".' in result.markdown
+    assert "(Seen in 1 source(s); mapping score 1.)" in result.markdown
 
 
 def test_build_ticket_faq_markdown_uses_document_rows_for_vocabulary_gap_only() -> None:
@@ -483,6 +492,43 @@ def test_build_ticket_faq_markdown_skips_vocabulary_gap_when_docs_match_customer
 
     assert result.items[0]["term_mappings"] == ()
     assert "**Vocabulary gaps:**" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_scores_vocabulary_gap_zero_result_searches() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "search_log",
+                "query_id": "search-1",
+                "search_query": "How do I export attribution report?",
+                "results_count": 0,
+                "evidence": [{
+                    "text": "How do I export attribution report?",
+                    "source_id": "search-1",
+                    "source_type": "search_log",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Export attribution",
+                "evidence": [{
+                    "text": "I cannot export attribution data.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            },
+        ],
+        documentation_terms=("Download report",),
+    )
+
+    mapping = result.items[0]["term_mappings"][0]
+    assert mapping["customer_term"] == "export"
+    assert mapping["source_id_count"] == 2
+    assert mapping["zero_result_source_count"] == 1
+    assert mapping["failure_risk_score"] == 2
+    assert mapping["failure_risk_signals"] == ("blocked_access", "zero_result_search")
+    assert mapping["opportunity_score"] == 6
+    assert "(Seen in 2 source(s); 1 zero-result search source(s); mapping score 6.)" in result.markdown
 
 
 def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -> None:
@@ -2024,9 +2070,57 @@ def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path)
         "customer_term": "export",
         "documentation_term": "Download report",
         "source_id_count": 1,
+        "zero_result_source_count": 0,
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "opportunity_score": 1,
         "first_source_id": "ticket-1",
     }]
     assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
+
+
+def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_path: Path) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "searches.csv",
+        [
+            {
+                "query_id": "search-1",
+                "search_query": "How do I export attribution report?",
+                "results_count": "0",
+            },
+            {
+                "ticket_id": "ticket-1",
+                "description": "I cannot export attribution data.",
+                "pain_category": "exports",
+            },
+            {
+                "ticket_id": "ticket-2",
+                "description": "Where can I find my bill?",
+                "pain_category": "billing",
+            },
+        ],
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Download report",
+        "--documentation-term",
+        "Invoice settings",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    mappings = result["diagnostics"]["term_mappings"]
+    assert [mapping["customer_term"] for mapping in mappings] == ["export", "bill"]
+    assert mappings[0]["opportunity_score"] == 6
+    assert mappings[0]["zero_result_source_count"] == 1
+    assert mappings[1]["opportunity_score"] == 1
+    assert mappings[1]["zero_result_source_count"] == 0
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Ranking.md

Ownership lane: content-ops/faq-generator

Vocabulary-gap mappings now need impact context, not just term pairs. This slice adds frequency, zero-result source count, failure-risk, and opportunity-score metadata to each mapping, renders compact impact context in Markdown, and sorts CLI mapping diagnostics by impact.

## Intentional
- No change to FAQ item ranking, grouping, output checks, or source filtering.
- Mapping impact mirrors the existing FAQ opportunity score for the rows that produced the mapping.
- Result JSON stays compact: first source id plus counts, no long source-id lists.

## Deferred
- Dedicated vocabulary-gap artifact separate from FAQ Markdown.
- Search-volume weighting when uploaded search exports include impression/count fields.
- Data-driven glossary/synonym rules.

## Verification
- Focused vocabulary-gap ranking pytest for builder and CLI behavior - passed, 5 tests.
- pytest tests/test_extracted_ticket_faq_markdown.py -q - passed, 76 tests.
- Py compile for affected Python files - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 Atlas runtime import findings.
- bash scripts/check_ascii_python.sh - passed.
- git diff --check - passed.
- bash scripts/local_pr_review.sh origin/main - passed after rebase.

## Diff size
4 files, +232 / -2