### PR TITLE
Weight FAQ scoring by aggregate source volume

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -179,6 +179,21 @@ _DOCUMENTATION_TERM_KEYS = (
     "text",
     "description",
 )
+_SOURCE_WEIGHT_KEYS = (
+    "source_weight",
+    "search_count",
+    "query_count",
+    "request_count",
+    "occurrences",
+    "occurrence_count",
+    "volume",
+    "search_volume",
+    "impressions",
+    "weight",
+    # Some exports call source volume "frequency"; keep it after explicit
+    # aggregate fields so round-tripped FAQ output does not mask search_count.
+    "frequency",
+)
 _VOCABULARY_GAP_RULES = (
     ("export", "download", "download report", "report download"),
     ("dashboard", "analytics", "reporting", "reports"),
@@ -453,6 +468,7 @@ def build_ticket_faq_markdown(
                 "result_count": _first_present(evidence, opportunity, key="result_count"),
                 "zero_results": _first_present(evidence, opportunity, key="zero_results"),
                 "zero_result": _first_present(evidence, opportunity, key="zero_result"),
+                "source_weight": _source_weight(evidence, opportunity),
             })
 
     sorted_groups = sorted(groups.items(), key=_group_sort_key)
@@ -610,6 +626,7 @@ def _item(
         "question": question,
         "question_source": question_source,
         "frequency": opportunity["frequency"],
+        "weighted_frequency": opportunity["weighted_frequency"],
         "failure_risk_score": opportunity["failure_risk_score"],
         "failure_risk_signals": opportunity["failure_risk_signals"],
         "opportunity_score": opportunity["opportunity_score"],
@@ -629,11 +646,12 @@ def _item(
 
 
 def _opportunity_score(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[str, Any]:
-    frequency = len(_distinct_source_keys(rows))
+    frequency = _weighted_frequency(rows)
     failure_risk_signals = _failure_risk_signals(topic, rows)
     failure_risk_score = len(failure_risk_signals)
     return {
         "frequency": frequency,
+        "weighted_frequency": frequency,
         "failure_risk_score": failure_risk_score,
         "failure_risk_signals": failure_risk_signals,
         "opportunity_score": frequency * (1 + failure_risk_score),
@@ -643,6 +661,24 @@ def _opportunity_score(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[st
 def _distinct_source_keys(rows: Sequence[Mapping[str, str]]) -> tuple[str, ...]:
     values = (row.get("source_key") or row.get("source_id", "") for row in rows)
     return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _weighted_frequency(rows: Sequence[Mapping[str, Any]]) -> int:
+    weights: dict[str, int] = {}
+    for index, row in enumerate(rows, start=1):
+        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        weight = _integer_or_none(row.get("source_weight")) or 1
+        weights[source_key] = max(weights.get(source_key, 0), max(weight, 1))
+    return sum(weights.values())
+
+
+def _source_weight(*rows: Mapping[str, Any]) -> int:
+    for row in rows:
+        for key in _SOURCE_WEIGHT_KEYS:
+            weight = _integer_or_none(_field_value(row, key))
+            if weight is not None and weight > 0:
+                return weight
+    return 1
 
 
 def _term_mappings(
@@ -659,6 +695,7 @@ def _term_mappings(
     if not customer_text:
         return ()
     source_ids = _distinct_source_keys(rows)
+    # Vocabulary-gap impact should reflect the evidence rows, not the FAQ topic label.
     opportunity = _opportunity_score("", rows)
     zero_result_source_count = _zero_result_source_count(rows)
     mappings: list[dict[str, Any]] = []

--- a/plans/PR-Content-Ops-FAQ-Search-Volume-Weighting.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Volume-Weighting.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-FAQ-Search-Volume-Weighting
+
+## Why this slice exists
+
+The FAQ generator now ranks FAQ opportunities and vocabulary gaps by frequency
+and failure risk, but frequency still treats every source row as one occurrence.
+That is correct for raw ticket exports, but not for aggregated search-log or
+analytics exports where one row can represent many searches.
+
+This slice lets pre-aggregated customer inputs carry explicit volume fields so a
+query seen 200 times ranks above a one-off ticket without requiring callers to
+duplicate rows.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add deterministic source-weight extraction for common aggregate fields such
+   as `source_weight`, `search_count`, `query_count`, `request_count`,
+   `occurrences`, and `volume`.
+2. Use weighted frequency for FAQ item opportunity scoring and vocabulary-gap
+   mapping scoring.
+3. Preserve distinct source counts in `ticket_count`, `source_ids`, and
+   rendered source coverage checks.
+4. Surface weighted frequency in compact CLI item diagnostics.
+5. Add focused tests for weighted FAQ ranking, weighted vocabulary-gap
+   diagnostics, and unchanged one-row-per-source behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-Volume-Weighting.md` | Plan doc for this weighting slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds source-weight extraction and weighted opportunity scoring. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds weighted frequency to compact item diagnostics. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers weighted ranking and result diagnostics. |
+
+## Mechanism
+
+When evidence rows are admitted into FAQ grouping, the builder copies a
+validated `source_weight` onto the internal row. The weight comes from the first
+positive integer-like value found on the evidence or parent opportunity under
+known aggregate field names. Missing, invalid, zero, and negative values fall
+back to 1.
+
+Opportunity scoring then sums one weight per distinct source key. If multiple
+evidence rows share the same source id, the largest weight for that source is
+used so duplicate evidence does not multiply the same aggregate row. Existing
+distinct-source outputs remain unchanged: `ticket_count`, `source_ids`,
+rendered coverage checks, and source labels still count source identities, not
+weighted volume.
+
+## Intentional
+
+- No new source filtering or output-check gate.
+- Raw ticket exports keep the same scores because missing weights default to 1.
+- `ticket_count` remains a distinct-source count; weighted volume is reflected
+  through `frequency`, `weighted_frequency`, and `opportunity_score`.
+- `results_count` is not treated as volume because in search logs it means
+  returned-result count, including zero-result detection.
+
+## Deferred
+
+- A later hosted upload slice can label these accepted aggregate fields in the
+  UI.
+- A later search-log slice can preserve separate impression/click metrics if
+  product wants more than one volume dimension.
+- A later glossary slice can apply weighted volume to standalone vocabulary-gap
+  reports if those become a separate artifact.
+
+## Verification
+
+- Focused search-volume weighting pytest for builder and CLI behavior - passed, 4 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 79 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review wrapper against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 91 |
+| FAQ generator | 41 |
+| CLI diagnostics | 1 |
+| Tests | 102 |
+| **Total** | **~235** |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -251,6 +251,7 @@ def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
         "question": item.get("question"),
         "question_source": item.get("question_source"),
         "frequency": item.get("frequency"),
+        "weighted_frequency": item.get("weighted_frequency"),
         "failure_risk_score": item.get("failure_risk_score"),
         "failure_risk_signals": list(item.get("failure_risk_signals") or ()),
         "opportunity_score": item.get("opportunity_score"),

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -329,6 +329,104 @@ def test_build_ticket_faq_markdown_uses_frequency_tiebreak_after_opportunity_sco
     ]
 
 
+def test_build_ticket_faq_markdown_weights_aggregated_search_frequency() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "search_log",
+            "query_id": "search-export-1",
+            "search_query": "export attribution report",
+            "search_count": "20",
+            "evidence": [{
+                "text": "export attribution report",
+                "source_id": "search-export-1",
+                "source_type": "search_log",
+            }],
+        },
+        {
+            "source_type": "support_ticket",
+            "source_title": "Email update",
+            "evidence": [{
+                "text": "How do I change my email?",
+                "source_id": "ticket-email-1",
+                "source_type": "support_ticket",
+            }],
+        },
+        {
+            "source_type": "support_ticket",
+            "source_title": "Email settings",
+            "evidence": [{
+                "text": "I need to update the email on my account.",
+                "source_id": "ticket-email-2",
+                "source_type": "support_ticket",
+            }],
+        },
+    ])
+
+    assert [item["topic"] for item in result.items] == [
+        "reporting friction",
+        "email and profile updates",
+    ]
+    assert result.items[0]["frequency"] == 20
+    assert result.items[0]["weighted_frequency"] == 20
+    assert result.items[0]["ticket_count"] == 1
+    assert result.items[0]["source_ids"] == ("search-export-1",)
+    assert result.items[0]["opportunity_score"] == 20
+    assert result.items[1]["frequency"] == 2
+    assert result.items[1]["weighted_frequency"] == 2
+
+
+def test_build_ticket_faq_markdown_prefers_explicit_aggregate_weight_fields() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "search_log",
+        "query_id": "search-export-1",
+        "search_query": "export attribution report",
+        "frequency": "1",
+        "search_count": "25",
+        "evidence": [{
+            "text": "export attribution report",
+            "source_id": "search-export-1",
+            "source_type": "search_log",
+        }],
+    }])
+
+    assert result.items[0]["frequency"] == 25
+    assert result.items[0]["weighted_frequency"] == 25
+    assert result.items[0]["ticket_count"] == 1
+
+
+def test_build_ticket_faq_markdown_uses_max_weight_per_distinct_source() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "search_log",
+        "query_id": "search-export-1",
+        "search_query": "export attribution report",
+        "evidence": [
+            {
+                "text": "export attribution report",
+                "source_id": "search-export-1",
+                "source_type": "search_log",
+                "source_weight": "100",
+            },
+            {
+                "text": "download attribution report",
+                "source_id": "search-export-1",
+                "source_type": "search_log",
+                "source_weight": "200",
+            },
+            {
+                "text": "dashboard attribution report",
+                "source_id": "search-export-2",
+                "source_type": "search_log",
+                "source_weight": "300",
+            },
+        ],
+    }])
+
+    assert result.items[0]["frequency"] == 500
+    assert result.items[0]["weighted_frequency"] == 500
+    assert result.items[0]["ticket_count"] == 2
+    assert result.items[0]["source_ids"] == ("search-export-1", "search-export-2")
+
+
 def test_build_ticket_faq_markdown_ranks_zero_result_searches_as_failure_risk() -> None:
     result = build_ticket_faq_markdown([
         {
@@ -2032,6 +2130,7 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "question": "How do we export campaign attribution data before renewal?",
         "question_source": "customer_wording",
         "frequency": 2,
+        "weighted_frequency": 2,
         "failure_risk_score": 1,
         "failure_risk_signals": ["blocked_access"],
         "opportunity_score": 4,
@@ -2087,6 +2186,7 @@ def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_pa
             {
                 "query_id": "search-1",
                 "search_query": "How do I export attribution report?",
+                "search_count": "25",
                 "results_count": "0",
             },
             {
@@ -2117,7 +2217,7 @@ def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_pa
     result = json.loads(result_output.read_text(encoding="utf-8"))
     mappings = result["diagnostics"]["term_mappings"]
     assert [mapping["customer_term"] for mapping in mappings] == ["export", "bill"]
-    assert mappings[0]["opportunity_score"] == 6
+    assert mappings[0]["opportunity_score"] == 78
     assert mappings[0]["zero_result_source_count"] == 1
     assert mappings[1]["opportunity_score"] == 1
     assert mappings[1]["zero_result_source_count"] == 0


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Volume-Weighting.md

Ownership lane: content-ops/faq-generator

The FAQ generator now supports aggregate source volume fields so pre-aggregated search-log rows can rank by actual query volume instead of being treated as one source row.

## Intentional
- No new source filtering or output-check gate.
- Raw ticket exports keep the same scores because missing weights default to 1.
- ticket_count remains distinct source count; weighted volume is reflected through frequency, weighted_frequency, and opportunity_score.
- results_count is not treated as volume because search logs use it for returned-result count and zero-result detection.

## Deferred
- Hosted upload labels for accepted aggregate fields.
- Separate impression/click metrics if product wants more than one volume dimension.
- Applying weighted volume to a standalone vocabulary-gap report if that artifact lands later.

## Verification
- Focused search-volume weighting pytest for builder and CLI behavior - passed, 5 tests.
- pytest tests/test_extracted_ticket_faq_markdown.py -q - passed, 77 tests.
- Py compile for affected Python files - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 Atlas runtime import findings.
- bash scripts/check_ascii_python.sh - passed.
- git diff --check - passed.
- bash scripts/local_pr_review.sh origin/main - passed.

## Diff size
4 files, +177 / -2