### PR TITLE
Add public landing page renderer v1

### DIFF
--- a/atlas-intel-ui/src/App.tsx
+++ b/atlas-intel-ui/src/App.tsx
@@ -17,6 +17,7 @@ const ReviewDetail = lazy(() => import('./pages/ReviewDetail'))
 const Landing = lazy(() => import('./pages/Landing'))
 const Blog = lazy(() => import('./pages/Blog'))
 const BlogPost = lazy(() => import('./pages/BlogPost'))
+const PublicLandingPage = lazy(() => import('./pages/PublicLandingPage'))
 const Login = lazy(() => import('./pages/Login'))
 const Signup = lazy(() => import('./pages/Signup'))
 const Onboarding = lazy(() => import('./pages/Onboarding'))
@@ -49,6 +50,7 @@ export default function App() {
         <Routes>
           {/* Public routes */}
           <Route path="/landing" element={renderLazyRoute(Landing)} />
+          <Route path="/lp/:id/:slug" element={renderLazyRoute(PublicLandingPage)} />
           <Route path="/blog" element={renderLazyRoute(Blog)} />
           <Route path="/blog/:slug" element={renderLazyRoute(BlogPost)} />
           <Route path="/login" element={renderLazyRoute(Login)} />

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -527,6 +527,16 @@ async function getAssetText(
   return rawText(res)
 }
 
+async function getPublicAssetJson<T>(path: string): Promise<T> {
+  const url = `${ASSETS_BASE}${path}`
+  const res = await fetchWithApiFallback(url)
+  if (!res.ok) {
+    const body = await rawText(res)
+    throw new Error(`API ${res.status}: ${body || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
 // ---------------------------------------------------------------------------
 // Public fetch wrappers
 // ---------------------------------------------------------------------------
@@ -574,6 +584,15 @@ export function reviewGeneratedAssetDrafts(
     asset,
     '/drafts/review-batch',
     { ids, status },
+  )
+}
+
+/** GET /content-assets/landing_page/public/{id} -- approved public landing page. */
+export function fetchPublicLandingPageDraft(
+  id: string,
+): Promise<GeneratedAssetDraft> {
+  return getPublicAssetJson<GeneratedAssetDraft>(
+    `/landing_page/public/${encodeURIComponent(id)}`,
   )
 }
 

--- a/atlas-intel-ui/src/components/SeoHead.tsx
+++ b/atlas-intel-ui/src/components/SeoHead.tsx
@@ -12,6 +12,7 @@ interface SeoHeadProps {
   keywords?: string[]
   faq?: FaqItem[]
   jsonLd?: object
+  robots?: string
 }
 
 /** Track elements we create so cleanup removes exactly what we added. */
@@ -59,7 +60,7 @@ function cleanup() {
   managed.clear()
 }
 
-export default function SeoHead({ title, description, canonical, ogType = 'article', ogImage, keywords, faq, jsonLd }: SeoHeadProps) {
+export default function SeoHead({ title, description, canonical, ogType = 'article', ogImage, keywords, faq, jsonLd, robots }: SeoHeadProps) {
   useEffect(() => {
     document.title = title
 
@@ -84,6 +85,10 @@ export default function SeoHead({ title, description, canonical, ogType = 'artic
       setMeta('keywords', keywords.join(', '), true)
     }
 
+    if (robots) {
+      setMeta('robots', robots, true)
+    }
+
     if (jsonLd) {
       setJsonLd('seo-jsonld', jsonLd)
     }
@@ -104,7 +109,7 @@ export default function SeoHead({ title, description, canonical, ogType = 'artic
     }
 
     return cleanup
-  }, [title, description, canonical, ogType, ogImage, keywords, faq, jsonLd])
+  }, [title, description, canonical, ogType, ogImage, keywords, faq, jsonLd, robots])
 
   return null
 }

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -4,8 +4,10 @@ import {
   ArrowRight,
   CheckCircle2,
   Code2,
+  Copy,
   Download,
   Eye,
+  ExternalLink,
   Loader2,
   RefreshCw,
   X,
@@ -583,8 +585,22 @@ function AssetDetailDrawer({
   const repairHistory = assetRepairHistory(row)
   const structuredData =
     asset === 'landing_page' ? structuredDataSummary(row.structured_data) : null
+  const publicUrl = publicLandingPageUrl(row, asset)
+  const publicUrlPending =
+    asset === 'landing_page' &&
+    Boolean(assetId(row)) &&
+    Boolean(textValue(row.slug)) &&
+    status !== 'approved'
+  const [copiedUrl, setCopiedUrl] = useState(false)
   const drawerRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  const handleCopyPublicUrl = async () => {
+    if (!publicUrl) return
+    await copyText(publicUrl)
+    setCopiedUrl(true)
+    window.setTimeout(() => setCopiedUrl(false), 1800)
+  }
 
   useEffect(() => {
     const previous = document.activeElement
@@ -656,6 +672,47 @@ function AssetDetailDrawer({
             <X className="h-4 w-4" />
           </button>
         </div>
+
+        {(publicUrl || publicUrlPending) && (
+          <section className="mt-6">
+            <h3 className="text-sm font-semibold text-slate-200">Public URL</h3>
+            <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-4">
+              {publicUrl ? (
+                <>
+                  <p className="break-all font-mono text-xs leading-5 text-slate-300">
+                    {publicUrl}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <a
+                      href={publicUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-2 rounded-md border border-cyan-500/40 px-3 py-2 text-sm text-cyan-200 hover:bg-cyan-500/10"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      Open
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => void handleCopyPublicUrl()}
+                      className="inline-flex items-center gap-2 rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 hover:border-cyan-400 hover:text-cyan-200"
+                    >
+                      <Copy className="h-4 w-4" />
+                      {copiedUrl ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <p className="mt-3 text-xs text-slate-500">
+                    Public rendering is approved-only. This v1 URL is marked noindex.
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-slate-400">
+                  Approve this landing page to make its public URL available.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
 
         {facts.length > 0 && (
           <section className="mt-6">
@@ -1036,6 +1093,18 @@ function focusableElements(root: HTMLElement | null): HTMLElement[] {
 
 function assetId(row: GeneratedAssetDraft): string {
   return textValue(row.id)
+}
+
+function publicLandingPageUrl(
+  row: GeneratedAssetDraft,
+  asset: GeneratedAssetType,
+): string | null {
+  if (asset !== 'landing_page') return null
+  if (textValue(row.status) !== 'approved') return null
+  const id = assetId(row)
+  const slug = textValue(row.slug)
+  if (!id || !slug) return null
+  return `${window.location.origin}/lp/${encodeURIComponent(id)}/${encodeURIComponent(slug)}`
 }
 
 function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string {
@@ -1455,4 +1524,20 @@ function downloadCsv(csv: string, filename: string): void {
   link.click()
   link.remove()
   window.setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+async function copyText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+  const textArea = document.createElement('textarea')
+  textArea.value = value
+  textArea.setAttribute('readonly', '')
+  textArea.style.position = 'fixed'
+  textArea.style.top = '-1000px'
+  document.body.appendChild(textArea)
+  textArea.select()
+  document.execCommand('copy')
+  textArea.remove()
 }

--- a/atlas-intel-ui/src/pages/PublicLandingPage.tsx
+++ b/atlas-intel-ui/src/pages/PublicLandingPage.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { marked } from 'marked'
+import { ArrowRight, Loader2 } from 'lucide-react'
+import {
+  fetchPublicLandingPageDraft,
+  type GeneratedAssetDraft,
+} from '../api/contentOps'
+import PublicLayout from '../components/PublicLayout'
+import SeoHead from '../components/SeoHead'
+
+type LandingPageSectionView = {
+  id: string
+  title: string
+  body: string
+}
+
+type PageState =
+  | { kind: 'idle'; id: string }
+  | { kind: 'loaded'; id: string; page: GeneratedAssetDraft }
+  | { kind: 'not_found'; id: string }
+  | { kind: 'error'; id: string; message: string }
+
+export default function PublicLandingPage() {
+  const { id = '', slug = '' } = useParams<{ id: string; slug: string }>()
+  const navigate = useNavigate()
+  const [pageState, setPageState] = useState<PageState>({ kind: 'idle', id: '' })
+
+  useEffect(() => {
+    let cancelled = false
+    fetchPublicLandingPageDraft(id)
+      .then((draft) => {
+        if (cancelled) return
+        setPageState({ kind: 'loaded', id, page: draft })
+        const canonicalSlug = textValue(draft.slug)
+        if (canonicalSlug && canonicalSlug !== slug) {
+          navigate(`/lp/${encodeURIComponent(id)}/${canonicalSlug}`, { replace: true })
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : String(err)
+        if (message.includes('API 404')) {
+          setPageState({ kind: 'not_found', id })
+        } else {
+          setPageState({ kind: 'error', id, message })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, slug, navigate])
+
+  const routeState: PageState = pageState.id === id ? pageState : { kind: 'idle', id }
+  const page = routeState.kind === 'loaded' ? routeState.page : null
+
+  const canonical = useMemo(() => {
+    if (!page) return ''
+    const canonicalSlug = textValue(page.slug) || slug
+    return `${window.location.origin}/lp/${encodeURIComponent(id)}/${canonicalSlug}`
+  }, [id, page, slug])
+
+  if (routeState.kind === 'idle') {
+    return (
+      <PublicLayout>
+        <section className="mx-auto flex min-h-[50vh] max-w-3xl items-center justify-center px-6 py-24">
+          <Loader2 className="h-6 w-6 animate-spin text-cyan-300" />
+        </section>
+      </PublicLayout>
+    )
+  }
+
+  if (routeState.kind === 'error') {
+    return (
+      <PublicLayout>
+        <section className="mx-auto max-w-3xl px-6 py-24 text-center">
+          <h1 className="text-3xl font-bold">Unable to load page</h1>
+          <p className="mt-4 text-slate-400">{routeState.message}</p>
+        </section>
+      </PublicLayout>
+    )
+  }
+
+  if (routeState.kind === 'not_found' || !page) {
+    return (
+      <PublicLayout>
+        <section className="mx-auto max-w-3xl px-6 py-24 text-center">
+          <h1 className="text-3xl font-bold">Landing page not found</h1>
+          <p className="mt-4 text-slate-400">
+            This page is not public, has moved, or is no longer available.
+          </p>
+          <Link
+            to="/landing"
+            className="mt-8 inline-flex items-center gap-2 rounded-lg bg-cyan-600 px-5 py-3 text-sm font-semibold text-white hover:bg-cyan-500"
+          >
+            Back to Atlas
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </section>
+      </PublicLayout>
+    )
+  }
+
+  const hero = recordValue(page.hero)
+  const cta = recordValue(page.cta)
+  const meta = recordValue(page.meta)
+  const sections = sectionList(page.sections)
+  const title = textValue(meta?.title_tag) || textValue(page.title) || 'Landing Page'
+  const description =
+    textValue(meta?.description) ||
+    textValue(hero?.subheadline) ||
+    textValue(page.value_prop) ||
+    title
+  const jsonLd = structuredDataWithCanonical(page.structured_data, canonical)
+  const ctaLabel = textValue(cta?.label) || textValue(hero?.cta_label)
+  const ctaUrl = textValue(cta?.url) || textValue(hero?.cta_url)
+
+  return (
+    <>
+      <SeoHead
+        title={title}
+        description={description}
+        canonical={canonical}
+        ogType="website"
+        jsonLd={jsonLd}
+        robots="noindex,follow"
+      />
+      <PublicLayout>
+        <article>
+          <section className="mx-auto max-w-5xl px-6 pb-20 pt-14">
+            <div className="max-w-3xl">
+              {textValue(page.persona) && (
+                <p className="text-sm font-semibold uppercase tracking-wide text-cyan-300">
+                  {textValue(page.persona)}
+                </p>
+              )}
+              <h1 className="mt-4 text-4xl font-bold leading-tight sm:text-5xl">
+                {textValue(hero?.headline) || textValue(page.title)}
+              </h1>
+              {(textValue(hero?.subheadline) || textValue(page.value_prop)) && (
+                <p className="mt-6 text-lg leading-8 text-slate-300">
+                  {textValue(hero?.subheadline) || textValue(page.value_prop)}
+                </p>
+              )}
+              {ctaLabel && ctaUrl && (
+                <a
+                  href={ctaUrl}
+                  className="mt-8 inline-flex items-center gap-2 rounded-lg bg-cyan-600 px-5 py-3 text-sm font-semibold text-white hover:bg-cyan-500"
+                >
+                  {ctaLabel}
+                  <ArrowRight className="h-4 w-4" />
+                </a>
+              )}
+            </div>
+          </section>
+
+          {sections.length > 0 && (
+            <section className="border-t border-slate-800">
+              <div className="mx-auto max-w-5xl space-y-10 px-6 py-16">
+                {sections.map((section, index) => (
+                  <section
+                    key={section.id || `${section.title}-${index}`}
+                    className="max-w-3xl"
+                  >
+                    <h2 className="text-2xl font-semibold text-white">
+                      {section.title || `Section ${index + 1}`}
+                    </h2>
+                    {section.body && (
+                      <div
+                        className="blog-prose mt-4 text-slate-300"
+                        dangerouslySetInnerHTML={{
+                          __html: renderSafeMarkdown(section.body),
+                        }}
+                      />
+                    )}
+                  </section>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {ctaLabel && ctaUrl && (
+            <section className="border-t border-slate-800">
+              <div className="mx-auto max-w-5xl px-6 py-16">
+                <div className="max-w-3xl rounded-xl border border-slate-700 bg-slate-800/60 p-8">
+                  <h2 className="text-2xl font-semibold text-white">
+                    {textValue(page.title)}
+                  </h2>
+                  <p className="mt-3 text-slate-300">{description}</p>
+                  <a
+                    href={ctaUrl}
+                    className="mt-6 inline-flex items-center gap-2 rounded-lg bg-cyan-600 px-5 py-3 text-sm font-semibold text-white hover:bg-cyan-500"
+                  >
+                    {ctaLabel}
+                    <ArrowRight className="h-4 w-4" />
+                  </a>
+                </div>
+              </div>
+            </section>
+          )}
+        </article>
+      </PublicLayout>
+    </>
+  )
+}
+
+function sectionList(value: unknown): LandingPageSectionView[] {
+  return recordList(value)
+    .map((section) => ({
+      id: textValue(section.id),
+      title: textValue(section.title) || textValue(section.heading),
+      body: textValue(section.body_markdown) || textValue(section.body),
+    }))
+    .filter((section) => section.title || section.body)
+}
+
+function recordList(value: unknown): Record<string, unknown>[] {
+  let rows = Array.isArray(value) ? value : []
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      rows = Array.isArray(parsed) ? parsed : []
+    } catch {
+      rows = []
+    }
+  }
+  return rows.filter((item): item is Record<string, unknown> =>
+    Boolean(item && typeof item === 'object' && !Array.isArray(item)),
+  )
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function renderSafeMarkdown(markdown: string): string {
+  const escapedMarkdown = markdown.replace(/[<>]/g, (char) =>
+    char === '<' ? '&lt;' : '&gt;',
+  )
+  const html = marked.parse(escapedMarkdown, { async: false }) as string
+  return sanitizeRenderedHtml(html)
+}
+
+function sanitizeRenderedHtml(html: string): string {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  for (const element of Array.from(template.content.querySelectorAll('*'))) {
+    for (const attr of Array.from(element.attributes)) {
+      const name = attr.name.toLowerCase()
+      if (name.startsWith('on') || name === 'style') {
+        element.removeAttribute(attr.name)
+        continue
+      }
+      if ((name === 'href' || name === 'src') && !safeUrl(attr.value)) {
+        element.removeAttribute(attr.name)
+      }
+    }
+  }
+  return template.innerHTML
+}
+
+function safeUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.startsWith('https://') ||
+    normalized.startsWith('http://') ||
+    normalized.startsWith('mailto:') ||
+    normalized.startsWith('tel:') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('#')
+  )
+}
+
+function structuredDataWithCanonical(value: unknown, canonical: string): object | undefined {
+  const raw = recordValue(value)
+  if (!raw) return undefined
+  const graph = recordList(raw['@graph'])
+  if (graph.length === 0) return raw
+  return {
+    ...raw,
+    '@graph': graph.map((node) => {
+      const type = node['@type']
+      if (type === 'WebPage') {
+        return { ...node, '@id': `${canonical}#webpage`, url: canonical }
+      }
+      if (type === 'FAQPage') {
+        return {
+          ...node,
+          '@id': `${canonical}#faq`,
+          mainEntityOfPage: { '@id': `${canonical}#webpage` },
+        }
+      }
+      return node
+    }),
+  }
+}

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -158,6 +158,7 @@ try:
     )
     from extracted_content_pipeline.api.generated_assets import (
         create_generated_asset_router,
+        create_public_landing_page_router,
     )
     from .._content_ops_services import build_content_ops_execution_services
     from .._content_ops_scope import (
@@ -205,6 +206,10 @@ try:
         dependencies=[Depends(_capture_content_ops_auth_user)],
     )
     router.include_router(content_assets_router)
+    public_landing_page_router = create_public_landing_page_router(
+        pool_provider=get_db_pool,
+    )
+    router.include_router(public_landing_page_router)
 except Exception as exc:  # pragma: no cover - defensive at import time
     logger.warning(
         "Content Ops router disabled during api package import: %s", exc

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -22,7 +22,10 @@ else:
 from ..campaign_ports import TenantScope
 from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
-from ..landing_page_export import export_landing_page_drafts
+from ..landing_page_export import (
+    export_landing_page_drafts,
+    public_landing_page_draft_row,
+)
 from ..landing_page_postgres import PostgresLandingPageRepository
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
@@ -321,6 +324,38 @@ def create_generated_asset_router(
     return router
 
 
+def create_public_landing_page_router(
+    *,
+    pool_provider: PoolProvider,
+    config: GeneratedAssetApiConfig | None = None,
+) -> APIRouter:
+    """Create unauthenticated public routes for approved landing pages."""
+    _require_fastapi()
+    resolved_config = config or GeneratedAssetApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+    )
+
+    @router.get("/landing_page/public/{landing_page_id}")
+    async def public_landing_page(
+        landing_page_id: str,
+    ) -> dict[str, Any]:
+        try:
+            public_id = str(UUID(landing_page_id))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Landing page not found") from None
+        pool = await _resolve_pool(pool_provider)
+        draft = await PostgresLandingPageRepository(pool).get_public_approved_draft(
+            public_id
+        )
+        if draft is None:
+            raise HTTPException(status_code=404, detail="Landing page not found")
+        return public_landing_page_draft_row(draft)
+
+    return router
+
+
 async def _export_for_asset(
     asset: str,
     pool: Any,
@@ -437,4 +472,5 @@ def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
 __all__ = [
     "GeneratedAssetApiConfig",
     "create_generated_asset_router",
+    "create_public_landing_page_router",
 ]

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -135,6 +135,29 @@ def _draft_row(draft: LandingPageDraft) -> JsonDict:
     return row
 
 
+def landing_page_draft_export_row(draft: LandingPageDraft) -> JsonDict:
+    """Return the host-facing export row for a single landing-page draft."""
+
+    return _draft_row(draft)
+
+
+def public_landing_page_draft_row(draft: LandingPageDraft) -> JsonDict:
+    """Return the unauthenticated public renderer payload for one draft."""
+
+    return {
+        "id": draft.id,
+        "slug": draft.slug,
+        "title": draft.title,
+        "persona": draft.persona,
+        "value_prop": draft.value_prop,
+        "hero": draft.hero,
+        "sections": list(draft.sections),
+        "cta": draft.cta,
+        "meta": draft.meta,
+        "structured_data": build_landing_page_structured_data(draft),
+    }
+
+
 def _metadata_summary(value: Any) -> JsonDict:
     metadata = _metadata_mapping(value)
     usage = _metadata_mapping(metadata.get("generation_usage"))
@@ -551,4 +574,6 @@ def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
 __all__ = [
     "LandingPageDraftExportResult",
     "export_landing_page_drafts",
+    "landing_page_draft_export_row",
+    "public_landing_page_draft_row",
 ]

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -161,6 +161,12 @@ class LandingPageRepository(Protocol):
     ) -> Sequence[LandingPageDraft]:
         """Return drafts filtered by tenant scope and optional facets."""
 
+    async def get_public_approved_draft(
+        self,
+        landing_page_id: str,
+    ) -> LandingPageDraft | None:
+        """Return one approved public draft by id, or None when not publishable."""
+
     async def update_status(
         self,
         landing_page_id: str,

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -194,6 +194,25 @@ class PostgresLandingPageRepository:
         rows = await self.pool.fetch(sql, *params)
         return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
 
+    async def get_public_approved_draft(
+        self,
+        landing_page_id: str,
+    ) -> LandingPageDraft | None:
+        rows = await self.pool.fetch(
+            """
+            SELECT id, campaign_name, persona, value_prop, title, slug,
+                   hero, sections, cta, meta, reference_ids, metadata, status
+              FROM landing_pages
+             WHERE id = $1
+               AND status = 'approved'
+             LIMIT 1
+            """,
+            landing_page_id,
+        )
+        if not rows:
+            return None
+        return _row_to_draft(row_to_dict(rows[0]))
+
     async def update_status(
         self,
         landing_page_id: str,

--- a/plans/PR-Public-Landing-Page-Renderer-V1.md
+++ b/plans/PR-Public-Landing-Page-Renderer-V1.md
@@ -1,0 +1,92 @@
+# PR-Public-Landing-Page-Renderer-V1
+
+## Why this slice exists
+
+Generated landing pages can now be reviewed, approved, exported, and inspected,
+but there is no public renderer for approved pages. This slice adds a v1 public
+route without turning pages into indexable SEO assets yet.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/public-landing-page-renderer-v1
+
+1. Add an approved-only public landing-page API lookup by id.
+2. Render public landing pages at `/lp/:id/:slug`.
+3. Redirect slug mismatches to the canonical slug returned by the API.
+4. Use frontend-derived canonical URLs and existing structured data.
+5. Mark v1 public generated landing pages `noindex,follow`.
+6. Show/copy/open the approved public URL in the landing-page review drawer.
+7. Keep the unauthenticated payload on a public allowlist and sanitize public
+   markdown rendering.
+
+### Files touched
+
+- `plans/PR-Public-Landing-Page-Renderer-V1.md`
+- `extracted_content_pipeline/landing_page_ports.py`
+- `extracted_content_pipeline/landing_page_postgres.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `atlas_brain/api/__init__.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/components/SeoHead.tsx`
+- `atlas-intel-ui/src/pages/PublicLandingPage.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/src/App.tsx`
+- `tests/test_extracted_landing_page_postgres.py`
+- `tests/test_extracted_landing_page_export.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+
+## Mechanism
+
+The backend adds `GET /content-assets/landing_page/public/{id}`. The route
+validates the id as a UUID, fetches only rows with `status = 'approved'`, and
+returns a dedicated public allowlist projection for renderer fields and
+`structured_data`. It does not return review/export metadata, tenant scope,
+reference ids, generation telemetry, reasoning fields, readiness fields, or
+raw status.
+
+The frontend adds the public route `/lp/:id/:slug`. It fetches by id without
+auth headers, redirects when the returned slug differs from the URL slug, and
+renders hero, sections, CTA, `SeoHead`, and JSON-LD. Section markdown disables
+raw HTML before parsing and removes unsafe attributes/URLs from rendered HTML.
+`SeoHead` gets optional robots meta support and the page uses `noindex,follow`.
+
+The review drawer shows the public URL for approved landing pages and lets
+operators open or copy it. Draft and rejected landing pages do not get an
+active public link because the backend route is approved-only.
+
+## Intentional
+
+- No sitemap or prerender entry in v1.
+- No slug-only lookup.
+- No account handles, custom domains, or tenant scoped public route.
+- No migration.
+- Draft, queued, rejected, expired, missing, and invalid ids all behave as
+  not found.
+
+## Deferred
+
+- `PR-Landing-Page-Indexable-Publish-Workflow` can add sitemap and index policy
+  once public pages are ready to be discoverable.
+
+## Verification
+
+- Focused backend tests for the public route, allowlist projection, repository
+  lookup, and export helpers - 54 passed.
+- Frontend lint in `atlas-intel-ui` - passed.
+- Frontend production build in `atlas-intel-ui` - passed.
+- Git whitespace check - passed.
+- Full extracted pipeline checks through `scripts/run_extracted_pipeline_checks.sh`
+  - 1644 passed.
+- Local PR review wrapper - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Backend public API | ~60 |
+| Frontend renderer and review URL UI | ~370 |
+| Tests | ~330 |
+| **Total** | **~835** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -34,6 +34,7 @@ def test_api_aggregator_mounts_generated_asset_routes() -> None:
     assert "/content-assets/{asset}/drafts" in paths
     assert "/content-assets/{asset}/drafts/export" in paths
     assert "/content-assets/{asset}/drafts/review" in paths
+    assert "/content-assets/landing_page/public/{landing_page_id}" in paths
 
 
 def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> None:
@@ -53,3 +54,21 @@ def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> 
     assert closure["pool_provider"].__name__ == "get_db_pool"
     assert closure["scope_provider"].__name__ == "build_content_ops_scope"
     assert "_capture_content_ops_auth_user" in dependency_names
+
+
+def test_public_landing_page_route_uses_pool_without_content_ops_auth_dependency() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-assets/landing_page/public/{landing_page_id}")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert "_capture_content_ops_auth_user" not in dependency_names

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from extracted_content_pipeline.api.generated_assets import (
     GeneratedAssetApiConfig,
     create_generated_asset_router,
+    create_public_landing_page_router,
 )
 import extracted_content_pipeline.api.generated_assets as asset_api
 from extracted_content_pipeline.campaign_ports import TenantScope
@@ -41,6 +42,18 @@ class _Pool:
     async def execute(self, query, *args):
         self.execute_calls.append((str(query), args))
         return self.execute_result
+
+
+class _PublicLandingPagePool(_Pool):
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        landing_page_id = args[0] if args else None
+        if "status = 'approved'" not in str(query):
+            return self.rows
+        return [
+            row for row in self.rows
+            if row.get("id") == landing_page_id and row.get("status") == "approved"
+        ]
 
 
 def _report_row():
@@ -186,6 +199,16 @@ def _client(
     return TestClient(app)
 
 
+def _public_client(pool) -> TestClient:
+    app = FastAPI()
+
+    async def pool_provider():
+        return pool
+
+    app.include_router(create_public_landing_page_router(pool_provider=pool_provider))
+    return TestClient(app)
+
+
 def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
     pool = _Pool(rows=[_report_row()])
 
@@ -276,6 +299,93 @@ def test_generated_asset_router_exports_landing_page_csv() -> None:
     query, args = pool.fetch_calls[0]
     assert "FROM landing_pages" in query
     assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+
+
+def test_generated_asset_router_returns_public_approved_landing_page() -> None:
+    row = {**_landing_page_row(), "status": "approved"}
+    row["id"] = "11111111-1111-1111-1111-111111111111"
+    row["meta"] = {
+        "title_tag": "Acme landing page",
+        "description": "A public approved landing page for Acme.",
+    }
+    row["reference_ids"] = ["internal-ref-1"]
+    row["metadata"] = {
+        "scope": {"account_id": "acct_1", "user_id": "user_1"},
+        "generation_usage": {"input_tokens": 10, "output_tokens": 5},
+        "reasoning_context": {"wedge": "support_gap", "confidence": 0.8},
+    }
+    pool = _Pool(rows=[row])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["slug"] == "acme-launch"
+    assert body["structured_data"]["@context"] == "https://schema.org"
+    assert set(body) == {
+        "id",
+        "slug",
+        "title",
+        "persona",
+        "value_prop",
+        "hero",
+        "sections",
+        "cta",
+        "meta",
+        "structured_data",
+    }
+    assert "status" not in body
+    assert "metadata" not in body
+    assert "reference_ids" not in body
+    assert "generation_input_tokens" not in body
+    assert "reasoning_context_used" not in body
+    assert "seo_aeo_readiness" not in body
+    query, args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in query
+    assert "status = 'approved'" in query
+    assert args == ("11111111-1111-1111-1111-111111111111",)
+
+
+def test_generated_asset_router_hides_non_public_landing_page() -> None:
+    pool = _Pool(rows=[])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page not found"
+    assert len(pool.fetch_calls) == 1
+
+
+def test_generated_asset_router_hides_non_approved_landing_page_row() -> None:
+    row = {**_landing_page_row(), "status": "draft"}
+    row["id"] = "11111111-1111-1111-1111-111111111111"
+    pool = _PublicLandingPagePool(rows=[row])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page not found"
+    assert len(pool.fetch_calls) == 1
+
+
+def test_generated_asset_router_rejects_invalid_public_landing_page_id() -> None:
+    pool = _Pool()
+
+    response = _public_client(pool).get("/content-assets/landing_page/public/not-a-uuid")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page not found"
+    assert pool.fetch_calls == []
 
 
 def test_generated_asset_router_exports_sales_brief_json_without_status_filter() -> None:
@@ -623,6 +733,34 @@ def test_generated_asset_router_honors_host_dependencies() -> None:
     assert pool.fetch_calls == []
 
 
+def test_public_landing_page_router_does_not_use_review_router_dependencies() -> None:
+    pool = _Pool(rows=[])
+
+    def require_auth():
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    app = FastAPI()
+
+    async def pool_provider():
+        return pool
+
+    app.include_router(
+        create_generated_asset_router(
+            pool_provider=pool_provider,
+            dependencies=[Depends(require_auth)],
+        )
+    )
+    app.include_router(create_public_landing_page_router(pool_provider=pool_provider))
+
+    response = TestClient(app).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 404
+    assert len(pool.fetch_calls) == 1
+
+
 def test_generated_asset_api_config_rejects_invalid_limits() -> None:
     with pytest.raises(ValueError, match="max_limit must be positive"):
         GeneratedAssetApiConfig(max_limit=0)
@@ -639,3 +777,6 @@ def test_generated_asset_router_requires_fastapi(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="FastAPI is required"):
         create_generated_asset_router(pool_provider=lambda: None)
+
+    with pytest.raises(RuntimeError, match="FastAPI is required"):
+        create_public_landing_page_router(pool_provider=lambda: None)

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -10,6 +10,7 @@ from extracted_content_pipeline.campaign_ports import (
 from extracted_content_pipeline.landing_page_export import (
     LandingPageDraftExportResult,
     export_landing_page_drafts,
+    public_landing_page_draft_row,
 )
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationConfig,
@@ -336,6 +337,35 @@ async def test_export_landing_page_drafts_derives_review_summary_fields() -> Non
     assert row["passed_output_checks"] == 3
     assert row["seo_aeo_readiness"]["status"] == "needs_review"
     assert row["geo_readiness"]["status"] == "needs_review"
+
+
+def test_public_landing_page_draft_row_uses_renderer_allowlist() -> None:
+    row = public_landing_page_draft_row(
+        _draft(metadata={
+            "scope": {"account_id": "acct_1", "user_id": "user_1"},
+            "generation_usage": {"input_tokens": 12, "output_tokens": 6},
+            "reasoning_context": {"wedge": "price_squeeze"},
+        })
+    )
+
+    assert set(row) == {
+        "id",
+        "slug",
+        "title",
+        "persona",
+        "value_prop",
+        "hero",
+        "sections",
+        "cta",
+        "meta",
+        "structured_data",
+    }
+    assert row["slug"] == "acme-q3-launch"
+    assert row["structured_data"]["@context"] == "https://schema.org"
+    assert "metadata" not in row
+    assert "reference_ids" not in row
+    assert "generation_input_tokens" not in row
+    assert "reasoning_context_used" not in row
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -38,6 +38,18 @@ class _Pool:
         return self.execute_result
 
 
+class _PublicLandingPagePool(_Pool):
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        landing_page_id = args[0] if args else None
+        if "status = 'approved'" not in str(query):
+            return self.fetch_rows
+        return [
+            row for row in self.fetch_rows
+            if row.get("id") == landing_page_id and row.get("status") == "approved"
+        ]
+
+
 def _draft() -> LandingPageDraft:
     return LandingPageDraft(
         campaign_name="acme-q3-launch",
@@ -231,6 +243,87 @@ async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
     assert drafts[0].meta == {"title_tag": "tt"}
     assert drafts[0].reference_ids == ("r1", "r2")
     assert drafts[0].metadata == {"key": "value"}
+
+
+@pytest.mark.asyncio
+async def test_get_public_approved_draft_filters_by_id_and_approved_status() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "approved",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero text"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "L"},
+            "meta": {"title_tag": "tt"},
+            "reference_ids": ["r1"],
+            "metadata": {"key": "value"},
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = await repo.get_public_approved_draft(
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert draft is not None
+    assert draft.id == "11111111-1111-1111-1111-111111111111"
+    assert draft.status == "approved"
+    assert draft.slug == "slug"
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "FROM landing_pages" in sql
+    assert "id = $1" in sql
+    assert "status = 'approved'" in sql
+    assert args == ("11111111-1111-1111-1111-111111111111",)
+
+
+@pytest.mark.asyncio
+async def test_get_public_approved_draft_returns_none_on_miss() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = await repo.get_public_approved_draft(
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert draft is None
+
+
+@pytest.mark.asyncio
+async def test_get_public_approved_draft_hides_non_approved_row() -> None:
+    pool = _PublicLandingPagePool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "draft",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero text"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "L"},
+            "meta": {"title_tag": "tt"},
+            "reference_ids": ["r1"],
+            "metadata": {"key": "value"},
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = await repo.get_public_approved_draft(
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert draft is None
+    sql = pool.fetch_calls[0]["query"]
+    assert "status = 'approved'" in sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add approved-only public landing-page lookup at `/content-assets/landing_page/public/{id}`
- mount the public route outside the Content Ops auth-gated generated-asset router
- return a dedicated public allowlist payload only: render fields plus structured data, with no tenant metadata, reference ids, status, telemetry, reasoning, or readiness fields
- render generated landing pages at `/lp/:id/:slug` with canonical slug replacement, sanitized markdown HTML, JSON-LD, and `noindex,follow`
- show/copy/open approved public landing-page URLs from the review drawer
- cover repository lookup, public allowlist behavior, public API behavior, host route wiring, and unauthenticated public access

Ownership lane: content-ops/public-landing-page-renderer-v1
Plan: plans/PR-Public-Landing-Page-Renderer-V1.md

## Verification
- Focused backend tests for public route/allowlist/repository/export helpers: 54 passed
- npm run lint in atlas-intel-ui: passed
- npm run build in atlas-intel-ui: passed
- bash scripts/run_extracted_pipeline_checks.sh: 1644 passed, 1 warning
- bash scripts/local_pr_review.sh origin/main: passed
