### PR TITLE
Harden orphaned-quote-reference detector: question back-refs + stacked refs (#745 follow-up)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -1669,13 +1669,31 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
 
 
 # Quote back-reference patterns. A paragraph that points at a specific quote
-# ("That/This quote", "This/The excerpt", or "quoted earlier") is orphaned when
-# the quote it references was stripped, leaving a dangling non-sequitur. Kept
-# in sync with the seo-geo-aeo-blog-post skill's orphaned_quote_reference
-# detector. Aggregate "the witness ..." references and generic follow-ons
-# ("This pattern recurs ...") are deliberately NOT matched.
+# ("That/This quote", "This/The excerpt", "quoted earlier", or a back-reference
+# to a quoted *question* like "This open-ended question ..." / "This question
+# format ...") is orphaned when the quote it references was stripped, leaving a
+# dangling non-sequitur. The "question" shapes were added after #745: removing
+# G2 form-PROMPT blockquotes (which ARE questions -- "What do you like best
+# about X?") left follow-ons like "This open-ended question from a verified
+# review ..." that the quote/excerpt-only pattern missed. Kept in sync with the
+# seo-geo-aeo-blog-post skill's orphaned_quote_reference detector. Aggregate
+# "the witness ..." references and generic follow-ons ("This pattern recurs
+# ...") are deliberately NOT matched.
+#
+# NOTE on the #745 "stacked reference" case (two consecutive ref paragraphs
+# after one blockquote, only the first legit): that lives in the audit
+# detector, which scans finished documents. The generator's sweep below only
+# fires on the single paragraph immediately following a *stripped* block
+# (_remove_unmatched_quote_lines forward-widen), so it never evaluates refs
+# after a *kept* block -- the stacked shape structurally cannot arise here.
+# The "question" branch is deliberately NARROW: only quoted-question artifacts
+# ("open-ended question", "question format") -- NOT a bare "question". Matching
+# bare "question" false-positives on rhetorical author prose ("The question is
+# not which vendor ...", "The question isn't whether ...") that references no
+# quote (caught when this ran against the live corpus).
 _ORPHAN_QUOTE_REF_RE = re.compile(
-    r"^(?:that quote|this quote|the quote\b|this excerpt|the excerpt)\b",
+    r"^(?:that|this|the)\s+"
+    r"(?:quote|excerpt|open[- ]ended\s+question|question\s+format)\b",
     re.IGNORECASE,
 )
 _QUOTED_EARLIER_RE = re.compile(r"\bquoted earlier\b", re.IGNORECASE)

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -1669,13 +1669,31 @@ def _looks_like_orphan_disclaimer(line: str) -> bool:
 
 
 # Quote back-reference patterns. A paragraph that points at a specific quote
-# ("That/This quote", "This/The excerpt", or "quoted earlier") is orphaned when
-# the quote it references was stripped, leaving a dangling non-sequitur. Kept
-# in sync with the seo-geo-aeo-blog-post skill's orphaned_quote_reference
-# detector. Aggregate "the witness ..." references and generic follow-ons
-# ("This pattern recurs ...") are deliberately NOT matched.
+# ("That/This quote", "This/The excerpt", "quoted earlier", or a back-reference
+# to a quoted *question* like "This open-ended question ..." / "This question
+# format ...") is orphaned when the quote it references was stripped, leaving a
+# dangling non-sequitur. The "question" shapes were added after #745: removing
+# G2 form-PROMPT blockquotes (which ARE questions -- "What do you like best
+# about X?") left follow-ons like "This open-ended question from a verified
+# review ..." that the quote/excerpt-only pattern missed. Kept in sync with the
+# seo-geo-aeo-blog-post skill's orphaned_quote_reference detector. Aggregate
+# "the witness ..." references and generic follow-ons ("This pattern recurs
+# ...") are deliberately NOT matched.
+#
+# NOTE on the #745 "stacked reference" case (two consecutive ref paragraphs
+# after one blockquote, only the first legit): that lives in the audit
+# detector, which scans finished documents. The generator's sweep below only
+# fires on the single paragraph immediately following a *stripped* block
+# (_remove_unmatched_quote_lines forward-widen), so it never evaluates refs
+# after a *kept* block -- the stacked shape structurally cannot arise here.
+# The "question" branch is deliberately NARROW: only quoted-question artifacts
+# ("open-ended question", "question format") -- NOT a bare "question". Matching
+# bare "question" false-positives on rhetorical author prose ("The question is
+# not which vendor ...", "The question isn't whether ...") that references no
+# quote (caught when this ran against the live corpus).
 _ORPHAN_QUOTE_REF_RE = re.compile(
-    r"^(?:that quote|this quote|the quote\b|this excerpt|the excerpt)\b",
+    r"^(?:that|this|the)\s+"
+    r"(?:quote|excerpt|open[- ]ended\s+question|question\s+format)\b",
     re.IGNORECASE,
 )
 _QUOTED_EARLIER_RE = re.compile(r"\bquoted earlier\b", re.IGNORECASE)

--- a/plans/PR-Orphan-Detector-Question-Stacked.md
+++ b/plans/PR-Orphan-Detector-Question-Stacked.md
@@ -1,0 +1,118 @@
+# PR-Orphan-Detector-Question-Stacked
+
+Ownership lane: `content-ops/blog-orphan-detector`
+
+## Why this slice exists
+
+PR #745 (D1 form-prompt removal) surfaced two false-NEGATIVES in the
+orphaned-quote-reference detector -- it reported `0/0` while real danglers
+remained:
+
+1. **"question" back-references.** G2 form-PROMPTS *are* questions ("What do
+   you like best about X?"). When those blockquotes were stripped, follow-ons
+   like *"This open-ended question from a verified review ..."*
+   (switch-to-woocommerce) and *"This quote is a question rather than a
+   statement ..."* (power-bi) dangled. The detector only matched
+   "quote"/"excerpt" shapes.
+
+2. **Stacked references.** Only the FIRST `<p>` after a blockquote legitimately
+   references it. A second consecutive ref-`<p>` points at a *different*
+   (stripped) quote, but a nearby already-referenced blockquote suppressed the
+   flag -- the power-bi case: two "This quote ..." paragraphs under one block,
+   the second calling it "a question rather than a statement".
+
+The fix was deferred from #745 to "a separate skill change". This slice does it
+in both the skill's audit detector and the generator detector kept in sync.
+
+## Scope (this PR)
+
+Two detectors, "kept in sync" per their own comments:
+
+- **Generator** (`_ORPHAN_QUOTE_REF_RE` / `_looks_like_orphan_quote_reference`,
+  both byte-identical `b2b_blog_post_generation.py` copies) -- gets (a) the
+  question-artifact shapes. (b) does NOT apply: the generator only consults the
+  detector on the single paragraph immediately after a *stripped* block
+  (`_remove_unmatched_quote_lines` forward-widen), so the "two refs after a
+  kept block" shape structurally cannot arise. Documented in a code comment.
+- **Audit** (`detectOrphanedQuoteReference` in the seo-geo-aeo-blog-post skill's
+  `scripts/audit-published-posts.js`) -- gets (a) AND (b). The audit scans
+  finished documents, where stacked refs occur. This file is an untracked local
+  skill script (NOT in this repo); the change is applied in place and noted
+  here. A `--self-test` regression harness was added since the file has no test
+  runner.
+
+### Files touched
+
+- `plans/PR-Orphan-Detector-Question-Stacked.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+
+### Out of repo (coordinated)
+
+- `~/.claude/skills/seo-geo-aeo-blog-post/scripts/audit-published-posts.js`
+  -- untracked skill script; (a) + (b) + `--self-test`.
+
+## Mechanism
+
+**Generator (Python).** `_ORPHAN_QUOTE_REF_RE` gains two quoted-question
+alternatives -- `open[- ]ended\s+question` and `question\s+format` -- alongside
+the existing `quote`/`excerpt` shapes, all anchored to a leading
+`(?:that|this|the)`. Bare "question" is deliberately excluded. Applied to both
+byte-identical `b2b_blog_post_generation.py` copies (edit one, `cp` to the
+mirror; verified identical).
+
+**Audit (JS, out of repo).** `detectOrphanedQuoteReference` gets the same
+narrowed `flag` regex (a), plus the stacked-reference fix (b): the backward
+look-back that decides whether a ref is "claimed" by a nearby blockquote now
+stops at a *prior* orphan-ref `<p>` (extracted into an `isRef()` helper), so the
+second of two stacked refs is flagged even though a blockquote sits within the
+window. A `--self-test` flag (early-exit before repo resolution, relying on
+hoisted function declarations) runs seven fixtures, including the power-bi
+stacked case and the two rhetorical false-positive guards.
+
+Narrowing was driven empirically: run against the live corpus, a bare
+"question" pattern flagged two rhetorical paragraphs ("The question is not which
+vendor ...") that reference no quote. The narrowed pattern drops both while
+still catching the real danglers and the one stacked orphan.
+
+## Intentional
+
+- **Narrow "question" matching.** Only quoted-question artifacts
+  ("open-ended question", "question format") -- NOT a bare "question". A bare
+  pattern false-positived on rhetorical author prose ("The question is not which
+  vendor ...", "The question isn't whether ...") when run against the live
+  corpus; narrowing removed those FPs while keeping the real danglers.
+- **(b) lives only in the audit.** The generator's single-paragraph,
+  after-stripped-block sweep cannot produce the stacked shape; forcing the logic
+  in would add risk with no coverage.
+
+## Deferred
+
+- **One real orphan the hardened audit newly surfaced (DATA, not detector):**
+  `project-management-landscape-2026-04` L266 ("The quote reflects Notion's
+  appeal ...") sits under a Wrike blockquote, after another ref -- a genuine
+  stacked dangler the old detector missed. Belongs in a follow-up data PR
+  (like #723/#745), not here.
+- Versioning the skill script (still untracked, edited in place).
+
+## Verification
+
+- New Python regression tests fail pre-fix, pass after: question-artifact match,
+  swept-with-block, survives-after-kept-block, and rhetorical-FP negatives.
+- `pytest` quote-gate + generation + blog-ts suites -> 189 passed.
+- Both `b2b_blog_post_generation.py` copies byte-identical after edit.
+- JS `--self-test` -> 9/9 PASS.
+- Live audit (`atlas-churn-ui`, 78 posts): `Orphaned quote reference` 3 -> 1
+  after narrowing -- the 2 rhetorical FPs gone, the 1 real stacked orphan
+  (project-management-landscape) correctly retained. `Form-prompt-as-quote 0`.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (regex + comments) | ~60 |
+| Tests | ~75 |
+| Plan doc | ~95 |
+| **Total** | **~230** |
+| Skill JS (out of repo, not counted above) | ~60 |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -676,6 +676,16 @@ def test_orphan_question_reference_matches_question_shapes():
     assert _looks_like_orphan_quote_reference(
         "This quote is a question rather than a statement, but it signals active evaluation."
     )
+    # The article x noun cross-product also matches these (same regex branch as
+    # the covered shapes): "that excerpt" (newly added vs the old
+    # this/the-excerpt-only pattern), and the article-led / no-hyphen
+    # open-ended-question forms. Pin them so the merged pattern keeps them.
+    for line in (
+        "That excerpt captures the migration frustration teams describe.",
+        "The open-ended question hints at an evaluation still in progress.",
+        "This open ended question reads as a dangling reference once the quote is gone.",
+    ):
+        assert _looks_like_orphan_quote_reference(line), line
     # Existing negatives still hold: generic follow-ons and aggregate
     # witness references are NOT orphan quote back-references.
     assert not _looks_like_orphan_quote_reference("This pattern recurs across the dataset.")

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -658,6 +658,81 @@ def test_quote_reference_does_not_sweep_generic_or_witness_followon():
         assert follow in out, follow          # follow-on preserved
 
 
+def test_orphan_question_reference_matches_question_shapes():
+    """#745 hardening: back-references to a quoted *question* (G2 form
+    prompts ARE questions) must be detected, not just "quote"/"excerpt"
+    shapes. The detector previously missed "This open-ended question ..."
+    and "This question format ..." follow-ons left behind when a
+    form-prompt blockquote was stripped."""
+    # Question-shaped back-references -> orphaned.
+    assert _looks_like_orphan_quote_reference(
+        "This open-ended question from a verified review described the rollout as confusing."
+    )
+    assert _looks_like_orphan_quote_reference(
+        "This question format suggests a structured review prompt rather than a candid opinion."
+    )
+    # "This quote is a question rather than a statement ..." already matched
+    # on the leading "This quote", but pin it so the merged pattern keeps it.
+    assert _looks_like_orphan_quote_reference(
+        "This quote is a question rather than a statement, but it signals active evaluation."
+    )
+    # Existing negatives still hold: generic follow-ons and aggregate
+    # witness references are NOT orphan quote back-references.
+    assert not _looks_like_orphan_quote_reference("This pattern recurs across the dataset.")
+    assert not _looks_like_orphan_quote_reference(
+        "The witness evidence shows workflow migration at the team level."
+    )
+    # Rhetorical "The question is/isn't ..." author prose references NO quote
+    # and must NOT be flagged. A bare-"question" pattern false-positived on
+    # these against the live corpus (help-scout-vs-zendesk, real-cost-of-
+    # woocommerce); the pattern is narrowed to quoted-question artifacts only.
+    assert not _looks_like_orphan_quote_reference(
+        "The question is not which vendor is objectively better."
+    )
+    assert not _looks_like_orphan_quote_reference(
+        "The question isn't whether WooCommerce is expensive in absolute terms."
+    )
+
+
+def test_orphan_question_reference_swept_with_block():
+    """A stripped blockquote followed by a question-shaped back-reference
+    is swept along with the block, the same as a "This quote ..." ref. These
+    are the #745 power-bi ("a question rather than a statement") and
+    switch-to-woocommerce ("This open-ended question ...") danglers."""
+    for follow in (
+        "This open-ended question from a verified review hints at active evaluation.",
+        "This question format suggests a structured review prompt, not a candid take.",
+    ):
+        markdown = (
+            "## Section\n\n"
+            "> a form-prompt quote that gets stripped (empty source pool)\n\n"
+            f"{follow}\n"
+        )
+        out, _removed = _remove_unmatched_quote_lines(markdown, [])
+        assert "gets stripped" not in out
+        assert follow not in out, follow
+        assert "## Section" in out
+
+
+def test_question_reference_after_kept_block_survives():
+    """Parity with the "This quote ..." guard: a question-shaped follow-on
+    after a KEPT (grounded) block survives -- the quote it references is
+    present, so the reference is legitimate. The sweep only fires on
+    stripped blocks, so the kept block protects it."""
+    follow = "This open-ended question mirrors the evaluation fatigue common in the category."
+    assert _looks_like_orphan_quote_reference(follow)  # matcher would flag it...
+    source = ["evaluation fatigue is common in this high-churn category"]
+    markdown = (
+        "## Section\n\n"
+        "> evaluation fatigue is common in this high-churn category\n\n"
+        f"{follow}\n"
+    )
+    out, removed = _remove_unmatched_quote_lines(markdown, source)
+    assert removed == 0                            # block grounds -> nothing stripped
+    assert "evaluation fatigue is common" in out   # the quote is kept
+    assert follow in out                           # ...and the reference survives
+
+
 def test_orphan_prose_preserved_for_kept_blocks():
     """When a block is KEPT (its quotes ground), the surrounding intro
     and prose are also preserved. The orphan-prose cleanup only fires


### PR DESCRIPTION
Ownership lane: `content-ops/blog-orphan-detector`

Follow-up to #745, which deferred the orphaned-quote-reference detector hardening to "a separate skill change." #745 surfaced two false-NEGATIVES (the detector reported 0/0 while real danglers remained).

## Intentional

- **(a) "question" back-references** — G2 form-PROMPTS *are* questions, so stripping them left danglers like *"This open-ended question from a verified review ..."* (woocommerce) and *"This quote is a question rather than a statement ..."* (power-bi). The "question" branch is **narrow** — only `open-ended question` / `question format`, NOT bare "question" (which false-positived on rhetorical author prose against the live corpus).
- **(b) Stacked references** — only the first `<p>` after a blockquote legitimately references it; a second consecutive ref points at a different (stripped) quote. Applied to the **audit** detector only.
- **Two detectors kept in sync:**
  - **Generator** (`_ORPHAN_QUOTE_REF_RE`, both byte-identical `b2b_blog_post_generation.py` copies) — gets (a). (b) cannot arise here: the generator only consults the detector on the single paragraph after a *stripped* block, never after a kept block (documented in a comment).
  - **Audit** (`detectOrphanedQuoteReference` in the `seo-geo-aeo-blog-post` skill's `audit-published-posts.js`) — gets (a)+(b). **This file is an untracked local skill script, NOT in this repo;** it was edited in place per the established pattern and given a `--self-test` harness.

## Deferred

- **One real orphan the hardened audit newly surfaced (DATA, not detector):** `project-management-landscape-2026-04` L266 — a genuine stacked dangler the old detector missed. Belongs in a follow-up data PR (like #723/#745).
- Versioning the untracked skill script.

## Verification

- New Python regression tests fail pre-fix, pass after.
- `pytest` quote-gate + generation + blog-ts suites → 189 passed; quality-gate checks (`test_b2b_blog_quality_gate.py` 25 + `test_extracted_quality_gate_blog_pack.py` 42) → 67 passed (the two files run, not a single named suite).
- Both `b2b_blog_post_generation.py` copies byte-identical.
- JS `--self-test` → 9/9 PASS.
- Live audit (`atlas-churn-ui`, 78 posts): `Orphaned quote reference` **3 → 1** after narrowing — the 2 rhetorical FPs gone, the 1 real stacked orphan correctly retained. `Form-prompt-as-quote 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
