### PR TITLE
PR-Content-Ops-FAQ-Custom-Vocabulary-Rules

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -279,6 +279,7 @@ class TicketFAQMarkdownConfig:
     support_contact: str | None = None
     intent_rules: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_INTENT_RULES
     documentation_terms: tuple[str, ...] = ()
+    vocabulary_gap_rules: tuple[tuple[str, ...], ...] = ()
 
 
 class TicketFAQMarkdownService:
@@ -309,6 +310,7 @@ class TicketFAQMarkdownService:
         support_contact: str | None = None,
         intent_rules: Sequence[tuple[str, Sequence[str]]] | None = None,
         documentation_terms: Sequence[str] | None = None,
+        vocabulary_gap_rules: Sequence[Sequence[str]] | None = None,
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
@@ -356,6 +358,11 @@ class TicketFAQMarkdownService:
             if documentation_terms is not None
             else self.config.documentation_terms
         )
+        resolved_vocabulary_gap_rules = (
+            vocabulary_gap_rules
+            if vocabulary_gap_rules is not None
+            else self.config.vocabulary_gap_rules
+        )
         title_text = title or self.config.title
         result = build_ticket_faq_markdown(
             normalized.opportunities,
@@ -368,6 +375,7 @@ class TicketFAQMarkdownService:
             support_contact=resolved_support_contact,
             intent_rules=resolved_intent_rules,
             documentation_terms=resolved_documentation_terms,
+            vocabulary_gap_rules=resolved_vocabulary_gap_rules,
         )
         result = replace(
             result,
@@ -395,6 +403,7 @@ class TicketFAQMarkdownService:
                             as_of_date=resolved_as_of_date,
                         ),
                         **_documentation_term_metadata(resolved_documentation_terms),
+                        **_vocabulary_gap_rule_metadata(resolved_vocabulary_gap_rules),
                     },
                 )
             ],
@@ -415,6 +424,7 @@ def build_ticket_faq_markdown(
     support_contact: str | None = None,
     intent_rules: Sequence[tuple[str, Sequence[str]]] = DEFAULT_INTENT_RULES,
     documentation_terms: Sequence[str] = (),
+    vocabulary_gap_rules: Sequence[Sequence[str]] = (),
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
@@ -426,6 +436,7 @@ def build_ticket_faq_markdown(
     allowed = {_source_type_key(item) for item in source_types if _source_type_key(item)}
     date_window = _date_window(window_days=window_days, as_of_date=as_of_date)
     resolved_documentation_terms = _documentation_terms(opportunities, documentation_terms)
+    resolved_vocabulary_gap_rules = _vocabulary_gap_rules(vocabulary_gap_rules)
     groups: dict[str, list[dict[str, str]]] = defaultdict(list)
     seen: set[tuple[str, str]] = set()
     source_keys: set[str] = set()
@@ -492,6 +503,7 @@ def build_ticket_faq_markdown(
             max_evidence_per_item=max_evidence_per_item,
             support_contact=support_contact,
             documentation_terms=resolved_documentation_terms,
+            vocabulary_gap_rules=resolved_vocabulary_gap_rules,
         )
         for topic, rows in selected_groups
     )
@@ -604,6 +616,7 @@ def _item(
     max_evidence_per_item: int,
     support_contact: str | None,
     documentation_terms: Sequence[str],
+    vocabulary_gap_rules: Sequence[Sequence[str]],
 ) -> dict[str, Any]:
     display_rows = rows[:max_evidence_per_item]
     sources = tuple(_source_label(row) for row in display_rows)
@@ -620,7 +633,7 @@ def _item(
     escalation = _escalation_guidance(topic, action_context, support_contact=support_contact)
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     opportunity = _opportunity_score(topic, rows)
-    term_mappings = _term_mappings(rows, documentation_terms)
+    term_mappings = _term_mappings(rows, documentation_terms, vocabulary_gap_rules)
     return {
         "topic": topic,
         "question": question,
@@ -684,6 +697,7 @@ def _source_weight(*rows: Mapping[str, Any]) -> int:
 def _term_mappings(
     rows: Sequence[Mapping[str, str]],
     documentation_terms: Sequence[str],
+    vocabulary_gap_rules: Sequence[Sequence[str]],
 ) -> tuple[dict[str, Any], ...]:
     doc_terms = _clean_terms(documentation_terms)
     if not rows or not doc_terms:
@@ -700,7 +714,7 @@ def _term_mappings(
     zero_result_source_count = _zero_result_source_count(rows)
     mappings: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
-    for aliases in _VOCABULARY_GAP_RULES:
+    for aliases in vocabulary_gap_rules:
         for customer_term in aliases:
             if not _keyword_matches(customer_text, customer_term):
                 continue
@@ -735,6 +749,26 @@ def _term_mappings(
         if len(mappings) >= 3:
             break
     return tuple(mappings)
+
+
+def _vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
+    return (*_custom_vocabulary_gap_rules(custom_rules), *_VOCABULARY_GAP_RULES)
+
+
+def _custom_vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
+    rules: list[tuple[str, ...]] = []
+    for aliases in custom_rules:
+        if isinstance(aliases, (str, bytes, bytearray)):
+            raise ValueError(
+                "vocabulary_gap_rules entries must include at least two terms"
+            )
+        cleaned = _clean_terms(aliases)
+        if len(cleaned) < 2:
+            raise ValueError(
+                "vocabulary_gap_rules entries must include at least two terms"
+            )
+        rules.append(cleaned)
+    return tuple(rules)
 
 
 def _zero_result_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
@@ -1368,6 +1402,13 @@ def _documentation_term_metadata(documentation_terms: Sequence[str]) -> dict[str
     if not terms:
         return {}
     return {"documentation_terms": list(terms)}
+
+
+def _vocabulary_gap_rule_metadata(rules: Sequence[Sequence[str]]) -> dict[str, Any]:
+    cleaned = _custom_vocabulary_gap_rules(rules)
+    if not cleaned:
+        return {}
+    return {"vocabulary_gap_rules": [list(rule) for rule in cleaned]}
 
 
 def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:

--- a/plans/PR-Content-Ops-FAQ-Custom-Vocabulary-Rules.md
+++ b/plans/PR-Content-Ops-FAQ-Custom-Vocabulary-Rules.md
@@ -1,0 +1,89 @@
+# PR-Content-Ops-FAQ-Custom-Vocabulary-Rules
+
+## Why this slice exists
+
+Vocabulary-gap detection can now rank mismatches between customer wording and
+documentation wording, but the alias rules are still limited to the generator's
+built-in generic SaaS and support terms. SMB and mid-market teams need to bring
+their own glossary terms, acronyms, product names, and synonym sets before the
+FAQ wedge feels production-ready for their actual support language.
+
+This slice adds a small custom vocabulary-rule input path while preserving the
+current default behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add configurable vocabulary-gap alias groups to the FAQ builder and service.
+2. Keep the built-in vocabulary-gap rules active, then append caller-provided
+   rules for product-specific glossary terms.
+3. Add a repeatable CLI flag for custom vocabulary-gap rules.
+4. Include the configured custom rules in compact CLI result diagnostics.
+5. Add focused tests for builder, service, CLI diagnostics, and CLI validation.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Custom-Vocabulary-Rules.md` | Plan doc for this custom vocabulary-rule slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Threads custom vocabulary-gap rules through builder/service and mapping detection. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds CLI parsing and result config output for custom vocabulary-gap rules. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers custom rule generation, service config, CLI diagnostics, and invalid rule input. |
+
+## Mechanism
+
+The builder accepts `vocabulary_gap_rules` as a sequence of alias groups, where
+each group must contain at least two cleaned aliases. The generator prepends
+custom groups before the built-in defaults so team glossary terms win the
+three-mapping display cap. Vocabulary-gap mapping then walks the resolved rules
+exactly as before: it looks for customer terms in source text, skips terms
+already present in documentation headings, and suggests the matching
+documentation term from the same alias group.
+
+The CLI exposes this as repeated `--vocabulary-gap-rule` values using a
+comma-separated alias group such as `SSO,single sign-on`. Invalid one-term rules
+and case-only duplicates fail before generation so a malformed glossary cannot
+silently produce a green empty diagnostic or leak a traceback.
+
+## Intentional
+
+- Custom rules are evaluated before defaults so customer glossary terms are not
+  starved by generic default mappings under the display cap.
+- Built-in defaults remain active after custom rules so existing callers keep
+  today's vocabulary-gap behavior when they do not pass custom rules.
+- Rule parsing is deterministic and local; this does not introduce an LLM,
+  runtime dependency, or external glossary fetch.
+- Result JSON records only configured custom rules, not the built-in defaults,
+  to keep diagnostics compact.
+
+## Deferred
+
+- A later hosted upload slice can expose custom glossary entry fields in the
+  Content Ops Station UI.
+- A later glossary import slice can support JSON or CSV rule files if repeated
+  CLI flags become too awkward for larger teams.
+- A later audit slice can add broader cross-generator glossary contract checks
+  if other content generators adopt the same rule shape.
+
+## Verification
+
+- Focused custom vocabulary-rule pytest for builder, service, validation, and
+  CLI behavior - passed, 9 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed,
+  83 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Generator, CLI, and tests | ~285 |
+| **Total** | ~370 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -90,6 +90,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--vocabulary-gap-rule",
+        action="append",
+        default=[],
+        help=(
+            "Comma-separated customer/documentation aliases used for "
+            "vocabulary-gap suggestions. Repeat to provide multiple rules."
+        ),
+    )
+    parser.add_argument(
         "--require-output-checks",
         action="store_true",
         help="Fail when generated FAQ output checks are not all true.",
@@ -114,6 +123,8 @@ def main(argv: list[str] | None = None) -> int:
             date.fromisoformat(args.as_of_date)
         except ValueError:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
+    vocabulary_gap_rules = _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
+    args.vocabulary_gap_rules = vocabulary_gap_rules
 
     loaded = load_source_campaign_opportunities_from_file(
         args.path,
@@ -130,6 +141,7 @@ def main(argv: list[str] | None = None) -> int:
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
         documentation_terms=args.documentation_term,
+        vocabulary_gap_rules=vocabulary_gap_rules,
     )
     failed_checks = _failed_output_checks(result.output_checks)
     if args.result_output:
@@ -186,6 +198,9 @@ def _result_payload(
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
             "documentation_terms": list(args.documentation_term),
+            "vocabulary_gap_rules": [
+                list(rule) for rule in args.vocabulary_gap_rules
+            ],
         },
         "source_count": result.source_count,
         "ticket_source_count": result.ticket_source_count,
@@ -206,6 +221,31 @@ def _result_payload(
             "items": [_item_summary(index, item) for index, item in enumerate(items, start=1)],
         },
     }
+
+
+def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
+    rules: list[tuple[str, ...]] = []
+    for value in values:
+        terms = _parse_vocabulary_gap_rule_terms(value)
+        if len(terms) < 2:
+            raise SystemExit(
+                "--vocabulary-gap-rule must include at least two comma-separated terms"
+            )
+        rules.append(terms)
+    return tuple(rules)
+
+
+def _parse_vocabulary_gap_rule_terms(value: str) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for part in value.split(","):
+        term = part.strip()
+        key = term.lower()
+        if not term or key in seen:
+            continue
+        seen.add(key)
+        terms.append(term)
+    return tuple(terms)
 
 
 def _output_check_details(

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -543,6 +543,93 @@ def test_build_ticket_faq_markdown_adds_vocabulary_gap_from_documentation_terms(
     assert "(Seen in 1 source(s); mapping score 1.)" in result.markdown
 
 
+def test_build_ticket_faq_markdown_accepts_custom_vocabulary_gap_rules() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "SSO access",
+            "evidence": [{
+                "text": "How do I configure SSO for my team?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        }],
+        documentation_terms=("Single sign-on setup",),
+        vocabulary_gap_rules=(("SSO", "single sign-on"),),
+    )
+
+    assert result.items[0]["term_mappings"] == (
+        {
+            "customer_term": "SSO",
+            "documentation_term": "Single sign-on setup",
+            "suggestion": (
+                'Add "SSO" as alternate phrasing for "Single sign-on setup" '
+                "in FAQ headings and answer text."
+            ),
+            "source_id_count": 1,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": (),
+            "opportunity_score": 1,
+            "first_source_id": "ticket-1",
+        },
+    )
+    assert 'Customers say "SSO"; documentation says "Single sign-on setup".' in result.markdown
+
+
+def test_build_ticket_faq_markdown_prioritizes_custom_vocabulary_gap_rules() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export dashboard bill SSO",
+            "evidence": [{
+                "text": "How do I export dashboard bill data after SSO setup?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        }],
+        documentation_terms=(
+            "Download report",
+            "Analytics",
+            "Invoice settings",
+            "Single sign-on setup",
+        ),
+        vocabulary_gap_rules=(("SSO", "single sign-on"),),
+    )
+
+    mappings = result.items[0]["term_mappings"]
+    assert len(mappings) == 3
+    assert mappings[0]["customer_term"] == "SSO"
+    assert mappings[0]["documentation_term"] == "Single sign-on setup"
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        ("SSO",),
+        (("SSO",),),
+        (("Export", "export"),),
+    ],
+)
+def test_build_ticket_faq_markdown_rejects_invalid_custom_vocabulary_gap_rules(
+    rules: object,
+) -> None:
+    with pytest.raises(ValueError, match="vocabulary_gap_rules entries"):
+        build_ticket_faq_markdown(
+            [{
+                "source_type": "support_ticket",
+                "source_title": "SSO access",
+                "evidence": [{
+                    "text": "How do I configure SSO for my team?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            }],
+            documentation_terms=("Single sign-on setup",),
+            vocabulary_gap_rules=rules,  # type: ignore[arg-type]
+        )
+
+
 def test_build_ticket_faq_markdown_uses_document_rows_for_vocabulary_gap_only() -> None:
     result = build_ticket_faq_markdown([
         {
@@ -1579,6 +1666,38 @@ async def test_ticket_faq_service_accepts_documentation_terms() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ticket_faq_service_accepts_custom_vocabulary_gap_rules() -> None:
+    repository = _FAQRepository()
+    service = TicketFAQMarkdownService(
+        TicketFAQMarkdownConfig(
+            documentation_terms=("Single sign-on setup",),
+            vocabulary_gap_rules=(("SSO", "single sign-on"),),
+        ),
+        ticket_faqs=repository,
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "message": "How do I enable SSO for my team?",
+                    "pain_category": "authentication",
+                }
+            ]
+        },
+    )
+
+    assert result.items[0]["term_mappings"][0]["customer_term"] == "SSO"
+    assert result.items[0]["term_mappings"][0]["documentation_term"] == "Single sign-on setup"
+    assert repository.saved[0]["drafts"][0].metadata["vocabulary_gap_rules"] == [
+        ["SSO", "single sign-on"]
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ticket_faq_service_saves_generated_markdown_when_repository_configured() -> None:
     repository = _FAQRepository()
     service = TicketFAQMarkdownService(ticket_faqs=repository)
@@ -2176,6 +2295,73 @@ def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path)
         "first_source_id": "ticket-1",
     }]
     assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
+
+
+def test_ticket_faq_cli_accepts_custom_vocabulary_gap_rule(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,SSO setup,How do I enable SSO for my team?,authentication",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Single sign-on setup",
+        "--vocabulary-gap-rule",
+        "SSO,single sign-on",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["vocabulary_gap_rules"] == [["SSO", "single sign-on"]]
+    assert result["diagnostics"]["term_mapping_count"] == 1
+    assert result["diagnostics"]["term_mappings"][0]["customer_term"] == "SSO"
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Single sign-on setup"
+    )
+
+
+def test_ticket_faq_cli_rejects_single_term_vocabulary_gap_rule(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,SSO setup,How do I enable SSO for my team?,authentication",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--vocabulary-gap-rule",
+        "SSO",
+    )
+
+    assert completed.returncode == 1
+    assert (
+        "--vocabulary-gap-rule must include at least two comma-separated terms"
+        in completed.stderr
+    )
+
+
+def test_ticket_faq_cli_rejects_case_duplicate_vocabulary_gap_rule(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Export setup,How do I export data?,exports",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--vocabulary-gap-rule",
+        "Export,export",
+    )
+
+    assert completed.returncode == 1
+    assert (
+        "--vocabulary-gap-rule must include at least two comma-separated terms"
+        in completed.stderr
+    )
+    assert "Traceback" not in completed.stderr
 
 
 def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Custom-Vocabulary-Rules.md

Adds configurable vocabulary-gap alias groups to the FAQ generator so teams can provide their own glossary, acronyms, and product-specific synonym sets while preserving built-in coverage.

## Intentional
- Custom rules are evaluated before defaults so customer glossary terms are not starved by generic default mappings under the display cap.
- Built-in defaults remain active after custom rules so existing callers keep today's vocabulary-gap behavior when they do not pass custom rules.
- Rule parsing is deterministic and local; this does not introduce an LLM, runtime dependency, or external glossary fetch.
- Result JSON records only configured custom rules, not the built-in defaults, to keep diagnostics compact.

## Deferred
- Hosted upload UI fields for custom glossary terms.
- JSON or CSV glossary-rule imports for larger rule sets.
- Cross-generator glossary contract checks if other content generators adopt this rule shape.

## Verification
- Focused custom vocabulary-rule pytest for builder, service, validation, and CLI behavior - passed, 9 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 88 tests.
- Py compile for affected Python files - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Git whitespace check - passed.
- Local PR review against origin/main - passed.

## Diff size
4 files, +358 / -2