### PR TITLE
Add landing page index policy

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -340,6 +340,7 @@ export interface GeneratedAssetDraft {
   seo_aeo_readiness?: GeneratedAssetReadiness | string
   geo_readiness?: GeneratedAssetReadiness | string
   structured_data?: Record<string, unknown> | string
+  robots?: string
   persona?: string
   value_prop?: string
   [key: string]: unknown

--- a/atlas-intel-ui/src/pages/PublicLandingPage.tsx
+++ b/atlas-intel-ui/src/pages/PublicLandingPage.tsx
@@ -114,6 +114,7 @@ export default function PublicLandingPage() {
   const jsonLd = structuredDataWithCanonical(page.structured_data, canonical)
   const ctaLabel = textValue(cta?.label) || textValue(hero?.cta_label)
   const ctaUrl = textValue(cta?.url) || textValue(hero?.cta_url)
+  const robots = textValue(page.robots) || 'noindex,follow'
 
   return (
     <>
@@ -123,7 +124,7 @@ export default function PublicLandingPage() {
         canonical={canonical}
         ogType="website"
         jsonLd={jsonLd}
-        robots="noindex,follow"
+        robots={robots}
       />
       <PublicLayout>
         <article>

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -154,8 +154,21 @@ def public_landing_page_draft_row(draft: LandingPageDraft) -> JsonDict:
         "sections": list(draft.sections),
         "cta": draft.cta,
         "meta": draft.meta,
+        "robots": public_landing_page_robots(draft),
         "structured_data": build_landing_page_structured_data(draft),
     }
+
+
+def public_landing_page_robots(draft: LandingPageDraft) -> str:
+    """Return the public robots policy for a generated landing-page draft."""
+
+    if draft.status != "approved":
+        return "noindex,follow"
+    if _seo_aeo_readiness(draft).get("status") != "ready":
+        return "noindex,follow"
+    if _geo_readiness(draft).get("status") != "ready":
+        return "noindex,follow"
+    return "index,follow"
 
 
 def _metadata_summary(value: Any) -> JsonDict:
@@ -576,4 +589,5 @@ __all__ = [
     "export_landing_page_drafts",
     "landing_page_draft_export_row",
     "public_landing_page_draft_row",
+    "public_landing_page_robots",
 ]

--- a/plans/PR-Landing-Page-Index-Policy.md
+++ b/plans/PR-Landing-Page-Index-Policy.md
@@ -1,0 +1,73 @@
+# PR-Landing-Page-Index-Policy
+
+## Why this slice exists
+
+Approved generated landing pages can now render publicly, but the first public
+renderer intentionally marks every page `noindex,follow`. This slice makes the
+indexing decision backend-owned so search discoverability can be enabled only
+when the approved page passes the existing landing-page SEO/AEO and GEO gates.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-index-policy
+
+1. Add a public landing-page robots policy helper.
+2. Keep the default public policy as `noindex,follow`.
+3. Return `index,follow` only for approved landing pages whose SEO/AEO and GEO
+   readiness summaries are both ready.
+4. Include only the robots policy in the public payload, not the underlying
+   readiness details.
+5. Wire the public renderer to use the backend-provided robots policy.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Index-Policy.md`
+- `extracted_content_pipeline/landing_page_export.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/PublicLandingPage.tsx`
+- `tests/test_extracted_landing_page_export.py`
+- `tests/test_extracted_content_asset_api.py`
+
+## Mechanism
+
+The public payload gets a `robots` field from the backend allowlist projection.
+The helper evaluates the already-existing `_seo_aeo_readiness` and
+`_geo_readiness` summaries and returns `index,follow` only when both are ready
+and the draft status is approved. All other public pages remain
+`noindex,follow`.
+
+The frontend does not calculate readiness. It reads `robots` from the public
+API response and falls back to `noindex,follow` if the field is missing.
+
+## Intentional
+
+- No sitemap or prerender inclusion in this slice.
+- No public exposure of readiness summaries, checks, reference ids, metadata,
+  tenant scope, generation telemetry, or reasoning fields.
+- No change to draft/rejected/expired visibility; those still 404 at the
+  public route.
+
+## Deferred
+
+- `PR-Landing-Page-Public-Sitemap` can add sitemap/prerender behavior after the
+  indexing policy is merged and reviewed.
+
+## Verification
+
+- Focused backend tests for landing-page export and public asset API - 45 passed.
+- Frontend lint in `atlas-intel-ui` - passed.
+- Frontend production build in `atlas-intel-ui` - passed.
+- Git whitespace check - passed.
+- Full extracted pipeline checks through `scripts/run_extracted_pipeline_checks.sh`
+  - 1651 passed.
+- Local PR review wrapper - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Backend policy | ~25 |
+| Frontend wiring | ~5 |
+| Tests | ~110 |
+| **Total** | **~200** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -138,6 +138,95 @@ def _landing_page_row():
     }
 
 
+def _ready_landing_page_row():
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "approved",
+        "campaign_name": "acme-support-retention",
+        "persona": "VP Engineering",
+        "value_prop": "Catch pressure early",
+        "title": "Acme support retention page",
+        "slug": "acme-support-retention",
+        "hero": {
+            "headline": "Catch support pressure before renewal risk builds",
+            "subheadline": (
+                "A landing page for VP Engineering teams that turns repeat "
+                "support signals into clearer answers before customers drift."
+            ),
+            "cta_label": "Book a demo",
+            "cta_url": "/demo",
+        },
+        "sections": [
+            {
+                "id": "problem",
+                "title": "Support problems that keep coming back",
+                "body_markdown": (
+                    "VP Engineering teams catch pressure early when repeated "
+                    "support issues are turned into visible answers before "
+                    "renewal risk builds. Support problems keep coming back "
+                    "when teams cannot see where customers get stuck."
+                ),
+                "metadata": {
+                    "kind": "problem",
+                    "primary_question": "Why do support problems become renewal risk?",
+                    "answer_summary": (
+                        "VP Engineering teams catch pressure early when repeated "
+                        "support issues are turned into visible answers before "
+                        "renewal risk builds."
+                    ),
+                },
+            },
+            {
+                "id": "solution",
+                "title": "A workflow for catching pressure early",
+                "body_markdown": (
+                    "The solution helps VP Engineering teams catch pressure early "
+                    "by turning repeated support signals into a clear page and "
+                    "follow-up workflow."
+                ),
+                "metadata": {
+                    "kind": "solution",
+                    "primary_question": "How does the workflow catch pressure early?",
+                    "answer_summary": (
+                        "The solution helps VP Engineering teams catch pressure "
+                        "early by turning repeated support signals into a clear "
+                        "page and follow-up workflow."
+                    ),
+                },
+            },
+            {
+                "id": "buyer_questions",
+                "title": "Questions buyers ask before rollout",
+                "body_markdown": (
+                    "VP Engineering buyers can answer implementation, pricing, "
+                    "and security questions before they have to email the team. "
+                    "This keeps the conversion path clear during rollout review."
+                ),
+                "metadata": {
+                    "kind": "objection",
+                    "primary_question": "What should buyers know before rollout?",
+                    "answer_summary": (
+                        "VP Engineering buyers can answer implementation, "
+                        "pricing, and security questions before they have to "
+                        "email the team."
+                    ),
+                },
+            },
+        ],
+        "cta": {"label": "Book a demo", "url": "/demo"},
+        "meta": {
+            "title_tag": "Acme Support Retention for VP Engineering",
+            "description": (
+                "See how VP Engineering teams catch support pressure early and "
+                "turn repeated customer questions into clearer retention pages."
+            ),
+            "og_title": "Acme Support Retention",
+        },
+        "reference_ids": ["r1"],
+        "metadata": {},
+    }
+
+
 def _sales_brief_row():
     return {
         "id": "brief-uuid-1",
@@ -336,8 +425,10 @@ def test_generated_asset_router_returns_public_approved_landing_page() -> None:
         "sections",
         "cta",
         "meta",
+        "robots",
         "structured_data",
     }
+    assert body["robots"] == "noindex,follow"
     assert "status" not in body
     assert "metadata" not in body
     assert "reference_ids" not in body
@@ -348,6 +439,21 @@ def test_generated_asset_router_returns_public_approved_landing_page() -> None:
     assert "FROM landing_pages" in query
     assert "status = 'approved'" in query
     assert args == ("11111111-1111-1111-1111-111111111111",)
+
+
+def test_generated_asset_router_indexes_public_ready_landing_page() -> None:
+    pool = _Pool(rows=[_ready_landing_page_row()])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["robots"] == "index,follow"
+    assert "seo_aeo_readiness" not in body
+    assert "geo_readiness" not in body
 
 
 def test_generated_asset_router_hides_non_public_landing_page() -> None:

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline.landing_page_export import (
     LandingPageDraftExportResult,
     export_landing_page_drafts,
     public_landing_page_draft_row,
+    public_landing_page_robots,
 )
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationConfig,
@@ -158,6 +159,8 @@ def _draft(**overrides) -> LandingPageDraft:
         meta=overrides.get("meta", draft.meta),
         reference_ids=overrides.get("reference_ids", draft.reference_ids),
         metadata=overrides.get("metadata", draft.metadata),
+        id=overrides.get("id", draft.id),
+        status=overrides.get("status", draft.status),
     )
 
 
@@ -268,6 +271,8 @@ def _ready_draft(**overrides) -> LandingPageDraft:
         meta=overrides.get("meta", draft.meta),
         reference_ids=overrides.get("reference_ids", draft.reference_ids),
         metadata=overrides.get("metadata", draft.metadata),
+        id=overrides.get("id", draft.id),
+        status=overrides.get("status", draft.status),
     )
 
 
@@ -358,14 +363,36 @@ def test_public_landing_page_draft_row_uses_renderer_allowlist() -> None:
         "sections",
         "cta",
         "meta",
+        "robots",
         "structured_data",
     }
     assert row["slug"] == "acme-q3-launch"
+    assert row["robots"] == "noindex,follow"
     assert row["structured_data"]["@context"] == "https://schema.org"
     assert "metadata" not in row
     assert "reference_ids" not in row
     assert "generation_input_tokens" not in row
     assert "reasoning_context_used" not in row
+    assert "seo_aeo_readiness" not in row
+    assert "geo_readiness" not in row
+
+
+def test_public_landing_page_robots_indexes_only_approved_ready_pages() -> None:
+    assert public_landing_page_robots(
+        _ready_draft(status="approved")
+    ) == "index,follow"
+
+
+def test_public_landing_page_robots_keeps_non_approved_pages_noindex() -> None:
+    assert public_landing_page_robots(
+        _ready_draft(status="draft")
+    ) == "noindex,follow"
+
+
+def test_public_landing_page_robots_keeps_incomplete_pages_noindex() -> None:
+    assert public_landing_page_robots(
+        _draft(status="approved")
+    ) == "noindex,follow"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add backend-owned public robots policy for generated landing pages
- keep public pages `noindex,follow` by default
- return `index,follow` only for approved pages whose SEO/AEO and GEO readiness summaries are ready
- include only `robots` in the public payload, without exposing readiness details
- wire the public renderer to use the backend-provided robots policy with a noindex fallback

Ownership lane: content-ops/landing-page-index-policy
Plan: plans/PR-Landing-Page-Index-Policy.md

## Verification
- pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q: 45 passed
- npm run lint in atlas-intel-ui: passed
- npm run build in atlas-intel-ui: passed
- bash scripts/run_extracted_pipeline_checks.sh: 1651 passed, 1 warning
- bash scripts/local_pr_review.sh origin/main: passed
