### PR TITLE
Scope _fetch_vendor_stats total to the source allowlist (D7, deep-dive slice)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -9699,6 +9699,14 @@ async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
     """Return review counts and urgency for a single vendor."""
     # APPROVED-ENRICHMENT-READ: urgency_score
     # Reason: inline aggregate query, structurally coupled to product output
+    #
+    # D7: scope the headline `total` to the SAME source allowlist as the
+    # enriched/churn stats (the ctx queries in _build_blog_topic_context all use
+    # `source = ANY(_blog_source_allowlist())`). Without it, `total` counted ALL
+    # sources (Capterra/Trustpilot/etc.) while `enriched` is effectively
+    # allowlist-only, so "N reviews collected / M enriched" did not share a
+    # denominator -- e.g. Zoho CRM read 1043 all-source vs 441 allowlist.
+    sources = _blog_source_allowlist()
     row = await pool.fetchrow(
         """
         SELECT
@@ -9714,8 +9722,10 @@ async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
         JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
         WHERE LOWER(vm.vendor_name) = LOWER($1)
           AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($2)
         """,
         vendor_name,
+        sources,
     )
     if not row or row["total"] == 0:
         return {}

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -9699,6 +9699,14 @@ async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
     """Return review counts and urgency for a single vendor."""
     # APPROVED-ENRICHMENT-READ: urgency_score
     # Reason: inline aggregate query, structurally coupled to product output
+    #
+    # D7: scope the headline `total` to the SAME source allowlist as the
+    # enriched/churn stats (the ctx queries in _build_blog_topic_context all use
+    # `source = ANY(_blog_source_allowlist())`). Without it, `total` counted ALL
+    # sources (Capterra/Trustpilot/etc.) while `enriched` is effectively
+    # allowlist-only, so "N reviews collected / M enriched" did not share a
+    # denominator -- e.g. Zoho CRM read 1043 all-source vs 441 allowlist.
+    sources = _blog_source_allowlist()
     row = await pool.fetchrow(
         """
         SELECT
@@ -9714,8 +9722,10 @@ async def _fetch_vendor_stats(pool, vendor_name: str) -> dict[str, Any]:
         JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
         WHERE LOWER(vm.vendor_name) = LOWER($1)
           AND r.duplicate_of_review_id IS NULL
+          AND r.source = ANY($2)
         """,
         vendor_name,
+        sources,
     )
     if not row or row["total"] == 0:
         return {}

--- a/plans/PR-Blog-D7-Corpus-Scope.md
+++ b/plans/PR-Blog-D7-Corpus-Scope.md
@@ -1,0 +1,90 @@
+# PR-Blog-D7-Corpus-Scope
+
+Ownership lane: `content-ops/blog-d7-corpus-scope`
+
+## Why this slice exists
+
+Defect **D7** (`reports/blog-audit-findings.md`): a blog post's headline
+"reviews collected" total is computed over a BROADER source scope than its
+"enriched"/churn numbers, so the stated corpus overstates the base actually
+analyzed -- and worse, "N collected / M enriched" do not share a denominator.
+
+Verified against the live DB (Zoho CRM, all-time, deduped):
+
+| metric | value |
+|---|---:|
+| `_fetch_vendor_stats.total` (all sources) | 1043 |
+| same, scoped to the blog source allowlist | 441 |
+| enriched (allowlist) | 263 |
+
+The published `zoho-crm-deep-dive` headline ("~940 collected, 268 enriched")
+pairs an all-source total with an allowlist-scoped enriched count -- the D7
+mismatch. This slice is the generator fix for the vendor-level path; the
+landscape overstatement and the published-data corrections are separate slices
+(see Deferred).
+
+## Scope (this PR)
+
+`_fetch_vendor_stats` (both byte-identical `b2b_blog_post_generation.py` copies)
+is the single source of the all-source total: its result flows into
+`ctx["review_count"]` / `total_reviews` / `reviews_a/b` for the vendor_deep_dive,
+vendor_showdown, switching_story, and pricing_reality_check topic types. The
+sibling category path (`_fetch_category_topic_stats`) and the
+`_build_blog_topic_context` ctx queries already scope to
+`_blog_source_allowlist()`; only `_fetch_vendor_stats` did not.
+
+### Files touched
+
+- `plans/PR-Blog-D7-Corpus-Scope.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation.py`
+
+## Mechanism
+
+Add `AND r.source = ANY($2)` to the `_fetch_vendor_stats` aggregate, binding
+`_blog_source_allowlist()` as the second parameter -- the exact scope the
+enriched/churn ctx queries already use. The function signature is unchanged
+(sources are fetched inside), so no call site changes. This scopes `total`,
+`enriched`, `negative`, and `avg_urgency` consistently to the allowlist, so the
+headline "collected" total now shares a denominator with the enriched count
+(441 / 263 for Zoho, not 1043 / 263). Applied to both byte-identical copies
+(edit one, `cp` to the mirror; verified identical).
+
+## Intentional
+
+- **Single-point fix.** `_fetch_vendor_stats` is the only vendor-level stat
+  source that omitted the allowlist; fixing it propagates to every topic type
+  that reads `stats["total"]` without touching their call sites.
+- **Match the existing scope, nothing more.** No `is_primary` or window filter
+  added -- the confirmed mismatch is source scope alone; the enriched/churn ctx
+  queries this aligns to also use source + dedup only.
+
+## Deferred
+
+- **PR-D7c (landscape overstatement):** `crm-landscape` shows "3,287 enriched"
+  -- impossible (CRM all-source enriched ceiling is 1,959; allowlist enriched
+  1,133). My first hypothesis (`read_market_landscape_candidates`'
+  `SUM(cs.total_reviews)`) was REFUTED by the DB (that sum = 107), so the exact
+  generator path is still being traced -- a separate slice, no guessing.
+- **PR-D7b (data fix):** correct the published `zoho-crm-deep-dive` and
+  `crm-landscape` numbers once the generator paths are fixed (like #745).
+
+## Verification
+
+- New regression test `test_fetch_vendor_stats_scopes_total_to_source_allowlist`
+  fails pre-fix (query had no `r.source = ANY(`), passes after; asserts the
+  bound arg equals `_blog_source_allowlist()`.
+- `pytest` generation + quote-gate suites -> 185 passed.
+- Both `b2b_blog_post_generation.py` copies byte-identical after edit.
+- Live DB: the fixed query returns 441 (allowlist) for Zoho CRM vs 1043
+  (all-source) before -- consistent with enriched 263.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (allowlist filter + comment) | ~40 |
+| Test | ~35 |
+| Plan doc | ~85 |
+| **Total** | **~160** |

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -706,6 +706,34 @@ async def test_regenerate_existing_posts_applies_scoped_filters_before_limit():
     assert captured["args"][4] == 10
 
 
+@pytest.mark.asyncio
+async def test_fetch_vendor_stats_scopes_total_to_source_allowlist():
+    """D7: the headline 'reviews collected' total must use the SAME source
+    allowlist as the enriched/churn stats, so 'N collected / M enriched' share a
+    denominator. Previously _fetch_vendor_stats.total counted ALL sources
+    (Capterra/Trustpilot/etc.), overstating the corpus vs the allowlist-scoped
+    enriched_count -- e.g. Zoho CRM showed 1043 all-source where the allowlist
+    base is 441 (enriched 263)."""
+    captured: dict[str, object] = {}
+
+    class Pool:
+        async def fetchrow(self, query, *args):
+            captured["query"] = query
+            captured["args"] = args
+            return {
+                "total": 441, "enriched": 263, "negative": 50,
+                "avg_urgency": 7.0, "category": "CRM",
+            }
+
+    out = await blog_mod._fetch_vendor_stats(Pool(), "Zoho CRM")
+    assert out["total"] == 441
+    # The query must scope reviews to the configured source allowlist...
+    assert "r.source = ANY(" in str(captured["query"])
+    # ...and bind that exact allowlist as a parameter (same scope the
+    # enriched/churn ctx queries use).
+    assert list(captured["args"][1]) == blog_mod._blog_source_allowlist()
+
+
 def _blog_anchor_context() -> dict:
     return {
         "reasoning_anchor_examples": {


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d7-corpus-scope`

Generator-first fix for **D7** (`reports/blog-audit-findings.md`): a post's headline "reviews collected" total used a broader source scope than its enriched/churn numbers, so "N collected / M enriched" didn't share a denominator and the corpus was overstated.

## Intentional

- `_fetch_vendor_stats` computed `total = COUNT(*)` with **no source filter** (all sources: Capterra/Trustpilot/etc.), while enriched is effectively allowlist-only and the ctx/category stat queries already scope to `_blog_source_allowlist()`. Its result feeds `ctx["review_count"]` / `total_reviews` / `reviews_a/b` for vendor_deep_dive, vendor_showdown, switching_story, and pricing_reality_check.
- **DB-verified** (Zoho CRM, all-time, deduped): **1043 all-source vs 441 allowlist**, enriched 263.
- Fix: add `AND r.source = ANY($2)` binding `_blog_source_allowlist()`. Signature unchanged (sources fetched inside) → no call-site changes. Both byte-identical `b2b_blog_post_generation.py` copies. Match the existing scope only — no `is_primary`/window added.

## Deferred

- **PR-D7c (landscape):** `crm-landscape` "3,287 enriched" is impossible (CRM all-source enriched ceiling 1,959; allowlist enriched 1,133). My first hypothesis (`SUM(cs.total_reviews)`) was **refuted by the DB** (that sum = 107), so the exact path is still being traced — separate slice, no guessing.
- **PR-D7b (data):** correct the published `zoho-crm-deep-dive` + `crm-landscape` numbers after the generator paths are fixed.

## Verification

- New test `test_fetch_vendor_stats_scopes_total_to_source_allowlist` fails pre-fix (no `r.source = ANY(`), passes after; asserts the bound arg equals `_blog_source_allowlist()`.
- generation + quote-gate suites → **185 passed**.
- Both copies byte-identical.
- Live DB: fixed query returns **441** (allowlist) for Zoho CRM vs 1043 before — consistent with enriched 263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)