### PR TITLE
Add public landing page sitemap feed

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import date
+from html import escape as html_escape
 from typing import Any
 from uuid import UUID
 
 try:
-    from fastapi import APIRouter, Body, HTTPException, Query, Response
+    from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
     APIRouter = None
     Body = None
     HTTPException = None
     Query = None
+    Request = Any
     Response = Any
     _FASTAPI_IMPORT_ERROR: ImportError | None = exc
 else:
@@ -25,6 +28,7 @@ from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import (
     export_landing_page_drafts,
     public_landing_page_draft_row,
+    public_landing_page_robots,
 )
 from ..landing_page_postgres import PostgresLandingPageRepository
 from ..report_export import export_report_drafts
@@ -61,6 +65,8 @@ class GeneratedAssetApiConfig:
     max_limit: int = 200
     max_batch_size: int = 200
     export_filename_prefix: str = "content_assets"
+    public_landing_page_base_url: str | None = None
+    public_sitemap_limit: int = 500
 
     def __post_init__(self) -> None:
         if self.default_limit < 0:
@@ -73,6 +79,8 @@ class GeneratedAssetApiConfig:
             raise ValueError("max_batch_size must be positive")
         if not _clean(self.export_filename_prefix):
             raise ValueError("export_filename_prefix is required")
+        if self.public_sitemap_limit <= 0:
+            raise ValueError("public_sitemap_limit must be positive")
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -337,6 +345,25 @@ def create_public_landing_page_router(
         tags=list(resolved_config.tags),
     )
 
+    @router.get("/landing_page/public/sitemap.xml", response_model=None)
+    async def public_landing_page_sitemap(request: Request) -> Response:
+        pool = await _resolve_pool(pool_provider)
+        candidates = await (
+            PostgresLandingPageRepository(pool).list_public_sitemap_candidates()
+        )
+        base_url = _public_landing_page_base_url(resolved_config, request)
+        urls: list[str] = []
+        for candidate in candidates:
+            if public_landing_page_robots(candidate.to_policy_draft()) != "index,follow":
+                continue
+            urls.append(_public_landing_page_url(base_url, candidate))
+            if len(urls) >= resolved_config.public_sitemap_limit:
+                break
+        return Response(
+            content=_sitemap_xml(urls),
+            media_type="application/xml",
+        )
+
     @router.get("/landing_page/public/{landing_page_id}")
     async def public_landing_page(
         landing_page_id: str,
@@ -354,6 +381,39 @@ def create_public_landing_page_router(
         return public_landing_page_draft_row(draft)
 
     return router
+
+
+def _public_landing_page_base_url(
+    config: GeneratedAssetApiConfig,
+    request: Request,
+) -> str:
+    configured = _clean(config.public_landing_page_base_url)
+    if configured:
+        return configured.rstrip("/")
+    return str(request.base_url).rstrip("/")
+
+
+def _public_landing_page_url(base_url: str, draft: Any) -> str:
+    return f"{base_url}/lp/{draft.id}/{draft.slug}"
+
+
+def _sitemap_xml(urls: Sequence[str]) -> str:
+    today = date.today().isoformat()
+    rows = "\n".join(
+        "  <url>\n"
+        f"    <loc>{html_escape(url, quote=True)}</loc>\n"
+        f"    <lastmod>{today}</lastmod>\n"
+        "    <changefreq>weekly</changefreq>\n"
+        "    <priority>0.7</priority>\n"
+        "  </url>"
+        for url in urls
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{rows}\n"
+        "</urlset>\n"
+    )
 
 
 async def _export_for_asset(

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -139,6 +139,46 @@ class LandingPageDraft:
         }
 
 
+@dataclass(frozen=True)
+class PublicLandingPageSitemapCandidate:
+    """Approved landing-page projection used for public sitemap policy checks.
+
+    This is intentionally narrower than ``LandingPageDraft`` so sitemap
+    generation does not carry tenant scope, generation metadata, or other
+    review-only fields through a public route.
+    """
+
+    campaign_name: str
+    persona: str
+    value_prop: str
+    title: str
+    slug: str
+    hero: Mapping[str, Any] = field(default_factory=dict)
+    sections: Sequence[LandingPageSection] = field(default_factory=tuple)
+    cta: Mapping[str, Any] = field(default_factory=dict)
+    meta: Mapping[str, Any] = field(default_factory=dict)
+    reference_ids: Sequence[str] = field(default_factory=tuple)
+    id: str = ""
+    status: str = ""
+
+    def to_policy_draft(self) -> LandingPageDraft:
+        return LandingPageDraft(
+            campaign_name=self.campaign_name,
+            persona=self.persona,
+            value_prop=self.value_prop,
+            title=self.title,
+            slug=self.slug,
+            hero=dict(self.hero),
+            sections=tuple(self.sections),
+            cta=dict(self.cta),
+            meta=dict(self.meta),
+            reference_ids=tuple(self.reference_ids),
+            metadata={},
+            id=self.id,
+            status=self.status,
+        )
+
+
 class LandingPageRepository(Protocol):
     """Persistence contract for generated landing-page drafts."""
 
@@ -166,6 +206,11 @@ class LandingPageRepository(Protocol):
         landing_page_id: str,
     ) -> LandingPageDraft | None:
         """Return one approved public draft by id, or None when not publishable."""
+
+    async def list_public_sitemap_candidates(
+        self,
+    ) -> Sequence[PublicLandingPageSitemapCandidate]:
+        """Return approved public sitemap candidates without tenant scoping."""
 
     async def update_status(
         self,
@@ -199,4 +244,5 @@ __all__ = [
     "LandingPageRepository",
     "LandingPageSection",
     "MarketingCampaign",
+    "PublicLandingPageSitemapCandidate",
 ]

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -18,6 +18,7 @@ from .campaign_ports import JsonDict, TenantScope
 from .landing_page_ports import (
     LandingPageDraft,
     LandingPageSection,
+    PublicLandingPageSitemapCandidate,
 )
 from .storage._jsonb_helpers import (
     decode_jsonb_field,
@@ -100,6 +101,45 @@ def _row_to_draft(row: Mapping[str, Any]) -> LandingPageDraft:
         meta=dict(meta_raw),
         reference_ids=tuple(str(r) for r in reference_ids_raw),
         metadata=dict(metadata_raw),
+        status=str(row.get("status") or ""),
+    )
+
+
+def _row_to_public_sitemap_candidate(
+    row: Mapping[str, Any],
+) -> PublicLandingPageSitemapCandidate:
+    sections_raw = decode_jsonb_field(row.get("sections"), default=[])
+    if not isinstance(sections_raw, Sequence) or isinstance(sections_raw, (str, bytes)):
+        sections_raw = []
+
+    reference_ids_raw = decode_jsonb_field(row.get("reference_ids"), default=[])
+    if not isinstance(reference_ids_raw, Sequence) or isinstance(reference_ids_raw, (str, bytes)):
+        reference_ids_raw = []
+
+    hero_raw = decode_jsonb_field(row.get("hero"), default={})
+    if not isinstance(hero_raw, Mapping):
+        hero_raw = {}
+
+    cta_raw = decode_jsonb_field(row.get("cta"), default={})
+    if not isinstance(cta_raw, Mapping):
+        cta_raw = {}
+
+    meta_raw = decode_jsonb_field(row.get("meta"), default={})
+    if not isinstance(meta_raw, Mapping):
+        meta_raw = {}
+
+    return PublicLandingPageSitemapCandidate(
+        id=str(row.get("id") or ""),
+        campaign_name=str(row.get("campaign_name") or ""),
+        persona=str(row.get("persona") or ""),
+        value_prop=str(row.get("value_prop") or ""),
+        title=str(row.get("title") or ""),
+        slug=str(row.get("slug") or ""),
+        hero=dict(hero_raw),
+        sections=tuple(_coerce_section(s) for s in sections_raw),
+        cta=dict(cta_raw),
+        meta=dict(meta_raw),
+        reference_ids=tuple(str(r) for r in reference_ids_raw),
         status=str(row.get("status") or ""),
     )
 
@@ -212,6 +252,22 @@ class PostgresLandingPageRepository:
         if not rows:
             return None
         return _row_to_draft(row_to_dict(rows[0]))
+
+    async def list_public_sitemap_candidates(
+        self,
+    ) -> Sequence[PublicLandingPageSitemapCandidate]:
+        rows = await self.pool.fetch(
+            """
+            SELECT id, campaign_name, persona, value_prop, title, slug,
+                   hero, sections, cta, meta, reference_ids, status
+              FROM landing_pages
+             WHERE status = 'approved'
+             ORDER BY updated_at DESC, created_at DESC
+            """
+        )
+        return tuple(
+            _row_to_public_sitemap_candidate(row_to_dict(row)) for row in rows
+        )
 
     async def update_status(
         self,

--- a/plans/PR-Landing-Page-Public-Sitemap.md
+++ b/plans/PR-Landing-Page-Public-Sitemap.md
@@ -1,0 +1,78 @@
+# PR-Landing-Page-Public-Sitemap
+
+## Why this slice exists
+
+Generated landing pages now have a backend-owned robots policy, but there is
+no public indexable URL feed for crawlers or deployment tooling. This slice
+adds a dynamic sitemap endpoint that includes only approved generated landing
+pages whose backend robots policy is `index,follow`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-public-sitemap
+
+1. Add a narrowed repository projection for approved public sitemap candidates.
+2. Add a public sitemap XML route for generated landing pages.
+3. Gate sitemap inclusion on `public_landing_page_robots(draft) == "index,follow"`.
+4. Keep non-ready approved pages out of the sitemap.
+5. Keep static Vite sitemap/prerender unchanged in this slice.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Public-Sitemap.md`
+- `extracted_content_pipeline/landing_page_ports.py`
+- `extracted_content_pipeline/landing_page_postgres.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_landing_page_postgres.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+
+## Mechanism
+
+The public router exposes `GET /content-assets/landing_page/public/sitemap.xml`.
+It fetches approved landing-page sitemap candidates, derives each candidate's
+robots policy with the same helper used by the public renderer payload, and
+emits XML only for candidates whose policy is `index,follow`. The configured
+URL cap is applied after readiness filtering so approved-but-not-ready rows
+cannot crowd out indexable pages.
+
+The route uses a configured public frontend base URL when supplied and falls
+back to the request origin otherwise. The response contains only absolute page
+URLs, `lastmod`, `changefreq`, and `priority`; it does not expose readiness
+details, metadata, tenant scope, reasoning, or reference ids.
+
+The repository projection intentionally omits the `metadata` column so tenant
+scope, generation usage, and review-only context never travel through the
+public sitemap path.
+
+## Intentional
+
+- No static Vite sitemap changes.
+- No static prerender of database-backed pages.
+- No sitemap inclusion for approved-but-not-ready pages.
+- No tenant-scoped public sitemap.
+
+## Deferred
+
+- `PR-Landing-Page-Static-Sitemap-Bridge` can wire the frontend/deployment
+  layer to this dynamic sitemap feed if the production routing layer needs one
+  canonical `/sitemap.xml`.
+
+## Verification
+
+- Focused backend tests for public sitemap, repository lookup, and host mount
+  - 52 passed.
+- Git whitespace check - passed.
+- Full extracted pipeline checks through `scripts/run_extracted_pipeline_checks.sh`
+  - 1655 passed.
+- Local PR review wrapper - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Backend sitemap route | ~85 |
+| Repository port/adapter | ~90 |
+| Tests | ~130 |
+| **Total** | **~380** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -34,6 +34,7 @@ def test_api_aggregator_mounts_generated_asset_routes() -> None:
     assert "/content-assets/{asset}/drafts" in paths
     assert "/content-assets/{asset}/drafts/export" in paths
     assert "/content-assets/{asset}/drafts/review" in paths
+    assert "/content-assets/landing_page/public/sitemap.xml" in paths
     assert "/content-assets/landing_page/public/{landing_page_id}" in paths
 
 

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -288,13 +288,22 @@ def _client(
     return TestClient(app)
 
 
-def _public_client(pool) -> TestClient:
+def _public_client(
+    pool,
+    *,
+    config: GeneratedAssetApiConfig | None = None,
+) -> TestClient:
     app = FastAPI()
 
     async def pool_provider():
         return pool
 
-    app.include_router(create_public_landing_page_router(pool_provider=pool_provider))
+    app.include_router(
+        create_public_landing_page_router(
+            pool_provider=pool_provider,
+            config=config,
+        )
+    )
     return TestClient(app)
 
 
@@ -454,6 +463,89 @@ def test_generated_asset_router_indexes_public_ready_landing_page() -> None:
     assert body["robots"] == "index,follow"
     assert "seo_aeo_readiness" not in body
     assert "geo_readiness" not in body
+
+
+def test_generated_asset_router_sitemap_includes_only_indexable_landing_pages() -> None:
+    incomplete = {**_landing_page_row(), "status": "approved"}
+    incomplete["id"] = "22222222-2222-2222-2222-222222222222"
+    incomplete["slug"] = "not-ready"
+    ready = _ready_landing_page_row()
+    ready["metadata"] = {
+        "scope": {"account_id": "acct_1", "user_id": "user_1"},
+        "generation_usage": {"input_tokens": 10, "output_tokens": 5},
+        "reasoning_context": {"wedge": "support_gap", "confidence": 0.8},
+    }
+    rejected = {**_ready_landing_page_row(), "status": "rejected"}
+    rejected["id"] = "33333333-3333-3333-3333-333333333333"
+    rejected["slug"] = "rejected-ready"
+    pool = _Pool(rows=[ready, incomplete, rejected])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/sitemap.xml"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+    assert (
+        "<loc>http://testserver/lp/"
+        "11111111-1111-1111-1111-111111111111/"
+        "acme-support-retention</loc>"
+    ) in response.text
+    assert "not-ready" not in response.text
+    assert "rejected-ready" not in response.text
+    assert "acct_1" not in response.text
+    assert "user_1" not in response.text
+    assert "generation_usage" not in response.text
+    assert "seo_aeo_readiness" not in response.text
+    assert "geo_readiness" not in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in query
+    assert "status = 'approved'" in query
+    assert "metadata" not in query
+    assert args == ()
+
+
+def test_generated_asset_router_sitemap_applies_limit_after_readiness_filter() -> None:
+    incomplete = {**_landing_page_row(), "status": "approved"}
+    incomplete["id"] = "22222222-2222-2222-2222-222222222222"
+    incomplete["slug"] = "not-ready"
+    ready = _ready_landing_page_row()
+    later_ready = _ready_landing_page_row()
+    later_ready["id"] = "33333333-3333-3333-3333-333333333333"
+    later_ready["slug"] = "later-ready"
+    pool = _Pool(rows=[incomplete, ready, later_ready])
+
+    response = _public_client(
+        pool,
+        config=GeneratedAssetApiConfig(public_sitemap_limit=1),
+    ).get("/content-assets/landing_page/public/sitemap.xml")
+
+    assert response.status_code == 200
+    assert "not-ready" not in response.text
+    assert "acme-support-retention" in response.text
+    assert "later-ready" not in response.text
+    assert response.text.count("<url>") == 1
+    query, args = pool.fetch_calls[0]
+    assert "LIMIT" not in query
+    assert args == ()
+
+
+def test_generated_asset_router_sitemap_uses_configured_public_base_url() -> None:
+    pool = _Pool(rows=[_ready_landing_page_row()])
+
+    response = _public_client(
+        pool,
+        config=GeneratedAssetApiConfig(
+            public_landing_page_base_url="https://example.com/"
+        ),
+    ).get("/content-assets/landing_page/public/sitemap.xml")
+
+    assert response.status_code == 200
+    assert (
+        "<loc>https://example.com/lp/"
+        "11111111-1111-1111-1111-111111111111/"
+        "acme-support-retention</loc>"
+    ) in response.text
 
 
 def test_generated_asset_router_hides_non_public_landing_page() -> None:
@@ -876,6 +968,9 @@ def test_generated_asset_api_config_rejects_invalid_limits() -> None:
 
     with pytest.raises(ValueError, match="max_batch_size must be positive"):
         GeneratedAssetApiConfig(max_batch_size=0)
+
+    with pytest.raises(ValueError, match="public_sitemap_limit must be positive"):
+        GeneratedAssetApiConfig(public_sitemap_limit=0)
 
 
 def test_generated_asset_router_requires_fastapi(monkeypatch) -> None:

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -327,6 +327,44 @@ async def test_get_public_approved_draft_hides_non_approved_row() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_public_sitemap_candidates_uses_public_projection() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "approved",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero text"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "L"},
+            "meta": {"title_tag": "tt"},
+            "reference_ids": ["r1"],
+            "metadata": {"key": "value"},
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    candidates = await repo.list_public_sitemap_candidates()
+
+    assert len(candidates) == 1
+    assert candidates[0].status == "approved"
+    assert candidates[0].slug == "slug"
+    assert candidates[0].to_policy_draft().metadata == {}
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "FROM landing_pages" in sql
+    assert "status = 'approved'" in sql
+    assert "ORDER BY updated_at DESC, created_at DESC" in sql
+    assert "metadata" not in sql
+    assert "LIMIT" not in sql
+    assert args == ()
+
+
+@pytest.mark.asyncio
 async def test_update_status_returns_true_on_hit_and_runs_scoped_update() -> None:
     pool = _Pool()
     pool.execute_result = "UPDATE 1"


### PR DESCRIPTION
## Summary
- add a public generated landing-page sitemap XML route at `/content-assets/landing_page/public/sitemap.xml`
- fetch approved landing-page candidates through a repository method
- include only pages whose backend robots policy resolves to `index,follow`
- keep approved-but-not-ready and non-approved pages out of the sitemap
- keep static Vite sitemap/prerender unchanged in this slice

Ownership lane: content-ops/landing-page-public-sitemap
Plan: plans/PR-Landing-Page-Public-Sitemap.md

## Verification
- pytest tests/test_extracted_content_asset_api.py tests/test_extracted_landing_page_postgres.py tests/test_atlas_content_ops_generated_assets_api.py -q: 51 passed, 1 warning
- git diff --check: passed
- bash scripts/run_extracted_pipeline_checks.sh: 1654 passed, 1 warning
- bash scripts/local_pr_review.sh origin/main: passed
