### PR TITLE
PR-Audit-Cross-Layer-Caller-Hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,10 @@ bash scripts/local_pr_review.sh
 ```
 
 This is the fast path. It catches plan-shape, diff-size, file-claim,
-MCP-doc, ASCII, plan/code, and whitespace failures before GitHub has to
-run anything.
+MCP-doc, ASCII, plan/code, cross-session drift, and whitespace failures
+before GitHub has to run anything. It also prints advisory cross-layer
+caller hints for changed Python symbols so builder and reviewer can see
+non-diff files that may need focused tests or inspection.
 
 To make that automatic for this checkout, install the optional pre-push
 hook:
@@ -178,6 +180,12 @@ After the mechanical bundle passes, hand the branch to a separate local
 reviewer session for judgment review. The reviewer should read the plan
 doc and diff locally, run any focused tests needed to verify the claims,
 and return a verdict before the builder opens the GitHub PR.
+
+For logic or shared-function PRs, the builder must read the cross-layer
+caller hints from local review and either add focused caller-layer tests
+or name why the referenced callers are unaffected. The hints are
+advisory rather than blocking because outside references can be valid,
+but silently ignoring them recreates the diff-only review gap.
 
 GitHub Actions still runs the same wrapper after the PR opens. Treat CI
 as the final enforcement layer, not the first reviewer.
@@ -302,6 +310,9 @@ Before LGTM, the reviewer confirms:
 - [ ] Diff size matches the plan's estimate (or the overage is
       justified in **Why**).
 - [ ] No regressions in the named test sweep.
+- [ ] For shared-function PRs, cross-layer caller hints were inspected
+      and the verdict names any caller-layer tests or unaffected
+      references.
 - [ ] No drift from the plan's stated scope (no scope creep, no
       "while I was at it" cleanups beyond the slice's contract).
 - [ ] Defensible trade-offs are explained in **Intentional**.

--- a/plans/PR-Audit-Cross-Layer-Caller-Hints.md
+++ b/plans/PR-Audit-Cross-Layer-Caller-Hints.md
@@ -1,0 +1,91 @@
+# PR-Audit-Cross-Layer-Caller-Hints
+
+## Why this slice exists
+
+Recent reviews found the same class of issue across multiple PRs: a shared
+function changed correctly in the diff, but a caller layer outside the obvious
+review path exposed the real break. Diff-only review is too narrow for logic and
+shared-function PRs because CLI, API, repository, UI, and service adapters can
+drift even when their files are not changed.
+
+This slice makes that risk visible during local review by surfacing non-diff
+caller references for changed Python symbols. It is mitigation, not a full proof
+of correctness: the output tells the builder and reviewer which outside files
+deserve focused tests or inspection.
+
+This is over the 400 LOC soft budget because an audit script must ship with its
+own parser and fixture tests; splitting the tests from the script would weaken
+the guardrail this slice is meant to add.
+
+## Scope (this PR)
+
+Ownership lane: audit/local-review
+
+1. Add an advisory Python caller-hint audit for changed Python functions and
+   classes.
+2. Wire the advisory into the local PR review bundle without making caller
+   presence itself a blocking failure.
+3. Document the builder and reviewer expectation for shared-function PRs.
+4. Add fixture tests for changed-symbol detection, non-diff caller reporting,
+   and pathological path handling.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Audit-Cross-Layer-Caller-Hints.md` | Plan doc for this mitigation slice. |
+| `AGENTS.md` | Documents the cross-layer caller-hint expectation for builders and reviewers. |
+| `scripts/audit_cross_layer_callers.py` | New advisory audit that lists non-diff references to changed Python symbols. |
+| `scripts/local_pr_review.sh` | Runs the advisory audit as part of local PR review. |
+| `tests/test_audit_cross_layer_callers.py` | Fixture coverage for the new audit. |
+
+## Mechanism
+
+The audit compares the branch against the selected base ref, gathers modified
+Python files, reads changed line numbers from `git diff --unified=0`, and maps
+those lines to top-level or nested Python `FunctionDef`, `AsyncFunctionDef`, and
+`ClassDef` spans using `ast`. Added Python files are skipped because they cannot
+have real pre-existing callers and mostly produce generic-name false positives.
+For each changed symbol, the audit searches tracked code files outside the
+branch diff and prints a compact advisory list of references. Top-level
+functions require call-shaped matches, methods require attribute-call matches,
+and Python files are tokenized so comments and string literals do not count as
+caller hints.
+
+`scripts/local_pr_review.sh` runs the audit after cross-session drift. The audit
+returns success when it finds caller hints because hints are review input, not a
+proof of failure. It returns non-zero only for invalid paths, missing refs, or
+unexpected audit errors.
+
+## Intentional
+
+- Advisory, not blocking: many shared helpers legitimately have outside
+  references, and the reviewer still needs judgment.
+- Token-aware text search over full call-graph construction: this keeps the
+  check fast and dependency-free while still surfacing the non-diff code files a
+  reviewer should inspect.
+- Python-only in this slice because the repeated failures were in Python
+  shared logic and CLI/library seams.
+
+## Deferred
+
+- TypeScript caller hints for frontend contract/helper changes.
+- A future stricter mode that requires a plan-doc cross-layer verification note
+  when high-risk symbols have outside callers.
+- A richer import/call graph if token-aware text-search hints become too noisy.
+
+## Verification
+
+- Cross-layer caller audit fixture tests - passed, 10 tests.
+- Python compile for the new audit script - passed.
+- Local PR review against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan and AGENTS docs | ~115 |
+| Audit script | ~255 |
+| Local review wiring | ~10 |
+| Tests | ~250 |
+| **Total** | ~630 |

--- a/scripts/audit_cross_layer_callers.py
+++ b/scripts/audit_cross_layer_callers.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Surface non-diff references to changed Python symbols.
+
+The audit reads the working tree, so direct dirty-tree runs can include
+uncommitted edits. The local review wrapper runs it after the clean-tree gate.
+Decorator-only edits and deleted symbols are advisory blind spots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+import tokenize
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Sequence
+
+CODE_SUFFIXES = {
+    ".py",
+    ".pyi",
+    ".sh",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+}
+SYMBOL_MIN_LENGTH = 4
+
+
+@dataclass(frozen=True)
+class ChangedSymbol:
+    path: str
+    name: str
+    qualname: str
+    kind: str
+    line: int
+
+
+@dataclass(frozen=True)
+class Reference:
+    path: str
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class CallerHint:
+    symbol: ChangedSymbol
+    references: tuple[Reference, ...]
+
+
+class AuditError(RuntimeError):
+    """Raised when the audit cannot safely inspect the repository."""
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="List non-diff references to changed Python functions/classes.",
+    )
+    parser.add_argument(
+        "base_ref",
+        nargs="?",
+        default="origin/main",
+        help="base ref to compare against (default: origin/main)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        hints = build_hints(args.base_ref)
+    except AuditError as exc:
+        print(f"cross-layer caller audit error: {exc}", file=sys.stderr)
+        return 2
+
+    render_hints(args.base_ref, hints)
+    return 0
+
+
+def build_hints(base_ref: str) -> tuple[CallerHint, ...]:
+    ensure_git_ref(base_ref)
+    base = git_stdout(["merge-base", "HEAD", base_ref]).strip()
+    changed = changed_files(base)
+    modified = modified_files(base)
+    changed_python = sorted(path for path in modified if path.endswith(".py"))
+    symbols: list[ChangedSymbol] = []
+    for path in changed_python:
+        validate_repo_path(path)
+        changed_lines = changed_line_numbers(base, path)
+        if not changed_lines:
+            continue
+        symbols.extend(changed_symbols(path, changed_lines))
+
+    if not symbols:
+        return ()
+
+    searchable = sorted(
+        path
+        for path in tracked_files()
+        if path not in changed and is_code_path(path)
+    )
+    return tuple(
+        CallerHint(symbol=symbol, references=find_references(symbol, searchable))
+        for symbol in symbols
+    )
+
+
+def ensure_git_ref(ref: str) -> None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", ref],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AuditError(f"base ref not found: {ref}")
+
+
+def changed_files(base: str) -> set[str]:
+    output = git_stdout(["diff", "--name-only", f"{base}...HEAD"])
+    files = {line for line in output.splitlines() if line.strip()}
+    for path in files:
+        validate_repo_path(path)
+    return files
+
+
+def modified_files(base: str) -> set[str]:
+    output = git_stdout(["diff", "--name-status", f"{base}...HEAD"])
+    files: set[str] = set()
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        status, *paths = line.split("\t")
+        if status == "M" and paths:
+            files.add(paths[0])
+        elif status.startswith("R") and len(paths) == 2:
+            files.add(paths[1])
+    for path in files:
+        validate_repo_path(path)
+    return files
+
+
+def tracked_files() -> set[str]:
+    output = git_stdout(["ls-files"])
+    files = {line for line in output.splitlines() if line.strip()}
+    for path in files:
+        validate_repo_path(path)
+    return files
+
+
+def changed_line_numbers(base: str, path: str) -> set[int]:
+    output = git_stdout(["diff", "--unified=0", f"{base}...HEAD", "--", path])
+    lines: set[int] = set()
+    for raw in output.splitlines():
+        match = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", raw)
+        if not match:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        if count == 0:
+            continue
+        lines.update(range(start, start + count))
+    return lines
+
+
+def changed_symbols(path: str, changed_lines: set[int]) -> tuple[ChangedSymbol, ...]:
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=path)
+    except SyntaxError as exc:
+        raise AuditError(f"could not parse changed Python file {path}: {exc}") from exc
+
+    symbols: list[ChangedSymbol] = []
+    for qualname, node in iter_symbol_nodes(tree):
+        name = node.name
+        if len(name) < SYMBOL_MIN_LENGTH:
+            continue
+        if node.end_lineno is None:
+            continue
+        span = range(node.lineno, node.end_lineno + 1)
+        if changed_lines.intersection(span):
+            symbols.append(
+                ChangedSymbol(
+                    path=path,
+                    name=name,
+                    qualname=qualname,
+                    kind=_symbol_kind(node),
+                    line=node.lineno,
+                )
+            )
+    return tuple(symbols)
+
+
+def iter_symbol_nodes(tree: ast.AST) -> Iterable[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef]]:
+    def visit(
+        node: ast.AST,
+        parents: tuple[str, ...],
+    ) -> Iterable[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef]]:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                qualname = ".".join((*parents, child.name))
+                yield qualname, child
+                yield from visit(child, (*parents, child.name))
+
+    yield from visit(tree, ())
+
+
+def _symbol_kind(node: ast.AST) -> str:
+    if isinstance(node, ast.ClassDef):
+        return "class"
+    if isinstance(node, ast.AsyncFunctionDef):
+        return "async_function"
+    return "function"
+
+
+def find_references(symbol: ChangedSymbol, paths: Sequence[str]) -> tuple[Reference, ...]:
+    references: list[Reference] = []
+    patterns = reference_patterns(symbol)
+    for path in paths:
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        candidate_lines = code_reference_lines(path, text, symbol)
+        for index, line in enumerate(text.splitlines(), start=1):
+            if index in candidate_lines and any(pattern.search(line) for pattern in patterns):
+                references.append(
+                    Reference(path=path, line=index, text=line.strip()[:160])
+                )
+    return tuple(references)
+
+
+def reference_patterns(symbol: ChangedSymbol) -> tuple[re.Pattern[str], ...]:
+    escaped = re.escape(symbol.name)
+    if symbol.kind == "class":
+        return (re.compile(rf"\b{escaped}\b"),)
+    if "." in symbol.qualname:
+        owner = re.escape(symbol.qualname.rsplit(".", 1)[0].split(".")[-1])
+        return (
+            re.compile(rf"\.{escaped}\s*\("),
+            re.compile(rf"\b{owner}\.{escaped}\s*\("),
+        )
+    return (re.compile(rf"\b{escaped}\s*\("),)
+
+
+def code_reference_lines(path: str, text: str, symbol: ChangedSymbol) -> set[int]:
+    if PurePosixPath(path).suffix in {".py", ".pyi"}:
+        return python_name_lines(text, symbol.name)
+    return non_python_candidate_lines(text)
+
+
+def python_name_lines(text: str, name: str) -> set[int]:
+    lines: set[int] = set()
+    try:
+        tokens = tokenize.generate_tokens(StringIO(text).readline)
+        for token in tokens:
+            if token.type == tokenize.NAME and token.string == name:
+                lines.add(token.start[0])
+    except tokenize.TokenError:
+        return set(range(1, len(text.splitlines()) + 1))
+    return lines
+
+
+def non_python_candidate_lines(text: str) -> set[int]:
+    lines: set[int] = set()
+    for index, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped and not stripped.startswith(("//", "#", "/*", "*")):
+            lines.add(index)
+    return lines
+
+
+def is_code_path(path: str) -> bool:
+    return PurePosixPath(path).suffix in CODE_SUFFIXES
+
+
+def validate_repo_path(path: str) -> None:
+    parsed = PurePosixPath(path)
+    if parsed.is_absolute() or ".." in parsed.parts or not path.strip():
+        raise AuditError(f"unsafe repository path: {path}")
+
+
+def render_hints(base_ref: str, hints: Sequence[CallerHint]) -> None:
+    references = sum(len(hint.references) for hint in hints)
+    print("cross-layer caller hints")
+    print(f"base ref: {base_ref}")
+    print(f"changed python symbols: {len(hints)}")
+    print(f"non-diff references: {references}")
+
+    if not hints:
+        print("OK: no changed Python symbols found")
+        return
+    if references == 0:
+        print("OK: no non-diff references found")
+        return
+
+    print("WARN: changed symbols have references outside this PR diff")
+    for hint in hints:
+        if not hint.references:
+            continue
+        symbol = hint.symbol
+        print(f"- {symbol.qualname} ({symbol.path}:{symbol.line})")
+        for reference in hint.references[:8]:
+            print(f"  - {reference.path}:{reference.line}: {reference.text}")
+        if len(hint.references) > 8:
+            print(f"  - ... {len(hint.references) - 8} more reference(s)")
+
+
+def git_stdout(args: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout).strip()
+        raise AuditError(message or f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -89,6 +89,14 @@ else
     echo "    SKIP (scripts/audit_pr_session_drift.py not found)"
 fi
 
+if [ -f scripts/audit_cross_layer_callers.py ]; then
+    run_check "Cross-layer caller hints" python scripts/audit_cross_layer_callers.py "$base_ref"
+else
+    echo
+    echo "==> Cross-layer caller hints"
+    echo "    SKIP (scripts/audit_cross_layer_callers.py not found)"
+fi
+
 committed_plan_docs=$(
     git diff --name-only --diff-filter=AM "$base"...HEAD -- 'plans/PR-*.md' 2>/dev/null |
         sort -u |

--- a/tests/test_audit_cross_layer_callers.py
+++ b/tests/test_audit_cross_layer_callers.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.audit_helpers import REPO_ROOT, load_auditor
+
+
+@pytest.fixture(scope="module")
+def auditor():
+    return load_auditor("audit_cross_layer_callers")
+
+
+def test_cli_warns_for_non_diff_reference_to_changed_symbol(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(repo, "pkg/lib.py", "def normalize(value):\n    return value.strip().lower()\n")
+    _commit(repo, "change shared helper")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: changed symbols have references outside this PR diff" in result.stdout
+    assert "normalize (pkg/lib.py:1)" in result.stdout
+    assert "scripts/cli.py" in result.stdout
+    assert "normalize(value)" in result.stdout
+
+
+def test_cli_ignores_references_inside_changed_files(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(repo, "pkg/lib.py", "def normalize(value):\n    return value.strip().lower()\n")
+    _write(
+        repo,
+        "scripts/cli.py",
+        "from pkg.lib import normalize\n\n\ndef run(value):\n    return normalize(value).lower()\n",
+    )
+    _commit(repo, "change helper and caller")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "changed python symbols: 1" in result.stdout
+    assert "OK: no non-diff references found" in result.stdout
+
+
+def test_cli_passes_for_non_python_diff(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(repo, "README.md", "changed docs\n")
+    _commit(repo, "change docs")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "changed python symbols: 0" in result.stdout
+    assert "OK: no changed Python symbols found" in result.stdout
+
+
+def test_cli_ignores_added_python_files(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(repo, "pkg/new_helper.py", "def normalize(value):\n    return value\n")
+    _commit(repo, "add helper")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "changed python symbols: 0" in result.stdout
+    assert "OK: no changed Python symbols found" in result.stdout
+
+
+def test_cli_uses_word_boundary_for_symbol_references(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(
+        repo,
+        "scripts/cli.py",
+        "\n".join((
+            "from pkg.lib import normalize",
+            "",
+            "def run(value):",
+            "    normalize_path = value",
+            "    _normalize = value",
+            "    normalizer = value",
+            "    return normalize(value)",
+            "",
+        )),
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add boundary fixture")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _write(repo, "pkg/lib.py", "def normalize(value):\n    return value.strip().lower()\n")
+    _commit(repo, "change shared helper")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "scripts/cli.py:7: return normalize(value)" in result.stdout
+    assert "normalize_path" not in result.stdout
+    assert "_normalize" not in result.stdout
+    assert "normalizer" not in result.stdout
+
+
+def test_cli_reports_method_attribute_calls_without_bare_name_noise(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(
+        repo,
+        "pkg/service.py",
+        "\n".join((
+            "class FAQService:",
+            "    def generate(self, value):",
+            "        return value.strip().lower() + '!'",
+            "",
+        )),
+    )
+    _write(
+        repo,
+        "scripts/method_cli.py",
+        "\n".join((
+            "from pkg.service import FAQService",
+            "",
+            "def generate(value):",
+            "    return value",
+            "",
+            "def run(service, value):",
+            "    generated = value",
+            "    return service.generate(value)",
+            "",
+        )),
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add method fixture")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _write(
+        repo,
+        "pkg/service.py",
+        "\n".join((
+            "class FAQService:",
+            "    def generate(self, value):",
+            "        return value.strip().lower()",
+            "",
+        )),
+    )
+    _commit(repo, "change method")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "FAQService.generate (pkg/service.py:2)" in result.stdout
+    assert "scripts/method_cli.py:8: return service.generate(value)" in result.stdout
+    assert "def generate(value)" not in result.stdout
+    assert "generated = value" not in result.stdout
+
+
+def test_cli_excludes_docs_and_json_references(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _write(repo, "README.md", "normalize(value) should be called here\n")
+    _write(repo, "config.json", '{"example": "normalize(value)"}\n')
+    _write(repo, "pkg/lib.py", "def normalize(value):\n    return value.strip().lower()\n")
+    _commit(repo, "change shared helper")
+
+    result = _run(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "README.md" not in result.stdout
+    assert "config.json" not in result.stdout
+    assert "scripts/cli.py" in result.stdout
+
+
+def test_cli_returns_two_for_missing_base_ref(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+
+    result = _run(repo, "does-not-exist-ref")
+
+    assert result.returncode == 2
+    assert "cross-layer caller audit error: base ref not found" in result.stderr
+
+
+def test_validate_repo_path_rejects_path_traversal(auditor) -> None:
+    with pytest.raises(auditor.AuditError, match="unsafe repository path"):
+        auditor.validate_repo_path("../outside.py")
+
+
+def test_validate_repo_path_rejects_absolute_path(auditor) -> None:
+    with pytest.raises(auditor.AuditError, match="unsafe repository path"):
+        auditor.validate_repo_path("/tmp/outside.py")
+
+
+def _write_fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _write(repo, "pkg/lib.py", "def normalize(value):\n    return value.strip()\n")
+    _write(
+        repo,
+        "scripts/cli.py",
+        "from pkg.lib import normalize\n\n\ndef run(value):\n    return normalize(value)\n",
+    )
+    _write(repo, "README.md", "fixture\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", "-b", "feature")
+    return repo
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "audit_cross_layer_callers.py"),
+            *args,
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout


### PR DESCRIPTION
Plan: plans/PR-Audit-Cross-Layer-Caller-Hints.md

Adds an advisory local-review audit that surfaces non-diff references to changed Python functions/classes, so shared-function PRs get caller-layer visibility before review instead of relying on diff-only inspection.

## Intentional
- Caller references are advisory, not blocking, because shared helpers can legitimately have outside users.
- Added Python files are skipped because they cannot have real pre-existing callers and mostly create generic-name noise.
- The audit searches code files only, uses call-shaped matching, and tokenizes Python files so comments and strings do not count as caller hints.
- Python-only in this slice; the repeated failures were in Python shared logic and CLI/library seams.

## Deferred
- TypeScript caller hints for frontend contract/helper changes.
- Stricter plan-doc enforcement when high-risk shared-function PRs have outside callers.
- Richer import/call graph if token-aware text-search hints become too noisy.

## Verification
- Cross-layer caller audit fixture tests - passed, 10 tests.
- Python compile for the new audit script - passed.
- Local PR review against origin/main - passed.

## Diff size
5 files, +680 / -2

Over 400 LOC because the audit script ships with parser/CLI fixture tests in the same slice.