### PR TITLE
PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI.md
+++ b/plans/PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI.md
@@ -1,0 +1,78 @@
+# PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI
+
+## Why this slice exists
+
+Intent-to-FAQ mapping is already partially implemented in the FAQ generator:
+library and service callers can pass `intent_rules`, and tests prove custom
+rules can group customer language into product-specific FAQ opportunities. The
+CLI path still cannot pass those rules, so offline runs and customer-data demos
+remain stuck on the built-in taxonomy.
+
+This slice exposes custom intent rules in the CLI and result diagnostics without
+changing the existing builder/service contract.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add repeatable CLI parsing for custom intent rules.
+2. Prepend custom CLI intent rules before built-in defaults so customer-specific
+   language wins deterministic topic matching.
+3. Include configured custom intent rules in compact result JSON.
+4. Add focused CLI tests for custom intent routing and invalid rule input.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI.md` | Plan doc for this CLI intent-rule slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds CLI custom intent-rule parsing, routing, and result config output. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers CLI custom intent routing and validation. |
+
+## Mechanism
+
+The CLI accepts repeated `--intent-rule` values shaped as
+`topic=keyword,keyword`. Each rule must include a non-empty topic and at least
+one non-empty keyword after case-insensitive dedupe. Parsed custom rules are
+stored on the parsed args for result diagnostics, then prepended to
+`DEFAULT_INTENT_RULES` before calling `build_ticket_faq_markdown`.
+
+The builder/service `intent_rules` parameter remains an exact rule sequence for
+existing host callers. This slice only adds a CLI convenience layer.
+
+## Intentional
+
+- Custom CLI rules take precedence over defaults so customer intent language is
+  not hidden by generic built-in topics.
+- The builder contract is unchanged; callers that already pass exact
+  `intent_rules` keep the same behavior.
+- Result JSON records only configured custom CLI rules, not the full default
+  catalog, to keep diagnostics compact.
+
+## Deferred
+
+- Hosted UI fields for custom intent rules.
+- JSON/CSV intent-rule imports for larger glossary-style rule sets.
+- A future shared parser if multiple CLIs adopt the same custom-rule shape.
+
+## Verification
+
+- Focused custom intent-rule CLI pytest - passed, 7 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed,
+  96 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review against origin/main - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| CLI parser/result changes | ~45 |
+| Tests | ~125 |
+| **Total** | ~250 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -20,6 +20,7 @@ from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     parse_default_fields_or_exit,
 )
 from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    DEFAULT_INTENT_RULES,
     DEFAULT_TITLE,
     build_ticket_faq_markdown,
 )
@@ -99,6 +100,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--intent-rule",
+        action="append",
+        default=[],
+        help=(
+            "Custom FAQ intent rule as topic=keyword,keyword. Repeat to "
+            "provide multiple rules."
+        ),
+    )
+    parser.add_argument(
         "--require-output-checks",
         action="store_true",
         help="Fail when generated FAQ output checks are not all true.",
@@ -125,6 +135,9 @@ def main(argv: list[str] | None = None) -> int:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
     vocabulary_gap_rules = _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
     args.vocabulary_gap_rules = vocabulary_gap_rules
+    custom_intent_rules = _parse_intent_rules(args.intent_rule)
+    args.custom_intent_rules = custom_intent_rules
+    intent_rules = (*custom_intent_rules, *DEFAULT_INTENT_RULES)
 
     loaded = load_source_campaign_opportunities_from_file(
         args.path,
@@ -140,6 +153,7 @@ def main(argv: list[str] | None = None) -> int:
         window_days=args.window_days,
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
+        intent_rules=intent_rules,
         documentation_terms=args.documentation_term,
         vocabulary_gap_rules=vocabulary_gap_rules,
     )
@@ -201,6 +215,10 @@ def _result_payload(
             "vocabulary_gap_rules": [
                 list(rule) for rule in args.vocabulary_gap_rules
             ],
+            "custom_intent_rules": [
+                {"topic": topic, "keywords": list(keywords)}
+                for topic, keywords in args.custom_intent_rules
+            ],
         },
         "source_count": result.source_count,
         "ticket_source_count": result.ticket_source_count,
@@ -246,6 +264,33 @@ def _parse_vocabulary_gap_rule_terms(value: str) -> tuple[str, ...]:
         seen.add(key)
         terms.append(term)
     return tuple(terms)
+
+
+def _parse_intent_rules(values: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for value in values:
+        topic, separator, raw_keywords = value.partition("=")
+        topic = topic.strip()
+        keywords = _parse_intent_rule_keywords(raw_keywords)
+        if not separator or not topic or not keywords:
+            raise SystemExit(
+                "--intent-rule must use topic=keyword,keyword with at least one keyword"
+            )
+        rules.append((topic, keywords))
+    return tuple(rules)
+
+
+def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for part in value.split(","):
+        keyword = part.strip()
+        key = keyword.lower()
+        if not keyword or key in seen:
+            continue
+        seen.add(key)
+        keywords.append(keyword)
+    return tuple(keywords)
 
 
 def _output_check_details(

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2364,6 +2364,129 @@ def test_ticket_faq_cli_rejects_case_duplicate_vocabulary_gap_rule(tmp_path: Pat
     assert "Traceback" not in completed.stderr
 
 
+def test_ticket_faq_cli_accepts_custom_intent_rule(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Warehouse sync lag,The warehouse sync is delayed.,sync",
+        "ticket-2,2026-05-01,Connector lag,CRM connector lag repeats every morning.,sync",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--intent-rule",
+        "data freshness=warehouse sync,connector lag",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "data freshness", "keywords": ["warehouse sync", "connector lag"]}
+    ]
+    assert result["diagnostics"]["items"][0]["topic"] == "data freshness"
+    assert result["diagnostics"]["items"][0]["ticket_count"] == 2
+
+
+def test_ticket_faq_cli_prioritizes_custom_intent_rule_over_defaults(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Export delay,The attribution export is late.,exports",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--intent-rule",
+        "custom reporting=attribution export",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["diagnostics"]["items"][0]["topic"] == "custom reporting"
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        "data freshness",
+        "=warehouse sync",
+        "data freshness=",
+        "data freshness=,",
+    ],
+)
+def test_ticket_faq_cli_rejects_invalid_intent_rule(tmp_path: Path, rule: str) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--intent-rule",
+        rule,
+    )
+
+    assert completed.returncode == 1
+    assert (
+        "--intent-rule must use topic=keyword,keyword with at least one keyword"
+        in completed.stderr
+    )
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_dedupes_custom_intent_keywords_by_case(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--intent-rule",
+        "data freshness=Warehouse Sync,warehouse sync",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "data freshness", "keywords": ["Warehouse Sync"]}
+    ]
+    assert result["diagnostics"]["items"][0]["topic"] == "data freshness"
+
+
+def test_ticket_faq_cli_uses_first_matching_custom_intent_rule(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--intent-rule",
+        "first topic=warehouse sync",
+        "--intent-rule",
+        "second topic=warehouse sync",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "first topic", "keywords": ["warehouse sync"]},
+        {"topic": "second topic", "keywords": ["warehouse sync"]},
+    ]
+    assert result["diagnostics"]["items"][0]["topic"] == "first topic"
+
+
 def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_path: Path) -> None:
     source = _write_source_csv(
         tmp_path,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Custom-Intent-Rules-CLI.md

Exposes the existing FAQ generator intent-rule seam through the CLI, so offline/demo runs can provide customer-specific intent language without changing the builder/service contract.

## Intentional
- CLI custom intent rules are prepended before defaults so customer wording wins topic matching.
- Builder and service `intent_rules` semantics stay unchanged for existing host callers.
- Result diagnostics record only configured custom CLI rules, not the full default catalog.

## Deferred
- Hosted UI fields for custom intent rules.
- JSON or CSV imports for larger intent-rule sets.
- A future shared parser if multiple CLIs adopt the same custom-rule shape.

## Verification
- Focused custom intent-rule CLI pytest - passed, 7 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 96 tests.
- Py compile for affected Python files - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Git whitespace check - passed.
- Local PR review against origin/main - passed.

## Diff size
3 files, +246 / -0