### PR TITLE
Bridge landing page sitemap into atlas intel UI

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs"
   },
   "dependencies": {

--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts
@@ -1,0 +1,21 @@
+export interface SitemapUrl {
+  loc: string
+  lastmod?: string
+  priority: string
+  changefreq: string
+}
+
+export function resolveLandingPageSitemapUrl(
+  env?: Record<string, string | undefined>,
+): string
+
+export function landingPageSitemapUrlsFromXml(
+  xml: string,
+  publicSiteUrl: string,
+): SitemapUrl[]
+
+export function fetchLandingPageSitemapUrls(options?: {
+  sitemapUrl?: string
+  publicSiteUrl: string
+  fetchImpl?: typeof fetch
+}): Promise<SitemapUrl[]>

--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs
@@ -1,0 +1,71 @@
+function clean(value) {
+  return String(value || '').trim()
+}
+
+function stripTrailingSlash(value) {
+  return value.replace(/\/+$/, '')
+}
+
+export function resolveLandingPageSitemapUrl(env = process.env) {
+  return clean(env.VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL)
+}
+
+function decodeXmlEntities(value) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+}
+
+export function landingPageSitemapUrlsFromXml(xml, publicSiteUrl) {
+  const siteBase = new URL(stripTrailingSlash(clean(publicSiteUrl)))
+  const seen = new Set()
+  const urls = []
+  const locMatches = String(xml || '').matchAll(/<loc>\s*([\s\S]*?)\s*<\/loc>/gi)
+
+  for (const match of locMatches) {
+    const rawLoc = decodeXmlEntities(match[1])
+    let parsed
+    try {
+      parsed = new URL(rawLoc)
+    } catch (_error) {
+      continue
+    }
+
+    if (!parsed.pathname.startsWith('/lp/')) continue
+
+    const loc = `${siteBase.origin}${parsed.pathname}`
+    if (seen.has(loc)) continue
+    seen.add(loc)
+    urls.push({
+      loc,
+      priority: '0.7',
+      changefreq: 'weekly',
+    })
+  }
+
+  return urls
+}
+
+export async function fetchLandingPageSitemapUrls({
+  sitemapUrl,
+  publicSiteUrl,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const feedUrl = clean(sitemapUrl)
+  if (!feedUrl) return []
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Landing-page sitemap bridge requires a fetch implementation')
+  }
+
+  const response = await fetchImpl(feedUrl)
+  if (!response || !response.ok) {
+    const status = response?.status ? `HTTP ${response.status}` : 'no response'
+    throw new Error(`Failed to fetch generated landing-page sitemap: ${status}`)
+  }
+
+  const xml = await response.text()
+  return landingPageSitemapUrlsFromXml(xml, publicSiteUrl)
+}

--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  fetchLandingPageSitemapUrls,
+  landingPageSitemapUrlsFromXml,
+  resolveLandingPageSitemapUrl,
+} from './landing-page-sitemap-bridge.mjs'
+
+const SITE_URL = 'https://atlas-intel-ui-two.vercel.app'
+
+test('resolveLandingPageSitemapUrl uses explicit feed URL only', () => {
+  assert.equal(
+    resolveLandingPageSitemapUrl({
+      VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL:
+        ' https://api.example.com/content-assets/landing_page/public/sitemap.xml ',
+      VITE_API_BASE: 'https://api.example.com',
+    }),
+    'https://api.example.com/content-assets/landing_page/public/sitemap.xml',
+  )
+  assert.equal(
+    resolveLandingPageSitemapUrl({ VITE_API_BASE: 'https://api.example.com' }),
+    '',
+  )
+})
+
+test('landingPageSitemapUrlsFromXml keeps lp paths and rewrites to public site', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://api.example.com/lp/111/acme-page</loc></url>
+  <url><loc>https://api.example.com/blog/not-imported</loc></url>
+  <url><loc>https://api.example.com/lp/222/second-page?variant=a&amp;b=1</loc></url>
+</urlset>`
+
+  assert.deepEqual(landingPageSitemapUrlsFromXml(xml, SITE_URL), [
+    {
+      loc: `${SITE_URL}/lp/111/acme-page`,
+      priority: '0.7',
+      changefreq: 'weekly',
+    },
+    {
+      loc: `${SITE_URL}/lp/222/second-page`,
+      priority: '0.7',
+      changefreq: 'weekly',
+    },
+  ])
+})
+
+test('landingPageSitemapUrlsFromXml dedupes and skips invalid loc entries', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://api.example.com/lp/111/acme-page</loc></url>
+  <url><loc>not a url</loc></url>
+  <url><loc>https://api.example.com/lp/111/acme-page</loc></url>
+</urlset>`
+
+  assert.deepEqual(landingPageSitemapUrlsFromXml(xml, `${SITE_URL}/`), [
+    {
+      loc: `${SITE_URL}/lp/111/acme-page`,
+      priority: '0.7',
+      changefreq: 'weekly',
+    },
+  ])
+})
+
+test('fetchLandingPageSitemapUrls fetches and parses configured feed', async () => {
+  const urls = await fetchLandingPageSitemapUrls({
+    sitemapUrl: 'https://api.example.com/content-assets/landing_page/public/sitemap.xml',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async url => {
+      assert.equal(
+        url,
+        'https://api.example.com/content-assets/landing_page/public/sitemap.xml',
+      )
+      return {
+        ok: true,
+        async text() {
+          return '<urlset><url><loc>https://api.example.com/lp/111/acme-page</loc></url></urlset>'
+        },
+      }
+    },
+  })
+
+  assert.equal(urls.length, 1)
+  assert.equal(urls[0].loc, `${SITE_URL}/lp/111/acme-page`)
+})
+
+test('fetchLandingPageSitemapUrls is a no-op without a feed URL', async () => {
+  const urls = await fetchLandingPageSitemapUrls({
+    sitemapUrl: '',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => {
+      throw new Error('fetch should not run')
+    },
+  })
+
+  assert.deepEqual(urls, [])
+})
+
+test('fetchLandingPageSitemapUrls fails when configured feed is unavailable', async () => {
+  await assert.rejects(
+    fetchLandingPageSitemapUrls({
+      sitemapUrl: 'https://api.example.com/content-assets/landing_page/public/sitemap.xml',
+      publicSiteUrl: SITE_URL,
+      fetchImpl: async () => ({ ok: false, status: 503 }),
+    }),
+    /Failed to fetch generated landing-page sitemap: HTTP 503/,
+  )
+})

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -16,6 +16,10 @@ import {
   type ChartValue,
   type FaqItem,
 } from './scripts/blog-source-metadata.mjs'
+import {
+  fetchLandingPageSitemapUrls,
+  resolveLandingPageSitemapUrl,
+} from './scripts/landing-page-sitemap-bridge.mjs'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
@@ -31,17 +35,30 @@ interface SitemapUrl {
   changefreq: string
 }
 
+function dedupeSitemapUrls(urls: SitemapUrl[]): SitemapUrl[] {
+  const seen = new Set<string>()
+  return urls.filter(url => {
+    if (seen.has(url.loc)) return false
+    seen.add(url.loc)
+    return true
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Sitemap plugin
 // ---------------------------------------------------------------------------
 function sitemapPlugin() {
   return {
     name: 'generate-sitemap',
-    closeBundle() {
+    async closeBundle() {
       const posts = collectBlogSourceMetadata(import.meta.dirname)
+      const generatedLandingPageUrls = await fetchLandingPageSitemapUrls({
+        sitemapUrl: resolveLandingPageSitemapUrl(),
+        publicSiteUrl: BASE_URL,
+      })
 
       const today = new Date().toISOString().split('T')[0]
-      const urls: SitemapUrl[] = [
+      const urls = dedupeSitemapUrls([
         { loc: `${BASE_URL}/landing`, priority: '1.0', changefreq: 'weekly' },
         { loc: `${BASE_URL}/blog`, priority: '0.9', changefreq: 'daily' },
         ...posts.map(post => ({
@@ -50,8 +67,9 @@ function sitemapPlugin() {
           priority: '0.7',
           changefreq: 'monthly',
         })),
+        ...generatedLandingPageUrls,
         { loc: `${BASE_URL}/`, priority: '0.3', changefreq: 'monthly' },
-      ]
+      ])
 
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/plans/PR-Landing-Page-Static-Sitemap-Bridge.md
+++ b/plans/PR-Landing-Page-Static-Sitemap-Bridge.md
@@ -1,0 +1,91 @@
+# PR-Landing-Page-Static-Sitemap-Bridge
+
+## Why this slice exists
+
+Generated landing pages now have a backend-owned public sitemap feed, but the
+public `atlas-intel-ui` build still emits a static sitemap with only the fixed
+marketing and blog routes. This slice bridges those two surfaces so crawler
+entry points can include approved generated landing pages without making the
+frontend own landing-page readiness logic.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-static-sitemap-bridge
+
+1. Add a small sitemap-bridge helper for build-time import of generated landing
+   page URLs.
+2. Wire the `atlas-intel-ui` Vite sitemap plugin to append generated `/lp/...`
+   URLs when a feed URL is configured.
+3. Normalize imported landing-page URLs onto the frontend origin and dedupe
+   sitemap entries.
+4. Keep backend readiness/indexing policy unchanged.
+5. Keep static prerender unchanged in this slice.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Static-Sitemap-Bridge.md`
+- `atlas-intel-ui/vite.config.ts`
+- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs`
+- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts`
+- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs`
+- `atlas-intel-ui/package.json`
+
+## Mechanism
+
+The Vite sitemap plugin builds the existing static URL list, then optionally
+fetches a configured generated landing-page sitemap feed from
+`VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`. The helper extracts `<loc>` entries,
+keeps only `/lp/...` paths, rewrites those paths to the frontend `BASE_URL`,
+and returns sitemap-ready URL objects.
+
+If no feed URL is configured, the build produces the same static sitemap it
+does today. If a feed URL is configured but the feed cannot be fetched or
+parsed, the helper throws so production builds do not silently ship a partial
+generated-page sitemap.
+
+## Intentional
+
+- No frontend copy/layout changes.
+- No backend sitemap or robots-policy changes.
+- No static prerender for database-backed generated landing pages.
+- No import of backend metadata/readiness details into the frontend build.
+
+## Deferred
+
+- `PR-Landing-Page-SEO-GEO-AEO-Input-Contract` should add first-class
+  landing-page inputs before more rendering work. The current code audit shows
+  review panels, save-time quality gates, and generation repair already exist,
+  while user-provided SEO/GEO/AEO inputs still do not have a clean form or a
+  broad generation input contract.
+- `PR-Landing-Page-Readiness-Validator-Unification` should then centralize the
+  export/public-readiness validators with the save-time quality gate so
+  generation, review, robots, and sitemap inclusion use one source of truth.
+- `PR-Landing-Page-Public-Prerender` can add static HTML prerendering later if
+  crawl diagnostics show the SPA route is not enough.
+
+## Verification
+
+- Node unit tests for feed URL resolution, XML loc extraction, origin
+  normalization, path filtering, dedupe, and fetch failure behavior.
+- `npm --prefix atlas-intel-ui run test:sitemap-bridge`
+  - 6 passed.
+- `npm --prefix atlas-intel-ui run build`
+  - passed without a generated landing-page feed.
+  - passed with a `data:` generated landing-page feed and wrote the normalized
+    `/lp/111/acme-page` URL into `dist/sitemap.xml`.
+- `npm --prefix atlas-intel-ui run verify:blog-geo`
+  - verified 14 blog pages.
+- `npm --prefix atlas-intel-ui run lint`
+  - passed.
+- Git whitespace check.
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Sitemap bridge helper | ~95 |
+| Vite sitemap wiring | ~25 |
+| Node tests/package script | ~95 |
+| **Total** | **~300** |


### PR DESCRIPTION
# PR-Landing-Page-Static-Sitemap-Bridge

## Why this slice exists

Generated landing pages now have a backend-owned public sitemap feed, but the
public `atlas-intel-ui` build still emits a static sitemap with only the fixed
marketing and blog routes. This slice bridges those two surfaces so crawler
entry points can include approved generated landing pages without making the
frontend own landing-page readiness logic.

## Scope (this PR)

Ownership lane: content-ops/landing-page-static-sitemap-bridge

1. Add a small sitemap-bridge helper for build-time import of generated landing
   page URLs.
2. Wire the `atlas-intel-ui` Vite sitemap plugin to append generated `/lp/...`
   URLs when a feed URL is configured.
3. Normalize imported landing-page URLs onto the frontend origin and dedupe
   sitemap entries.
4. Keep backend readiness/indexing policy unchanged.
5. Keep static prerender unchanged in this slice.

### Files touched

- `plans/PR-Landing-Page-Static-Sitemap-Bridge.md`
- `atlas-intel-ui/vite.config.ts`
- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs`
- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts`
- `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs`
- `atlas-intel-ui/package.json`

## Mechanism

The Vite sitemap plugin builds the existing static URL list, then optionally
fetches a configured generated landing-page sitemap feed from
`VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`. The helper extracts `<loc>` entries,
keeps only `/lp/...` paths, rewrites those paths to the frontend `BASE_URL`,
and returns sitemap-ready URL objects.

If no feed URL is configured, the build produces the same static sitemap it
does today. If a feed URL is configured but the feed cannot be fetched or
parsed, the helper throws so production builds do not silently ship a partial
generated-page sitemap.

## Intentional

- No frontend copy/layout changes.
- No backend sitemap or robots-policy changes.
- No static prerender for database-backed generated landing pages.
- No import of backend metadata/readiness details into the frontend build.

## Deferred

- `PR-Landing-Page-Public-Prerender` can add static HTML prerendering for
  approved generated landing pages if crawl diagnostics show the SPA route is
  not enough.

## Verification

- Node unit tests for feed URL resolution, XML loc extraction, origin
  normalization, path filtering, dedupe, and fetch failure behavior.
- `npm --prefix atlas-intel-ui run test:sitemap-bridge`
  - 6 passed.
- `npm --prefix atlas-intel-ui run build`
  - passed without a generated landing-page feed.
  - passed with a `data:` generated landing-page feed and wrote the normalized
    `/lp/111/acme-page` URL into `dist/sitemap.xml`.
- `npm --prefix atlas-intel-ui run verify:blog-geo`
  - verified 14 blog pages.
- `npm --prefix atlas-intel-ui run lint`
  - passed.
- Git whitespace check.
  - passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Plan | ~85 |
| Sitemap bridge helper | ~95 |
| Vite sitemap wiring | ~25 |
| Node tests/package script | ~95 |
| **Total** | **~300** |
