### PR TITLE
Category-scope landscape corpus counts (D7c)

### DIFF
--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -6129,8 +6129,14 @@ async def _gather_data(
         vendor_names.append(topic_ctx["vendor_b"])
     if topic_ctx.get("from_vendor"):
         vendor_names.append(topic_ctx["from_vendor"])
-    # For category-level topics, pull all vendors in the category
+    # For category-level topics (landscape/roundup/best-fit), pull all vendors
+    # in the category AND remember the category. The corpus counts below then
+    # scope to the category, not to "any review mentioning a category vendor" --
+    # counting by vendor mention overstates the corpus because free-form
+    # community threads name many products across categories (D7).
+    category_scope: str | None = None
     if not vendor_names and topic_ctx.get("category"):
+        category_scope = topic_ctx["category"]
         cat_rows = await pool.fetch(
             "SELECT DISTINCT vm.vendor_name "
             "FROM b2b_reviews r "
@@ -6142,7 +6148,27 @@ async def _gather_data(
 
     # APPROVED-ENRICHMENT-READ: churn_signals.intent_to_leave
     # Reason: inline aggregate query, structurally coupled to product output
-    if vendor_names:
+    if category_scope:
+        # Category-level topic: scope the headline corpus to the category, not
+        # to vendor mentions (D7 -- mention-scoping over-counts via off-category
+        # community cross-mentions; CRM read ~5,931 mention-scoped vs ~1,133
+        # category-scoped enriched).
+        ctx_row = await pool.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS total_reviews,
+                COUNT(*) FILTER (WHERE enrichment_status = 'enriched') AS enriched,
+                COUNT(*) FILTER (WHERE (enrichment->'churn_signals'->>'intent_to_leave')::boolean = true) AS churn_intent,
+                MIN(imported_at)::date AS earliest,
+                MAX(imported_at)::date AS latest
+            FROM b2b_reviews
+            WHERE product_category = $1
+              AND duplicate_of_review_id IS NULL
+              AND source = ANY($2)
+            """,
+            category_scope, ctx_sources,
+        )
+    elif vendor_names:
         ctx_row = await pool.fetchrow(
             """
             SELECT
@@ -6207,7 +6233,7 @@ async def _gather_data(
             data["data_context"][vk] = topic_ctx[vk]
 
     # Source distribution and data quality metadata
-    source_dist = await _fetch_source_distribution(pool, vendor_names)
+    source_dist = await _fetch_source_distribution(pool, vendor_names, category=category_scope)
     data["data_context"]["source_distribution"] = source_dist
     data["data_context"]["data_source_label"] = "Public B2B software review platforms"
     data["data_context"]["data_disclaimer"] = (
@@ -6878,24 +6904,49 @@ async def _fetch_category_overview_entry(pool, category: str) -> dict[str, Any] 
     return None
 
 
-async def _fetch_source_distribution(pool, vendor_names: list[str]) -> dict[str, Any]:
-    """Return review counts by source platform for the given vendors."""
-    if not vendor_names:
-        return {"sources": [], "verified_count": 0, "community_count": 0}
+async def _fetch_source_distribution(
+    pool, vendor_names: list[str], *, category: str | None = None,
+) -> dict[str, Any]:
+    """Return review counts by source platform.
+
+    D7: ``category`` selects the scope. A category-level topic
+    (landscape/roundup/best-fit) MUST count reviews IN the category, not every
+    review that merely MENTIONS one of the category's vendors -- free-form
+    community threads (Reddit etc.) name many products across categories, so
+    mention-scoping overstates the corpus and inflates the community split (CRM:
+    5,931 mention-scoped / community 5,442 vs 1,133 / 963 category-scoped). A
+    vendor-level topic passes ``category=None`` and keeps vendor-mention scope.
+    """
     allowed = _blog_source_allowlist()
-    rows = await pool.fetch(
-        """
-        SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
-        FROM b2b_reviews r
-        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
-        WHERE vm.vendor_name = ANY($1) AND r.enrichment_status = 'enriched'
-          AND r.duplicate_of_review_id IS NULL
-          AND r.source = ANY($2)
-        GROUP BY r.source
-        ORDER BY cnt DESC
-        """,
-        vendor_names, allowed,
-    )
+    if category:
+        rows = await pool.fetch(
+            """
+            SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
+            FROM b2b_reviews r
+            WHERE r.product_category = $1 AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            GROUP BY r.source
+            ORDER BY cnt DESC
+            """,
+            category, allowed,
+        )
+    elif vendor_names:
+        rows = await pool.fetch(
+            """
+            SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
+            FROM b2b_reviews r
+            JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+            WHERE vm.vendor_name = ANY($1) AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            GROUP BY r.source
+            ORDER BY cnt DESC
+            """,
+            vendor_names, allowed,
+        )
+    else:
+        return {"sources": [], "verified_count": 0, "community_count": 0}
     sources = [{"name": r["src"], "count": r["cnt"]} for r in rows]
     verified = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") in VERIFIED_SOURCES)
     community = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") not in VERIFIED_SOURCES)

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -6129,8 +6129,14 @@ async def _gather_data(
         vendor_names.append(topic_ctx["vendor_b"])
     if topic_ctx.get("from_vendor"):
         vendor_names.append(topic_ctx["from_vendor"])
-    # For category-level topics, pull all vendors in the category
+    # For category-level topics (landscape/roundup/best-fit), pull all vendors
+    # in the category AND remember the category. The corpus counts below then
+    # scope to the category, not to "any review mentioning a category vendor" --
+    # counting by vendor mention overstates the corpus because free-form
+    # community threads name many products across categories (D7).
+    category_scope: str | None = None
     if not vendor_names and topic_ctx.get("category"):
+        category_scope = topic_ctx["category"]
         cat_rows = await pool.fetch(
             "SELECT DISTINCT vm.vendor_name "
             "FROM b2b_reviews r "
@@ -6142,7 +6148,27 @@ async def _gather_data(
 
     # APPROVED-ENRICHMENT-READ: churn_signals.intent_to_leave
     # Reason: inline aggregate query, structurally coupled to product output
-    if vendor_names:
+    if category_scope:
+        # Category-level topic: scope the headline corpus to the category, not
+        # to vendor mentions (D7 -- mention-scoping over-counts via off-category
+        # community cross-mentions; CRM read ~5,931 mention-scoped vs ~1,133
+        # category-scoped enriched).
+        ctx_row = await pool.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS total_reviews,
+                COUNT(*) FILTER (WHERE enrichment_status = 'enriched') AS enriched,
+                COUNT(*) FILTER (WHERE (enrichment->'churn_signals'->>'intent_to_leave')::boolean = true) AS churn_intent,
+                MIN(imported_at)::date AS earliest,
+                MAX(imported_at)::date AS latest
+            FROM b2b_reviews
+            WHERE product_category = $1
+              AND duplicate_of_review_id IS NULL
+              AND source = ANY($2)
+            """,
+            category_scope, ctx_sources,
+        )
+    elif vendor_names:
         ctx_row = await pool.fetchrow(
             """
             SELECT
@@ -6207,7 +6233,7 @@ async def _gather_data(
             data["data_context"][vk] = topic_ctx[vk]
 
     # Source distribution and data quality metadata
-    source_dist = await _fetch_source_distribution(pool, vendor_names)
+    source_dist = await _fetch_source_distribution(pool, vendor_names, category=category_scope)
     data["data_context"]["source_distribution"] = source_dist
     data["data_context"]["data_source_label"] = "Public B2B software review platforms"
     data["data_context"]["data_disclaimer"] = (
@@ -6878,24 +6904,49 @@ async def _fetch_category_overview_entry(pool, category: str) -> dict[str, Any] 
     return None
 
 
-async def _fetch_source_distribution(pool, vendor_names: list[str]) -> dict[str, Any]:
-    """Return review counts by source platform for the given vendors."""
-    if not vendor_names:
-        return {"sources": [], "verified_count": 0, "community_count": 0}
+async def _fetch_source_distribution(
+    pool, vendor_names: list[str], *, category: str | None = None,
+) -> dict[str, Any]:
+    """Return review counts by source platform.
+
+    D7: ``category`` selects the scope. A category-level topic
+    (landscape/roundup/best-fit) MUST count reviews IN the category, not every
+    review that merely MENTIONS one of the category's vendors -- free-form
+    community threads (Reddit etc.) name many products across categories, so
+    mention-scoping overstates the corpus and inflates the community split (CRM:
+    5,931 mention-scoped / community 5,442 vs 1,133 / 963 category-scoped). A
+    vendor-level topic passes ``category=None`` and keeps vendor-mention scope.
+    """
     allowed = _blog_source_allowlist()
-    rows = await pool.fetch(
-        """
-        SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
-        FROM b2b_reviews r
-        JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
-        WHERE vm.vendor_name = ANY($1) AND r.enrichment_status = 'enriched'
-          AND r.duplicate_of_review_id IS NULL
-          AND r.source = ANY($2)
-        GROUP BY r.source
-        ORDER BY cnt DESC
-        """,
-        vendor_names, allowed,
-    )
+    if category:
+        rows = await pool.fetch(
+            """
+            SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
+            FROM b2b_reviews r
+            WHERE r.product_category = $1 AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            GROUP BY r.source
+            ORDER BY cnt DESC
+            """,
+            category, allowed,
+        )
+    elif vendor_names:
+        rows = await pool.fetch(
+            """
+            SELECT COALESCE(r.source, 'unknown') AS src, COUNT(DISTINCT r.id) AS cnt
+            FROM b2b_reviews r
+            JOIN b2b_review_vendor_mentions vm ON vm.review_id = r.id
+            WHERE vm.vendor_name = ANY($1) AND r.enrichment_status = 'enriched'
+              AND r.duplicate_of_review_id IS NULL
+              AND r.source = ANY($2)
+            GROUP BY r.source
+            ORDER BY cnt DESC
+            """,
+            vendor_names, allowed,
+        )
+    else:
+        return {"sources": [], "verified_count": 0, "community_count": 0}
     sources = [{"name": r["src"], "count": r["cnt"]} for r in rows]
     verified = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") in VERIFIED_SOURCES)
     community = sum(r["cnt"] for r in rows if r["src"].lower().replace(" ", "_") not in VERIFIED_SOURCES)

--- a/plans/PR-Blog-D7c-Landscape-Scope.md
+++ b/plans/PR-Blog-D7c-Landscape-Scope.md
@@ -1,0 +1,95 @@
+# PR-Blog-D7c-Landscape-Scope
+
+Ownership lane: `content-ops/blog-d7c-landscape-scope`
+
+## Why this slice exists
+
+Defect **D7** (`reports/blog-audit-findings.md`), landscape instance. The
+`crm-landscape` post claims "3,287 enriched reviews ... (172 verified + 3,115
+community)" -- impossible for the CRM category (all-source enriched ceiling
+1,959; allowlist enriched 1,133). PR-D7a (#760) fixed the vendor deep-dive total;
+this slice fixes the category-LEVEL (landscape/roundup/best-fit) corpus counts.
+
+Root cause (DB-verified, not the `SUM(cs.total_reviews)` theory the DB earlier
+refuted at 107): a category-level topic derives its vendor set from the category,
+then counts reviews by **vendor mention** with no `product_category` filter. So a
+free-form community thread (Reddit etc.) that merely *mentions* a CRM vendor
+among other tools is counted as a CRM "enriched review." Verified for CRM:
+
+| | mention-scoped (buggy) | category-scoped (correct) |
+|---|---:|---:|
+| total enriched | ~5,931 | **1,133** |
+| community split | ~5,442 | **963** |
+| verified split | (≈ correct) | **170** |
+
+Verified sources (G2/Gartner/PeerSpot) are category-aligned, so their count
+(170 ≈ the post's 172) was already right -- only the community number inflates.
+
+## Scope (this PR)
+
+Two mention-scoped reads in the data-context builder (`_gather_data`) feed the
+inflated headline, both gated to the new `category_scope` (set only for
+category-level topics, where the vendor set is derived from the category):
+
+- the `ctx_row` aggregate -> `enriched_count` / `total_reviews_analyzed`
+  (the "3,287 enriched");
+- `_fetch_source_distribution` -> `verified_count` / `community_count`
+  (the "172 verified + 3,115 community").
+
+Vendor-level topics (deep-dive/showdown/switching) keep vendor-mention scope --
+that path is correct and PR-D7a already aligned its source allowlist.
+
+### Files touched
+
+- `plans/PR-Blog-D7c-Landscape-Scope.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation.py`
+
+## Mechanism
+
+`_gather_data` captures `category_scope = topic_ctx["category"]` exactly where it
+already fills the vendor set from the category. When set, the `ctx_row` query
+scopes `WHERE product_category = $1` (instead of `EXISTS vm.vendor_name = ANY`),
+and `_fetch_source_distribution` is called with `category=category_scope`.
+`_fetch_source_distribution` gains a keyword `category`: when present it counts
+`COUNT(DISTINCT r.id)` over `r.product_category = $1` (dropping the
+vendor-mentions join); when absent it keeps the existing vendor-mention query.
+Both byte-identical `b2b_blog_post_generation.py` copies (edit one, `cp` to the
+mirror; verified identical).
+
+## Intentional
+
+- **Category scope for category-level topics only.** Gated on `category_scope`,
+  so vendor deep-dives are untouched -- mention-scoping is correct for them.
+- **Match D7a's scope vocabulary.** Same `_blog_source_allowlist()` + dedup;
+  this slice only swaps the vendor-mention predicate for a `product_category`
+  predicate on the category path.
+
+## Deferred
+
+- **PR-D7b (data fix):** correct the published `crm-landscape` + `zoho-crm-deep-dive`
+  numbers to the category-scoped values (like #745), plus the
+  `project-management-landscape` L266 orphan from #757.
+- **D8** (vendor-count vs coverage) and **D2/D3/D4** (pipedrive) remain.
+
+## Verification
+
+- New `test_fetch_source_distribution_scopes_by_category`: with `category=`, the
+  query filters `r.product_category = $1`, binds the category, and drops the
+  vendor-mentions join. `test_fetch_source_distribution_reads_vendor_mentions`
+  still pins the vendor-level path.
+- `pytest` generation + quote-gate suites -> 192 passed; existing `_gather_data`
+  tests unaffected.
+- Both copies byte-identical after edit.
+- Live DB: category-scoped CRM enriched = 1,133 (verified 170 / community 963)
+  vs the mention-scoped ~5,931 / 5,442 the old path produced.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (category gate + scoped queries, incl. duplicated ctx_row branch) | ~180 |
+| Test | ~25 |
+| Plan doc | ~90 |
+| **Total** | **~295** |

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -1604,6 +1604,57 @@ async def test_fetch_source_distribution_scopes_by_category():
 
 
 @pytest.mark.asyncio
+async def test_gather_data_category_topic_routes_through_category_scope(monkeypatch):
+    """D7c seam test: a category-level topic (no vendor in topic_ctx) must take
+    the `category_scope` path -- the ctx_row aggregate scopes
+    `WHERE product_category = $1` (not `EXISTS vm.vendor_name = ANY`), and
+    _fetch_source_distribution is called with `category=<category>`. The four
+    existing _gather_data tests all pass a vendor (the `elif vendor_names`
+    path), so this is the only test that enters the seam where the D7 bug lived:
+    reverting the category_scope capture, the ctx_row branch, or the `category=`
+    kwarg each silently falls back to mention-scoping and must fail HERE."""
+    ctx_rows: list[tuple[str, tuple]] = []
+
+    class Pool:
+        async def fetch(self, query, *args):
+            # cat_rows: the category->vendor-set query populates vendor_names.
+            if "SELECT DISTINCT vm.vendor_name" in query:
+                return [{"vendor_name": "Salesforce"}, {"vendor_name": "HubSpot"}]
+            return []  # vendor_pains etc.
+
+        async def fetchrow(self, query, *args):
+            ctx_rows.append((query, args))
+            return {
+                "total_reviews": 1133, "enriched": 1133, "churn_intent": 40,
+                "earliest": "2026-02-25", "latest": "2026-04-07",
+            }
+
+    source_dist = AsyncMock(
+        return_value={"sources": [], "verified_count": 170, "community_count": 963},
+    )
+    monkeypatch.setattr(blog_mod, "_fetch_source_distribution", source_dist)
+    monkeypatch.setattr(blog_mod, "_fetch_quotable_reviews", AsyncMock(return_value=[]))
+    monkeypatch.setattr(blog_mod, "_fetch_affiliate_partner", AsyncMock(return_value=None))
+    monkeypatch.setattr(blog_mod, "_fetch_category_overview_entry", AsyncMock(return_value=None))
+    monkeypatch.setattr(blog_mod, "_fetch_affiliate_partner_by_category", AsyncMock(return_value=None))
+    monkeypatch.setattr(blog_mod, "_match_affiliate_partner_for_vendors", AsyncMock(return_value=None))
+
+    await _gather_data(
+        Pool(),
+        "pain_point_roundup",
+        {"category": "CRM", "vendor_count": 8, "total_complaints": 480, "slug": "crm-complaints"},
+    )
+
+    # The corpus aggregate (carries churn_intent) must be the category-scoped form.
+    ctx_sql, ctx_args = next((q, a) for q, a in ctx_rows if "churn_intent" in q)
+    assert "WHERE product_category = $1" in ctx_sql
+    assert "EXISTS" not in ctx_sql
+    assert ctx_args[0] == "CRM"
+    # ...and the source-distribution split is category-scoped, not vendor-mention.
+    assert source_dist.await_args.kwargs.get("category") == "CRM"
+
+
+@pytest.mark.asyncio
 async def test_fetch_vendor_stats_reads_vendor_mentions():
     pool = SimpleNamespace(fetchrow=AsyncMock(return_value=None))
 

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -1585,6 +1585,25 @@ async def test_fetch_source_distribution_reads_vendor_mentions():
 
 
 @pytest.mark.asyncio
+async def test_fetch_source_distribution_scopes_by_category():
+    """D7: a category-level topic must count reviews IN the category, not every
+    review that MENTIONS a category vendor -- free-form community threads name
+    many products across categories, so mention-scoping overstates the corpus
+    (CRM: ~5,931 mention-scoped / community 5,442 vs 1,133 / 963 category).
+    With category=, the query filters r.product_category and drops the
+    vendor_mentions join."""
+    pool = SimpleNamespace(fetch=AsyncMock(return_value=[]))
+
+    await blog_mod._fetch_source_distribution(pool, ["Salesforce", "HubSpot"], category="CRM")
+
+    args = pool.fetch.await_args.args
+    sql = args[0]
+    assert "r.product_category = $1" in sql
+    assert "JOIN b2b_review_vendor_mentions" not in sql
+    assert args[1] == "CRM"  # category bound as $1, not the vendor list
+
+
+@pytest.mark.asyncio
 async def test_fetch_vendor_stats_reads_vendor_mentions():
     pool = SimpleNamespace(fetchrow=AsyncMock(return_value=None))
 


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d7c-landscape-scope`

D7 landscape instance (follow-up to PR-D7a #760, which fixed the vendor deep-dive total).

## Intentional

- **Root cause (DB-verified):** a category-level topic (landscape/roundup/best-fit) derives its vendor set from the category, then counts reviews by **vendor mention** with no `product_category` filter. So a free-form community thread (Reddit etc.) that merely *mentions* a CRM vendor among other tools is counted as a CRM "enriched review." `crm-landscape` read "3,287 enriched (172 verified + 3,115 community)".

  | CRM | mention-scoped (buggy) | category-scoped (correct) |
  |---|---:|---:|
  | total enriched | ~5,931 | **1,133** |
  | community | ~5,442 | **963** |
  | verified | (≈ correct) | **170** (post said 172) |

  Verified/structured sources are category-aligned, so only the community number inflated.
- **Fix:** `_gather_data` captures `category_scope` where it fills the vendor set from the category; on that path the `ctx_row` aggregate scopes `WHERE product_category` (not `EXISTS vm.vendor_name = ANY`), and `_fetch_source_distribution(category=...)` counts by `product_category` (dropping the vendor-mentions join). Vendor-level topics keep mention scope (correct). Both byte-identical copies.

## Deferred

- **PR-D7b (data fix):** correct the published `crm-landscape` + `zoho-crm-deep-dive` numbers (like #745), plus the `project-management-landscape` L266 orphan from #757.
- **D8** (vendor-count vs coverage), **D2/D3/D4** (pipedrive) remain.

## Verification

- New `test_fetch_source_distribution_scopes_by_category` (category= → `product_category = $1`, no vendor-mentions join); `test_fetch_source_distribution_reads_vendor_mentions` still pins the vendor path.
- generation + quote-gate suites → **192 passed**; existing `_gather_data` tests unaffected.
- Both copies byte-identical.
- Live DB: category-scoped CRM enriched = 1,133 (170 / 963) vs mention-scoped ~5,931 / 5,442.

Note: the `ctx_row` category branch is verified by the DB cross-check + the shared gated pattern (the source-distribution unit test pins the category-scoping). Happy to add a `_gather_data`-level capture test for it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)