### PR TITLE
PR-Content-Ops-FAQ-Rule-File-Import

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Rule-File-Import.md
+++ b/plans/PR-Content-Ops-FAQ-Rule-File-Import.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-FAQ-Rule-File-Import
+
+## Why this slice exists
+
+The FAQ CLI can now accept custom vocabulary-gap rules and custom intent rules,
+but larger SMB and mid-market runs should not require long command lines. Teams
+need a small rule-file path for reusable product glossary and intent mappings
+that can travel with demos, offline customer samples, and repeatable validation
+runs.
+
+This slice adds JSON rule-file import for the existing CLI custom-rule seams.
+It is over the 400 LOC soft budget after review because the delimiter
+round-trip guard and operator-error branches need to ship with fixture coverage
+in the same slice; splitting those tests out would recreate the under-tested
+error-path pattern this family of PRs has been correcting.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add a repeatable `--rule-file` CLI flag for JSON rule files.
+2. Accept `intent_rules` and `vocabulary_gap_rules` from the JSON file.
+3. Let explicit CLI flags take precedence over file rules for deterministic
+   first-match intent routing.
+4. Include configured rule-file paths in compact result JSON.
+5. Add focused CLI tests for rule-file routing, precedence, and validation.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Rule-File-Import.md` | Plan doc for this rule-file slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds JSON rule-file parsing and combines file rules with explicit CLI rules. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers rule-file import, precedence, and invalid payload handling. |
+
+## Mechanism
+
+The CLI reads each `--rule-file` as a JSON object with optional
+`intent_rules` and `vocabulary_gap_rules` arrays. Intent rules use objects shaped
+as `{"topic": "...", "keywords": ["...", "..."]}`. Vocabulary-gap rules use
+arrays of aliases such as `["SSO", "single sign-on"]`.
+
+File rules are parsed through the same validation helpers as the existing CLI
+flags. Explicit CLI rules are placed before file rules so command-line overrides
+win in first-match intent routing and first-listed vocabulary mappings.
+
+## Intentional
+
+- JSON only in this slice. CSV import is deferred until the rule-file contract
+  proves useful.
+- Explicit CLI flags win over file rules because they are the most local
+  operator intent.
+- JSON rule-file values must be strings and cannot contain the CLI delimiters
+  used for the corresponding rule type; the CLI rejects those cases rather than
+  silently re-splitting a rule into the wrong shape.
+- The builder/service contracts remain unchanged; this is a CLI ergonomics
+  layer over existing rule inputs.
+- Local review's cross-layer caller hints for generic script helper names such
+  as `_parse_args`, `main`, and `_result_payload` were inspected as unrelated
+  same-name helpers in other scripts; this slice does not change shared library
+  behavior.
+
+## Deferred
+
+- CSV rule-file import.
+- Hosted UI upload/entry fields for custom FAQ rules.
+- A shared custom-rule parser module if another CLI adopts this shape.
+
+## Verification
+
+- Focused FAQ rule-file/custom-rule CLI pytest - passed, 33 tests.
+- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed,
+  115 tests.
+- Py compile for affected Python files - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Git whitespace check - passed.
+- Local PR review against origin/main - passed; advisory cross-layer caller
+  hints inspected, no actionable external caller impact.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| CLI parser/result changes | ~155 |
+| Tests | ~220 |
+| **Total** | ~455 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -100,6 +100,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--rule-file",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "JSON file with intent_rules and/or vocabulary_gap_rules. "
+            "Repeat to load multiple files."
+        ),
+    )
+    parser.add_argument(
         "--intent-rule",
         action="append",
         default=[],
@@ -133,9 +143,16 @@ def main(argv: list[str] | None = None) -> int:
             date.fromisoformat(args.as_of_date)
         except ValueError:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
-    vocabulary_gap_rules = _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
+    file_rules = _load_rule_files(args.rule_file)
+    vocabulary_gap_rules = (
+        *_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
+        *file_rules["vocabulary_gap_rules"],
+    )
     args.vocabulary_gap_rules = vocabulary_gap_rules
-    custom_intent_rules = _parse_intent_rules(args.intent_rule)
+    custom_intent_rules = (
+        *_parse_intent_rules(args.intent_rule),
+        *file_rules["intent_rules"],
+    )
     args.custom_intent_rules = custom_intent_rules
     intent_rules = (*custom_intent_rules, *DEFAULT_INTENT_RULES)
 
@@ -211,6 +228,7 @@ def _result_payload(
             "as_of_date": args.as_of_date,
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
+            "rule_files": [str(path) for path in args.rule_file],
             "documentation_terms": list(args.documentation_term),
             "vocabulary_gap_rules": [
                 list(rule) for rule in args.vocabulary_gap_rules
@@ -291,6 +309,133 @@ def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
         seen.add(key)
         keywords.append(keyword)
     return tuple(keywords)
+
+
+def _load_rule_files(paths: list[Path]) -> dict[str, tuple[Any, ...]]:
+    intent_rules: list[tuple[str, tuple[str, ...]]] = []
+    vocabulary_gap_rules: list[tuple[str, ...]] = []
+    for path in paths:
+        payload = _load_rule_file(path)
+        intent_rules.extend(_parse_intent_rule_payloads(payload.get("intent_rules", []), path))
+        vocabulary_gap_rules.extend(
+            _parse_vocabulary_gap_rule_payloads(
+                payload.get("vocabulary_gap_rules", []),
+                path,
+            )
+        )
+    return {
+        "intent_rules": tuple(intent_rules),
+        "vocabulary_gap_rules": tuple(vocabulary_gap_rules),
+    }
+
+
+def _load_rule_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"--rule-file not found: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"--rule-file must be valid JSON: {path}: {exc.msg}") from None
+    if not isinstance(payload, dict):
+        raise SystemExit(f"--rule-file must contain a JSON object: {path}")
+    allowed = {"intent_rules", "vocabulary_gap_rules"}
+    unknown = sorted(str(key) for key in payload if key not in allowed)
+    if unknown:
+        raise SystemExit(
+            f"--rule-file contains unsupported key(s): {', '.join(unknown)}"
+        )
+    return payload
+
+
+def _parse_intent_rule_payloads(
+    values: Any,
+    path: Path,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if not isinstance(values, list):
+        raise SystemExit(f"--rule-file intent_rules must be an array: {path}")
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for index, value in enumerate(values, start=1):
+        if not isinstance(value, dict):
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}] must be an object: {path}"
+            )
+        topic = _rule_file_text(
+            value.get("topic"),
+            path=path,
+            label=f"intent_rules[{index}].topic",
+            forbidden=("=", ","),
+        )
+        keywords = value.get("keywords")
+        if not isinstance(keywords, list):
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}].keywords must be an array: {path}"
+            )
+        parsed_keywords = [
+            _rule_file_text(
+                keyword,
+                path=path,
+                label=f"intent_rules[{index}].keywords",
+                forbidden=(",",),
+            )
+            for keyword in keywords
+        ]
+        rule_text = f"{topic}={','.join(parsed_keywords)}"
+        try:
+            rules.extend(_parse_intent_rules([rule_text]))
+        except SystemExit as exc:
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}] is invalid: {path}: {exc}"
+            ) from None
+    return tuple(rules)
+
+
+def _parse_vocabulary_gap_rule_payloads(
+    values: Any,
+    path: Path,
+) -> tuple[tuple[str, ...], ...]:
+    if not isinstance(values, list):
+        raise SystemExit(f"--rule-file vocabulary_gap_rules must be an array: {path}")
+    rules: list[tuple[str, ...]] = []
+    for index, value in enumerate(values, start=1):
+        if not isinstance(value, list):
+            raise SystemExit(
+                f"--rule-file vocabulary_gap_rules[{index}] must be an array: {path}"
+            )
+        aliases = [
+            _rule_file_text(
+                alias,
+                path=path,
+                label=f"vocabulary_gap_rules[{index}]",
+                forbidden=(",",),
+            )
+            for alias in value
+        ]
+        rule_text = ",".join(aliases)
+        try:
+            rules.extend(_parse_vocabulary_gap_rules([rule_text]))
+        except SystemExit as exc:
+            raise SystemExit(
+                f"--rule-file vocabulary_gap_rules[{index}] is invalid: {path}: {exc}"
+            ) from None
+    return tuple(rules)
+
+
+def _rule_file_text(
+    value: Any,
+    *,
+    path: Path,
+    label: str,
+    forbidden: tuple[str, ...],
+) -> str:
+    if not isinstance(value, str):
+        raise SystemExit(f"--rule-file {label} must contain string values: {path}")
+    text = value.strip()
+    for delimiter in forbidden:
+        if delimiter in text:
+            raise SystemExit(
+                f"--rule-file {label} cannot contain delimiter {delimiter!r}: {path}"
+            )
+    return text
 
 
 def _output_check_details(

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2487,6 +2487,223 @@ def test_ticket_faq_cli_uses_first_matching_custom_intent_rule(tmp_path: Path) -
     assert result["diagnostics"]["items"][0]["topic"] == "first topic"
 
 
+def test_ticket_faq_cli_accepts_json_rule_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,SSO sync,How do I enable SSO after warehouse sync?,sync",
+    )
+    rule_file = tmp_path / "faq_rules.json"
+    rule_file.write_text(
+        json.dumps({
+            "intent_rules": [
+                {"topic": "data freshness", "keywords": ["warehouse sync"]}
+            ],
+            "vocabulary_gap_rules": [["SSO", "single sign-on"]],
+        }),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Single sign-on setup",
+        "--rule-file",
+        str(rule_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["rule_files"] == [str(rule_file)]
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "data freshness", "keywords": ["warehouse sync"]}
+    ]
+    assert result["config"]["vocabulary_gap_rules"] == [["SSO", "single sign-on"]]
+    assert result["diagnostics"]["items"][0]["topic"] == "data freshness"
+    assert result["diagnostics"]["term_mappings"][0]["customer_term"] == "SSO"
+
+
+def test_ticket_faq_cli_rule_flags_take_precedence_over_rule_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+    rule_file = tmp_path / "faq_rules.json"
+    rule_file.write_text(
+        json.dumps({
+            "intent_rules": [
+                {"topic": "file topic", "keywords": ["warehouse sync"]}
+            ]
+        }),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--rule-file",
+        str(rule_file),
+        "--intent-rule",
+        "cli topic=warehouse sync",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "cli topic", "keywords": ["warehouse sync"]},
+        {"topic": "file topic", "keywords": ["warehouse sync"]},
+    ]
+    assert result["diagnostics"]["items"][0]["topic"] == "cli topic"
+
+
+def test_ticket_faq_cli_vocabulary_flags_take_precedence_over_rule_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,SSO setup,How do I enable SSO for my team?,auth",
+    )
+    rule_file = tmp_path / "faq_rules.json"
+    rule_file.write_text(
+        json.dumps({"vocabulary_gap_rules": [["login", "authentication"]]}),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Single sign-on setup",
+        "--rule-file",
+        str(rule_file),
+        "--vocabulary-gap-rule",
+        "SSO,single sign-on",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["vocabulary_gap_rules"] == [
+        ["SSO", "single sign-on"],
+        ["login", "authentication"],
+    ]
+    assert result["diagnostics"]["term_mappings"][0]["customer_term"] == "SSO"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "--rule-file must contain a JSON object"),
+        ({"unknown": []}, "--rule-file contains unsupported key(s): unknown"),
+        ({"intent_rules": "bad"}, "--rule-file intent_rules must be an array"),
+        (
+            {"intent_rules": ["bad"]},
+            "--rule-file intent_rules[1] must be an object",
+        ),
+        (
+            {"intent_rules": [{"topic": "data freshness", "keywords": "bad"}]},
+            "--rule-file intent_rules[1].keywords must be an array",
+        ),
+        (
+            {"intent_rules": [{"topic": "data freshness", "keywords": []}]},
+            "--rule-file intent_rules[1] is invalid",
+        ),
+        (
+            {"intent_rules": [{"topic": "data=freshness", "keywords": ["sync"]}]},
+            "--rule-file intent_rules[1].topic cannot contain delimiter",
+        ),
+        (
+            {"intent_rules": [{"topic": "data freshness", "keywords": ["sync,lag"]}]},
+            "--rule-file intent_rules[1].keywords cannot contain delimiter",
+        ),
+        (
+            {"intent_rules": [{"topic": "data freshness", "keywords": [5]}]},
+            "--rule-file intent_rules[1].keywords must contain string values",
+        ),
+        (
+            {"vocabulary_gap_rules": "bad"},
+            "--rule-file vocabulary_gap_rules must be an array",
+        ),
+        (
+            {"vocabulary_gap_rules": ["bad"]},
+            "--rule-file vocabulary_gap_rules[1] must be an array",
+        ),
+        (
+            {"vocabulary_gap_rules": [["SSO"]]},
+            "--rule-file vocabulary_gap_rules[1] is invalid",
+        ),
+        (
+            {"vocabulary_gap_rules": [["SSO,login", "single sign-on"]]},
+            "--rule-file vocabulary_gap_rules[1] cannot contain delimiter",
+        ),
+        (
+            {"vocabulary_gap_rules": [["SSO", None]]},
+            "--rule-file vocabulary_gap_rules[1] must contain string values",
+        ),
+    ],
+)
+def test_ticket_faq_cli_rejects_invalid_rule_file(
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+    rule_file = tmp_path / "faq_rules.json"
+    rule_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--rule-file",
+        str(rule_file),
+    )
+
+    assert completed.returncode == 1
+    assert message in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_missing_rule_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--rule-file",
+        str(tmp_path / "missing.json"),
+    )
+
+    assert completed.returncode == 1
+    assert "--rule-file not found:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_malformed_rule_file_json(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Sync lag,The warehouse sync is delayed.,sync",
+    )
+    rule_file = tmp_path / "faq_rules.json"
+    rule_file.write_text("{", encoding="utf-8")
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--rule-file",
+        str(rule_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--rule-file must be valid JSON:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
 def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_path: Path) -> None:
     source = _write_source_csv(
         tmp_path,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Rule-File-Import.md

Adds JSON rule-file import for the FAQ CLI so reusable customer intent and vocabulary-gap rules do not require long command lines.

## Intentional
- JSON only in this slice; CSV import remains deferred.
- Explicit CLI rules take precedence over file rules.
- JSON rule-file values must be strings and cannot contain CLI delimiters for the corresponding rule type; the CLI rejects those cases instead of silently re-splitting a rule.
- Builder and service contracts stay unchanged.
- Local review cross-layer caller hints for generic script helper names were inspected as unrelated same-name helpers in other scripts; this slice does not change shared library behavior.

## Deferred
- CSV rule-file import.
- Hosted UI fields for custom FAQ rules.
- A shared custom-rule parser module if another CLI adopts this shape.

## Verification
- Focused FAQ rule-file/custom-rule CLI pytest - passed, 33 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 115 tests.
- Py compile for affected Python files - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Git whitespace check - passed.
- Local PR review against origin/main - passed; advisory cross-layer caller hints inspected, no actionable external caller impact.

## Diff size
3 files, +454 / -2

Over 400 LOC because the delimiter round-trip guard and operator-error branches ship with fixture coverage in the same slice.