### PR TITLE
Consume landing page SEO GEO AEO prompt inputs

### DIFF
--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -56,6 +56,19 @@ Field rules:
 - `meta.description`: SEO meta description, 120-160 characters. Keep the title tag and description aligned with visible page copy.
 - `reference_ids`: customer logos, case studies, testimonials, or other social-proof source ids the page cites. Empty when none. Do not invent reference ids.
 
+SEO/GEO/AEO input policy:
+- Optional operator-supplied inputs live in `campaign.context`. Use them when present, but do not invent missing fields.
+- `target_keyword`: make this the primary SEO phrase for `meta.title_tag`, `meta.description`, the hero/subheadline, and at least one visible section when it fits naturally.
+- `secondary_keywords`: weave these into visible copy only where natural. Do not keyword-stuff or repeat awkward phrases.
+- `search_intent`: align the hero promise, first problem/solution answer, and FAQ or objection coverage with what the searcher is trying to understand or buy.
+- `primary_entity` and `audience_entity`: make the offer and audience unmistakable in the first viewport and metadata. Use the exact entity language when it is clear and not awkward.
+- `competitors`: use as comparison or alternative context only when supplied. Do not make unsupported superiority claims.
+- `objections`: address supplied objections directly in objection, FAQ, pricing, implementation, risk-reversal, or proof sections.
+- `faq_questions`: answer supplied questions with plain-language section titles or FAQ entries. Each answer must start with the direct answer before expanding.
+- `source_period`: use as freshness context when relevant, such as "based on the last 90 days of tickets"; do not imply live or ongoing analysis unless the campaign says so.
+- `internal_links`: include only supplied links and only when they fit the page. Do not create fake URLs.
+- `cta_label` and `cta_url`: use these for `hero.cta_label`, `hero.cta_url`, and the page-level `cta` unless the campaign gives a stronger CTA pattern.
+
 Readiness rules:
 - The first viewport must make it clear what the offer is, who it is for, and why that reader should care.
 - Include a clear problem section and a clear solution or how-it-works section tied to `campaign.value_prop`.

--- a/plans/PR-Landing-Page-Prompt-Consumes-SEO-GEO-AEO-Inputs.md
+++ b/plans/PR-Landing-Page-Prompt-Consumes-SEO-GEO-AEO-Inputs.md
@@ -1,0 +1,89 @@
+# PR-Landing-Page-Prompt-Consumes-SEO-GEO-AEO-Inputs
+
+## Why this slice exists
+
+PR #768 adds first-class landing-page SEO/GEO/AEO inputs to the control
+surface and threads them into `MarketingCampaign.context`. That closes the
+input-capture gap, but the bundled landing-page prompt still only gives broad
+readiness guidance. The generator can receive fields such as
+`target_keyword`, `search_intent`, `faq_questions`, `objections`, `cta_label`,
+and `cta_url`, but the prompt does not explicitly tell the model how to use
+them.
+
+This slice makes the existing prompt consume those optional context fields so
+generated landing pages can use operator-supplied SEO, GEO, and AEO inputs
+without changing the output schema or readiness validators.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-prompt-contract
+
+1. Update the packaged landing-page generation prompt with explicit
+   instructions for optional `campaign.context` SEO/GEO/AEO fields.
+2. Keep the existing JSON output contract unchanged.
+3. Preserve the source-row evidence and fake-proof protections already in the
+   prompt.
+4. Add prompt-registry tests that pin the new SEO/GEO/AEO instructions.
+5. Add a generator test proving campaign context fields still reach the system
+   prompt payload the model receives.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Prompt-Consumes-SEO-GEO-AEO-Inputs.md`
+- `extracted_content_pipeline/skills/digest/landing_page_generation.md`
+- `tests/test_extracted_campaign_skill_registry.py`
+- `tests/test_extracted_landing_page_generation.py`
+
+## Mechanism
+
+The landing-page generator already serializes the full campaign payload into
+the system prompt through `{campaign_json}`. This PR does not add a new runtime
+mapping layer. Instead, it makes the packaged prompt treat
+`campaign.context` as the location for optional operator-supplied landing-page
+SEO/GEO/AEO inputs.
+
+The prompt will instruct the model to:
+
+- use `target_keyword` in visible copy and `meta.title_tag` when it is present;
+- use `secondary_keywords` naturally, without keyword stuffing;
+- align hero/subheadline and the first answer-shaped sections with
+  `search_intent`;
+- use `primary_entity` and `audience_entity` to clarify the offer and audience;
+- cover supplied `objections` and `faq_questions` in objection/FAQ sections;
+- respect supplied `cta_label` and `cta_url`;
+- use `source_period` as freshness context when relevant;
+- use `internal_links` only as real page links when they are supplied;
+- avoid inventing competitors, proof, or sources when those fields are absent.
+
+## Intentional
+
+- No schema changes. The existing output shape is still the contract.
+- No quality-gate changes. Validator unification is a separate slice.
+- The prompt now depends on PR #768's shared contract keys in tests so prompt
+  coverage fails if the input contract drifts.
+- No generated-page edit path. Editable drafts remain a later slice.
+
+## Deferred
+
+- `PR-Landing-Page-Readiness-Validator-Unification` should centralize
+  export/public readiness checks and save-time quality gates.
+- `PR-Landing-Page-Editable-Drafts` should add PATCH + structured edit UI.
+- `PR-Landing-Page-Review-Repair-Action` should add operator-triggered repair
+  for saved drafts.
+- `PR-Landing-Page-Public-Prerender` remains later, after input quality and
+  validator consistency are tightened.
+
+## Verification
+
+- Passed after review NIT fix: `pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py -q` - 43 passed.
+- Passed after review NIT fix: `git diff --check`.
+- Passed after review NIT fix: local PR review wrapper.
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Prompt | ~35 |
+| Tests | ~35 |
+| **Total** | **~150** |

--- a/tests/test_extracted_campaign_skill_registry.py
+++ b/tests/test_extracted_campaign_skill_registry.py
@@ -4,6 +4,9 @@ from extracted_content_pipeline.skills.registry import (
     LocalSkillRegistry,
     get_skill_registry,
 )
+from extracted_content_pipeline.landing_page_input_contract import (
+    LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS,
+)
 from extracted_quality_gate.landing_page_section_contract import (
     LANDING_PAGE_SECTION_KINDS,
 )
@@ -110,6 +113,24 @@ def test_packaged_landing_page_prompt_requests_aeo_geo_section_metadata() -> Non
     assert "supports answer extraction" in prompt
     for kind in LANDING_PAGE_SECTION_KINDS:
         assert kind in prompt
+
+
+def test_packaged_landing_page_prompt_consumes_seo_geo_aeo_context_inputs() -> None:
+    prompt = get_skill_registry().get_prompt("digest/landing_page_generation")
+
+    assert prompt is not None
+    assert "Optional operator-supplied inputs live in `campaign.context`" in prompt
+    for key in LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS:
+        assert f"`{key}`" in prompt
+    assert "`target_keyword`: make this the primary SEO phrase" in prompt
+    assert "`secondary_keywords`: weave these into visible copy only where natural" in prompt
+    assert "`search_intent`: align the hero promise" in prompt
+    assert "`primary_entity` and `audience_entity`" in prompt
+    assert "`objections`: address supplied objections directly" in prompt
+    assert "`faq_questions`: answer supplied questions" in prompt
+    assert "`source_period`: use as freshness context" in prompt
+    assert "`internal_links`: include only supplied links" in prompt
+    assert "`cta_label` and `cta_url`" in prompt
 
 
 def test_local_skill_registry_accepts_host_root_override(tmp_path) -> None:

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -339,6 +339,43 @@ async def test_generate_substitutes_campaign_json_into_system_prompt_only() -> N
 
 
 @pytest.mark.asyncio
+async def test_generate_threads_seo_geo_aeo_context_into_system_prompt_payload() -> None:
+    service, _lp, llm, _skills, _rp = _service(
+        prompts={"digest/landing_page_generation": "C={campaign_json}"},
+    )
+
+    await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        campaign=MarketingCampaign(
+            name="support-faq-report",
+            persona="10-50 person SaaS team",
+            value_prop="Turn repeat support tickets into customer-ready FAQs",
+            context={
+                "target_keyword": "support ticket FAQ",
+                "secondary_keywords": ["reduce repeat support tickets"],
+                "search_intent": "Find a low-friction way to turn old tickets into help-center answers.",
+                "primary_entity": "FAQ Report",
+                "audience_entity": "small SaaS team",
+                "objections": ["Will this publish automatically?"],
+                "faq_questions": ["What happens after upload?"],
+                "source_period": "Last 90 days of support tickets",
+                "internal_links": ["/systems/ai-content-ops/intake"],
+                "cta_label": "Upload Ticket CSV -- Free Analysis",
+                "cta_url": "/systems/ai-content-ops/intake",
+            },
+        ),
+    )
+
+    system_msg = llm.calls[0]["messages"][0].content
+    user_msg = llm.calls[0]["messages"][1].content
+    assert '"target_keyword":"support ticket FAQ"' in system_msg
+    assert '"secondary_keywords":["reduce repeat support tickets"]' in system_msg
+    assert '"primary_entity":"FAQ Report"' in system_msg
+    assert '"cta_url":"/systems/ai-content-ops/intake"' in system_msg
+    assert "support ticket FAQ" not in user_msg
+
+
+@pytest.mark.asyncio
 async def test_generate_skips_unparseable_response() -> None:
     service, landing_pages, _llm, _skills, _rp = _service(
         responses=["not json garbage", "still not json"]


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Prompt-Consumes-SEO-GEO-AEO-Inputs.md

This updates the packaged landing-page prompt so optional SEO/GEO/AEO fields in campaign.context are explicitly consumed by the model without changing the JSON output schema or quality gates.

## Intentional
- Prompt-only slice; the generator already serializes campaign.context into {campaign_json}.
- No dependency on PR #768 code, though #768 makes these fields easier to provide from the UI/catalog path.
- No readiness-validator, edit-route, or public-rendering changes.

## Deferred
- Validator unification, editable drafts, saved-draft repair actions, and public prerendering remain follow-up slices.

## Verification
- pytest tests/test_extracted_campaign_skill_registry.py tests/test_extracted_landing_page_generation.py -q
- git diff --check
- local PR review wrapper

## Diff size
4 files, +155 / -0