### PR TITLE
PR-Content-Ops-FAQ-Rule-File-Docs

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -190,6 +190,40 @@ show a support phone number, email, or help URL; the builder never invents one.
 Pass `--require-output-checks` in host smoke runs when weak FAQ output should
 fail the command instead of producing a reviewable draft.
 
+Reusable customer glossary and intent mappings can live in a JSON rule file:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --documentation-term "Single sign-on setup" \
+  --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
+  --result-output support_ticket_faq_result.json \
+  --output support_ticket_faq.md
+```
+
+The rule file accepts two optional arrays:
+
+```json
+{
+  "intent_rules": [
+    {"topic": "data freshness", "keywords": ["warehouse sync", "connector lag"]}
+  ],
+  "vocabulary_gap_rules": [
+    ["SSO", "single sign-on"]
+  ]
+}
+```
+
+Intent rules group customer language under a product-specific FAQ topic.
+Vocabulary-gap rules map customer terms to documentation terms passed with
+`--documentation-term`, so the result JSON and Markdown can suggest alternate
+phrasing. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
+`--vocabulary-gap-rule` flags are placed before file rules, so command-line
+overrides win when multiple rules match. Rule-file values use the same CLI
+delimiter guardrails: intent topics cannot contain `=` or `,`, and keywords or
+vocabulary aliases cannot contain `,`.
+
 For large-upload validation, compare the scale smoke `run_summary.json` against
 the checked-in failure profiles:
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -239,6 +239,27 @@ inspect grounding before choosing whether to generate campaigns or longer
 assets. Add `--as-of-date YYYY-MM-DD` with `--window-days` for reproducible
 canary runs.
 
+Reusable customer glossary and intent mappings can be loaded from a checked JSON
+rule file:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_sources.csv \
+  --source-format csv \
+  --documentation-term "Single sign-on setup" \
+  --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
+  --result-output support_ticket_faq_result.json \
+  --output support_ticket_faq.md
+```
+
+The JSON object accepts optional `intent_rules` entries shaped as
+`{"topic": "...", "keywords": ["...", "..."]}` and optional
+`vocabulary_gap_rules` entries shaped as `["customer term", "documentation term"]`.
+Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
+`--vocabulary-gap-rule` flags take precedence over file rules. Rule-file values
+use the same CLI delimiter guardrails: intent topics cannot contain `=` or `,`,
+and keywords or vocabulary aliases cannot contain `,`.
+
 When `ticket_faq_markdown` migrations are installed, prove the persisted review
 loop with the FAQ lifecycle smoke:
 

--- a/extracted_content_pipeline/examples/faq_custom_rules.json
+++ b/extracted_content_pipeline/examples/faq_custom_rules.json
@@ -1,0 +1,17 @@
+{
+  "intent_rules": [
+    {
+      "topic": "data freshness",
+      "keywords": [
+        "warehouse sync",
+        "connector lag"
+      ]
+    }
+  ],
+  "vocabulary_gap_rules": [
+    [
+      "SSO",
+      "single sign-on"
+    ]
+  ]
+}

--- a/plans/PR-Content-Ops-FAQ-Rule-File-Docs.md
+++ b/plans/PR-Content-Ops-FAQ-Rule-File-Docs.md
@@ -1,0 +1,100 @@
+# PR-Content-Ops-FAQ-Rule-File-Docs
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Rule-File-Import added reusable JSON rule files for custom
+FAQ intent and vocabulary-gap rules, but the checked repo still lacks a
+copyable example and a host-facing command that shows the schema in context.
+Operators should not have to reverse-engineer the shape from CLI tests or the
+prior plan doc before running customer glossary and intent mappings.
+
+This slice documents the rule-file contract and adds a small checked example
+that is exercised by the existing FAQ CLI test suite.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add a checked JSON example for FAQ custom intent and vocabulary-gap rules.
+2. Document the `--rule-file` schema and precedence in the extracted package
+   README.
+3. Mirror the operator command in the host install runbook.
+4. Add a CLI smoke test proving the checked example file changes generated
+   intent routing and vocabulary-gap diagnostics.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Rule-File-Docs.md` | Plan doc for this docs/example slice. |
+| `extracted_content_pipeline/examples/faq_custom_rules.json` | Checked JSON example for reusable FAQ rules. |
+| `extracted_content_pipeline/README.md` | Documents rule-file schema, command usage, and precedence. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Adds the same operator-facing FAQ rule-file command. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Smoke test for the committed example file. |
+
+## Mechanism
+
+The checked example uses the existing JSON contract:
+
+```json
+{
+  "intent_rules": [
+    {"topic": "data freshness", "keywords": ["warehouse sync", "connector lag"]}
+  ],
+  "vocabulary_gap_rules": [
+    ["SSO", "single sign-on"]
+  ]
+}
+```
+
+The CLI smoke test loads that file through `--rule-file`, supplies a temporary
+ticket row that contains the example terms, and writes compact result JSON. The
+assertions verify that the file path appears in config diagnostics, the custom
+intent topic is used for the generated FAQ item, and the custom vocabulary rule
+produces a term mapping against an existing documentation term.
+
+## Intentional
+
+- No parser or generator behavior changes. This slice only makes the existing
+  rule-file capability easier to run and harder to regress.
+- The example is intentionally short so operators can copy and adapt it without
+  deleting demo-specific noise.
+- Explicit CLI rules still take precedence over file rules; this slice documents
+  the behavior rather than changing it.
+- Rule-file delimiter restrictions are documented here because the parser
+  already rejects those values with a clean operator error.
+
+## Deferred
+
+- CSV rule-file import remains deferred until the JSON contract has more use.
+- Hosted UI upload/entry fields for custom FAQ rules remain a later product
+  slice.
+- Broader customer glossary templates can be added once a real customer import
+  path needs them.
+
+## Verification
+
+- Focused checked-rule-file FAQ CLI pytest - passed, 1 test.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  116 tests.
+- Py compile for the affected Python test file - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Local PR review against origin/main - passed with `--allow-dirty` because the
+  worktree already had unrelated untracked user audit notes outside this PR.
+- Reviewer NIT docs update: git whitespace check passed; local PR review against
+  origin/main passed with the same unrelated untracked user audit note present.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| JSON example | ~12 |
+| README docs | ~35 |
+| Host runbook docs | ~20 |
+| CLI smoke test | ~35 |
+| **Total** | ~177 |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -25,6 +25,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
 SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
 SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
+FAQ_CUSTOM_RULES = ROOT / "extracted_content_pipeline/examples/faq_custom_rules.json"
 
 
 class _RenderedFAQHTML(HTMLParser):
@@ -2523,6 +2524,48 @@ def test_ticket_faq_cli_accepts_json_rule_file(tmp_path: Path) -> None:
     assert result["config"]["vocabulary_gap_rules"] == [["SSO", "single sign-on"]]
     assert result["diagnostics"]["items"][0]["topic"] == "data freshness"
     assert result["diagnostics"]["term_mappings"][0]["customer_term"] == "SSO"
+
+
+def test_ticket_faq_cli_checked_rule_file_example_affects_output(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,SSO sync,How do I enable SSO after warehouse sync?,sync",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Single sign-on setup",
+        "--rule-file",
+        str(FAQ_CUSTOM_RULES),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["rule_files"] == [str(FAQ_CUSTOM_RULES)]
+    assert result["config"]["custom_intent_rules"] == [
+        {
+            "topic": "data freshness",
+            "keywords": ["warehouse sync", "connector lag"],
+        }
+    ]
+    assert result["config"]["vocabulary_gap_rules"] == [["SSO", "single sign-on"]]
+    assert result["diagnostics"]["items"][0]["topic"] == "data freshness"
+    assert result["diagnostics"]["term_mappings"][0] == {
+        "customer_term": "SSO",
+        "documentation_term": "Single sign-on setup",
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "first_source_id": "ticket-1",
+        "opportunity_score": 1,
+        "rank": 1,
+        "source_id_count": 1,
+        "topic": "data freshness",
+        "zero_result_source_count": 0,
+    }
 
 
 def test_ticket_faq_cli_rule_flags_take_precedence_over_rule_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Rule-File-Docs.md

Document the reusable FAQ rule-file JSON contract and add a checked example that the CLI smoke test exercises, so operators can copy the schema instead of reverse-engineering it from tests or prior PRs.

## Intentional
- No parser or generator behavior changes; this documents and tests the existing rule-file path.
- The example stays small so operators can copy and adapt it directly.
- Explicit CLI rules still take precedence over file rules.

## Deferred
- CSV rule-file import.
- Hosted UI upload/entry fields for custom FAQ rules.
- Broader customer glossary templates once a real customer import path needs them.

## Verification
- Focused checked-rule-file FAQ CLI pytest - passed, 1 test.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 116 tests.
- Py compile for the affected Python test file - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed with --allow-dirty because the worktree already had unrelated untracked user audit notes outside this PR; the clean push worktree also ran the managed pre-push hook and passed.

## Diff size
5 files, +207 / -0