### PR TITLE
PR-Content-Ops-FAQ-Documentation-Term-File

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -196,7 +196,7 @@ Reusable customer glossary and intent mappings can live in a JSON rule file:
 python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
-  --documentation-term "Single sign-on setup" \
+  --documentation-term-file extracted_content_pipeline/examples/faq_documentation_terms.txt \
   --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
   --result-output support_ticket_faq_result.json \
   --output support_ticket_faq.md
@@ -217,8 +217,10 @@ The rule file accepts two optional arrays:
 
 Intent rules group customer language under a product-specific FAQ topic.
 Vocabulary-gap rules map customer terms to documentation terms passed with
-`--documentation-term`, so the result JSON and Markdown can suggest alternate
-phrasing. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
+`--documentation-term` or `--documentation-term-file`, so the result JSON and
+Markdown can suggest alternate phrasing. Documentation-term files are UTF-8
+plain text with one term per line; blank lines and `#` comment lines are
+ignored. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 `--vocabulary-gap-rule` flags are placed before file rules, so command-line
 overrides win when multiple rules match. Rule-file values use the same CLI
 delimiter guardrails: intent topics cannot contain `=` or `,`, and keywords or

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -246,7 +246,7 @@ rule file:
 python scripts/build_extracted_ticket_faq_markdown.py \
   extracted_content_pipeline/examples/support_ticket_sources.csv \
   --source-format csv \
-  --documentation-term "Single sign-on setup" \
+  --documentation-term-file extracted_content_pipeline/examples/faq_documentation_terms.txt \
   --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
   --result-output support_ticket_faq_result.json \
   --output support_ticket_faq.md
@@ -255,6 +255,8 @@ python scripts/build_extracted_ticket_faq_markdown.py \
 The JSON object accepts optional `intent_rules` entries shaped as
 `{"topic": "...", "keywords": ["...", "..."]}` and optional
 `vocabulary_gap_rules` entries shaped as `["customer term", "documentation term"]`.
+Documentation-term files are UTF-8 plain text with one term per line; blank
+lines and `#` comment lines are ignored.
 Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 `--vocabulary-gap-rule` flags take precedence over file rules. Rule-file values
 use the same CLI delimiter guardrails: intent topics cannot contain `=` or `,`,

--- a/extracted_content_pipeline/examples/faq_documentation_terms.txt
+++ b/extracted_content_pipeline/examples/faq_documentation_terms.txt
@@ -1,0 +1,4 @@
+# Existing help-center headings or glossary terms, one per line.
+Single sign-on setup
+Download report
+Dashboard analytics

--- a/plans/PR-Content-Ops-FAQ-Documentation-Term-File.md
+++ b/plans/PR-Content-Ops-FAQ-Documentation-Term-File.md
@@ -1,0 +1,92 @@
+# PR-Content-Ops-FAQ-Documentation-Term-File
+
+## Why this slice exists
+
+Vocabulary-gap detection can compare customer language against documentation
+terms, and custom rule files now make intent and alias rules reusable. The
+remaining operator friction is documentation terms: larger SMB and mid-market
+docs exports should not require dozens of repeated `--documentation-term`
+flags.
+
+This slice adds a small documentation-term file input to the existing FAQ CLI
+so help-center headings or glossary terms can be loaded from a checked or
+exported text file.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add repeatable `--documentation-term-file` support to the FAQ Markdown CLI.
+2. Read one documentation term per nonblank line, with `#` comment lines
+   ignored for copyable examples.
+3. Combine explicit `--documentation-term` values before file-loaded terms and
+   expose both the file paths and resolved terms in compact result JSON.
+4. Add a checked example documentation-term file and CLI tests for success and
+   missing-file failure.
+5. Document the term-file command in the extracted README and host runbook.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Documentation-Term-File.md` | Plan doc for this slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds term-file CLI parsing, result config, and validation. |
+| `extracted_content_pipeline/examples/faq_documentation_terms.txt` | Checked one-term-per-line example. |
+| `extracted_content_pipeline/README.md` | Documents documentation-term file usage. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Mirrors the operator command in host docs. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers term-file success and missing-file failure. |
+
+## Mechanism
+
+The CLI accepts `--documentation-term-file PATH` repeatedly. Each file is read
+as UTF-8 plain text. Blank lines and lines whose first non-space character is
+`#` are ignored; all other lines become documentation terms. Inline
+`--documentation-term` values are placed before file values, then cleaned and
+deduplicated case-insensitively before calling `build_ticket_faq_markdown`.
+
+The result JSON records `documentation_term_files` and the resolved
+`documentation_terms` list so large-upload runs remain auditable.
+
+## Intentional
+
+- Plain text only in this slice. JSON or CSV documentation exports can be added
+  later if a host export requires them.
+- No vocabulary-gap matching changes. The existing deterministic mapping logic
+  consumes the resolved documentation-term list.
+- Inline `--documentation-term` values stay first because command-line values
+  are the most local operator intent.
+- CLI-only helper names are prefixed with `_cli_` so they do not look like the
+  FAQ library's private documentation-term helpers in cross-layer audits.
+
+## Deferred
+
+- CSV/JSON documentation-term imports.
+- Hosted UI upload/entry fields for documentation terms and rule files.
+- Larger customer glossary templates beyond the checked copyable example.
+
+## Verification
+
+- Focused documentation-term-file FAQ CLI pytest - passed, 2 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  118 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Local PR review against origin/main - passed; cross-layer caller hints for
+  generic script helpers were inspected and no external caller impact was found.
+- Reviewer NIT test update: focused documentation-term-file FAQ CLI pytest
+  passed, 3 tests; git whitespace check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| CLI parser/result changes | ~55 |
+| Example file | ~5 |
+| README/runbook docs | ~25 |
+| Tests | ~55 |
+| **Total** | ~220 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -91,6 +91,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--documentation-term-file",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "UTF-8 text file with one documentation term or heading per line. "
+            "Repeat to load multiple files."
+        ),
+    )
+    parser.add_argument(
         "--vocabulary-gap-rule",
         action="append",
         default=[],
@@ -143,6 +153,11 @@ def main(argv: list[str] | None = None) -> int:
             date.fromisoformat(args.as_of_date)
         except ValueError:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
+    documentation_terms = _cli_documentation_terms(
+        args.documentation_term,
+        args.documentation_term_file,
+    )
+    args.documentation_terms = documentation_terms
     file_rules = _load_rule_files(args.rule_file)
     vocabulary_gap_rules = (
         *_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
@@ -171,7 +186,7 @@ def main(argv: list[str] | None = None) -> int:
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
         intent_rules=intent_rules,
-        documentation_terms=args.documentation_term,
+        documentation_terms=documentation_terms,
         vocabulary_gap_rules=vocabulary_gap_rules,
     )
     failed_checks = _failed_output_checks(result.output_checks)
@@ -229,7 +244,10 @@ def _result_payload(
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
             "rule_files": [str(path) for path in args.rule_file],
-            "documentation_terms": list(args.documentation_term),
+            "documentation_term_files": [
+                str(path) for path in args.documentation_term_file
+            ],
+            "documentation_terms": list(args.documentation_terms),
             "vocabulary_gap_rules": [
                 list(rule) for rule in args.vocabulary_gap_rules
             ],
@@ -309,6 +327,41 @@ def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
         seen.add(key)
         keywords.append(keyword)
     return tuple(keywords)
+
+
+def _cli_documentation_terms(
+    inline_terms: list[str],
+    files: list[Path],
+) -> tuple[str, ...]:
+    terms: list[str] = []
+    terms.extend(inline_terms)
+    for path in files:
+        terms.extend(_load_cli_documentation_term_file(path))
+    return _clean_cli_documentation_terms(terms)
+
+
+def _load_cli_documentation_term_file(path: Path) -> tuple[str, ...]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        raise SystemExit(f"--documentation-term-file not found: {path}") from None
+    terms = [
+        line.strip()
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if not terms:
+        raise SystemExit(f"--documentation-term-file contains no terms: {path}")
+    return tuple(terms)
+
+
+def _clean_cli_documentation_terms(terms: list[str]) -> tuple[str, ...]:
+    out: dict[str, str] = {}
+    for term in terms:
+        text = " ".join(str(term).split())
+        if text:
+            out.setdefault(text.lower(), text)
+    return tuple(out.values())
 
 
 def _load_rule_files(paths: list[Path]) -> dict[str, tuple[Any, ...]]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -26,6 +26,9 @@ CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
 SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
 SUPPORT_TICKET_BUNDLE = ROOT / "extracted_content_pipeline/examples/support_ticket_bundle.json"
 FAQ_CUSTOM_RULES = ROOT / "extracted_content_pipeline/examples/faq_custom_rules.json"
+FAQ_DOCUMENTATION_TERMS = (
+    ROOT / "extracted_content_pipeline/examples/faq_documentation_terms.txt"
+)
 
 
 class _RenderedFAQHTML(HTMLParser):
@@ -2296,6 +2299,77 @@ def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path)
         "first_source_id": "ticket-1",
     }]
     assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
+
+
+def test_ticket_faq_cli_accepts_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term",
+        "Billing center",
+        "--documentation-term-file",
+        str(FAQ_DOCUMENTATION_TERMS),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_term_files"] == [
+        str(FAQ_DOCUMENTATION_TERMS)
+    ]
+    assert result["config"]["documentation_terms"] == [
+        "Billing center",
+        "Single sign-on setup",
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert result["diagnostics"]["term_mappings"][0]["customer_term"] == "export"
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
+def test_ticket_faq_cli_rejects_missing_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(tmp_path / "missing_terms.txt"),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file not found:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_empty_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.txt"
+    term_file.write_text("\n# headings export placeholder\n  \n", encoding="utf-8")
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file contains no terms:" in completed.stderr
+    assert "Traceback" not in completed.stderr
 
 
 def test_ticket_faq_cli_accepts_custom_vocabulary_gap_rule(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Documentation-Term-File.md

Add a repeatable FAQ CLI documentation-term file input so vocabulary-gap detection can use checked or exported help-center headings without dozens of repeated --documentation-term flags.

## Intentional
- Plain text only in this slice; JSON/CSV term imports remain deferred.
- No vocabulary-gap matching behavior changes; the existing deterministic mapper consumes the resolved term list.
- Inline --documentation-term values stay first because command-line values are the most local operator intent.
- CLI-only helper names are prefixed with _cli_ to avoid looking like FAQ library private helpers in cross-layer audits.

## Deferred
- CSV/JSON documentation-term imports.
- Hosted UI upload/entry fields for documentation terms and rule files.
- Larger customer glossary templates beyond the checked copyable example.

## Verification
- Focused documentation-term-file FAQ CLI pytest - passed, 2 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 118 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed; cross-layer caller hints for generic script helpers were inspected and no external caller impact was found.

## Diff size
6 files, +212 / -6