### PR TITLE
Unify landing page readiness validation

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -7,20 +7,15 @@ import csv
 from dataclasses import dataclass
 from io import StringIO
 import json
-import re
 from typing import Any
 
 from .campaign_ports import TenantScope
 from .landing_page_ports import LandingPageDraft, LandingPageRepository
-from .landing_page_structured_data import build_landing_page_structured_data
-from extracted_quality_gate.landing_page_section_contract import (
-    LANDING_PAGE_OBJECTION_SECTION_KINDS,
-    LANDING_PAGE_PROBLEM_SECTION_KINDS,
-    LANDING_PAGE_QUESTION_SECTION_KINDS,
-    LANDING_PAGE_SECTION_KINDS,
-    LANDING_PAGE_SOLUTION_SECTION_KINDS,
-    normalize_landing_page_section_kind,
+from .landing_page_readiness import (
+    landing_page_geo_readiness,
+    landing_page_seo_aeo_readiness,
 )
+from .landing_page_structured_data import build_landing_page_structured_data
 
 
 JsonDict = dict[str, Any]
@@ -126,11 +121,11 @@ def _draft_row(draft: LandingPageDraft) -> JsonDict:
     row["section_count"] = len(draft.sections)
     row["reference_count"] = len(draft.reference_ids)
     row.update(_metadata_summary(draft.metadata))
-    readiness = _seo_aeo_readiness(draft)
+    readiness = landing_page_seo_aeo_readiness(draft)
     row["output_checks"] = readiness["checks"]
     row["passed_output_checks"] = readiness["passed"]
     row["seo_aeo_readiness"] = readiness
-    row["geo_readiness"] = _geo_readiness(draft)
+    row["geo_readiness"] = landing_page_geo_readiness(draft)
     row["structured_data"] = build_landing_page_structured_data(draft)
     return row
 
@@ -164,9 +159,9 @@ def public_landing_page_robots(draft: LandingPageDraft) -> str:
 
     if draft.status != "approved":
         return "noindex,follow"
-    if _seo_aeo_readiness(draft).get("status") != "ready":
+    if landing_page_seo_aeo_readiness(draft).get("status") != "ready":
         return "noindex,follow"
-    if _geo_readiness(draft).get("status") != "ready":
+    if landing_page_geo_readiness(draft).get("status") != "ready":
         return "noindex,follow"
     return "index,follow"
 
@@ -203,361 +198,6 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
-
-
-_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-_UNRESOLVED_TOKEN_RE = re.compile(
-    r"\{\{[^{}]+\}\}|\b(?:todo|tbd|lorem ipsum)\b",
-    re.IGNORECASE,
-)
-_NUMERIC_CLAIM_RE = re.compile(r"\b\d+(?:[\d,]*|\.\d+)?%?\b")
-_EVIDENCE_RE = re.compile(
-    r"\b(?:case stud(?:y|ies)|customer(?:s)?|testimonial(?:s)?|review(?:s)?|"
-    r"source(?:s)?|data|survey(?:s)?|benchmark(?:s)?|ticket(?:s)?|"
-    r"last\s+\d+\s+(?:days?|weeks?|months?|years?))\b",
-    re.IGNORECASE,
-)
-_OBJECTION_SECTION_RE = re.compile(
-    r"\b(?:faq|question(?:s)?|objection(?:s)?|concern(?:s)?|how it works|"
-    r"pricing|compare|comparison|proof|risk|security|implementation)\b",
-    re.IGNORECASE,
-)
-_PROBLEM_RE = re.compile(r"\b(?:problem|pain|challenge|risk|stuck|friction)\b", re.IGNORECASE)
-_SOLUTION_RE = re.compile(r"\b(?:solution|solve|fix|how it works|approach|workflow|way)\b", re.IGNORECASE)
-_GENERIC_SLUGS = frozenset({"landing-page", "campaign", "demo", "offer", "page"})
-_GENERIC_AUDIENCES = frozenset({
-    "business",
-    "businesses",
-    "companies",
-    "company",
-    "customers",
-    "people",
-    "teams",
-    "users",
-})
-_GENERIC_SECTION_TITLES = frozenset({
-    "benefits",
-    "conclusion",
-    "features",
-    "introduction",
-    "overview",
-    "summary",
-})
-_STOPWORDS = frozenset({
-    "about",
-    "after",
-    "again",
-    "also",
-    "and",
-    "are",
-    "before",
-    "business",
-    "can",
-    "company",
-    "customer",
-    "customers",
-    "for",
-    "from",
-    "have",
-    "into",
-    "landing",
-    "page",
-    "problem",
-    "problems",
-    "same",
-    "that",
-    "the",
-    "their",
-    "this",
-    "turn",
-    "use",
-    "with",
-    "your",
-})
-
-
-def _seo_aeo_readiness(draft: LandingPageDraft) -> JsonDict:
-    meta = _metadata_mapping(draft.meta)
-    text = _visible_text(draft)
-    hero_text = _mapping_text(draft.hero)
-    checks = {
-        "title_tag": _text_len_between(meta.get("title_tag"), min_len=8, max_len=70),
-        "meta_description": _text_len_between(
-            meta.get("description"),
-            min_len=50,
-            max_len=180,
-        ),
-        "slug_quality": _slug_quality(draft.slug),
-        "metadata_consistency": _metadata_consistency(draft, meta),
-        "answer_first_hero": _answer_first_hero(draft, hero_text),
-        "problem_solution_clarity": _problem_solution_clarity(draft),
-        "audience_specificity": _audience_specificity(draft, text),
-        "objection_coverage": _objection_coverage(draft),
-    }
-    return _readiness_summary(checks)
-
-
-def _geo_readiness(draft: LandingPageDraft) -> JsonDict:
-    text = _visible_text(draft)
-    checks = {
-        "offer_entity_clarity": _offer_entity_clarity(draft, text),
-        "audience_entity_clarity": _audience_specificity(draft, text),
-        "answer_extractability": _answer_extractability(draft),
-        "section_semantics": _section_semantics(draft),
-        "trust_signal_visibility": _trust_signal_visibility(draft, text),
-        "conversion_path_clarity": _conversion_path_clarity(draft),
-        "claim_safety": _claim_safety(draft, text),
-    }
-    return _readiness_summary(checks)
-
-
-def _readiness_summary(checks: Mapping[str, bool]) -> JsonDict:
-    missing = [key for key, value in checks.items() if not value]
-    passed = sum(1 for value in checks.values() if value)
-    return {
-        "status": "ready" if not missing else "needs_review",
-        "passed": passed,
-        "total": len(checks),
-        "missing": missing,
-        "checks": dict(checks),
-    }
-
-
-def _text_len_between(value: Any, *, min_len: int, max_len: int) -> bool:
-    text = _clean_text(value)
-    return min_len <= len(text) <= max_len and not _UNRESOLVED_TOKEN_RE.search(text)
-
-
-def _slug_quality(value: Any) -> bool:
-    slug = _clean_text(value)
-    return bool(_SLUG_RE.fullmatch(slug)) and slug not in _GENERIC_SLUGS
-
-
-def _metadata_consistency(draft: LandingPageDraft, meta: Mapping[str, Any]) -> bool:
-    metadata_text = _normalize_text(" ".join((
-        _clean_text(meta.get("title_tag")),
-        _clean_text(meta.get("description")),
-        _clean_text(meta.get("og_title")),
-    )))
-    if not metadata_text:
-        return False
-    return _contains_any(metadata_text, _key_terms(
-        draft.campaign_name,
-        draft.title,
-        draft.value_prop,
-        _mapping_text(draft.hero),
-    ))
-
-
-def _answer_first_hero(draft: LandingPageDraft, hero_text: str) -> bool:
-    headline = _clean_text(_metadata_mapping(draft.hero).get("headline"))
-    subheadline = _clean_text(_metadata_mapping(draft.hero).get("subheadline"))
-    if not headline or not subheadline:
-        return False
-    normalized = _normalize_text(hero_text)
-    return _contains_any(normalized, _key_terms(draft.persona, draft.value_prop))
-
-
-def _problem_solution_clarity(draft: LandingPageDraft) -> bool:
-    section_text = " ".join(
-        f"{section.id} {section.title} {section.body_markdown} "
-        f"{_mapping_text(section.metadata)}"
-        for section in draft.sections
-    )
-    section_kinds = {_section_kind(section) for section in draft.sections}
-    has_problem = bool(_PROBLEM_RE.search(section_text)) or bool(
-        section_kinds.intersection(LANDING_PAGE_PROBLEM_SECTION_KINDS)
-    )
-    has_solution = bool(_SOLUTION_RE.search(section_text)) or bool(
-        section_kinds.intersection(LANDING_PAGE_SOLUTION_SECTION_KINDS)
-    )
-    value_terms = _key_terms(draft.value_prop)
-    return (
-        has_problem
-        and has_solution
-        and _contains_any(_normalize_text(section_text), value_terms)
-    )
-
-
-def _audience_specificity(draft: LandingPageDraft, text: str) -> bool:
-    persona = _clean_text(draft.persona)
-    if len(persona) < 4 or persona.lower() in _GENERIC_AUDIENCES:
-        return False
-    return _contains_any(_normalize_text(text), _key_terms(persona))
-
-
-def _objection_coverage(draft: LandingPageDraft) -> bool:
-    for section in draft.sections:
-        if _section_kind(section) in LANDING_PAGE_OBJECTION_SECTION_KINDS:
-            return True
-        if _OBJECTION_SECTION_RE.search(f"{section.id} {section.title}"):
-            return True
-    return False
-
-
-def _offer_entity_clarity(draft: LandingPageDraft, text: str) -> bool:
-    if not _clean_text(draft.campaign_name) and not _clean_text(draft.title):
-        return False
-    return _contains_any(_normalize_text(text), _key_terms(
-        draft.campaign_name,
-        draft.title,
-        draft.value_prop,
-    ))
-
-
-def _answer_extractability(draft: LandingPageDraft) -> bool:
-    hero_text = _mapping_text(draft.hero)
-    words = hero_text.split()
-    if 12 <= len(words) <= 90 and _answer_first_hero(draft, hero_text):
-        return True
-    if not draft.sections:
-        return False
-    summary = _section_answer_summary(draft.sections[0])
-    if not _section_answer_summary_visible(draft.sections[0]):
-        return False
-    return _contains_any(
-        _normalize_text(summary),
-        _key_terms(draft.persona, draft.value_prop, draft.title),
-    )
-
-
-def _section_semantics(draft: LandingPageDraft) -> bool:
-    if not draft.sections:
-        return False
-    for section in draft.sections:
-        title = _clean_text(section.title)
-        if len(title) < 4 or title.lower() in _GENERIC_SECTION_TITLES:
-            return False
-        kind = _section_kind(section)
-        if kind not in LANDING_PAGE_SECTION_KINDS:
-            return False
-        if _section_requires_visible_answer(section) and not _section_answer_summary_visible(section):
-            return False
-    return True
-
-
-def _section_kind(section: LandingPageSection) -> str:
-    return normalize_landing_page_section_kind(
-        _metadata_mapping(section.metadata).get("kind")
-    )
-
-
-def _section_primary_question(section: LandingPageSection) -> str:
-    return _clean_text(_metadata_mapping(section.metadata).get("primary_question"))
-
-
-def _section_answer_summary(section: LandingPageSection) -> str:
-    return _clean_text(_metadata_mapping(section.metadata).get("answer_summary"))
-
-
-def _section_requires_visible_answer(section: LandingPageSection) -> bool:
-    return bool(_section_primary_question(section)) or (
-        _section_kind(section) in LANDING_PAGE_QUESTION_SECTION_KINDS
-    )
-
-
-def _section_answer_summary_visible(section: LandingPageSection) -> bool:
-    summary = _section_answer_summary(section)
-    body = _clean_text(section.body_markdown)
-    words = summary.split()
-    if len(words) < 6 or len(words) > 90:
-        return False
-    normalized_summary = _normalize_text(summary)
-    normalized_body = _normalize_text(body)
-    return bool(normalized_summary and normalized_body.startswith(normalized_summary))
-
-
-def _trust_signal_visibility(draft: LandingPageDraft, text: str) -> bool:
-    return bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
-
-
-def _conversion_path_clarity(draft: LandingPageDraft) -> bool:
-    cta = _metadata_mapping(draft.cta)
-    label = _clean_text(cta.get("label"))
-    url = _clean_text(cta.get("url"))
-    if not label or not url or url in {"#", "/#", "javascript:void(0)"}:
-        return False
-    hero = _metadata_mapping(draft.hero)
-    hero_label = _clean_text(hero.get("cta_label"))
-    if hero_label and not _shared_terms(label, hero_label):
-        return False
-    return True
-
-
-def _claim_safety(draft: LandingPageDraft, text: str) -> bool:
-    if _UNRESOLVED_TOKEN_RE.search(text):
-        return False
-    has_evidence = bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
-    if _NUMERIC_CLAIM_RE.search(text) and not has_evidence:
-        return False
-    return True
-
-
-def _visible_text(draft: LandingPageDraft) -> str:
-    parts = [
-        draft.title,
-        _mapping_text(draft.hero),
-        _mapping_text(draft.cta),
-    ]
-    for section in draft.sections:
-        parts.extend((
-            section.id,
-            section.title,
-            section.body_markdown,
-            _mapping_text(section.metadata),
-        ))
-    return " ".join(_clean_text(part) for part in parts if _clean_text(part))
-
-
-def _mapping_text(value: Any) -> str:
-    if isinstance(value, Mapping):
-        return " ".join(_mapping_text(item) for item in value.values())
-    if isinstance(value, (list, tuple)):
-        return " ".join(_mapping_text(item) for item in value)
-    return _clean_text(value)
-
-
-def _clean_text(value: Any) -> str:
-    return str(value or "").strip()
-
-
-def _normalize_text(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", _clean_text(value).lower()).strip()
-
-
-def _key_terms(*values: Any) -> tuple[str, ...]:
-    terms: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        normalized = _normalize_text(value)
-        if not normalized:
-            continue
-        words = [
-            word for word in normalized.split()
-            if len(word) >= 4 and word not in _STOPWORDS
-        ]
-        if len(words) > 1:
-            phrase = " ".join(words)
-            if phrase not in seen:
-                seen.add(phrase)
-                terms.append(phrase)
-        for word in words:
-            if word not in seen:
-                seen.add(word)
-                terms.append(word)
-    return tuple(terms)
-
-
-def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
-    if not terms:
-        return False
-    return any(term in text for term in terms)
-
-
-def _shared_terms(left: str, right: str) -> bool:
-    left_terms = set(_key_terms(left))
-    right_terms = set(_key_terms(right))
-    return bool(left_terms and right_terms and left_terms.intersection(right_terms))
 
 
 def _csv_value(value: Any) -> Any:

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -45,6 +45,7 @@ from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     normalize_landing_page_quality_repair_attempts,
 )
+from .landing_page_readiness import landing_page_readiness_repair_issues
 from .services.campaign_reasoning_context import (
     campaign_reasoning_context_metadata,
     campaign_reasoning_context_payload,
@@ -362,6 +363,8 @@ class LandingPageGenerationService:
             }
             quality = self._quality_check(
                 parsed,
+                campaign=campaign,
+                campaign_payload=campaign_payload,
                 quality_gates_enabled=resolved_quality_gates_enabled,
             )
             quality_repair_history.append(
@@ -507,6 +510,8 @@ class LandingPageGenerationService:
         self,
         parsed: Mapping[str, Any],
         *,
+        campaign: MarketingCampaign,
+        campaign_payload: Mapping[str, Any] | None = None,
         quality_gates_enabled: bool = True,
     ) -> dict[str, Any]:
         # PR-OptionA-4: opt out of the quality gate per call. The plan
@@ -529,6 +534,19 @@ class LandingPageGenerationService:
         report = evaluate_landing_page(report_input, policy=self._config.quality_policy)
         blockers = tuple(f.message for f in report.blockers)
         warnings = tuple(f.message for f in report.warnings)
+        if report.passed:
+            draft = self._build_draft(
+                parsed,
+                campaign=campaign,
+                campaign_payload=campaign_payload,
+            )
+            readiness_issues = landing_page_readiness_repair_issues(draft)
+            if readiness_issues:
+                return {
+                    "passed": False,
+                    "blockers": readiness_issues,
+                    "repair_issues": readiness_issues,
+                }
         return {
             "passed": report.passed,
             "blockers": blockers,

--- a/extracted_content_pipeline/landing_page_readiness.py
+++ b/extracted_content_pipeline/landing_page_readiness.py
@@ -1,0 +1,407 @@
+"""Shared landing-page SEO/AEO/GEO readiness scoring."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import re
+from typing import Any
+
+from .landing_page_ports import LandingPageDraft, LandingPageSection
+from extracted_quality_gate.landing_page_section_contract import (
+    LANDING_PAGE_OBJECTION_SECTION_KINDS,
+    LANDING_PAGE_PROBLEM_SECTION_KINDS,
+    LANDING_PAGE_QUESTION_SECTION_KINDS,
+    LANDING_PAGE_SECTION_KINDS,
+    LANDING_PAGE_SOLUTION_SECTION_KINDS,
+    normalize_landing_page_section_kind,
+)
+
+
+JsonDict = dict[str, Any]
+
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_UNRESOLVED_TOKEN_RE = re.compile(
+    r"\{\{[^{}]+\}\}|\b(?:todo|tbd|lorem ipsum)\b",
+    re.IGNORECASE,
+)
+_NUMERIC_CLAIM_RE = re.compile(r"\b\d+(?:[\d,]*|\.\d+)?%?\b")
+_EVIDENCE_RE = re.compile(
+    r"\b(?:case stud(?:y|ies)|customer(?:s)?|testimonial(?:s)?|review(?:s)?|"
+    r"source(?:s)?|data|survey(?:s)?|benchmark(?:s)?|ticket(?:s)?|"
+    r"last\s+\d+\s+(?:days?|weeks?|months?|years?))\b",
+    re.IGNORECASE,
+)
+_OBJECTION_SECTION_RE = re.compile(
+    r"\b(?:faq|question(?:s)?|objection(?:s)?|concern(?:s)?|how it works|"
+    r"pricing|compare|comparison|proof|risk|security|implementation)\b",
+    re.IGNORECASE,
+)
+_PROBLEM_RE = re.compile(r"\b(?:problem|pain|challenge|risk|stuck|friction)\b", re.IGNORECASE)
+_SOLUTION_RE = re.compile(r"\b(?:solution|solve|fix|how it works|approach|workflow|way)\b", re.IGNORECASE)
+_GENERIC_SLUGS = frozenset({"landing-page", "campaign", "demo", "offer", "page"})
+_GENERIC_AUDIENCES = frozenset({
+    "business",
+    "businesses",
+    "companies",
+    "company",
+    "customers",
+    "people",
+    "teams",
+    "users",
+})
+_GENERIC_SECTION_TITLES = frozenset({
+    "benefits",
+    "conclusion",
+    "features",
+    "introduction",
+    "overview",
+    "summary",
+})
+_STOPWORDS = frozenset({
+    "about",
+    "after",
+    "again",
+    "also",
+    "and",
+    "are",
+    "before",
+    "business",
+    "can",
+    "company",
+    "customer",
+    "customers",
+    "for",
+    "from",
+    "have",
+    "into",
+    "landing",
+    "page",
+    "problem",
+    "problems",
+    "same",
+    "that",
+    "the",
+    "their",
+    "this",
+    "turn",
+    "use",
+    "with",
+    "your",
+})
+
+
+def landing_page_seo_aeo_readiness(draft: LandingPageDraft) -> JsonDict:
+    meta = _metadata_mapping(draft.meta)
+    text = _visible_text(draft)
+    hero_text = _mapping_text(draft.hero)
+    checks = {
+        "title_tag": _text_len_between(meta.get("title_tag"), min_len=8, max_len=70),
+        "meta_description": _text_len_between(
+            meta.get("description"),
+            min_len=50,
+            max_len=180,
+        ),
+        "slug_quality": _slug_quality(draft.slug),
+        "metadata_consistency": _metadata_consistency(draft, meta),
+        "answer_first_hero": _answer_first_hero(draft, hero_text),
+        "problem_solution_clarity": _problem_solution_clarity(draft),
+        "audience_specificity": _audience_specificity(draft, text),
+        "objection_coverage": _objection_coverage(draft),
+    }
+    return _readiness_summary(checks)
+
+
+def landing_page_geo_readiness(draft: LandingPageDraft) -> JsonDict:
+    text = _visible_text(draft)
+    checks = {
+        "offer_entity_clarity": _offer_entity_clarity(draft, text),
+        "audience_entity_clarity": _audience_specificity(draft, text),
+        "answer_extractability": _answer_extractability(draft),
+        "section_semantics": _section_semantics(draft),
+        "trust_signal_visibility": _trust_signal_visibility(draft, text),
+        "conversion_path_clarity": _conversion_path_clarity(draft),
+        "claim_safety": _claim_safety(draft, text),
+    }
+    return _readiness_summary(checks)
+
+
+def landing_page_readiness_repair_issues(draft: LandingPageDraft) -> tuple[str, ...]:
+    """Return stable repair issue names for missing SEO/AEO/GEO readiness checks."""
+
+    seo = landing_page_seo_aeo_readiness(draft)
+    geo = landing_page_geo_readiness(draft)
+    return tuple(
+        [f"seo_aeo_readiness:{item}" for item in seo.get("missing") or ()]
+        + [f"geo_readiness:{item}" for item in geo.get("missing") or ()]
+    )
+
+
+def _readiness_summary(checks: Mapping[str, bool]) -> JsonDict:
+    missing = [key for key, value in checks.items() if not value]
+    passed = sum(1 for value in checks.values() if value)
+    return {
+        "status": "ready" if not missing else "needs_review",
+        "passed": passed,
+        "total": len(checks),
+        "missing": missing,
+        "checks": dict(checks),
+    }
+
+
+def _metadata_mapping(value: Any) -> JsonDict:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {str(key): item for key, item in parsed.items()}
+    return {}
+
+
+def _text_len_between(value: Any, *, min_len: int, max_len: int) -> bool:
+    text = _clean_text(value)
+    return min_len <= len(text) <= max_len and not _UNRESOLVED_TOKEN_RE.search(text)
+
+
+def _slug_quality(value: Any) -> bool:
+    slug = _clean_text(value)
+    return bool(_SLUG_RE.fullmatch(slug)) and slug not in _GENERIC_SLUGS
+
+
+def _metadata_consistency(draft: LandingPageDraft, meta: Mapping[str, Any]) -> bool:
+    metadata_text = _normalize_text(" ".join((
+        _clean_text(meta.get("title_tag")),
+        _clean_text(meta.get("description")),
+        _clean_text(meta.get("og_title")),
+    )))
+    if not metadata_text:
+        return False
+    return _contains_any(metadata_text, _key_terms(
+        draft.campaign_name,
+        draft.title,
+        draft.value_prop,
+        _mapping_text(draft.hero),
+    ))
+
+
+def _answer_first_hero(draft: LandingPageDraft, hero_text: str) -> bool:
+    headline = _clean_text(_metadata_mapping(draft.hero).get("headline"))
+    subheadline = _clean_text(_metadata_mapping(draft.hero).get("subheadline"))
+    if not headline or not subheadline:
+        return False
+    normalized = _normalize_text(hero_text)
+    return _contains_any(normalized, _key_terms(draft.persona, draft.value_prop))
+
+
+def _problem_solution_clarity(draft: LandingPageDraft) -> bool:
+    section_text = " ".join(
+        f"{section.id} {section.title} {section.body_markdown} "
+        f"{_mapping_text(section.metadata)}"
+        for section in draft.sections
+    )
+    section_kinds = {_section_kind(section) for section in draft.sections}
+    has_problem = bool(_PROBLEM_RE.search(section_text)) or bool(
+        section_kinds.intersection(LANDING_PAGE_PROBLEM_SECTION_KINDS)
+    )
+    has_solution = bool(_SOLUTION_RE.search(section_text)) or bool(
+        section_kinds.intersection(LANDING_PAGE_SOLUTION_SECTION_KINDS)
+    )
+    value_terms = _key_terms(draft.value_prop)
+    return (
+        has_problem
+        and has_solution
+        and _contains_any(_normalize_text(section_text), value_terms)
+    )
+
+
+def _audience_specificity(draft: LandingPageDraft, text: str) -> bool:
+    persona = _clean_text(draft.persona)
+    if len(persona) < 4 or persona.lower() in _GENERIC_AUDIENCES:
+        return False
+    return _contains_any(_normalize_text(text), _key_terms(persona))
+
+
+def _objection_coverage(draft: LandingPageDraft) -> bool:
+    for section in draft.sections:
+        if _section_kind(section) in LANDING_PAGE_OBJECTION_SECTION_KINDS:
+            return True
+        if _OBJECTION_SECTION_RE.search(f"{section.id} {section.title}"):
+            return True
+    return False
+
+
+def _offer_entity_clarity(draft: LandingPageDraft, text: str) -> bool:
+    if not _clean_text(draft.campaign_name) and not _clean_text(draft.title):
+        return False
+    return _contains_any(_normalize_text(text), _key_terms(
+        draft.campaign_name,
+        draft.title,
+        draft.value_prop,
+    ))
+
+
+def _answer_extractability(draft: LandingPageDraft) -> bool:
+    hero_text = _mapping_text(draft.hero)
+    words = hero_text.split()
+    if 12 <= len(words) <= 90 and _answer_first_hero(draft, hero_text):
+        return True
+    if not draft.sections:
+        return False
+    summary = _section_answer_summary(draft.sections[0])
+    if not _section_answer_summary_visible(draft.sections[0]):
+        return False
+    return _contains_any(
+        _normalize_text(summary),
+        _key_terms(draft.persona, draft.value_prop, draft.title),
+    )
+
+
+def _section_semantics(draft: LandingPageDraft) -> bool:
+    if not draft.sections:
+        return False
+    for section in draft.sections:
+        title = _clean_text(section.title)
+        if len(title) < 4 or title.lower() in _GENERIC_SECTION_TITLES:
+            return False
+        kind = _section_kind(section)
+        if kind not in LANDING_PAGE_SECTION_KINDS:
+            return False
+        if _section_requires_visible_answer(section) and not _section_answer_summary_visible(section):
+            return False
+    return True
+
+
+def _section_kind(section: LandingPageSection) -> str:
+    return normalize_landing_page_section_kind(
+        _metadata_mapping(section.metadata).get("kind")
+    )
+
+
+def _section_primary_question(section: LandingPageSection) -> str:
+    return _clean_text(_metadata_mapping(section.metadata).get("primary_question"))
+
+
+def _section_answer_summary(section: LandingPageSection) -> str:
+    return _clean_text(_metadata_mapping(section.metadata).get("answer_summary"))
+
+
+def _section_requires_visible_answer(section: LandingPageSection) -> bool:
+    return bool(_section_primary_question(section)) or (
+        _section_kind(section) in LANDING_PAGE_QUESTION_SECTION_KINDS
+    )
+
+
+def _section_answer_summary_visible(section: LandingPageSection) -> bool:
+    summary = _section_answer_summary(section)
+    body = _clean_text(section.body_markdown)
+    words = summary.split()
+    if len(words) < 6 or len(words) > 90:
+        return False
+    normalized_summary = _normalize_text(summary)
+    normalized_body = _normalize_text(body)
+    return bool(normalized_summary and normalized_body.startswith(normalized_summary))
+
+
+def _trust_signal_visibility(draft: LandingPageDraft, text: str) -> bool:
+    return bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
+
+
+def _conversion_path_clarity(draft: LandingPageDraft) -> bool:
+    cta = _metadata_mapping(draft.cta)
+    label = _clean_text(cta.get("label"))
+    url = _clean_text(cta.get("url"))
+    if not label or not url or url in {"#", "/#", "javascript:void(0)"}:
+        return False
+    hero = _metadata_mapping(draft.hero)
+    hero_label = _clean_text(hero.get("cta_label"))
+    if hero_label and not _shared_terms(label, hero_label):
+        return False
+    return True
+
+
+def _claim_safety(draft: LandingPageDraft, text: str) -> bool:
+    if _UNRESOLVED_TOKEN_RE.search(text):
+        return False
+    has_evidence = bool(draft.reference_ids) or bool(_EVIDENCE_RE.search(text))
+    if _NUMERIC_CLAIM_RE.search(text) and not has_evidence:
+        return False
+    return True
+
+
+def _visible_text(draft: LandingPageDraft) -> str:
+    parts = [
+        draft.title,
+        _mapping_text(draft.hero),
+        _mapping_text(draft.cta),
+    ]
+    for section in draft.sections:
+        parts.extend((
+            section.id,
+            section.title,
+            section.body_markdown,
+            _mapping_text(section.metadata),
+        ))
+    return " ".join(_clean_text(part) for part in parts if _clean_text(part))
+
+
+def _mapping_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(_mapping_text(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return " ".join(_mapping_text(item) for item in value)
+    return _clean_text(value)
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", _clean_text(value).lower()).strip()
+
+
+def _key_terms(*values: Any) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = _normalize_text(value)
+        if not normalized:
+            continue
+        words = [
+            word for word in normalized.split()
+            if len(word) >= 4 and word not in _STOPWORDS
+        ]
+        if len(words) > 1:
+            phrase = " ".join(words)
+            if phrase not in seen:
+                seen.add(phrase)
+                terms.append(phrase)
+        for word in words:
+            if word not in seen:
+                seen.add(word)
+                terms.append(word)
+    return tuple(terms)
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    if not terms:
+        return False
+    return any(term in text for term in terms)
+
+
+def _shared_terms(left: str, right: str) -> bool:
+    left_terms = set(_key_terms(left))
+    right_terms = set(_key_terms(right))
+    return bool(left_terms and right_terms and left_terms.intersection(right_terms))
+
+
+__all__ = [
+    "landing_page_geo_readiness",
+    "landing_page_readiness_repair_issues",
+    "landing_page_seo_aeo_readiness",
+]

--- a/plans/PR-Landing-Page-Readiness-Validator-Unification.md
+++ b/plans/PR-Landing-Page-Readiness-Validator-Unification.md
@@ -1,0 +1,113 @@
+# PR-Landing-Page-Readiness-Validator-Unification
+
+## Why this slice exists
+
+Landing-page SEO/AEO and GEO readiness is currently computed inside
+`landing_page_export.py`. Export rows and public robots use that logic, but
+save-time generation only runs the structural landing-page quality pack. That
+leaves two separate notions of "ready": a draft can pass generation and persist
+even when the export/public readiness checks would immediately mark it
+`needs_review`.
+
+This slice makes the landing-page readiness scorer a shared helper and wires it
+into the generation quality gate so export, public robots, and save-time repair
+use the same source for SEO/AEO/GEO readiness checks.
+
+This PR is intentionally over the normal 400 LOC target because the clean
+source-level fix moves the existing readiness helper out of export instead of
+copying it into generation. The large diff is mostly code movement plus tests
+that pin export parity and generation-time blocking.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-readiness-validator
+
+1. Move the SEO/AEO/GEO readiness scoring code out of
+   `landing_page_export.py` into `landing_page_readiness.py`.
+2. Keep export row shape, public robots behavior, and readiness payload shape
+   unchanged.
+3. Make `LandingPageGenerationService` run the shared readiness scorer after
+   the existing structural quality pack.
+4. Feed missing readiness checks into the existing quality repair loop so the
+   model gets actionable repair blockers.
+5. Add focused tests for the shared helper and generation-time readiness
+   blocking/repair behavior.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Readiness-Validator-Unification.md`
+- `extracted_content_pipeline/landing_page_readiness.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/landing_page_generation.py`
+- `tests/test_landing_page_readiness.py`
+- `tests/test_extracted_landing_page_export.py`
+- `tests/test_extracted_landing_page_generation.py`
+
+## Mechanism
+
+`landing_page_readiness.py` owns three public functions:
+
+- `landing_page_seo_aeo_readiness(draft)`
+- `landing_page_geo_readiness(draft)`
+- `landing_page_readiness_repair_issues(draft)`
+
+Export uses the first two functions directly for rows and public robots.
+Generation builds a provisional `LandingPageDraft` from the parsed model output
+using the same `_build_draft` path it uses before persistence, then runs
+`landing_page_readiness_repair_issues`. Missing SEO/AEO/GEO checks are surfaced
+as deterministic repair issues with stable prefixes, e.g.
+`seo_aeo_readiness:meta_description` and `geo_readiness:claim_safety`.
+
+The existing structural quality pack remains load-bearing for hard schema and
+safety blockers such as missing CTA, invalid slug, unresolved placeholders, and
+blocked phrasing. The shared readiness scorer adds the export/public readiness
+contract to save-time validation without moving that logic into the
+`extracted_quality_gate` package in this slice.
+
+This changes operator-facing behavior: some landing pages that previously
+persisted as drafts with `seo_aeo_readiness` or `geo_readiness` set to
+`needs_review` will now return `quality_blocked` if the default repair attempt
+does not clear every readiness issue. That increase is expected. It means
+generation is stopping earlier instead of saving drafts that public robots and
+sitemap publishing would later reject. Hosts that need the previous advisory
+behavior can still pass `quality_gates_enabled=False`; hosts that want more
+repair headroom can raise `landing_page_quality_repair_attempts` up to the
+existing cap.
+
+## Intentional
+
+- No readiness payload shape changes. Existing export/UI consumers continue to
+  receive `status`, `passed`, `total`, `missing`, and `checks`.
+- No public route or UI changes.
+- No attempt to delete the structural quality pack. It still catches schema and
+  safety issues before readiness scoring runs.
+- Readiness issues are repair issues, not a new exception type.
+- No default repair-attempt change in this slice. The current default of 1
+  preserves the cost model and avoids silently increasing generation spend.
+  The existing per-run `landing_page_quality_repair_attempts` input remains the
+  operator control for drafts that need more repair passes.
+
+## Deferred
+
+- `PR-Landing-Page-Review-Repair-Action` should expose operator-triggered
+  repair for saved drafts.
+- `PR-Landing-Page-Editable-Drafts` should add PATCH + structured edit UI.
+- `PR-Landing-Page-Public-Prerender` remains later after generation and saved
+  draft readiness behavior are consistent.
+
+## Verification
+
+- Passed: `pytest tests/test_landing_page_readiness.py tests/test_extracted_landing_page_export.py tests/test_extracted_landing_page_generation.py -q` - 44 passed.
+- Passed: Python compile check for the changed modules and tests.
+- Passed: `git diff --check`.
+- Passed: local PR review wrapper.
+
+## Estimated Diff Size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~100 |
+| Readiness helper move | ~740 |
+| Export/generation wiring | ~60 |
+| Tests | ~275 |
+| **Total** | **~1175** |

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from extracted_content_pipeline.campaign_ports import (
@@ -63,15 +65,82 @@ class _SavingRepository(_Repository):
 class _LLM:
     async def complete(self, messages, *, max_tokens, temperature, metadata=None):
         return LLMResponse(
-            content=(
-                '{"title":"Acme launch","slug":"acme-launch",'
-                '"hero":{"headline":"Stop renewal surprises"},'
-                '"sections":[{"id":"problem","title":"Problem",'
-                '"body_markdown":"Pricing pressure is rising"}],'
-                '"cta":{"label":"Book a demo","url":"/demo"},'
-                '"meta":{"title_tag":"Acme launch"},'
-                '"reference_ids":["r1"]}'
-            ),
+            content=json.dumps({
+                "title": "Acme launch for VP Engineering",
+                "slug": "acme-launch",
+                "hero": {
+                    "headline": "Stop renewal surprises",
+                    "subheadline": (
+                        "VP Engineering teams catch pressure early before "
+                        "renewal risk creates more customer churn."
+                    ),
+                    "cta_label": "Book a demo",
+                    "cta_url": "/demo",
+                },
+                "sections": [
+                    {
+                        "id": "problem",
+                        "title": "Renewal pressure creates customer risk",
+                        "body_markdown": (
+                            "VP Engineering teams face renewal pressure when "
+                            "customer problems stay hidden until pricing "
+                            "reviews. Pricing pressure is rising."
+                        ),
+                        "metadata": {
+                            "kind": "problem",
+                            "primary_question": "Why does renewal pressure matter?",
+                            "answer_summary": (
+                                "VP Engineering teams face renewal pressure "
+                                "when customer problems stay hidden until "
+                                "pricing reviews."
+                            ),
+                        },
+                    },
+                    {
+                        "id": "solution",
+                        "title": "Catch pressure before renewal review",
+                        "body_markdown": (
+                            "VP Engineering teams catch pressure early by "
+                            "turning customer signals into answers before "
+                            "renewal review."
+                        ),
+                        "metadata": {
+                            "kind": "solution",
+                            "primary_question": "How does Acme help?",
+                            "answer_summary": (
+                                "VP Engineering teams catch pressure early "
+                                "by turning customer signals into answers."
+                            ),
+                        },
+                    },
+                    {
+                        "id": "objections",
+                        "title": "Questions before rollout",
+                        "body_markdown": (
+                            "VP Engineering teams can review rollout and "
+                            "pricing questions before booking time with the "
+                            "team."
+                        ),
+                        "metadata": {
+                            "kind": "objection",
+                            "primary_question": "What should teams know first?",
+                            "answer_summary": (
+                                "VP Engineering teams can review rollout and "
+                                "pricing questions before booking time."
+                            ),
+                        },
+                    },
+                ],
+                "cta": {"label": "Book a demo", "url": "/demo"},
+                "meta": {
+                    "title_tag": "Acme Launch for VP Engineering",
+                    "description": (
+                        "Acme helps VP Engineering teams catch renewal "
+                        "pressure early so customer risk is easier to see."
+                    ),
+                },
+                "reference_ids": ["r1"],
+            }),
             model="test-model",
             usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
         )

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -149,6 +149,25 @@ def _valid_response(*, slug="acme-q3-launch") -> str:
                     ),
                 },
             },
+            {
+                "id": "implementation_questions",
+                "title": "Implementation questions",
+                "body_markdown": (
+                    "VP Engineering teams can review pricing, rollout, "
+                    "and risk questions before booking time with sales. "
+                    "That keeps the renewal review moving with clearer "
+                    "answers."
+                ),
+                "metadata": {
+                    "order": 3,
+                    "kind": "objection",
+                    "primary_question": "What should teams know before rollout?",
+                    "answer_summary": (
+                        "VP Engineering teams can review pricing, rollout, "
+                        "and risk questions before booking time with sales."
+                    ),
+                },
+            },
         ],
         "cta": {"label": "Book a 15-min demo", "url": "/demo", "variant": "primary"},
         "meta": {
@@ -475,6 +494,24 @@ async def test_generate_skips_when_quality_pack_blocks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_skips_when_shared_readiness_blocks() -> None:
+    response = json.loads(_valid_response())
+    response["meta"].pop("description")
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[json.dumps(response)],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert "seo_aeo_readiness:meta_description" in result.errors[0]["blockers"]
+
+
+@pytest.mark.asyncio
 async def test_generate_repairs_quality_blocked_response_once_and_persists() -> None:
     """Parsed JSON that fails the quality gate gets one targeted repair pass."""
     bad_response = json.dumps({
@@ -534,6 +571,40 @@ async def test_generate_repairs_quality_blocked_response_once_and_persists() -> 
     assert (
         draft.metadata["generation_quality_repair_history"]
         == result.quality_repair_history
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_repairs_shared_readiness_blocker_once_and_persists() -> None:
+    needs_repair = json.loads(_valid_response())
+    needs_repair["meta"].pop("description")
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[
+            {
+                "content": json.dumps(needs_repair),
+                "model": "first-model",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+            },
+            {
+                "content": _valid_response(),
+                "model": "final-model",
+                "usage": {"input_tokens": 7, "output_tokens": 3},
+            },
+        ],
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 1
+    assert result.saved_ids == ("lp-1",)
+    assert len(llm.calls) == 2
+    repair_prompt = llm.calls[1]["messages"][1].content
+    assert "seo_aeo_readiness:meta_description" in repair_prompt
+    assert landing_pages.saved[0]["drafts"][0].metadata[
+        "generation_quality_repair_attempts"
+    ] == 1
+    assert result.quality_repair_history[0]["blockers"] == (
+        "seo_aeo_readiness:meta_description",
     )
 
 

--- a/tests/test_landing_page_readiness.py
+++ b/tests/test_landing_page_readiness.py
@@ -1,0 +1,120 @@
+from extracted_content_pipeline.landing_page_ports import (
+    LandingPageDraft,
+    LandingPageSection,
+)
+from extracted_content_pipeline.landing_page_readiness import (
+    landing_page_geo_readiness,
+    landing_page_readiness_repair_issues,
+    landing_page_seo_aeo_readiness,
+)
+
+
+def _ready_draft(**overrides) -> LandingPageDraft:
+    values = {
+        "campaign_name": "support-faq-report",
+        "persona": "10-50 person SaaS team",
+        "value_prop": "Turn repeat support tickets into customer-ready FAQs",
+        "title": "Support FAQ Report for Small SaaS Teams",
+        "slug": "support-faq-report",
+        "hero": {
+            "headline": "Turn repeat tickets into answers",
+            "subheadline": (
+                "10-50 person SaaS teams turn repeat support tickets into "
+                "customer-ready FAQs before customers wait again."
+            ),
+            "cta_label": "Upload Ticket CSV -- Free Analysis",
+            "cta_url": "/systems/ai-content-ops/intake",
+        },
+        "sections": (
+            LandingPageSection(
+                id="repeat_support_problem",
+                title="Repeat support questions become customer frustration",
+                body_markdown=(
+                    "10-50 person SaaS teams lose time when customers ask "
+                    "the same support questions again and again. Repeat "
+                    "questions create friction because the answer is not "
+                    "where customers are looking."
+                ),
+                metadata={
+                    "kind": "problem",
+                    "primary_question": "Why do repeat support questions matter?",
+                    "answer_summary": (
+                        "10-50 person SaaS teams lose time when customers "
+                        "ask the same support questions again and again."
+                    ),
+                },
+            ),
+            LandingPageSection(
+                id="faq_report_solution",
+                title="A FAQ Report turns tickets into findable answers",
+                body_markdown=(
+                    "10-50 person SaaS teams use the FAQ Report workflow to "
+                    "turn old support tickets into clear answers customers "
+                    "can find before they email support."
+                ),
+                metadata={
+                    "kind": "solution",
+                    "primary_question": "How does the FAQ Report help?",
+                    "answer_summary": (
+                        "10-50 person SaaS teams use the FAQ Report workflow "
+                        "to turn old support tickets into clear answers."
+                    ),
+                },
+            ),
+            LandingPageSection(
+                id="before_upload_questions",
+                title="Questions before uploading tickets",
+                body_markdown=(
+                    "10-50 person SaaS teams can review privacy, publishing, "
+                    "and setup questions before uploading tickets. That keeps "
+                    "the process clear without giving up help-center control."
+                ),
+                metadata={
+                    "kind": "objection",
+                    "primary_question": "What should teams know before upload?",
+                    "answer_summary": (
+                        "10-50 person SaaS teams can review privacy, "
+                        "publishing, and setup questions before uploading "
+                        "tickets."
+                    ),
+                },
+            ),
+        ),
+        "cta": {
+            "label": "Upload Ticket CSV -- Free Analysis",
+            "url": "/systems/ai-content-ops/intake",
+            "variant": "primary",
+        },
+        "meta": {
+            "title_tag": "Support FAQ Report for Small SaaS Teams",
+            "description": (
+                "Turn repeat support tickets into customer-ready FAQ answers "
+                "small SaaS teams can publish before customers wait again."
+            ),
+        },
+        "reference_ids": ("support-ticket-sample",),
+    }
+    values.update(overrides)
+    return LandingPageDraft(**values)
+
+
+def test_landing_page_readiness_reports_ready_payloads() -> None:
+    draft = _ready_draft()
+
+    assert landing_page_seo_aeo_readiness(draft)["status"] == "ready"
+    assert landing_page_geo_readiness(draft)["status"] == "ready"
+    assert landing_page_readiness_repair_issues(draft) == ()
+
+
+def test_landing_page_readiness_repair_issues_prefix_missing_checks() -> None:
+    draft = _ready_draft(
+        slug="landing-page",
+        meta={"title_tag": "Support"},
+        cta={"label": "Upload Ticket CSV -- Free Analysis", "url": "#"},
+    )
+
+    issues = landing_page_readiness_repair_issues(draft)
+
+    assert "seo_aeo_readiness:meta_description" in issues
+    assert "seo_aeo_readiness:slug_quality" in issues
+    assert "geo_readiness:conversion_path_clarity" in issues


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Readiness-Validator-Unification.md

This extracts landing-page SEO/AEO/GEO readiness scoring from export into a shared helper and makes generation use that same helper after the structural quality pack, so export/public robots and save-time repair evaluate the same readiness checks.

## Operator impact
- Expected behavior change: some landing pages that previously persisted as drafts with seo_aeo_readiness or geo_readiness set to needs_review will now return quality_blocked if the default repair attempt does not clear every readiness issue.
- This is intentional: generation now stops earlier instead of saving drafts that public robots and sitemap publishing would later reject.
- The default repair cap stays at 1 in this slice to preserve the current cost model. Hosts can still pass quality_gates_enabled=false for advisory behavior or raise landing_page_quality_repair_attempts up to the existing cap when they want more repair headroom.

## Intentional
- Larger-than-normal diff is mostly moving existing readiness logic out of export into a shared helper.
- Structural quality pack remains load-bearing for schema, placeholders, CTA, slug, and blocked-phrasing issues.
- Export row shape, public robots behavior, and readiness payload shape stay unchanged.
- Readiness failures feed the existing repair loop as deterministic repair issues.

## Deferred
- Saved-draft repair action, editable drafts, and public prerendering remain follow-up slices.

## Verification
- pytest tests/test_landing_page_readiness.py tests/test_extracted_landing_page_export.py tests/test_extracted_landing_page_generation.py -q
- Python compile check for changed modules and tests
- git diff --check
- local PR review wrapper

## Diff size
7 files, +815 / -377