### PR TITLE
PR-Content-Ops-FAQ-Documentation-Term-Structured-Files

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -218,9 +218,11 @@ The rule file accepts two optional arrays:
 Intent rules group customer language under a product-specific FAQ topic.
 Vocabulary-gap rules map customer terms to documentation terms passed with
 `--documentation-term` or `--documentation-term-file`, so the result JSON and
-Markdown can suggest alternate phrasing. Documentation-term files are UTF-8
-plain text with one term per line; blank lines and `#` comment lines are
-ignored. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
+Markdown can suggest alternate phrasing. Documentation-term files can be UTF-8
+plain text, JSON, JSONL, or CSV. Text files use one term per line and ignore
+blank or `#` comment lines. Structured files read common fields such as
+`documentation_term`, `term`, `heading`, `title`, `page_title`, `name`, or
+`label`. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 `--vocabulary-gap-rule` flags are placed before file rules, so command-line
 overrides win when multiple rules match. Rule-file values use the same CLI
 delimiter guardrails: intent topics cannot contain `=` or `,`, and keywords or

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -256,7 +256,10 @@ The JSON object accepts optional `intent_rules` entries shaped as
 `{"topic": "...", "keywords": ["...", "..."]}` and optional
 `vocabulary_gap_rules` entries shaped as `["customer term", "documentation term"]`.
 Documentation-term files are UTF-8 plain text with one term per line; blank
-lines and `#` comment lines are ignored.
+lines and `#` comment lines are ignored. JSON, JSONL, and CSV documentation
+exports are also accepted when rows use common fields such as
+`documentation_term`, `term`, `heading`, `title`, `page_title`, `name`, or
+`label`.
 Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 `--vocabulary-gap-rule` flags take precedence over file rules. Rule-file values
 use the same CLI delimiter guardrails: intent topics cannot contain `=` or `,`,

--- a/plans/PR-Content-Ops-FAQ-Documentation-Term-Structured-Files.md
+++ b/plans/PR-Content-Ops-FAQ-Documentation-Term-Structured-Files.md
@@ -1,0 +1,96 @@
+# PR-Content-Ops-FAQ-Documentation-Term-Structured-Files
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Documentation-Term-File made documentation terms reusable
+through a plain text file, but the next real customer source is likely a docs
+export from a help center or knowledge base. Those exports commonly arrive as
+CSV, JSON, or JSONL rows with `title`, `heading`, or `term` fields.
+
+This slice keeps the existing `--documentation-term-file` flag and teaches it
+to load common structured documentation-term exports by suffix.
+
+This is over the 400 LOC soft budget after review because the structured-file
+surface needs the parser and error-path fixture coverage to ship together:
+JSON, JSONL, CSV, malformed JSON, malformed JSONL, BOM CSV headers, quoted
+multiline CSV cells, and nested JSON term values are all part of the same
+operator input contract.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Extend `--documentation-term-file` auto-detection to JSON, JSONL, and CSV
+   files while preserving existing plain-text behavior.
+2. Extract terms from common keys such as `documentation_term`, `term`,
+   `heading`, `title`, `page_title`, `name`, and `label`.
+3. Accept JSON bundles with list keys such as `documentation_terms`, `terms`,
+   `headings`, `documents`, `pages`, `articles`, `rows`, and `data`.
+4. Fail cleanly for malformed JSON/JSONL and structured files that contain no
+   usable terms.
+5. Add focused CLI tests for JSON, JSONL, CSV, and malformed JSONL handling.
+6. Document the supported documentation-term file formats in the extracted
+   README and host runbook.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Documentation-Term-Structured-Files.md` | Plan doc for this structured term-file slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds structured term-file loading for JSON/JSONL/CSV. |
+| `extracted_content_pipeline/README.md` | Documents structured documentation-term file support. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Mirrors host-facing format notes. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers JSON, JSONL, CSV, and malformed JSONL term files. |
+
+## Mechanism
+
+The existing `--documentation-term-file` path now resolves by suffix. JSON files
+load either a list or an object bundle. JSONL files load one JSON value per
+nonblank line. CSV files use `csv.DictReader`. Unknown suffixes keep the
+existing plain text behavior.
+
+Structured rows are intentionally conservative: only common documentation-term
+keys are extracted, and bundle traversal only follows known list keys. This
+avoids treating unrelated metadata as headings while still supporting typical
+help-center exports.
+
+## Intentional
+
+- No new CLI flag. Operators can keep using `--documentation-term-file` and let
+  suffix-based detection choose the parser.
+- No vocabulary-gap matching behavior changes. This only changes how
+  documentation terms enter the existing deterministic mapper.
+- JSON/CSV parsing is local to the FAQ CLI for now; a shared docs-export loader
+  can be introduced if another command needs the same contract.
+
+## Deferred
+
+- Explicit `--documentation-term-format` override if hosts need suffixless
+  structured files.
+- Hosted UI upload/entry fields for documentation terms and rule files.
+- Richer docs export metadata, such as URLs or section paths, in result JSON.
+
+## Verification
+
+- Focused structured documentation-term-file FAQ CLI pytest - passed, 5 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  124 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Reviewer feedback update: focused structured term-file regressions passed, 7
+  tests; full FAQ pytest passed, 126 tests; py compile and git whitespace check
+  passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| CLI structured parser | ~130 |
+| README/runbook docs | ~15 |
+| Tests | ~230 |
+| **Total** | ~465 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import csv
 from datetime import date
+import io
 import json
 from pathlib import Path
 import sys
@@ -14,6 +16,26 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+_DOCUMENTATION_TERM_ROW_KEYS = (
+    "documentation_term",
+    "documentation_terms",
+    "term",
+    "heading",
+    "title",
+    "page_title",
+    "name",
+    "label",
+)
+_DOCUMENTATION_TERM_LIST_KEYS = (
+    "terms",
+    "headings",
+    "documents",
+    "pages",
+    "articles",
+    "rows",
+    "data",
+)
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
@@ -342,17 +364,116 @@ def _cli_documentation_terms(
 
 def _load_cli_documentation_term_file(path: Path) -> tuple[str, ...]:
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         raise SystemExit(f"--documentation-term-file not found: {path}") from None
-    terms = [
-        line.strip()
-        for line in lines
-        if line.strip() and not line.lstrip().startswith("#")
-    ]
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        terms = _load_cli_documentation_term_json(text, path)
+    elif suffix == ".jsonl":
+        terms = _load_cli_documentation_term_jsonl(text, path)
+    elif suffix == ".csv":
+        terms = _load_cli_documentation_term_csv(text, path)
+    else:
+        terms = _load_cli_documentation_term_text(text)
     if not terms:
         raise SystemExit(f"--documentation-term-file contains no terms: {path}")
     return tuple(terms)
+
+
+def _load_cli_documentation_term_text(text: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def _load_cli_documentation_term_json(text: str, path: Path) -> tuple[str, ...]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"--documentation-term-file must be valid JSON: {path}: {exc.msg}"
+        ) from None
+    return tuple(_documentation_terms_from_payload(payload))
+
+
+def _load_cli_documentation_term_jsonl(text: str, path: Path) -> tuple[str, ...]:
+    terms = [
+        term
+        for line_no, line in enumerate(text.splitlines(), start=1)
+        for term in _documentation_terms_from_jsonl_line(line, path, line_no)
+    ]
+    return tuple(terms)
+
+
+def _documentation_terms_from_jsonl_line(
+    line: str,
+    path: Path,
+    line_no: int,
+) -> tuple[str, ...]:
+    text = line.strip()
+    if not text:
+        return ()
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            "--documentation-term-file must be valid JSONL: "
+            f"{path}: line {line_no}: {exc.msg}"
+        ) from None
+    return tuple(_documentation_terms_from_payload(payload))
+
+
+def _load_cli_documentation_term_csv(text: str, path: Path) -> tuple[str, ...]:
+    rows = list(csv.DictReader(io.StringIO(text, newline="")))
+    if not rows:
+        return ()
+    return tuple(
+        term
+        for row in rows
+        for term in _documentation_terms_from_mapping(row)
+    )
+
+
+def _documentation_terms_from_payload(payload: Any) -> tuple[str, ...]:
+    if isinstance(payload, str):
+        return (payload,)
+    if isinstance(payload, dict):
+        terms = list(_documentation_terms_from_mapping(payload))
+        for key in _DOCUMENTATION_TERM_LIST_KEYS:
+            value = _case_insensitive_get(payload, key)
+            if value is not None:
+                terms.extend(_documentation_terms_from_payload(value))
+        return tuple(terms)
+    if isinstance(payload, list):
+        return tuple(
+            term
+            for item in payload
+            for term in _documentation_terms_from_payload(item)
+        )
+    return ()
+
+
+def _documentation_terms_from_mapping(
+    row: dict[str, Any],
+) -> tuple[str, ...]:
+    for key in _DOCUMENTATION_TERM_ROW_KEYS:
+        value = _case_insensitive_get(row, key)
+        if value not in (None, ""):
+            if isinstance(value, (dict, list)):
+                return _documentation_terms_from_payload(value)
+            return (str(value),)
+    return ()
+
+
+def _case_insensitive_get(row: dict[str, Any], key: str) -> Any:
+    target = key.lower()
+    for raw_key, value in row.items():
+        if str(raw_key).lstrip("\ufeff").lower() == target:
+            return value
+    return None
 
 
 def _clean_cli_documentation_terms(terms: list[str]) -> tuple[str, ...]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2336,6 +2336,191 @@ def test_ticket_faq_cli_accepts_documentation_term_file(tmp_path: Path) -> None:
     )
 
 
+def test_ticket_faq_cli_accepts_json_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.json"
+    term_file.write_text(
+        json.dumps({
+            "documentation_terms": ["Single sign-on setup"],
+            "documents": [
+                {"title": "Download report"},
+                {"heading": "Dashboard analytics"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == [
+        "Single sign-on setup",
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
+def test_ticket_faq_cli_accepts_nested_json_documentation_term_values(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.json"
+    term_file.write_text(
+        json.dumps({
+            "documentation_terms": [
+                {"title": "Download report"},
+                {"heading": "Dashboard analytics"},
+            ]
+        }),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == [
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert not any(
+        term.startswith("{") for term in result["config"]["documentation_terms"]
+    )
+
+
+def test_ticket_faq_cli_accepts_jsonl_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.jsonl"
+    term_file.write_text(
+        "\n".join((
+            json.dumps("Single sign-on setup"),
+            json.dumps({"page_title": "Download report"}),
+            json.dumps({"term": "Dashboard analytics"}),
+            "",
+        )),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == [
+        "Single sign-on setup",
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
+def test_ticket_faq_cli_accepts_csv_documentation_term_file(tmp_path: Path) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.csv"
+    term_file.write_text(
+        "\n".join((
+            "title,slug",
+            "Single sign-on setup,sso",
+            "Download report,download-report",
+            "Dashboard analytics,dashboard",
+            "",
+        )),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == [
+        "Single sign-on setup",
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
+def test_ticket_faq_cli_accepts_bom_and_multiline_csv_documentation_term_file(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.csv"
+    term_file.write_text(
+        '\ufefftitle,body\n"Download report","First line\nsecond line"\n',
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_terms"] == ["Download report"]
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
 def test_ticket_faq_cli_rejects_missing_documentation_term_file(tmp_path: Path) -> None:
     source = _write_ticket_csv(
         tmp_path,
@@ -2369,6 +2554,49 @@ def test_ticket_faq_cli_rejects_empty_documentation_term_file(tmp_path: Path) ->
 
     assert completed.returncode == 1
     assert "--documentation-term-file contains no terms:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_malformed_json_documentation_term_file(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.json"
+    term_file.write_text("{", encoding="utf-8")
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file must be valid JSON:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_malformed_jsonl_documentation_term_file(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.jsonl"
+    term_file.write_text('{"title": "Download report"}\n{', encoding="utf-8")
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file must be valid JSONL:" in completed.stderr
+    assert "line 2" in completed.stderr
     assert "Traceback" not in completed.stderr
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Documentation-Term-Structured-Files.md

Extend the existing FAQ --documentation-term-file input so vocabulary-gap detection can consume structured help-center exports in JSON, JSONL, and CSV, while preserving plain-text term files.

## Intentional
- No new CLI flag; suffix-based detection keeps operator usage stable.
- No vocabulary-gap matching behavior changes; this only changes how documentation terms enter the existing mapper.
- JSON/CSV parsing is local to the FAQ CLI for now; a shared docs-export loader can be introduced if another command needs the same contract.

## Deferred
- Explicit --documentation-term-format override for suffixless structured files.
- Hosted UI upload/entry fields for documentation terms and rule files.
- Richer docs export metadata, such as URLs or section paths, in result JSON.

## Verification
- Focused structured documentation-term-file FAQ CLI pytest - passed, 5 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 124 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed; no cross-layer non-diff references found.

## Diff size
5 files, +381 / -9