### PR TITLE
Derive landscape headline vendor count from rendered chart (D8)

### DIFF
--- a/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
@@ -2,8 +2,8 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'crm-landscape-2026-04',
-  title: 'CRM Landscape 2026: 8 Vendors Compared by Real User Data',
-  description: 'A comprehensive market overview of the CRM landscape based on 1,054 enriched reviews across 8 vendors. Covers churn urgency, recurring pain patterns, and vendor-by-vendor strengths and weaknesses.',
+  title: 'CRM Landscape 2026: 7 Vendors Compared by Real User Data',
+  description: 'A comprehensive market overview of the CRM landscape based on 1,054 enriched reviews across 7 vendors. Covers churn urgency, recurring pain patterns, and vendor-by-vendor strengths and weaknesses.',
   date: '2026-04-07',
   author: 'Churn Signals Team',
   tags: ["crm", "market-landscape", "comparison", "b2b-intelligence"],
@@ -119,8 +119,8 @@ const post: BlogPost = {
   },
   "booking_url": "https://churnsignals.co"
 },
-  seo_title: 'CRM Software Comparison 2026: 8 Vendors by User Reviews',
-  seo_description: 'Compare 8 CRM vendors using 1,054 real user reviews. See churn risk, pain patterns, and vendor strengths across Salesforce, HubSpot, Pipedrive, Zoho CRM, and more.',
+  seo_title: 'CRM Software Comparison 2026: 7 Vendors by User Reviews',
+  seo_description: 'Compare 7 CRM vendors using 1,054 real user reviews. See churn risk, pain patterns, and vendor strengths across Salesforce, HubSpot, Pipedrive, Zoho CRM, and more.',
   target_keyword: 'CRM software comparison',
   secondary_keywords: ["best CRM software", "CRM vendor comparison", "CRM churn signals"],
   faq: [
@@ -130,7 +130,7 @@ const post: BlogPost = {
   },
   {
     "question": "What are the most common pain points across CRM platforms?",
-    "answer": "The most frequent complaints cluster around overall dissatisfaction, pricing, and user experience. These three categories account for the majority of negative sentiment across all 8 vendors analyzed between February 25 and April 7, 2026."
+    "answer": "The most frequent complaints cluster around overall dissatisfaction, pricing, and user experience. These three categories account for the majority of negative sentiment across all 7 vendors analyzed between February 25 and April 7, 2026."
   },
   {
     "question": "How many reviews were analyzed for this CRM comparison?",
@@ -155,7 +155,7 @@ const post: BlogPost = {
   "category_filter": "CRM"
 },
   content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
-<p>The CRM market in 2026 is crowded, competitive, and under pricing pressure. Between February 25 and April 7, 2026, we analyzed 1,054 enriched reviews across 8 major vendors to map the current landscape. The sample includes 147 verified reviews from platforms like G2, Gartner, and PeerSpot, plus 907 community reviews from Reddit and similar forums.</p>
+<p>The CRM market in 2026 is crowded, competitive, and under pricing pressure. Between February 25 and April 7, 2026, we analyzed 1,054 enriched reviews across 7 major vendors to map the current landscape. The sample includes 147 verified reviews from platforms like G2, Gartner, and PeerSpot, plus 907 community reviews from Reddit and similar forums.</p>
 <p>This analysis covers 1,054 total churn signals with an average urgency score of 2.1 across the category. The goal is not to crown a winner, but to show which vendors face the highest churn risk, which pain points recur across platforms, and where each product holds strength or shows weakness.</p>
 <p>The CRM category is in a price competition regime. HubSpot is emerging as the dominant consolidator, capturing displacement flows from Pipedrive (19 mentions), Zoho CRM (6 mentions), and Nutshell (4 mentions). The unidirectional flow pattern and absence of counter-displacement signals suggest a durable consolidation trend rather than cyclical competition.</p>
 <p>This is a self-selected sample. Reviewers who take the time to write are not representative of all users. Treat the findings as sentiment and pattern evidence, not universal product truth.</p>
@@ -165,7 +165,7 @@ const post: BlogPost = {
 <p>These patterns suggest that month-end periods—when compensation reviews and performance evaluations occur—create natural windows for external opportunity consideration. The timing hook is not unique to one vendor, but recurs across the category.</p>
 <p>Counterevidence exists. Despite pricing frustration, some customers remain due to overall satisfaction with the platform, acceptable pricing for certain segments, positive UX experiences, and reliable performance. However, these retention anchors are vulnerable to competitive pressure on pricing-related value propositions.</p>
 <h2 id="which-vendors-face-the-highest-churn-risk">Which Vendors Face the Highest Churn Risk?</h2>
-<p>Churn urgency varies significantly across the 8 vendors. Urgency scores reflect the intensity and frequency of switching signals in the review sample, not absolute churn rates.</p>
+<p>Churn urgency varies significantly across the 7 vendors. Urgency scores reflect the intensity and frequency of switching signals in the review sample, not absolute churn rates.</p>
 <p>{{chart:vendor-urgency}}</p>
 <p>Copper and Freshsales show the highest urgency scores. Copper's 24 reviews in scope reveal concentrated pain in overall dissatisfaction and pricing. Freshsales' 31 reviews cluster around features, overall dissatisfaction, and user experience.</p>
 <p>Close, Pipedrive, and Insightly sit in the middle range. Close's 12 reviews show pricing and UX pressure, while Insightly's 26 reviews highlight features and support as recurring pain points.</p>

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -8368,6 +8368,21 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
     }
 
     charts = []
+    # D8: derive the headline vendor count from the vendors actually rendered in
+    # the urgency comparison below (one bar per vendor with signals), so the
+    # headline can't overclaim vs the chart (e.g. "8 vendors" while the chart
+    # shows 7). Computed here as the single source of truth for both the chart
+    # and the headline; falls back to the category count only if no vendor has
+    # signals (degenerate landscape).
+    urgency_data = []
+    for vs in vendor_signals:
+        vendor = vs["vendor"]
+        sigs = vs.get("signals", [])
+        if sigs:
+            avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
+            urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
+    rendered_vendor_count = len(urgency_data) or vendor_count
+
     sections = [
         SectionSpec(
             id="hook",
@@ -8375,13 +8390,13 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             goal=f"Frame this as a comprehensive market overview of the {category} space",
             key_stats={
                 "category": category,
-                "vendor_count": vendor_count,
+                "vendor_count": rendered_vendor_count,
                 "total_reviews": ctx["total_reviews"],
                 "avg_urgency": ctx["avg_urgency"],
                 "market_regime": market_regime,
             },
             data_summary=(
-                f"The {category} landscape has {vendor_count} major vendors "
+                f"The {category} landscape has {rendered_vendor_count} major vendors "
                 f"with {ctx['total_reviews']} total churn signals analyzed."
             ),
         ),
@@ -8395,14 +8410,8 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             data_summary=f"Current market regime: {market_regime}.",
         ))
 
-    # Urgency comparison chart across vendors
-    urgency_data = []
-    for vs in vendor_signals:
-        vendor = vs["vendor"]
-        sigs = vs.get("signals", [])
-        if sigs:
-            avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
-            urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
+    # Urgency comparison chart across vendors (urgency_data computed above, where
+    # it also drives the headline vendor count).
     if urgency_data:
         urgency_chart = ChartSpec(
             chart_id="vendor-urgency",
@@ -8487,7 +8496,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
                 ),
             ))
 
-    takeaway_stats: dict[str, Any] = {"category": category, "vendor_count": vendor_count}
+    takeaway_stats: dict[str, Any] = {"category": category, "vendor_count": rendered_vendor_count}
     cat_dyn = data.get("pool_category") or {}
     regime = cat_dyn.get("market_regime") or {}
     xv_lookup_ml = data.get("xv_synthesis_lookup") or {}
@@ -8539,7 +8548,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
     return PostBlueprint(
         topic_type="market_landscape",
         slug=ctx["slug"],
-        suggested_title=f"{category} Landscape {date.today().year}: {vendor_count} Vendors Compared by Real User Data",
+        suggested_title=f"{category} Landscape {date.today().year}: {rendered_vendor_count} Vendors Compared by Real User Data",
         tags=[category.lower(), "market-landscape", "comparison", "b2b-intelligence"],
         data_context={**data["data_context"], "category": category},
         sections=sections,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -8368,6 +8368,21 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
     }
 
     charts = []
+    # D8: derive the headline vendor count from the vendors actually rendered in
+    # the urgency comparison below (one bar per vendor with signals), so the
+    # headline can't overclaim vs the chart (e.g. "8 vendors" while the chart
+    # shows 7). Computed here as the single source of truth for both the chart
+    # and the headline; falls back to the category count only if no vendor has
+    # signals (degenerate landscape).
+    urgency_data = []
+    for vs in vendor_signals:
+        vendor = vs["vendor"]
+        sigs = vs.get("signals", [])
+        if sigs:
+            avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
+            urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
+    rendered_vendor_count = len(urgency_data) or vendor_count
+
     sections = [
         SectionSpec(
             id="hook",
@@ -8375,13 +8390,13 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             goal=f"Frame this as a comprehensive market overview of the {category} space",
             key_stats={
                 "category": category,
-                "vendor_count": vendor_count,
+                "vendor_count": rendered_vendor_count,
                 "total_reviews": ctx["total_reviews"],
                 "avg_urgency": ctx["avg_urgency"],
                 "market_regime": market_regime,
             },
             data_summary=(
-                f"The {category} landscape has {vendor_count} major vendors "
+                f"The {category} landscape has {rendered_vendor_count} major vendors "
                 f"with {ctx['total_reviews']} total churn signals analyzed."
             ),
         ),
@@ -8395,14 +8410,8 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             data_summary=f"Current market regime: {market_regime}.",
         ))
 
-    # Urgency comparison chart across vendors
-    urgency_data = []
-    for vs in vendor_signals:
-        vendor = vs["vendor"]
-        sigs = vs.get("signals", [])
-        if sigs:
-            avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
-            urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
+    # Urgency comparison chart across vendors (urgency_data computed above, where
+    # it also drives the headline vendor count).
     if urgency_data:
         urgency_chart = ChartSpec(
             chart_id="vendor-urgency",
@@ -8487,7 +8496,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
                 ),
             ))
 
-    takeaway_stats: dict[str, Any] = {"category": category, "vendor_count": vendor_count}
+    takeaway_stats: dict[str, Any] = {"category": category, "vendor_count": rendered_vendor_count}
     cat_dyn = data.get("pool_category") or {}
     regime = cat_dyn.get("market_regime") or {}
     xv_lookup_ml = data.get("xv_synthesis_lookup") or {}
@@ -8539,7 +8548,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
     return PostBlueprint(
         topic_type="market_landscape",
         slug=ctx["slug"],
-        suggested_title=f"{category} Landscape {date.today().year}: {vendor_count} Vendors Compared by Real User Data",
+        suggested_title=f"{category} Landscape {date.today().year}: {rendered_vendor_count} Vendors Compared by Real User Data",
         tags=[category.lower(), "market-landscape", "comparison", "b2b-intelligence"],
         data_context={**data["data_context"], "category": category},
         sections=sections,

--- a/plans/PR-Blog-D8-Vendor-Count.md
+++ b/plans/PR-Blog-D8-Vendor-Count.md
@@ -1,0 +1,79 @@
+# PR-Blog-D8-Vendor-Count
+
+Ownership lane: `content-ops/blog-d8-vendor-count`
+
+## Why this slice exists
+
+Defect **D8** (`reports/blog-audit-findings.md`): a landscape post states a vendor
+count independently of the vendors it actually renders. `crm-landscape` claimed
+"**8** vendors" (title, seo, faq, prose) while the churn-urgency chart shows
+**7** (Copper, Freshsales, Zoho CRM, Close, Pipedrive, Insightly, Nutshell --
+no Salesforce/HubSpot). Generator fix + the one published-post correction.
+
+## Scope (this PR)
+
+- **Generator** (`_blueprint_market_landscape`, both byte-identical
+  `b2b_blog_post_generation.py` copies): the headline `vendor_count` came from
+  `ctx["vendor_count"]` (an independent category-wide count); derive it instead
+  from the vendors actually rendered in the urgency chart.
+- **Data** (`crm-landscape-2026-04.ts`): correct the 7 published "8 vendors"
+  claims to **7** (the charted count).
+
+### Files touched
+
+- `plans/PR-Blog-D8-Vendor-Count.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+- `atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts`
+
+## Mechanism
+
+The urgency-chart loop (`urgency_data`, one entry per vendor with signals) is
+moved above the section list so it is the single source of truth, and
+`rendered_vendor_count = len(urgency_data) or vendor_count` replaces
+`ctx["vendor_count"]` in the four headline surfaces (hook key_stats + summary,
+takeaway stats, suggested title). The fallback to `vendor_count` keeps a
+degenerate no-signals landscape from rendering "0 vendors". The pain-chart
+`dataKey: "vendor_count"` (a chart column, different semantic) is untouched.
+
+Data: contextual phrase replacements (never bare `8`) took the count from 8 -> 7
+in all 7 spots (title, seo_title, description, seo_description, faq, two prose
+lines). The seo vendor-name list ("Salesforce, HubSpot, ...") is left as-is --
+that is editorial naming, a different defect class than the count.
+
+## Intentional
+
+- **Single source of truth.** Deriving from `len(urgency_data)` (not a separate
+  `sum(... if signals)`) means the headline can't drift from the chart if the
+  chart's inclusion rule later changes.
+- **Count only, in the data fix.** Per the catalog, D8 is the count defect;
+  the seo vendor-name list is out of scope.
+
+## Deferred
+
+- **D8b -- profile coverage gap:** the description's "vendor-by-vendor strengths
+  and weaknesses" implies the full set, but only 5 of the 7 charted vendors get
+  strength/weakness profiles. Complement of the count defect; separate slice.
+- **D2/D3/D4** (pipedrive cluster).
+
+## Verification
+
+- New `test_market_landscape_headline_vendor_count_reflects_rendered_chart`:
+  ctx says 8 but only 7 vendor_signals carry signals -> the hook reads 7
+  (`key_stats["vendor_count"] == 7`, "7 major vendors" in summary). Verified it
+  FAILS on revert (`rendered_vendor_count = vendor_count` -> `8 == 7`).
+- `pytest` generation + quote-gate suites -> 194 passed; both copies
+  byte-identical.
+- Data: case-insensitive grep -> zero "8 vendor" claims remain; the 7 spots now
+  read "7"; the `"vendor_count": 7` pain-chart values (already 7) untouched.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (loop move + derived count) | ~55 |
+| Test | ~35 |
+| crm-landscape data (7 count corrections) | ~14 |
+| Plan doc | ~90 |
+| **Total** | **~195** |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -1533,6 +1533,36 @@ def test_market_landscape_blueprint_routes_quotes_through_contract_gate():
     assert quote["field"] == "pricing_phrases"
 
 
+def test_market_landscape_headline_vendor_count_reflects_rendered_chart():
+    """D8: the headline "{N} major vendors" must reflect the vendors actually
+    rendered in the urgency chart (one bar per vendor with signals), NOT the
+    independent category-wide ctx["vendor_count"]. The published crm-landscape
+    claimed "8 vendors" while the chart showed 7. Here ctx says 8 but only 7
+    vendor_signals carry signals -> the hook section must read 7. Reverting to
+    ctx["vendor_count"] fails this."""
+    data = {
+        "data_context": {"category": "CRM"},
+        "quotes": [],
+        "vendor_signals": [
+            {"vendor": f"Vendor {i}",
+             "signals": [{"pain_category": "pricing", "avg_urgency": 5.0}]}
+            for i in range(7)
+        ],
+    }
+    ctx = {
+        "slug": "crm-landscape-2026",
+        "category": "CRM",
+        "vendor_count": 8,  # independent category-wide count (the overclaiming source)
+        "total_reviews": 1200,
+        "avg_urgency": 6.5,
+    }
+    blueprint = _blueprint_market_landscape(ctx, data)
+    hook = next(s for s in blueprint.sections if s.id == "hook")
+    assert hook.key_stats["vendor_count"] == 7   # rendered, not ctx's 8
+    assert "7 major vendors" in hook.data_summary
+    assert "8 major vendors" not in hook.data_summary
+
+
 def test_pain_point_roundup_blueprint_routes_quotes_through_contract_gate():
     row = _v4_row(
         text="Salesforce reporting takes forever to load and constantly times out",


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d8-vendor-count`

**D8:** a landscape stated its vendor count independently of what it renders. `crm-landscape` claimed "**8** vendors" (title, seo, faq, prose) while the churn-urgency chart shows **7** (Copper, Freshsales, Zoho CRM, Close, Pipedrive, Insightly, Nutshell — no Salesforce/HubSpot). Generator fix + the one published-post correction.

## Intentional

- **Generator** (`_blueprint_market_landscape`, both byte-identical copies): the headline `vendor_count` came from `ctx["vendor_count"]` (independent category-wide count). Moved the `urgency_data` loop above the sections so it's the single source of truth, and use `rendered_vendor_count = len(urgency_data) or vendor_count` in the four headline surfaces (hook key_stats + summary, takeaway stats, suggested title). Fallback keeps a no-signals landscape from rendering "0". The pain-chart `dataKey: "vendor_count"` (a chart column) is untouched.
- **Data** (`crm-landscape-2026-04.ts`): 8 → 7 in all **7** published claims (title, seo_title, description, seo_description, faq, two prose lines), contextual phrases only. The seo vendor-name list ("Salesforce, HubSpot, …") is left as-is — editorial naming, a different defect class than the count.

## Deferred

- **D8b — profile coverage gap:** the description's "vendor-by-vendor strengths and weaknesses" implies the full set, but only 5 of the 7 charted vendors get strength/weakness profiles. Complement of the count defect; separate slice.
- **D2/D3/D4** (pipedrive cluster).

## Verification

- New `test_market_landscape_headline_vendor_count_reflects_rendered_chart`: ctx says 8 but only 7 vendor_signals carry signals → the hook reads 7. **Verified it fails on revert** (`rendered_vendor_count = vendor_count` → `8 == 7`).
- generation + quote-gate suites → **194 passed**; both copies byte-identical.
- Data: case-insensitive grep → zero "8 vendor" claims remain; the 7 spots read "7"; the `"vendor_count": 7` pain-chart values (already 7) untouched. Audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)