### PR TITLE
PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields.md
+++ b/plans/PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields.md
@@ -1,0 +1,80 @@
+# PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Documentation-Term-Structured-Files added CSV, JSON, and
+JSONL documentation-term imports, but parseable structured exports with the
+wrong field names still fall through to the generic "contains no terms" error.
+That slows down operator triage because it does not say whether the file was
+empty or the export used unrecognized columns or keys.
+
+This slice adds small diagnostics for that failure path so larger docs exports
+are easier to correct without changing the vocabulary-gap matching behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Detect CSV documentation-term files that contain rows but none of the
+   supported term columns.
+2. Detect JSON and JSONL documentation-term files that contain structured rows
+   or bundles but none of the supported term keys.
+3. Raise clean CLI errors that list the expected term keys and avoid raw
+   tracebacks.
+4. Add focused CLI regression tests for unrecognized CSV, JSON, and JSONL
+   structured files.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields.md` | Plan doc for this diagnostic slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds structured term-file field diagnostics. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers unrecognized CSV, JSON, and JSONL term-file failures. |
+
+## Mechanism
+
+The CLI keeps the same suffix-based loaders. CSV now distinguishes "no rows" from
+"rows present but no recognized term column." JSON and JSONL reuse the existing
+structured traversal but record whether a mapping-shaped row or bundle was seen
+without yielding a term.
+
+When a structured file has parseable rows but no supported field, the loader
+raises `SystemExit` with the expected field list. Empty files and plain text
+files keep the existing generic "contains no terms" behavior.
+
+## Intentional
+
+- No new accepted field names in this slice. The goal is clearer diagnostics,
+  not a broader import contract.
+- No result JSON changes. The failure happens before a FAQ run result exists,
+  and stderr is the operator surface for bad CLI input.
+- The diagnostic stays CLI-local because documentation-term file parsing is
+  currently a CLI feature.
+
+## Deferred
+
+- Format override flags for suffixless structured files.
+- Hosted UI upload diagnostics for documentation term files.
+- Rich docs export metadata such as URLs or section paths in result JSON.
+
+## Verification
+
+- Focused documentation-term-file FAQ CLI pytest - passed, 11 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  129 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| CLI diagnostics | ~65 |
+| Tests | ~75 |
+| **Total** | ~220 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -36,6 +36,8 @@ _DOCUMENTATION_TERM_LIST_KEYS = (
     "rows",
     "data",
 )
+_DOCUMENTATION_TERM_KEY_HINT = ", ".join(_DOCUMENTATION_TERM_ROW_KEYS)
+_EMPTY_JSONL_LINE = object()
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
@@ -396,45 +398,57 @@ def _load_cli_documentation_term_json(text: str, path: Path) -> tuple[str, ...]:
         raise SystemExit(
             f"--documentation-term-file must be valid JSON: {path}: {exc.msg}"
         ) from None
-    return tuple(_documentation_terms_from_payload(payload))
+    terms = tuple(_documentation_terms_from_payload(payload))
+    if not terms and _payload_has_unrecognized_term_fields(payload):
+        _raise_unrecognized_documentation_term_fields(path)
+    return terms
 
 
 def _load_cli_documentation_term_jsonl(text: str, path: Path) -> tuple[str, ...]:
-    terms = [
-        term
-        for line_no, line in enumerate(text.splitlines(), start=1)
-        for term in _documentation_terms_from_jsonl_line(line, path, line_no)
-    ]
+    saw_unrecognized_fields = False
+    terms: list[str] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        payload = _parse_documentation_term_jsonl_payload(line, path, line_no)
+        if payload is _EMPTY_JSONL_LINE:
+            continue
+        line_terms = tuple(_documentation_terms_from_payload(payload))
+        if not line_terms and _payload_has_unrecognized_term_fields(payload):
+            saw_unrecognized_fields = True
+        terms.extend(line_terms)
+    if not terms and saw_unrecognized_fields:
+        _raise_unrecognized_documentation_term_fields(path)
     return tuple(terms)
 
 
-def _documentation_terms_from_jsonl_line(
+def _parse_documentation_term_jsonl_payload(
     line: str,
     path: Path,
     line_no: int,
-) -> tuple[str, ...]:
+) -> Any:
     text = line.strip()
     if not text:
-        return ()
+        return _EMPTY_JSONL_LINE
     try:
-        payload = json.loads(text)
+        return json.loads(text)
     except json.JSONDecodeError as exc:
         raise SystemExit(
             "--documentation-term-file must be valid JSONL: "
             f"{path}: line {line_no}: {exc.msg}"
         ) from None
-    return tuple(_documentation_terms_from_payload(payload))
 
 
 def _load_cli_documentation_term_csv(text: str, path: Path) -> tuple[str, ...]:
     rows = list(csv.DictReader(io.StringIO(text, newline="")))
     if not rows:
         return ()
-    return tuple(
+    terms = tuple(
         term
         for row in rows
         for term in _documentation_terms_from_mapping(row)
     )
+    if not terms:
+        _raise_unrecognized_documentation_term_fields(path)
+    return terms
 
 
 def _documentation_terms_from_payload(payload: Any) -> tuple[str, ...]:
@@ -456,6 +470,25 @@ def _documentation_terms_from_payload(payload: Any) -> tuple[str, ...]:
     return ()
 
 
+def _payload_has_unrecognized_term_fields(payload: Any) -> bool:
+    if isinstance(payload, dict):
+        has_row_key = any(
+            _case_insensitive_has_key(payload, key)
+            for key in _DOCUMENTATION_TERM_ROW_KEYS
+        )
+        list_values = [
+            value
+            for key in _DOCUMENTATION_TERM_LIST_KEYS
+            if (value := _case_insensitive_get(payload, key)) is not None
+        ]
+        if not has_row_key and not list_values:
+            return bool(payload)
+        return any(_payload_has_unrecognized_term_fields(value) for value in list_values)
+    if isinstance(payload, list):
+        return any(_payload_has_unrecognized_term_fields(item) for item in payload)
+    return False
+
+
 def _documentation_terms_from_mapping(
     row: dict[str, Any],
 ) -> tuple[str, ...]:
@@ -474,6 +507,18 @@ def _case_insensitive_get(row: dict[str, Any], key: str) -> Any:
         if str(raw_key).lstrip("\ufeff").lower() == target:
             return value
     return None
+
+
+def _case_insensitive_has_key(row: dict[str, Any], key: str) -> bool:
+    target = key.lower()
+    return any(str(raw_key).lstrip("\ufeff").lower() == target for raw_key in row)
+
+
+def _raise_unrecognized_documentation_term_fields(path: Path) -> None:
+    raise SystemExit(
+        "--documentation-term-file has no recognized term fields: "
+        f"{path}; expected one of: {_DOCUMENTATION_TERM_KEY_HINT}"
+    )
 
 
 def _clean_cli_documentation_terms(terms: list[str]) -> tuple[str, ...]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2557,6 +2557,85 @@ def test_ticket_faq_cli_rejects_empty_documentation_term_file(tmp_path: Path) ->
     assert "Traceback" not in completed.stderr
 
 
+def test_ticket_faq_cli_rejects_unrecognized_csv_documentation_term_fields(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.csv"
+    term_file.write_text(
+        "\n".join((
+            "url,slug",
+            "https://help.example/export,export",
+            "",
+        )),
+        encoding="utf-8",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file has no recognized term fields:" in completed.stderr
+    assert "expected one of: documentation_term" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_unrecognized_json_documentation_term_fields(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.json"
+    term_file.write_text(
+        json.dumps({"documents": [{"url": "https://help.example/export"}]}),
+        encoding="utf-8",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file has no recognized term fields:" in completed.stderr
+    assert "expected one of: documentation_term" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_rejects_unrecognized_jsonl_documentation_term_fields(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms.jsonl"
+    term_file.write_text(
+        json.dumps({"url": "https://help.example/export"}) + "\n",
+        encoding="utf-8",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file has no recognized term fields:" in completed.stderr
+    assert "expected one of: documentation_term" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
 def test_ticket_faq_cli_rejects_malformed_json_documentation_term_file(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Documentation-Term-Unrecognized-Fields.md

Structured documentation-term imports can parse successfully but still produce no usable terms when a docs export uses unsupported field names. This slice adds targeted CLI diagnostics for CSV, JSON, and JSONL so operators can distinguish empty files from unrecognized columns or keys.

## Intentional
- No new accepted field names; this slice only improves bad-input diagnostics.
- No result JSON change because invalid term files fail before a run result exists.
- The diagnostic stays CLI-local because documentation-term file parsing is currently a CLI feature.

## Deferred
- Format override flags for suffixless structured files.
- Hosted UI upload diagnostics for documentation term files.
- Rich docs export metadata such as URLs or section paths in result JSON.

## Verification
- Focused documentation-term-file FAQ CLI pytest - passed, 11 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 129 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed, including drift and caller-hint checks.

## Diff size
3 files, +216 / -12