### PR TITLE
Add landing page draft edit API

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -12,6 +12,7 @@
  *   POST /content-ops/execute
  *   GET  /content-assets/{asset}/drafts
  *   GET  /content-assets/{asset}/drafts/export
+ *   PATCH /content-assets/landing_page/drafts/{id}
  *   POST /content-assets/{asset}/drafts/review
  *   POST /content-assets/{asset}/drafts/review-batch
  *
@@ -395,6 +396,16 @@ export interface GeneratedAssetBatchReviewResponse {
   missing_ids: string[]
 }
 
+export interface GeneratedLandingPageDraftUpdate {
+  title?: string
+  slug?: string
+  hero?: Record<string, unknown>
+  sections?: Array<Record<string, unknown>>
+  cta?: Record<string, unknown>
+  meta?: Record<string, unknown>
+  reference_ids?: string[]
+}
+
 // ---------------------------------------------------------------------------
 // Internal fetch plumbing
 // ---------------------------------------------------------------------------
@@ -516,6 +527,26 @@ async function postAssetJson<T>(
   return rawJson<T>(res)
 }
 
+async function patchAssetJson<T>(
+  asset: GeneratedAssetType,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const url = `${ASSETS_BASE}/${asset}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify(body),
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
 async function getAssetText(
   asset: GeneratedAssetType,
   path: string,
@@ -588,6 +619,18 @@ export function reviewGeneratedAssetDrafts(
     asset,
     '/drafts/review-batch',
     { ids, status },
+  )
+}
+
+/** PATCH /content-assets/landing_page/drafts/{id} -- edit a generated landing page draft. */
+export function updateGeneratedLandingPageDraft(
+  id: string,
+  body: GeneratedLandingPageDraftUpdate,
+): Promise<GeneratedAssetDraft> {
+  return patchAssetJson<GeneratedAssetDraft>(
+    'landing_page',
+    `/drafts/${encodeURIComponent(id)}`,
+    { ...body },
   )
 }
 

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -27,10 +27,12 @@ from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import (
     export_landing_page_drafts,
+    landing_page_draft_export_row,
     public_landing_page_draft_row,
     public_landing_page_robots,
 )
 from ..landing_page_postgres import PostgresLandingPageRepository
+from ..landing_page_ports import LandingPageDraft, LandingPageSection
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
 from ..sales_brief_export import export_sales_brief_drafts
@@ -329,6 +331,47 @@ def create_generated_asset_router(
             "missing_ids": missing_ids,
         }
 
+    @router.patch("/{asset}/drafts/{draft_id}")
+    async def update_landing_page_draft(
+        asset: str,
+        draft_id: str,
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
+        if asset_name != "landing_page":
+            raise HTTPException(
+                status_code=400,
+                detail="only landing_page drafts can be edited",
+            )
+        try:
+            landing_page_id = str(UUID(draft_id))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Landing page draft not found") from None
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        repository = PostgresLandingPageRepository(pool)
+        existing = await repository.get_draft(landing_page_id, scope=tenant)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="Landing page draft not found")
+        if existing.status == "approved":
+            raise HTTPException(
+                status_code=409,
+                detail="approved landing pages cannot be edited",
+            )
+        updated_draft = _patched_landing_page_draft(existing, payload)
+        updated = await repository.update_draft(
+            landing_page_id,
+            updated_draft,
+            scope=tenant,
+        )
+        if updated is None:
+            raise HTTPException(
+                status_code=409,
+                detail="landing page draft could not be edited",
+            )
+        return landing_page_draft_export_row(updated)
+
     return router
 
 
@@ -527,6 +570,122 @@ def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
             user_id=str(value.get("user_id") or "") or None,
         )
     return TenantScope()
+
+
+_LANDING_PAGE_EDITABLE_FIELDS = frozenset({
+    "title",
+    "slug",
+    "hero",
+    "sections",
+    "cta",
+    "meta",
+    "reference_ids",
+})
+
+
+def _patched_landing_page_draft(
+    existing: LandingPageDraft,
+    payload: Mapping[str, Any],
+) -> LandingPageDraft:
+    fields = set(payload).intersection(_LANDING_PAGE_EDITABLE_FIELDS)
+    if not fields:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "payload must include at least one editable landing page field: "
+                + ", ".join(sorted(_LANDING_PAGE_EDITABLE_FIELDS))
+            ),
+        )
+    return LandingPageDraft(
+        id=existing.id,
+        status="draft",
+        campaign_name=existing.campaign_name,
+        persona=existing.persona,
+        value_prop=existing.value_prop,
+        title=_patch_text(payload, "title", existing.title),
+        slug=_patch_text(payload, "slug", existing.slug),
+        hero=_patch_mapping(payload, "hero", existing.hero),
+        sections=_patch_sections(payload, "sections", existing.sections),
+        cta=_patch_mapping(payload, "cta", existing.cta),
+        meta=_patch_mapping(payload, "meta", existing.meta),
+        reference_ids=_patch_string_list(
+            payload,
+            "reference_ids",
+            existing.reference_ids,
+        ),
+        metadata=dict(existing.metadata or {}),
+    )
+
+
+def _patch_text(payload: Mapping[str, Any], key: str, current: str) -> str:
+    if key not in payload:
+        return current
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{key} must be a string")
+    return value.strip()
+
+
+def _patch_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+    current: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if key not in payload:
+        return dict(current or {})
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise HTTPException(status_code=400, detail=f"{key} must be an object")
+    return dict(value)
+
+
+def _patch_sections(
+    payload: Mapping[str, Any],
+    key: str,
+    current: Sequence[LandingPageSection],
+) -> Sequence[LandingPageSection]:
+    if key not in payload:
+        return tuple(current or ())
+    value = payload.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise HTTPException(status_code=400, detail=f"{key} must be a list")
+    sections: list[LandingPageSection] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{key}[{index}] must be an object",
+            )
+        metadata = item.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{key}[{index}].metadata must be an object",
+            )
+        sections.append(
+            LandingPageSection(
+                id=str(item.get("id") or ""),
+                title=str(item.get("title") or ""),
+                body_markdown=str(
+                    item.get("body_markdown") or item.get("body") or ""
+                ),
+                metadata=dict(metadata),
+            )
+        )
+    return tuple(sections)
+
+
+def _patch_string_list(
+    payload: Mapping[str, Any],
+    key: str,
+    current: Sequence[str],
+) -> Sequence[str]:
+    if key not in payload:
+        return tuple(str(item) for item in current)
+    value = payload.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise HTTPException(status_code=400, detail=f"{key} must be a list")
+    return tuple(str(item).strip() for item in value if str(item).strip())
 
 
 __all__ = [

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -201,6 +201,28 @@ class LandingPageRepository(Protocol):
     ) -> Sequence[LandingPageDraft]:
         """Return drafts filtered by tenant scope and optional facets."""
 
+    async def get_draft(
+        self,
+        landing_page_id: str,
+        *,
+        scope: TenantScope,
+    ) -> LandingPageDraft | None:
+        """Return one tenant-scoped landing-page draft by id, or None on miss."""
+
+    async def update_draft(
+        self,
+        landing_page_id: str,
+        draft: LandingPageDraft,
+        *,
+        scope: TenantScope,
+    ) -> LandingPageDraft | None:
+        """Update editable draft fields and return the updated row.
+
+        Implementations must keep the update tenant-scoped and must not mutate
+        approved rows. Editing an approved public landing page would bypass the
+        review flow.
+        """
+
     async def get_public_approved_draft(
         self,
         landing_page_id: str,

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -234,6 +234,69 @@ class PostgresLandingPageRepository:
         rows = await self.pool.fetch(sql, *params)
         return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
 
+    async def get_draft(
+        self,
+        landing_page_id: str,
+        *,
+        scope: TenantScope,
+    ) -> LandingPageDraft | None:
+        rows = await self.pool.fetch(
+            """
+            SELECT id, campaign_name, persona, value_prop, title, slug,
+                   hero, sections, cta, meta, reference_ids, metadata, status
+              FROM landing_pages
+             WHERE id = $1
+               AND account_id = $2
+             LIMIT 1
+            """,
+            landing_page_id,
+            scope.account_id or "",
+        )
+        if not rows:
+            return None
+        return _row_to_draft(row_to_dict(rows[0]))
+
+    async def update_draft(
+        self,
+        landing_page_id: str,
+        draft: LandingPageDraft,
+        *,
+        scope: TenantScope,
+    ) -> LandingPageDraft | None:
+        sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
+        reference_ids_payload = [str(r) for r in draft.reference_ids]
+        rows = await self.pool.fetch(
+            """
+            UPDATE landing_pages
+               SET title = $3,
+                   slug = $4,
+                   hero = $5::jsonb,
+                   sections = $6::jsonb,
+                   cta = $7::jsonb,
+                   meta = $8::jsonb,
+                   reference_ids = $9::jsonb,
+                   status = 'draft',
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $2
+               AND status <> 'approved'
+            RETURNING id, campaign_name, persona, value_prop, title, slug,
+                      hero, sections, cta, meta, reference_ids, metadata, status
+            """,
+            landing_page_id,
+            scope.account_id or "",
+            draft.title,
+            draft.slug,
+            json_dump_jsonb(dict(draft.hero or {})),
+            json_dump_jsonb(sections_payload),
+            json_dump_jsonb(dict(draft.cta or {})),
+            json_dump_jsonb(dict(draft.meta or {})),
+            json_dump_jsonb(reference_ids_payload),
+        )
+        if not rows:
+            return None
+        return _row_to_draft(row_to_dict(rows[0]))
+
     async def get_public_approved_draft(
         self,
         landing_page_id: str,

--- a/plans/PR-Landing-Page-Draft-Edit-API.md
+++ b/plans/PR-Landing-Page-Draft-Edit-API.md
@@ -1,0 +1,98 @@
+# PR-Landing-Page-Draft-Edit-API
+
+## Why this slice exists
+
+The landing-page SEO/AEO/GEO work now has input contracts, prompt alignment,
+save-time readiness checks, and review UI visibility. The next gap is that an
+operator still cannot make a small correction to a generated landing page
+without leaving the app or regenerating the whole asset.
+
+This slice adds the backend edit contract first so the later UI editor can call
+a real tenant-scoped API instead of inventing client-only state.
+
+This exceeds the 400 LOC soft cap because the repository contract, Postgres
+adapter, API route, frontend client wrapper, and tenant/readiness regression
+tests need to land together. Splitting the route from the repository would leave
+no callable edit primitive; splitting the tests would leave the write path
+under-specified.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-draft-edit-api
+
+1. Add tenant-scoped landing-page draft read/update methods to the repository
+   contract and Postgres adapter.
+2. Add a landing-page-only `PATCH /content-assets/landing_page/drafts/{id}`
+   route for editable draft fields.
+3. Re-run landing-page export/readiness shaping after an edit and return the
+   updated review row.
+4. Add a typed frontend API wrapper for the future review-drawer editor.
+5. Cover repository and API behavior with focused tests.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Draft-Edit-API.md` | Plan doc for this API slice. |
+| `extracted_content_pipeline/landing_page_ports.py` | Add draft read/update methods to the landing-page repository contract. |
+| `extracted_content_pipeline/landing_page_postgres.py` | Implement tenant-scoped draft read/update persistence. |
+| `extracted_content_pipeline/api/generated_assets.py` | Add the landing-page edit route and payload validation. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Add the typed client wrapper for the edit endpoint. |
+| `tests/test_extracted_landing_page_postgres.py` | Add repository read/update tests. |
+| `tests/test_extracted_content_asset_api.py` | Add generated-asset edit API tests. |
+
+## Mechanism
+
+The route accepts only the fields the generated landing-page draft already
+owns: `title`, `slug`, `hero`, `sections`, `cta`, `meta`, and
+`reference_ids`. It loads the existing row through tenant scope, rejects missing
+or approved drafts, applies the patch, persists the updated content, and returns
+`landing_page_draft_export_row(updated_draft)`.
+
+Returning the export row is the key integration point: the UI receives the same
+shape it already knows how to render, including `seo_aeo_readiness`,
+`geo_readiness`, structured data, section counts, and metadata summaries.
+
+## Intentional
+
+- Approved landing pages are not editable through this endpoint. Editing an
+  approved public page would silently mutate live content and bypass review.
+- A successful edit resets the row status to `draft` so rejected or blocked
+  drafts re-enter the existing review queue.
+- The route does not call an LLM or auto-repair copy. This is a manual edit
+  primitive, not the saved-draft repair loop.
+- No database migration is needed; the editable fields already exist on
+  `landing_pages`.
+
+## Deferred
+
+- PR-Landing-Page-Draft-Edit-UI should add the drawer/editor controls that call
+  this endpoint.
+- PR-Landing-Page-Saved-Draft-Repair should add an LLM repair action for
+  missing readiness checks.
+- PR-Landing-Page-Edit-Audit-Trail can add richer editor/user audit metadata
+  once the host exposes a stable user identity to this router.
+
+## Verification
+
+- Python compile check for the changed backend modules -> passed.
+- Focused generated-asset API and landing-page Postgres pytest suite -> 60 passed.
+- Atlas Intel UI lint -> passed.
+- Atlas Intel UI production build -> passed.
+- Git whitespace check -> passed.
+- Extracted content pipeline validation wrapper -> passed.
+- Extracted content pipeline reasoning-import guard -> passed.
+- Extracted standalone audit -> passed.
+- Extracted content pipeline ASCII check -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Backend API/repository | ~244 |
+| Frontend API wrapper | ~43 |
+| Tests | ~300 |
+| Total | ~685 |
+
+This is above the soft cap for the reason named in "Why this slice exists."

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -54,6 +56,44 @@ class _PublicLandingPagePool(_Pool):
             row for row in self.rows
             if row.get("id") == landing_page_id and row.get("status") == "approved"
         ]
+
+
+class _EditableLandingPagePool(_Pool):
+    def __init__(self, row=None) -> None:
+        super().__init__(rows=[])
+        self.row = dict(row) if row is not None else None
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        if "UPDATE landing_pages" not in str(query):
+            if (
+                self.row is not None
+                and "account_id" in self.row
+                and self.row["account_id"] != args[1]
+            ):
+                return []
+            return [] if self.row is None else [self.row]
+        if (
+            self.row is None
+            or self.row.get("status") == "approved"
+            or (
+                "account_id" in self.row
+                and self.row["account_id"] != args[1]
+            )
+        ):
+            return []
+        self.row.update({
+            "id": args[0],
+            "title": args[2],
+            "slug": args[3],
+            "hero": json.loads(args[4]),
+            "sections": json.loads(args[5]),
+            "cta": json.loads(args[6]),
+            "meta": json.loads(args[7]),
+            "reference_ids": json.loads(args[8]),
+            "status": "draft",
+        })
+        return [self.row]
 
 
 def _report_row():
@@ -397,6 +437,153 @@ def test_generated_asset_router_exports_landing_page_csv() -> None:
     query, args = pool.fetch_calls[0]
     assert "FROM landing_pages" in query
     assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+
+
+def test_generated_asset_router_updates_landing_page_draft_with_readiness() -> None:
+    row = {**_ready_landing_page_row(), "status": "rejected"}
+    pool = _EditableLandingPagePool(row)
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={
+            "title": "Edited support retention page",
+            "meta": {
+                **row["meta"],
+                "title_tag": "Edited Support Retention for VP Engineering",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["title"] == "Edited support retention page"
+    assert body["status"] == "draft"
+    assert body["seo_aeo_readiness"]["status"] == "ready"
+    assert body["geo_readiness"]["status"] == "ready"
+    assert len(pool.fetch_calls) == 2
+    select_query, select_args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in select_query
+    assert select_args == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct_1",
+    )
+    update_query, update_args = pool.fetch_calls[1]
+    assert "UPDATE landing_pages" in update_query
+    assert "status <> 'approved'" in update_query
+    assert update_args[0:4] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct_1",
+        "Edited support retention page",
+        "acme-support-retention",
+    )
+
+
+def test_generated_asset_router_blocks_approved_landing_page_edit() -> None:
+    pool = _EditableLandingPagePool(_ready_landing_page_row())
+
+    response = _client(pool).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={"title": "Edited title"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "approved landing pages cannot be edited"
+    assert len(pool.fetch_calls) == 1
+
+
+def test_generated_asset_router_returns_404_for_missing_landing_page_edit() -> None:
+    pool = _EditableLandingPagePool()
+
+    response = _client(pool).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={"title": "Edited title"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page draft not found"
+    assert len(pool.fetch_calls) == 1
+
+
+def test_generated_asset_router_returns_404_for_cross_tenant_landing_page_edit() -> None:
+    row = {**_ready_landing_page_row(), "status": "draft", "account_id": "acct_1"}
+    pool = _EditableLandingPagePool(row)
+
+    response = _client(pool, scope=TenantScope(account_id="acct_2")).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={"title": "Edited title"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page draft not found"
+    assert len(pool.fetch_calls) == 1
+
+
+def test_generated_asset_router_ignores_status_and_metadata_mass_assignment() -> None:
+    row = {
+        **_ready_landing_page_row(),
+        "status": "quality_blocked",
+        "metadata": {
+            "scope": {"account_id": "acct_1", "user_id": "user_1"},
+            "generation_usage": {"input_tokens": 10},
+        },
+    }
+    pool = _EditableLandingPagePool(row)
+
+    response = _client(pool, scope=TenantScope(account_id="acct_1")).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={
+            "title": "Edited support retention page",
+            "status": "approved",
+            "metadata": {"scope": {"account_id": "acct_2", "user_id": "user_2"}},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["title"] == "Edited support retention page"
+    assert body["status"] == "draft"
+    assert body["metadata"]["scope"] == {"account_id": "acct_1", "user_id": "user_1"}
+    update_query, update_args = pool.fetch_calls[1]
+    assert "metadata =" not in update_query
+    assert "approved" not in update_args
+
+
+def test_generated_asset_router_rejects_non_landing_page_edit() -> None:
+    pool = _Pool()
+
+    response = _client(pool).patch(
+        "/content-assets/blog_post/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={"title": "Edited title"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "only landing_page drafts can be edited"
+    assert pool.fetch_calls == []
+
+
+def test_generated_asset_router_rejects_empty_landing_page_edit_payload() -> None:
+    pool = _EditableLandingPagePool({**_ready_landing_page_row(), "status": "draft"})
+
+    response = _client(pool).patch(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111",
+        json={"campaign_name": "not-editable"},
+    )
+
+    assert response.status_code == 400
+    assert "payload must include at least one editable landing page field" in (
+        response.json()["detail"]
+    )
 
 
 def test_generated_asset_router_returns_public_approved_landing_page() -> None:

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -246,6 +246,136 @@ async def test_list_drafts_handles_pre_decoded_jsonb_columns() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_draft_filters_by_id_and_scope() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "draft",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero text"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "L"},
+            "meta": {"title_tag": "tt"},
+            "reference_ids": ["r1"],
+            "metadata": {"key": "value"},
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = await repo.get_draft(
+        "11111111-1111-1111-1111-111111111111",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert draft is not None
+    assert draft.id == "11111111-1111-1111-1111-111111111111"
+    assert draft.status == "draft"
+    assert draft.hero["headline"] == "Hero text"
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "FROM landing_pages" in sql
+    assert "id = $1" in sql
+    assert "account_id = $2" in sql
+    assert args == ("11111111-1111-1111-1111-111111111111", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_get_draft_returns_none_on_miss() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    draft = await repo.get_draft(
+        "11111111-1111-1111-1111-111111111111",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert draft is None
+
+
+@pytest.mark.asyncio
+async def test_update_draft_updates_editable_fields_and_returns_row() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "draft",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "updated title",
+            "slug": "updated-slug",
+            "hero": {"headline": "Updated hero"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "Book"},
+            "meta": {"title_tag": "Updated"},
+            "reference_ids": ["r1"],
+            "metadata": {"key": "value"},
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+    draft = LandingPageDraft(
+        campaign_name="acme",
+        persona="vp",
+        value_prop="vp",
+        title="updated title",
+        slug="updated-slug",
+        hero={"headline": "Updated hero"},
+        sections=(LandingPageSection(id="s1", title="T", body_markdown="B"),),
+        cta={"label": "Book"},
+        meta={"title_tag": "Updated"},
+        reference_ids=("r1",),
+        metadata={"key": "value"},
+    )
+
+    updated = await repo.update_draft(
+        "11111111-1111-1111-1111-111111111111",
+        draft,
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is not None
+    assert updated.title == "updated title"
+    assert updated.slug == "updated-slug"
+    assert updated.status == "draft"
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "UPDATE landing_pages" in sql
+    assert "status <> 'approved'" in sql
+    assert "RETURNING id" in sql
+    assert args[0:4] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct-1",
+        "updated title",
+        "updated-slug",
+    )
+    assert json.loads(args[4]) == {"headline": "Updated hero"}
+    assert json.loads(args[5])[0]["id"] == "s1"
+    assert json.loads(args[6]) == {"label": "Book"}
+    assert json.loads(args[7]) == {"title_tag": "Updated"}
+    assert json.loads(args[8]) == ["r1"]
+
+
+@pytest.mark.asyncio
+async def test_update_draft_returns_none_on_miss_or_approved_row() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    updated = await repo.update_draft(
+        "11111111-1111-1111-1111-111111111111",
+        _draft(),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is None
+    assert len(pool.fetch_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_get_public_approved_draft_filters_by_id_and_approved_status() -> None:
     pool = _Pool()
     pool.fetch_rows = [


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Draft-Edit-API.md

Adds the first backend edit primitive for generated landing pages: tenant-scoped draft lookup/update, a landing-page-only PATCH route, readiness recheck in the returned review row, and a typed Intel UI API wrapper for the follow-up drawer editor.

## Intentional
- Approved landing pages are not editable through this endpoint; editing live public content should not bypass review.
- Successful edits reset non-approved rows to draft so rejected or blocked drafts re-enter the review queue.
- This is a manual edit primitive, not the saved-draft LLM repair loop.
- The PR is above the 400 LOC soft cap because the repository contract, route, client wrapper, and regression tests need to land together.

## Deferred
- PR-Landing-Page-Draft-Edit-UI will add review-drawer editor controls.
- PR-Landing-Page-Saved-Draft-Repair will add LLM repair for missing readiness checks.
- PR-Landing-Page-Edit-Audit-Trail can add richer editor/user audit metadata once the host exposes stable user identity to this router.

## Verification
- python3 -m py_compile extracted_content_pipeline/api/generated_assets.py extracted_content_pipeline/landing_page_ports.py extracted_content_pipeline/landing_page_postgres.py
- pytest tests/test_extracted_content_asset_api.py tests/test_extracted_landing_page_postgres.py -q -> 58 passed
- npm run lint in atlas-intel-ui
- npm run build in atlas-intel-ui
- git diff --check
- bash scripts/validate_extracted_content_pipeline.sh
- python3 extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python3 scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh

## Diff size
7 files, +643 / -0