### PR TITLE
PR-Content-Ops-FAQ-Source-Mix-Diagnostics

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -856,7 +856,9 @@ def _failure_risk_signals(topic: str, rows: Sequence[Mapping[str, str]]) -> tupl
     return tuple(signals)
 
 
-def _is_zero_result_search_row(row: Mapping[str, Any]) -> bool:
+def is_zero_result_search_row(row: Mapping[str, Any]) -> bool:
+    """Return whether a normalized source row represents a zero-result search."""
+
     source_type = _source_type_key(row.get("source_type"))
     if source_type not in {"search_log", "search_query"}:
         return False
@@ -869,6 +871,10 @@ def _is_zero_result_search_row(row: Mapping[str, Any]) -> bool:
         if count == 0:
             return True
     return False
+
+
+def _is_zero_result_search_row(row: Mapping[str, Any]) -> bool:
+    return is_zero_result_search_row(row)
 
 
 def _truthy(value: Any) -> bool:

--- a/plans/PR-Content-Ops-FAQ-Source-Mix-Diagnostics.md
+++ b/plans/PR-Content-Ops-FAQ-Source-Mix-Diagnostics.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-FAQ-Source-Mix-Diagnostics
+
+## Why this slice exists
+
+The FAQ generator now accepts support tickets, chat-like conversations, search
+logs, sales objections, and public complaint-style rows. The compact result JSON
+already exposes generated FAQ items and vocabulary-gap mappings, but it does not
+summarize the input mix. That makes larger uploads harder to audit because an
+operator cannot quickly confirm which demand channels were recognized.
+
+This slice adds lightweight source-mix diagnostics to the FAQ CLI result output
+so SMB and mid-market proof runs can show that multiple customer-language
+sources were processed without inspecting the Markdown body.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add source-type counts to the FAQ CLI compact result JSON.
+2. Add higher-level source-channel counts for support tickets, chats/search
+   logs, sales inputs, complaints, and other rows.
+3. Add a zero-result search source count so search-log demand is visible even
+   when it is not the top FAQ item.
+4. Add focused CLI regression coverage for mixed-source result diagnostics.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Source-Mix-Diagnostics.md` | Plan doc for this result-diagnostics slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Exposes the canonical zero-result search row helper for CLI diagnostics. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds source-mix diagnostics to compact result JSON. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers mixed-source diagnostics in CLI result output. |
+
+## Mechanism
+
+The CLI already has the normalized `loaded.opportunities` before generation.
+`_result_payload` now receives those opportunities and builds a small
+diagnostics block from their normalized `source_type`, source id, evidence rows,
+and zero-result metadata.
+
+Zero-result search counting uses the same public helper as the FAQ generator's
+failure-risk scoring, so the diagnostic cannot drift from the scoring rule.
+
+The diagnostics stay compact: sorted `source_type_counts`, sorted
+`source_channel_counts`, and a distinct zero-result search source count. The
+Markdown body and generator ranking stay unchanged.
+
+## Intentional
+
+- CLI result JSON only. The library result object stays focused on generated FAQ
+  content and item metadata.
+- No source ingestion changes. This slice reports what the existing adapter
+  already normalizes.
+- No weighted-volume rollup in this slice. Weighted frequency already appears
+  on generated items and term mappings; this adds input visibility only.
+
+## Deferred
+
+- Hosted UI display for source-mix diagnostics.
+- Per-topic source-channel breakdowns.
+- Weighted input-volume diagnostics across all source rows.
+
+## Verification
+
+- Focused source-mix FAQ CLI pytest - passed, 2 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  130 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Local PR review against origin/main - passed; cross-layer caller hints for
+  generic `main` and an unrelated same-name `_result_payload` helper were
+  inspected and no external caller impact was found.
+- Reviewer update: focused source-mix/zero-result FAQ pytest passed, 3 tests;
+  full FAQ pytest passed, 130 tests; py compile, git whitespace check, extracted
+  validation, extracted reasoning guard, extracted standalone audit, and
+  extracted ASCII check passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Generator helper exposure | ~10 |
+| CLI diagnostics | ~95 |
+| Tests | ~65 |
+| **Total** | ~250 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -47,7 +47,27 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     DEFAULT_INTENT_RULES,
     DEFAULT_TITLE,
     build_ticket_faq_markdown,
+    is_zero_result_search_row,
 )
+
+_SOURCE_CHANNELS = {
+    # Mirrors the generator's accepted FAQ source types at channel granularity;
+    # unknown future types intentionally bucket to "other" until classified.
+    "case": "support_tickets",
+    "support_ticket": "support_tickets",
+    "ticket": "support_tickets",
+    "chat": "chats",
+    "chat_transcript": "chats",
+    "conversation": "chats",
+    "transcript": "chats",
+    "search_log": "search_logs",
+    "search_query": "search_logs",
+    "objection": "sales_inputs",
+    "sales_call": "sales_inputs",
+    "sales_objection": "sales_inputs",
+    "meeting": "sales_inputs",
+    "complaint": "complaints",
+}
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -217,7 +237,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.result_output:
         args.result_output.write_text(
             json.dumps(
-                _result_payload(args, result, loaded.warning_dicts(), failed_checks),
+                _result_payload(
+                    args,
+                    result,
+                    loaded.warning_dicts(),
+                    failed_checks,
+                    loaded.opportunities,
+                ),
                 indent=2,
                 sort_keys=True,
             )
@@ -242,6 +268,7 @@ def _result_payload(
     result: Any,
     load_warnings: list[dict[str, Any]],
     failed_checks: list[str],
+    opportunities: list[dict[str, Any]],
 ) -> dict[str, Any]:
     items = [dict(item) for item in result.items]
     ticket_counts = [int(item.get("ticket_count") or 0) for item in items]
@@ -288,6 +315,7 @@ def _result_payload(
         "diagnostics": {
             "output_check_details": _output_check_details(result, failed_checks, rendered_ticket_source_count),
             "question_source_counts": question_source_counts,
+            "source_mix": _source_mix_diagnostics(opportunities),
             "ticket_counts": ticket_counts,
             "rendered_ticket_source_count": rendered_ticket_source_count,
             "unrepresented_ticket_sources": max(result.ticket_source_count - rendered_ticket_source_count, 0),
@@ -299,6 +327,65 @@ def _result_payload(
             "items": [_item_summary(index, item) for index, item in enumerate(items, start=1)],
         },
     }
+
+
+def _source_mix_diagnostics(opportunities: list[dict[str, Any]]) -> dict[str, Any]:
+    source_type_counts: dict[str, int] = {}
+    source_channel_counts: dict[str, int] = {}
+    zero_result_search_sources: set[str] = set()
+    for index, opportunity in enumerate(opportunities, start=1):
+        source_type = _diagnostic_source_type(opportunity)
+        source_type_counts[source_type] = source_type_counts.get(source_type, 0) + 1
+        channel = _SOURCE_CHANNELS.get(source_type, "other")
+        source_channel_counts[channel] = source_channel_counts.get(channel, 0) + 1
+        if _is_zero_result_search_source(opportunity):
+            zero_result_search_sources.add(_diagnostic_source_key(opportunity, index))
+    return {
+        "source_type_counts": dict(sorted(source_type_counts.items())),
+        "source_channel_counts": dict(sorted(source_channel_counts.items())),
+        "zero_result_search_source_count": len(zero_result_search_sources),
+    }
+
+
+def _diagnostic_source_type(opportunity: dict[str, Any]) -> str:
+    source_type = _clean_diagnostic_text(opportunity.get("source_type")).lower()
+    if source_type:
+        return source_type
+    for evidence in _diagnostic_evidence_rows(opportunity):
+        source_type = _clean_diagnostic_text(evidence.get("source_type")).lower()
+        if source_type:
+            return source_type
+    return "unknown"
+
+
+def _diagnostic_source_key(opportunity: dict[str, Any], index: int) -> str:
+    for key in ("source_id", "target_id", "id"):
+        value = _clean_diagnostic_text(opportunity.get(key))
+        if value:
+            return value
+    for evidence in _diagnostic_evidence_rows(opportunity):
+        value = _clean_diagnostic_text(evidence.get("source_id"))
+        if value:
+            return value
+    return f"row:{index}"
+
+
+def _diagnostic_evidence_rows(opportunity: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    evidence = opportunity.get("evidence")
+    if isinstance(evidence, list):
+        return tuple(row for row in evidence if isinstance(row, dict))
+    return ()
+
+
+def _is_zero_result_search_source(
+    opportunity: dict[str, Any],
+) -> bool:
+    rows = (opportunity, *_diagnostic_evidence_rows(opportunity))
+    return any(is_zero_result_search_row(row) for row in rows)
+
+
+def _clean_diagnostic_text(value: Any) -> str:
+    return " ".join(str(value or "").split())
 
 
 def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2244,6 +2244,11 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert result["diagnostics"]["question_source_counts"] == {
         "customer_wording": 2,
     }
+    assert result["diagnostics"]["source_mix"] == {
+        "source_channel_counts": {"support_tickets": 4},
+        "source_type_counts": {"support_ticket": 4},
+        "zero_result_search_source_count": 0,
+    }
     assert result["diagnostics"]["ticket_counts"] == [2, 2]
     assert result["diagnostics"]["term_mapping_count"] == 0
     assert result["diagnostics"]["term_mappings"] == []
@@ -2299,6 +2304,60 @@ def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path)
         "first_source_id": "ticket-1",
     }]
     assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
+
+
+def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> None:
+    source = _write_source_csv(
+        tmp_path,
+        "mixed_sources.csv",
+        [
+            {
+                "ticket_id": "ticket-1",
+                "subject": "Export blocked",
+                "description": "I cannot export the report.",
+            },
+            {
+                "query_id": "search-1",
+                "search_query": "download report",
+                "results_count": "0",
+                "search_count": "25",
+            },
+            {
+                "chat_id": "chat-1",
+                "message": "How do I change my login email?",
+            },
+            {
+                "sales_objection_id": "objection-1",
+                "sales_objection": "Prospect asked whether reporting exports are available.",
+            },
+        ],
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["source_count"] == 4
+    assert result["diagnostics"]["source_mix"] == {
+        "source_channel_counts": {
+            "chats": 1,
+            "sales_inputs": 1,
+            "search_logs": 1,
+            "support_tickets": 1,
+        },
+        "source_type_counts": {
+            "chat": 1,
+            "sales_objection": 1,
+            "search_log": 1,
+            "support_ticket": 1,
+        },
+        "zero_result_search_source_count": 1,
+    }
 
 
 def test_ticket_faq_cli_accepts_documentation_term_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Source-Mix-Diagnostics.md

The FAQ CLI result JSON now exposes the input source mix so larger proof runs can show which customer-language channels were recognized without inspecting the Markdown body.

## Intentional
- CLI result JSON only; the library result object and Markdown output stay focused on generated FAQ content.
- No source ingestion changes; this reports what the existing adapter already normalizes.
- No weighted-volume rollup in this slice; weighted frequency remains on generated items and term mappings.

## Deferred
- Hosted UI display for source-mix diagnostics.
- Per-topic source-channel breakdowns.
- Weighted input-volume diagnostics across all source rows.

## Verification
- Focused source-mix FAQ CLI pytest - passed, 2 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 130 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed; generic caller-hint warnings inspected with no external caller impact.

## Diff size
3 files, +255 / -1