### PR TITLE
Honest profile-coverage claim for landscape (D8b)

### DIFF
--- a/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts
@@ -3,7 +3,7 @@ import type { BlogPost } from './index'
 const post: BlogPost = {
   slug: 'crm-landscape-2026-04',
   title: 'CRM Landscape 2026: 7 Vendors Compared by Real User Data',
-  description: 'A comprehensive market overview of the CRM landscape based on 1,054 enriched reviews across 7 vendors. Covers churn urgency, recurring pain patterns, and vendor-by-vendor strengths and weaknesses.',
+  description: 'A comprehensive market overview of the CRM landscape based on 1,054 enriched reviews across 7 vendors. Covers churn urgency, recurring pain patterns, and strength and weakness profiles for the leading vendors.',
   date: '2026-04-07',
   author: 'Churn Signals Team',
   tags: ["crm", "market-landscape", "comparison", "b2b-intelligence"],
@@ -156,7 +156,7 @@ const post: BlogPost = {
 },
   content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-04-07. It captures reviewer perception, not a census of all users.</em></p>
 <p>The CRM market in 2026 is crowded, competitive, and under pricing pressure. Between February 25 and April 7, 2026, we analyzed 1,054 enriched reviews across 7 major vendors to map the current landscape. The sample includes 147 verified reviews from platforms like G2, Gartner, and PeerSpot, plus 907 community reviews from Reddit and similar forums.</p>
-<p>This analysis covers 1,054 total churn signals with an average urgency score of 2.1 across the category. The goal is not to crown a winner, but to show which vendors face the highest churn risk, which pain points recur across platforms, and where each product holds strength or shows weakness.</p>
+<p>This analysis covers 1,054 total churn signals with an average urgency score of 2.1 across the category. The goal is not to crown a winner, but to show which vendors face the highest churn risk, which pain points recur across platforms, and where the leading vendors show strength or weakness.</p>
 <p>The CRM category is in a price competition regime. HubSpot is emerging as the dominant consolidator, capturing displacement flows from Pipedrive (19 mentions), Zoho CRM (6 mentions), and Nutshell (4 mentions). The unidirectional flow pattern and absence of counter-displacement signals suggest a durable consolidation trend rather than cyclical competition.</p>
 <p>This is a self-selected sample. Reviewers who take the time to write are not representative of all users. Treat the findings as sentiment and pattern evidence, not universal product truth.</p>
 <h2 id="what-market-regime-are-we-in">What Market Regime Are We In?</h2>

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -8382,6 +8382,12 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
             urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
     rendered_vendor_count = len(urgency_data) or vendor_count
+    # D8b: the landscape renders strength/weakness profiles for at most the
+    # leading vendors (vendor_profiles[:5]), not every charted vendor. Surface
+    # that count so the description can frame profile coverage honestly
+    # ("profiles for the leading vendors") instead of implying every charted
+    # vendor is profiled.
+    profile_count = min(len(vendor_profiles), 5)
 
     sections = [
         SectionSpec(
@@ -8391,6 +8397,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             key_stats={
                 "category": category,
                 "vendor_count": rendered_vendor_count,
+                "profile_count": profile_count,
                 "total_reviews": ctx["total_reviews"],
                 "avg_urgency": ctx["avg_urgency"],
                 "market_regime": market_regime,

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -8382,12 +8382,18 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
             urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
     rendered_vendor_count = len(urgency_data) or vendor_count
-    # D8b: the landscape renders strength/weakness profiles for at most the
-    # leading vendors (vendor_profiles[:5]), not every charted vendor. Surface
-    # that count so the description can frame profile coverage honestly
-    # ("profiles for the leading vendors") instead of implying every charted
-    # vendor is profiled.
-    profile_count = min(len(vendor_profiles), 5)
+    # D8b: count the vendors that ACTUALLY render a profile section -- the loop
+    # below caps at vendor_profiles[:5] AND only emits a section when strengths
+    # or weaknesses is non-empty, so count with the same predicate (not bare
+    # len), or the stat would overstate coverage and reintroduce the mismatch
+    # this slice fixes (Codex P2 on #780). Wired into data_summary below so the
+    # honest count is deterministically USED, not just surfaced.
+    profile_count = sum(
+        1
+        for vp in vendor_profiles[:5]
+        if (vp.get("profile") or {}).get("strengths")
+        or (vp.get("profile") or {}).get("weaknesses")
+    )
 
     sections = [
         SectionSpec(
@@ -8404,7 +8410,8 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             },
             data_summary=(
                 f"The {category} landscape has {rendered_vendor_count} major vendors "
-                f"with {ctx['total_reviews']} total churn signals analyzed."
+                f"with {ctx['total_reviews']} total churn signals analyzed. "
+                f"Strength and weakness profiles cover the {profile_count} leading vendors."
             ),
         ),
     ]

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -8382,6 +8382,12 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
             urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
     rendered_vendor_count = len(urgency_data) or vendor_count
+    # D8b: the landscape renders strength/weakness profiles for at most the
+    # leading vendors (vendor_profiles[:5]), not every charted vendor. Surface
+    # that count so the description can frame profile coverage honestly
+    # ("profiles for the leading vendors") instead of implying every charted
+    # vendor is profiled.
+    profile_count = min(len(vendor_profiles), 5)
 
     sections = [
         SectionSpec(
@@ -8391,6 +8397,7 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             key_stats={
                 "category": category,
                 "vendor_count": rendered_vendor_count,
+                "profile_count": profile_count,
                 "total_reviews": ctx["total_reviews"],
                 "avg_urgency": ctx["avg_urgency"],
                 "market_regime": market_regime,

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -8382,12 +8382,18 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             avg_urg = sum(s.get("avg_urgency", 0) for s in sigs) / len(sigs) if sigs else 0
             urgency_data.append({"name": vendor[:20], "urgency": round(avg_urg, 1)})
     rendered_vendor_count = len(urgency_data) or vendor_count
-    # D8b: the landscape renders strength/weakness profiles for at most the
-    # leading vendors (vendor_profiles[:5]), not every charted vendor. Surface
-    # that count so the description can frame profile coverage honestly
-    # ("profiles for the leading vendors") instead of implying every charted
-    # vendor is profiled.
-    profile_count = min(len(vendor_profiles), 5)
+    # D8b: count the vendors that ACTUALLY render a profile section -- the loop
+    # below caps at vendor_profiles[:5] AND only emits a section when strengths
+    # or weaknesses is non-empty, so count with the same predicate (not bare
+    # len), or the stat would overstate coverage and reintroduce the mismatch
+    # this slice fixes (Codex P2 on #780). Wired into data_summary below so the
+    # honest count is deterministically USED, not just surfaced.
+    profile_count = sum(
+        1
+        for vp in vendor_profiles[:5]
+        if (vp.get("profile") or {}).get("strengths")
+        or (vp.get("profile") or {}).get("weaknesses")
+    )
 
     sections = [
         SectionSpec(
@@ -8404,7 +8410,8 @@ def _blueprint_market_landscape(ctx: dict, data: dict) -> PostBlueprint:
             },
             data_summary=(
                 f"The {category} landscape has {rendered_vendor_count} major vendors "
-                f"with {ctx['total_reviews']} total churn signals analyzed."
+                f"with {ctx['total_reviews']} total churn signals analyzed. "
+                f"Strength and weakness profiles cover the {profile_count} leading vendors."
             ),
         ),
     ]

--- a/plans/PR-Blog-D8b-Profile-Coverage.md
+++ b/plans/PR-Blog-D8b-Profile-Coverage.md
@@ -1,0 +1,73 @@
+# PR-Blog-D8b-Profile-Coverage
+
+Ownership lane: `content-ops/blog-d8b-profile-coverage`
+
+## Why this slice exists
+
+D8b (the coverage complement of D8 #775): `crm-landscape` charts 7 vendors but
+renders strength/weakness profiles for only 5 (`vendor_profiles[:5]` cap), while
+the description claimed "vendor-by-vendor strengths and weaknesses" and the prose
+said "where each product holds strength or shows weakness" -- both implying every
+vendor is profiled. Charted-but-unprofiled: Zoho CRM, Pipedrive.
+
+## Scope (this PR)
+
+- **Generator** (`_blueprint_market_landscape`, both byte-identical copies):
+  surface `profile_count = min(len(vendor_profiles), 5)` in the hook key_stats,
+  so the description can be framed honestly around the count actually rendered.
+- **Data** (`crm-landscape-2026-04.ts`): soften the two over-claims to "the
+  leading vendors". Leave the body's "vendor-by-vendor churn risk scores" -- that
+  is the urgency chart (7 vendors), which is accurate.
+
+### Files touched
+
+- `plans/PR-Blog-D8b-Profile-Coverage.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation_quote_gate.py`
+- `atlas-churn-ui/src/content/blog/crm-landscape-2026-04.ts`
+
+## Mechanism
+
+`profile_count = min(len(vendor_profiles), 5)` is computed alongside the existing
+`rendered_vendor_count` and added to the hook key_stats. Data: two contextual
+phrase replacements, identical "leading vendors" wording in both:
+- description: "...and vendor-by-vendor strengths and weaknesses." -> "...and
+  strength and weakness profiles for the leading vendors."
+- prose: "...where each product holds strength or shows weakness." -> "...where
+  the leading vendors show strength or weakness."
+
+## Intentional
+
+- **Honesty of claim, not raising the cap.** The catalog's other option ("ensure
+  all N charted+profiled") would mean authoring strength/weakness profile PROSE
+  for Zoho CRM + Pipedrive in the already-published post -- inventing content for
+  vendors that weren't profiled, which the repo's "never invent content" rule
+  forbids. The `[:5]` cap is a deliberate length choice; the defect is the claim,
+  so the claim is what changes.
+- **Left the body's "vendor-by-vendor churn risk scores".** That refers to the
+  urgency chart (7 vendors), which is accurate -- not a profile claim.
+
+## Deferred
+
+- **D2/D3/D4** (pipedrive cluster).
+
+## Verification
+
+- New `test_market_landscape_exposes_capped_profile_count`: 7 profiles available
+  -> hook `profile_count == 5`. Verified it FAILS on revert (`profile_count =
+  len(vendor_profiles)` -> `7 == 5`).
+- `pytest` generation + quote-gate suites -> 195 passed; both copies
+  byte-identical.
+- Data: over-claim grep -> 0 ("vendor-by-vendor strengths"/"each product holds"
+  gone); "vendor-by-vendor churn risk scores" (chart) left intact; audit clean.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (profile_count + key_stat) | ~18 |
+| Test | ~30 |
+| crm-landscape data (2 phrase softenings) | ~4 |
+| Plan doc | ~85 |
+| **Total** | **~135** |

--- a/plans/PR-Blog-D8b-Profile-Coverage.md
+++ b/plans/PR-Blog-D8b-Profile-Coverage.md
@@ -13,8 +13,10 @@ vendor is profiled. Charted-but-unprofiled: Zoho CRM, Pipedrive.
 ## Scope (this PR)
 
 - **Generator** (`_blueprint_market_landscape`, both byte-identical copies):
-  surface `profile_count = min(len(vendor_profiles), 5)` in the hook key_stats,
-  so the description can be framed honestly around the count actually rendered.
+  surface `profile_count` -- counting only vendors that actually emit a profile
+  section (`vendor_profiles[:5]` with non-empty strengths/weaknesses, the
+  render-loop predicate) -- in the hook key_stats, AND wire it into the hook
+  data_summary so the honest count is deterministically used, not just surfaced.
 - **Data** (`crm-landscape-2026-04.ts`): soften the two over-claims to "the
   leading vendors". Leave the body's "vendor-by-vendor churn risk scores" -- that
   is the urgency chart (7 vendors), which is accurate.
@@ -29,9 +31,12 @@ vendor is profiled. Charted-but-unprofiled: Zoho CRM, Pipedrive.
 
 ## Mechanism
 
-`profile_count = min(len(vendor_profiles), 5)` is computed alongside the existing
-`rendered_vendor_count` and added to the hook key_stats. Data: two contextual
-phrase replacements, identical "leading vendors" wording in both:
+`profile_count` is computed alongside the existing `rendered_vendor_count` by
+counting `vendor_profiles[:5]` whose profile has non-empty strengths or
+weaknesses (the exact predicate the profile-section render loop uses), then
+added to the hook key_stats and appended to the hook data_summary ("Strength and
+weakness profiles cover the {profile_count} leading vendors."). Data: two
+contextual phrase replacements, identical "leading vendors" wording in both:
 - description: "...and vendor-by-vendor strengths and weaknesses." -> "...and
   strength and weakness profiles for the leading vendors."
 - prose: "...where each product holds strength or shows weakness." -> "...where
@@ -54,10 +59,13 @@ phrase replacements, identical "leading vendors" wording in both:
 
 ## Verification
 
-- New `test_market_landscape_exposes_capped_profile_count`: 7 profiles available
-  -> hook `profile_count == 5`. Verified it FAILS on revert (`profile_count =
-  len(vendor_profiles)` -> `7 == 5`).
-- `pytest` generation + quote-gate suites -> 195 passed; both copies
+- `test_market_landscape_exposes_capped_profile_count`: 7 (all populated) ->
+  `profile_count == 5` (the cap).
+- `test_profile_count_counts_only_rendered_sections` (Codex P2): one empty
+  profile in the top 5 -> `profile_count == 4` and "4 leading vendors" in the
+  data_summary. Verified it FAILS on revert to the bare `min(len(...), 5)`
+  (`5 == 4`).
+- `pytest` generation + quote-gate suites -> 196 passed; both copies
   byte-identical.
 - Data: over-claim grep -> 0 ("vendor-by-vendor strengths"/"each product holds"
   gone); "vendor-by-vendor churn risk scores" (chart) left intact; audit clean.

--- a/plans/PR-Blog-D8b-Profile-Coverage.md
+++ b/plans/PR-Blog-D8b-Profile-Coverage.md
@@ -74,8 +74,8 @@ contextual phrase replacements, identical "leading vendors" wording in both:
 
 | Area | LOC |
 |---|---:|
-| 2 generator copies (profile_count + key_stat) | ~18 |
-| Test | ~30 |
+| 2 generator copies (profile_count predicate + key_stat + data_summary) | ~32 |
+| Tests (capped + render-predicate) | ~55 |
 | crm-landscape data (2 phrase softenings) | ~4 |
-| Plan doc | ~85 |
-| **Total** | **~135** |
+| Plan doc | ~90 |
+| **Total** | **~180** |

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -1563,6 +1563,34 @@ def test_market_landscape_headline_vendor_count_reflects_rendered_chart():
     assert "8 major vendors" not in hook.data_summary
 
 
+def test_market_landscape_exposes_capped_profile_count():
+    """D8b: the landscape profiles at most the leading vendors
+    (vendor_profiles[:5]), not every charted vendor, so the hook must surface
+    profile_count = min(len(vendor_profiles), 5). This lets the description say
+    "profiles for the leading vendors" honestly. With 7 profiles available,
+    profile_count is 5 (the cap). Reverting (drop the key, or use the uncapped
+    len) fails this."""
+    data = {
+        "data_context": {"category": "CRM"},
+        "quotes": [],
+        "vendor_signals": [],
+        "vendor_profiles": [
+            {"vendor": f"V{i}", "profile": {"strengths": ["s"], "weaknesses": ["w"]}}
+            for i in range(7)
+        ],
+    }
+    ctx = {
+        "slug": "crm-landscape-2026",
+        "category": "CRM",
+        "vendor_count": 7,
+        "total_reviews": 1000,
+        "avg_urgency": 5.0,
+    }
+    blueprint = _blueprint_market_landscape(ctx, data)
+    hook = next(s for s in blueprint.sections if s.id == "hook")
+    assert hook.key_stats["profile_count"] == 5   # capped, not the 7 available
+
+
 def test_pain_point_roundup_blueprint_routes_quotes_through_contract_gate():
     row = _v4_row(
         text="Salesforce reporting takes forever to load and constantly times out",

--- a/tests/test_b2b_blog_post_generation_quote_gate.py
+++ b/tests/test_b2b_blog_post_generation_quote_gate.py
@@ -1565,11 +1565,11 @@ def test_market_landscape_headline_vendor_count_reflects_rendered_chart():
 
 def test_market_landscape_exposes_capped_profile_count():
     """D8b: the landscape profiles at most the leading vendors
-    (vendor_profiles[:5]), not every charted vendor, so the hook must surface
-    profile_count = min(len(vendor_profiles), 5). This lets the description say
-    "profiles for the leading vendors" honestly. With 7 profiles available,
+    (vendor_profiles[:5]), not every charted vendor, so the hook surfaces a
+    profile_count capped at 5. With 7 profiles available (all populated),
     profile_count is 5 (the cap). Reverting (drop the key, or use the uncapped
-    len) fails this."""
+    len) fails this. (The empty-profile predicate is pinned separately by
+    test_profile_count_counts_only_rendered_sections.)"""
     data = {
         "data_context": {"category": "CRM"},
         "quotes": [],
@@ -1589,6 +1589,37 @@ def test_market_landscape_exposes_capped_profile_count():
     blueprint = _blueprint_market_landscape(ctx, data)
     hook = next(s for s in blueprint.sections if s.id == "hook")
     assert hook.key_stats["profile_count"] == 5   # capped, not the 7 available
+
+
+def test_profile_count_counts_only_rendered_sections():
+    """D8b / Codex P2 on #780: profile_count must count vendors that ACTUALLY
+    emit a profile section (strengths OR weaknesses non-empty, the render-loop
+    predicate), not bare len(vendor_profiles[:5]) -- otherwise an empty profile
+    in the top 5 overstates coverage. Here B has an empty profile, so 5 entries
+    -> 4 rendered. The count is also wired deterministically into data_summary."""
+    data = {
+        "data_context": {"category": "CRM"},
+        "quotes": [],
+        "vendor_signals": [],
+        "vendor_profiles": [
+            {"vendor": "A", "profile": {"strengths": ["s"], "weaknesses": ["w"]}},
+            {"vendor": "B", "profile": {"strengths": [], "weaknesses": []}},  # emits no section
+            {"vendor": "C", "profile": {"strengths": ["s"]}},
+            {"vendor": "D", "profile": {"weaknesses": ["w"]}},
+            {"vendor": "E", "profile": {"strengths": ["s"], "weaknesses": ["w"]}},
+        ],
+    }
+    ctx = {
+        "slug": "crm-landscape-2026",
+        "category": "CRM",
+        "vendor_count": 5,
+        "total_reviews": 500,
+        "avg_urgency": 5.0,
+    }
+    blueprint = _blueprint_market_landscape(ctx, data)
+    hook = next(s for s in blueprint.sections if s.id == "hook")
+    assert hook.key_stats["profile_count"] == 4   # B's empty profile is not counted
+    assert "4 leading vendors" in hook.data_summary   # deterministically used, not just surfaced
 
 
 def test_pain_point_roundup_blueprint_routes_quotes_through_contract_gate():


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d8b-profile-coverage`

**D8b** (coverage complement of **D8** #775): `crm-landscape` charts 7 vendors but renders strength/weakness profiles for only 5 (`vendor_profiles[:5]` cap), while the description claimed "vendor-by-vendor strengths and weaknesses" and the prose said "each product holds strength or shows weakness" — implying all are profiled. Charted-but-unprofiled: Zoho CRM, Pipedrive.

## Intentional

- **Generator** (`_blueprint_market_landscape`, both byte-identical copies): surface `profile_count = min(len(vendor_profiles), 5)` in the hook key_stats, so the description can be framed around the count actually rendered.
- **Data** (`crm-landscape-2026-04.ts`): soften the two over-claims to "the leading vendors" (identical wording in both). **Left** the body's "vendor-by-vendor **churn risk scores**" — that's the urgency chart (7 vendors), which is accurate, not a profile claim.
- **Chose honesty-of-claim over raising the `[:5]` cap.** The catalog's other option ("ensure all N charted+profiled") would mean authoring strength/weakness profile *prose* for Zoho CRM + Pipedrive in the already-published post — inventing content for vendors that weren't profiled, which the repo's "never invent content" rule forbids. The cap is a deliberate length choice; the defect is the claim.

## Deferred

- **D2/D3/D4** (pipedrive cluster).

## Verification

- New `test_market_landscape_exposes_capped_profile_count`: 7 profiles available → hook `profile_count == 5`. **Verified it fails on revert** (`profile_count = len(vendor_profiles)` → `7 == 5`).
- generation + quote-gate suites → **195 passed**; both copies byte-identical.
- Data: over-claim grep → 0; "vendor-by-vendor churn risk scores" (chart) intact; audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)