### PR TITLE
PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -685,13 +685,19 @@ def _weighted_frequency(rows: Sequence[Mapping[str, Any]]) -> int:
     return sum(weights.values())
 
 
-def _source_weight(*rows: Mapping[str, Any]) -> int:
+def source_row_weight(*rows: Mapping[str, Any]) -> int:
+    """Return the represented source volume for normalized source rows."""
+
     for row in rows:
         for key in _SOURCE_WEIGHT_KEYS:
             weight = _integer_or_none(_field_value(row, key))
             if weight is not None and weight > 0:
                 return weight
     return 1
+
+
+def _source_weight(*rows: Mapping[str, Any]) -> int:
+    return source_row_weight(*rows)
 
 
 def _term_mappings(

--- a/plans/PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics.md
+++ b/plans/PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Source-Mix-Diagnostics shows which source channels the FAQ
+CLI recognized, but it still reports only row counts. Search exports and other
+aggregated customer-language inputs can represent hundreds or thousands of
+queries through fields such as `search_count`, `query_count`, or
+`source_weight`.
+
+This slice adds weighted input-volume diagnostics so proof runs can show both
+physical row count and represented customer-demand volume without changing FAQ
+generation behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Expose the generator's source-weight resolution as a public helper for CLI
+   diagnostics.
+2. Add total weighted input volume to the FAQ CLI source-mix diagnostics.
+3. Add weighted input volume by source type and source channel.
+4. Add focused CLI regression coverage for weighted mixed-source result
+   diagnostics.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics.md` | Plan doc for this diagnostics slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Exposes the canonical source-weight helper. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds weighted input-volume values to source-mix diagnostics. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers weighted input-volume diagnostics. |
+
+## Mechanism
+
+The FAQ generator already resolves row weight from canonical fields such as
+`source_weight`, `search_count`, `query_count`, `request_count`, `occurrences`,
+`volume`, and `frequency`. This PR exposes that helper and has the CLI call it
+for each normalized opportunity plus its evidence rows.
+
+Source-mix diagnostics remain compact and additive. They keep the existing counts and add
+sorted weighted totals: one overall value, one by source type, and one by source
+channel. Repeated source ids use the maximum seen weight for that source key,
+matching the generator's "one represented source, largest aggregate count"
+approach.
+
+## Intentional
+
+- CLI result JSON only. Markdown and generated FAQ items are unchanged.
+- No new accepted input fields. The diagnostics use the generator's existing
+  source-weight contract.
+- No per-topic volume breakdown in this slice; this is input-level visibility.
+
+## Deferred
+
+- Hosted UI display for weighted source-mix diagnostics.
+- Per-topic source-channel and weighted-volume breakdowns.
+- Scale-run summary tables that combine output checks, source mix, and item
+  score distribution.
+
+## Verification
+
+- Focused source-mix/weighted FAQ CLI pytest - passed, 1 test.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  130 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Generator helper exposure | ~10 |
+| CLI diagnostics | ~60 |
+| Tests | ~25 |
+| **Total** | ~180 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -48,6 +48,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     DEFAULT_TITLE,
     build_ticket_faq_markdown,
     is_zero_result_search_row,
+    source_row_weight,
 )
 
 _SOURCE_CHANNELS = {
@@ -332,17 +333,35 @@ def _result_payload(
 def _source_mix_diagnostics(opportunities: list[dict[str, Any]]) -> dict[str, Any]:
     source_type_counts: dict[str, int] = {}
     source_channel_counts: dict[str, int] = {}
+    source_weights: dict[str, int] = {}
+    source_type_weights: dict[tuple[str, str], int] = {}
+    source_channel_weights: dict[tuple[str, str], int] = {}
     zero_result_search_sources: set[str] = set()
     for index, opportunity in enumerate(opportunities, start=1):
         source_type = _diagnostic_source_type(opportunity)
         source_type_counts[source_type] = source_type_counts.get(source_type, 0) + 1
         channel = _SOURCE_CHANNELS.get(source_type, "other")
         source_channel_counts[channel] = source_channel_counts.get(channel, 0) + 1
+        source_key = _diagnostic_source_key(opportunity, index)
+        weight = _diagnostic_source_weight(opportunity)
+        source_weights[source_key] = max(source_weights.get(source_key, 0), weight)
+        type_key = (source_type, source_key)
+        channel_key = (channel, source_key)
+        source_type_weights[type_key] = max(source_type_weights.get(type_key, 0), weight)
+        source_channel_weights[channel_key] = max(
+            source_channel_weights.get(channel_key, 0),
+            weight,
+        )
         if _is_zero_result_search_source(opportunity):
-            zero_result_search_sources.add(_diagnostic_source_key(opportunity, index))
+            zero_result_search_sources.add(source_key)
     return {
         "source_type_counts": dict(sorted(source_type_counts.items())),
         "source_channel_counts": dict(sorted(source_channel_counts.items())),
+        "weighted_source_volume": sum(source_weights.values()),
+        "weighted_source_volume_by_type": _weighted_counts_by_group(source_type_weights),
+        "weighted_source_volume_by_channel": _weighted_counts_by_group(
+            source_channel_weights
+        ),
         "zero_result_search_source_count": len(zero_result_search_sources),
     }
 
@@ -375,6 +394,17 @@ def _diagnostic_evidence_rows(opportunity: dict[str, Any]) -> tuple[dict[str, An
     if isinstance(evidence, list):
         return tuple(row for row in evidence if isinstance(row, dict))
     return ()
+
+
+def _diagnostic_source_weight(opportunity: dict[str, Any]) -> int:
+    return source_row_weight(opportunity, *_diagnostic_evidence_rows(opportunity))
+
+
+def _weighted_counts_by_group(weights: dict[tuple[str, str], int]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for (group, _source_key), weight in weights.items():
+        counts[group] = counts.get(group, 0) + weight
+    return dict(sorted(counts.items()))
 
 
 def _is_zero_result_search_source(

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2247,6 +2247,9 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
     assert result["diagnostics"]["source_mix"] == {
         "source_channel_counts": {"support_tickets": 4},
         "source_type_counts": {"support_ticket": 4},
+        "weighted_source_volume": 4,
+        "weighted_source_volume_by_channel": {"support_tickets": 4},
+        "weighted_source_volume_by_type": {"support_ticket": 4},
         "zero_result_search_source_count": 0,
     }
     assert result["diagnostics"]["ticket_counts"] == [2, 2]
@@ -2323,6 +2326,11 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
                 "search_count": "25",
             },
             {
+                "query_id": "search-1",
+                "search_query": "export report",
+                "search_count": "10",
+            },
+            {
                 "chat_id": "chat-1",
                 "message": "How do I change my login email?",
             },
@@ -2342,18 +2350,31 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
 
     assert completed.returncode == 0
     result = json.loads(result_output.read_text(encoding="utf-8"))
-    assert result["source_count"] == 4
+    assert result["source_count"] == 5
     assert result["diagnostics"]["source_mix"] == {
         "source_channel_counts": {
             "chats": 1,
             "sales_inputs": 1,
-            "search_logs": 1,
+            "search_logs": 2,
             "support_tickets": 1,
         },
         "source_type_counts": {
             "chat": 1,
             "sales_objection": 1,
-            "search_log": 1,
+            "search_log": 2,
+            "support_ticket": 1,
+        },
+        "weighted_source_volume": 28,
+        "weighted_source_volume_by_channel": {
+            "chats": 1,
+            "sales_inputs": 1,
+            "search_logs": 25,
+            "support_tickets": 1,
+        },
+        "weighted_source_volume_by_type": {
+            "chat": 1,
+            "sales_objection": 1,
+            "search_log": 25,
             "support_ticket": 1,
         },
         "zero_result_search_source_count": 1,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Weighted-Input-Volume-Diagnostics.md

The FAQ CLI source-mix diagnostics now show represented input volume, not just physical row counts, so proof runs can demonstrate aggregate search/query volume such as 500 or 1000 represented requests.

## Intentional
- CLI result JSON only; Markdown and generated FAQ items are unchanged.
- No new accepted input fields; diagnostics reuse the generator source-weight contract.
- No per-topic volume breakdown in this slice; this is input-level visibility.

## Deferred
- Hosted UI display for weighted source-mix diagnostics.
- Per-topic source-channel and weighted-volume breakdowns.
- Scale-run summary tables that combine output checks, source mix, and item score distribution.

## Verification
- Focused source-mix/weighted FAQ CLI pytest - passed, 1 test.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 130 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed, including drift and caller-hint checks.

## Diff size
4 files, +144 / -5