### PR TITLE
Add landing page saved draft repair service

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -187,7 +187,7 @@ def _landing_page_user_prompt(
         blockers = "\n".join(f"- {str(item)}" for item in quality_blockers)
         prompt = (
             f"{prompt}\n\n"
-            "The previous landing-page JSON parsed, but it failed the "
+            "The current or previous landing-page JSON parsed, but it failed the "
             "deterministic quality gate. Fix these issues and return one "
             "corrected JSON object only:\n"
             f"{blockers}"
@@ -415,6 +415,231 @@ class LandingPageGenerationService:
             quality_repair_history=tuple(quality_repair_history),
         )
 
+    async def repair_draft(
+        self,
+        *,
+        scope: TenantScope,
+        draft: LandingPageDraft,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        parse_retry_attempts: int | None = None,
+        parse_retry_response_excerpt_chars: int | None = None,
+        quality_gates_enabled: bool | None = None,
+        quality_repair_attempts: int | None = None,
+    ) -> LandingPageGenerationResult:
+        """Repair an existing saved landing-page draft and update the same row."""
+
+        if not str(draft.id or "").strip():
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({"reason": "missing_landing_page_id"},),
+            )
+        if str(draft.status or "").strip() == "approved":
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({
+                    "landing_page_id": draft.id,
+                    "reason": "approved_draft_not_repairable",
+                },),
+            )
+
+        campaign = MarketingCampaign(
+            name=draft.campaign_name,
+            persona=draft.persona,
+            value_prop=draft.value_prop,
+            context=_repair_context(draft, repair_issues=()),
+        )
+        parsed_existing = _draft_to_parsed(draft)
+        resolved_quality_gates_enabled = (
+            self._config.quality_gates_enabled
+            if quality_gates_enabled is None
+            else bool(quality_gates_enabled)
+        )
+        initial_quality = self._quality_check(
+            parsed_existing,
+            campaign=campaign,
+            campaign_payload=campaign.as_dict(),
+            quality_gates_enabled=resolved_quality_gates_enabled,
+        )
+        quality_repair_history: list[dict[str, Any]] = [
+            _quality_repair_history_row(0, initial_quality)
+        ]
+        if initial_quality["passed"]:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=0,
+                saved_ids=(draft.id,),
+                quality_repair_history=tuple(quality_repair_history),
+            )
+
+        resolved_quality_repair_attempts = (
+            self._config.quality_repair_attempts
+            if quality_repair_attempts is None
+            else quality_repair_attempts
+        )
+        repair_limit = normalize_landing_page_quality_repair_attempts(
+            resolved_quality_repair_attempts
+        )
+        if not resolved_quality_gates_enabled:
+            repair_limit = 0
+        if repair_limit <= 0:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({
+                    "landing_page_id": draft.id,
+                    "reason": "quality_blocked",
+                    "blockers": tuple(str(item) for item in initial_quality["blockers"]),
+                    "quality_repair_attempts": repair_limit,
+                    "quality_repair_history": tuple(quality_repair_history),
+                },),
+                quality_repair_history=tuple(quality_repair_history),
+            )
+
+        prompt_template = self._skills.get_prompt(self._config.skill_name)
+        if not prompt_template:
+            raise ValueError(
+                f"Landing-page generation skill not found: {self._config.skill_name}"
+            )
+        resolved_temperature = (
+            self._config.temperature if temperature is None else float(temperature)
+        )
+        resolved_max_tokens = (
+            self._config.max_tokens if max_tokens is None else int(max_tokens)
+        )
+        resolved_parse_retry_attempts = (
+            self._config.parse_retry_attempts
+            if parse_retry_attempts is None
+            else int(parse_retry_attempts)
+        )
+        resolved_parse_retry_response_excerpt_chars = (
+            self._config.parse_retry_response_excerpt_chars
+            if parse_retry_response_excerpt_chars is None
+            else int(parse_retry_response_excerpt_chars)
+        )
+
+        quality = initial_quality
+        quality_blockers = tuple(str(item) for item in quality["repair_issues"])
+        total_usage: dict[str, Any] = {}
+        total_parse_attempts = 0
+        parsed: dict[str, Any] | None = None
+        campaign_payload: dict[str, Any] = campaign.as_dict()
+        for repair_attempt_no in range(1, repair_limit + 1):
+            campaign_payload = {
+                **campaign_payload,
+                "context": _repair_context(draft, repair_issues=quality_blockers),
+            }
+            try:
+                parsed = await self._generate_one(
+                    prompt_template,
+                    campaign_payload=campaign_payload,
+                    temperature=resolved_temperature,
+                    max_tokens=resolved_max_tokens,
+                    parse_retry_attempts=resolved_parse_retry_attempts,
+                    parse_retry_response_excerpt_chars=resolved_parse_retry_response_excerpt_chars,
+                    quality_blockers=quality_blockers,
+                    quality_repair_attempt_no=repair_attempt_no,
+                )
+            except Exception as exc:
+                return LandingPageGenerationResult(
+                    requested=1,
+                    generated=0,
+                    skipped=1,
+                    errors=({
+                        "landing_page_id": draft.id,
+                        "reason": str(exc),
+                    },),
+                    quality_repair_history=tuple(quality_repair_history),
+                )
+            if not parsed:
+                return LandingPageGenerationResult(
+                    requested=1,
+                    generated=0,
+                    skipped=1,
+                    errors=({
+                        "landing_page_id": draft.id,
+                        "reason": "unparseable_response",
+                        "quality_blockers": quality_blockers,
+                        "quality_repair_history": tuple(quality_repair_history),
+                    },),
+                    quality_repair_history=tuple(quality_repair_history),
+                )
+            total_usage = accumulate_usage(total_usage, parsed.get("_usage"))
+            total_parse_attempts += int(parsed.get("_parse_attempts") or 0)
+            parsed = {
+                **parsed,
+                "_usage": total_usage,
+                "_parse_attempts": total_parse_attempts,
+                "_quality_repair_attempts": repair_attempt_no,
+            }
+            quality = self._quality_check(
+                parsed,
+                campaign=campaign,
+                campaign_payload=campaign_payload,
+                quality_gates_enabled=resolved_quality_gates_enabled,
+            )
+            quality_repair_history.append(
+                _quality_repair_history_row(repair_attempt_no, quality)
+            )
+            parsed = {
+                **parsed,
+                "_quality_repair_history": tuple(quality_repair_history),
+            }
+            if quality["passed"]:
+                break
+            quality_blockers = tuple(str(item) for item in quality["repair_issues"])
+
+        if parsed is None or not quality["passed"]:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({
+                    "landing_page_id": draft.id,
+                    "reason": "quality_blocked",
+                    "blockers": tuple(str(item) for item in quality["blockers"]),
+                    "quality_repair_attempts": repair_limit,
+                    "quality_repair_history": tuple(quality_repair_history),
+                },),
+                quality_repair_history=tuple(quality_repair_history),
+            )
+
+        repaired = self._build_draft(
+            parsed,
+            campaign=campaign,
+            campaign_payload=campaign_payload,
+        )
+        repaired = _trusted_repaired_draft(repaired, source=draft)
+        updated = await self._landing_pages.update_draft(
+            draft.id,
+            repaired,
+            scope=scope,
+        )
+        if updated is None:
+            return LandingPageGenerationResult(
+                requested=1,
+                generated=0,
+                skipped=1,
+                errors=({
+                    "landing_page_id": draft.id,
+                    "reason": "repair_update_missed",
+                },),
+                quality_repair_history=tuple(quality_repair_history),
+            )
+        return LandingPageGenerationResult(
+            requested=1,
+            generated=1,
+            skipped=0,
+            saved_ids=(draft.id,),
+            quality_repair_history=tuple(quality_repair_history),
+        )
+
     async def _campaign_with_reasoning_context(
         self,
         *,
@@ -623,6 +848,57 @@ def _quality_repair_history_row(
             str(item) for item in quality.get("repair_issues") or ()
         ),
     }
+
+
+def _draft_to_parsed(draft: LandingPageDraft) -> dict[str, Any]:
+    return {
+        "title": draft.title,
+        "slug": draft.slug,
+        "hero": dict(draft.hero or {}),
+        "sections": [section.as_dict() for section in draft.sections],
+        "cta": dict(draft.cta or {}),
+        "meta": dict(draft.meta or {}),
+        "reference_ids": list(draft.reference_ids),
+    }
+
+
+def _repair_context(
+    draft: LandingPageDraft,
+    *,
+    repair_issues: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "repair_mode": "saved_draft",
+        "repair_issues": [str(item) for item in repair_issues],
+        "current_draft": _draft_to_parsed(draft),
+    }
+
+
+def _trusted_repaired_draft(
+    repaired: LandingPageDraft,
+    *,
+    source: LandingPageDraft,
+) -> LandingPageDraft:
+    metadata = {
+        **dict(source.metadata or {}),
+        **dict(repaired.metadata or {}),
+        "saved_draft_repair_source_id": source.id,
+    }
+    return LandingPageDraft(
+        id=source.id,
+        status="draft",
+        campaign_name=source.campaign_name,
+        persona=source.persona,
+        value_prop=source.value_prop,
+        title=repaired.title,
+        slug=repaired.slug,
+        hero=dict(repaired.hero or {}),
+        sections=tuple(repaired.sections),
+        cta=dict(repaired.cta or {}),
+        meta=dict(repaired.meta or {}),
+        reference_ids=tuple(repaired.reference_ids),
+        metadata=metadata,
+    )
 
 
 __all__ = [

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -216,11 +216,12 @@ class LandingPageRepository(Protocol):
         *,
         scope: TenantScope,
     ) -> LandingPageDraft | None:
-        """Update editable draft fields and return the updated row.
+        """Update trusted draft fields and return the updated row.
 
         Implementations must keep the update tenant-scoped and must not mutate
         approved rows. Editing an approved public landing page would bypass the
-        review flow.
+        review flow. Callers that accept user input must construct metadata
+        from trusted state, not request payloads.
         """
 
     async def get_public_approved_draft(

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -275,6 +275,7 @@ class PostgresLandingPageRepository:
                    cta = $7::jsonb,
                    meta = $8::jsonb,
                    reference_ids = $9::jsonb,
+                   metadata = $10::jsonb,
                    status = 'draft',
                    updated_at = NOW()
              WHERE id = $1
@@ -292,6 +293,7 @@ class PostgresLandingPageRepository:
             json_dump_jsonb(dict(draft.cta or {})),
             json_dump_jsonb(dict(draft.meta or {})),
             json_dump_jsonb(reference_ids_payload),
+            json_dump_jsonb(dict(draft.metadata or {})),
         )
         if not rows:
             return None

--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -69,6 +69,13 @@ SEO/GEO/AEO input policy:
 - `internal_links`: include only supplied links and only when they fit the page. Do not create fake URLs.
 - `cta_label` and `cta_url`: use these for `hero.cta_label`, `hero.cta_url`, and the page-level `cta` unless the campaign gives a stronger CTA pattern.
 
+Saved-draft repair policy:
+- If `campaign.context.current_draft` is present, repair that existing landing page instead of starting from a blank page.
+- Use `campaign.context.repair_issues` as the exact list of quality/readiness problems to fix.
+- Preserve the current draft's campaign, audience, CTA intent, useful section structure, and honest claims unless a repair issue requires changing them.
+- Return the full corrected landing-page JSON object, not a patch or commentary.
+- Do not invent new proof, reference IDs, customer names, competitors, or URLs while repairing.
+
 Readiness rules:
 - The first viewport must make it clear what the offer is, who it is for, and why that reader should care.
 - Include a clear problem section and a clear solution or how-it-works section tied to `campaign.value_prop`.

--- a/plans/PR-Landing-Page-Saved-Draft-Repair-Service.md
+++ b/plans/PR-Landing-Page-Saved-Draft-Repair-Service.md
@@ -1,0 +1,94 @@
+# PR-Landing-Page-Saved-Draft-Repair-Service
+
+## Why this slice exists
+
+Landing pages now have save-time readiness gates, review UI readiness panels,
+and a manual edit path. The remaining operator gap is repairing a saved draft
+that is already in the review queue without starting a brand-new run.
+
+This slice adds the service-level repair primitive first. It reuses the
+existing landing-page generator, readiness checks, and quality repair prompt
+loop, and updates the same saved draft row when the repair passes. The API
+button is intentionally deferred until the service contract is pinned.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-saved-draft-repair-service
+
+1. Add prompt guidance for saved-draft repair mode.
+2. Add `LandingPageGenerationService.repair_draft(...)` for existing saved
+   landing-page drafts.
+3. Persist repaired content back to the same tenant-scoped draft row.
+4. Persist trusted repair metadata/history through the repository update path.
+5. Add focused service and repository tests.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Saved-Draft-Repair-Service.md` | Plan doc for this service slice. |
+| `extracted_content_pipeline/skills/digest/landing_page_generation.md` | Add saved-draft repair prompt guidance. |
+| `extracted_content_pipeline/landing_page_ports.py` | Clarify that update callers must pass trusted metadata. |
+| `extracted_content_pipeline/landing_page_generation.py` | Add saved-draft repair orchestration. |
+| `extracted_content_pipeline/landing_page_postgres.py` | Persist trusted metadata on draft updates. |
+| `tests/test_extracted_landing_page_generation.py` | Add service repair tests. |
+| `tests/test_extracted_landing_page_postgres.py` | Update repository update test for metadata persistence. |
+| `tests/test_extracted_content_asset_api.py` | Keep edit API mass-assignment test aligned with trusted metadata persistence. |
+
+## Mechanism
+
+`repair_draft(...)` accepts a `LandingPageDraft`, evaluates its existing
+readiness/quality state, and, when it fails, sends the current draft plus stable
+repair issues through the existing landing-page generation prompt. The LLM must
+return a full landing-page JSON object. The service then runs the same quality
+and readiness checks used by generation. Passing repairs update the same row
+through `LandingPageRepository.update_draft(...)`.
+
+The repository update path now writes metadata from the trusted draft object.
+The review edit API remains protected because it constructs the draft metadata
+from the existing row and ignores user-supplied `metadata`.
+
+## Intentional
+
+- No generated-assets API route in this slice. The repair button should call a
+  pinned service contract, not define service behavior inside the router.
+- Approved landing pages are not repaired by this service.
+- Repair updates the same draft id instead of creating a sibling draft.
+- The LLM receives the current draft as context, but quality/readiness checks
+  still decide whether the repair can persist.
+
+## Deferred
+
+- `PR-Landing-Page-Saved-Draft-Repair-API` should expose the service through an
+  authenticated generated-assets route.
+- `PR-Landing-Page-Saved-Draft-Repair-UI` should add the review-drawer button
+  after the API route lands.
+- `PR-Landing-Page-Edit-Audit-Trail` can add richer user/editor audit metadata.
+
+## Verification
+
+- Python compile for `extracted_content_pipeline/landing_page_generation.py`,
+  `extracted_content_pipeline/landing_page_postgres.py`, and
+  `extracted_content_pipeline/landing_page_ports.py` -> passed.
+- Focused pytest for `tests/test_extracted_landing_page_generation.py`,
+  `tests/test_extracted_landing_page_postgres.py`, and
+  `tests/test_extracted_content_asset_api.py` -> 93 passed.
+- `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` for
+  `extracted_content_pipeline` -> passed.
+- `scripts/audit_extracted_standalone.py` for `extracted_content_pipeline` ->
+  passed with 0 findings.
+- `scripts/check_ascii_python.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| Prompt | ~15 |
+| Service/repository | ~190 |
+| Tests | ~180 |
+| Total | ~475 |
+
+This exceeds the 400 LOC target because the service method, trusted metadata
+persistence, and tests need to land together for a usable repair primitive.

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -91,6 +91,7 @@ class _EditableLandingPagePool(_Pool):
             "cta": json.loads(args[6]),
             "meta": json.loads(args[7]),
             "reference_ids": json.loads(args[8]),
+            "metadata": json.loads(args[9]),
             "status": "draft",
         })
         return [self.row]
@@ -553,7 +554,10 @@ def test_generated_asset_router_ignores_status_and_metadata_mass_assignment() ->
     assert body["status"] == "draft"
     assert body["metadata"]["scope"] == {"account_id": "acct_1", "user_id": "user_1"}
     update_query, update_args = pool.fetch_calls[1]
-    assert "metadata =" not in update_query
+    assert "metadata = $10::jsonb" in update_query
+    persisted_metadata = json.loads(update_args[9])
+    assert persisted_metadata["scope"] == {"account_id": "acct_1", "user_id": "user_1"}
+    assert "acct_2" not in json.dumps(persisted_metadata)
     assert "approved" not in update_args
 
 

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -16,6 +16,7 @@ from extracted_content_pipeline.landing_page_generation import (
 )
 from extracted_content_pipeline.landing_page_ports import (
     LandingPageDraft,
+    LandingPageSection,
     MarketingCampaign,
 )
 
@@ -28,10 +29,19 @@ from extracted_content_pipeline.landing_page_ports import (
 class _LandingPages:
     def __init__(self):
         self.saved = []
+        self.updated = []
 
     async def save_drafts(self, drafts, *, scope):
         self.saved.append({"drafts": list(drafts), "scope": scope})
         return [f"lp-{index + 1}" for index, _ in enumerate(drafts)]
+
+    async def update_draft(self, landing_page_id, draft, *, scope):
+        self.updated.append({
+            "id": landing_page_id,
+            "draft": draft,
+            "scope": scope,
+        })
+        return draft
 
     async def list_drafts(self, *, scope, status=None, campaign_name=None, slug=None, limit=None):  # pragma: no cover
         raise AssertionError("not used")
@@ -176,6 +186,40 @@ def _valid_response(*, slug="acme-q3-launch") -> str:
         },
         "reference_ids": ["customer-logo-1"],
     })
+
+
+def _draft_from_response(
+    response: str | dict[str, object],
+    *,
+    landing_page_id: str = "11111111-1111-1111-1111-111111111111",
+    status: str = "quality_blocked",
+    metadata: dict[str, object] | None = None,
+) -> LandingPageDraft:
+    payload = json.loads(response) if isinstance(response, str) else dict(response)
+    return LandingPageDraft(
+        id=landing_page_id,
+        status=status,
+        campaign_name="acme-q3-launch",
+        persona="VP Engineering at mid-market SaaS",
+        value_prop="Cut renewal pricing leakage by 40%",
+        title=str(payload["title"]),
+        slug=str(payload["slug"]),
+        hero=dict(payload.get("hero") or {}),
+        sections=tuple(
+            LandingPageSection(
+                id=str(section.get("id") or ""),
+                title=str(section.get("title") or ""),
+                body_markdown=str(section.get("body_markdown") or ""),
+                metadata=dict(section.get("metadata") or {}),
+            )
+            for section in payload.get("sections") or ()
+            if isinstance(section, dict)
+        ),
+        cta=dict(payload.get("cta") or {}),
+        meta=dict(payload.get("meta") or {}),
+        reference_ids=tuple(str(item) for item in payload.get("reference_ids") or ()),
+        metadata=dict(metadata or {}),
+    )
 
 
 def _service(*, responses=None, prompts=None, reasoning_context=None, config=None):
@@ -606,6 +650,136 @@ async def test_generate_repairs_shared_readiness_blocker_once_and_persists() -> 
     assert result.quality_repair_history[0]["blockers"] == (
         "seo_aeo_readiness:meta_description",
     )
+
+
+@pytest.mark.asyncio
+async def test_repair_draft_sends_current_draft_and_repair_issues_and_updates_same_row() -> None:
+    needs_repair = json.loads(_valid_response())
+    needs_repair["meta"].pop("description")
+    draft = _draft_from_response(
+        needs_repair,
+        metadata={"source": "review_drawer"},
+    )
+    service, landing_pages, llm, _skills, _rp = _service(
+        responses=[
+            {
+                "content": _valid_response(),
+                "model": "repair-model",
+                "usage": {"input_tokens": 9, "output_tokens": 4},
+            },
+        ],
+    )
+
+    result = await service.repair_draft(
+        scope=TenantScope(account_id="acct-1"),
+        draft=draft,
+    )
+
+    assert result.requested == 1
+    assert result.generated == 1
+    assert result.skipped == 0
+    assert result.saved_ids == (draft.id,)
+    assert landing_pages.saved == []
+    assert len(landing_pages.updated) == 1
+    assert landing_pages.updated[0]["id"] == draft.id
+    repaired = landing_pages.updated[0]["draft"]
+    assert repaired.id == draft.id
+    assert repaired.status == "draft"
+    assert repaired.metadata["source"] == "review_drawer"
+    assert repaired.metadata["generation_model"] == "repair-model"
+    assert repaired.metadata["generation_usage"] == {
+        "input_tokens": 9,
+        "output_tokens": 4,
+    }
+    assert repaired.metadata["generation_parse_attempts"] == 1
+    assert repaired.metadata["generation_quality_repair_attempts"] == 1
+    assert repaired.metadata["saved_draft_repair_source_id"] == draft.id
+    assert result.quality_repair_history[0]["attempt"] == 0
+    assert result.quality_repair_history[0]["passed"] is False
+    assert result.quality_repair_history[0]["blockers"] == (
+        "seo_aeo_readiness:meta_description",
+    )
+    assert result.quality_repair_history[1] == {
+        "attempt": 1,
+        "passed": True,
+        "blockers": (),
+        "repair_issues": (),
+    }
+    system_prompt = llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert '"repair_mode":"saved_draft"' in system_prompt
+    assert '"current_draft"' in system_prompt
+    assert '"repair_issues":["seo_aeo_readiness:meta_description"]' in system_prompt
+    assert "seo_aeo_readiness:meta_description" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_repair_draft_rejects_approved_draft_without_llm_call() -> None:
+    draft = _draft_from_response(_valid_response(), status="approved")
+    service, landing_pages, llm, _skills, _rp = _service()
+
+    result = await service.repair_draft(
+        scope=TenantScope(account_id="acct-1"),
+        draft=draft,
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors == ({
+        "landing_page_id": draft.id,
+        "reason": "approved_draft_not_repairable",
+    },)
+    assert llm.calls == []
+    assert landing_pages.updated == []
+
+
+@pytest.mark.asyncio
+async def test_repair_draft_returns_quality_blocked_when_no_repair_attempts() -> None:
+    needs_repair = json.loads(_valid_response())
+    needs_repair["meta"].pop("description")
+    draft = _draft_from_response(needs_repair)
+    service, landing_pages, llm, _skills, _rp = _service(
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
+
+    result = await service.repair_draft(
+        scope=TenantScope(account_id="acct-1"),
+        draft=draft,
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert result.errors[0]["blockers"] == (
+        "seo_aeo_readiness:meta_description",
+    )
+    assert result.quality_repair_history[0]["attempt"] == 0
+    assert result.quality_repair_history[0]["passed"] is False
+    assert llm.calls == []
+    assert landing_pages.updated == []
+
+
+@pytest.mark.asyncio
+async def test_repair_draft_noops_when_existing_draft_already_passes() -> None:
+    draft = _draft_from_response(_valid_response(), status="draft")
+    service, landing_pages, llm, _skills, _rp = _service()
+
+    result = await service.repair_draft(
+        scope=TenantScope(account_id="acct-1"),
+        draft=draft,
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 0
+    assert result.saved_ids == (draft.id,)
+    assert result.quality_repair_history == ({
+        "attempt": 0,
+        "passed": True,
+        "blockers": (),
+        "repair_issues": (),
+    },)
+    assert llm.calls == []
+    assert landing_pages.updated == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -346,6 +346,7 @@ async def test_update_draft_updates_editable_fields_and_returns_row() -> None:
     args = pool.fetch_calls[0]["args"]
     assert "UPDATE landing_pages" in sql
     assert "status <> 'approved'" in sql
+    assert "metadata = $10::jsonb" in sql
     assert "RETURNING id" in sql
     assert args[0:4] == (
         "11111111-1111-1111-1111-111111111111",
@@ -358,6 +359,7 @@ async def test_update_draft_updates_editable_fields_and_returns_row() -> None:
     assert json.loads(args[6]) == {"label": "Book"}
     assert json.loads(args[7]) == {"title_tag": "Updated"}
     assert json.loads(args[8]) == ["r1"]
+    assert json.loads(args[9]) == {"key": "value"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add saved-draft repair mode to the landing-page generator prompt and service
- repair existing landing-page drafts through the same quality/readiness loop, then update the same tenant-scoped row
- persist trusted repair metadata/history through repository updates while keeping API mass-assignment protection covered

## Verification
- python3 -m py_compile extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/landing_page_postgres.py extracted_content_pipeline/landing_page_ports.py
- pytest tests/test_extracted_landing_page_generation.py tests/test_extracted_landing_page_postgres.py tests/test_extracted_content_asset_api.py -q
- bash scripts/validate_extracted_content_pipeline.sh
- python3 extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python3 scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh