### PR TITLE
Add landing page saved draft repair API

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -160,6 +160,10 @@ try:
         create_generated_asset_router,
         create_public_landing_page_router,
     )
+    from .._content_ops_infrastructure import (
+        build_content_ops_llm_client,
+        build_content_ops_skill_store,
+    )
     from .._content_ops_services import build_content_ops_execution_services
     from .._content_ops_scope import (
         build_content_ops_scope,
@@ -203,6 +207,8 @@ try:
     content_assets_router = create_generated_asset_router(
         pool_provider=get_db_pool,
         scope_provider=build_content_ops_scope,
+        llm_provider=build_content_ops_llm_client,
+        skills_provider=build_content_ops_skill_store,
         dependencies=[Depends(_capture_content_ops_auth_user)],
     )
     router.include_router(content_assets_router)

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -22,7 +22,7 @@ except ImportError as exc:  # pragma: no cover - exercised in dependency-light C
 else:
     _FASTAPI_IMPORT_ERROR = None
 
-from ..campaign_ports import TenantScope
+from ..campaign_ports import LLMClient, SkillStore, TenantScope
 from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import (
@@ -31,6 +31,7 @@ from ..landing_page_export import (
     public_landing_page_draft_row,
     public_landing_page_robots,
 )
+from ..landing_page_generation import LandingPageGenerationService
 from ..landing_page_postgres import PostgresLandingPageRepository
 from ..landing_page_ports import LandingPageDraft, LandingPageSection
 from ..report_export import export_report_drafts
@@ -42,7 +43,9 @@ from ..ticket_faq_postgres import PostgresTicketFAQRepository
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
+LLMProvider = Callable[[], LLMClient | Awaitable[LLMClient]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 
@@ -109,6 +112,19 @@ async def _resolve_scope(
     if scope is None or isinstance(scope, (TenantScope, Mapping)):
         return scope
     raise HTTPException(status_code=500, detail="Invalid tenant scope")
+
+
+async def _resolve_required_provider(
+    provider: Callable[[], Any | Awaitable[Any]] | None,
+    *,
+    detail: str,
+) -> Any:
+    if provider is None:
+        raise HTTPException(status_code=503, detail=detail)
+    value = await _maybe_await(provider())
+    if value is None:
+        raise HTTPException(status_code=503, detail=detail)
+    return value
 
 
 def _api_limit(value: int | None, config: GeneratedAssetApiConfig) -> int:
@@ -179,6 +195,8 @@ def create_generated_asset_router(
     *,
     pool_provider: PoolProvider,
     scope_provider: ScopeProvider | None = None,
+    llm_provider: LLMProvider | None = None,
+    skills_provider: SkillsProvider | None = None,
     config: GeneratedAssetApiConfig | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -371,6 +389,59 @@ def create_generated_asset_router(
                 detail="landing page draft could not be edited",
             )
         return landing_page_draft_export_row(updated)
+
+    @router.post("/{asset}/drafts/{draft_id}/repair")
+    async def repair_landing_page_draft(
+        asset: str,
+        draft_id: str,
+    ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
+        if asset_name != "landing_page":
+            raise HTTPException(
+                status_code=400,
+                detail="only landing_page drafts can be repaired",
+            )
+        try:
+            landing_page_id = str(UUID(draft_id))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Landing page draft not found") from None
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        repository = PostgresLandingPageRepository(pool)
+        existing = await repository.get_draft(landing_page_id, scope=tenant)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="Landing page draft not found")
+        if existing.status == "approved":
+            raise HTTPException(
+                status_code=409,
+                detail="approved landing pages cannot be repaired",
+            )
+        llm = await _resolve_required_provider(llm_provider, detail="LLM unavailable")
+        skills = await _resolve_required_provider(
+            skills_provider,
+            detail="Landing page generation skills unavailable",
+        )
+        result = await LandingPageGenerationService(
+            landing_pages=repository,
+            llm=llm,
+            skills=skills,
+        ).repair_draft(scope=tenant, draft=existing)
+        result_payload = result.as_dict()
+        if result.generated == 0 and result.skipped > 0:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "landing page draft could not be repaired",
+                    "repair_result": result_payload,
+                },
+            )
+        refreshed = await repository.get_draft(landing_page_id, scope=tenant)
+        if refreshed is None:
+            raise HTTPException(status_code=404, detail="Landing page draft not found")
+        row = landing_page_draft_export_row(refreshed)
+        row["repair_result"] = result_payload
+        return row
 
     return router
 

--- a/plans/PR-Landing-Page-Saved-Draft-Repair-API.md
+++ b/plans/PR-Landing-Page-Saved-Draft-Repair-API.md
@@ -1,0 +1,79 @@
+# PR-Landing-Page-Saved-Draft-Repair-API
+
+## Why this slice exists
+
+The saved-draft landing-page repair service now exists, but nothing in the
+generated asset review API can call it yet. Operators need a backend route
+that repairs the draft already in the review queue instead of starting a new
+generation run.
+
+This slice wires the service into the generated-assets router while keeping the
+UI button deferred. The route stays landing-page-only, tenant-scoped, and uses
+the same review row shape the existing drawer already consumes.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-saved-draft-repair-api
+
+1. Add optional LLM and skill providers to the generated-assets router.
+2. Add `POST /content-assets/landing_page/drafts/{id}/repair`.
+3. Fetch the tenant-scoped draft, reject approved drafts, call the repair
+   service, refetch the draft, and return the review row plus repair result.
+4. Add API tests for success, missing LLM wiring, approved draft blocking, and
+   non-landing-page rejection.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Saved-Draft-Repair-API.md` | Plan doc for this API slice. |
+| `extracted_content_pipeline/api/generated_assets.py` | Add repair providers and landing-page repair route. |
+| `atlas_brain/api/__init__.py` | Wire host LLM and skill providers into generated-assets routes. |
+| `tests/test_extracted_content_asset_api.py` | Add repair route tests and local LLM/skills fakes. |
+
+## Mechanism
+
+The repair route resolves the database pool and tenant scope exactly like the
+existing edit route. It loads the draft through `PostgresLandingPageRepository`,
+rejects missing or approved drafts, resolves host-provided LLM and skill ports,
+and calls `LandingPageGenerationService.repair_draft(...)`.
+
+Successful repairs update the same row through the service. The route refetches
+that row and returns `landing_page_draft_export_row(...)` with a
+`repair_result` object attached so the UI can update the drawer without learning
+a second response shape.
+
+## Intentional
+
+- No UI button in this slice.
+- No non-landing-page repair route.
+- No auto-repair on edit or list. Repair remains an explicit operator action.
+- No fallback LLM creation inside the router. The host must wire the LLM and
+  skill providers so production behavior is explicit.
+
+## Deferred
+
+- `PR-Landing-Page-Saved-Draft-Repair-UI` should add the review-drawer repair
+  action after this route lands.
+- A later audit slice can add richer repair metrics/events if needed.
+
+## Verification
+
+- Python compile for `extracted_content_pipeline/api/generated_assets.py` and
+  `atlas_brain/api/__init__.py` -> passed.
+- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 49 passed.
+- `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` for
+  `extracted_content_pipeline` -> passed.
+- `scripts/audit_extracted_standalone.py` for `extracted_content_pipeline` ->
+  passed with 0 findings.
+- `scripts/check_ascii_python.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| API | ~75 |
+| Tests | ~130 |
+| Total | ~275 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -15,7 +15,7 @@ from extracted_content_pipeline.api.generated_assets import (
     create_public_landing_page_router,
 )
 import extracted_content_pipeline.api.generated_assets as asset_api
-from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
 
 
 BATCH_REPORT_ID_1 = "11111111-1111-1111-1111-111111111111"
@@ -95,6 +95,36 @@ class _EditableLandingPagePool(_Pool):
             "status": "draft",
         })
         return [self.row]
+
+
+class _LLM:
+    def __init__(self, responses) -> None:
+        self.responses = list(responses)
+        self.calls = []
+
+    async def complete(self, messages, *, max_tokens, temperature, metadata=None):
+        self.calls.append({
+            "messages": list(messages),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "metadata": dict(metadata or {}),
+        })
+        response = self.responses.pop(0)
+        return LLMResponse(
+            content=response,
+            model="test-model",
+            usage={"input_tokens": 9, "output_tokens": 4},
+        )
+
+
+class _Skills:
+    def __init__(self, prompt: str = "TEMPLATE: {campaign_json}") -> None:
+        self.prompt = prompt
+        self.calls = []
+
+    def get_prompt(self, name):
+        self.calls.append(name)
+        return self.prompt
 
 
 def _report_row():
@@ -268,6 +298,18 @@ def _ready_landing_page_row():
     }
 
 
+def _landing_page_generation_response(row: dict[str, object]) -> str:
+    return json.dumps({
+        "title": row["title"],
+        "slug": row["slug"],
+        "hero": row["hero"],
+        "sections": row["sections"],
+        "cta": row["cta"],
+        "meta": row["meta"],
+        "reference_ids": row["reference_ids"],
+    })
+
+
 def _sales_brief_row():
     return {
         "id": "brief-uuid-1",
@@ -307,6 +349,8 @@ def _client(
     pool,
     *,
     scope=None,
+    llm=None,
+    skills=None,
     config: GeneratedAssetApiConfig | None = None,
     dependencies=None,
 ) -> TestClient:
@@ -318,10 +362,18 @@ def _client(
     async def scope_provider():
         return scope
 
+    async def llm_provider():
+        return llm
+
+    async def skills_provider():
+        return skills
+
     app.include_router(
         create_generated_asset_router(
             pool_provider=pool_provider,
             scope_provider=scope_provider if scope is not None else None,
+            llm_provider=llm_provider if llm is not None else None,
+            skills_provider=skills_provider if skills is not None else None,
             config=config,
             dependencies=dependencies,
         )
@@ -588,6 +640,196 @@ def test_generated_asset_router_rejects_empty_landing_page_edit_payload() -> Non
     assert "payload must include at least one editable landing page field" in (
         response.json()["detail"]
     )
+
+
+def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_row() -> None:
+    repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    needs_repair = {
+        **repaired_row,
+        "meta": {
+            key: value
+            for key, value in repaired_row["meta"].items()
+            if key != "description"
+        },
+    }
+    pool = _EditableLandingPagePool(needs_repair)
+    llm = _LLM([_landing_page_generation_response(repaired_row)])
+    skills = _Skills()
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["status"] == "draft"
+    assert body["seo_aeo_readiness"]["status"] == "ready"
+    assert body["geo_readiness"]["status"] == "ready"
+    assert body["repair_result"]["generated"] == 1
+    assert body["repair_result"]["saved_ids"] == [
+        "11111111-1111-1111-1111-111111111111"
+    ]
+    assert len(pool.fetch_calls) == 3
+    select_query, select_args = pool.fetch_calls[0]
+    assert "FROM landing_pages" in select_query
+    assert select_args == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct_1",
+    )
+    update_query, update_args = pool.fetch_calls[1]
+    assert "UPDATE landing_pages" in update_query
+    assert update_args[0:2] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct_1",
+    )
+    persisted_metadata = json.loads(update_args[9])
+    assert persisted_metadata["saved_draft_repair_source_id"] == (
+        "11111111-1111-1111-1111-111111111111"
+    )
+    assert persisted_metadata["generation_quality_repair_attempts"] == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    assert '"repair_mode":"saved_draft"' in system_prompt
+    assert '"repair_issues":["seo_aeo_readiness:meta_description"]' in system_prompt
+    assert skills.calls == ["digest/landing_page_generation"]
+
+
+def test_generated_asset_router_repair_requires_llm_provider() -> None:
+    row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    row["meta"] = {"title_tag": row["meta"]["title_tag"]}
+    pool = _EditableLandingPagePool(row)
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        skills=_Skills(),
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "LLM unavailable"
+
+
+def test_generated_asset_router_repair_requires_skills_provider() -> None:
+    row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    row["meta"] = {"title_tag": row["meta"]["title_tag"]}
+    pool = _EditableLandingPagePool(row)
+    llm = _LLM([])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Landing page generation skills unavailable"
+    assert llm.calls == []
+
+
+def test_generated_asset_router_returns_404_for_cross_tenant_landing_page_repair() -> None:
+    row = {
+        **_ready_landing_page_row(),
+        "status": "quality_blocked",
+        "account_id": "acct_1",
+    }
+    row["meta"] = {"title_tag": row["meta"]["title_tag"]}
+    pool = _EditableLandingPagePool(row)
+    llm = _LLM([])
+    skills = _Skills()
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_2"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Landing page draft not found"
+    assert len(pool.fetch_calls) == 1
+    assert llm.calls == []
+    assert skills.calls == []
+
+
+def test_generated_asset_router_returns_repair_result_when_repair_fails() -> None:
+    needs_repair = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    needs_repair["meta"] = {
+        key: value
+        for key, value in needs_repair["meta"].items()
+        if key != "description"
+    }
+    pool = _EditableLandingPagePool(needs_repair)
+    llm = _LLM([_landing_page_generation_response(needs_repair)])
+    skills = _Skills()
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["message"] == "landing page draft could not be repaired"
+    assert detail["repair_result"]["generated"] == 0
+    assert detail["repair_result"]["skipped"] == 1
+    assert detail["repair_result"]["errors"][0]["reason"] == "quality_blocked"
+    assert detail["repair_result"]["errors"][0]["blockers"] == [
+        "seo_aeo_readiness:meta_description"
+    ]
+    assert len(pool.fetch_calls) == 1
+    assert len(llm.calls) == 1
+    assert skills.calls == ["digest/landing_page_generation"]
+
+
+def test_generated_asset_router_blocks_approved_landing_page_repair() -> None:
+    pool = _EditableLandingPagePool(_ready_landing_page_row())
+    llm = _LLM([])
+
+    response = _client(
+        pool,
+        llm=llm,
+        skills=_Skills(),
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "approved landing pages cannot be repaired"
+    assert llm.calls == []
+
+
+def test_generated_asset_router_rejects_non_landing_page_repair() -> None:
+    pool = _Pool()
+
+    response = _client(pool).post(
+        "/content-assets/blog_post/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "only landing_page drafts can be repaired"
+    assert pool.fetch_calls == []
 
 
 def test_generated_asset_router_returns_public_approved_landing_page() -> None:


### PR DESCRIPTION
## Summary
- add a landing-page-only repair endpoint for saved draft review rows
- wire generated-assets routes with the host Content Ops LLM and skill providers
- return the repaired review row with the service repair result attached

## Verification
- python3 -m py_compile extracted_content_pipeline/api/generated_assets.py atlas_brain/api/__init__.py
- pytest tests/test_extracted_content_asset_api.py -q
- bash scripts/validate_extracted_content_pipeline.sh
- python3 extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python3 scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh