### PR TITLE
PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -652,6 +652,8 @@ def _item(
         "term_mappings": term_mappings,
         "source_ids": source_ids,
         "source_labels": sources,
+        "source_type_counts": _item_source_type_counts(rows),
+        "weighted_source_volume_by_type": _item_weighted_source_volume_by_type(rows),
         "evidence_count": len(display_rows),
         "displayed_evidence_count": len(display_rows),
         "ticket_count": len(source_ids),
@@ -674,6 +676,33 @@ def _opportunity_score(topic: str, rows: Sequence[Mapping[str, str]]) -> dict[st
 def _distinct_source_keys(rows: Sequence[Mapping[str, str]]) -> tuple[str, ...]:
     values = (row.get("source_key") or row.get("source_id", "") for row in rows)
     return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _item_source_type_counts(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    source_keys_by_type: dict[str, set[str]] = {}
+    for index, row in enumerate(rows, start=1):
+        source_type = _source_type_key(row.get("source_type")) or "unknown"
+        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        source_keys_by_type.setdefault(source_type, set()).add(source_key)
+    return {
+        source_type: len(source_keys)
+        for source_type, source_keys in sorted(source_keys_by_type.items())
+    }
+
+
+def _item_weighted_source_volume_by_type(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    weights: dict[tuple[str, str], int] = {}
+    for index, row in enumerate(rows, start=1):
+        source_type = _source_type_key(row.get("source_type")) or "unknown"
+        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        weight = _integer_or_none(row.get("source_weight")) or 1
+        # Breakdown is by type, so a rare multi-type source key is counted once per type.
+        key = (source_type, source_key)
+        weights[key] = max(weights.get(key, 0), max(weight, 1))
+    counts: dict[str, int] = {}
+    for (source_type, _source_key), weight in weights.items():
+        counts[source_type] = counts.get(source_type, 0) + weight
+    return dict(sorted(counts.items()))
 
 
 def _weighted_frequency(rows: Sequence[Mapping[str, Any]]) -> int:

--- a/plans/PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics.md
+++ b/plans/PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics.md
@@ -1,0 +1,79 @@
+# PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics
+
+## Why this slice exists
+
+The FAQ CLI now reports whole-upload source mix and weighted represented volume.
+Operators can see that a run included tickets, search logs, chats, sales inputs,
+and aggregate search demand, but they still cannot tell which source channels
+contributed to each generated FAQ opportunity.
+
+This slice adds compact per-item source-mix diagnostics so a ranked FAQ
+opportunity can show whether it came from tickets alone, search demand, sales
+objections, or a blend of channels.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add per-item source-type counts from the generator's grouped evidence rows.
+2. Add per-item weighted source volume by source type.
+3. Include per-item source-channel counts and weighted source-channel volume in
+   the CLI compact item summaries.
+4. Add focused CLI regression coverage for item-level mixed-source diagnostics.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics.md` | Plan doc for this item diagnostics slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds per-item source-type and weighted-volume metadata. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds per-item source-channel diagnostics to compact result JSON. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers item-level mixed-source diagnostics. |
+
+## Mechanism
+
+The generator already builds each FAQ item from grouped normalized source rows.
+This PR summarizes those rows before rendering: distinct source keys by
+source type become source-type counts, and the existing source-weight value
+on each row is summed by source type using the same max-per-source approach as
+weighted frequency.
+
+The CLI item summary keeps the raw source-type maps and derives channel maps
+from the existing source-channel classifier. The Markdown body stays unchanged.
+
+## Intentional
+
+- No generation or ranking changes. This only adds metadata to item diagnostics.
+- No new source channels. The CLI uses the same source-channel classifier as
+  whole-upload source-mix diagnostics.
+- No hosted UI display yet; this remains compact result JSON.
+
+## Deferred
+
+- Hosted UI display for item-level source-mix diagnostics.
+- Per-item zero-result source counts by channel.
+- Scale-run summary tables that combine item source mix with output checks.
+
+## Verification
+
+- Focused item/source-mix FAQ CLI pytest - passed, 2 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  130 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Local PR review against origin/main - passed after renaming the new helper to
+  avoid a same-name private-helper caller-hint warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Generator item metadata | ~55 |
+| CLI item diagnostics | ~40 |
+| Tests | ~35 |
+| **Total** | ~210 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -811,6 +811,10 @@ def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
     source_ids = item.get("source_ids") or ()
     steps = item.get("steps") or ()
     term_mappings = item.get("term_mappings") or ()
+    source_type_counts = _clean_count_mapping(item.get("source_type_counts"))
+    weighted_source_volume_by_type = _clean_count_mapping(
+        item.get("weighted_source_volume_by_type")
+    )
     return {
         "rank": index,
         "topic": item.get("topic"),
@@ -825,9 +829,36 @@ def _item_summary(index: int, item: dict[str, Any]) -> dict[str, Any]:
         "evidence_count": item.get("evidence_count"),
         "source_id_count": len(source_ids),
         "first_source_id": source_ids[0] if source_ids else None,
+        "source_type_counts": source_type_counts,
+        "source_channel_counts": _source_channel_counts_from_types(source_type_counts),
+        "weighted_source_volume_by_type": weighted_source_volume_by_type,
+        "weighted_source_volume_by_channel": _source_channel_counts_from_types(
+            weighted_source_volume_by_type
+        ),
         "step_count": len(steps),
         "term_mapping_count": len(term_mappings),
     }
+
+
+def _clean_count_mapping(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, int] = {}
+    for key, count in value.items():
+        try:
+            amount = int(count)
+        except (TypeError, ValueError):
+            continue
+        out[str(key)] = amount
+    return dict(sorted(out.items()))
+
+
+def _source_channel_counts_from_types(source_type_counts: dict[str, int]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for source_type, count in source_type_counts.items():
+        channel = _SOURCE_CHANNELS.get(source_type, "other")
+        counts[channel] = counts.get(channel, 0) + count
+    return dict(sorted(counts.items()))
 
 
 def _term_mapping_count(items: list[dict[str, Any]]) -> int:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2269,6 +2269,10 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "evidence_count": 2,
         "source_id_count": 2,
         "first_source_id": "ticket-northstar-1",
+        "source_type_counts": {"support_ticket": 2},
+        "source_channel_counts": {"support_tickets": 2},
+        "weighted_source_volume_by_type": {"support_ticket": 2},
+        "weighted_source_volume_by_channel": {"support_tickets": 2},
         "step_count": 3,
         "term_mapping_count": 0,
     }
@@ -2321,13 +2325,13 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
             },
             {
                 "query_id": "search-1",
-                "search_query": "download report",
+                "search_query": "export report",
                 "results_count": "0",
                 "search_count": "25",
             },
             {
                 "query_id": "search-1",
-                "search_query": "export report",
+                "search_query": "export attribution report",
                 "search_count": "10",
             },
             {
@@ -2336,7 +2340,7 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
             },
             {
                 "sales_objection_id": "objection-1",
-                "sales_objection": "Prospect asked whether reporting exports are available.",
+                "sales_objection": "Prospect asked whether reporting export is available.",
             },
         ],
     )
@@ -2378,6 +2382,28 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
             "support_ticket": 1,
         },
         "zero_result_search_source_count": 1,
+    }
+    reporting_item = result["diagnostics"]["items"][0]
+    assert reporting_item["topic"] == "reporting friction"
+    assert reporting_item["source_type_counts"] == {
+        "sales_objection": 1,
+        "search_log": 1,
+        "support_ticket": 1,
+    }
+    assert reporting_item["source_channel_counts"] == {
+        "sales_inputs": 1,
+        "search_logs": 1,
+        "support_tickets": 1,
+    }
+    assert reporting_item["weighted_source_volume_by_type"] == {
+        "sales_objection": 1,
+        "search_log": 25,
+        "support_ticket": 1,
+    }
+    assert reporting_item["weighted_source_volume_by_channel"] == {
+        "sales_inputs": 1,
+        "search_logs": 25,
+        "support_tickets": 1,
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics.md

The FAQ CLI item summaries now expose source mix per generated FAQ opportunity, so a ranked item can show whether it came from tickets, search logs, sales inputs, or a blend of channels.

## Intentional
- No generation or ranking changes; this only adds metadata to item diagnostics.
- No new source channels; item summaries reuse the existing source-channel classifier.
- No hosted UI display yet; this remains compact result JSON.

## Deferred
- Hosted UI display for item-level source-mix diagnostics.
- Per-item zero-result source counts by channel.
- Scale-run summary tables that combine item source mix with output checks.

## Verification
- Focused item/source-mix FAQ CLI pytest - passed, 2 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 130 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed, including drift and caller-hint checks.

## Diff size
4 files, +167 / -3