### PR TITLE
PR-Content-Ops-FAQ-Weighted-Aggregation-Helper

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import date, datetime, timedelta
 import re
@@ -691,27 +691,44 @@ def _item_source_type_counts(rows: Sequence[Mapping[str, Any]]) -> dict[str, int
 
 
 def _item_weighted_source_volume_by_type(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
-    weights: dict[tuple[str, str], int] = {}
-    for index, row in enumerate(rows, start=1):
-        source_type = _source_type_key(row.get("source_type")) or "unknown"
-        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
-        weight = _integer_or_none(row.get("source_weight")) or 1
-        # Breakdown is by type, so a rare multi-type source key is counted once per type.
-        key = (source_type, source_key)
-        weights[key] = max(weights.get(key, 0), max(weight, 1))
-    counts: dict[str, int] = {}
-    for (source_type, _source_key), weight in weights.items():
-        counts[source_type] = counts.get(source_type, 0) + weight
-    return dict(sorted(counts.items()))
+    # Breakdown is by type, so a rare multi-type source key is counted once per type.
+    return weighted_source_volume_by_group(
+        rows,
+        group_key=lambda row: _source_type_key(row.get("source_type")) or "unknown",
+    )
 
 
 def _weighted_frequency(rows: Sequence[Mapping[str, Any]]) -> int:
-    weights: dict[str, int] = {}
+    return weighted_source_volume_by_group(rows, group_key=lambda _row: "all").get("all", 0)
+
+
+def weighted_source_volume_by_group(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    group_key: Callable[[Mapping[str, Any]], str],
+    source_key: Callable[[Mapping[str, Any], int], str] | None = None,
+    row_weight: Callable[[Mapping[str, Any]], int] | None = None,
+) -> dict[str, int]:
+    """Sum max represented source weight by group.
+
+    Default weighting honors all source-weight aliases. In the ranking path,
+    rows are already normalized with source_weight before this helper runs.
+    """
+
+    weights: dict[tuple[str, str], int] = {}
     for index, row in enumerate(rows, start=1):
-        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
-        weight = _integer_or_none(row.get("source_weight")) or 1
-        weights[source_key] = max(weights.get(source_key, 0), max(weight, 1))
-    return sum(weights.values())
+        group = group_key(row) or "unknown"
+        key = (
+            source_key(row, index)
+            if source_key is not None
+            else _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        )
+        weight = row_weight(row) if row_weight is not None else source_row_weight(row)
+        weights[(group, key)] = max(weights.get((group, key), 0), max(weight, 1))
+    counts: dict[str, int] = {}
+    for (group, _source_key), weight in weights.items():
+        counts[group] = counts.get(group, 0) + weight
+    return dict(sorted(counts.items()))
 
 
 def source_row_weight(*rows: Mapping[str, Any]) -> int:

--- a/plans/PR-Content-Ops-FAQ-Weighted-Aggregation-Helper.md
+++ b/plans/PR-Content-Ops-FAQ-Weighted-Aggregation-Helper.md
@@ -1,0 +1,81 @@
+# PR-Content-Ops-FAQ-Weighted-Aggregation-Helper
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Item-Source-Mix-Diagnostics added the last planned
+source-mix diagnostic surface, and the reviewer correctly noted that the
+max-per-source weighted aggregation now appears in multiple places. Leaving that
+logic duplicated invites drift between item ranking, per-item weighted source
+mix, and upload-level weighted source mix.
+
+This slice consolidates that aggregation after the diagnostics surfaces have
+settled, without changing generated Markdown or result JSON shape.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add one shared weighted-source aggregation helper in the FAQ generator.
+2. Route item weighted frequency through the helper.
+3. Route item source-type weighted volume through the helper.
+4. Route CLI source-mix weighted input volume through the helper.
+5. Re-run focused regression coverage that locks output parity for the existing
+   weighted diagnostics.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Weighted-Aggregation-Helper.md` | Plan doc for this refactor slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds the shared weighted aggregation helper and uses it for item ranking/metadata. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Uses the shared helper for upload-level source-mix weighted volume. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Adds direct coverage for the public helper's default weight aliases. |
+
+## Mechanism
+
+The new helper accepts normalized rows plus a group-key function. For each
+group/source-key pair it keeps the maximum represented source weight, then sums
+those maximums by group. The default source-key and weight behavior matches the
+existing generator logic; CLI diagnostics can pass their existing source-key and
+weight callbacks for opportunity-level rows.
+
+Using the same helper preserves current behavior while making the
+max-per-source rule a single implementation.
+
+## Intentional
+
+- Refactor only. No generated Markdown, ranking, or result JSON field names
+  change.
+- The helper supports custom source-key and weight callbacks because CLI
+  upload-level diagnostics aggregate opportunities plus evidence rows, while
+  generator item metadata aggregates already-grouped evidence rows.
+- The per-type breakdown can still count a rare multi-type source key once per
+  type; the previous PR documented that behavior and this helper preserves it.
+
+## Deferred
+
+- Hosted UI display for item-level source-mix diagnostics.
+- Per-item zero-result source counts by channel.
+- Scale-run summary tables that combine item source mix with output checks.
+
+## Verification
+
+- Reviewer update: focused weighted/source-mix FAQ CLI pytest - passed, 2 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  131 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Generator helper refactor | ~45 |
+| CLI helper reuse | ~25 |
+| Tests | ~15 |
+| **Total** | ~170 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -49,6 +49,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     build_ticket_faq_markdown,
     is_zero_result_search_row,
     source_row_weight,
+    weighted_source_volume_by_group,
 )
 
 _SOURCE_CHANNELS = {
@@ -333,9 +334,6 @@ def _result_payload(
 def _source_mix_diagnostics(opportunities: list[dict[str, Any]]) -> dict[str, Any]:
     source_type_counts: dict[str, int] = {}
     source_channel_counts: dict[str, int] = {}
-    source_weights: dict[str, int] = {}
-    source_type_weights: dict[tuple[str, str], int] = {}
-    source_channel_weights: dict[tuple[str, str], int] = {}
     zero_result_search_sources: set[str] = set()
     for index, opportunity in enumerate(opportunities, start=1):
         source_type = _diagnostic_source_type(opportunity)
@@ -343,24 +341,32 @@ def _source_mix_diagnostics(opportunities: list[dict[str, Any]]) -> dict[str, An
         channel = _SOURCE_CHANNELS.get(source_type, "other")
         source_channel_counts[channel] = source_channel_counts.get(channel, 0) + 1
         source_key = _diagnostic_source_key(opportunity, index)
-        weight = _diagnostic_source_weight(opportunity)
-        source_weights[source_key] = max(source_weights.get(source_key, 0), weight)
-        type_key = (source_type, source_key)
-        channel_key = (channel, source_key)
-        source_type_weights[type_key] = max(source_type_weights.get(type_key, 0), weight)
-        source_channel_weights[channel_key] = max(
-            source_channel_weights.get(channel_key, 0),
-            weight,
-        )
         if _is_zero_result_search_source(opportunity):
             zero_result_search_sources.add(source_key)
+    source_weights = weighted_source_volume_by_group(
+        opportunities,
+        group_key=lambda _opportunity: "all",
+        source_key=_diagnostic_source_key,
+        row_weight=_diagnostic_source_weight,
+    )
     return {
         "source_type_counts": dict(sorted(source_type_counts.items())),
         "source_channel_counts": dict(sorted(source_channel_counts.items())),
-        "weighted_source_volume": sum(source_weights.values()),
-        "weighted_source_volume_by_type": _weighted_counts_by_group(source_type_weights),
-        "weighted_source_volume_by_channel": _weighted_counts_by_group(
-            source_channel_weights
+        "weighted_source_volume": source_weights.get("all", 0),
+        "weighted_source_volume_by_type": weighted_source_volume_by_group(
+            opportunities,
+            group_key=_diagnostic_source_type,
+            source_key=_diagnostic_source_key,
+            row_weight=_diagnostic_source_weight,
+        ),
+        "weighted_source_volume_by_channel": weighted_source_volume_by_group(
+            opportunities,
+            group_key=lambda opportunity: _SOURCE_CHANNELS.get(
+                _diagnostic_source_type(opportunity),
+                "other",
+            ),
+            source_key=_diagnostic_source_key,
+            row_weight=_diagnostic_source_weight,
         ),
         "zero_result_search_source_count": len(zero_result_search_sources),
     }
@@ -398,13 +404,6 @@ def _diagnostic_evidence_rows(opportunity: dict[str, Any]) -> tuple[dict[str, An
 
 def _diagnostic_source_weight(opportunity: dict[str, Any]) -> int:
     return source_row_weight(opportunity, *_diagnostic_evidence_rows(opportunity))
-
-
-def _weighted_counts_by_group(weights: dict[tuple[str, str], int]) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for (group, _source_key), weight in weights.items():
-        counts[group] = counts.get(group, 0) + weight
-    return dict(sorted(counts.items()))
 
 
 def _is_zero_result_search_source(

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -18,6 +18,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
     build_ticket_faq_markdown,
+    weighted_source_volume_by_group,
 )
 
 
@@ -396,6 +397,20 @@ def test_build_ticket_faq_markdown_prefers_explicit_aggregate_weight_fields() ->
     assert result.items[0]["frequency"] == 25
     assert result.items[0]["weighted_frequency"] == 25
     assert result.items[0]["ticket_count"] == 1
+
+
+def test_weighted_source_volume_by_group_accepts_unnormalized_weight_fields() -> None:
+    result = weighted_source_volume_by_group(
+        [{
+            "source_type": "search_log",
+            "query_id": "search-export-1",
+            "search_count": "25",
+        }],
+        group_key=lambda row: str(row.get("source_type") or "unknown"),
+        source_key=lambda row, _index: str(row.get("query_id") or "unknown"),
+    )
+
+    assert result == {"search_log": 25}
 
 
 def test_build_ticket_faq_markdown_uses_max_weight_per_distinct_source() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Weighted-Aggregation-Helper.md

Consolidates the FAQ max-per-source weighted aggregation after source-mix diagnostics settled, so ranking, per-item weighted source mix, and upload-level weighted source mix all share one helper.

## Intentional
- Refactor only; generated Markdown, ranking outputs, and result JSON field names stay unchanged.
- Helper accepts custom callbacks because CLI upload diagnostics aggregate opportunities while generator item metadata aggregates grouped evidence rows.
- The per-type breakdown can still count a rare multi-type source key once per type; this preserves the documented behavior from the prior PR.

## Deferred
- Hosted UI display for item-level source-mix diagnostics.
- Per-item zero-result source counts by channel.
- Scale-run summary tables that combine item source mix with output checks.

## Verification
- Focused weighted/source-mix FAQ CLI pytest - passed, 2 tests.
- Full FAQ pytest for tests/test_extracted_ticket_faq_markdown.py - passed, 130 tests.
- Py compile for affected Python files - passed.
- Git whitespace check - passed.
- Extracted manifest/import validation script - passed.
- Extracted reasoning import guard - passed.
- Extracted standalone audit - passed, 0 Atlas runtime import findings.
- Extracted ASCII Python check - passed.
- Local PR review against origin/main - passed, including drift and caller-hint checks.

## Diff size
3 files, +132 / -41