### PR TITLE
Add landing page saved draft repair UI

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -13,6 +13,7 @@
  *   GET  /content-assets/{asset}/drafts
  *   GET  /content-assets/{asset}/drafts/export
  *   PATCH /content-assets/landing_page/drafts/{id}
+ *   POST /content-assets/landing_page/drafts/{id}/repair
  *   POST /content-assets/{asset}/drafts/review
  *   POST /content-assets/{asset}/drafts/review-batch
  *
@@ -300,6 +301,16 @@ export interface GeneratedAssetDraftMetadata {
   [key: string]: unknown
 }
 
+export interface GeneratedAssetRepairResult {
+  requested?: number
+  generated?: number
+  skipped?: number
+  saved_ids?: string[]
+  errors?: Array<Record<string, unknown>>
+  quality_repair_history?: GeneratedAssetRepairHistoryEntry[] | string
+  [key: string]: unknown
+}
+
 export interface GeneratedAssetDraft {
   id?: string
   title?: string
@@ -343,6 +354,7 @@ export interface GeneratedAssetDraft {
   passed_output_checks?: number
   seo_aeo_readiness?: GeneratedAssetReadiness | string
   geo_readiness?: GeneratedAssetReadiness | string
+  repair_result?: GeneratedAssetRepairResult | string
   structured_data?: Record<string, unknown> | string
   robots?: string
   persona?: string
@@ -631,6 +643,17 @@ export function updateGeneratedLandingPageDraft(
     'landing_page',
     `/drafts/${encodeURIComponent(id)}`,
     { ...body },
+  )
+}
+
+/** POST /content-assets/landing_page/drafts/{id}/repair -- repair a generated landing page draft. */
+export function repairGeneratedLandingPageDraft(
+  id: string,
+): Promise<GeneratedAssetDraft> {
+  return postAssetJson<GeneratedAssetDraft>(
+    'landing_page',
+    `/drafts/${encodeURIComponent(id)}/repair`,
+    {},
   )
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -20,6 +20,7 @@ import {
   Pencil,
   RefreshCw,
   Save,
+  Wrench,
   X,
   XCircle,
 } from 'lucide-react'
@@ -27,6 +28,7 @@ import { clsx } from 'clsx'
 import {
   exportGeneratedAssetDraftsCsv,
   fetchGeneratedAssetDrafts,
+  repairGeneratedLandingPageDraft,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
   updateGeneratedLandingPageDraft,
@@ -271,6 +273,33 @@ export default function ContentOpsAssetsReview() {
     }
   }
 
+  const handleRepairLandingPageDraft = async (row: GeneratedAssetDraft) => {
+    const id = assetId(row)
+    if (!id) throw new Error('Draft id missing')
+    setBusyId(id)
+    setActionError(null)
+    try {
+      const updated = await repairGeneratedLandingPageDraft(id)
+      setData((current) => {
+        if (!current) return current
+        return {
+          ...current,
+          rows: current.rows.map((item) =>
+            assetId(item) === id ? updated : item,
+          ),
+        }
+      })
+      setDetailRow(updated)
+      return updated
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setActionError(message)
+      throw err
+    } finally {
+      setBusyId(null)
+    }
+  }
+
   if (error && !data) {
     return <PageError error={error} onRetry={() => void load(true)} />
   }
@@ -476,6 +505,7 @@ export default function ContentOpsAssetsReview() {
           asset={asset}
           saving={busyId === assetId(detailRow)}
           onSaveLandingPage={handleSaveLandingPageDraft}
+          onRepairLandingPage={handleRepairLandingPageDraft}
           onClose={() => setDetailRow(null)}
         />
       )}
@@ -641,6 +671,7 @@ function AssetDetailDrawer({
   asset,
   saving,
   onSaveLandingPage,
+  onRepairLandingPage,
   onClose,
 }: {
   row: GeneratedAssetDraft
@@ -650,6 +681,7 @@ function AssetDetailDrawer({
     row: GeneratedAssetDraft,
     update: GeneratedLandingPageDraftUpdate,
   ) => Promise<GeneratedAssetDraft>
+  onRepairLandingPage: (row: GeneratedAssetDraft) => Promise<GeneratedAssetDraft>
   onClose: () => void
 }) {
   const title = assetTitle(row, asset)
@@ -671,11 +703,13 @@ function AssetDetailDrawer({
     status !== 'approved'
   const canEditLandingPage =
     asset === 'landing_page' && Boolean(assetId(row)) && status !== 'approved'
+  const canRepairLandingPage = canEditLandingPage
   const [isEditing, setIsEditing] = useState(false)
   const [editState, setEditState] = useState<LandingPageEditState>(() =>
     landingPageEditState(row),
   )
   const [editError, setEditError] = useState<string | null>(null)
+  const [repairError, setRepairError] = useState<string | null>(null)
   const [copiedUrl, setCopiedUrl] = useState(false)
   const drawerRef = useRef<HTMLElement | null>(null)
   const closeButtonRef = useRef<HTMLButtonElement | null>(null)
@@ -705,6 +739,16 @@ function AssetDetailDrawer({
       setIsEditing(false)
     } catch (err) {
       setEditError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleRepair = async () => {
+    setRepairError(null)
+    try {
+      await onRepairLandingPage(row)
+      setIsEditing(false)
+    } catch (err) {
+      setRepairError(err instanceof Error ? err.message : String(err))
     }
   }
 
@@ -778,6 +822,21 @@ function AssetDetailDrawer({
                 {isEditing ? 'View' : 'Edit'}
               </button>
             )}
+            {canRepairLandingPage && (
+              <button
+                type="button"
+                onClick={() => void handleRepair()}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-md border border-amber-500/40 px-3 py-2 text-sm text-amber-200 hover:bg-amber-500/10 disabled:opacity-60"
+              >
+                {saving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Wrench className="h-4 w-4" />
+                )}
+                Repair
+              </button>
+            )}
             <button
               ref={closeButtonRef}
               type="button"
@@ -789,6 +848,12 @@ function AssetDetailDrawer({
             </button>
           </div>
         </div>
+
+        {repairError && (
+          <div className="mt-4 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+            {repairError}
+          </div>
+        )}
 
         {isEditing && canEditLandingPage && (
           <LandingPageDraftEditor

--- a/plans/PR-Landing-Page-Saved-Draft-Repair-UI.md
+++ b/plans/PR-Landing-Page-Saved-Draft-Repair-UI.md
@@ -1,0 +1,68 @@
+# PR-Landing-Page-Saved-Draft-Repair-UI
+
+## Why this slice exists
+
+The saved-draft landing-page repair API is merged, but operators still have no
+in-app action for using it. The review drawer already shows landing-page
+readiness and repair history, so the natural next step is a focused repair
+button there.
+
+This slice keeps the UI change small: call the new repair endpoint from the
+landing-page detail drawer, update the current row in-place, and let the
+existing readiness and repair-history panels show the result.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-saved-draft-repair-ui
+
+1. Add a frontend API wrapper for
+   `POST /content-assets/landing_page/drafts/{id}/repair`.
+2. Add a landing-page-only Repair action to the detail drawer.
+3. Reuse the existing row busy state, action error handling, readiness panels,
+   and repair-history display.
+4. Keep approve/reject/edit behavior unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Saved-Draft-Repair-UI.md` | Plan doc for this UI slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Add repair result typing and repair API wrapper. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Add drawer repair action and row refresh handling. |
+
+## Mechanism
+
+The drawer shows Repair only for non-approved landing pages with an id. Clicking
+it calls `repairGeneratedLandingPageDraft(id)`. On success, the returned review
+row replaces the matching row in the current list and becomes the open detail
+row. On failure, the existing page-level action error and drawer-local repair
+error surfaces show the backend message.
+
+## Intentional
+
+- No table-row repair button in this slice. Keeping the mutation inside the
+  detail drawer makes the operator inspect readiness before spending an LLM
+  repair call.
+- No polling. The backend route is synchronous and returns the repaired row.
+- No new readiness rendering. Existing panels already consume the repaired row.
+
+## Deferred
+
+- Rate-limit/idempotency indicators can be added after backend rate limits
+  exist.
+- A future UX pass can add success toasts or inline repair result summaries if
+  the drawer feels too quiet after repair.
+
+## Verification
+
+- `npm run build` in `atlas-intel-ui` -> passed.
+- `npm run lint` in `atlas-intel-ui` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| API wrapper/types | ~25 |
+| Review drawer | ~60 |
+| Total | ~150 |


### PR DESCRIPTION
## Summary
- add a frontend wrapper for POST /content-assets/landing_page/drafts/{id}/repair
- add a landing-page-only Repair action in the generated asset detail drawer
- replace the open/list row with the repaired review row so existing readiness and repair-history panels update in place

## Verification
- npm run build (atlas-intel-ui)
- npm run lint (atlas-intel-ui)
- bash scripts/local_pr_review.sh