### PR TITLE
Exclude self + case-dedup deep-dive competitor list (D2)

### DIFF
--- a/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
@@ -290,7 +290,7 @@ const post: BlogPost = {
 </ol>
 <p>These signals offer directional guidance but lack the precision required for account-based outreach.</p>
 <h2 id="how-pipedrive-stacks-up-against-competitors">How Pipedrive Stacks Up Against Competitors</h2>
-<p>Reviewers frequently compare Pipedrive to six primary alternatives: HubSpot, Salesforce, Zoho, Monday, and Zoho CRM.</p>
+<p>Reviewers frequently compare Pipedrive to five primary alternatives: HubSpot, Salesforce, Zoho, Monday, and Zoho CRM.</p>
 <p>The competitive context reveals different friction points across vendors:</p>
 <table>
 <thead>

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -8254,17 +8254,34 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
     # Competitive landscape
     compared = profile.get("commonly_compared_to", [])
     if compared:
-        comp_names = [
-            (c.get("vendor", c) if isinstance(c, dict) else str(c))[:25]
-            for c in compared[:6]
-        ]
-        sections.append(SectionSpec(
-            id="competitive_landscape",
-            heading=f"How {vendor} Stacks Up Against Competitors",
-            goal="Position the vendor relative to frequently compared alternatives",
-            key_stats={"competitors": comp_names},
-            data_summary=f"Commonly compared to: {', '.join(comp_names)}.",
-        ))
+        # D2: exclude the vendor itself (it appears in its own
+        # commonly_compared_to by mention count -- systemic across profiles) and
+        # case-dedup BEFORE capping, so the count and list reflect distinct
+        # external alternatives, not self + casing variants ("HubSpot"/"Hubspot",
+        # "Zoho"/"ZOHO"). The data_summary states the count so the description
+        # uses a deterministic number rather than miscounting the rendered list.
+        seen: set[str] = set()
+        comp_names: list[str] = []
+        for c in compared:
+            name = (c.get("vendor", c) if isinstance(c, dict) else str(c)).strip()
+            key = name.lower()
+            if not name or key == vendor.strip().lower() or key in seen:
+                continue
+            seen.add(key)
+            comp_names.append(name[:25])
+            if len(comp_names) >= 6:
+                break
+        if comp_names:
+            sections.append(SectionSpec(
+                id="competitive_landscape",
+                heading=f"How {vendor} Stacks Up Against Competitors",
+                goal="Position the vendor relative to frequently compared alternatives",
+                key_stats={"competitors": comp_names},
+                data_summary=(
+                    f"Commonly compared to {len(comp_names)} alternatives: "
+                    f"{', '.join(comp_names)}."
+                ),
+            ))
 
     market_position_stats: dict[str, Any] = {}
     if contract_category:

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -8254,17 +8254,34 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
     # Competitive landscape
     compared = profile.get("commonly_compared_to", [])
     if compared:
-        comp_names = [
-            (c.get("vendor", c) if isinstance(c, dict) else str(c))[:25]
-            for c in compared[:6]
-        ]
-        sections.append(SectionSpec(
-            id="competitive_landscape",
-            heading=f"How {vendor} Stacks Up Against Competitors",
-            goal="Position the vendor relative to frequently compared alternatives",
-            key_stats={"competitors": comp_names},
-            data_summary=f"Commonly compared to: {', '.join(comp_names)}.",
-        ))
+        # D2: exclude the vendor itself (it appears in its own
+        # commonly_compared_to by mention count -- systemic across profiles) and
+        # case-dedup BEFORE capping, so the count and list reflect distinct
+        # external alternatives, not self + casing variants ("HubSpot"/"Hubspot",
+        # "Zoho"/"ZOHO"). The data_summary states the count so the description
+        # uses a deterministic number rather than miscounting the rendered list.
+        seen: set[str] = set()
+        comp_names: list[str] = []
+        for c in compared:
+            name = (c.get("vendor", c) if isinstance(c, dict) else str(c)).strip()
+            key = name.lower()
+            if not name or key == vendor.strip().lower() or key in seen:
+                continue
+            seen.add(key)
+            comp_names.append(name[:25])
+            if len(comp_names) >= 6:
+                break
+        if comp_names:
+            sections.append(SectionSpec(
+                id="competitive_landscape",
+                heading=f"How {vendor} Stacks Up Against Competitors",
+                goal="Position the vendor relative to frequently compared alternatives",
+                key_stats={"competitors": comp_names},
+                data_summary=(
+                    f"Commonly compared to {len(comp_names)} alternatives: "
+                    f"{', '.join(comp_names)}."
+                ),
+            ))
 
     market_position_stats: dict[str, Any] = {}
     if contract_category:

--- a/plans/PR-Blog-D2-Competitor-Dedup.md
+++ b/plans/PR-Blog-D2-Competitor-Dedup.md
@@ -1,0 +1,79 @@
+# PR-Blog-D2-Competitor-Dedup
+
+Ownership lane: `content-ops/blog-d2-competitor-dedup`
+
+## Why this slice exists
+
+Defect **D2** (`reports/blog-audit-findings.md`), first of the pipedrive cluster.
+`pipedrive-deep-dive` reads "compare Pipedrive to **six** primary alternatives:
+HubSpot, Salesforce, Zoho, Monday, and Zoho CRM" -- says six, lists five. The
+generator's competitive-landscape section took `commonly_compared_to[:6]` with
+no self-exclusion and no dedup, and the count was stated independently of the
+rendered list.
+
+DB confirms the cause is broader than the catalog noted: a vendor appears in its
+OWN `commonly_compared_to` by mention count (Pipedrive self-lists at 20), and
+casing variants duplicate ("HubSpot"/"Hubspot", "Zoho"/"ZOHO"). Self-inclusion
+is **systemic** -- CrowdStrike, HubSpot, Mailchimp, WooCommerce, Asana, ClickUp,
+and others self-list too -- so this generator fix corrects every deep-dive.
+
+## Scope (this PR)
+
+- **Generator** (`_blueprint_vendor_deep_dive`, both byte-identical copies):
+  exclude the vendor itself and case-dedup BEFORE the `[:6]` cap, and state the
+  count in `data_summary` so the description uses a deterministic number.
+- **Data** (`pipedrive-deep-dive-2026-04.ts`): "six" -> "five" (the count of
+  names actually listed). The name list is unchanged.
+
+### Files touched
+
+- `plans/PR-Blog-D2-Competitor-Dedup.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation.py`
+- `atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts`
+
+## Mechanism
+
+The `comp_names = compared[:6]` comprehension is replaced with a loop that skips
+`name.lower() == vendor.lower()` (self) and `name.lower() in seen` (case dup)
+before appending, capping at 6 distinct external alternatives. `data_summary`
+becomes "Commonly compared to {len(comp_names)} alternatives: {list}." so the
+count is derived from the rendered list, not miscounted by the LLM.
+
+## Intentional
+
+- **Self-exclude + case-dedup only.** Both are mechanical and unambiguous.
+- **"Zoho" vs "Zoho CRM" left distinct (deferred).** That is a suite-vs-product
+  registry decision; `_canonicalize_competitor` (resolve_vendor_name_cached)
+  returned both unchanged in an isolated import, so its production merge
+  behavior is unverified -- merging product variants is not a per-PR call.
+
+## Deferred
+
+- **D2-followup: vendor suite/product alias unification** ("Zoho" vs "Zoho CRM"),
+  a vendor-registry concern.
+- **D3** (prose-vs-chart "dominant pain") and **D4** (strengths/weaknesses chart
+  mislabel) -- separate slices.
+
+## Verification
+
+- New `test_deep_dive_competitor_list_excludes_self_and_case_dedups`: feeds
+  `[Pipedrive, HubSpot, Hubspot, Salesforce, Zoho, ZOHO, Monday, Zoho CRM]` for
+  vendor=Pipedrive and asserts `competitors == [HubSpot, Salesforce, Zoho,
+  Monday, Zoho CRM]` (self gone, case dups gone, Zoho/Zoho CRM kept distinct)
+  and "5 alternatives" in data_summary. Verified it FAILS on revert to the raw
+  `compared[:6]` (got `[Pipedrive, ..., Zoho, ZOHO]`).
+- `pytest` generation + quote-gate suites -> 197 passed; both copies
+  byte-identical.
+- Data: pipedrive post now reads "five primary alternatives: ..."; audit clean.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (self-exclude + dedup loop + count) | ~44 |
+| Test | ~45 |
+| pipedrive data (one word) | ~2 |
+| Plan doc | ~90 |
+| **Total** | **~180** |

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -1163,6 +1163,48 @@ def test_build_blog_generation_payload_includes_section_budget_and_manifest():
     ]
 
 
+def test_deep_dive_competitor_list_excludes_self_and_case_dedups():
+    """D2: the competitive-landscape section must exclude the vendor itself
+    (vendors appear in their own commonly_compared_to by mention count --
+    systemic across profiles) and case-dedup BEFORE capping, so the count and
+    list reflect distinct external alternatives. The data_summary states the
+    count deterministically. (Zoho vs Zoho CRM stays distinct -- the
+    suite/product alias merge is deferred.) Reverting the self-filter, the
+    case-dedup, or the count fails this."""
+    blueprint = blog_mod._blueprint_vendor_deep_dive(
+        {
+            "vendor": "Pipedrive",
+            "category": "CRM",
+            "review_count": 42,
+            "profile_richness": 4,
+            "slug": "pipedrive-deep-dive-2026-04",
+        },
+        {
+            "profile": {
+                "commonly_compared_to": [
+                    {"vendor": "Pipedrive"},   # self -> excluded
+                    {"vendor": "HubSpot"},
+                    {"vendor": "Hubspot"},     # case dup of HubSpot -> excluded
+                    {"vendor": "Salesforce"},
+                    {"vendor": "Zoho"},
+                    {"vendor": "ZOHO"},        # case dup of Zoho -> excluded
+                    {"vendor": "Monday"},
+                    {"vendor": "Zoho CRM"},    # distinct (suite/product merge deferred)
+                ],
+            },
+            "signals": [],
+            "quotes": [],
+            "data_context": {"vendor": "Pipedrive", "category": "CRM",
+                             "review_period": "2026-02 to 2026-04"},
+        },
+    )
+    comp = next(s for s in blueprint.sections if s.id == "competitive_landscape")
+    assert comp.key_stats["competitors"] == [
+        "HubSpot", "Salesforce", "Zoho", "Monday", "Zoho CRM",
+    ]
+    assert "5 alternatives" in comp.data_summary
+
+
 def test_blueprint_vendor_deep_dive_promotes_reasoning_sections():
     blueprint = blog_mod._blueprint_vendor_deep_dive(
         {


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d2-competitor-dedup`

**D2** (first of the pipedrive cluster): `pipedrive-deep-dive` read "compare Pipedrive to **six** primary alternatives: HubSpot, Salesforce, Zoho, Monday, and Zoho CRM" — says six, lists five. The competitive-landscape section took `commonly_compared_to[:6]` with no self-exclusion and no dedup; the count was stated independently of the list.

## Intentional

- **Root cause (DB-confirmed):** a vendor self-lists in its own `commonly_compared_to` by mention count (Pipedrive at 20), and casing variants duplicate (HubSpot/Hubspot, Zoho/ZOHO). **Self-inclusion is systemic** — CrowdStrike, HubSpot, Mailchimp, WooCommerce, Asana, ClickUp… also self-list — so the generator fix corrects every deep-dive.
- **Generator** (`_blueprint_vendor_deep_dive`, both byte-identical copies): skip self (`name.lower() == vendor.lower()`) and case dups before the `[:6]` cap; state the count in `data_summary` so the description uses a deterministic number.
- **Data** (`pipedrive-deep-dive-2026-04.ts`): "six" → "five" (count of names actually listed); name list unchanged.
- **Left "Zoho" vs "Zoho CRM" distinct** — suite/product registry merge is unverified (`_canonicalize_competitor` returned both unchanged in an isolated import); deferred.

## Deferred

- **D2-followup:** vendor suite/product alias unification ("Zoho" vs "Zoho CRM") — a vendor-registry concern.
- **D3** (prose-vs-chart "dominant pain") and **D4** (strengths/weaknesses chart mislabel) — separate slices.

## Verification

- New `test_deep_dive_competitor_list_excludes_self_and_case_dedups`: feeds `[Pipedrive, HubSpot, Hubspot, Salesforce, Zoho, ZOHO, Monday, Zoho CRM]` (vendor=Pipedrive) → asserts `competitors == [HubSpot, Salesforce, Zoho, Monday, Zoho CRM]` and "5 alternatives" in summary. **Verified it fails on revert** to raw `compared[:6]` (got `[Pipedrive, …, Zoho, ZOHO]`).
- generation + quote-gate suites → **197 passed**; both copies byte-identical.
- Data: pipedrive post now reads "five primary alternatives: …"; audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)