### PR TITLE
PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics.md
@@ -1,0 +1,81 @@
+# PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics
+
+## Why this slice exists
+
+The FAQ CLI now reports upload source mix, weighted represented volume, per-item
+source mix, output-check details, and compact item diagnostics. Those fields are
+useful individually, but a large run still requires stitching together several
+JSON paths to answer the operator's first question: did this upload produce a
+healthy FAQ run, and what volume and score shape did it cover?
+
+This slice adds a compact run-summary block that combines output-check status,
+source-mix volume, generated count, and item score distribution without changing
+FAQ generation behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add a `diagnostics.run_summary` block to the FAQ CLI compact result JSON.
+2. Include output-check pass/fail counts and failed-check names.
+3. Include upload volume summary from existing source-mix diagnostics.
+4. Include item opportunity-score distribution for large-run triage.
+5. Add focused CLI regression coverage for success and fail-closed result
+   summaries.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics.md` | Plan doc for this run-summary diagnostics slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds compact run-summary diagnostics derived from existing result fields. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers run-summary diagnostics for passing and failing output-check runs. |
+
+## Mechanism
+
+`_result_payload` will compute source-mix diagnostics once, then pass that
+dictionary plus the generated item summaries, output checks, failed checks, and
+warnings into a new private `_run_summary` helper.
+
+The summary is intentionally compact and structured: status, generated/source
+counts, weighted source volume, source-channel counts, output-check counts,
+failed-check names, warning count, and item score distribution. Score
+distribution uses existing item `opportunity_score` values and reports min,
+max, average, and band counts so a 1,000-row run can be triaged without opening
+the Markdown body.
+
+## Intentional
+
+- CLI result JSON only. Markdown, ranking, source adapters, and library result
+  objects remain unchanged.
+- The summary duplicates only small aggregate values already present elsewhere
+  in diagnostics; it does not duplicate item bodies, answers, steps, or the
+  Markdown artifact.
+- Score bands are broad triage buckets, not product scoring semantics.
+
+## Deferred
+
+- Hosted UI display for the run-summary block remains separate.
+- Scale-smoke wrapper display can consume this block in a follow-up without
+  changing the FAQ CLI schema again.
+
+## Verification
+
+- Focused run-summary/source-mix/output-check FAQ CLI pytest - passed, 3 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  131 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| CLI run-summary diagnostics | ~90 |
+| Tests | ~55 |
+| **Total** | ~220 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -277,6 +277,10 @@ def _result_payload(
     question_source_counts = _count_by(items, "question_source")
     rendered_ticket_source_count = _rendered_ticket_source_count(items)
     warnings = load_warnings + [dict(warning) for warning in result.warnings]
+    source_mix = _source_mix_diagnostics(opportunities)
+    item_summaries = [
+        _item_summary(index, item) for index, item in enumerate(items, start=1)
+    ]
     return {
         "status": "failed_output_checks" if failed_checks else "ok",
         "input": {
@@ -317,7 +321,14 @@ def _result_payload(
         "diagnostics": {
             "output_check_details": _output_check_details(result, failed_checks, rendered_ticket_source_count),
             "question_source_counts": question_source_counts,
-            "source_mix": _source_mix_diagnostics(opportunities),
+            "run_summary": _run_summary(
+                result=result,
+                failed_checks=failed_checks,
+                source_mix=source_mix,
+                item_summaries=item_summaries,
+                warnings=warnings,
+            ),
+            "source_mix": source_mix,
             "ticket_counts": ticket_counts,
             "rendered_ticket_source_count": rendered_ticket_source_count,
             "unrepresented_ticket_sources": max(result.ticket_source_count - rendered_ticket_source_count, 0),
@@ -326,8 +337,76 @@ def _result_payload(
             "warning_count": len(warnings),
             "warnings": warnings[:50],
             "warnings_truncated": len(warnings) > 50,
-            "items": [_item_summary(index, item) for index, item in enumerate(items, start=1)],
+            "items": item_summaries,
         },
+    }
+
+
+def _run_summary(
+    *,
+    result: Any,
+    failed_checks: list[str],
+    source_mix: dict[str, Any],
+    item_summaries: list[dict[str, Any]],
+    warnings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    output_checks = dict(result.output_checks)
+    return {
+        "status": "failed_output_checks" if failed_checks else "ok",
+        "source_count": result.source_count,
+        "ticket_source_count": result.ticket_source_count,
+        "generated": len(item_summaries),
+        "weighted_source_volume": int(source_mix.get("weighted_source_volume") or 0),
+        "source_channel_counts": _clean_count_mapping(
+            source_mix.get("source_channel_counts")
+        ),
+        "zero_result_search_source_count": int(
+            source_mix.get("zero_result_search_source_count") or 0
+        ),
+        "output_checks": {
+            "passed": sum(1 for passed in output_checks.values() if passed is True),
+            "failed": len(failed_checks),
+            "total": len(output_checks),
+            "failed_checks": list(failed_checks),
+        },
+        "item_score_distribution": _item_score_distribution(item_summaries),
+        "warning_count": len(warnings),
+    }
+
+
+def _item_score_distribution(item_summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    scores = [
+        _integer_or_zero(item.get("opportunity_score")) for item in item_summaries
+    ]
+    bands = {
+        "zero": 0,
+        "low_1_to_4": 0,
+        "medium_5_to_9": 0,
+        "high_10_plus": 0,
+    }
+    for score in scores:
+        if score <= 0:
+            bands["zero"] += 1
+        elif score <= 4:
+            bands["low_1_to_4"] += 1
+        elif score <= 9:
+            bands["medium_5_to_9"] += 1
+        else:
+            bands["high_10_plus"] += 1
+    if not scores:
+        return {
+            "count": 0,
+            "min": 0,
+            "max": 0,
+            "average": 0.0,
+            "bands": bands,
+        }
+    return {
+        "count": len(scores),
+        "min": min(scores),
+        "max": max(scores),
+        "average": round(sum(scores) / len(scores), 2),
+        "bands": bands,
     }
 
 
@@ -850,6 +929,13 @@ def _clean_count_mapping(value: Any) -> dict[str, int]:
             continue
         out[str(key)] = amount
     return dict(sorted(out.items()))
+
+
+def _integer_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _source_channel_counts_from_types(source_type_counts: dict[str, int]) -> dict[str, int]:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2267,6 +2267,34 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "weighted_source_volume_by_type": {"support_ticket": 4},
         "zero_result_search_source_count": 0,
     }
+    assert result["diagnostics"]["run_summary"] == {
+        "status": "ok",
+        "source_count": 4,
+        "ticket_source_count": 4,
+        "generated": 2,
+        "weighted_source_volume": 4,
+        "source_channel_counts": {"support_tickets": 4},
+        "zero_result_search_source_count": 0,
+        "output_checks": {
+            "passed": 3,
+            "failed": 0,
+            "total": 3,
+            "failed_checks": [],
+        },
+        "item_score_distribution": {
+            "count": 2,
+            "min": 2,
+            "max": 4,
+            "average": 3.0,
+            "bands": {
+                "zero": 0,
+                "low_1_to_4": 2,
+                "medium_5_to_9": 0,
+                "high_10_plus": 0,
+            },
+        },
+        "warning_count": 0,
+    }
     assert result["diagnostics"]["ticket_counts"] == [2, 2]
     assert result["diagnostics"]["term_mapping_count"] == 0
     assert result["diagnostics"]["term_mappings"] == []
@@ -2398,6 +2426,19 @@ def test_ticket_faq_cli_writes_source_mix_result_diagnostics(tmp_path: Path) -> 
         },
         "zero_result_search_source_count": 1,
     }
+    assert result["diagnostics"]["run_summary"]["weighted_source_volume"] == 28
+    assert result["diagnostics"]["run_summary"]["source_channel_counts"] == {
+        "chats": 1,
+        "sales_inputs": 1,
+        "search_logs": 2,
+        "support_tickets": 1,
+    }
+    assert result["diagnostics"]["run_summary"]["zero_result_search_source_count"] == 1
+    assert result["diagnostics"]["run_summary"]["output_checks"]["failed"] == 0
+    assert (
+        result["diagnostics"]["run_summary"]["item_score_distribution"]["count"]
+        == result["generated"]
+    )
     reporting_item = result["diagnostics"]["items"][0]
     assert reporting_item["topic"] == "reporting friction"
     assert reporting_item["source_type_counts"] == {
@@ -3413,6 +3454,15 @@ def test_ticket_faq_cli_fails_required_output_checks_for_weak_rows(tmp_path: Pat
         {"check": "has_action_items", "passed": True},
         {"check": "uses_user_vocabulary", "passed": True},
     ]
+    assert result["diagnostics"]["run_summary"]["status"] == "failed_output_checks"
+    assert result["diagnostics"]["run_summary"]["output_checks"] == {
+        "passed": 2,
+        "failed": 1,
+        "total": 3,
+        "failed_checks": ["condensed"],
+    }
+    assert result["diagnostics"]["run_summary"]["generated"] == 2
+    assert result["diagnostics"]["run_summary"]["item_score_distribution"]["count"] == 2
 
 
 def test_ticket_faq_cli_rejects_as_of_date_without_window(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics.md

Adds a compact FAQ CLI run-summary block so large uploads can be triaged from one JSON path: output-check status, upload source mix, weighted source volume, warning count, and item score distribution.

## Intentional
- CLI result JSON only; FAQ generation, ranking, Markdown, and library result objects are unchanged.
- Summary duplicates only small aggregate values already present elsewhere in diagnostics.
- Score bands are broad triage buckets, not product scoring semantics.

## Deferred
- Hosted UI display for the run-summary block remains separate.
- Scale-smoke wrapper display can consume this block in a follow-up without changing the FAQ CLI schema again.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py -k "writes_markdown_file or source_mix_result_diagnostics or fails_required_output_checks"` — 3 passed.
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py` — 131 passed.
- `python -m py_compile scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` — passed.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed, 0 findings.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` — passed; `_result_payload` caller-hint warning inspected as unrelated same-name helper.

## Diff size
3 files, +219 / -2
