### PR TITLE
Polish landing page repair UI errors

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -650,11 +650,70 @@ export function updateGeneratedLandingPageDraft(
 export function repairGeneratedLandingPageDraft(
   id: string,
 ): Promise<GeneratedAssetDraft> {
-  return postAssetJson<GeneratedAssetDraft>(
-    'landing_page',
-    `/drafts/${encodeURIComponent(id)}/repair`,
-    {},
-  )
+  const url = `${ASSETS_BASE}/landing_page/drafts/${encodeURIComponent(id)}/repair`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: '{}',
+    })
+  return withRefreshOn401(doFetch).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(await repairErrorMessage(res))
+    }
+    return rawJson<GeneratedAssetDraft>(res)
+  })
+}
+
+async function repairErrorMessage(res: Response): Promise<string> {
+  const text = await rawText(res)
+  const body = jsonFromText(text)
+  if (body !== null) {
+    const detail = recordValue(body)?.detail
+    if (typeof detail === 'string' && detail.trim()) {
+      return `API ${res.status}: ${detail.trim()}`
+    }
+    const detailRecord = recordValue(detail)
+    if (detailRecord) {
+      const message = textValue(detailRecord.message)
+      const blockers = repairResultBlockers(detailRecord.repair_result)
+      const suffix = blockers.length > 0 ? `: ${blockers.join(', ')}` : ''
+      return `API ${res.status}: ${message || 'Landing page repair failed'}${suffix}`
+    }
+  }
+  return `API ${res.status}: ${text || res.statusText}`
+}
+
+function jsonFromText(text: string): unknown {
+  if (!text.trim()) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+function repairResultBlockers(value: unknown): string[] {
+  const result = recordValue(value)
+  const errors = Array.isArray(result?.errors) ? result.errors : []
+  const firstError = recordValue(errors[0])
+  return valueList(firstError?.blockers).slice(0, 4)
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function valueList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(textValue).filter(Boolean)
+  const text = textValue(value)
+  return text ? text.split(',').map((item) => item.trim()).filter(Boolean) : []
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
 }
 
 /** GET /content-assets/landing_page/public/{id} -- approved public landing page. */

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -703,7 +703,8 @@ function AssetDetailDrawer({
     status !== 'approved'
   const canEditLandingPage =
     asset === 'landing_page' && Boolean(assetId(row)) && status !== 'approved'
-  const canRepairLandingPage = canEditLandingPage
+  const canRepairLandingPage =
+    canEditLandingPage && landingPageNeedsRepair(readinessPanels)
   const [isEditing, setIsEditing] = useState(false)
   const [editState, setEditState] = useState<LandingPageEditState>(() =>
     landingPageEditState(row),
@@ -1975,6 +1976,11 @@ function assetReadinessPanels(
     readinessPanel('SEO/AEO', row.seo_aeo_readiness),
     readinessPanel('GEO', row.geo_readiness),
   ].filter((panel): panel is ReadinessPanel => Boolean(panel))
+}
+
+function landingPageNeedsRepair(panels: ReadinessPanel[]): boolean {
+  if (panels.length === 0) return true
+  return panels.some((panel) => panel.status !== 'ready')
 }
 
 function readinessPanel(label: string, value: unknown): ReadinessPanel | null {

--- a/plans/PR-Landing-Page-Repair-UI-Polish.md
+++ b/plans/PR-Landing-Page-Repair-UI-Polish.md
@@ -1,0 +1,68 @@
+# PR-Landing-Page-Repair-UI-Polish
+
+## Why this slice exists
+
+The saved-draft repair UI is merged. Review flagged two non-blocking but useful
+operator polish items: failed repairs currently surface raw JSON, and already
+ready landing pages still show the Repair action even though the backend will
+no-op.
+
+This slice addresses those two points without changing the repair API contract
+or the broader review drawer behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-repair-ui-polish
+
+1. Parse repair failure responses into operator-readable messages.
+2. Include the first repair blockers in the drawer error when the backend
+   returns a failed repair result.
+3. Hide the Repair button when all landing-page readiness panels are already
+   `ready`.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Repair-UI-Polish.md` | Plan doc for this polish slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Parse repair endpoint errors instead of showing raw JSON. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Hide Repair for already-ready landing pages. |
+
+## Mechanism
+
+`repairGeneratedLandingPageDraft` now handles the fetch directly so it can parse
+the repair endpoint's structured error body. When the backend returns
+`{detail: {message, repair_result}}`, the UI error becomes a short message plus
+the first blocker labels.
+
+The drawer computes repair availability from the same readiness panels it
+already renders. If every panel is `ready`, Repair is hidden. Missing readiness
+panels still allow Repair because the UI cannot prove the draft is ready.
+
+## Intentional
+
+- No backend changes.
+- No new success toast or status surface.
+- No attempt to parse every API error globally. This is scoped to the repair
+  endpoint because it has a known structured failure shape.
+
+## Deferred
+
+- A broader API error-normalization pass can improve all frontend mutation
+  wrappers later.
+- A backend rate-limit/idempotency slice can add hard cost controls for repeated
+  repair calls.
+
+## Verification
+
+- `npm run build` in `atlas-intel-ui` -> passed.
+- `npm run lint` in `atlas-intel-ui` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| API error parsing | ~45 |
+| Repair button gate | ~10 |
+| Total | ~120 |


### PR DESCRIPTION
## Summary
- parse structured repair 409 responses into readable drawer errors
- include the first repair blockers in the error message
- hide the Repair action when all landing-page readiness panels are already ready

## Verification
- npm run build (atlas-intel-ui)
- npm run lint (atlas-intel-ui)
- bash scripts/local_pr_review.sh