### PR TITLE
PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary.md
@@ -1,0 +1,75 @@
+# PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Scale-Run-Summary-Diagnostics added a compact FAQ CLI
+`diagnostics.run_summary` block for large-upload triage. The scale-smoke wrapper
+still buries that block inside the full CLI `result` payload, so operators have
+to know the nested path before they can compare volume, generated count,
+output-check status, and score shape.
+
+This slice surfaces the FAQ run summary at the scale-smoke layer without
+changing FAQ generation behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Copy `result.diagnostics.run_summary` into top-level
+   `faq_run_summary` in the scale-smoke summary artifact.
+2. Include a compact FAQ health fragment in the scale-smoke console line.
+3. Preserve fail-closed exit behavior and the existing full `result` payload.
+4. Add focused scale-smoke regression coverage for success and output-check
+   failure summaries.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary.md` | Plan doc for this scale-smoke summary slice. |
+| `scripts/smoke_content_ops_faq_scale_run.py` | Surfaces the FAQ CLI run summary in scale-smoke JSON and console output. |
+| `tests/test_smoke_content_ops_faq_scale_run.py` | Covers top-level run summary passthrough and console visibility. |
+
+## Mechanism
+
+`run_scale_smoke(...)` already reads the FAQ CLI result JSON. A small helper will
+extract `diagnostics.run_summary` when present and copy it to a top-level
+`faq_run_summary` key before writing the scale-smoke summary artifact.
+
+The console printer will use the same top-level block, not reparse the nested
+result, to append a short fragment such as generated item count, weighted source
+volume, failed output-check count, and max opportunity score.
+
+## Intentional
+
+- No FAQ CLI, generator, Markdown, or scoring changes.
+- The full CLI `result` payload remains unchanged; this only adds a convenience
+  alias and console visibility at the scale-smoke layer.
+- Missing or older result payloads degrade to `faq=unavailable` rather than
+  failing the wrapper.
+
+## Deferred
+
+- Hosted UI display for `faq_run_summary` remains separate.
+- Updating checked-in historical failure examples can be a later docs/data slice
+  if we want those static artifacts to include the new convenience alias.
+
+## Verification
+
+- Scale-smoke FAQ pytest for `tests/test_smoke_content_ops_faq_scale_run.py` -
+  passed, 18 tests.
+- Py compile for affected Python files - passed.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Scale-smoke summary/console | ~55 |
+| Tests | ~35 |
+| **Total** | ~170 |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -97,6 +97,7 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     stdout_path.write_text(completed.stdout, encoding="utf-8")
     stderr_path.write_text(completed.stderr, encoding="utf-8")
     result_payload = _read_json(result_path)
+    faq_run_summary = _faq_run_summary(result_payload)
     artifact_paths = {
         "markdown": markdown_path,
         "result": result_path,
@@ -120,6 +121,7 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "summary": str(summary_path),
         },
         "artifact_details": _artifact_details(artifact_paths),
+        "faq_run_summary": faq_run_summary,
         "failure": _failure_summary(
             returncode=completed.returncode,
             result_payload=result_payload,
@@ -135,6 +137,16 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     ):
         return 0, summary
     return completed.returncode, summary
+
+
+def _faq_run_summary(result_payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(result_payload, dict):
+        return None
+    diagnostics = result_payload.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return None
+    run_summary = diagnostics.get("run_summary")
+    return dict(run_summary) if isinstance(run_summary, dict) else None
 
 
 def _build_command(
@@ -310,17 +322,18 @@ def _print_scale_summary(summary: Mapping[str, Any]) -> None:
     artifacts = summary.get("artifacts") if isinstance(summary.get("artifacts"), Mapping) else {}
     summary_path = artifacts.get("summary") if isinstance(artifacts, Mapping) else None
     profile = _console_input_profile(summary.get("input_profile"))
+    faq_profile = _console_faq_run_summary(summary.get("faq_run_summary"))
     if summary.get("ok") is True:
         print(
             "Content Ops FAQ scale smoke passed: "
-            f"{profile} summary={summary_path}"
+            f"{profile} {faq_profile} summary={summary_path}"
         )
         return
     failure = summary.get("failure") if isinstance(summary.get("failure"), Mapping) else {}
     failure_type = failure.get("type") if isinstance(failure, Mapping) else None
     print(
         "Content Ops FAQ scale smoke failed: "
-        f"{profile} failure={failure_type or 'unknown'} summary={summary_path}",
+        f"{profile} {faq_profile} failure={failure_type or 'unknown'} summary={summary_path}",
         file=sys.stderr,
     )
 
@@ -346,6 +359,34 @@ def _console_input_profile(value: Any) -> str:
 
 def _console_value(value: Any) -> str:
     return str(value) if value is not None else "unknown"
+
+
+def _console_faq_run_summary(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return "faq=unavailable"
+    parts = ["faq=available"]
+    for key, label in (
+        ("generated", "generated"),
+        ("weighted_source_volume", "weighted_volume"),
+    ):
+        item = value.get(key)
+        if item is not None:
+            parts.append(f"{label}={item}")
+    output_checks = value.get("output_checks")
+    if isinstance(output_checks, Mapping):
+        failed = output_checks.get("failed")
+        total = output_checks.get("total")
+        if failed is not None or total is not None:
+            parts.append(
+                f"checks_failed={_console_value(failed)}/{_console_value(total)}"
+            )
+    score_distribution = value.get("item_score_distribution")
+    if (
+        isinstance(score_distribution, Mapping)
+        and score_distribution.get("max") is not None
+    ):
+        parts.append(f"score_max={score_distribution.get('max')}")
+    return " ".join(parts)
 
 
 def _failure_summary(

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -106,6 +106,10 @@ def test_faq_scale_smoke_writes_standard_artifacts(
     assert result["failed_output_checks"] == []
     assert saved_summary["exit_code"] == 0
     assert saved_summary["result"]["generated"] == result["generated"]
+    assert saved_summary["faq_run_summary"] == result["diagnostics"]["run_summary"]
+    assert saved_summary["faq_run_summary"]["generated"] == result["generated"]
+    assert saved_summary["faq_run_summary"]["weighted_source_volume"] == 4
+    assert saved_summary["faq_run_summary"]["output_checks"]["failed"] == 0
     assert saved_summary["source_format"] == fmt
     assert saved_summary["input_profile"]["status"] == "ok"
     assert saved_summary["input_profile"]["raw_row_count"] == 4
@@ -149,6 +153,9 @@ def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path
     assert summary["failure"]["type"] == "output_checks"
     assert summary["failure"]["failed_output_checks"] == ["condensed"]
     assert "FAQ output checks failed: condensed" in summary["failure"]["stderr_tail"]
+    assert summary["faq_run_summary"] == result["diagnostics"]["run_summary"]
+    assert summary["faq_run_summary"]["status"] == "failed_output_checks"
+    assert summary["faq_run_summary"]["output_checks"]["failed_checks"] == ["condensed"]
     assert summary["input_profile"]["raw_row_count"] == 3
     assert summary["input_profile"]["usable_source_count"] == 2
     assert summary["input_profile"]["warnings_by_code"]["missing_source_text"] == 1
@@ -181,6 +188,7 @@ def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> Non
     assert code != 0
     assert summary["ok"] is False
     assert summary["result"] is None
+    assert summary["faq_run_summary"] is None
     assert summary["input_profile"]["status"] == "error"
     assert "No such file or directory" in summary["input_profile"]["error"]
     assert summary["failure"]["type"] == "cli_error"
@@ -200,6 +208,11 @@ def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path, capsys) -> None:
     assert code == 0
     assert "Content Ops FAQ scale smoke passed:" in captured.out
     assert "source_rows=4/4" in captured.out
+    assert "faq=available" in captured.out
+    assert "generated=2" in captured.out
+    assert "weighted_volume=4" in captured.out
+    assert "checks_failed=0/3" in captured.out
+    assert "score_max=4" in captured.out
     assert "summary=" in captured.out
     assert captured.err == ""
     assert result["input"]["source_format"] == "auto"
@@ -221,6 +234,9 @@ def test_faq_scale_smoke_main_prints_profile_on_failure(tmp_path: Path, capsys) 
     assert captured.out == ""
     assert "Content Ops FAQ scale smoke failed:" in captured.err
     assert "source_rows=2/3" in captured.err
+    assert "faq=available" in captured.err
+    assert "generated=2" in captured.err
+    assert "checks_failed=1/3" in captured.err
     assert "skipped_rows=1" in captured.err
     assert "missing_source_text=1" in captured.err
     assert "failure=output_checks" in captured.err


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Smoke-Run-Summary.md

Surfaces the FAQ CLI `diagnostics.run_summary` block at the scale-smoke layer as top-level `faq_run_summary`, and appends a compact FAQ health fragment to the scale-smoke console output.

## Intentional
- No FAQ generation, Markdown, scoring, or CLI result schema changes.
- The top-level scale-smoke field is a convenience alias for the nested CLI diagnostics block.
- Missing or older result payloads degrade to `faq=unavailable` rather than failing the wrapper.

## Deferred
- Hosted UI display for `faq_run_summary` remains separate.
- Updating checked-in historical failure examples can be a later docs/data slice.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_scale_run.py` — 18 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_scale_run.py` — passed.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed, 0 findings.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` — passed.

## Diff size
3 files, +134 / -2
