### PR TITLE
Guard landing page repair spend

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -29,4 +29,28 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-None yet.
+## 2026-05-22
+
+### Surface skipped landing-page repair locks
+- File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
+- Description: Pools without `acquire()` skip the advisory-lock guard without an operator-visible signal.
+- Why it matters: A host misconfiguration could silently disable duplicate-spend protection.
+- Effort: S
+- Category: polish
+- Found during: PR-Landing-Page-Repair-Cost-Guard review
+
+### Consider a wider advisory-lock hash key
+- File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
+- Description: `hashtext()` is 32-bit, so unrelated draft lock keys could theoretically collide.
+- Why it matters: A collision would create a false `409` for an unrelated draft repair.
+- Effort: S
+- Category: correctness
+- Found during: PR-Landing-Page-Repair-Cost-Guard review
+
+### Revisit repair lock connection hold time
+- File/location: `extracted_content_pipeline/api/generated_assets.py`, `repair_landing_page_draft`
+- Description: The advisory-lock connection stays checked out while the LLM repair runs.
+- Why it matters: This is acceptable for operator-triggered repair, but higher repair volume could turn LLM latency into pool pressure.
+- Effort: M
+- Category: tech-debt
+- Found during: PR-Landing-Page-Repair-Cost-Guard review

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
 from html import escape as html_escape
@@ -48,6 +49,7 @@ ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[
 SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
+_LANDING_PAGE_REPAIR_LOCK_NAMESPACE = "content-assets:landing-page-repair"
 
 
 def _require_fastapi() -> None:
@@ -125,6 +127,60 @@ async def _resolve_required_provider(
     if value is None:
         raise HTTPException(status_code=503, detail=detail)
     return value
+
+
+def _landing_page_repair_lock_key(scope: TenantScope, landing_page_id: str) -> str:
+    account_id = _clean(scope.account_id) or "unscoped"
+    return f"account={account_id}:landing_page={landing_page_id}"
+
+
+@asynccontextmanager
+async def _landing_page_repair_lock(
+    pool: Any,
+    *,
+    scope: TenantScope,
+    landing_page_id: str,
+):
+    """Hold a DB-backed session advisory lock for one repair request.
+
+    The extracted router can run against simple fake pools in tests and host
+    environments. When the injected pool does not expose asyncpg-style
+    ``acquire()``, the context degrades to no locking instead of changing the
+    port contract for every host.
+    """
+
+    acquire = getattr(pool, "acquire", None)
+    if not callable(acquire):
+        yield True
+        return
+
+    lock_key = _landing_page_repair_lock_key(scope, landing_page_id)
+    conn = await _maybe_await(acquire())
+    try:
+        acquired = bool(await conn.fetchval(
+            """
+            SELECT pg_try_advisory_lock(hashtext($1), hashtext($2))
+            """,
+            _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
+            lock_key,
+        ))
+        if not acquired:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            await conn.fetchval(
+                """
+                SELECT pg_advisory_unlock(hashtext($1), hashtext($2))
+                """,
+                _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
+                lock_key,
+            )
+    finally:
+        release = getattr(pool, "release", None)
+        if callable(release):
+            await _maybe_await(release(conn))
 
 
 def _api_limit(value: int | None, config: GeneratedAssetApiConfig) -> int:
@@ -417,31 +473,41 @@ def create_generated_asset_router(
                 status_code=409,
                 detail="approved landing pages cannot be repaired",
             )
-        llm = await _resolve_required_provider(llm_provider, detail="LLM unavailable")
-        skills = await _resolve_required_provider(
-            skills_provider,
-            detail="Landing page generation skills unavailable",
-        )
-        result = await LandingPageGenerationService(
-            landing_pages=repository,
-            llm=llm,
-            skills=skills,
-        ).repair_draft(scope=tenant, draft=existing)
-        result_payload = result.as_dict()
-        if result.generated == 0 and result.skipped > 0:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "message": "landing page draft could not be repaired",
-                    "repair_result": result_payload,
-                },
+        async with _landing_page_repair_lock(
+            pool,
+            scope=tenant,
+            landing_page_id=landing_page_id,
+        ) as repair_lock_acquired:
+            if not repair_lock_acquired:
+                raise HTTPException(
+                    status_code=409,
+                    detail="landing page draft repair already in progress",
+                )
+            llm = await _resolve_required_provider(llm_provider, detail="LLM unavailable")
+            skills = await _resolve_required_provider(
+                skills_provider,
+                detail="Landing page generation skills unavailable",
             )
-        refreshed = await repository.get_draft(landing_page_id, scope=tenant)
-        if refreshed is None:
-            raise HTTPException(status_code=404, detail="Landing page draft not found")
-        row = landing_page_draft_export_row(refreshed)
-        row["repair_result"] = result_payload
-        return row
+            result = await LandingPageGenerationService(
+                landing_pages=repository,
+                llm=llm,
+                skills=skills,
+            ).repair_draft(scope=tenant, draft=existing)
+            result_payload = result.as_dict()
+            if result.generated == 0 and result.skipped > 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": "landing page draft could not be repaired",
+                        "repair_result": result_payload,
+                    },
+                )
+            refreshed = await repository.get_draft(landing_page_id, scope=tenant)
+            if refreshed is None:
+                raise HTTPException(status_code=404, detail="Landing page draft not found")
+            row = landing_page_draft_export_row(refreshed)
+            row["repair_result"] = result_payload
+            return row
 
     return router
 

--- a/plans/PR-Landing-Page-Repair-Cost-Guard.md
+++ b/plans/PR-Landing-Page-Repair-Cost-Guard.md
@@ -1,0 +1,94 @@
+# PR-Landing-Page-Repair-Cost-Guard
+
+## Why this slice exists
+
+Saved landing-page repair now calls the LLM from the review drawer. That is the
+right operator workflow, but the endpoint should not spend twice when a user
+double-clicks Repair, the browser retries, or two operators repair the same
+draft at the same time.
+
+This slice adds a backend in-flight guard at the repair endpoint so duplicate
+repair requests for the same tenant-scoped landing-page draft fail before LLM
+provider resolution or prompt generation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-repair-cost-guard
+
+1. Add a Postgres advisory lock around saved landing-page draft repair.
+2. Return `409` for duplicate in-flight repair requests before LLM work starts.
+3. Release the advisory lock after successful or failed repair handling.
+4. Add API tests for lock acquisition, lock release, and duplicate-request
+   rejection before LLM calls.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Repair-Cost-Guard.md` | Plan doc for this cost-control slice. |
+| `HARDENING.md` | Park non-blocking review findings outside this thin slice. |
+| `extracted_content_pipeline/api/generated_assets.py` | Add tenant-scoped landing-page repair advisory lock around the repair endpoint. |
+| `tests/test_extracted_content_asset_api.py` | Cover successful lock release and duplicate in-flight repair rejection. |
+
+## Mechanism
+
+The repair endpoint already loads the draft through tenant-scoped repository
+access before it resolves LLM and skill providers. After that load and the
+approved-row guard, this slice acquires a Postgres session advisory lock using
+a stable namespace plus an account/draft lock key. The key follows the draft's
+repository scope, so two operators in the same account contend for the same
+draft lock.
+
+If the lock is already held, the endpoint returns `409` with
+`landing page draft repair already in progress` and does not resolve providers
+or call the LLM. If the lock is acquired, the existing repair service runs
+unchanged and the lock is released in a `finally` block through the same manual
+pool connection. The same connection is then released back to the pool.
+
+The extracted router still supports host test doubles or non-asyncpg pools that
+do not expose `acquire()`. Those environments get the existing behavior instead
+of a new hard port requirement.
+
+## Intentional
+
+- No UI-only debounce. The guard lives at the backend integration point where
+  spend is triggered.
+- No new draft status such as `repairing`, avoiding a migration and avoiding a
+  row that can get stuck if a process dies mid-request.
+- No sequential daily/monthly quota in this slice. This protects duplicate
+  in-flight requests, which is the immediate double-spend risk from the repair
+  button.
+
+## Deferred
+
+- `PR-Landing-Page-Repair-Quota` can add persisted per-draft or per-tenant
+  repair-attempt quotas if operators need hard spend budgets across time.
+- `PR-Landing-Page-Repair-Audit-Trail` can persist repair attempt metadata for
+  failed attempts, not just successful repaired drafts.
+
+## Parked hardening
+
+- Surface skipped landing-page repair locks when a host pool has no
+  `acquire()` method.
+- Consider a wider advisory-lock hash key than `hashtext()`.
+- Revisit holding the repair lock connection across LLM latency if repair
+  volume grows.
+
+## Verification
+
+- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
+  passed.
+- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 51 passed.
+- Extracted content pipeline validation -> passed.
+- Extracted reasoning import guard -> passed.
+- Extracted standalone audit -> passed with 0 findings.
+- ASCII Python policy -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan and hardening docs | ~105 |
+| API repair lock | ~115 |
+| API tests | ~110 |
+| Total | ~330 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -97,6 +97,40 @@ class _EditableLandingPagePool(_Pool):
         return [self.row]
 
 
+class _RepairLockConnection:
+    def __init__(self, pool, *, acquired: bool) -> None:
+        self.pool = pool
+        self.acquired = acquired
+
+    async def fetchval(self, query, *args):
+        self.pool.lock_calls.append((str(query), args))
+        if "pg_try_advisory_lock" in str(query):
+            return self.acquired
+        if "pg_advisory_unlock" in str(query):
+            self.pool.unlocked = True
+            return True
+        raise AssertionError(f"unexpected lock query: {query}")
+
+
+class _LockingEditableLandingPagePool(_EditableLandingPagePool):
+    def __init__(self, row=None, *, lock_acquired: bool = True) -> None:
+        super().__init__(row)
+        self.lock_acquired = lock_acquired
+        self.lock_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.acquire_calls = 0
+        self.release_calls = 0
+        self.released_connections = []
+        self.unlocked = False
+
+    async def acquire(self):
+        self.acquire_calls += 1
+        return _RepairLockConnection(self, acquired=self.lock_acquired)
+
+    async def release(self, conn):
+        self.release_calls += 1
+        self.released_connections.append(conn)
+
+
 class _LLM:
     def __init__(self, responses) -> None:
         self.responses = list(responses)
@@ -652,7 +686,7 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
             if key != "description"
         },
     }
-    pool = _EditableLandingPagePool(needs_repair)
+    pool = _LockingEditableLandingPagePool(needs_repair)
     llm = _LLM([_landing_page_generation_response(repaired_row)])
     skills = _Skills()
 
@@ -698,6 +732,63 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
     assert '"repair_mode":"saved_draft"' in system_prompt
     assert '"repair_issues":["seo_aeo_readiness:meta_description"]' in system_prompt
     assert skills.calls == ["digest/landing_page_generation"]
+    assert pool.acquire_calls == 1
+    assert pool.release_calls == 1
+    assert pool.released_connections
+    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
+    assert pool.unlocked is True
+
+
+def test_landing_page_repair_lock_key_is_account_scoped() -> None:
+    landing_page_id = "11111111-1111-1111-1111-111111111111"
+
+    first_key = asset_api._landing_page_repair_lock_key(
+        TenantScope(account_id="acct_1", user_id="user_1"),
+        landing_page_id,
+    )
+    second_key = asset_api._landing_page_repair_lock_key(
+        TenantScope(account_id="acct_1", user_id="user_2"),
+        landing_page_id,
+    )
+
+    assert first_key == second_key
+    assert first_key == (
+        "account=acct_1:landing_page=11111111-1111-1111-1111-111111111111"
+    )
+
+
+def test_generated_asset_router_blocks_concurrent_landing_page_repair_before_llm() -> None:
+    row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    row["meta"] = {
+        key: value
+        for key, value in row["meta"].items()
+        if key != "description"
+    }
+    pool = _LockingEditableLandingPagePool(row, lock_acquired=False)
+    llm = _LLM([])
+    skills = _Skills()
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "landing page draft repair already in progress"
+    assert len(pool.fetch_calls) == 1
+    assert pool.acquire_calls == 1
+    assert pool.release_calls == 1
+    assert pool.released_connections
+    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert pool.unlocked is False
+    assert llm.calls == []
+    assert skills.calls == []
 
 
 def test_generated_asset_router_repair_requires_llm_provider() -> None:
@@ -773,7 +864,7 @@ def test_generated_asset_router_returns_repair_result_when_repair_fails() -> Non
         for key, value in needs_repair["meta"].items()
         if key != "description"
     }
-    pool = _EditableLandingPagePool(needs_repair)
+    pool = _LockingEditableLandingPagePool(needs_repair)
     llm = _LLM([_landing_page_generation_response(needs_repair)])
     skills = _Skills()
 
@@ -797,6 +888,12 @@ def test_generated_asset_router_returns_repair_result_when_repair_fails() -> Non
         "seo_aeo_readiness:meta_description"
     ]
     assert len(pool.fetch_calls) == 1
+    assert pool.acquire_calls == 1
+    assert pool.release_calls == 1
+    assert pool.released_connections
+    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
+    assert pool.unlocked is True
     assert len(llm.calls) == 1
     assert skills.calls == ["digest/landing_page_generation"]
 


### PR DESCRIPTION
# PR-Landing-Page-Repair-Cost-Guard

## Why this slice exists

Saved landing-page repair now calls the LLM from the review drawer. That is the
right operator workflow, but the endpoint should not spend twice when a user
double-clicks Repair, the browser retries, or two operators repair the same
draft at the same time.

This slice adds a backend in-flight guard at the repair endpoint so duplicate
repair requests for the same tenant-scoped landing-page draft fail before LLM
provider resolution or prompt generation.

## Scope (this PR)

Ownership lane: content-ops/landing-page-repair-cost-guard

1. Add a Postgres advisory lock around saved landing-page draft repair.
2. Return `409` for duplicate in-flight repair requests before LLM work starts.
3. Release the advisory lock after successful or failed repair handling.
4. Add API tests for lock acquisition, lock release, and duplicate-request
   rejection before LLM calls.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Repair-Cost-Guard.md` | Plan doc for this cost-control slice. |
| `HARDENING.md` | Park non-blocking review findings outside this thin slice. |
| `extracted_content_pipeline/api/generated_assets.py` | Add tenant-scoped landing-page repair advisory lock around the repair endpoint. |
| `tests/test_extracted_content_asset_api.py` | Cover successful lock release and duplicate in-flight repair rejection. |

## Mechanism

The repair endpoint already loads the draft through tenant-scoped repository
access before it resolves LLM and skill providers. After that load and the
approved-row guard, this slice acquires a Postgres session advisory lock using
a stable namespace plus an account/draft lock key. The key follows the draft's
repository scope, so two operators in the same account contend for the same
draft lock.

If the lock is already held, the endpoint returns `409` with
`landing page draft repair already in progress` and does not resolve providers
or call the LLM. If the lock is acquired, the existing repair service runs
unchanged and the lock is released in a `finally` block through the same manual
pool connection. The same connection is then released back to the pool.

The extracted router still supports host test doubles or non-asyncpg pools that
do not expose `acquire()`. Those environments get the existing behavior instead
of a new hard port requirement.

## Intentional

- No UI-only debounce. The guard lives at the backend integration point where
  spend is triggered.
- No new draft status such as `repairing`, avoiding a migration and avoiding a
  row that can get stuck if a process dies mid-request.
- No sequential daily/monthly quota in this slice. This protects duplicate
  in-flight requests, which is the immediate double-spend risk from the repair
  button.

## Deferred

- `PR-Landing-Page-Repair-Quota` can add persisted per-draft or per-tenant
  repair-attempt quotas if operators need hard spend budgets across time.
- `PR-Landing-Page-Repair-Audit-Trail` can persist repair attempt metadata for
  failed attempts, not just successful repaired drafts.

## Parked hardening

- Surface skipped landing-page repair locks when a host pool has no
  `acquire()` method.
- Consider a wider advisory-lock hash key than `hashtext()`.
- Revisit holding the repair lock connection across LLM latency if repair
  volume grows.

## Verification

- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
  passed.
- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 51 passed.
- Extracted content pipeline validation -> passed.
- Extracted reasoning import guard -> passed.
- Extracted standalone audit -> passed with 0 findings.
- ASCII Python policy -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Plan and hardening docs | ~105 |
| API repair lock | ~115 |
| API tests | ~110 |
| Total | ~330 |
