### PR TITLE
Rank deep-dive pain section by urgency to match the radar (D3)

### DIFF
--- a/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
@@ -172,16 +172,16 @@ const post: BlogPost = {
 <p>One Trustpilot reviewer captured the support frustration directly: "to sign up and promise the world, Then no service. No support and they don't care."</p>
 <p>The data does not support claims that these weaknesses affect all users or that they represent product capability gaps. What it does show is a pattern of reviewer-reported friction concentrated in specific operational areas.</p>
 <h2 id="where-pipedrive-users-feel-the-most-pain">Where Pipedrive Users Feel the Most Pain</h2>
-<p>Breaking down pain categories by mention frequency reveals where friction surfaces most often in reviewer experience.</p>
+<p>Breaking down pain categories by reviewer urgency reveals where the most acute friction concentrates.</p>
 <p>{{chart:pain-radar}}</p>
-<p>Pricing emerges as the dominant pain category, followed by UX friction and support quality concerns. Contract lock-in and data migration appear as secondary pain points.</p>
+<p>UX friction emerges as the most acute pain category (urgency 10.0), followed by pricing (7.2) and contract lock-in (6.8). Data migration, API limitations, and support concerns appear at lower intensity.</p>
 <p>The pricing complaints show specific patterns. One Reddit reviewer mentioned Pipedrive at "$15/user/mo" while evaluating alternatives, noting "basic" reporting capabilities. Another reviewer signaled pricing backlash within a 2-month window, indicating recent friction rather than historical grievance.</p>
 <blockquote>
 <p>I recently had the challenge to find the right CRM for our company.</p>
 <p>-- reviewer on Reddit</p>
 </blockquote>
 <p>Support complaints cluster around billing disputes and escalation failures. The Trustpilot reviewer who mentioned "no service. No support and they don't care" represents a broader pattern of support responsiveness concerns when billing issues arise.</p>
-<p>UX pain points appear less acute than pricing or support friction, but reviewers mention interface limitations and workflow constraints. One Software Advice reviewer noted "limited built-in marketing tools mean you'll need integrations for a complete solution," pointing to feature gaps rather than fundamental usability problems.</p>
+<p>UX pain points carry the highest urgency in the radar, with reviewers citing interface limitations and workflow constraints. One Software Advice reviewer noted "limited built-in marketing tools mean you'll need integrations for a complete solution," pointing to feature gaps rather than fundamental usability problems.</p>
 <p>The radar chart distribution suggests Pipedrive faces multiple friction points rather than a single catastrophic weakness. No single pain category dominates to the exclusion of others, indicating varied user contexts and deployment scenarios.</p>
 <h2 id="the-pipedrive-ecosystem-integrations-use-cases">The Pipedrive Ecosystem: Integrations &amp; Use Cases</h2>
 <p>Pipedrive's integration landscape and typical deployment patterns reveal how teams actually use the platform beyond vendor marketing.</p>

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -8144,9 +8144,18 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
 
     # Pain signals chart
     if signals:
+        # D3: sort by urgency so the radar's visual peak, the deterministic
+        # data_summary ranking, and the description's "most acute pain" framing
+        # all agree on the SAME metric (urgency, the chart's dataKey). Before,
+        # pain_data took signals in frequency order while the chart plotted
+        # urgency, so the description leaned on frequency ("Pricing dominant")
+        # while the radar's urgency peak was a different category.
+        sorted_signals = sorted(
+            signals, key=lambda s: s.get("avg_urgency", 0) or 0, reverse=True
+        )
         pain_data = [
             {"name": s["pain_category"] or "Other", "urgency": s["avg_urgency"]}
-            for s in signals[:6]
+            for s in sorted_signals[:6]
         ]
         pain_chart = ChartSpec(
             chart_id="pain-radar",
@@ -8159,11 +8168,17 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
             },
         )
         charts.append(pain_chart)
+        top = pain_data[0]
         sections.append(SectionSpec(
             id="pain_analysis",
             heading=f"Where {vendor} Users Feel the Most Pain",
-            goal="Break down the top pain categories from review analysis",
+            goal="Break down the top pain categories from review analysis by reviewer urgency",
             chart_ids=["pain-radar"],
+            data_summary=(
+                f"Pain categories ranked by reviewer urgency (0-10). "
+                f"{top['name']} shows the most acute friction (urgency {top['urgency']}), "
+                f"followed by: {', '.join(p['name'] for p in pain_data[1:4])}."
+            ),
         ))
 
     # Integrations and use cases -- prefer mention-counted extended context over flat profile arrays

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -8144,9 +8144,18 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
 
     # Pain signals chart
     if signals:
+        # D3: sort by urgency so the radar's visual peak, the deterministic
+        # data_summary ranking, and the description's "most acute pain" framing
+        # all agree on the SAME metric (urgency, the chart's dataKey). Before,
+        # pain_data took signals in frequency order while the chart plotted
+        # urgency, so the description leaned on frequency ("Pricing dominant")
+        # while the radar's urgency peak was a different category.
+        sorted_signals = sorted(
+            signals, key=lambda s: s.get("avg_urgency", 0) or 0, reverse=True
+        )
         pain_data = [
             {"name": s["pain_category"] or "Other", "urgency": s["avg_urgency"]}
-            for s in signals[:6]
+            for s in sorted_signals[:6]
         ]
         pain_chart = ChartSpec(
             chart_id="pain-radar",
@@ -8159,11 +8168,17 @@ def _blueprint_vendor_deep_dive(ctx: dict, data: dict) -> PostBlueprint:
             },
         )
         charts.append(pain_chart)
+        top = pain_data[0]
         sections.append(SectionSpec(
             id="pain_analysis",
             heading=f"Where {vendor} Users Feel the Most Pain",
-            goal="Break down the top pain categories from review analysis",
+            goal="Break down the top pain categories from review analysis by reviewer urgency",
             chart_ids=["pain-radar"],
+            data_summary=(
+                f"Pain categories ranked by reviewer urgency (0-10). "
+                f"{top['name']} shows the most acute friction (urgency {top['urgency']}), "
+                f"followed by: {', '.join(p['name'] for p in pain_data[1:4])}."
+            ),
         ))
 
     # Integrations and use cases -- prefer mention-counted extended context over flat profile arrays

--- a/plans/PR-Blog-D3-Dominant-Pain-Metric.md
+++ b/plans/PR-Blog-D3-Dominant-Pain-Metric.md
@@ -1,0 +1,93 @@
+# PR-Blog-D3-Dominant-Pain-Metric
+
+Ownership lane: `content-ops/blog-d3-dominant-pain-metric`
+
+## Why this slice exists
+
+Defect **D3** (pipedrive cluster): the "Where Pipedrive Users Feel the Most
+Pain" section's prose ranked pain by FREQUENCY ("Pricing emerges as the dominant
+pain category") while the pain-radar chart it introduces plots URGENCY -- where
+UX (10.0) is the peak, not pricing (7.2). The prose also mislabeled the chart as
+"by mention frequency", and a later line ("UX pain points appear less acute than
+pricing or support friction") directly contradicted UX being the urgency peak.
+
+Root cause: the `pain_analysis` section had NO `data_summary`, so the LLM
+free-wrote the ranking; and `pain_data` took `signals[:6]` in frequency order
+while the chart's `dataKey` is urgency -- so prose and chart used different
+metrics.
+
+## Scope (this PR)
+
+- **Generator** (`_blueprint_vendor_deep_dive`, both byte-identical copies):
+  sort signals by urgency before building `pain_data`, and add a deterministic
+  `data_summary` that states the metric ("by reviewer urgency, 0-10") and the
+  urgency-ranked top categories.
+- **Data** (`pipedrive-deep-dive-2026-04.ts`): three sentences re-framed to the
+  chart's urgency truth (UX 10.0 > pricing 7.2 > contract lock-in 6.8).
+
+### Files touched
+
+- `plans/PR-Blog-D3-Dominant-Pain-Metric.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation.py`
+- `atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts`
+
+## Mechanism
+
+`sorted_signals = sorted(signals, key=avg_urgency, reverse=True)` feeds
+`pain_data` (so the radar's first/peak entry is the highest-urgency category),
+and the `pain_analysis` section gains a `data_summary`:
+"Pain categories ranked by reviewer urgency (0-10). {top} shows the most acute
+friction (urgency {n}), followed by: ...". The empty case is guarded by the
+existing `if signals:`.
+
+Data (urgency values read from the published chart, not assumed):
+- L175: "by mention frequency ... most often" -> "by reviewer urgency ... most
+  acute friction concentrates."
+- L177: "Pricing emerges as the dominant ..." -> "UX friction emerges as the
+  most acute pain category (urgency 10.0), followed by pricing (7.2) and
+  contract lock-in (6.8). Data migration, API limitations, and support concerns
+  appear at lower intensity." (same shape, urgency-correct ranking)
+- L184: "UX pain points appear less acute than pricing or support friction ..."
+  -> "UX pain points carry the highest urgency in the radar ..." (the Software
+  Advice quote + "feature gaps" conclusion are unchanged).
+
+## Intentional
+
+- **Urgency is the canonical metric for this section.** The chart is hardwired
+  to urgency; "most pain" maps to intensity, not count; and the frequency view
+  is a different chart. So prose + chart + data_summary all rank by urgency.
+- **Read the chart, not the recalled values.** Support is urgency 3.0 (lowest),
+  not high -- it's frequently complained about but low-intensity; L183 (which is
+  about complaint frequency/kind) correctly stays. L185 ("no single category
+  dominates") stays -- 10/7.2/6.8/4.1/3.5/3.0 is a spread, not catastrophic.
+
+## Deferred
+
+- **D3-followup:** harmonize the OTHER pain view -- the frequency-ranked
+  pain-category chart and its prose -- if both the urgency and frequency views
+  remain in the post (design work, not this slice).
+- **D4** (strengths/weaknesses chart mislabel).
+
+## Verification
+
+- New `test_deep_dive_pain_section_ranks_by_urgency_not_frequency`: signals where
+  pricing is most frequent but ux most urgent -> the radar's first entry and the
+  data_summary "most acute" are both ux, and the metric is labeled "reviewer
+  urgency". Verified it FAILS on revert to the unsorted `signals[:6]` (radar[0]
+  == "pricing").
+- `pytest` generation + quote-gate suites -> 198 passed; both copies
+  byte-identical.
+- Data: no stale "dominant pain"/"mention frequency"/"less acute"; the post now
+  reads UX-most-acute consistent with the chart; audit clean.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (urgency sort + data_summary) | ~40 |
+| Test | ~40 |
+| pipedrive data (3 sentences) | ~6 |
+| Plan doc | ~95 |
+| **Total** | **~180** |

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -1205,6 +1205,42 @@ def test_deep_dive_competitor_list_excludes_self_and_case_dedups():
     assert "5 alternatives" in comp.data_summary
 
 
+def test_deep_dive_pain_section_ranks_by_urgency_not_frequency():
+    """D3: the pain-radar section must rank by reviewer URGENCY (the chart's
+    dataKey), not signals' frequency order. Otherwise the description called a
+    high-frequency/low-urgency category "dominant" while the radar's urgency
+    peak was a different category (pipedrive: prose said "Pricing dominant" but
+    the radar peak was UX at 10.0). Feed signals where pricing is most FREQUENT
+    but ux is most URGENT; the radar's first entry and the section's
+    data_summary "most acute" must both be ux, and the metric must be labeled.
+    Reverting the sort fails this."""
+    blueprint = blog_mod._blueprint_vendor_deep_dive(
+        {
+            "vendor": "Pipedrive",
+            "category": "CRM",
+            "review_count": 42,
+            "profile_richness": 4,
+            "slug": "pipedrive-deep-dive-2026-04",
+        },
+        {
+            "profile": {},
+            "quotes": [],
+            "data_context": {"vendor": "Pipedrive", "category": "CRM",
+                             "review_period": "2026-02 to 2026-04"},
+            "signals": [
+                {"pain_category": "pricing", "avg_urgency": 5.0, "signal_count": 100, "feature_gaps": []},
+                {"pain_category": "ux", "avg_urgency": 9.0, "signal_count": 10, "feature_gaps": []},
+                {"pain_category": "support", "avg_urgency": 3.0, "signal_count": 50, "feature_gaps": []},
+            ],
+        },
+    )
+    radar = next(c for c in blueprint.charts if c.chart_id == "pain-radar")
+    assert radar.data[0]["name"] == "ux"   # urgency-sorted (9.0), not frequency (pricing 100)
+    pain = next(s for s in blueprint.sections if s.id == "pain_analysis")
+    assert "reviewer urgency" in pain.data_summary
+    assert "ux shows the most acute friction" in pain.data_summary
+
+
 def test_blueprint_vendor_deep_dive_promotes_reasoning_sections():
     blueprint = blog_mod._blueprint_vendor_deep_dive(
         {


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d3-dominant-pain-metric`

**D3** (pipedrive cluster): the "Where Pipedrive Users Feel the Most Pain" section ranked pain by **frequency** ("Pricing emerges as the dominant pain category") while the pain-radar it introduces plots **urgency** — where UX (10.0) is the peak, not pricing (7.2). It also mislabeled the chart "by mention frequency", and a later line ("UX pain points appear less acute than pricing or support friction") contradicted UX being the urgency peak.

## Intentional

- **Root cause:** the `pain_analysis` section had **no `data_summary`** (LLM free-wrote the ranking), and `pain_data` took `signals[:6]` in frequency order while the chart's `dataKey` is urgency.
- **Generator** (`_blueprint_vendor_deep_dive`, both copies): sort signals by `avg_urgency` before `pain_data` (so the radar's peak is the highest-urgency category) and add a deterministic `data_summary` ("ranked by reviewer urgency (0-10); {top} shows the most acute friction…"). Existing `if signals:` guards the empty case.
- **Urgency is canonical here** — the chart is hardwired to urgency, "most pain" = intensity, and frequency is a *different* chart. I read the urgency values **off the published chart** (Ux 10.0, Pricing 7.2, contract_lock_in 6.8, Support **3.0** — support is frequently complained about but low-urgency), not from memory.
- **Data** (`pipedrive-deep-dive-2026-04.ts`), 3 sentences re-framed to that truth: L175 (metric label), L177 (urgency ranking), L184 (UX framing). L183 (support complaint *kind*) and L185 (spread) left — both still accurate.

## Deferred

- **D3-followup:** harmonize the *other* pain view (the frequency-ranked pain-category chart + prose) if both views remain — design work.
- **D4** (strengths/weaknesses chart mislabel).

## Verification

- New `test_deep_dive_pain_section_ranks_by_urgency_not_frequency`: signals where pricing is most *frequent* but ux most *urgent* → radar's first entry and the data_summary "most acute" are both **ux**, metric labeled "reviewer urgency". **Verified it fails on revert** to unsorted `signals[:6]` (`'pricing' == 'ux'`).
- generation + quote-gate suites → **198 passed**; both copies byte-identical; audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)