### PR TITLE
Warn when landing page repair lock is skipped

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -31,14 +31,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-22
 
-### Surface skipped landing-page repair locks
-- File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
-- Description: Pools without `acquire()` skip the advisory-lock guard without an operator-visible signal.
-- Why it matters: A host misconfiguration could silently disable duplicate-spend protection.
-- Effort: S
-- Category: polish
-- Found during: PR-Landing-Page-Repair-Cost-Guard review
-
 ### Consider a wider advisory-lock hash key
 - File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
 - Description: `hashtext()` is 32-bit, so unrelated draft lock keys could theoretically collide.

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
 from html import escape as html_escape
+import logging
 from typing import Any
 from uuid import UUID
 
@@ -50,6 +51,7 @@ SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 _LANDING_PAGE_REPAIR_LOCK_NAMESPACE = "content-assets:landing-page-repair"
+logger = logging.getLogger(__name__)
 
 
 def _require_fastapi() -> None:
@@ -151,6 +153,13 @@ async def _landing_page_repair_lock(
 
     acquire = getattr(pool, "acquire", None)
     if not callable(acquire):
+        logger.warning(
+            "Landing page repair advisory lock skipped because pool has no acquire()",
+            extra={
+                "landing_page_id": landing_page_id,
+                "account_id": _clean(scope.account_id) or None,
+            },
+        )
         yield True
         return
 

--- a/plans/PR-Landing-Page-Repair-Lock-Skip-Warning.md
+++ b/plans/PR-Landing-Page-Repair-Lock-Skip-Warning.md
@@ -1,0 +1,80 @@
+# PR-Landing-Page-Repair-Lock-Skip-Warning
+
+## Why this slice exists
+
+`PR-Landing-Page-Repair-Cost-Guard` added an advisory-lock guard around saved
+landing-page repair. The extracted router still supports host pools that do not
+expose `acquire()`, but that fallback silently skips duplicate-spend
+protection. That was parked in `HARDENING.md`.
+
+This slice drains that parked item with the thinnest real end-to-end behavior:
+when repair continues without a lock because the pool has no `acquire()`, the
+router emits an operator-visible warning.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-repair-lock-skip-warning
+
+1. Log a warning when the landing-page repair lock fallback skips advisory
+   locking because the injected pool has no `acquire()`.
+2. Include the account id and landing-page id in the log record.
+3. Add route-level coverage proving repair still works and the warning is
+   emitted.
+4. Remove the drained parked item from `HARDENING.md`.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Repair-Lock-Skip-Warning.md` | Plan doc for this hardening-drain slice. |
+| `HARDENING.md` | Remove the drained skipped-lock visibility item. |
+| `extracted_content_pipeline/api/generated_assets.py` | Emit a warning when repair locking is skipped. |
+| `tests/test_extracted_content_asset_api.py` | Cover the fallback warning through the repair route. |
+
+## Mechanism
+
+`_landing_page_repair_lock` already detects pools without `acquire()` and
+continues without locking so lightweight extracted hosts do not need to adopt a
+new pool port. This slice keeps that behavior, but logs a warning before the
+fallback yields.
+
+The focused test uses the existing no-`acquire()` editable pool and calls the
+real repair route. It asserts the repair succeeds, the LLM is called once, and
+the warning includes the account id and landing-page id.
+
+## Intentional
+
+- No new hard pool requirement for extracted hosts.
+- No quota or lock redesign.
+- No attempt to drain the remaining `hashtext()` or connection-hold parked
+  items in this slice.
+
+## Deferred
+
+- `HARDENING.md` still tracks the theoretical `hashtext()` collision risk.
+- `HARDENING.md` still tracks repair lock connection hold time across LLM
+  latency.
+
+## Parked hardening
+
+- None added. This slice drains the skipped-lock visibility item and leaves the
+  unrelated parked items in place.
+
+## Verification
+
+- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
+  passed.
+- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 52 passed.
+- Extracted content pipeline validation -> passed.
+- Extracted reasoning import guard -> passed.
+- Extracted standalone audit -> passed with 0 findings.
+- ASCII Python policy -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan and hardening docs | ~70 |
+| API warning | ~10 |
+| API test | ~35 |
+| Total | ~115 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -738,6 +739,42 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
     assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
     assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
     assert pool.unlocked is True
+
+
+def test_generated_asset_router_warns_when_landing_page_repair_lock_is_skipped(caplog) -> None:
+    repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    needs_repair = {
+        **repaired_row,
+        "meta": {
+            key: value
+            for key, value in repaired_row["meta"].items()
+            if key != "description"
+        },
+    }
+    pool = _EditableLandingPagePool(needs_repair)
+    llm = _LLM([_landing_page_generation_response(repaired_row)])
+    skills = _Skills()
+    caplog.set_level(logging.WARNING, logger=asset_api.__name__)
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["repair_result"]["generated"] == 1
+    assert len(llm.calls) == 1
+    assert any(
+        "repair advisory lock skipped" in record.getMessage()
+        and record.landing_page_id == "11111111-1111-1111-1111-111111111111"
+        and record.account_id == "acct_1"
+        for record in caplog.records
+    )
 
 
 def test_landing_page_repair_lock_key_is_account_scoped() -> None:


### PR DESCRIPTION
# PR-Landing-Page-Repair-Lock-Skip-Warning

## Why this slice exists

`PR-Landing-Page-Repair-Cost-Guard` added an advisory-lock guard around saved
landing-page repair. The extracted router still supports host pools that do not
expose `acquire()`, but that fallback silently skips duplicate-spend
protection. That was parked in `HARDENING.md`.

This slice drains that parked item with the thinnest real end-to-end behavior:
when repair continues without a lock because the pool has no `acquire()`, the
router emits an operator-visible warning.

## Scope (this PR)

Ownership lane: content-ops/landing-page-repair-lock-skip-warning

1. Log a warning when the landing-page repair lock fallback skips advisory
   locking because the injected pool has no `acquire()`.
2. Include the account id and landing-page id in the log record.
3. Add route-level coverage proving repair still works and the warning is
   emitted.
4. Remove the drained parked item from `HARDENING.md`.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Repair-Lock-Skip-Warning.md` | Plan doc for this hardening-drain slice. |
| `HARDENING.md` | Remove the drained skipped-lock visibility item. |
| `extracted_content_pipeline/api/generated_assets.py` | Emit a warning when repair locking is skipped. |
| `tests/test_extracted_content_asset_api.py` | Cover the fallback warning through the repair route. |

## Mechanism

`_landing_page_repair_lock` already detects pools without `acquire()` and
continues without locking so lightweight extracted hosts do not need to adopt a
new pool port. This slice keeps that behavior, but logs a warning before the
fallback yields.

The focused test uses the existing no-`acquire()` editable pool and calls the
real repair route. It asserts the repair succeeds, the LLM is called once, and
the warning includes the account id and landing-page id.

## Intentional

- No new hard pool requirement for extracted hosts.
- No quota or lock redesign.
- No attempt to drain the remaining `hashtext()` or connection-hold parked
  items in this slice.

## Deferred

- `HARDENING.md` still tracks the theoretical `hashtext()` collision risk.
- `HARDENING.md` still tracks repair lock connection hold time across LLM
  latency.

## Parked hardening

- None added. This slice drains the skipped-lock visibility item and leaves the
  unrelated parked items in place.

## Verification

- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
  passed.
- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 52 passed.
- Extracted content pipeline validation -> passed.
- Extracted reasoning import guard -> passed.
- Extracted standalone audit -> passed with 0 findings.
- ASCII Python policy -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Plan and hardening docs | ~70 |
| API warning | ~10 |
| API test | ~35 |
| Total | ~115 |
