### PR TITLE
Widen landing page repair lock hash

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -24,6 +24,7 @@ register under `docs/technical-debt/`.
 - Why it matters:
 - Effort: S / M / L
 - Category: correctness / polish / tech-debt / security
+- Owner/session:
 - Found during:
 ```
 
@@ -36,13 +37,14 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-22
 
-### Consider a wider advisory-lock hash key
+### Remove landing-page repair legacy lock after rollout
 - File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
-- Description: `hashtext()` is 32-bit, so unrelated draft lock keys could theoretically collide.
-- Why it matters: A collision would create a false `409` for an unrelated draft repair.
+- Description: The repair lock still acquires the legacy `hashtext()` advisory lock for rolling-deploy compatibility while also acquiring the widened `hashtextextended()` lock.
+- Why it matters: After the widened-lock release is fully deployed, keeping the legacy compatibility lock preserves the old 32-bit collision surface as a transition guard.
 - Effort: S
-- Category: correctness
-- Found during: PR-Landing-Page-Repair-Cost-Guard review
+- Category: tech-debt
+- Owner/session: landing-page repair session
+- Found during: PR-Landing-Page-Repair-Lock-Hash-Key review
 
 ### Revisit repair lock connection hold time
 - File/location: `extracted_content_pipeline/api/generated_assets.py`, `repair_landing_page_draft`
@@ -50,4 +52,5 @@ register under `docs/technical-debt/`.
 - Why it matters: This is acceptable for operator-triggered repair, but higher repair volume could turn LLM latency into pool pressure.
 - Effort: M
 - Category: tech-debt
+- Owner/session: landing-page repair session
 - Found during: PR-Landing-Page-Repair-Cost-Guard review

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -51,6 +51,7 @@ SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 _LANDING_PAGE_REPAIR_LOCK_NAMESPACE = "content-assets:landing-page-repair"
+_LANDING_PAGE_REPAIR_LOCK_HASH_SEED = 0
 logger = logging.getLogger(__name__)
 
 
@@ -133,6 +134,17 @@ async def _resolve_required_provider(
 
 def _landing_page_repair_lock_key(scope: TenantScope, landing_page_id: str) -> str:
     account_id = _clean(scope.account_id) or "unscoped"
+    return (
+        f"{_LANDING_PAGE_REPAIR_LOCK_NAMESPACE}:"
+        f"account={account_id}:landing_page={landing_page_id}"
+    )
+
+
+def _landing_page_repair_legacy_lock_key(
+    scope: TenantScope,
+    landing_page_id: str,
+) -> str:
+    account_id = _clean(scope.account_id) or "unscoped"
     return f"account={account_id}:landing_page={landing_page_id}"
 
 
@@ -164,29 +176,49 @@ async def _landing_page_repair_lock(
         return
 
     lock_key = _landing_page_repair_lock_key(scope, landing_page_id)
+    legacy_lock_key = _landing_page_repair_legacy_lock_key(scope, landing_page_id)
     conn = await _maybe_await(acquire())
+    acquired_new_lock = False
+    acquired_legacy_lock = False
     try:
-        acquired = bool(await conn.fetchval(
+        acquired_legacy_lock = bool(await conn.fetchval(
             """
             SELECT pg_try_advisory_lock(hashtext($1), hashtext($2))
             """,
             _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
-            lock_key,
+            legacy_lock_key,
         ))
-        if not acquired:
+        if not acquired_legacy_lock:
             yield False
             return
-        try:
-            yield True
-        finally:
+        acquired_new_lock = bool(await conn.fetchval(
+            """
+            SELECT pg_try_advisory_lock(hashtextextended($1, $2))
+            """,
+            lock_key,
+            _LANDING_PAGE_REPAIR_LOCK_HASH_SEED,
+        ))
+        if not acquired_new_lock:
+            yield False
+            return
+        yield True
+    finally:
+        if acquired_new_lock:
+            await conn.fetchval(
+                """
+                SELECT pg_advisory_unlock(hashtextextended($1, $2))
+                """,
+                lock_key,
+                _LANDING_PAGE_REPAIR_LOCK_HASH_SEED,
+            )
+        if acquired_legacy_lock:
             await conn.fetchval(
                 """
                 SELECT pg_advisory_unlock(hashtext($1), hashtext($2))
                 """,
                 _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
-                lock_key,
+                legacy_lock_key,
             )
-    finally:
         release = getattr(pool, "release", None)
         if callable(release):
             await _maybe_await(release(conn))

--- a/plans/PR-Landing-Page-Repair-Lock-Hash-Key.md
+++ b/plans/PR-Landing-Page-Repair-Lock-Hash-Key.md
@@ -1,0 +1,87 @@
+# PR-Landing-Page-Repair-Lock-Hash-Key
+
+## Why this slice exists
+
+The saved landing-page repair lock used PostgreSQL advisory locks with
+`hashtext()`. That hashes the account/draft lock key to 32 bits, which leaves a
+small but avoidable chance that unrelated draft repairs collide and return a
+false `409`.
+
+This slice drains that parked `HARDENING.md` item by adding a 64-bit advisory
+lock hash while preserving rolling-deploy compatibility with the legacy lock.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-repair-lock-hash-key
+
+1. Fold the repair-lock namespace into the account/draft lock key string.
+2. Use PostgreSQL `hashtextextended($1, $2)` for the widened advisory lock and
+   unlock SQL.
+3. Keep acquiring the legacy `hashtext()` lock during rollout so old and new
+   app instances still contend for the same repair.
+4. Add focused API tests that pin both the legacy compatibility lock and the
+   widened lock SQL/arguments.
+5. Remove the drained hash-key item from `HARDENING.md`.
+6. Add `Owner/session` markers so other sessions know the remaining parked work
+   belongs to the landing-page repair thread.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Repair-Lock-Hash-Key.md` | Plan doc for this hardening-drain slice. |
+| `HARDENING.md` | Remove the drained hash-key item and mark remaining repair items owner/session. |
+| `extracted_content_pipeline/api/generated_assets.py` | Use a namespaced 64-bit advisory lock hash with legacy rollout compatibility. |
+| `tests/test_extracted_content_asset_api.py` | Cover the widened lock SQL, legacy lock SQL, and account/draft lock key. |
+
+## Mechanism
+
+`_landing_page_repair_lock_key` now returns a namespaced account/draft key:
+`content-assets:landing-page-repair:account=<account>:landing_page=<id>`.
+
+The lock and unlock SQL now call PostgreSQL `hashtextextended($1, $2)` with a
+stable seed, producing the bigint key expected by the single-argument advisory
+lock functions. The same key and seed are used for unlock.
+
+For rolling deploys, the new path still acquires the legacy
+`hashtext(namespace, account/draft)` lock before the widened lock. That keeps
+new instances mutually exclusive with old instances until all running processes
+use the widened lock path. Both locks are released in reverse order.
+
+## Intentional
+
+- No behavior change to the repair endpoint.
+- No change to the endpoint's lock acquisition/release lifecycle.
+- No quota or audit trail work.
+
+## Deferred
+
+- `HARDENING.md` still tracks repair lock connection hold time across LLM
+  latency. It is marked `Owner/session: landing-page repair session`; after
+  this slice, this session will wait rather than continue draining parked items.
+- `HARDENING.md` now tracks removal of the legacy compatibility lock after the
+  widened-lock release is fully rolled out.
+
+## Parked hardening
+
+- Added: `Remove landing-page repair legacy lock after rollout`.
+- Drained: `Consider a wider advisory-lock hash key`.
+
+## Verification
+
+- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
+  passed.
+- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 52 passed.
+- Extracted content pipeline validation -> passed.
+- Extracted reasoning import guard -> passed.
+- Extracted standalone audit -> passed with 0 findings.
+- ASCII Python policy -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan and hardening docs | ~90 |
+| API lock SQL | ~30 |
+| API tests | ~25 |
+| Total | ~145 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -737,7 +737,15 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
     assert pool.release_calls == 1
     assert pool.released_connections
     assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert "hashtext($1), hashtext($2)" in pool.lock_calls[0][0]
+    assert "pg_try_advisory_lock" in pool.lock_calls[1][0]
+    assert "hashtextextended($1, $2)" in pool.lock_calls[1][0]
+    assert "pg_advisory_unlock" in pool.lock_calls[-2][0]
+    assert "hashtextextended($1, $2)" in pool.lock_calls[-2][0]
     assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
+    assert "hashtext($1), hashtext($2)" in pool.lock_calls[-1][0]
+    assert pool.lock_calls[-2][1] == pool.lock_calls[1][1]
+    assert pool.lock_calls[-1][1] == pool.lock_calls[0][1]
     assert pool.unlocked is True
 
 
@@ -791,6 +799,7 @@ def test_landing_page_repair_lock_key_is_account_scoped() -> None:
 
     assert first_key == second_key
     assert first_key == (
+        "content-assets:landing-page-repair:"
         "account=acct_1:landing_page=11111111-1111-1111-1111-111111111111"
     )
 
@@ -823,6 +832,11 @@ def test_generated_asset_router_blocks_concurrent_landing_page_repair_before_llm
     assert pool.release_calls == 1
     assert pool.released_connections
     assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert "hashtext($1), hashtext($2)" in pool.lock_calls[0][0]
+    assert pool.lock_calls[0][1] == (
+        "content-assets:landing-page-repair",
+        "account=acct_1:landing_page=11111111-1111-1111-1111-111111111111",
+    )
     assert pool.unlocked is False
     assert llm.calls == []
     assert skills.calls == []
@@ -929,7 +943,11 @@ def test_generated_asset_router_returns_repair_result_when_repair_fails() -> Non
     assert pool.release_calls == 1
     assert pool.released_connections
     assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
+    assert "pg_try_advisory_lock" in pool.lock_calls[1][0]
+    assert "hashtextextended($1, $2)" in pool.lock_calls[1][0]
     assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
+    assert pool.lock_calls[-2][1] == pool.lock_calls[1][1]
+    assert pool.lock_calls[-1][1] == pool.lock_calls[0][1]
     assert pool.unlocked is True
     assert len(llm.calls) == 1
     assert skills.calls == ["digest/landing_page_generation"]


### PR DESCRIPTION
# PR-Landing-Page-Repair-Lock-Hash-Key

## Why this slice exists

The saved landing-page repair lock used PostgreSQL advisory locks with
`hashtext()`. That hashes the account/draft lock key to 32 bits, which leaves a
small but avoidable chance that unrelated draft repairs collide and return a
false `409`.

This slice drains that parked `HARDENING.md` item by adding a 64-bit advisory
lock hash while preserving rolling-deploy compatibility with the legacy lock.

## Scope (this PR)

Ownership lane: content-ops/landing-page-repair-lock-hash-key

1. Fold the repair-lock namespace into the account/draft lock key string.
2. Use PostgreSQL `hashtextextended($1, $2)` for the widened advisory lock and
   unlock SQL.
3. Keep acquiring the legacy `hashtext()` lock during rollout so old and new
   app instances still contend for the same repair.
4. Add focused API tests that pin both the legacy compatibility lock and the
   widened lock SQL/arguments.
5. Remove the drained hash-key item from `HARDENING.md`.
6. Add `Owner/session` markers so other sessions know the remaining parked work
   belongs to the landing-page repair thread.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Repair-Lock-Hash-Key.md` | Plan doc for this hardening-drain slice. |
| `HARDENING.md` | Remove the drained hash-key item and mark remaining repair items owner/session. |
| `extracted_content_pipeline/api/generated_assets.py` | Use a namespaced 64-bit advisory lock hash with legacy rollout compatibility. |
| `tests/test_extracted_content_asset_api.py` | Cover the widened lock SQL, legacy lock SQL, and account/draft lock key. |

## Mechanism

`_landing_page_repair_lock_key` now returns a namespaced account/draft key:
`content-assets:landing-page-repair:account=<account>:landing_page=<id>`.

The lock and unlock SQL now call PostgreSQL `hashtextextended($1, $2)` with a
stable seed, producing the bigint key expected by the single-argument advisory
lock functions. The same key and seed are used for unlock.

For rolling deploys, the new path still acquires the legacy
`hashtext(namespace, account/draft)` lock before the widened lock. That keeps
new instances mutually exclusive with old instances until all running processes
use the widened lock path. Both locks are released in reverse order.

## Intentional

- No behavior change to the repair endpoint.
- No change to the endpoint's lock acquisition/release lifecycle.
- No quota or audit trail work.

## Deferred

- `HARDENING.md` still tracks repair lock connection hold time across LLM
  latency. It is marked `Owner/session: landing-page repair session`; after
  this slice, this session will wait rather than continue draining parked items.
- `HARDENING.md` now tracks removal of the legacy compatibility lock after the
  widened-lock release is fully rolled out.

## Parked hardening

- Added: `Remove landing-page repair legacy lock after rollout`.
- Drained: `Consider a wider advisory-lock hash key`.

## Verification

- Python compile for `extracted_content_pipeline/api/generated_assets.py` ->
  passed.
- Focused pytest for `tests/test_extracted_content_asset_api.py` -> 52 passed.
- Extracted content pipeline validation -> passed.
- Extracted reasoning import guard -> passed.
- Extracted standalone audit -> passed with 0 findings.
- ASCII Python policy -> passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Plan and hardening docs | ~90 |
| API lock SQL | ~30 |
| API tests | ~25 |
| Total | ~145 |
