### PR TITLE
Add FAQ run-summary vocabulary-gap visibility

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -243,7 +243,7 @@ The first pass is `input_profile.usable_source_count` divided by
 prep problem. If the ratio is healthy and `failure.type` is `output_checks`,
 debug the FAQ generator path. Use top-level `faq_run_summary` for the FAQ health
 rollup: generated item count, weighted represented source volume, failed output
-checks, warning count, and item score distribution.
+checks, warning count, vocabulary-gap counts, and item score distribution.
 
 The same artifact can run through the Content Ops execution seam by selecting
 `faq_markdown` and passing inline `source_material`. It remains zero-provider.

--- a/extracted_content_pipeline/examples/faq_scale_density_limited_summary.json
+++ b/extracted_content_pipeline/examples/faq_scale_density_limited_summary.json
@@ -35,6 +35,13 @@
         "condensed"
       ]
     },
+    "vocabulary_gaps": {
+      "term_mapping_count": 0,
+      "mapped_topic_count": 0,
+      "zero_result_mapping_count": 0,
+      "max_opportunity_score": 0,
+      "top_customer_terms": []
+    },
     "item_score_distribution": {
       "count": 8,
       "min": 2,

--- a/extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json
+++ b/extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json
@@ -34,6 +34,13 @@
         "uses_user_vocabulary"
       ]
     },
+    "vocabulary_gaps": {
+      "term_mapping_count": 0,
+      "mapped_topic_count": 0,
+      "zero_result_mapping_count": 0,
+      "max_opportunity_score": 0,
+      "top_customer_terms": []
+    },
     "item_score_distribution": {
       "count": 12,
       "min": 1,

--- a/plans/PR-Content-Ops-FAQ-Run-Summary-Vocabulary-Gaps.md
+++ b/plans/PR-Content-Ops-FAQ-Run-Summary-Vocabulary-Gaps.md
@@ -1,0 +1,103 @@
+# PR-Content-Ops-FAQ-Run-Summary-Vocabulary-Gaps
+
+## Why this slice exists
+
+The FAQ generator now detects vocabulary gaps and writes full term-mapping
+diagnostics, but the compact run summary used for large-upload triage does not
+say whether any mappings were found. Operators running 500 or 1,000 rows can
+see upload density, output-check status, and score shape at a glance, but still
+have to dig into nested diagnostics to answer whether customer language differed
+from documentation language.
+
+This slice adds a small vocabulary-gap rollup to the existing FAQ run summary so
+the real CLI and scale-smoke artifacts expose the signal without adding a new
+generation path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add compact vocabulary-gap counts and top customer terms to
+   `diagnostics.run_summary`.
+2. Keep the detailed `diagnostics.term_mappings` list unchanged.
+3. Refresh the checked-in scale-smoke examples so they match the new guarded
+   run-summary schema.
+4. Extend focused tests for CLI output and checked-in examples.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Run-Summary-Vocabulary-Gaps.md` | Plan doc for this visibility slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds vocabulary-gap rollup to compact FAQ run summary. |
+| `extracted_content_pipeline/examples/faq_scale_density_limited_summary.json` | Refreshes static example run-summary shape. |
+| `extracted_content_pipeline/examples/faq_scale_output_check_failure_summary.json` | Refreshes static example run-summary shape. |
+| `extracted_content_pipeline/README.md` | Notes that run-summary now includes vocabulary-gap visibility. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers vocabulary-gap summary values in CLI result JSON. |
+| `tests/test_smoke_content_ops_faq_scale_run.py` | Pins refreshed example vocabulary-gap summary values. |
+
+## Mechanism
+
+`_result_payload` already builds sorted compact term-mapping diagnostics. This
+slice computes those summaries once, passes them into `_run_summary`, and adds a
+small nested `vocabulary_gaps` block:
+
+```json
+{
+  "term_mapping_count": 2,
+  "mapped_topic_count": 2,
+  "zero_result_mapping_count": 1,
+  "max_opportunity_score": 78,
+  "top_customer_terms": ["export", "bill"]
+}
+```
+
+The run summary stays compact and deterministic. It does not duplicate full
+mapping bodies or suggestions; those remain in `diagnostics.term_mappings`.
+
+## Intentional
+
+- CLI/result visibility only. FAQ generation, ranking, Markdown body text, and
+  output-check rules do not change.
+- `top_customer_terms` is capped to three values because this summary is for
+  triage, not a full report.
+- The static examples remain representative artifacts; the schema guard added
+  in the prior slice ensures their shape tracks the runtime summary.
+
+## Deferred
+
+- Hosted UI display for the vocabulary-gap run-summary block remains separate.
+- CSV rule-file import and explicit documentation-term format overrides remain
+  separate CLI slices.
+- Parked hardening for this slice: none. The hardening tracker has no entries
+  for this lane yet.
+
+## Verification
+
+- Focused FAQ CLI and scale-smoke pytest - passed, 4 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` and
+  `tests/test_smoke_content_ops_faq_scale_run.py` - passed, 149 tests.
+- JSON parse check for both refreshed scale-smoke examples - passed.
+- Py compile for affected Python files - passed.
+- CLI demo with packaged support tickets, documentation terms, and custom rules
+  - passed. The emitted `diagnostics.run_summary.vocabulary_gaps` was:
+  `term_mapping_count=2`, `mapped_topic_count=1`, `max_opportunity_score=4`,
+  `top_customer_terms=["export", "reporting"]`.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Full extracted pipeline checks - passed, 1,755 tests, 1 existing torch/pynvml
+  warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| CLI run-summary payload | ~35 |
+| Example JSON | ~30 |
+| README | ~5 |
+| Tests | ~35 |
+| **Total** | ~190 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -281,6 +281,7 @@ def _result_payload(
     item_summaries = [
         _item_summary(index, item) for index, item in enumerate(items, start=1)
     ]
+    term_mappings = _term_mapping_summaries(items)
     return {
         "status": "failed_output_checks" if failed_checks else "ok",
         "input": {
@@ -326,14 +327,15 @@ def _result_payload(
                 failed_checks=failed_checks,
                 source_mix=source_mix,
                 item_summaries=item_summaries,
+                term_mappings=term_mappings,
                 warnings=warnings,
             ),
             "source_mix": source_mix,
             "ticket_counts": ticket_counts,
             "rendered_ticket_source_count": rendered_ticket_source_count,
             "unrepresented_ticket_sources": max(result.ticket_source_count - rendered_ticket_source_count, 0),
-            "term_mapping_count": _term_mapping_count(items),
-            "term_mappings": _term_mapping_summaries(items),
+            "term_mapping_count": len(term_mappings),
+            "term_mappings": term_mappings,
             "warning_count": len(warnings),
             "warnings": warnings[:50],
             "warnings_truncated": len(warnings) > 50,
@@ -348,6 +350,7 @@ def _run_summary(
     failed_checks: list[str],
     source_mix: dict[str, Any],
     item_summaries: list[dict[str, Any]],
+    term_mappings: list[dict[str, Any]],
     warnings: list[dict[str, Any]],
 ) -> dict[str, Any]:
     output_checks = dict(result.output_checks)
@@ -369,8 +372,42 @@ def _run_summary(
             "total": len(output_checks),
             "failed_checks": list(failed_checks),
         },
+        "vocabulary_gaps": _vocabulary_gap_summary(term_mappings),
         "item_score_distribution": _item_score_distribution(item_summaries),
         "warning_count": len(warnings),
+    }
+
+
+def _vocabulary_gap_summary(
+    term_mappings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    topics = {
+        str(mapping.get("topic"))
+        for mapping in term_mappings
+        if mapping.get("topic")
+    }
+    top_customer_terms: list[str] = []
+    seen_terms: set[str] = set()
+    zero_result_mapping_count = 0
+    max_opportunity_score = 0
+    for mapping in term_mappings:
+        if _integer_or_zero(mapping.get("zero_result_source_count")) > 0:
+            zero_result_mapping_count += 1
+        max_opportunity_score = max(
+            max_opportunity_score,
+            _integer_or_zero(mapping.get("opportunity_score")),
+        )
+        term = str(mapping.get("customer_term") or "").strip()
+        key = term.lower()
+        if term and key not in seen_terms and len(top_customer_terms) < 3:
+            seen_terms.add(key)
+            top_customer_terms.append(term)
+    return {
+        "term_mapping_count": len(term_mappings),
+        "mapped_topic_count": len(topics),
+        "zero_result_mapping_count": zero_result_mapping_count,
+        "max_opportunity_score": max_opportunity_score,
+        "top_customer_terms": top_customer_terms,
     }
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2281,6 +2281,13 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
             "total": 3,
             "failed_checks": [],
         },
+        "vocabulary_gaps": {
+            "term_mapping_count": 0,
+            "mapped_topic_count": 0,
+            "zero_result_mapping_count": 0,
+            "max_opportunity_score": 0,
+            "top_customer_terms": [],
+        },
         "item_score_distribution": {
             "count": 2,
             "min": 2,
@@ -2353,6 +2360,13 @@ def test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics(tmp_path: Path)
         "opportunity_score": 1,
         "first_source_id": "ticket-1",
     }]
+    assert result["diagnostics"]["run_summary"]["vocabulary_gaps"] == {
+        "term_mapping_count": 1,
+        "mapped_topic_count": 1,
+        "zero_result_mapping_count": 0,
+        "max_opportunity_score": 1,
+        "top_customer_terms": ["export"],
+    }
     assert result["diagnostics"]["items"][0]["term_mapping_count"] == 1
 
 
@@ -3333,6 +3347,13 @@ def test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact(tmp_pa
     assert mappings[0]["zero_result_source_count"] == 1
     assert mappings[1]["opportunity_score"] == 1
     assert mappings[1]["zero_result_source_count"] == 0
+    assert result["diagnostics"]["run_summary"]["vocabulary_gaps"] == {
+        "term_mapping_count": 2,
+        "mapped_topic_count": 2,
+        "zero_result_mapping_count": 1,
+        "max_opportunity_score": 78,
+        "top_customer_terms": ["export", "bill"],
+    }
 
 
 def test_ticket_faq_cli_filters_csv_to_date_window(tmp_path: Path) -> None:

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -296,6 +296,13 @@ def test_faq_scale_failure_examples_separate_density_from_output_checks() -> Non
     assert density["faq_run_summary"]["warning_count"] == 954
     assert density["faq_run_summary"]["generated"] == 8
     assert density["faq_run_summary"]["output_checks"]["failed_checks"] == ["condensed"]
+    assert density["faq_run_summary"]["vocabulary_gaps"] == {
+        "term_mapping_count": 0,
+        "mapped_topic_count": 0,
+        "zero_result_mapping_count": 0,
+        "max_opportunity_score": 0,
+        "top_customer_terms": [],
+    }
 
     assert output_checks["ok"] is False
     assert _mapping_shape(output_checks["faq_run_summary"]) == expected_summary_shape
@@ -308,6 +315,13 @@ def test_faq_scale_failure_examples_separate_density_from_output_checks() -> Non
     assert output_checks["faq_run_summary"]["weighted_source_volume"] == 1000
     assert output_checks["faq_run_summary"]["warning_count"] == 0
     assert output_checks["faq_run_summary"]["output_checks"]["failed"] == 2
+    assert output_checks["faq_run_summary"]["vocabulary_gaps"] == {
+        "term_mapping_count": 0,
+        "mapped_topic_count": 0,
+        "zero_result_mapping_count": 0,
+        "max_opportunity_score": 0,
+        "top_customer_terms": [],
+    }
 
 
 def _runtime_faq_run_summary() -> dict[str, object]:
@@ -328,6 +342,7 @@ def _runtime_faq_run_summary() -> dict[str, object]:
             "zero_result_search_source_count": 0,
         },
         item_summaries=[{"opportunity_score": 1}],
+        term_mappings=[],
         warnings=[],
     )
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Run-Summary-Vocabulary-Gaps.md

Add a compact vocabulary-gap rollup to the FAQ CLI run summary so large-upload and scale-smoke artifacts show term-mapping health without requiring operators to open nested diagnostics.

## Intentional
- CLI/result visibility only; FAQ generation, ranking, Markdown body text, and output-check rules are unchanged.
- `top_customer_terms` is capped at three because the run summary is for triage, not a full report.
- Static examples remain representative artifacts, guarded by the runtime summary schema test.

## Deferred
- Hosted UI display for the vocabulary-gap run-summary block remains separate.
- CSV rule-file import and explicit documentation-term format overrides remain separate CLI slices.
- Parked hardening: none. `HARDENING.md` has no entries for this lane.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_writes_markdown_file tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_writes_vocabulary_gap_result_diagnostics tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_sorts_vocabulary_gap_result_diagnostics_by_impact tests/test_smoke_content_ops_faq_scale_run.py::test_faq_scale_failure_examples_separate_density_from_output_checks` — 4 passed.
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_faq_scale_run.py` — 149 passed.
- JSON parse check for both refreshed scale-smoke examples — passed.
- `python -m py_compile scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_faq_scale_run.py` — passed.
- CLI demo with packaged support tickets + documentation terms + custom rules — emitted `vocabulary_gaps` with `term_mapping_count=2`, `mapped_topic_count=1`, `max_opportunity_score=4`, `top_customer_terms=["export", "reporting"]`.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed, 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 1,755 passed, 1 existing torch/pynvml warning.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` — passed.

## Diff size
7 files, +196 / -3