### PR TITLE
Add FAQ documentation-term format override

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -219,8 +219,10 @@ Intent rules group customer language under a product-specific FAQ topic.
 Vocabulary-gap rules map customer terms to documentation terms passed with
 `--documentation-term` or `--documentation-term-file`, so the result JSON and
 Markdown can suggest alternate phrasing. Documentation-term files can be UTF-8
-plain text, JSON, JSONL, or CSV. Text files use one term per line and ignore
-blank or `#` comment lines. Structured files read common fields such as
+plain text, JSON, JSONL, or CSV. Use `--documentation-term-format csv` (or
+`json`, `jsonl`, or `text`) when a suffixless export needs an explicit parser.
+Text files use one term per line and ignore blank or `#` comment lines.
+Structured files read common fields such as
 `documentation_term`, `term`, `heading`, `title`, `page_title`, `name`, or
 `label`. Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 `--vocabulary-gap-rule` flags are placed before file rules, so command-line

--- a/plans/PR-Content-Ops-FAQ-Documentation-Term-Format.md
+++ b/plans/PR-Content-Ops-FAQ-Documentation-Term-Format.md
@@ -1,0 +1,92 @@
+# PR-Content-Ops-FAQ-Documentation-Term-Format
+
+## Why this slice exists
+
+Vocabulary-gap detection depends on loading the customer's existing
+documentation terms. The CLI already accepts documentation-term files as text,
+JSON, JSONL, or CSV, but format detection is suffix-based. Real exports often
+arrive as suffixless files from help-center or docs pipelines, which currently
+fall back to text parsing and can miss structured headings.
+
+This slice adds an explicit documentation-term format override so suffixless
+docs exports can exercise the real vocabulary-gap flow without renaming files.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+1. Add `--documentation-term-format` with `auto`, `text`, `json`, `jsonl`, and
+   `csv` choices.
+2. Thread the selected format through the existing documentation-term file
+   loader.
+3. Record the selected format in compact CLI result config.
+4. Add focused CLI coverage for suffixless CSV exports and malformed override
+   failures.
+5. Update README guidance for documentation-term file formats.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Documentation-Term-Format.md` | Plan doc for this CLI ergonomics slice. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Adds and threads the documentation-term format override. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers suffixless CSV parsing and malformed override errors. |
+| `extracted_content_pipeline/README.md` | Documents the explicit format override. |
+
+## Mechanism
+
+The parser gets a new option:
+
+```bash
+--documentation-term-format auto|text|json|jsonl|csv
+```
+
+`auto` preserves the current suffix-based behavior. Any explicit value bypasses
+suffix detection and calls the matching existing parser for every
+`--documentation-term-file`. Errors continue to use the same
+`--documentation-term-file ...` messages because only parser selection changes.
+
+## Intentional
+
+- CLI-only behavior. FAQ generation, vocabulary-gap scoring, Markdown rendering,
+  and rule-file parsing do not change.
+- One format applies to all documentation-term files in the invocation. Mixed
+  file formats still work with `auto` when suffixes are present.
+- No new parser or field names are introduced; this only exposes parser
+  selection for existing formats.
+
+## Deferred
+
+- Hosted UI upload controls for documentation terms and rule files remain a
+  separate product slice.
+- Per-file format overrides can be considered later if a real customer export
+  requires mixed suffixless files in one command.
+- Parked hardening considered: current `HARDENING.md` entries are landing-page
+  repair items and do not touch this FAQ lane.
+
+## Verification
+
+- Focused documentation-term format pytest - passed, 3 tests.
+- Full FAQ pytest for `tests/test_extracted_ticket_faq_markdown.py` - passed,
+  133 tests.
+- Py compile for affected Python files - passed.
+- CLI demo with suffixless CSV documentation export - passed. The result config
+  recorded `documentation_term_format=csv`, loaded 3 documentation terms, and
+  produced `term_mapping_count=2`.
+- Git whitespace check - passed.
+- Extracted manifest/import validation script - passed.
+- Extracted reasoning import guard - passed.
+- Extracted standalone audit - passed, 0 Atlas runtime import findings.
+- Extracted ASCII Python check - passed.
+- Full extracted pipeline checks - passed, 1,758 tests, 1 existing torch/pynvml
+  warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| CLI parser/loader/config | ~40 |
+| Tests | ~70 |
+| README | ~5 |
+| **Total** | ~205 |

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -37,6 +37,7 @@ _DOCUMENTATION_TERM_LIST_KEYS = (
     "data",
 )
 _DOCUMENTATION_TERM_KEY_HINT = ", ".join(_DOCUMENTATION_TERM_ROW_KEYS)
+_DOCUMENTATION_TERM_FORMATS = ("auto", "text", "json", "jsonl", "csv")
 _EMPTY_JSONL_LINE = object()
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
@@ -147,6 +148,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--documentation-term-format",
+        choices=_DOCUMENTATION_TERM_FORMATS,
+        default="auto",
+        help=(
+            "Format for documentation-term files. Defaults to suffix-based "
+            "auto detection."
+        ),
+    )
+    parser.add_argument(
         "--vocabulary-gap-rule",
         action="append",
         default=[],
@@ -202,6 +212,7 @@ def main(argv: list[str] | None = None) -> int:
     documentation_terms = _cli_documentation_terms(
         args.documentation_term,
         args.documentation_term_file,
+        args.documentation_term_format,
     )
     args.documentation_terms = documentation_terms
     file_rules = _load_rule_files(args.rule_file)
@@ -305,6 +316,7 @@ def _result_payload(
             "documentation_term_files": [
                 str(path) for path in args.documentation_term_file
             ],
+            "documentation_term_format": args.documentation_term_format,
             "documentation_terms": list(args.documentation_terms),
             "vocabulary_gap_rules": [
                 list(rule) for rule in args.vocabulary_gap_rules
@@ -588,25 +600,40 @@ def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
 def _cli_documentation_terms(
     inline_terms: list[str],
     files: list[Path],
+    file_format: str = "auto",
 ) -> tuple[str, ...]:
     terms: list[str] = []
     terms.extend(inline_terms)
     for path in files:
-        terms.extend(_load_cli_documentation_term_file(path))
+        terms.extend(_load_cli_documentation_term_file(path, file_format=file_format))
     return _clean_cli_documentation_terms(terms)
 
 
-def _load_cli_documentation_term_file(path: Path) -> tuple[str, ...]:
+def _load_cli_documentation_term_file(
+    path: Path,
+    *,
+    file_format: str = "auto",
+) -> tuple[str, ...]:
     try:
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         raise SystemExit(f"--documentation-term-file not found: {path}") from None
     suffix = path.suffix.lower()
-    if suffix == ".json":
+    resolved_format = file_format
+    if resolved_format == "auto":
+        if suffix == ".json":
+            resolved_format = "json"
+        elif suffix == ".jsonl":
+            resolved_format = "jsonl"
+        elif suffix == ".csv":
+            resolved_format = "csv"
+        else:
+            resolved_format = "text"
+    if resolved_format == "json":
         terms = _load_cli_documentation_term_json(text, path)
-    elif suffix == ".jsonl":
+    elif resolved_format == "jsonl":
         terms = _load_cli_documentation_term_jsonl(text, path)
-    elif suffix == ".csv":
+    elif resolved_format == "csv":
         terms = _load_cli_documentation_term_csv(text, path)
     else:
         terms = _load_cli_documentation_term_text(text)

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2666,6 +2666,50 @@ def test_ticket_faq_cli_accepts_csv_documentation_term_file(tmp_path: Path) -> N
     )
 
 
+def test_ticket_faq_cli_accepts_suffixless_csv_documentation_term_file_with_format(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms_export"
+    term_file.write_text(
+        "\n".join((
+            "title,slug",
+            "Single sign-on setup,sso",
+            "Download report,download-report",
+            "Dashboard analytics,dashboard",
+            "",
+        )),
+        encoding="utf-8",
+    )
+    result_output = tmp_path / "ticket_faq_result.json"
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--documentation-term-format",
+        "csv",
+        "--result-output",
+        str(result_output),
+    )
+
+    assert completed.returncode == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_term_format"] == "csv"
+    assert result["config"]["documentation_terms"] == [
+        "Single sign-on setup",
+        "Download report",
+        "Dashboard analytics",
+    ]
+    assert (
+        result["diagnostics"]["term_mappings"][0]["documentation_term"]
+        == "Download report"
+    )
+
+
 def test_ticket_faq_cli_accepts_bom_and_multiline_csv_documentation_term_file(
     tmp_path: Path,
 ) -> None:
@@ -2809,6 +2853,32 @@ def test_ticket_faq_cli_rejects_unrecognized_jsonl_documentation_term_fields(
     assert completed.returncode == 1
     assert "--documentation-term-file has no recognized term fields:" in completed.stderr
     assert "expected one of: documentation_term" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_ticket_faq_cli_applies_documentation_term_format_to_suffixless_file(
+    tmp_path: Path,
+) -> None:
+    source = _write_ticket_csv(
+        tmp_path,
+        "ticket-1,2026-05-01,Attribution export,How do I export attribution data?,exports",
+    )
+    term_file = tmp_path / "terms_export"
+    term_file.write_text(
+        "title,slug\nDownload report,download-report\n",
+        encoding="utf-8",
+    )
+
+    completed = _run_ticket_faq_cli(
+        source,
+        "--documentation-term-file",
+        str(term_file),
+        "--documentation-term-format",
+        "json",
+    )
+
+    assert completed.returncode == 1
+    assert "--documentation-term-file must be valid JSON:" in completed.stderr
     assert "Traceback" not in completed.stderr
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Documentation-Term-Format.md

Add an explicit `--documentation-term-format` override so suffixless help-center/docs exports can feed vocabulary-gap detection without renaming files.

## Intentional
- CLI-only behavior; FAQ generation, vocabulary-gap scoring, Markdown rendering, and rule-file parsing are unchanged.
- One format applies to all documentation-term files in the invocation. Mixed file formats still work with `auto` when suffixes are present.
- No new parser or field names are introduced; this only exposes parser selection for existing formats.

## Deferred
- Hosted UI upload controls for documentation terms and rule files remain separate.
- Per-file format overrides can be considered later if a real customer export requires mixed suffixless files in one command.
- Parked hardening considered: current `HARDENING.md` entries are landing-page repair items and do not touch this FAQ lane.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_accepts_suffixless_csv_documentation_term_file_with_format tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_applies_documentation_term_format_to_suffixless_file tests/test_extracted_ticket_faq_markdown.py::test_ticket_faq_cli_accepts_csv_documentation_term_file` — 3 passed.
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py` — 133 passed.
- `python -m py_compile scripts/build_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py` — passed.
- CLI demo with suffixless CSV documentation export — recorded `documentation_term_format=csv`, loaded 3 documentation terms, and produced `term_mapping_count=2`.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed, 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 1,758 passed, 1 existing torch/pynvml warning.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` — passed; only broad same-name cross-layer hints for `_parse_args`, `main`, and unrelated `_result_payload`.

## Diff size
4 files, +198 / -7