### PR TITLE
Correct quote source-attribution lead-in in zoho deep-dive (D6)

### DIFF
--- a/ATLAS-HARDENING.md
+++ b/ATLAS-HARDENING.md
@@ -29,6 +29,14 @@ parked and note in the plan's Deferred.
 
 ## 2026-05-22
 
+### zoho-crm-deep-dive L158 source list omits Slashdot (a quoted source) -- quote-pool vs corpus-count scope mismatch
+- File/location: `atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts` L158; generator-side, the quote pool (`_fetch_quotable_reviews`) vs the corpus counts (`_fetch_source_distribution`).
+- Description: L158 reads "The data comes from G2, Gartner, PeerSpot, and Reddit -- ... (24 reviews) ... (237 reviews)", but the post quotes a Slashdot reviewer (L166/L168, the D6 fix). The naive fix ("add Slashdot to the community bucket and the 237 reconciles", per the #802 review) does NOT work: DB-verified, the windowed-ENRICHED zoho corpus is reddit(237)/g2(11)/peerspot(8)/gartner(5) -- no Slashdot. The Slashdot quote's review is `enrichment_status=not_applicable` (in-window, Zoho-mention, but NOT enriched), so it's excluded from the 261/237 counts. So the quote pool includes non-enriched reviews the corpus counts exclude.
+- Why it matters: live-misleading (a source quoted but undeclared, and it can't simply be added without breaking the verified/community reconciliation). Real fix is a Phase-2 reconciliation of the quote-pool scope vs the corpus-count scope (either restrict quotes to the counted corpus, or count the sources actually quoted). This is the D5 source-list pattern (52 posts) with an extra quote-provenance wrinkle.
+- Effort: M
+- Category: correctness
+- Found during: D6 review (#802); part of the Phase-2 source-list cleanup.
+
 ### Deep-dive quote lead-ins can name a platform the quote isn't from
 - File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`, the reviewer/strengths section that surfaces `quote_highlights` to the LLM (around the `quote_highlights = _blog_quote_highlights(...)` call in `_blueprint_vendor_deep_dive`).
 - Description: the LLM-written prose lead-in for a quote can name a platform that doesn't match the quote's `source_name`. The blockquote attribution uses `source_name` correctly; only the free-text lead-in drifts. Found in zoho-crm-deep-dive: "verified reviewer on G2" prose against a Slashdot-source quote (fixed in the published post by D6; the generator can recur).

--- a/ATLAS-HARDENING.md
+++ b/ATLAS-HARDENING.md
@@ -29,6 +29,22 @@ parked and note in the plan's Deferred.
 
 ## 2026-05-22
 
+### Deep-dive quote lead-ins can name a platform the quote isn't from
+- File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`, the reviewer/strengths section that surfaces `quote_highlights` to the LLM (around the `quote_highlights = _blog_quote_highlights(...)` call in `_blueprint_vendor_deep_dive`).
+- Description: the LLM-written prose lead-in for a quote can name a platform that doesn't match the quote's `source_name`. The blockquote attribution uses `source_name` correctly; only the free-text lead-in drifts. Found in zoho-crm-deep-dive: "verified reviewer on G2" prose against a Slashdot-source quote (fixed in the published post by D6; the generator can recur).
+- Why it matters: a prose-vs-attribution mismatch that's data-untruthful but only caught at audit; future deep-dives can repeat it.
+- Effort: M (prompt-guidance change in the section goal/data_summary; uncertain effectiveness -- the LLM doesn't always honor narrow phrasing constraints).
+- Category: correctness
+- Found during: D6
+
+### Orphaned quote lead-in in salesforce-deep-dive (no quote follows)
+- File/location: `atlas-churn-ui/src/content/blog/salesforce-deep-dive-2026-04.ts` L159; generator-side, the strengths section in `_blueprint_vendor_deep_dive` that emits a colon-terminated quote lead-in.
+- Description: L159 reads "...One verified reviewer on G2 notes the platform's ability to handle intricate workflows:" but no blockquote follows (L160 is unrelated prose) -- a dangling lead-in promising a quote that isn't there. Separate defect class from D6's platform-mismatch (this is an orphaned intro, not a source mismatch); pre-existing, surfaced while scoping D6.
+- Why it matters: misleading published content (promises a reviewer quote that never appears). Likely a stripped/never-emitted quote leaving its lead-in. Candidate for a follow-up data fix (drop the dangling lead-in) + a generator guard (don't emit a quote lead-in without a quote).
+- Effort: S (data: drop the line) / M (generator guard)
+- Category: correctness
+- Found during: D6
+
 ### Deep-dive strengths/weaknesses chart fallback cannot show true strengths
 - File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` ~L8092 (and the byte-identical `extracted_content_pipeline` mirror), the `if len(strengths) + len(weaknesses) < 3 and signals:` fallback in `_blueprint_vendor_deep_dive`.
 - Description: when the product profile is too thin, the "Strengths vs Weaknesses" chart is built only from pain-category signals, which carry weakness data only -- so the `strengths` series is always 0 (a one-sided chart). D4 made the bucketing truthful (all pain -> weaknesses) but did not give the fallback a real strengths source.

--- a/atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts
@@ -163,7 +163,7 @@ const post: BlogPost = {
 <p>Reviewer sentiment splits into clear strength and weakness categories. The platform shows distinct advantages in certain areas while revealing consistent pain points in others.</p>
 <p>{{chart:strengths-weaknesses}}</p>
 <h3 id="strengths">Strengths</h3>
-<p><strong>Dashboard accessibility and lead tracking</strong> emerge as the most frequently praised capabilities. One verified reviewer on G2 describes the core value:</p>
+<p><strong>Dashboard accessibility and lead tracking</strong> emerge as the most frequently praised capabilities. One reviewer on Slashdot describes the core value:</p>
 <blockquote>
 <p>"Zoho CRM is an advanced CRM that gives us easy to approach every lead indication directly from its dashboard" -- Senior Project Manager at a company with 100-499 employees, reviewer on Slashdot</p>
 </blockquote>

--- a/plans/PR-Blog-D6-Quote-Source-Attribution.md
+++ b/plans/PR-Blog-D6-Quote-Source-Attribution.md
@@ -1,0 +1,86 @@
+# PR-Blog-D6-Quote-Source-Attribution
+
+Ownership lane: `content-ops/blog-d6-quote-source`
+
+## Why this slice exists
+
+Defect **D6** (`reports/blog-audit-findings.md`): a quote's prose lead-in names a
+different platform than the blockquote attribution and the real source. In
+`zoho-crm-deep-dive`, L166 reads "One **verified** reviewer on **G2** describes
+the core value:" but the blockquote (L168) attributes the quote to **Slashdot**,
+and the DB confirms the quote's `source` is **slashdot** (1 occurrence). The
+prose "G2" (and "verified", since Slashdot is a community source) is wrong.
+
+Data-untruthful output, so the published prose is fixed inline. The prose lead-in
+is LLM free-text (the quote already carries `source_name`, used correctly in the
+blockquote), so deterministic generator-prevention is fuzzy and is parked.
+
+## Scope (this PR)
+
+Data-only thin slice: correct the one published mismatch.
+
+- **Data** (`zoho-crm-deep-dive-2026-04.ts` L166): "One verified reviewer on G2
+  describes the core value:" -> "One reviewer on Slashdot describes the core
+  value:" -- matches the blockquote and the DB.
+
+### Files touched
+
+- `plans/PR-Blog-D6-Quote-Source-Attribution.md`
+- `ATLAS-HARDENING.md`
+- `atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts`
+
+## Mechanism
+
+One contextual phrase replacement (asserted count = 1). No generator change: the
+quote carries `source_name` (the blockquote uses it correctly); only the LLM's
+free-text lead-in drifted, which can't be fixed deterministically in scope.
+
+A corpus-wide grep confirmed D6's blast radius before editing: "verified reviewer
+on <platform>" is widespread but almost all are blockquote ATTRIBUTIONS (the
+quote's real source, correct). Only three posts have the prose-lead-in shape:
+zoho (this mismatch), top-complaint-every-helpdesk (lead-in "Gartner" matches its
+blockquote -- no defect), and salesforce (a different defect -- orphaned lead-in,
+no quote follows -- parked, not D6).
+
+## Intentional
+
+- **Data-truthful fix, no generator change.** The source path is correct
+  (blockquote uses `source_name`); the defect is LLM lead-in drift, parked.
+- **Match the blockquote, drop "verified".** Slashdot is a community source, so
+  "verified reviewer" was doubly wrong.
+
+## Deferred
+
+**Parked hardening** in `ATLAS-HARDENING.md` (separate from root `HARDENING.md`,
+per the maintainer; root carries a pointer):
+
+- Deep-dive quote lead-ins can name a platform the quote isn't from
+  (generator/LLM drift; prompt-guidance fix, uncertain). Effort M, correctness.
+- Orphaned quote lead-in in `salesforce-deep-dive` L159 ("...verified reviewer on
+  G2 notes ...:" with no quote following) -- a separate orphaned-intro defect,
+  pre-existing, surfaced while scoping D6. Effort S (data) / M (generator guard),
+  correctness.
+
+Also remaining: D5 (source-list incompleteness), D2-followup (Zoho/Zoho CRM
+registry merge), D3-followup (frequency-view chart).
+
+## Verification
+
+- Re-grep: "verified reviewer on G2" in the zoho post -> 0; L166 lead-in now
+  reads "One reviewer on Slashdot describes the core value:", matching the L168
+  blockquote ("reviewer on Slashdot") and the DB (`source = slashdot`, 1 row).
+- Corpus-wide grep established the fix is a single instance (others are
+  attributions or a different defect class).
+- `audit-published-posts.js` -> orphaned-quote-reference / form-prompt /
+  empty-blockquote all 0. No new defects.
+- (No generator change, so no unit test -- data-only slice demonstrated by grep +
+  audit, per AGENTS.md 3d.)
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| zoho data (one lead-in) | ~2 |
+| ATLAS-HARDENING.md (2 parked entries) | ~16 |
+| Plan doc | ~70 |
+| **Total** | **~88** |

--- a/plans/PR-Blog-D6-Quote-Source-Attribution.md
+++ b/plans/PR-Blog-D6-Quote-Source-Attribution.md
@@ -60,6 +60,11 @@ per the maintainer; root carries a pointer):
   G2 notes ...:" with no quote following) -- a separate orphaned-intro defect,
   pre-existing, surfaced while scoping D6. Effort S (data) / M (generator guard),
   correctness.
+- zoho L158 source list omits Slashdot (a quoted source) -- added on the #802
+  review. DB-verified the naive "add Slashdot to the 237 community count"
+  doesn't reconcile: the Slashdot quote's review is `not_applicable` (non-enriched,
+  in-window, Zoho-mention), so it's outside the enriched 261/237 counts. Needs a
+  Phase-2 quote-pool-vs-corpus-count reconciliation. M, correctness.
 
 Also remaining: D5 (source-list incompleteness), D2-followup (Zoho/Zoho CRM
 registry merge), D3-followup (frequency-view chart).
@@ -83,4 +88,4 @@ registry merge), D3-followup (frequency-view chart).
 | zoho data (one lead-in) | ~2 |
 | ATLAS-HARDENING.md (2 parked entries) | ~16 |
 | Plan doc | ~70 |
-| **Total** | **~88** |
+| **Total** | **~115** |


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d6-quote-source`

**D6**: a quote's prose lead-in named a different platform than its blockquote/real source. `zoho-crm-deep-dive` L166 read "One **verified** reviewer **on G2** describes the core value:" but the blockquote attributes the quote to **Slashdot** and the DB confirms `source = slashdot` (1 row). Data-untruthful → fixed inline.

Data-only thin slice (AGENTS.md §3d).

## What shipped

- **Data** (`zoho-crm-deep-dive-2026-04.ts` L166): "One verified reviewer on G2 describes the core value:" → "One reviewer on Slashdot describes the core value:" — matches the blockquote + DB; dropped "verified" (Slashdot is a community source).
- **No generator change.** The quote carries `source_name` (the blockquote uses it correctly); only the LLM free-text lead-in drifted, which can't be fixed deterministically in scope → parked.

## How demonstrated

- Re-grep: "verified reviewer on G2" in the zoho post → 0; lead-in now matches the L168 blockquote ("reviewer on Slashdot") and the DB.
- **Corpus-wide grep before editing** confirmed blast radius: "verified reviewer on <platform>" is widespread but almost all are blockquote *attributions* (correct). Only 3 posts have the prose-lead-in shape — zoho (this mismatch), helpdesk (lead-in matches its blockquote → no defect), salesforce (a *different* defect: orphaned lead-in, no quote → parked).
- `audit-published-posts.js` → orphaned-quote-reference / form-prompt / empty-blockquote all 0. (Data-only slice, so no unit test — grep + audit per §3d.)

## Parked hardening

In **`ATLAS-HARDENING.md`** (separate file per the maintainer; root `HARDENING.md` has the pointer):
1. Deep-dive quote lead-ins can name a platform the quote isn't from (LLM drift; prompt-guidance fix, uncertain). *M / correctness.*
2. Orphaned quote lead-in in `salesforce-deep-dive` L159 ("…verified reviewer on G2 notes …:" with **no quote following**) — a separate orphaned-intro defect, pre-existing, surfaced while scoping D6. *S–M / correctness.*

(Remaining: D5, D2-followup, D3-followup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)