### PR TITLE
Prerender public landing pages

### DIFF
--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts
@@ -5,9 +5,28 @@ export interface SitemapUrl {
   changefreq: string
 }
 
+export interface LandingPageSitemapEntry extends SitemapUrl {
+  path: string
+  id: string
+  slug: string
+}
+
+export interface LandingPagePrerenderEntry extends LandingPageSitemapEntry {
+  page: Record<string, unknown>
+}
+
 export function resolveLandingPageSitemapUrl(
   env?: Record<string, string | undefined>,
 ): string
+
+export function resolveLandingPagePublicApiBase(
+  env?: Record<string, string | undefined>,
+): string
+
+export function landingPageSitemapEntriesFromXml(
+  xml: string,
+  publicSiteUrl: string,
+): LandingPageSitemapEntry[]
 
 export function landingPageSitemapUrlsFromXml(
   xml: string,
@@ -19,3 +38,10 @@ export function fetchLandingPageSitemapUrls(options?: {
   publicSiteUrl: string
   fetchImpl?: typeof fetch
 }): Promise<SitemapUrl[]>
+
+export function fetchLandingPagePrerenderEntries(options?: {
+  sitemapUrl?: string
+  publicSiteUrl: string
+  apiBaseUrl?: string
+  fetchImpl?: typeof fetch
+}): Promise<LandingPagePrerenderEntry[]>

--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs
@@ -10,6 +10,19 @@ export function resolveLandingPageSitemapUrl(env = process.env) {
   return clean(env.VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL)
 }
 
+export function resolveLandingPagePublicApiBase(env = process.env) {
+  const configured = stripTrailingSlash(clean(env.VITE_API_BASE))
+  if (configured) return configured
+
+  const sitemapUrl = resolveLandingPageSitemapUrl(env)
+  if (!sitemapUrl) return ''
+  try {
+    return new URL(sitemapUrl).origin
+  } catch (_error) {
+    return ''
+  }
+}
+
 function decodeXmlEntities(value) {
   return value
     .replace(/&amp;/g, '&')
@@ -19,10 +32,19 @@ function decodeXmlEntities(value) {
     .replace(/&gt;/g, '>')
 }
 
-export function landingPageSitemapUrlsFromXml(xml, publicSiteUrl) {
+function landingPagePathParts(pathname) {
+  const parts = String(pathname || '').split('/').filter(Boolean)
+  if (parts[0] !== 'lp' || !parts[1] || !parts[2]) return null
+  return {
+    id: parts[1],
+    slug: parts.slice(2).join('/'),
+  }
+}
+
+export function landingPageSitemapEntriesFromXml(xml, publicSiteUrl) {
   const siteBase = new URL(stripTrailingSlash(clean(publicSiteUrl)))
   const seen = new Set()
-  const urls = []
+  const entries = []
   const locMatches = String(xml || '').matchAll(/<loc>\s*([\s\S]*?)\s*<\/loc>/gi)
 
   for (const match of locMatches) {
@@ -34,19 +56,32 @@ export function landingPageSitemapUrlsFromXml(xml, publicSiteUrl) {
       continue
     }
 
-    if (!parsed.pathname.startsWith('/lp/')) continue
+    const parts = landingPagePathParts(parsed.pathname)
+    if (!parts) continue
 
-    const loc = `${siteBase.origin}${parsed.pathname}`
+    const path = parsed.pathname
+    const loc = `${siteBase.origin}${path}`
     if (seen.has(loc)) continue
     seen.add(loc)
-    urls.push({
+    entries.push({
       loc,
+      path,
+      id: decodeURIComponent(parts.id),
+      slug: decodeURIComponent(parts.slug),
       priority: '0.7',
       changefreq: 'weekly',
     })
   }
 
-  return urls
+  return entries
+}
+
+export function landingPageSitemapUrlsFromXml(xml, publicSiteUrl) {
+  return landingPageSitemapEntriesFromXml(xml, publicSiteUrl).map((entry) => ({
+    loc: entry.loc,
+    priority: entry.priority,
+    changefreq: entry.changefreq,
+  }))
 }
 
 export async function fetchLandingPageSitemapUrls({
@@ -68,4 +103,54 @@ export async function fetchLandingPageSitemapUrls({
 
   const xml = await response.text()
   return landingPageSitemapUrlsFromXml(xml, publicSiteUrl)
+}
+
+function landingPagePublicApiUrl(apiBaseUrl, id) {
+  const base = stripTrailingSlash(clean(apiBaseUrl))
+  if (!base) {
+    throw new Error('Landing-page public prerender requires VITE_API_BASE or a sitemap URL origin')
+  }
+  return `${base}/api/v1/content-assets/landing_page/public/${encodeURIComponent(id)}`
+}
+
+export async function fetchLandingPagePrerenderEntries({
+  sitemapUrl,
+  publicSiteUrl,
+  apiBaseUrl,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const feedUrl = clean(sitemapUrl)
+  if (!feedUrl) return []
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Landing-page prerender requires a fetch implementation')
+  }
+
+  const sitemapResponse = await fetchImpl(feedUrl)
+  if (!sitemapResponse || !sitemapResponse.ok) {
+    const status = sitemapResponse?.status ? `HTTP ${sitemapResponse.status}` : 'no response'
+    throw new Error(`Failed to fetch generated landing-page sitemap: ${status}`)
+  }
+
+  const xml = await sitemapResponse.text()
+  const entries = landingPageSitemapEntriesFromXml(xml, publicSiteUrl)
+  const resolvedApiBase = clean(apiBaseUrl) || resolveLandingPagePublicApiBase({
+    VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL: feedUrl,
+  })
+
+  const pages = []
+  for (const entry of entries) {
+    const response = await fetchImpl(landingPagePublicApiUrl(resolvedApiBase, entry.id))
+    if (!response || !response.ok) {
+      const status = response?.status ? `HTTP ${response.status}` : 'no response'
+      throw new Error(`Failed to fetch generated landing-page ${entry.id}: ${status}`)
+    }
+    const page = await response.json()
+    if (clean(page?.robots).toLowerCase() !== 'index,follow') continue
+    pages.push({
+      ...entry,
+      page,
+    })
+  }
+
+  return pages
 }

--- a/atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs
+++ b/atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  fetchLandingPagePrerenderEntries,
   fetchLandingPageSitemapUrls,
+  landingPageSitemapEntriesFromXml,
   landingPageSitemapUrlsFromXml,
+  resolveLandingPagePublicApiBase,
   resolveLandingPageSitemapUrl,
 } from './landing-page-sitemap-bridge.mjs'
 
@@ -22,6 +25,52 @@ test('resolveLandingPageSitemapUrl uses explicit feed URL only', () => {
     resolveLandingPageSitemapUrl({ VITE_API_BASE: 'https://api.example.com' }),
     '',
   )
+})
+
+test('resolveLandingPagePublicApiBase prefers VITE_API_BASE and falls back to sitemap origin', () => {
+  assert.equal(
+    resolveLandingPagePublicApiBase({
+      VITE_API_BASE: ' https://api.example.com/ ',
+      VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL:
+        'https://other.example.com/api/v1/content-assets/landing_page/public/sitemap.xml',
+    }),
+    'https://api.example.com',
+  )
+  assert.equal(
+    resolveLandingPagePublicApiBase({
+      VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL:
+        'https://api.example.com/api/v1/content-assets/landing_page/public/sitemap.xml',
+    }),
+    'https://api.example.com',
+  )
+  assert.equal(resolveLandingPagePublicApiBase({}), '')
+})
+
+test('landingPageSitemapEntriesFromXml exposes lp path, id, and slug', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://api.example.com/lp/111/acme-page</loc></url>
+  <url><loc>https://api.example.com/lp/222/second-page?variant=a&amp;b=1</loc></url>
+</urlset>`
+
+  assert.deepEqual(landingPageSitemapEntriesFromXml(xml, SITE_URL), [
+    {
+      loc: `${SITE_URL}/lp/111/acme-page`,
+      path: '/lp/111/acme-page',
+      id: '111',
+      slug: 'acme-page',
+      priority: '0.7',
+      changefreq: 'weekly',
+    },
+    {
+      loc: `${SITE_URL}/lp/222/second-page`,
+      path: '/lp/222/second-page',
+      id: '222',
+      slug: 'second-page',
+      priority: '0.7',
+      changefreq: 'weekly',
+    },
+  ])
 })
 
 test('landingPageSitemapUrlsFromXml keeps lp paths and rewrites to public site', () => {
@@ -106,4 +155,78 @@ test('fetchLandingPageSitemapUrls fails when configured feed is unavailable', as
     }),
     /Failed to fetch generated landing-page sitemap: HTTP 503/,
   )
+})
+
+test('fetchLandingPagePrerenderEntries fetches public page payloads from api base', async () => {
+  const calls = []
+  const entries = await fetchLandingPagePrerenderEntries({
+    sitemapUrl: 'https://api.example.com/api/v1/content-assets/landing_page/public/sitemap.xml',
+    publicSiteUrl: SITE_URL,
+    apiBaseUrl: 'https://api.example.com',
+    fetchImpl: async url => {
+      calls.push(url)
+      if (url.endsWith('/sitemap.xml')) {
+        return {
+          ok: true,
+          async text() {
+            return '<urlset><url><loc>https://api.example.com/lp/111/acme-page</loc></url></urlset>'
+          },
+        }
+      }
+      assert.equal(
+        url,
+        'https://api.example.com/api/v1/content-assets/landing_page/public/111',
+      )
+      return {
+        ok: true,
+        async json() {
+          return {
+            id: '111',
+            slug: 'acme-page',
+            title: 'Acme Page',
+            robots: 'index,follow',
+          }
+        },
+      }
+    },
+  })
+
+  assert.deepEqual(calls, [
+    'https://api.example.com/api/v1/content-assets/landing_page/public/sitemap.xml',
+    'https://api.example.com/api/v1/content-assets/landing_page/public/111',
+  ])
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].path, '/lp/111/acme-page')
+  assert.equal(entries[0].page.title, 'Acme Page')
+})
+
+test('fetchLandingPagePrerenderEntries skips noindex public page payloads', async () => {
+  const entries = await fetchLandingPagePrerenderEntries({
+    sitemapUrl: 'https://api.example.com/api/v1/content-assets/landing_page/public/sitemap.xml',
+    publicSiteUrl: SITE_URL,
+    apiBaseUrl: 'https://api.example.com',
+    fetchImpl: async url => {
+      if (url.endsWith('/sitemap.xml')) {
+        return {
+          ok: true,
+          async text() {
+            return '<urlset><url><loc>https://api.example.com/lp/111/acme-page</loc></url></urlset>'
+          },
+        }
+      }
+      return {
+        ok: true,
+        async json() {
+          return {
+            id: '111',
+            slug: 'acme-page',
+            title: 'Acme Page',
+            robots: 'noindex,follow',
+          }
+        },
+      }
+    },
+  })
+
+  assert.deepEqual(entries, [])
 })

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -17,7 +17,9 @@ import {
   type FaqItem,
 } from './scripts/blog-source-metadata.mjs'
 import {
+  fetchLandingPagePrerenderEntries,
   fetchLandingPageSitemapUrls,
+  resolveLandingPagePublicApiBase,
   resolveLandingPageSitemapUrl,
 } from './scripts/landing-page-sitemap-bridge.mjs'
 
@@ -110,6 +112,19 @@ interface PrerenderedRoute {
   ogType: string
   jsonLd?: object
   bodyHtml?: string
+  robots?: string
+}
+
+interface PublicLandingPagePrerenderEntry {
+  path: string
+  loc: string
+  page: Record<string, unknown>
+}
+
+interface LandingPageSectionView {
+  id: string
+  title: string
+  body: string
 }
 
 function escapeHtml(value: string): string {
@@ -222,38 +237,191 @@ function buildFaqJsonLd(faq: FaqItem[]): object | null {
 function buildHeadHtml(route: PrerenderedRoute): string {
   const { title, description, canonical, ogType, jsonLd } = route
   const lines = [
-    `<meta name="description" content="${description}" />`,
-    `<link rel="canonical" href="${canonical}" />`,
-    `<meta property="og:title" content="${title}" />`,
-    `<meta property="og:description" content="${description}" />`,
-    `<meta property="og:url" content="${canonical}" />`,
-    `<meta property="og:type" content="${ogType}" />`,
+    `<meta name="description" content="${escapeHtml(description)}" />`,
+    `<link rel="canonical" href="${escapeHtml(canonical)}" />`,
+    `<meta property="og:title" content="${escapeHtml(title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(description)}" />`,
+    `<meta property="og:url" content="${escapeHtml(canonical)}" />`,
+    `<meta property="og:type" content="${escapeHtml(ogType)}" />`,
     `<meta property="og:site_name" content="Atlas Intelligence" />`,
     `<meta property="og:image" content="${DEFAULT_OG_IMAGE}" />`,
     `<meta property="og:image:width" content="1200" />`,
     `<meta property="og:image:height" content="630" />`,
     `<meta name="twitter:card" content="summary_large_image" />`,
-    `<meta name="twitter:title" content="${title}" />`,
-    `<meta name="twitter:description" content="${description}" />`,
+    `<meta name="twitter:title" content="${escapeHtml(title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(description)}" />`,
     `<meta name="twitter:image" content="${DEFAULT_OG_IMAGE}" />`,
   ]
+  if (route.robots) {
+    lines.push(`<meta name="robots" content="${escapeHtml(route.robots)}" />`)
+  }
   if (jsonLd) {
     lines.push(
-      `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`,
+      `<script type="application/ld+json">${jsonLdScriptContent(jsonLd)}</script>`,
     )
   }
   return lines.map(l => `    ${l}`).join('\n')
 }
 
+function jsonLdScriptContent(value: object): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c')
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function recordList(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === 'object' && !Array.isArray(item)),
+    )
+    : []
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function safePublicHref(value: string): string {
+  const href = value.trim()
+  const normalized = href.toLowerCase()
+  if (
+    normalized.startsWith('https://') ||
+    normalized.startsWith('http://') ||
+    normalized.startsWith('mailto:') ||
+    normalized.startsWith('tel:') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('#')
+  ) {
+    return href
+  }
+  return ''
+}
+
+function landingPageSections(value: unknown): LandingPageSectionView[] {
+  return recordList(value)
+    .map((section) => ({
+      id: textValue(section.id),
+      title: textValue(section.title) || textValue(section.heading),
+      body: textValue(section.body_markdown) || textValue(section.body),
+    }))
+    .filter((section) => section.title || section.body)
+}
+
+function paragraphHtml(value: string): string {
+  return value
+    .split(/\n{2,}/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => `<p>${escapeHtml(part).replace(/\n/g, '<br />')}</p>`)
+    .join('\n')
+}
+
+function structuredDataWithCanonical(value: unknown, canonical: string): object | undefined {
+  const raw = recordValue(value)
+  if (!raw) return undefined
+  const graph = recordList(raw['@graph'])
+  if (graph.length === 0) return raw
+  return {
+    ...raw,
+    '@graph': graph.map((node) => {
+      const type = node['@type']
+      if (type === 'WebPage') {
+        return { ...node, '@id': `${canonical}#webpage`, url: canonical }
+      }
+      if (type === 'FAQPage') {
+        return {
+          ...node,
+          '@id': `${canonical}#faq`,
+          mainEntityOfPage: { '@id': `${canonical}#webpage` },
+        }
+      }
+      return node
+    }),
+  }
+}
+
+function buildLandingPageBodyHtml(page: Record<string, unknown>): string {
+  const hero = recordValue(page.hero)
+  const cta = recordValue(page.cta)
+  const sections = landingPageSections(page.sections)
+  const title = textValue(hero?.headline) || textValue(page.title)
+  const subheadline =
+    textValue(hero?.subheadline) || textValue(page.value_prop)
+  const persona = textValue(page.persona)
+  const ctaLabel = textValue(cta?.label) || textValue(hero?.cta_label)
+  const ctaUrl = safePublicHref(textValue(cta?.url) || textValue(hero?.cta_url))
+  const sectionHtml = sections.map((section, index) => `
+      <section data-prerendered-landing-page-section="${escapeHtml(section.id || String(index + 1))}">
+        <h2>${escapeHtml(section.title || `Section ${index + 1}`)}</h2>
+        ${paragraphHtml(section.body)}
+      </section>`).join('\n')
+  const ctaHtml = ctaLabel && ctaUrl
+    ? `
+      <p>
+        <a href="${escapeHtml(ctaUrl)}">${escapeHtml(ctaLabel)}</a>
+      </p>`
+    : ''
+
+  return `
+    <article data-prerendered-landing-page="true">
+      <header>
+        ${persona ? `<p>${escapeHtml(persona)}</p>` : ''}
+        <h1>${escapeHtml(title)}</h1>
+        ${subheadline ? `<p>${escapeHtml(subheadline)}</p>` : ''}
+        ${ctaHtml}
+      </header>
+      ${sectionHtml}
+      ${ctaHtml ? `
+      <section data-prerendered-landing-page-cta="true">
+        <h2>${escapeHtml(textValue(page.title) || title)}</h2>
+        ${subheadline ? `<p>${escapeHtml(subheadline)}</p>` : ''}
+        ${ctaHtml}
+      </section>` : ''}
+    </article>`
+}
+
+function landingPageRoute(entry: PublicLandingPagePrerenderEntry): PrerenderedRoute {
+  const page = entry.page
+  const hero = recordValue(page.hero)
+  const meta = recordValue(page.meta)
+  const title = textValue(meta?.title_tag) || textValue(page.title) || 'Landing Page'
+  const description =
+    textValue(meta?.description) ||
+    textValue(hero?.subheadline) ||
+    textValue(page.value_prop) ||
+    title
+  return {
+    path: entry.path,
+    title,
+    description,
+    canonical: entry.loc,
+    ogType: 'website',
+    bodyHtml: buildLandingPageBodyHtml(page),
+    jsonLd: structuredDataWithCanonical(page.structured_data, entry.loc),
+    robots: textValue(page.robots) || 'noindex,follow',
+  }
+}
+
 function prerenderPlugin() {
   return {
     name: 'prerender-public-routes',
-    closeBundle() {
+    async closeBundle() {
       const distDir = resolve(import.meta.dirname, 'dist')
       const indexHtmlPath = join(distDir, 'index.html')
       if (!existsSync(indexHtmlPath)) return
 
       const baseHtml = readFileSync(indexHtmlPath, 'utf-8')
+      const landingPageRoutes = (
+        await fetchLandingPagePrerenderEntries({
+          sitemapUrl: resolveLandingPageSitemapUrl(),
+          publicSiteUrl: BASE_URL,
+          apiBaseUrl: resolveLandingPagePublicApiBase(),
+        }) as PublicLandingPagePrerenderEntry[]
+      ).map(landingPageRoute)
 
       const blogRoutes: PrerenderedRoute[] = []
       for (const post of collectBlogSourceMetadata(import.meta.dirname)) {
@@ -363,6 +531,7 @@ function prerenderPlugin() {
           ogType: 'website',
         },
         ...blogRoutes,
+        ...landingPageRoutes,
       ]
 
       let count = 0
@@ -372,7 +541,7 @@ function prerenderPlugin() {
         const rendered = baseHtml
           .replace(
             /<title>[^<]*<\/title>/,
-            `<title>${route.title}</title>`,
+            `<title>${escapeHtml(route.title)}</title>`,
           )
           .replace('</head>', `${headHtml}\n  </head>`)
           .replace('<div id="root"></div>', `<div id="root">${route.bodyHtml || ''}</div>`)

--- a/plans/PR-Landing-Page-Public-Prerender.md
+++ b/plans/PR-Landing-Page-Public-Prerender.md
@@ -1,0 +1,91 @@
+# PR: Landing Page Public Prerender
+
+## Why this slice exists
+
+Generated landing pages now have a public API route, sitemap feed, metadata,
+structured data, and review/repair readiness. The frontend route at `/lp/:id/:slug`
+still renders the generated page through client-side JavaScript. That means a
+crawler can receive the SPA shell before the generated hero, body, CTA, meta,
+and JSON-LD are visible in the returned HTML.
+
+This slice makes approved generated landing pages crawler-visible at the
+frontend build boundary.
+
+Ownership lane: content-ops/landing-page-public-prerender
+
+## Scope (this PR)
+
+1. Extend the landing-page sitemap bridge so the build can:
+   - parse `/lp/{id}/{slug}` entries from the public landing-page sitemap,
+   - resolve the public landing-page API base,
+   - fetch the approved public landing-page JSON payload for each sitemap entry.
+2. Extend the Vite public-route prerender plugin to write static
+   `dist/lp/{id}/{slug}/index.html` files for fetched generated landing pages.
+3. Include generated landing-page title, description, canonical, body copy, CTA,
+   robots policy, and JSON-LD in the static HTML.
+4. Escape generated title, description, route body text, CTA URLs, and JSON-LD
+   script content in the static HTML path.
+5. Add focused bridge tests for sitemap parsing, API-base resolution, and page
+   payload fetching.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Public-Prerender.md` | Plan doc for this public prerender slice. |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs` | Parse public landing-page sitemap entries and fetch public page payloads for prerendering. |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts` | Expose TypeScript declarations for the new sitemap/prerender helpers. |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs` | Cover entry parsing, API-base resolution, payload fetching, and noindex filtering. |
+| `atlas-intel-ui/vite.config.ts` | Prerender fetched generated landing pages into static public route HTML. |
+
+## Mechanism
+
+The existing sitemap bridge remains the source of generated landing-page URLs.
+When `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` is configured, the build fetches the
+sitemap, extracts approved `/lp/...` entries, fetches each public JSON payload
+through `VITE_API_BASE` or the sitemap URL origin, and turns each payload into a
+normal `PrerenderedRoute`.
+
+The existing prerender plugin then writes one static HTML file per generated
+landing page, the same way it already writes public blog routes. Runtime React
+still hydrates and can refetch the same public payload.
+
+## Intentional
+
+- No backend route changes.
+- No database changes.
+- No public approval policy changes.
+- No attempt to prerender when the public landing-page sitemap URL is absent.
+- No reliance on generated landing pages being available in local dev builds.
+
+## Deferred
+
+- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
+  and repair lock connection hold time. Both are parked under
+  `Owner/session: landing-page repair session` and are not required for public
+  prerendering.
+- Rich markdown rendering parity can be improved later if operators need exact
+  static/React HTML matching. This slice prioritizes crawler-visible text,
+  metadata, CTA, and JSON-LD.
+
+## Parked hardening
+
+- None added.
+
+## Verification
+
+- Sitemap bridge test -> 10 passed.
+- Atlas Intel UI production build -> passed.
+- Blog GEO prerender verification -> verified 14 blog pages.
+- Local PR review -> passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs` | 95 |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts` | 30 |
+| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs` | 85 |
+| `atlas-intel-ui/vite.config.ts` | 190 |
+| `plans/PR-Landing-Page-Public-Prerender.md` | 65 |
+| **Total** | **465** |


### PR DESCRIPTION
# PR: Landing Page Public Prerender

## Why this slice exists

Generated landing pages now have a public API route, sitemap feed, metadata,
structured data, and review/repair readiness. The frontend route at `/lp/:id/:slug`
still renders the generated page through client-side JavaScript. That means a
crawler can receive the SPA shell before the generated hero, body, CTA, meta,
and JSON-LD are visible in the returned HTML.

This slice makes approved generated landing pages crawler-visible at the
frontend build boundary.

Ownership lane: content-ops/landing-page-public-prerender

## Scope (this PR)

1. Extend the landing-page sitemap bridge so the build can:
   - parse `/lp/{id}/{slug}` entries from the public landing-page sitemap,
   - resolve the public landing-page API base,
   - fetch the approved public landing-page JSON payload for each sitemap entry.
2. Extend the Vite public-route prerender plugin to write static
   `dist/lp/{id}/{slug}/index.html` files for fetched generated landing pages.
3. Include generated landing-page title, description, canonical, body copy, CTA,
   robots policy, and JSON-LD in the static HTML.
4. Escape generated title, description, route body text, CTA URLs, and JSON-LD
   script content in the static HTML path.
5. Add focused bridge tests for sitemap parsing, API-base resolution, and page
   payload fetching.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Public-Prerender.md` | Plan doc for this public prerender slice. |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs` | Parse public landing-page sitemap entries and fetch public page payloads for prerendering. |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts` | Expose TypeScript declarations for the new sitemap/prerender helpers. |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs` | Cover entry parsing, API-base resolution, payload fetching, and noindex filtering. |
| `atlas-intel-ui/vite.config.ts` | Prerender fetched generated landing pages into static public route HTML. |

## Mechanism

The existing sitemap bridge remains the source of generated landing-page URLs.
When `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` is configured, the build fetches the
sitemap, extracts approved `/lp/...` entries, fetches each public JSON payload
through `VITE_API_BASE` or the sitemap URL origin, and turns each payload into a
normal `PrerenderedRoute`.

The existing prerender plugin then writes one static HTML file per generated
landing page, the same way it already writes public blog routes. Runtime React
still hydrates and can refetch the same public payload.

## Intentional

- No backend route changes.
- No database changes.
- No public approval policy changes.
- No attempt to prerender when the public landing-page sitemap URL is absent.
- No reliance on generated landing pages being available in local dev builds.

## Deferred

- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
  and repair lock connection hold time. Both are parked under
  `Owner/session: landing-page repair session` and are not required for public
  prerendering.
- Rich markdown rendering parity can be improved later if operators need exact
  static/React HTML matching. This slice prioritizes crawler-visible text,
  metadata, CTA, and JSON-LD.

## Parked hardening

- None added.

## Verification

- Sitemap bridge test -> 10 passed.
- Atlas Intel UI production build -> passed.
- Blog GEO prerender verification -> verified 14 blog pages.
- Local PR review -> passed.

## Estimated diff size

| File | Estimated LOC |
| --- | ---: |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.mjs` | 95 |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.d.mts` | 30 |
| `atlas-intel-ui/scripts/landing-page-sitemap-bridge.test.mjs` | 85 |
| `atlas-intel-ui/vite.config.ts` | 190 |
| `plans/PR-Landing-Page-Public-Prerender.md` | 65 |
| **Total** | **465** |
