### PR TITLE
Expose FAQ vocabulary gaps in asset review

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -81,6 +81,15 @@ type FAQItemPreview = {
   answer: string
   actionItems: string[]
   sourceLabels: string[]
+  termMappings: FAQTermMappingPreview[]
+}
+
+type FAQTermMappingPreview = {
+  customerTerm: string
+  documentationTerm: string
+  sourceIdCount: string
+  zeroResultSourceCount: string
+  opportunityScore: string
 }
 
 type StructuredDataSummary = {
@@ -1038,6 +1047,42 @@ function AssetDetailDrawer({
                       </div>
                     </div>
                   )}
+                  {item.termMappings.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Vocabulary gaps
+                      </div>
+                      <ul className="mt-2 space-y-2 text-sm text-slate-300">
+                        {item.termMappings.map((mapping, mappingIndex) => (
+                          <li
+                            key={`${mapping.customerTerm}-${mapping.documentationTerm}-${mappingIndex}`}
+                            className="border-l border-cyan-500/40 pl-3"
+                          >
+                            <div>
+                              <span className="text-cyan-200">
+                                {mapping.customerTerm}
+                              </span>
+                              <span className="text-slate-500">{' -> '}</span>
+                              <span>{mapping.documentationTerm}</span>
+                            </div>
+                            <div className="mt-1 flex flex-wrap gap-2 text-xs text-slate-500">
+                              {mapping.sourceIdCount && (
+                                <span>{mapping.sourceIdCount} source(s)</span>
+                              )}
+                              {mapping.zeroResultSourceCount && (
+                                <span>
+                                  {mapping.zeroResultSourceCount} zero-result source(s)
+                                </span>
+                              )}
+                              {mapping.opportunityScore && (
+                                <span>score {mapping.opportunityScore}</span>
+                              )}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -1728,6 +1773,7 @@ function addAssetSpecificFacts(
     addFact(facts, 'ticket sources', row.ticket_source_count)
     addFact(facts, 'source rows', row.source_count)
     addFact(facts, 'checks passed', row.passed_output_checks)
+    addFact(facts, 'vocab gaps', faqVocabularyGapCount(row.items))
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -1786,6 +1832,7 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
     const items = faqItemList(row.items)
     const first = items[0]
     const checks = outputCheckLabels(row.output_checks)
+    const vocabularyGapCount = faqVocabularyGapCount(row.items)
     const sourceMeta =
       first?.sourceLabels.slice(0, 2).map((source) => `source: ${source}`) ?? []
     return previewOrNull({
@@ -1793,8 +1840,9 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
       body: excerpt(first?.answer || textValue(row.markdown)),
       meta: [
         ...sourceMeta,
+        vocabularyGapCount ? `vocab gaps: ${vocabularyGapCount}` : '',
         ...checks.slice(0, 3).map((check) => `check: ${check}`),
-      ],
+      ].filter(Boolean),
     })
   }
   const section = firstSection(row.sections)
@@ -1838,7 +1886,27 @@ function faqItemList(value: unknown): FAQItemPreview[] {
     answer: textValue(item.answer),
     actionItems: valueList(item.action_items),
     sourceLabels: valueList(item.source_labels),
+    termMappings: faqTermMappingList(item.term_mappings),
   })).filter((item) => item.question || item.answer)
+}
+
+function faqTermMappingList(value: unknown): FAQTermMappingPreview[] {
+  return recordList(value)
+    .map((mapping) => ({
+      customerTerm: textValue(mapping.customer_term),
+      documentationTerm: textValue(mapping.documentation_term),
+      sourceIdCount: numberText(mapping.source_id_count),
+      zeroResultSourceCount: numberText(mapping.zero_result_source_count),
+      opportunityScore: numberText(mapping.opportunity_score),
+    }))
+    .filter((mapping) => mapping.customerTerm || mapping.documentationTerm)
+}
+
+function faqVocabularyGapCount(value: unknown): number {
+  return faqItemList(value).reduce(
+    (total, item) => total + item.termMappings.length,
+    0,
+  )
 }
 
 function recordList(value: unknown): Record<string, unknown>[] {

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Review-UI.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Review-UI.md
@@ -1,0 +1,72 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Review-UI
+
+## Why this slice exists
+
+The FAQ generator now detects vocabulary gaps end to end in CLI/library output,
+and the compact run summary exposes the signal for large runs. Reviewers in the
+hosted Content Ops asset queue can inspect FAQ items, action steps, and sources,
+but vocabulary-gap mappings are still only visible in the raw JSON dump.
+
+This slice surfaces the existing per-item term mappings in the FAQ review drawer
+so an operator can see customer phrasing versus documentation phrasing before
+approving the generated FAQ.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-review-ui
+
+1. Parse existing `items[].term_mappings` on FAQ Markdown drafts.
+2. Show a compact vocabulary-gap count in FAQ preview/facts.
+3. Render per-item vocabulary-gap mappings in the FAQ item drawer section.
+4. Avoid backend/schema changes; use the row shape already exported by the FAQ
+   draft API.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Review-UI.md` | Plan doc for this review UI slice. |
+| `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` | Displays FAQ vocabulary-gap mappings from existing item data. |
+
+## Mechanism
+
+`faqItemList(...)` already normalizes FAQ item records for the drawer. This
+slice extends that normalized item shape with `termMappings`, sourced from
+`term_mappings` on each item. Each mapping keeps only the review-visible fields:
+customer term, documentation term, source count, zero-result count, and score.
+
+The drawer renders those mappings under each FAQ item. The list view adds a
+small `vocab gaps: N` fact/meta label so reviewers know whether opening the
+drawer is useful.
+
+## Intentional
+
+- UI-only. No generated output, API, repository, or database change.
+- No new hosted upload controls in this slice; this displays mappings already
+  produced by CLI/library/service paths.
+- No chart or table abstraction. The existing FAQ drawer cards are sufficient
+  for this thin review surface.
+
+## Deferred
+
+- Hosted upload controls for documentation terms and vocabulary rules remain a
+  separate product slice.
+- Bulk filtering/sorting by vocabulary-gap count remains deferred until a real
+  review queue needs it.
+- Parked hardening considered: current `HARDENING.md` entries are landing-page
+  repair items and do not touch this FAQ lane.
+
+## Verification
+
+- `npm run lint` from `atlas-intel-ui` - passed.
+- `npm run build` from `atlas-intel-ui` - passed.
+- `git diff --check` - passed.
+- Local Vite dev server started at `http://127.0.0.1:5175/` for manual review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Review UI parser/rendering | ~90 |
+| **Total** | ~170 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Review-UI.md

Surface generated FAQ vocabulary-gap mappings in the Content Ops asset review drawer so reviewers can see customer phrasing versus documentation phrasing before approving FAQ Markdown drafts.

## Intentional
- UI-only; no generated output, API, repository, or database changes.
- No hosted upload controls in this slice; this displays mappings already produced by CLI/library/service paths.
- No chart or table abstraction; the existing FAQ drawer cards are enough for this thin review surface.

## Deferred
- Hosted upload controls for documentation terms and vocabulary rules remain separate.
- Bulk filtering/sorting by vocabulary-gap count remains deferred until a real review queue needs it.
- Parked hardening considered: current `HARDENING.md` entries are landing-page repair items and do not touch this FAQ lane.

## Verification
- `npm run lint` from `atlas-intel-ui` — passed.
- `npm run build` from `atlas-intel-ui` — passed.
- `git diff --check` — passed.
- Local Vite dev server started at `http://127.0.0.1:5175/` for manual review.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` — passed.

## Diff size
2 files, +141 / -1