### PR TITLE
Verify public landing page prerenders

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -47,8 +47,14 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test landing-page prerender verifier
+        run: npm run test:landing-page-prerender
+
       - name: Build
         run: npm run build
 
       - name: Verify blog GEO prerender
         run: npm run verify:blog-geo
+
+      - name: Verify landing-page GEO prerender
+        run: npm run verify:landing-page-geo

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -8,8 +8,10 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
-    "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs"
+    "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",
+    "verify:landing-page-geo": "node scripts/verify-landing-page-geo-prerender.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs
+++ b/atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs
@@ -1,0 +1,175 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const rootDir = fileURLToPath(new URL('..', import.meta.url))
+const defaultDistDir = join(rootDir, 'dist')
+
+function readText(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function decodeXmlEntities(value) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+}
+
+function landingPageUrlsFromSitemap(sitemap) {
+  const urls = []
+  const locMatches = String(sitemap || '').matchAll(/<loc>\s*([\s\S]*?)\s*<\/loc>/gi)
+  for (const match of locMatches) {
+    const rawLoc = decodeXmlEntities(match[1])
+    let parsed
+    try {
+      parsed = new URL(rawLoc)
+    } catch (_error) {
+      continue
+    }
+    if (!parsed.pathname.startsWith('/lp/')) continue
+    urls.push({
+      loc: `${parsed.origin}${parsed.pathname}`,
+      path: parsed.pathname,
+    })
+  }
+  return urls
+}
+
+function landingPageHtmlPath(pathname, distDir) {
+  const parts = pathname.split('/').filter(Boolean)
+  return join(distDir, ...parts, 'index.html')
+}
+
+function attrValue(tag, attr) {
+  const pattern = new RegExp(`${attr}=["']([^"']*)["']`, 'i')
+  return tag.match(pattern)?.[1] || ''
+}
+
+function findMeta(html, keyAttr, keyValue) {
+  const pattern = new RegExp(
+    `<meta\\b(?=[^>]*\\b${keyAttr}=["']${escapeRegex(keyValue)}["'])[^>]*>`,
+    'i',
+  )
+  return html.match(pattern)?.[0] || ''
+}
+
+function findLink(html, rel) {
+  const pattern = new RegExp(
+    `<link\\b(?=[^>]*\\brel=["']${escapeRegex(rel)}["'])[^>]*>`,
+    'i',
+  )
+  return html.match(pattern)?.[0] || ''
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function scriptJsonLdBlocks(html) {
+  return [...html.matchAll(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)]
+    .map(match => match[1].trim())
+    .filter(Boolean)
+}
+
+function hasJsonLdGraph(html) {
+  return scriptJsonLdBlocks(html).some((block) => {
+    try {
+      const parsed = JSON.parse(block)
+      return parsed && parsed['@context'] === 'https://schema.org'
+    } catch (_error) {
+      return false
+    }
+  })
+}
+
+function verifyLandingPage(url, distDir, fail) {
+  const htmlPath = landingPageHtmlPath(url.path, distDir)
+  if (!existsSync(htmlPath)) {
+    fail(`${url.path} is listed in sitemap.xml but missing ${htmlPath}`)
+    return
+  }
+
+  const html = readText(htmlPath)
+  const title = html.match(/<title>([^<]+)<\/title>/i)?.[1]?.trim() || ''
+  if (!title || title === 'Atlas Intelligence - Amazon Review Monitoring & Competitor Signals') {
+    fail(`${url.path} has missing or fallback <title>`)
+  }
+
+  const description = findMeta(html, 'name', 'description')
+  if (!attrValue(description, 'content')) {
+    fail(`${url.path} missing meta description`)
+  }
+
+  const canonical = findLink(html, 'canonical')
+  if (attrValue(canonical, 'href') !== url.loc) {
+    fail(`${url.path} canonical href must be ${url.loc}`)
+  }
+
+  const robots = findMeta(html, 'name', 'robots')
+  if (attrValue(robots, 'content').toLowerCase() !== 'index,follow') {
+    fail(`${url.path} must be index,follow in prerendered robots meta`)
+  }
+
+  const ogUrl = findMeta(html, 'property', 'og:url')
+  if (attrValue(ogUrl, 'content') !== url.loc) {
+    fail(`${url.path} og:url must be ${url.loc}`)
+  }
+
+  if (!hasJsonLdGraph(html)) {
+    fail(`${url.path} missing valid Schema.org JSON-LD`)
+  }
+
+  if (!html.includes('data-prerendered-landing-page="true"')) {
+    fail(`${url.path} missing prerendered landing-page body marker`)
+  }
+
+  if (!/<h1>[^<]+<\/h1>/i.test(html)) {
+    fail(`${url.path} missing prerendered H1`)
+  }
+
+  if (!/<a\b[^>]*href=["'][^"']+["'][^>]*>[^<]+<\/a>/i.test(html)) {
+    fail(`${url.path} missing prerendered CTA link`)
+  }
+}
+
+export function verifyLandingPagePrerender({
+  distDir = defaultDistDir,
+  logger = console,
+} = {}) {
+  const sitemapPath = join(distDir, 'sitemap.xml')
+  const failures = []
+  const fail = message => failures.push(message)
+  let checked = 0
+
+  if (!existsSync(sitemapPath)) {
+    fail(`Missing sitemap.xml at ${sitemapPath}`)
+    return { checked, failures }
+  }
+
+  const urls = landingPageUrlsFromSitemap(readText(sitemapPath))
+  for (const url of urls) {
+    verifyLandingPage(url, distDir, fail)
+  }
+  checked = urls.length
+  if (urls.length === 0) {
+    logger.log('No generated landing-page sitemap entries found; skipping landing-page GEO prerender verification.')
+  } else {
+    logger.log(`Verified GEO prerender metadata for ${urls.length} generated landing page(s)`)
+  }
+
+  return { checked, failures }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { failures } = verifyLandingPagePrerender()
+  if (failures.length) {
+    console.error('Landing-page GEO prerender verification failed:')
+    for (const failure of failures) {
+      console.error(`- ${failure}`)
+    }
+    process.exit(1)
+  }
+}

--- a/atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs
+++ b/atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { verifyLandingPagePrerender } from './verify-landing-page-geo-prerender.mjs'
+
+const SITE_URL = 'https://atlas-intel-ui-two.vercel.app'
+
+function withTempDist(fn) {
+  const distDir = mkdtempSync(join(tmpdir(), 'atlas-lp-prerender-'))
+  try {
+    return fn(distDir)
+  } finally {
+    rmSync(distDir, { recursive: true, force: true })
+  }
+}
+
+function writeSitemap(distDir, urls) {
+  writeFileSync(
+    join(distDir, 'sitemap.xml'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+${urls.map(url => `  <url><loc>${url}</loc></url>`).join('\n')}
+</urlset>
+`,
+  )
+}
+
+function writeLandingPageHtml(distDir, path, html) {
+  const outDir = join(distDir, ...path.split('/').filter(Boolean))
+  mkdirSync(outDir, { recursive: true })
+  writeFileSync(join(outDir, 'index.html'), html)
+}
+
+function landingPageHtml({ loc = `${SITE_URL}/lp/111/acme-page` } = {}) {
+  return `<!doctype html>
+<html>
+  <head>
+    <title>Acme Support FAQ Report</title>
+    <meta name="description" content="Turn support tickets into clear FAQ answers." />
+    <link rel="canonical" href="${loc}" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:url" content="${loc}" />
+    <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"WebPage"}]}</script>
+  </head>
+  <body>
+    <article data-prerendered-landing-page="true">
+      <h1>Acme Support FAQ Report</h1>
+      <p>Turn repeat questions into answers customers can find.</p>
+      <a href="/upload">Upload Ticket CSV</a>
+    </article>
+  </body>
+</html>`
+}
+
+test('verifyLandingPagePrerender passes when lp sitemap entry has static HTML contract', () => {
+  withTempDist((distDir) => {
+    const loc = `${SITE_URL}/lp/111/acme-page`
+    writeSitemap(distDir, [loc])
+    writeLandingPageHtml(distDir, '/lp/111/acme-page', landingPageHtml({ loc }))
+
+    const result = verifyLandingPagePrerender({
+      distDir,
+      logger: { log() {} },
+    })
+
+    assert.equal(result.checked, 1)
+    assert.deepEqual(result.failures, [])
+  })
+})
+
+test('verifyLandingPagePrerender fails when lp sitemap entry lacks static HTML', () => {
+  withTempDist((distDir) => {
+    writeSitemap(distDir, [`${SITE_URL}/lp/111/acme-page`])
+
+    const result = verifyLandingPagePrerender({
+      distDir,
+      logger: { log() {} },
+    })
+
+    assert.equal(result.checked, 1)
+    assert.match(result.failures[0], /missing .*index\.html/)
+  })
+})
+
+test('verifyLandingPagePrerender skips builds with no generated landing pages', () => {
+  withTempDist((distDir) => {
+    writeSitemap(distDir, [`${SITE_URL}/blog/example`])
+
+    const result = verifyLandingPagePrerender({
+      distDir,
+      logger: { log() {} },
+    })
+
+    assert.equal(result.checked, 0)
+    assert.deepEqual(result.failures, [])
+  })
+})

--- a/plans/PR-Landing-Page-Public-Prerender-Verify.md
+++ b/plans/PR-Landing-Page-Public-Prerender-Verify.md
@@ -1,0 +1,88 @@
+# PR: Landing Page Public Prerender Verify
+
+## Why this slice exists
+
+PR #804 made approved generated landing pages prerender into static `/lp/...`
+HTML when the public sitemap feed is configured. That closes the crawler-visible
+rendering gap, but the build currently has no verifier that fails when sitemap
+entries exist without matching static HTML, metadata, JSON-LD, body copy, or CTA
+content.
+
+This slice adds a publish-surface guard for generated landing-page prerendering.
+
+Ownership lane: content-ops/landing-page-public-prerender-verify
+
+## Scope (this PR)
+
+1. Add a landing-page prerender verification script for built `dist` output.
+2. Check every `/lp/...` URL in `dist/sitemap.xml` has a matching
+   `dist/lp/.../index.html`.
+3. Verify each generated landing-page HTML file includes title/meta,
+   canonical, robots `index,follow`, JSON-LD, prerendered body marker, H1, and
+   CTA markup.
+4. Add an npm script and wire it into the Atlas Intel UI CI workflow after the
+   production build.
+5. Keep the verifier a no-op when the build has no generated `/lp/...` sitemap
+   entries.
+6. Add fixture tests for the verifier's pass, missing-file failure, and no-op
+   paths.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Public-Prerender-Verify.md` | Plan doc for this verifier slice. |
+| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs` | Verify built public generated landing-page HTML. |
+| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs` | Cover verifier behavior with temporary built-output fixtures. |
+| `atlas-intel-ui/package.json` | Add the landing-page GEO verification script. |
+| `.github/workflows/atlas_intel_ui_checks.yml` | Run the landing-page verifier in CI after build. |
+
+## Mechanism
+
+The verifier reads `dist/sitemap.xml`, extracts URLs whose path starts with
+`/lp/`, maps each URL path to the corresponding static file under `dist`, and
+checks the HTML for the crawler-visible artifacts the public landing-page
+contract needs.
+
+No generated landing-page feed is required for local or CI builds. If the
+sitemap contains no `/lp/...` entries, the verifier reports that and exits
+successfully.
+
+## Intentional
+
+- No runtime route changes.
+- No build plugin changes.
+- No live network calls.
+- No public landing-page content fixtures.
+
+## Deferred
+
+- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
+  and repair lock connection hold time. Both are parked under
+  `Owner/session: landing-page repair session` and are not required for public
+  prerender verification.
+
+## Parked hardening
+
+- None added.
+
+## Verification
+
+- Atlas Intel UI lint -> passed.
+- Landing-page prerender verifier test -> 3 passed.
+- Atlas Intel UI production build -> passed.
+- Blog GEO prerender verification -> verified 14 blog pages.
+- Landing-page GEO prerender verification -> passed; no generated landing-page
+  sitemap entries found in local build.
+- Local PR review -> passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs` | 165 |
+| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs` | 105 |
+| `atlas-intel-ui/package.json` | 3 |
+| `.github/workflows/atlas_intel_ui_checks.yml` | 6 |
+| `plans/PR-Landing-Page-Public-Prerender-Verify.md` | 75 |
+| **Total** | **354** |


### PR DESCRIPTION
# PR: Landing Page Public Prerender Verify

## Why this slice exists

PR #804 made approved generated landing pages prerender into static `/lp/...`
HTML when the public sitemap feed is configured. That closes the crawler-visible
rendering gap, but the build currently has no verifier that fails when sitemap
entries exist without matching static HTML, metadata, JSON-LD, body copy, or CTA
content.

This slice adds a publish-surface guard for generated landing-page prerendering.

Ownership lane: content-ops/landing-page-public-prerender-verify

## Scope (this PR)

1. Add a landing-page prerender verification script for built `dist` output.
2. Check every `/lp/...` URL in `dist/sitemap.xml` has a matching
   `dist/lp/.../index.html`.
3. Verify each generated landing-page HTML file includes title/meta,
   canonical, robots `index,follow`, JSON-LD, prerendered body marker, H1, and
   CTA markup.
4. Add an npm script and wire it into the Atlas Intel UI CI workflow after the
   production build.
5. Keep the verifier a no-op when the build has no generated `/lp/...` sitemap
   entries.
6. Add fixture tests for the verifier's pass, missing-file failure, and no-op
   paths.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Public-Prerender-Verify.md` | Plan doc for this verifier slice. |
| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs` | Verify built public generated landing-page HTML. |
| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs` | Cover verifier behavior with temporary built-output fixtures. |
| `atlas-intel-ui/package.json` | Add the landing-page GEO verification script. |
| `.github/workflows/atlas_intel_ui_checks.yml` | Run the landing-page verifier in CI after build. |

## Mechanism

The verifier reads `dist/sitemap.xml`, extracts URLs whose path starts with
`/lp/`, maps each URL path to the corresponding static file under `dist`, and
checks the HTML for the crawler-visible artifacts the public landing-page
contract needs.

No generated landing-page feed is required for local or CI builds. If the
sitemap contains no `/lp/...` entries, the verifier reports that and exits
successfully.

## Intentional

- No runtime route changes.
- No build plugin changes.
- No live network calls.
- No public landing-page content fixtures.

## Deferred

- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
  and repair lock connection hold time. Both are parked under
  `Owner/session: landing-page repair session` and are not required for public
  prerender verification.

## Parked hardening

- None added.

## Verification

- Atlas Intel UI lint -> passed.
- Landing-page prerender verifier test -> 3 passed.
- Atlas Intel UI production build -> passed.
- Blog GEO prerender verification -> verified 14 blog pages.
- Landing-page GEO prerender verification -> passed; no generated landing-page
  sitemap entries found in local build.
- Local PR review -> passed.

## Estimated diff size

| File | Estimated LOC |
| --- | ---: |
| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.mjs` | 165 |
| `atlas-intel-ui/scripts/verify-landing-page-geo-prerender.test.mjs` | 105 |
| `atlas-intel-ui/package.json` | 3 |
| `.github/workflows/atlas_intel_ui_checks.yml` | 6 |
| `plans/PR-Landing-Page-Public-Prerender-Verify.md` | 75 |
| **Total** | **354** |
