### PR TITLE
Document landing page prerender env

### DIFF
--- a/atlas-intel-ui/README.md
+++ b/atlas-intel-ui/README.md
@@ -1,0 +1,64 @@
+# Atlas Intel UI
+
+React/Vite frontend for Atlas Intelligence public pages, generated-asset review,
+and B2B intelligence workflows.
+
+## Build Checks
+
+Run the frontend checks from this directory:
+
+```bash
+npm run lint
+npm run test:landing-page-prerender
+npm run build
+npm run verify:blog-geo
+npm run verify:landing-page-geo
+```
+
+The GitHub `Atlas Intel UI Checks` workflow runs the same build and public
+prerender verification path.
+
+## Environment
+
+### `VITE_API_BASE`
+
+Set this in production to the Atlas backend origin, without the API path:
+
+```bash
+VITE_API_BASE=https://atlas-api.example.com
+```
+
+The browser uses this value for `/api/v1/...` calls. The build also uses it
+when prerendering generated landing pages, because each sitemap entry is fetched
+from:
+
+```text
+{VITE_API_BASE}/api/v1/content-assets/landing_page/public/{id}
+```
+
+Leave it empty in local development when the Vite dev proxy should handle
+`/api` requests.
+
+### `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`
+
+Set this only when generated landing pages should be included in the static
+public sitemap and prerendered as crawler-visible HTML:
+
+```bash
+VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL=https://atlas-api.example.com/api/v1/content-assets/landing_page/public/sitemap.xml
+```
+
+When this is configured, the Vite build fetches the sitemap, keeps `/lp/...`
+entries, fetches each approved public landing-page payload, and writes static
+HTML to:
+
+```text
+dist/lp/{id}/{slug}/index.html
+```
+
+The landing-page verifier then checks those built files for canonical metadata,
+robots policy, JSON-LD, visible body copy, H1, and CTA markup.
+
+If this variable is absent, generated landing-page prerendering is skipped and
+`npm run verify:landing-page-geo` exits successfully when no `/lp/...` sitemap
+entries exist.

--- a/atlas-intel-ui/src/vite-env.d.ts
+++ b/atlas-intel-ui/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE?: string
+  readonly VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL?: string
 }
 
 interface ImportMeta {

--- a/plans/PR-Landing-Page-Prerender-Env-Docs.md
+++ b/plans/PR-Landing-Page-Prerender-Env-Docs.md
@@ -1,0 +1,72 @@
+# PR: Landing Page Prerender Env Docs
+
+## Why this slice exists
+
+Generated landing-page public prerendering now depends on build-time
+configuration. The code supports `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` and
+`VITE_API_BASE`, but the Atlas Intel UI has no local README explaining that
+deployment contract, and the Vite env type declaration only lists
+`VITE_API_BASE`.
+
+This slice documents the deployment knobs that make generated landing-page
+prerendering active.
+
+Ownership lane: content-ops/landing-page-prerender-env-docs
+
+## Scope (this PR)
+
+1. Add a focused Atlas Intel UI README section for public landing-page
+   prerendering.
+2. Document when to set `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`.
+3. Document how `VITE_API_BASE` is used for public page payload fetches.
+4. Add the missing Vite env type for `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Prerender-Env-Docs.md` | Plan doc for this env-doc slice. |
+| `atlas-intel-ui/README.md` | Document Atlas Intel UI build and public landing-page prerender env vars. |
+| `atlas-intel-ui/src/vite-env.d.ts` | Add the public landing-page sitemap env type. |
+
+## Mechanism
+
+The README records the production setup:
+
+- `VITE_API_BASE` points browser and build-time public payload fetches at the
+  Atlas backend origin.
+- `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` points the Vite build at the backend
+  public generated landing-page sitemap feed.
+- If the sitemap URL is absent, generated landing-page prerendering is skipped
+  and the verifier no-ops.
+
+## Intentional
+
+- No runtime code changes.
+- No build plugin changes.
+- No CI behavior changes.
+
+## Deferred
+
+- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
+  and repair lock connection hold time. Both are parked under
+  `Owner/session: landing-page repair session` and are not required for env
+  docs.
+
+## Parked hardening
+
+- None added.
+
+## Verification
+
+- TypeScript build -> passed.
+- Local PR review -> passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `atlas-intel-ui/README.md` | 55 |
+| `atlas-intel-ui/src/vite-env.d.ts` | 1 |
+| `plans/PR-Landing-Page-Prerender-Env-Docs.md` | 65 |
+| **Total** | **121** |


### PR DESCRIPTION
# PR: Landing Page Prerender Env Docs

## Why this slice exists

Generated landing-page public prerendering now depends on build-time
configuration. The code supports `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` and
`VITE_API_BASE`, but the Atlas Intel UI has no local README explaining that
deployment contract, and the Vite env type declaration only lists
`VITE_API_BASE`.

This slice documents the deployment knobs that make generated landing-page
prerendering active.

Ownership lane: content-ops/landing-page-prerender-env-docs

## Scope (this PR)

1. Add a focused Atlas Intel UI README section for public landing-page
   prerendering.
2. Document when to set `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`.
3. Document how `VITE_API_BASE` is used for public page payload fetches.
4. Add the missing Vite env type for `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL`.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Prerender-Env-Docs.md` | Plan doc for this env-doc slice. |
| `atlas-intel-ui/README.md` | Document Atlas Intel UI build and public landing-page prerender env vars. |
| `atlas-intel-ui/src/vite-env.d.ts` | Add the public landing-page sitemap env type. |

## Mechanism

The README records the production setup:

- `VITE_API_BASE` points browser and build-time public payload fetches at the
  Atlas backend origin.
- `VITE_PUBLIC_LANDING_PAGE_SITEMAP_URL` points the Vite build at the backend
  public generated landing-page sitemap feed.
- If the sitemap URL is absent, generated landing-page prerendering is skipped
  and the verifier no-ops.

## Intentional

- No runtime code changes.
- No build plugin changes.
- No CI behavior changes.

## Deferred

- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
  and repair lock connection hold time. Both are parked under
  `Owner/session: landing-page repair session` and are not required for env
  docs.

## Parked hardening

- None added.

## Verification

- TypeScript build -> passed.
- Local PR review -> passed.

## Estimated diff size

| File | Estimated LOC |
| --- | ---: |
| `atlas-intel-ui/README.md` | 55 |
| `atlas-intel-ui/src/vite-env.d.ts` | 1 |
| `plans/PR-Landing-Page-Prerender-Env-Docs.md` | 65 |
| **Total** | **121** |
