### PR TITLE
Thread FAQ vocabulary-gap config through execution

### DIFF
--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -15,6 +15,7 @@ from .generation_plan import GenerationPlan, GenerationPlanStep, build_generatio
 from .landing_page_input_contract import LANDING_PAGE_CONTEXT_INPUT_KEYS
 from .landing_page_ports import MarketingCampaign
 from .reasoning_signals import REASONING_VALIDATION_BLOCKED
+from .ticket_faq_markdown import normalize_vocabulary_gap_rules
 
 logger = logging.getLogger(__name__)
 
@@ -553,6 +554,11 @@ async def _dispatch_faq_markdown(
         window_days=_step_config_int(step.config, "window_days"),
         as_of_date=_step_config_text(step.config, "as_of_date"),
         support_contact=_step_config_text(step.config, "support_contact"),
+        documentation_terms=_step_config_sequence(step.config, "documentation_terms"),
+        vocabulary_gap_rules=_step_config_nested_sequence(
+            step.config,
+            "vocabulary_gap_rules",
+        ),
     )
 
 
@@ -675,6 +681,18 @@ def _step_config_sequence(
     else:
         return None
     return tuple(items) if items else None
+
+
+def _step_config_nested_sequence(
+    config: Mapping[str, Any],
+    key: str,
+) -> tuple[tuple[str, ...], ...] | None:
+    if not isinstance(config, Mapping):
+        return None
+    raw = config.get(key)
+    if raw is None:
+        return None
+    return normalize_vocabulary_gap_rules(raw, label=key) or None
 
 
 def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -33,7 +33,10 @@ from .reasoning_policy import (
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
-from .ticket_faq_markdown import TicketFAQMarkdownConfig
+from .ticket_faq_markdown import (
+    TicketFAQMarkdownConfig,
+    normalize_vocabulary_gap_rules,
+)
 
 @dataclass(frozen=True)
 class GenerationPlanStep:
@@ -232,6 +235,14 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
         as_of_date=as_of_date,
         support_contact=_text_input(request.inputs, "faq_support_contact")
         or defaults.support_contact,
+        documentation_terms=(
+            _text_sequence_input(request.inputs, "faq_documentation_terms")
+            or defaults.documentation_terms
+        ),
+        vocabulary_gap_rules=(
+            _nested_text_sequence_input(request.inputs, "faq_vocabulary_gap_rules")
+            or defaults.vocabulary_gap_rules
+        ),
     )
 
 
@@ -266,6 +277,16 @@ def _text_sequence_input(inputs: Mapping[str, Any], key: str) -> tuple[str, ...]
     else:
         return None
     return items or None
+
+
+def _nested_text_sequence_input(
+    inputs: Mapping[str, Any],
+    key: str,
+) -> tuple[tuple[str, ...], ...] | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    return normalize_vocabulary_gap_rules(raw, label=key) or None
 
 
 def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:
@@ -385,6 +406,12 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             step_config["as_of_date"] = config.as_of_date
         if config.support_contact:
             step_config["support_contact"] = config.support_contact
+        if config.documentation_terms:
+            step_config["documentation_terms"] = list(config.documentation_terms)
+        if config.vocabulary_gap_rules:
+            step_config["vocabulary_gap_rules"] = [
+                list(rule) for rule in config.vocabulary_gap_rules
+            ]
         return GenerationPlanStep(
             output=output,
             runner="TicketFAQMarkdownService.generate",

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -807,20 +807,32 @@ def _vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[
     return (*_custom_vocabulary_gap_rules(custom_rules), *_VOCABULARY_GAP_RULES)
 
 
-def _custom_vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
+def normalize_vocabulary_gap_rules(
+    custom_rules: Sequence[Sequence[str]],
+    *,
+    label: str = "vocabulary_gap_rules",
+) -> tuple[tuple[str, ...], ...]:
+    """Normalize caller-supplied vocabulary-gap alias groups."""
+    if not isinstance(custom_rules, Sequence) or isinstance(
+        custom_rules,
+        (str, bytes, bytearray),
+    ):
+        raise ValueError(f"{label} must be an array of string arrays")
     rules: list[tuple[str, ...]] = []
-    for aliases in custom_rules:
+    for index, aliases in enumerate(custom_rules, start=1):
         if isinstance(aliases, (str, bytes, bytearray)):
-            raise ValueError(
-                "vocabulary_gap_rules entries must include at least two terms"
-            )
+            raise ValueError(f"{label} entries must include at least two terms")
+        if not isinstance(aliases, Sequence):
+            raise ValueError(f"{label}[{index}] must be a string array")
         cleaned = _clean_terms(aliases)
         if len(cleaned) < 2:
-            raise ValueError(
-                "vocabulary_gap_rules entries must include at least two terms"
-            )
+            raise ValueError(f"{label} entries must include at least two terms")
         rules.append(cleaned)
     return tuple(rules)
+
+
+def _custom_vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
+    return normalize_vocabulary_gap_rules(custom_rules)
 
 
 def _zero_result_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
@@ -1555,4 +1567,5 @@ __all__ = [
     "TicketFAQMarkdownResult",
     "TicketFAQMarkdownService",
     "build_ticket_faq_markdown",
+    "normalize_vocabulary_gap_rules",
 ]

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config.md
@@ -1,0 +1,93 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config
+
+## Why this slice exists
+
+Vocabulary-gap detection works in the FAQ generator and CLI, and reviewers can
+now see generated mappings in the asset review drawer. The hosted Content Ops
+execution path still cannot pass documentation terms or custom vocabulary-gap
+rules from request inputs into `TicketFAQMarkdownService.generate`, so hosted
+runs cannot intentionally exercise that feature.
+
+This slice threads the existing generator configuration through the real
+`/content-ops/execute` planning and dispatch path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-execute-config
+
+1. Accept `faq_documentation_terms` from request inputs and pass them into FAQ
+   Markdown generation config.
+2. Accept `faq_vocabulary_gap_rules` as an array of term arrays and pass them
+   into FAQ Markdown generation config.
+3. Include those values in the FAQ plan step config so execution dispatch can
+   use the same planned values.
+4. Add focused execution coverage proving hosted FAQ generation emits a
+   vocabulary-gap mapping.
+5. Reuse the FAQ library vocabulary-rule normalizer and pin invalid hosted API
+   input to a clean `400` response.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config.md` | Plan doc for this hosted execution config slice. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Exposes the shared vocabulary-gap rule normalizer for plan/dispatch reuse. |
+| `extracted_content_pipeline/generation_plan.py` | Reads FAQ documentation terms and vocabulary rules from request inputs and includes them in step config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Dispatches FAQ documentation terms and vocabulary rules to the service. |
+| `tests/test_extracted_content_control_surface_api.py` | Proves invalid hosted FAQ vocabulary rules return a clean 400 response. |
+| `tests/test_extracted_content_ops_execution.py` | Proves hosted execution produces term mappings from request-supplied config. |
+
+## Mechanism
+
+`TicketFAQMarkdownConfig` already has `documentation_terms` and
+`vocabulary_gap_rules`, and `TicketFAQMarkdownService.generate(...)` already
+accepts both as per-call overrides. This slice fills the missing middle:
+
+```python
+request.inputs -> GenerationPlanStep.config -> _dispatch_faq_markdown(...)
+```
+
+`faq_documentation_terms` uses the existing string-sequence input helper.
+`faq_vocabulary_gap_rules` accepts a JSON-like sequence of string sequences,
+matching the service/library shape. Both the generation plan and dispatcher use
+the FAQ library normalizer so the array-of-arrays contract does not drift.
+
+## Intentional
+
+- Backend execution threading only. No new generator scoring, Markdown
+  rendering, persistence, CLI, or hosted UI controls.
+- Custom vocabulary rules must be structured arrays in this slice. Textarea or
+  CSV parsing for hosted UI input remains separate.
+- Empty or missing optional inputs preserve existing behavior.
+
+## Deferred
+
+- Hosted UI controls for entering documentation terms and vocabulary rules
+  remain a separate product slice.
+- Per-file documentation term upload in hosted runs remains separate.
+- Parked hardening considered: current `HARDENING.md` entries are landing-page
+  repair items and do not touch this FAQ lane.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material` - passed, 1 test.
+- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_400 tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_rejects_invalid_custom_vocabulary_gap_rules` - passed, 5 tests.
+- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_execution.py` - passed.
+- `git diff --check` - passed.
+- `python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py` - passed, 67 tests.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 1759 tests and 1 existing `torch`/`pynvml` warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| Shared vocabulary-rule normalizer | ~30 |
+| Generation plan threading | ~35 |
+| Execution dispatch threading | ~20 |
+| Tests | ~65 |
+| **Total** | ~240 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -861,6 +861,39 @@ async def test_execute_generation_route_rejects_invalid_signal_text_cap_as_400()
 
 
 @pytest.mark.asyncio
+async def test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_400():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=_CampaignService()
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": [
+                        {
+                            "source_type": "ticket",
+                            "text": "How do I enable SSO?",
+                        }
+                    ],
+                    "faq_vocabulary_gap_rules": [["SSO"]],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 400
+    assert (
+        exc.value.detail
+        == "faq_vocabulary_gap_rules entries must include at least two terms"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_requires_configured_services():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -505,8 +505,8 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
                         "ticket_id": "ticket-1",
                         "source_type": "ticket",
                         "created_at": "2026-05-01",
-                        "subject": "Profile email change",
-                        "message": "How do I change my email address?",
+                        "subject": "SSO setup",
+                        "message": "How do I enable SSO for my team?",
                         "pain_category": "login",
                     },
                     {
@@ -521,6 +521,8 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
                 "faq_window_days": 90,
                 "faq_as_of_date": "2026-05-20",
                 "faq_support_contact": "1-800-555-0100",
+                "faq_documentation_terms": ["Single sign-on setup"],
+                "faq_vocabulary_gap_rules": [["SSO", "single sign-on"]],
             },
         },
         services=ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService()),
@@ -531,8 +533,19 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
     assert step["output"] == "faq_markdown"
     assert step["result"]["generated"] == 1
     assert step["result"]["markdown"].startswith("# Support FAQ")
-    assert "How do I change my email address?" in step["result"]["markdown"]
+    assert "How do I enable SSO for my team?" in step["result"]["markdown"]
     assert "contact support at 1-800-555-0100" in step["result"]["markdown"]
+    assert result["plan"]["steps"][0]["config"]["documentation_terms"] == [
+        "Single sign-on setup"
+    ]
+    assert result["plan"]["steps"][0]["config"]["vocabulary_gap_rules"] == [
+        ["SSO", "single sign-on"]
+    ]
+    assert step["result"]["items"][0]["term_mappings"][0]["customer_term"] == "SSO"
+    assert (
+        step["result"]["items"][0]["term_mappings"][0]["documentation_term"]
+        == "Single sign-on setup"
+    )
     assert "Billing export is confusing." not in step["result"]["markdown"]
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config.md

Hosted Content Ops FAQ runs could generate vocabulary-gap mappings in the library/CLI, but the execute path had no way to pass documentation terms or custom vocabulary-gap rules into the FAQ service. This threads request inputs through the generation plan step config and dispatcher so hosted execution can intentionally exercise the feature. Review NITs are addressed by reusing the FAQ library normalizer and pinning invalid hosted FAQ vocabulary-rule input to a clean 400 response.

## Intentional
- Backend execution threading only; no generator scoring, Markdown rendering, persistence, CLI, or hosted UI controls.
- Custom vocabulary rules must be structured arrays in this slice.
- Empty or missing optional inputs preserve existing behavior.

## Deferred
- Hosted UI controls for entering documentation terms and vocabulary rules remain a separate product slice.
- Per-file documentation term upload in hosted runs remains separate.
- Existing HARDENING.md items are outside this FAQ lane.

## Verification
- `python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material` - passed, 1 test.
- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_400 tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_rejects_invalid_custom_vocabulary_gap_rules` - passed, 5 tests.
- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_execution.py` - passed.
- `git diff --check` - passed.
- `python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_runs_faq_markdown_service_from_source_material tests/test_extracted_content_ops_execution.py tests/test_extracted_content_ops_execution_smoke.py` - passed, 67 tests.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 1759 tests and 1 existing torch/pynvml warning.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed after rebase onto current origin/main.

## Diff size
6 files, +209 / -12