### PR TITLE
Gate public landing pages on real CTA URLs

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -20,6 +20,14 @@ from .landing_page_structured_data import build_landing_page_structured_data
 
 JsonDict = dict[str, Any]
 
+_PUBLIC_CTA_PLACEHOLDER_URLS = frozenset({
+    "#",
+    "/#",
+    "/demo",
+    "javascript:void(0)",
+    "javascript:;",
+})
+
 
 _EXPORT_COLUMNS = (
     "campaign_name",
@@ -163,7 +171,22 @@ def public_landing_page_robots(draft: LandingPageDraft) -> str:
         return "noindex,follow"
     if landing_page_geo_readiness(draft).get("status") != "ready":
         return "noindex,follow"
+    if not _public_cta_url_indexable(draft.cta):
+        return "noindex,follow"
     return "index,follow"
+
+
+def _public_cta_url_indexable(value: Any) -> bool:
+    cta = _metadata_mapping(value)
+    url = str(cta.get("url") or "").strip()
+    normalized = url.lower()
+    if not normalized or normalized in _PUBLIC_CTA_PLACEHOLDER_URLS:
+        return False
+    if normalized.startswith("javascript:"):
+        return False
+    if normalized.startswith(("https://", "http://", "mailto:", "tel:", "/")):
+        return True
+    return False
 
 
 def _metadata_summary(value: Any) -> JsonDict:

--- a/plans/PR-Landing-Page-Public-CTA-Index-Policy.md
+++ b/plans/PR-Landing-Page-Public-CTA-Index-Policy.md
@@ -1,0 +1,77 @@
+# PR: Landing Page Public CTA Index Policy
+
+## Why this slice exists
+
+The landing-page publish contract says placeholder CTA URLs such as `#` and
+`/demo` should fail the publish check unless the host has a real route. The
+draft quality gate blocks obvious placeholders like `#`, but the public robots
+policy can still index an approved, readiness-passing page whose CTA points to
+`/demo`.
+
+This slice makes the public index policy reject placeholder CTA destinations.
+
+Ownership lane: content-ops/landing-page-public-index-policy
+
+## Scope (this PR)
+
+1. Add a public CTA URL indexability helper to `landing_page_export.py`.
+2. Return `noindex,follow` from `public_landing_page_robots(...)` when the
+   public CTA URL is missing, JavaScript, fragment-only, or `/demo`.
+3. Keep draft generation and draft quality gates unchanged.
+4. Update export tests so ready public pages use a real local route and
+   placeholder public CTAs stay noindex.
+5. Update public generated-asset API tests so sitemap and renderer fixtures use
+   a real local route and `/demo` remains noindex.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Public-CTA-Index-Policy.md` | Plan doc for this public index-policy slice. |
+| `extracted_content_pipeline/landing_page_export.py` | Add public CTA URL indexability check to robots policy. |
+| `tests/test_extracted_landing_page_export.py` | Cover indexable CTA and placeholder CTA behavior. |
+| `tests/test_extracted_content_asset_api.py` | Cover public API/sitemap behavior with the stricter CTA policy. |
+
+## Mechanism
+
+`public_landing_page_robots(...)` remains the publish-surface policy gate. It
+still requires approved status and ready SEO/AEO/GEO checks, then adds one
+public-only conversion-path check for the page-level CTA URL.
+
+The helper intentionally lives in export/publish shaping rather than the draft
+quality gate so operators can still draft or repair pages before a final public
+destination is chosen.
+
+## Intentional
+
+- No generator prompt changes.
+- No draft quality-gate changes.
+- No public route changes.
+- No assumptions about a complete frontend route registry beyond the known
+  placeholder `/demo`.
+
+## Deferred
+
+- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
+  and repair lock connection hold time. Both are parked under
+  `Owner/session: landing-page repair session` and are not required for this
+  public CTA index-policy slice.
+
+## Parked hardening
+
+- None added.
+
+## Verification
+
+- Focused landing-page export and generated-asset API tests -> 67 passed.
+- Local PR review -> passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `extracted_content_pipeline/landing_page_export.py` | 25 |
+| `tests/test_extracted_landing_page_export.py` | 25 |
+| `tests/test_extracted_content_asset_api.py` | 15 |
+| `plans/PR-Landing-Page-Public-CTA-Index-Policy.md` | 75 |
+| **Total** | **140** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -260,7 +260,7 @@ def _ready_landing_page_row():
                 "support signals into clearer answers before customers drift."
             ),
             "cta_label": "Book a demo",
-            "cta_url": "/demo",
+            "cta_url": "/landing",
         },
         "sections": [
             {
@@ -319,7 +319,7 @@ def _ready_landing_page_row():
                 },
             },
         ],
-        "cta": {"label": "Book a demo", "url": "/demo"},
+        "cta": {"label": "Book a demo", "url": "/landing"},
         "meta": {
             "title_tag": "Acme Support Retention for VP Engineering",
             "description": (
@@ -1053,6 +1053,20 @@ def test_generated_asset_router_indexes_public_ready_landing_page() -> None:
     assert body["robots"] == "index,follow"
     assert "seo_aeo_readiness" not in body
     assert "geo_readiness" not in body
+
+
+def test_generated_asset_router_keeps_placeholder_cta_landing_page_noindex() -> None:
+    row = _ready_landing_page_row()
+    row["cta"] = {"label": "Book a demo", "url": "/demo"}
+    pool = _Pool(rows=[row])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["robots"] == "noindex,follow"
 
 
 def test_generated_asset_router_sitemap_includes_only_indexable_landing_pages() -> None:

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -307,10 +307,10 @@ def _ready_draft(**overrides) -> LandingPageDraft:
                 "support signals into clearer answers before customers drift."
             ),
             "cta_label": "Book a demo",
-            "cta_url": "/demo",
+            "cta_url": "/landing",
         },
         sections=sections,
-        cta={"label": "Book a demo", "url": "/demo"},
+        cta={"label": "Book a demo", "url": "/landing"},
         meta={
             "title_tag": "Acme Support Retention for VP Engineering",
             "description": (
@@ -461,6 +461,12 @@ def test_public_landing_page_robots_keeps_non_approved_pages_noindex() -> None:
 def test_public_landing_page_robots_keeps_incomplete_pages_noindex() -> None:
     assert public_landing_page_robots(
         _draft(status="approved")
+    ) == "noindex,follow"
+
+
+def test_public_landing_page_robots_keeps_placeholder_cta_noindex() -> None:
+    assert public_landing_page_robots(
+        _ready_draft(status="approved", cta={"label": "Book a demo", "url": "/demo"})
     ) == "noindex,follow"
 
 


### PR DESCRIPTION
# PR: Landing Page Public CTA Index Policy

## Why this slice exists

The landing-page publish contract says placeholder CTA URLs such as `#` and
`/demo` should fail the publish check unless the host has a real route. The
draft quality gate blocks obvious placeholders like `#`, but the public robots
policy can still index an approved, readiness-passing page whose CTA points to
`/demo`.

This slice makes the public index policy reject placeholder CTA destinations.

Ownership lane: content-ops/landing-page-public-index-policy

## Scope (this PR)

1. Add a public CTA URL indexability helper to `landing_page_export.py`.
2. Return `noindex,follow` from `public_landing_page_robots(...)` when the
   public CTA URL is missing, JavaScript, fragment-only, or `/demo`.
3. Keep draft generation and draft quality gates unchanged.
4. Update export tests so ready public pages use a real local route and
   placeholder public CTAs stay noindex.
5. Update public generated-asset API tests so sitemap and renderer fixtures use
   a real local route and `/demo` remains noindex.

### Files touched

| File | Change |
|---|---|
| `plans/PR-Landing-Page-Public-CTA-Index-Policy.md` | Plan doc for this public index-policy slice. |
| `extracted_content_pipeline/landing_page_export.py` | Add public CTA URL indexability check to robots policy. |
| `tests/test_extracted_landing_page_export.py` | Cover indexable CTA and placeholder CTA behavior. |
| `tests/test_extracted_content_asset_api.py` | Cover public API/sitemap behavior with the stricter CTA policy. |

## Mechanism

`public_landing_page_robots(...)` remains the publish-surface policy gate. It
still requires approved status and ready SEO/AEO/GEO checks, then adds one
public-only conversion-path check for the page-level CTA URL.

The helper intentionally lives in export/publish shaping rather than the draft
quality gate so operators can still draft or repair pages before a final public
destination is chosen.

## Intentional

- No generator prompt changes.
- No draft quality-gate changes.
- No public route changes.
- No assumptions about a complete frontend route registry beyond the known
  placeholder `/demo`.

## Deferred

- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
  and repair lock connection hold time. Both are parked under
  `Owner/session: landing-page repair session` and are not required for this
  public CTA index-policy slice.

## Parked hardening

- None added.

## Verification

- Focused landing-page export and generated-asset API tests -> 67 passed.
- Local PR review -> passed.

## Estimated diff size

| File | Estimated LOC |
| --- | ---: |
| `extracted_content_pipeline/landing_page_export.py` | 25 |
| `tests/test_extracted_landing_page_export.py` | 25 |
| `tests/test_extracted_content_asset_api.py` | 15 |
| `plans/PR-Landing-Page-Public-CTA-Index-Policy.md` | 75 |
| **Total** | **140** |
