### PR TITLE
Reject landing page demo CTA variants

### DIFF
--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from io import StringIO
 import json
 from typing import Any
+from urllib.parse import urlsplit
 
 from .campaign_ports import TenantScope
 from .landing_page_ports import LandingPageDraft, LandingPageRepository
@@ -184,9 +185,21 @@ def _public_cta_url_indexable(value: Any) -> bool:
         return False
     if normalized.startswith("javascript:"):
         return False
+    if _public_cta_local_path(normalized) == "/demo":
+        return False
     if normalized.startswith(("https://", "http://", "mailto:", "tel:", "/")):
         return True
     return False
+
+
+def _public_cta_local_path(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return ""
+    if parsed.scheme or parsed.netloc:
+        return ""
+    return parsed.path.rstrip("/") or parsed.path
 
 
 def _metadata_summary(value: Any) -> JsonDict:

--- a/plans/PR-Landing-Page-Public-CTA-Variant-Policy.md
+++ b/plans/PR-Landing-Page-Public-CTA-Variant-Policy.md
@@ -58,6 +58,12 @@ blocked destination.
   and repair lock connection hold time. Both are parked under
   `Owner/session: landing-page repair session` and are not required for this
   public CTA variant-policy slice.
+- Anchor-fragment placeholder variants (`/#<frag>`, e.g. `/#section`) remain
+  indexable. Only `/demo` gets variant normalization in this slice. Unlike a
+  `/demo` variant -- which is unambiguously the demo placeholder -- a
+  `/#pricing`-style CTA can be a legitimate same-page anchor on a finished
+  page, so blanket-rejecting `/#<frag>` would de-index real pages. The bare
+  `#` and `/#` placeholders stay rejected via the exact-match set.
 
 ## Parked hardening
 

--- a/plans/PR-Landing-Page-Public-CTA-Variant-Policy.md
+++ b/plans/PR-Landing-Page-Public-CTA-Variant-Policy.md
@@ -1,0 +1,79 @@
+# PR: Landing Page Public CTA Variant Policy
+
+## Why this slice exists
+
+PR-Landing-Page-Public-CTA-Index-Policy made the public robots policy reject
+the known local placeholder CTA /demo. The review on PR #810 found a narrow
+gap: /demo/, /demo?utm=..., and /demo#anchor are still treated as
+indexable because the policy compares only the exact string before allowing
+local paths.
+
+This slice closes that variant gap at the public index-policy source so a
+readiness-passing page cannot be indexed with the same placeholder CTA expressed
+with a trailing slash, query string, or fragment.
+
+Ownership lane: content-ops/landing-page-public-index-policy
+
+## Scope (this PR)
+
+1. Normalize same-origin local CTA paths before the public CTA indexability
+   decision.
+2. Keep /demo and simple variants such as /demo/, /demo?utm=..., and
+   /demo#anchor as noindex,follow.
+3. Keep real local routes, absolute HTTP(S) URLs, mailto:, and tel: CTAs
+   indexable when the draft is otherwise approved and ready.
+4. Add helper-level and public API regression coverage for the reviewed gap.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Public-CTA-Variant-Policy.md` | Plan doc for this follow-up CTA variant slice. |
+| `extracted_content_pipeline/landing_page_export.py` | Normalize local CTA paths before rejecting the /demo placeholder. |
+| `tests/test_extracted_landing_page_export.py` | Cover /demo variants in the robots helper. |
+| `tests/test_extracted_content_asset_api.py` | Cover /demo variants through the public generated-asset API. |
+
+## Mechanism
+
+`_public_cta_url_indexable(...)` keeps the existing allowlist shape, but parses
+local relative URLs before the final local-path allow. If the URL has no scheme
+or netloc, its parsed path is lowercased and stripped of a trailing slash for
+the placeholder comparison. That catches /demo/, /demo?utm=..., and
+/demo#anchor without turning every absolute URL ending in /demo into a
+blocked destination.
+
+## Intentional
+
+- No generator prompt changes.
+- No draft quality-gate changes.
+- No public route registry or frontend route assumptions beyond the known local
+  /demo placeholder.
+- Absolute HTTP(S) URLs remain allowed, including external demo-booking URLs,
+  because the public policy cannot know whether a third-party /demo path is a
+  real destination.
+
+## Deferred
+
+- `HARDENING.md` still tracks landing-page repair legacy-lock rollout cleanup
+  and repair lock connection hold time. Both are parked under
+  `Owner/session: landing-page repair session` and are not required for this
+  public CTA variant-policy slice.
+
+## Parked hardening
+
+- None added.
+
+## Verification
+
+- pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q -> 75 passed.
+- bash scripts/local_pr_review.sh -> passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `extracted_content_pipeline/landing_page_export.py` | 20 |
+| `tests/test_extracted_landing_page_export.py` | 15 |
+| `tests/test_extracted_content_asset_api.py` | 15 |
+| `plans/PR-Landing-Page-Public-CTA-Variant-Policy.md` | 70 |
+| **Total** | **120** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1069,6 +1069,24 @@ def test_generated_asset_router_keeps_placeholder_cta_landing_page_noindex() -> 
     assert response.json()["robots"] == "noindex,follow"
 
 
+@pytest.mark.parametrize(
+    "url",
+    ["/demo/", "/demo?utm=1", "/demo#hero", "/demo/?utm=1"],
+)
+def test_generated_asset_router_keeps_demo_cta_variants_noindex(url: str) -> None:
+    row = _ready_landing_page_row()
+    row["cta"] = {"label": "Book a demo", "url": url}
+    pool = _Pool(rows=[row])
+
+    response = _public_client(pool).get(
+        "/content-assets/landing_page/public/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["robots"] == "noindex,follow"
+
+
 def test_generated_asset_router_sitemap_includes_only_indexable_landing_pages() -> None:
     incomplete = {**_landing_page_row(), "status": "approved"}
     incomplete["id"] = "22222222-2222-2222-2222-222222222222"

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -470,6 +470,18 @@ def test_public_landing_page_robots_keeps_placeholder_cta_noindex() -> None:
     ) == "noindex,follow"
 
 
+@pytest.mark.parametrize(
+    "url",
+    ["/demo/", "/demo?utm=1", "/demo#hero", "/demo/?utm=1"],
+)
+def test_public_landing_page_robots_keeps_demo_cta_variants_noindex(
+    url: str,
+) -> None:
+    assert public_landing_page_robots(
+        _ready_draft(status="approved", cta={"label": "Book a demo", "url": url})
+    ) == "noindex,follow"
+
+
 @pytest.mark.asyncio
 async def test_export_landing_page_drafts_surfaces_ready_readiness() -> None:
     result = await export_landing_page_drafts(

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -482,6 +482,19 @@ def test_public_landing_page_robots_keeps_demo_cta_variants_noindex(
     ) == "noindex,follow"
 
 
+@pytest.mark.parametrize(
+    "url",
+    ["/demos", "/demo/foo", "/demo-page", "/"],
+)
+def test_public_landing_page_robots_indexes_demo_near_misses(url: str) -> None:
+    # Guards the tight `== "/demo"` boundary: real routes whose path only
+    # resembles the placeholder must stay indexable. A future switch to a
+    # prefix match (e.g. startswith("/demo")) would silently de-index these.
+    assert public_landing_page_robots(
+        _ready_draft(status="approved", cta={"label": "Book a demo", "url": url})
+    ) == "index,follow"
+
+
 @pytest.mark.asyncio
 async def test_export_landing_page_drafts_surfaces_ready_readiness() -> None:
     result = await export_landing_page_drafts(


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Public-CTA-Variant-Policy.md

PR #810 made the public robots policy reject the known local /demo placeholder, but review found that trailing slash, query-string, and fragment variants still passed because the check compared only the exact string. This closes that public index-policy gap at the source.

## Intentional
- Keep the change in the public robots policy, not draft generation or the draft quality gate.
- Absolute HTTP(S), mailto, tel, and real local routes remain indexable when the draft is otherwise approved and ready.
- No route registry or frontend route assumptions beyond the known local /demo placeholder.

## Deferred
- No generator prompt, draft quality-gate, or public route changes in this slice.

## Parked hardening
- None added. Existing landing-page repair session items remain parked in HARDENING.md and are not required for this public CTA variant-policy slice.

## Verification
- pytest tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_api.py -q -> 75 passed.
- bash scripts/local_pr_review.sh -> passed.

## Diff size
4 files, +122 / -0