### PR TITLE
Add hosted FAQ vocabulary-gap input controls

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -97,6 +97,9 @@ const LANDING_PAGE_QUALITY_REPAIR_INPUT =
   'landing_page_quality_repair_attempts'
 const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
+const FAQ_MARKDOWN_OUTPUT = 'faq_markdown'
+const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
+const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_ORDER = [
   'target_keyword',
   'secondary_keywords',
@@ -194,6 +197,7 @@ export default function ContentOpsNewRun() {
     ? reasoningStatusHint(catalog.reasoning)
     : ''
   const landingPageOutputSelected = request.outputs.includes('landing_page')
+  const faqMarkdownOutputSelected = request.outputs.includes(FAQ_MARKDOWN_OUTPUT)
   const landingPageRepairAttemptContract = landingPageOutputSelected
     ? integerInputContract(catalog, LANDING_PAGE_QUALITY_REPAIR_INPUT)
     : null
@@ -216,6 +220,7 @@ export default function ContentOpsNewRun() {
     ? landingPageSeoGeoAeoInputContracts(catalog)
     : []
   const landingPageInputsDisabled = !parsedInputsForControls.ok
+  const faqInputsDisabled = !parsedInputsForControls.ok
   const landingPageRepairAttemptDisabled =
     !parsedInputsForControls.ok || !landingPageRepairAttemptContract
 
@@ -262,6 +267,20 @@ export default function ContentOpsNewRun() {
     value: string,
   ) => {
     const updated = updateLandingPageInputJson(inputsJson, contract, value)
+    if (!updated.ok) return
+    setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleFaqDocumentationTermsChange = (value: string) => {
+    const updated = updateFaqDocumentationTermsInputJson(inputsJson, value)
+    if (!updated.ok) return
+    setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleFaqVocabularyRulesChange = (value: string) => {
+    const updated = updateFaqVocabularyRulesInputJson(inputsJson, value)
     if (!updated.ok) return
     setInputsJson(updated.value)
     markStale()
@@ -878,6 +897,49 @@ export default function ContentOpsNewRun() {
               >
                 {landingPageRepairAttemptMessage}
               </p>
+            </div>
+          )}
+          {faqMarkdownOutputSelected && (
+            <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-3">
+              <div className="mb-3">
+                <h3 className="text-sm font-medium text-slate-200">
+                  FAQ vocabulary-gap inputs
+                </h3>
+              </div>
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                <label className="block text-sm">
+                  <span className="text-slate-300">Documentation terms</span>
+                  <textarea
+                    value={faqDocumentationTermsDraftValue(parsedInputsForControls)}
+                    onChange={(e) =>
+                      handleFaqDocumentationTermsChange(e.target.value)
+                    }
+                    rows={4}
+                    disabled={faqInputsDisabled}
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    placeholder={'Single sign-on setup\nData export guide'}
+                  />
+                </label>
+                <label className="block text-sm">
+                  <span className="text-slate-300">Vocabulary-gap rules</span>
+                  <textarea
+                    value={faqVocabularyRulesDraftValue(parsedInputsForControls)}
+                    onChange={(e) =>
+                      handleFaqVocabularyRulesChange(e.target.value)
+                    }
+                    rows={4}
+                    disabled={faqInputsDisabled}
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    placeholder={'SSO, single sign-on\nexport, data export'}
+                  />
+                </label>
+              </div>
+              {!parsedInputsForControls.ok && (
+                <p className="mt-2 text-xs text-amber-200">
+                  Fix inputs JSON before changing FAQ fields:{' '}
+                  {parsedInputsForControls.message}
+                </p>
+              )}
             </div>
           )}
         </section>
@@ -1577,6 +1639,78 @@ function updateLandingPageInputJson(
   }
 
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function faqDocumentationTermsDraftValue(parsed: ParsedInputsJsonObject): string {
+  if (!parsed.ok) return ''
+  const raw = parsed.value[FAQ_DOCUMENTATION_TERMS_INPUT]
+  if (raw === null || typeof raw === 'undefined') return ''
+  return stringListDraftValue(raw)
+}
+
+function updateFaqDocumentationTermsInputJson(
+  current: string,
+  draftValue: string,
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+
+  const next = { ...parsed.value }
+  const values = stringListFromDraft(draftValue)
+  if (values.length === 0) {
+    delete next[FAQ_DOCUMENTATION_TERMS_INPUT]
+  } else {
+    next[FAQ_DOCUMENTATION_TERMS_INPUT] = values
+  }
+
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function faqVocabularyRulesDraftValue(parsed: ParsedInputsJsonObject): string {
+  if (!parsed.ok) return ''
+  const raw = parsed.value[FAQ_VOCABULARY_GAP_RULES_INPUT]
+  if (raw === null || typeof raw === 'undefined') return ''
+  if (!Array.isArray(raw)) return scalarDraftValue(raw)
+  return raw
+    .filter((rule) => typeof rule !== 'undefined' && rule !== null)
+    .map((rule) =>
+      Array.isArray(rule)
+        ? rule
+            .filter((term) => typeof term !== 'undefined' && term !== null)
+            .map((term) => String(term))
+            .join(', ')
+        : String(rule),
+    )
+    .join('\n')
+}
+
+function updateFaqVocabularyRulesInputJson(
+  current: string,
+  draftValue: string,
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+
+  const next = { ...parsed.value }
+  const rules = vocabularyRulesFromDraft(draftValue)
+  if (rules.length === 0) {
+    delete next[FAQ_VOCABULARY_GAP_RULES_INPUT]
+  } else {
+    next[FAQ_VOCABULARY_GAP_RULES_INPUT] = rules
+  }
+
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function vocabularyRulesFromDraft(value: string): string[][] {
+  const rules: string[][] = []
+  for (const line of value.split(/\r?\n/)) {
+    const terms = stringListFromDraft(line)
+    if (terms.length > 0) {
+      rules.push(terms)
+    }
+  }
+  return rules
 }
 
 function stringListDraftValue(value: unknown): string {

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-UI-Inputs.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-UI-Inputs.md
@@ -1,0 +1,80 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-UI-Inputs
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Config wired
+`faq_documentation_terms` and `faq_vocabulary_gap_rules` through hosted
+execution, but the Content Ops run form still requires operators to hand-edit
+the raw inputs JSON to exercise vocabulary-gap detection.
+
+This slice adds the thinnest hosted UI path for entering those two FAQ inputs
+and sending them through the existing preview/plan/execute request flow.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-ui-inputs
+
+1. Show a FAQ vocabulary-gap inputs panel only when `faq_markdown` is selected.
+2. Let operators enter documentation terms as a newline/comma-separated list.
+3. Let operators enter vocabulary-gap rules as one rule per line using
+   `customer term, documentation term`.
+4. Serialize non-empty controls into the existing inputs JSON under the backend
+   keys `faq_documentation_terms` and `faq_vocabulary_gap_rules`.
+5. Keep invalid raw inputs JSON as the existing blocking state for per-output
+   controls.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-UI-Inputs.md` | Plan doc for this hosted UI input slice. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Adds FAQ-only controls that write documentation terms and vocabulary-gap rules into the request inputs JSON. |
+
+## Mechanism
+
+The existing Content Ops form already treats `inputsJson` as the canonical
+request state and has landing-page helper controls that patch that JSON. This
+slice follows the same pattern for FAQ Markdown:
+
+```ts
+faq panel draft -> update FAQ keys in inputsJson -> buildDomainRequest()
+```
+
+The documentation-term field uses the existing string-list parser. The custom
+rule field parses each non-empty line into a string array, preserving the
+backend's structured `string[][]` contract from PR-Content-Ops-FAQ-
+Vocabulary-Gap-Execute-Config. Backend validation still enforces at least two
+terms per rule.
+
+## Intentional
+
+- UI-only slice. No backend generator, dispatcher, API, persistence, or CLI
+  changes.
+- No separate React state for FAQ inputs; the inputs JSON remains canonical.
+- No file upload for documentation terms or rule files in this slice.
+- Invalid vocabulary-rule line shape is allowed to surface through the backend
+  400 path; this slice keeps the UI thin and only serializes structured arrays.
+
+## Deferred
+
+- Per-file documentation term upload remains a separate product slice.
+- Rich validation or inline per-line error messages for FAQ rules remain
+  hardening unless the current slice cannot submit the real flow.
+- Current `HARDENING.md` entries were scanned; they are landing-page repair
+  items and do not touch this FAQ UI lane.
+
+## Verification
+
+- `npm run lint` from `atlas-intel-ui/` - passed.
+- `npm run build` from `atlas-intel-ui/` - passed; Vite built
+  `ContentOpsNewRun` and generated sitemap/prerender output.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| FAQ UI controls | ~90 |
+| FAQ input helpers | ~80 |
+| **Total** | ~245 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-UI-Inputs.md

The hosted FAQ backend now accepts documentation terms and vocabulary-gap rules, but the Content Ops run form still required hand-editing raw JSON. This adds the thinnest FAQ-only UI controls that write those explicit backend keys into the existing inputs JSON before preview, plan, or execute.

## Intentional
- UI-only slice; no backend generator, dispatcher, API, persistence, or CLI changes.
- Inputs JSON remains the canonical request state.
- No file upload for documentation terms or rule files in this slice.
- Invalid vocabulary-rule line shape can still surface through the backend 400 path.

## Deferred
- Per-file documentation term upload remains separate.
- Rich inline validation or per-line error messages for FAQ rules remain hardening.
- Existing HARDENING.md items are outside this FAQ UI lane.

## Verification
- `npm run lint` from `atlas-intel-ui/` - passed.
- `npm run build` from `atlas-intel-ui/` - passed; Vite built ContentOpsNewRun and generated sitemap/prerender output.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed.

## Diff size
2 files, +214 / -0