### PR TITLE
Generalize source-coverage phrasing for the LLM (D5)

### DIFF
--- a/ATLAS-HARDENING.md
+++ b/ATLAS-HARDENING.md
@@ -29,6 +29,22 @@ parked and note in the plan's Deferred.
 
 ## 2026-05-22
 
+### LLM may still narrate a partial source set despite the generalized field (D5 residual)
+- File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`, blog generation payload + the external `digest/b2b_blog_post_generation` skill (system prompt).
+- Description: D5 stops feeding the per-platform `source_distribution.sources` list to the LLM payload and provides a generalized `source_description`, but the model could still infer/mention platform names from quote `source_name`s or chart labels in the payload, or just not use `source_description`. LLM-fidelity is empirically unverified (same class as the D6 lead-in drift).
+- Why it matters: the deterministic lever is closed, but corpus-wide adherence needs checking; this is what the Phase-2 deep pass should verify (and a detector could flag prose source-lists that omit a quoted source).
+- Effort: M
+- Category: correctness
+- Found during: D5
+
+### Unused `_top_source_summary` helper after D5 dropped its only caller
+- File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` ~L2461 (and mirror).
+- Description: `_build_coverage_snapshot_note` no longer calls `_top_source_summary`; it's now dead code. (It also had a latent bug — it was fed the `{sources, verified_count, community_count}` dict instead of `{name: count}`.) Remove next pass.
+- Why it matters: dead code + a latent bug; removing it is cleanup, deliberately out of D5's thin scope.
+- Effort: S
+- Category: tech-debt
+- Found during: D5
+
 ### Deep-dive strengths/weaknesses chart fallback cannot show true strengths
 - File/location: `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py` ~L8092 (and the byte-identical `extracted_content_pipeline` mirror), the `if len(strengths) + len(weaknesses) < 3 and signals:` fallback in `_blueprint_vendor_deep_dive`.
 - Description: when the product profile is too thin, the "Strengths vs Weaknesses" chart is built only from pain-category signals, which carry weakness data only -- so the `strengths` series is always 0 (a one-sided chart). D4 made the bucketing truthful (all pain -> weaknesses) but did not give the fallback a real strengths source.

--- a/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
+++ b/atlas_brain/autonomous/tasks/b2b_blog_post_generation.py
@@ -2485,7 +2485,7 @@ def _build_coverage_snapshot_note(blueprint: PostBlueprint) -> str:
     enriched_count = int(data_context.get("enriched_count") or 0)
     churn_intent_count = int(data_context.get("churn_intent_count") or 0)
     review_period = str(data_context.get("review_period") or "").strip()
-    source_summary = _top_source_summary(data_context.get("source_distribution"))
+    source_description = str(data_context.get("source_description") or "").strip()
     data_quality = data_context.get("data_quality")
     confidence = ""
     if isinstance(data_quality, dict):
@@ -2507,8 +2507,8 @@ def _build_coverage_snapshot_note(blueprint: PostBlueprint) -> str:
         details.append(f"with {witnesses_in_scope} witness-backed examples in scope")
     if review_period:
         details.append(f"collected between {review_period}")
-    if source_summary:
-        details.append(f"with the visible source mix led by {source_summary}")
+    if source_description:
+        details.append(f"with sources {source_description}")
     if confidence:
         details.append(f"and a current data-quality posture of {confidence} confidence")
 
@@ -6236,6 +6236,17 @@ async def _gather_data(
     source_dist = await _fetch_source_distribution(pool, vendor_names, category=category_scope)
     data["data_context"]["source_distribution"] = source_dist
     data["data_context"]["data_source_label"] = "Public B2B software review platforms"
+    # D5: a GENERALIZED source description for narrative prose, so the model
+    # describes coverage as verified-platform vs community-forum buckets instead
+    # of enumerating a partial subset of platform names (which omits sources the
+    # post actually quotes). The per-platform source_distribution.sources stays
+    # for the source-mix chart; only the narrative input is generalized.
+    _v = int(source_dist.get("verified_count") or 0)
+    _c = int(source_dist.get("community_count") or 0)
+    data["data_context"]["source_description"] = (
+        f"{_v} reviews from verified review platforms and "
+        f"{_c} reviews from community forums"
+    )
     data["data_context"]["data_disclaimer"] = (
         "Analysis based on self-selected reviewer feedback. "
         "Results reflect reviewer perception, not product capability."
@@ -9171,10 +9182,27 @@ def _build_blog_generation_payload(
     _attach_blog_blueprint_runtime_metadata(blueprint)
     length_policy = _blog_length_policy(blueprint.topic_type)
     section_word_budget = _blog_section_word_budget(blueprint)
+    # D5: hand the LLM a GENERALIZED source_distribution (counts only) so
+    # narrative prose can't enumerate a partial platform list (which omits
+    # sources the post actually quotes). The stored blueprint.data_context keeps
+    # the per-platform sources for the source-mix chart; this shapes only the
+    # LLM-facing copy. source_description carries the generalized phrasing.
+    payload_data_context = blueprint.data_context
+    if isinstance(payload_data_context, dict) and isinstance(
+        payload_data_context.get("source_distribution"), dict
+    ):
+        _sd = payload_data_context["source_distribution"]
+        payload_data_context = {
+            **payload_data_context,
+            "source_distribution": {
+                "verified_count": _sd.get("verified_count", 0),
+                "community_count": _sd.get("community_count", 0),
+            },
+        }
     payload: dict[str, Any] = {
         "topic_type": blueprint.topic_type,
         "suggested_title": blueprint.suggested_title,
-        "data_context": blueprint.data_context,
+        "data_context": payload_data_context,
         "length_policy": length_policy,
         "section_word_budget": section_word_budget,
         "sections": [

--- a/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
+++ b/extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py
@@ -2485,7 +2485,7 @@ def _build_coverage_snapshot_note(blueprint: PostBlueprint) -> str:
     enriched_count = int(data_context.get("enriched_count") or 0)
     churn_intent_count = int(data_context.get("churn_intent_count") or 0)
     review_period = str(data_context.get("review_period") or "").strip()
-    source_summary = _top_source_summary(data_context.get("source_distribution"))
+    source_description = str(data_context.get("source_description") or "").strip()
     data_quality = data_context.get("data_quality")
     confidence = ""
     if isinstance(data_quality, dict):
@@ -2507,8 +2507,8 @@ def _build_coverage_snapshot_note(blueprint: PostBlueprint) -> str:
         details.append(f"with {witnesses_in_scope} witness-backed examples in scope")
     if review_period:
         details.append(f"collected between {review_period}")
-    if source_summary:
-        details.append(f"with the visible source mix led by {source_summary}")
+    if source_description:
+        details.append(f"with sources {source_description}")
     if confidence:
         details.append(f"and a current data-quality posture of {confidence} confidence")
 
@@ -6236,6 +6236,17 @@ async def _gather_data(
     source_dist = await _fetch_source_distribution(pool, vendor_names, category=category_scope)
     data["data_context"]["source_distribution"] = source_dist
     data["data_context"]["data_source_label"] = "Public B2B software review platforms"
+    # D5: a GENERALIZED source description for narrative prose, so the model
+    # describes coverage as verified-platform vs community-forum buckets instead
+    # of enumerating a partial subset of platform names (which omits sources the
+    # post actually quotes). The per-platform source_distribution.sources stays
+    # for the source-mix chart; only the narrative input is generalized.
+    _v = int(source_dist.get("verified_count") or 0)
+    _c = int(source_dist.get("community_count") or 0)
+    data["data_context"]["source_description"] = (
+        f"{_v} reviews from verified review platforms and "
+        f"{_c} reviews from community forums"
+    )
     data["data_context"]["data_disclaimer"] = (
         "Analysis based on self-selected reviewer feedback. "
         "Results reflect reviewer perception, not product capability."
@@ -9171,10 +9182,27 @@ def _build_blog_generation_payload(
     _attach_blog_blueprint_runtime_metadata(blueprint)
     length_policy = _blog_length_policy(blueprint.topic_type)
     section_word_budget = _blog_section_word_budget(blueprint)
+    # D5: hand the LLM a GENERALIZED source_distribution (counts only) so
+    # narrative prose can't enumerate a partial platform list (which omits
+    # sources the post actually quotes). The stored blueprint.data_context keeps
+    # the per-platform sources for the source-mix chart; this shapes only the
+    # LLM-facing copy. source_description carries the generalized phrasing.
+    payload_data_context = blueprint.data_context
+    if isinstance(payload_data_context, dict) and isinstance(
+        payload_data_context.get("source_distribution"), dict
+    ):
+        _sd = payload_data_context["source_distribution"]
+        payload_data_context = {
+            **payload_data_context,
+            "source_distribution": {
+                "verified_count": _sd.get("verified_count", 0),
+                "community_count": _sd.get("community_count", 0),
+            },
+        }
     payload: dict[str, Any] = {
         "topic_type": blueprint.topic_type,
         "suggested_title": blueprint.suggested_title,
-        "data_context": blueprint.data_context,
+        "data_context": payload_data_context,
         "length_policy": length_policy,
         "section_word_budget": section_word_budget,
         "sections": [

--- a/plans/PR-Blog-D5-Source-Generalization.md
+++ b/plans/PR-Blog-D5-Source-Generalization.md
@@ -1,0 +1,92 @@
+# PR-Blog-D5-Source-Generalization
+
+Ownership lane: `content-ops/blog-d5-source-generalization`
+
+## Why this slice exists
+
+Defect **D5** (`reports/blog-audit-findings.md`): blog prose names a PARTIAL
+source set ("verified platforms including G2, Gartner Peer Insights, and
+PeerSpot, alongside community discussions on Reddit") that omits sources the post
+actually quotes (e.g. Slashdot, Software Advice). A corpus grep found the at-risk
+phrasing in **52 of 78 posts** -- so D5 is corpus-wide, not the single instance
+the catalog implied.
+
+Per maintainer direction: **thin-slice the generator-generalization NOW** (so new
+posts stop naming a partial set); the 52 published posts are cleaned in the
+Phase-2 deep pass, not here.
+
+Root cause: the generator hands the LLM the per-platform `source_distribution.sources`
+list in the payload `data_context`; the model narrates a partial subset of it as
+"the data comes from X, Y, Z".
+
+## Scope (this PR)
+
+Generator-only. Make the LLM's source guidance generalized + deterministic.
+
+### Files touched
+
+- `plans/PR-Blog-D5-Source-Generalization.md`
+- `ATLAS-HARDENING.md`
+- `atlas_brain/autonomous/tasks/b2b_blog_post_generation.py`
+- `extracted_content_pipeline/autonomous/tasks/b2b_blog_post_generation.py`
+- `tests/test_b2b_blog_post_generation.py`
+
+## Mechanism
+
+1. `_gather_data` adds a generalized `data_context["source_description"]` =
+   "{verified} reviews from verified review platforms and {community} reviews
+   from community forums".
+2. `_build_blog_generation_payload` hands the LLM a GENERALIZED
+   `source_distribution` (verified/community counts only) -- the per-platform
+   `sources` list is dropped from the LLM-facing payload copy, so the model has
+   no partial list to enumerate. The STORED `blueprint.data_context` is
+   untouched, so the source-mix chart still has the per-platform sources.
+3. `_build_coverage_snapshot_note` now uses `source_description` instead of the
+   (buggy, partial-by-design) `_top_source_summary` -- a deterministic note.
+
+## Intentional
+
+- **Deterministic lever, not a prompt plea.** Dropping the per-platform list
+  from the LLM payload (vs only instructing the model) is what actually prevents
+  enumeration -- the model can't name what it doesn't see. The stored context
+  keeps `sources` for the chart, so nothing visual is lost.
+- **Counts kept.** verified/community counts stay in the payload so the
+  "N verified + M community" sentence still has its numbers.
+- **No published-post edits.** The 52 corpus posts are Phase-2 (maintainer's
+  call); this slice only changes generation going forward.
+
+## Deferred
+
+**Parked hardening** in `ATLAS-HARDENING.md` (separate file per maintainer; root
+`HARDENING.md` has the pointer):
+- LLM may still mention a platform inferred from a quote `source_name` / chart
+  label, or ignore `source_description` -- LLM-fidelity residual, Phase-2 corpus
+  check + a candidate detector. M / correctness.
+- `_top_source_summary` is now dead code (and had a latent dict-shape bug) --
+  remove next pass. S / tech-debt.
+
+Also remaining: the 52-post source-list cleanup (Phase-2 deep pass); D2-followup;
+D3-followup.
+
+## Verification
+
+- New `test_coverage_snapshot_note_uses_generalized_source_description`: the note
+  contains the generalized "verified review platforms / community forums"
+  phrasing and NO platform name (G2/Reddit/Gartner/PeerSpot). Verified it FAILS
+  on revert to `_top_source_summary`.
+- New `test_blog_payload_generalizes_source_distribution_for_llm`: the LLM
+  payload's `source_distribution` has no per-platform `sources` (counts +
+  `source_description` only); the STORED `data_context` still has `sources` for
+  the chart.
+- `pytest` generation + quote-gate suites -> 201 passed; both copies
+  byte-identical.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 2 generator copies (source_description + payload generalize + coverage note) | ~60 |
+| Tests (2 deterministic + a shared fixture) | ~55 |
+| ATLAS-HARDENING.md (2 parked entries) | ~16 |
+| Plan doc | ~95 |
+| **Total** | **~225** |

--- a/tests/test_b2b_blog_post_generation.py
+++ b/tests/test_b2b_blog_post_generation.py
@@ -323,6 +323,54 @@ def test_ensure_methodology_context_injects_review_period_and_disclaimer():
     assert "self-selected" in updated["content"]
 
 
+def _source_blueprint():
+    return blog_mod.PostBlueprint(
+        topic_type="vendor_deep_dive",
+        slug="x-deep-dive-2026-04",
+        suggested_title="X Deep Dive",
+        tags=["crm"],
+        data_context={
+            "enriched_count": 261,
+            "source_distribution": {
+                "sources": [{"name": "g2", "count": 11}, {"name": "reddit", "count": 237}],
+                "verified_count": 24,
+                "community_count": 237,
+            },
+            "source_description": (
+                "24 reviews from verified review platforms and "
+                "237 reviews from community forums"
+            ),
+        },
+        sections=[blog_mod.SectionSpec(id="hook", heading="Introduction", goal="x")],
+        charts=[],
+    )
+
+
+def test_coverage_snapshot_note_uses_generalized_source_description():
+    """D5: the coverage snapshot note must describe sources via the generalized
+    source_description (verified-platform / community-forum buckets), NOT a
+    partial platform enumeration. Reverting to _top_source_summary fails this."""
+    note = blog_mod._build_coverage_snapshot_note(_source_blueprint())
+    assert "24 reviews from verified review platforms and 237 reviews from community forums" in note
+    for platform in ("G2", "g2", "Reddit", "reddit", "Gartner", "PeerSpot"):
+        assert platform not in note
+
+
+def test_blog_payload_generalizes_source_distribution_for_llm():
+    """D5: the LLM payload must NOT carry the per-platform source list (the model
+    enumerates a partial subset of it). It gets counts + the generalized
+    source_description; the stored data_context keeps sources for the chart."""
+    blueprint = _source_blueprint()
+    payload = blog_mod._build_blog_generation_payload(blueprint)
+    payload_sd = payload["data_context"]["source_distribution"]
+    assert "sources" not in payload_sd          # no per-platform list to the LLM
+    assert payload_sd.get("verified_count") == 24
+    assert payload_sd.get("community_count") == 237
+    assert payload["data_context"]["source_description"]
+    # stored data_context untouched -> the source-mix chart still has platforms
+    assert blueprint.data_context["source_distribution"]["sources"]
+
+
 @pytest.mark.asyncio
 async def test_generate_content_async_traces_blog_business_metadata(monkeypatch):
     blueprint = blog_mod.PostBlueprint(


### PR DESCRIPTION
Ownership lane: `content-ops/blog-d5-source-generalization`

**D5**: blog prose names a *partial* source set ("verified platforms including G2, Gartner Peer Insights, and PeerSpot, alongside community discussions on Reddit") that omits sources the post quotes (Slashdot, Software Advice). A corpus grep found the at-risk phrasing in **52 of 78 posts** — corpus-wide, not single-instance.

Per maintainer: **thin-slice the generator-generalization now**; the 52 published posts are cleaned in the **Phase-2 deep pass** (not here).

## What shipped (generator-only)

- **Root cause:** the LLM payload carries the per-platform `source_distribution.sources` list, which the model narrates partially.
- `_gather_data` adds a generalized `data_context["source_description"]` ("{v} reviews from verified review platforms and {c} reviews from community forums").
- `_build_blog_generation_payload` hands the LLM a **generalized** `source_distribution` (counts only) — the per-platform `sources` list is dropped from the LLM-facing payload copy, so the model can't enumerate it. The **stored** `data_context` keeps `sources` for the source-mix chart.
- `_build_coverage_snapshot_note` uses `source_description` (drops the buggy, partial-by-design `_top_source_summary`).
- **Deterministic lever, not a prompt plea** — the model can't name what it doesn't see.

## How demonstrated

- `test_coverage_snapshot_note_uses_generalized_source_description`: note contains the generalized phrasing and **no** platform name; **fails on revert** to `_top_source_summary`.
- `test_blog_payload_generalizes_source_distribution_for_llm`: payload's `source_distribution` has no per-platform `sources` (counts + `source_description` only); the stored `data_context` still has `sources` for the chart.
- generation + quote-gate suites → **201 passed**; both copies byte-identical.

## Parked hardening (`ATLAS-HARDENING.md`)

- LLM-fidelity residual: model may still mention a platform inferred from a quote `source_name`/chart label, or ignore `source_description` — Phase-2 corpus check + candidate detector. *M/correctness.*
- `_top_source_summary` is now dead code (had a latent dict-shape bug) — remove next pass. *S/tech-debt.*

(Caveat: this closes the deterministic lever; the LLM's adherence to the generalized phrasing is empirically unverified and will be checked corpus-wide in Phase 2. The 52 published posts are not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)