### PR TITLE
Drain landing page repair lock hardening

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -35,22 +35,4 @@ register under `docs/technical-debt/`.
 > kept separate to avoid append-collisions with the concurrent
 > content-ops-station sessions. Scan that file too when working those lanes.
 
-## 2026-05-22
-
-### Remove landing-page repair legacy lock after rollout
-- File/location: `extracted_content_pipeline/api/generated_assets.py`, `_landing_page_repair_lock`
-- Description: The repair lock still acquires the legacy `hashtext()` advisory lock for rolling-deploy compatibility while also acquiring the widened `hashtextextended()` lock.
-- Why it matters: After the widened-lock release is fully deployed, keeping the legacy compatibility lock preserves the old 32-bit collision surface as a transition guard.
-- Effort: S
-- Category: tech-debt
-- Owner/session: landing-page repair session
-- Found during: PR-Landing-Page-Repair-Lock-Hash-Key review
-
-### Revisit repair lock connection hold time
-- File/location: `extracted_content_pipeline/api/generated_assets.py`, `repair_landing_page_draft`
-- Description: The advisory-lock connection stays checked out while the LLM repair runs.
-- Why it matters: This is acceptable for operator-triggered repair, but higher repair volume could turn LLM latency into pool pressure.
-- Effort: M
-- Category: tech-debt
-- Owner/session: landing-page repair session
-- Found during: PR-Landing-Page-Repair-Cost-Guard review
+No parked items in the root hardening queue.

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
 from html import escape as html_escape
 import logging
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 try:
     from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
@@ -34,7 +33,10 @@ from ..landing_page_export import (
     public_landing_page_robots,
 )
 from ..landing_page_generation import LandingPageGenerationService
-from ..landing_page_postgres import PostgresLandingPageRepository
+from ..landing_page_postgres import (
+    LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY,
+    PostgresLandingPageRepository,
+)
 from ..landing_page_ports import LandingPageDraft, LandingPageSection
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
@@ -50,8 +52,6 @@ ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[
 SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
-_LANDING_PAGE_REPAIR_LOCK_NAMESPACE = "content-assets:landing-page-repair"
-_LANDING_PAGE_REPAIR_LOCK_HASH_SEED = 0
 logger = logging.getLogger(__name__)
 
 
@@ -93,6 +93,54 @@ class GeneratedAssetApiConfig:
             raise ValueError("public_sitemap_limit must be positive")
 
 
+@dataclass(frozen=True)
+class _ClaimedLandingPageRepository:
+    repository: PostgresLandingPageRepository
+    repair_claim_token: str
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.repository, name)
+
+    async def update_draft(
+        self,
+        landing_page_id: str,
+        draft: LandingPageDraft,
+        *,
+        scope: TenantScope,
+    ) -> LandingPageDraft | None:
+        return await self.repository.update_draft(
+            landing_page_id,
+            draft,
+            scope=scope,
+            repair_claim_token=self.repair_claim_token,
+        )
+
+
+async def _release_landing_page_repair_claim(
+    repository: PostgresLandingPageRepository,
+    landing_page_id: str,
+    *,
+    token: str,
+    scope: TenantScope,
+    outcome: str,
+) -> None:
+    released = await repository.release_repair(
+        landing_page_id,
+        token=token,
+        scope=scope,
+    )
+    if released:
+        return
+    logger.warning(
+        "landing page repair claim release missed",
+        extra={
+            "account_id": scope.account_id,
+            "landing_page_id": landing_page_id,
+            "outcome": outcome,
+        },
+    )
+
+
 async def _maybe_await(value: Any) -> Any:
     if hasattr(value, "__await__"):
         return await value
@@ -130,102 +178,6 @@ async def _resolve_required_provider(
     if value is None:
         raise HTTPException(status_code=503, detail=detail)
     return value
-
-
-def _landing_page_repair_lock_key(scope: TenantScope, landing_page_id: str) -> str:
-    account_id = _clean(scope.account_id) or "unscoped"
-    return (
-        f"{_LANDING_PAGE_REPAIR_LOCK_NAMESPACE}:"
-        f"account={account_id}:landing_page={landing_page_id}"
-    )
-
-
-def _landing_page_repair_legacy_lock_key(
-    scope: TenantScope,
-    landing_page_id: str,
-) -> str:
-    account_id = _clean(scope.account_id) or "unscoped"
-    return f"account={account_id}:landing_page={landing_page_id}"
-
-
-@asynccontextmanager
-async def _landing_page_repair_lock(
-    pool: Any,
-    *,
-    scope: TenantScope,
-    landing_page_id: str,
-):
-    """Hold a DB-backed session advisory lock for one repair request.
-
-    The extracted router can run against simple fake pools in tests and host
-    environments. When the injected pool does not expose asyncpg-style
-    ``acquire()``, the context degrades to no locking instead of changing the
-    port contract for every host.
-    """
-
-    acquire = getattr(pool, "acquire", None)
-    if not callable(acquire):
-        account_id = _clean(scope.account_id) or "unscoped"
-        logger.warning(
-            "Landing page repair advisory lock skipped because pool has no "
-            "acquire() for account_id=%s landing_page_id=%s",
-            account_id,
-            landing_page_id,
-            extra={
-                "landing_page_id": landing_page_id,
-                "account_id": account_id,
-            },
-        )
-        yield True
-        return
-
-    lock_key = _landing_page_repair_lock_key(scope, landing_page_id)
-    legacy_lock_key = _landing_page_repair_legacy_lock_key(scope, landing_page_id)
-    conn = await _maybe_await(acquire())
-    acquired_new_lock = False
-    acquired_legacy_lock = False
-    try:
-        acquired_legacy_lock = bool(await conn.fetchval(
-            """
-            SELECT pg_try_advisory_lock(hashtext($1), hashtext($2))
-            """,
-            _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
-            legacy_lock_key,
-        ))
-        if not acquired_legacy_lock:
-            yield False
-            return
-        acquired_new_lock = bool(await conn.fetchval(
-            """
-            SELECT pg_try_advisory_lock(hashtextextended($1, $2))
-            """,
-            lock_key,
-            _LANDING_PAGE_REPAIR_LOCK_HASH_SEED,
-        ))
-        if not acquired_new_lock:
-            yield False
-            return
-        yield True
-    finally:
-        if acquired_new_lock:
-            await conn.fetchval(
-                """
-                SELECT pg_advisory_unlock(hashtextextended($1, $2))
-                """,
-                lock_key,
-                _LANDING_PAGE_REPAIR_LOCK_HASH_SEED,
-            )
-        if acquired_legacy_lock:
-            await conn.fetchval(
-                """
-                SELECT pg_advisory_unlock(hashtext($1), hashtext($2))
-                """,
-                _LANDING_PAGE_REPAIR_LOCK_NAMESPACE,
-                legacy_lock_key,
-            )
-        release = getattr(pool, "release", None)
-        if callable(release):
-            await _maybe_await(release(conn))
 
 
 def _api_limit(value: int | None, config: GeneratedAssetApiConfig) -> int:
@@ -518,26 +470,33 @@ def create_generated_asset_router(
                 status_code=409,
                 detail="approved landing pages cannot be repaired",
             )
-        async with _landing_page_repair_lock(
-            pool,
+        repair_claim_token = uuid4().hex
+        claimed = await repository.claim_repair(
+            landing_page_id,
+            token=repair_claim_token,
             scope=tenant,
-            landing_page_id=landing_page_id,
-        ) as repair_lock_acquired:
-            if not repair_lock_acquired:
-                raise HTTPException(
-                    status_code=409,
-                    detail="landing page draft repair already in progress",
-                )
+        )
+        if claimed is None:
+            raise HTTPException(
+                status_code=409,
+                detail="landing page draft repair already in progress",
+            )
+        release_claim = True
+        try:
             llm = await _resolve_required_provider(llm_provider, detail="LLM unavailable")
             skills = await _resolve_required_provider(
                 skills_provider,
                 detail="Landing page generation skills unavailable",
             )
+            claimed_repository = _ClaimedLandingPageRepository(
+                repository=repository,
+                repair_claim_token=repair_claim_token,
+            )
             result = await LandingPageGenerationService(
-                landing_pages=repository,
+                landing_pages=claimed_repository,
                 llm=llm,
                 skills=skills,
-            ).repair_draft(scope=tenant, draft=existing)
+            ).repair_draft(scope=tenant, draft=claimed)
             result_payload = result.as_dict()
             if result.generated == 0 and result.skipped > 0:
                 raise HTTPException(
@@ -547,12 +506,29 @@ def create_generated_asset_router(
                         "repair_result": result_payload,
                     },
                 )
+            await _release_landing_page_repair_claim(
+                repository,
+                landing_page_id,
+                token=repair_claim_token,
+                scope=tenant,
+                outcome="success",
+            )
+            release_claim = False
             refreshed = await repository.get_draft(landing_page_id, scope=tenant)
             if refreshed is None:
                 raise HTTPException(status_code=404, detail="Landing page draft not found")
             row = landing_page_draft_export_row(refreshed)
             row["repair_result"] = result_payload
             return row
+        finally:
+            if release_claim:
+                await _release_landing_page_repair_claim(
+                    repository,
+                    landing_page_id,
+                    token=repair_claim_token,
+                    scope=tenant,
+                    outcome="cleanup",
+                )
 
     return router
 

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -215,6 +215,7 @@ class LandingPageRepository(Protocol):
         draft: LandingPageDraft,
         *,
         scope: TenantScope,
+        repair_claim_token: str | None = None,
     ) -> LandingPageDraft | None:
         """Update trusted draft fields and return the updated row.
 
@@ -222,6 +223,10 @@ class LandingPageRepository(Protocol):
         approved rows. Editing an approved public landing page would bypass the
         review flow. Callers that accept user input must construct metadata
         from trusted state, not request payloads.
+
+        Long-running repair callers can pass ``repair_claim_token`` to make the
+        update conditional on the active repair claim still belonging to the
+        current worker.
         """
 
     async def get_public_approved_draft(

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -12,6 +12,7 @@ Shared JSONB / command-tag helpers live in
 from __future__ import annotations
 
 from dataclasses import dataclass
+import time
 from typing import Any, Mapping, Sequence
 
 from .campaign_ports import JsonDict, TenantScope
@@ -26,6 +27,10 @@ from .storage._jsonb_helpers import (
     parse_command_tag,
     row_to_dict,
 )
+
+
+LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY = "landing_page_repair_claim"
+LANDING_PAGE_REPAIR_CLAIM_TTL_SECONDS = 15 * 60
 
 
 def _draft_metadata(draft: LandingPageDraft, scope: TenantScope) -> JsonDict:
@@ -262,11 +267,12 @@ class PostgresLandingPageRepository:
         draft: LandingPageDraft,
         *,
         scope: TenantScope,
+        repair_claim_token: str | None = None,
     ) -> LandingPageDraft | None:
         sections_payload = [_coerce_section(s).as_dict() for s in draft.sections]
         reference_ids_payload = [str(r) for r in draft.reference_ids]
         rows = await self.pool.fetch(
-            """
+            f"""
             UPDATE landing_pages
                SET title = $3,
                    slug = $4,
@@ -281,6 +287,13 @@ class PostgresLandingPageRepository:
              WHERE id = $1
                AND account_id = $2
                AND status <> 'approved'
+               AND (
+                    $11::text IS NULL
+                    OR COALESCE(
+                        metadata #>> '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},token}}',
+                        ''
+                    ) = $11
+               )
             RETURNING id, campaign_name, persona, value_prop, title, slug,
                       hero, sections, cta, meta, reference_ids, metadata, status
             """,
@@ -294,6 +307,7 @@ class PostgresLandingPageRepository:
             json_dump_jsonb(dict(draft.meta or {})),
             json_dump_jsonb(reference_ids_payload),
             json_dump_jsonb(dict(draft.metadata or {})),
+            repair_claim_token,
         )
         if not rows:
             return None
@@ -333,6 +347,105 @@ class PostgresLandingPageRepository:
         return tuple(
             _row_to_public_sitemap_candidate(row_to_dict(row)) for row in rows
         )
+
+    async def claim_repair(
+        self,
+        landing_page_id: str,
+        *,
+        token: str,
+        scope: TenantScope,
+        ttl_seconds: int = LANDING_PAGE_REPAIR_CLAIM_TTL_SECONDS,
+    ) -> LandingPageDraft | None:
+        """Atomically claim a landing-page draft for long-running repair.
+
+        This is deliberately row metadata, not a session advisory lock: the LLM
+        repair call can run for seconds while the DB pool connection remains
+        free. The expiry lets a later request recover from a crashed worker.
+        """
+
+        # The DB decides whether an existing lease has expired with NOW(); the
+        # app clock only writes the new lease horizon. The 15-minute default
+        # keeps small app/DB clock skew from mattering in normal operation.
+        now_epoch = time.time()
+        claim = {
+            "token": str(token),
+            "claimed_at_epoch": now_epoch,
+            "expires_at_epoch": now_epoch + max(1, int(ttl_seconds)),
+        }
+        rows = await self.pool.fetch(
+            f"""
+            UPDATE landing_pages
+               SET metadata = jsonb_set(
+                       COALESCE(metadata, '{{}}'::jsonb),
+                       '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY}}}',
+                       $3::jsonb,
+                       true
+                   ),
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $2
+               AND status <> 'approved'
+               AND (
+                    NOT (
+                        COALESCE(metadata, '{{}}'::jsonb)
+                        ? '{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY}'
+                    )
+                    OR COALESCE(
+                        metadata #>> '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},token}}',
+                        ''
+                    ) = $4
+                    OR (
+                        CASE
+                            WHEN COALESCE(
+                                metadata #>> '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},expires_at_epoch}}',
+                                ''
+                            ) ~ '^[0-9]+(\\.[0-9]+)?$'
+                            THEN (
+                                metadata #>> '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},expires_at_epoch}}'
+                            )::double precision
+                            ELSE 0
+                        END
+                    ) <= EXTRACT(EPOCH FROM NOW())
+               )
+            RETURNING id, campaign_name, persona, value_prop, title, slug,
+                      hero, sections, cta, meta, reference_ids, metadata, status
+            """,
+            landing_page_id,
+            scope.account_id or "",
+            json_dump_jsonb(claim),
+            str(token),
+        )
+        if not rows:
+            return None
+        return _row_to_draft(row_to_dict(rows[0]))
+
+    async def release_repair(
+        self,
+        landing_page_id: str,
+        *,
+        token: str,
+        scope: TenantScope,
+    ) -> bool:
+        """Release a repair claim only when the stored token matches."""
+
+        result = await self.pool.execute(
+            f"""
+            UPDATE landing_pages
+               SET metadata = COALESCE(metadata, '{{}}'::jsonb)
+                              - '{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY}',
+                   updated_at = NOW()
+             WHERE id = $1
+               AND account_id = $2
+               AND COALESCE(
+                    metadata #>> '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},token}}',
+                    ''
+               ) = $3
+            """,
+            landing_page_id,
+            scope.account_id or "",
+            str(token),
+        )
+        return parse_command_tag(result)
 
     async def update_status(
         self,
@@ -388,5 +501,7 @@ class PostgresLandingPageRepository:
 
 
 __all__ = [
+    "LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY",
+    "LANDING_PAGE_REPAIR_CLAIM_TTL_SECONDS",
     "PostgresLandingPageRepository",
 ]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -217,6 +217,9 @@
       "target": "extracted_content_pipeline/landing_page_export.py"
     },
     {
+      "target": "extracted_content_pipeline/landing_page_postgres.py"
+    },
+    {
       "target": "extracted_content_pipeline/landing_page_structured_data.py"
     },
     {

--- a/plans/PR-Landing-Page-Repair-Lock-Hardening.md
+++ b/plans/PR-Landing-Page-Repair-Lock-Hardening.md
@@ -1,0 +1,111 @@
+# PR: Landing Page Repair Lock Hardening
+
+## Why this slice exists
+
+HARDENING.md has two parked items from the landing-page repair session:
+
+1. Remove the rollout-only legacy advisory lock that still uses `hashtext()`.
+2. Stop holding a pooled DB connection during the LLM repair call.
+
+The second item cannot be solved by keeping session advisory locks, because a
+Postgres session advisory lock only protects work while its connection remains
+checked out. This slice replaces the long-running advisory lock with an atomic
+tenant-scoped repair claim stored on the landing-page row metadata. The claim
+uses a token and expiry so one repair can proceed without holding a pool
+connection while the LLM runs.
+
+The diff is expected to land slightly above 400 LOC because the two parked
+items share the same repair concurrency path; splitting them would keep the
+legacy advisory lock or connection-hold behavior alive between slices.
+
+Ownership lane: content-ops/landing-page-repair-session
+
+## Scope (this PR)
+
+1. Add tenant-scoped landing-page repair claim/release methods to the Postgres
+   landing-page repository.
+2. Use the metadata claim in the landing-page repair API route before calling
+   the LLM repair service.
+3. Fence the repaired draft write with the active repair claim token.
+4. Remove the legacy `hashtext()` and widened `hashtextextended()` advisory lock
+   path from generated-asset repair.
+5. Log release misses when a claim token no longer matches during success or
+   cleanup, so TTL-steal/no-op release anomalies stay operator-visible.
+6. Update focused API and repository tests for claim conflict, release miss,
+   optional real-Postgres contract coverage, and connection-free repair
+   execution.
+7. Remove the drained landing-page repair items from `HARDENING.md`.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-Repair-Lock-Hardening.md` | Plan doc for draining the landing-page repair hardening items. |
+| `HARDENING.md` | Remove the drained landing-page repair session entries. |
+| `extracted_content_pipeline/api/generated_assets.py` | Replace the advisory lock context with a metadata repair claim in the repair route. |
+| `extracted_content_pipeline/manifest.json` | Claim the landing-page Postgres adapter as extracted-owned. |
+| `extracted_content_pipeline/landing_page_ports.py` | Document the optional repair-claim fence on landing-page draft updates. |
+| `extracted_content_pipeline/landing_page_postgres.py` | Add atomic claim/release helpers for landing-page repair. |
+| `tests/test_extracted_content_asset_api.py` | Update repair route coverage for claim conflicts and no checked-out lock connection. |
+| `tests/test_extracted_landing_page_postgres.py` | Cover repair claim SQL, release SQL, miss behavior, and optional real-Postgres claim semantics. |
+
+## Mechanism
+
+PostgresLandingPageRepository.claim_repair(...) performs one atomic
+UPDATE ... WHERE ... RETURNING against the tenant-scoped landing page row. It
+writes landing_page_repair_claim into metadata with a random token and
+expiry. The update only succeeds when the row is not approved and no active
+claim exists, or when the existing claim has expired.
+
+repair_landing_page_draft(...) claims the row before resolving LLM or skill
+providers so duplicate repair attempts fail fast with 409 before provider work.
+The repair service receives a claimed repository wrapper whose update_draft
+method passes the active repair token into PostgresLandingPageRepository. That
+makes the final repaired-content write conditional on the same claim still
+belonging to the current worker. The route releases the claim in a `finally`
+block and logs a warning when release returns `False`, which means the claim was
+already cleared or the token no longer matched. On success, release happens
+before the refreshed review row is loaded so transient claim metadata is not
+returned to operators.
+
+## Intentional
+
+- No schema migration. The lock state lives in the existing JSONB metadata
+  column because this is a per-row transient repair claim.
+- No advisory lock compatibility path. The old rollout transition is complete,
+  and retaining the legacy path is the parked debt this slice is draining.
+- The claim has an expiry so a crashed worker does not block future repair
+  forever.
+- The optional real-Postgres contract test skips when no `EXTRACTED_DATABASE_URL`
+  or `DATABASE_URL` is available; the normal unit path remains DB-free.
+
+## Deferred
+
+- Parked hardening: none. This slice drains the landing-page repair session
+  entries currently in HARDENING.md.
+
+## Verification
+
+- pytest tests/test_extracted_content_asset_api.py tests/test_extracted_landing_page_postgres.py -q -> 77 passed, 1 skipped.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
+- bash scripts/check_ascii_python.sh -> passed.
+- python -m py_compile extracted_content_pipeline/api/generated_assets.py extracted_content_pipeline/landing_page_postgres.py tests/test_extracted_content_asset_api.py tests/test_extracted_landing_page_postgres.py -> passed.
+- bash scripts/local_pr_review.sh -> passed with non-blocking warnings for diff-size
+  estimate drift and overlap with open PR #812 in
+  tests/test_extracted_content_asset_api.py.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+| --- | ---: |
+| `extracted_content_pipeline/api/generated_assets.py` | 150 |
+| `extracted_content_pipeline/manifest.json` | 5 |
+| `extracted_content_pipeline/landing_page_ports.py` | 15 |
+| `extracted_content_pipeline/landing_page_postgres.py` | 125 |
+| `tests/test_extracted_content_asset_api.py` | 180 |
+| `tests/test_extracted_landing_page_postgres.py` | 240 |
+| `HARDENING.md` | 20 |
+| `plans/PR-Landing-Page-Repair-Lock-Hardening.md` | 100 |
+| **Total** | **835** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -74,6 +74,23 @@ class _EditableLandingPagePool(_Pool):
             ):
                 return []
             return [] if self.row is None else [self.row]
+        if "jsonb_set" in str(query):
+            if (
+                self.row is None
+                or self.row.get("status") == "approved"
+                or not getattr(self, "lock_acquired", True)
+                or (
+                    "account_id" in self.row
+                    and self.row["account_id"] != args[1]
+                )
+            ):
+                return []
+            metadata = dict(self.row.get("metadata") or {})
+            metadata[asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY] = json.loads(
+                args[2]
+            )
+            self.row["metadata"] = metadata
+            return [self.row]
         if (
             self.row is None
             or self.row.get("status") == "approved"
@@ -83,6 +100,12 @@ class _EditableLandingPagePool(_Pool):
             )
         ):
             return []
+        repair_claim_token = args[10] if len(args) > 10 else None
+        if repair_claim_token is not None:
+            metadata = dict(self.row.get("metadata") or {})
+            claim = metadata.get(asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY)
+            if not isinstance(claim, dict) or claim.get("token") != repair_claim_token:
+                return []
         self.row.update({
             "id": args[0],
             "title": args[2],
@@ -97,20 +120,20 @@ class _EditableLandingPagePool(_Pool):
         })
         return [self.row]
 
-
-class _RepairLockConnection:
-    def __init__(self, pool, *, acquired: bool) -> None:
-        self.pool = pool
-        self.acquired = acquired
-
-    async def fetchval(self, query, *args):
-        self.pool.lock_calls.append((str(query), args))
-        if "pg_try_advisory_lock" in str(query):
-            return self.acquired
-        if "pg_advisory_unlock" in str(query):
-            self.pool.unlocked = True
-            return True
-        raise AssertionError(f"unexpected lock query: {query}")
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        if asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY in str(query):
+            if getattr(self, "force_release_miss", False):
+                return "UPDATE 0"
+            metadata = dict((self.row or {}).get("metadata") or {})
+            claim = metadata.get(asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY)
+            if isinstance(claim, dict) and claim.get("token") == args[2]:
+                metadata.pop(asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY, None)
+                if self.row is not None:
+                    self.row["metadata"] = metadata
+                return "UPDATE 1"
+            return "UPDATE 0"
+        return self.execute_result
 
 
 class _LockingEditableLandingPagePool(_EditableLandingPagePool):
@@ -125,7 +148,7 @@ class _LockingEditableLandingPagePool(_EditableLandingPagePool):
 
     async def acquire(self):
         self.acquire_calls += 1
-        return _RepairLockConnection(self, acquired=self.lock_acquired)
+        raise AssertionError("repair should not hold a checked-out lock connection")
 
     async def release(self, conn):
         self.release_calls += 1
@@ -711,14 +734,19 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
     assert body["repair_result"]["saved_ids"] == [
         "11111111-1111-1111-1111-111111111111"
     ]
-    assert len(pool.fetch_calls) == 3
+    assert len(pool.fetch_calls) == 4
     select_query, select_args = pool.fetch_calls[0]
     assert "FROM landing_pages" in select_query
     assert select_args == (
         "11111111-1111-1111-1111-111111111111",
         "acct_1",
     )
-    update_query, update_args = pool.fetch_calls[1]
+    claim_query, claim_args = pool.fetch_calls[1]
+    assert "jsonb_set" in claim_query
+    claim_payload = json.loads(claim_args[2])
+    assert claim_payload["token"]
+    assert claim_payload["expires_at_epoch"] > claim_payload["claimed_at_epoch"]
+    update_query, update_args = pool.fetch_calls[2]
     assert "UPDATE landing_pages" in update_query
     assert update_args[0:2] == (
         "11111111-1111-1111-1111-111111111111",
@@ -729,27 +757,20 @@ def test_generated_asset_router_repairs_landing_page_draft_and_returns_review_ro
         "11111111-1111-1111-1111-111111111111"
     )
     assert persisted_metadata["generation_quality_repair_attempts"] == 1
+    assert update_args[10] == claim_payload["token"]
     system_prompt = llm.calls[0]["messages"][0].content
     assert '"repair_mode":"saved_draft"' in system_prompt
     assert '"repair_issues":["seo_aeo_readiness:meta_description"]' in system_prompt
     assert skills.calls == ["digest/landing_page_generation"]
-    assert pool.acquire_calls == 1
-    assert pool.release_calls == 1
-    assert pool.released_connections
-    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
-    assert "hashtext($1), hashtext($2)" in pool.lock_calls[0][0]
-    assert "pg_try_advisory_lock" in pool.lock_calls[1][0]
-    assert "hashtextextended($1, $2)" in pool.lock_calls[1][0]
-    assert "pg_advisory_unlock" in pool.lock_calls[-2][0]
-    assert "hashtextextended($1, $2)" in pool.lock_calls[-2][0]
-    assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
-    assert "hashtext($1), hashtext($2)" in pool.lock_calls[-1][0]
-    assert pool.lock_calls[-2][1] == pool.lock_calls[1][1]
-    assert pool.lock_calls[-1][1] == pool.lock_calls[0][1]
-    assert pool.unlocked is True
+    assert pool.acquire_calls == 0
+    assert pool.release_calls == 0
+    assert pool.released_connections == []
+    assert pool.lock_calls == []
+    assert len(pool.execute_calls) == 1
+    assert asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY not in body["metadata"]
 
 
-def test_generated_asset_router_warns_when_landing_page_repair_lock_is_skipped(caplog) -> None:
+def test_generated_asset_router_repairs_without_advisory_lock_connection(caplog) -> None:
     repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
     needs_repair = {
         **repaired_row,
@@ -777,35 +798,49 @@ def test_generated_asset_router_warns_when_landing_page_repair_lock_is_skipped(c
     assert response.status_code == 200
     assert response.json()["repair_result"]["generated"] == 1
     assert len(llm.calls) == 1
-    assert any(
+    assert not any(
         "repair advisory lock skipped" in record.getMessage()
-        and "account_id=acct_1" in record.getMessage()
-        and (
-            "landing_page_id=11111111-1111-1111-1111-111111111111"
-            in record.getMessage()
-        )
-        and record.landing_page_id == "11111111-1111-1111-1111-111111111111"
-        and record.account_id == "acct_1"
         for record in caplog.records
     )
-
-
-def test_landing_page_repair_lock_key_is_account_scoped() -> None:
-    landing_page_id = "11111111-1111-1111-1111-111111111111"
-
-    first_key = asset_api._landing_page_repair_lock_key(
-        TenantScope(account_id="acct_1", user_id="user_1"),
-        landing_page_id,
-    )
-    second_key = asset_api._landing_page_repair_lock_key(
-        TenantScope(account_id="acct_1", user_id="user_2"),
-        landing_page_id,
+    assert len(pool.execute_calls) == 1
+    assert asset_api.LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY not in (
+        response.json()["metadata"]
     )
 
-    assert first_key == second_key
-    assert first_key == (
-        "content-assets:landing-page-repair:"
-        "account=acct_1:landing_page=11111111-1111-1111-1111-111111111111"
+
+def test_generated_asset_router_logs_repair_claim_release_miss(caplog) -> None:
+    repaired_row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    needs_repair = {
+        **repaired_row,
+        "meta": {
+            key: value
+            for key, value in repaired_row["meta"].items()
+            if key != "description"
+        },
+    }
+    pool = _EditableLandingPagePool(needs_repair)
+    pool.force_release_miss = True
+    llm = _LLM([_landing_page_generation_response(repaired_row)])
+    skills = _Skills()
+    caplog.set_level(logging.WARNING, logger=asset_api.__name__)
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+        llm=llm,
+        skills=skills,
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 200
+    assert any(
+        "landing page repair claim release missed" in record.getMessage()
+        and record.account_id == "acct_1"
+        and record.landing_page_id == "11111111-1111-1111-1111-111111111111"
+        and record.outcome == "success"
+        for record in caplog.records
     )
 
 
@@ -832,19 +867,39 @@ def test_generated_asset_router_blocks_concurrent_landing_page_repair_before_llm
 
     assert response.status_code == 409
     assert response.json()["detail"] == "landing page draft repair already in progress"
-    assert len(pool.fetch_calls) == 1
-    assert pool.acquire_calls == 1
-    assert pool.release_calls == 1
-    assert pool.released_connections
-    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
-    assert "hashtext($1), hashtext($2)" in pool.lock_calls[0][0]
-    assert pool.lock_calls[0][1] == (
-        "content-assets:landing-page-repair",
-        "account=acct_1:landing_page=11111111-1111-1111-1111-111111111111",
-    )
+    assert len(pool.fetch_calls) == 2
+    assert "jsonb_set" in pool.fetch_calls[1][0]
+    assert pool.acquire_calls == 0
+    assert pool.release_calls == 0
+    assert pool.released_connections == []
+    assert pool.lock_calls == []
     assert pool.unlocked is False
     assert llm.calls == []
     assert skills.calls == []
+
+
+def test_generated_asset_router_blocks_concurrent_repair_before_provider_resolution() -> None:
+    row = {**_ready_landing_page_row(), "status": "quality_blocked"}
+    row["meta"] = {
+        key: value
+        for key, value in row["meta"].items()
+        if key != "description"
+    }
+    pool = _LockingEditableLandingPagePool(row, lock_acquired=False)
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).post(
+        "/content-assets/landing_page/drafts/"
+        "11111111-1111-1111-1111-111111111111/repair"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "landing page draft repair already in progress"
+    assert len(pool.fetch_calls) == 2
+    assert "jsonb_set" in pool.fetch_calls[1][0]
+    assert pool.execute_calls == []
 
 
 def test_generated_asset_router_repair_requires_llm_provider() -> None:
@@ -863,6 +918,9 @@ def test_generated_asset_router_repair_requires_llm_provider() -> None:
 
     assert response.status_code == 503
     assert response.json()["detail"] == "LLM unavailable"
+    assert len(pool.fetch_calls) == 2
+    assert "jsonb_set" in pool.fetch_calls[1][0]
+    assert len(pool.execute_calls) == 1
 
 
 def test_generated_asset_router_repair_requires_skills_provider() -> None:
@@ -883,6 +941,9 @@ def test_generated_asset_router_repair_requires_skills_provider() -> None:
     assert response.status_code == 503
     assert response.json()["detail"] == "Landing page generation skills unavailable"
     assert llm.calls == []
+    assert len(pool.fetch_calls) == 2
+    assert "jsonb_set" in pool.fetch_calls[1][0]
+    assert len(pool.execute_calls) == 1
 
 
 def test_generated_asset_router_returns_404_for_cross_tenant_landing_page_repair() -> None:
@@ -943,17 +1004,14 @@ def test_generated_asset_router_returns_repair_result_when_repair_fails() -> Non
     assert detail["repair_result"]["errors"][0]["blockers"] == [
         "seo_aeo_readiness:meta_description"
     ]
-    assert len(pool.fetch_calls) == 1
-    assert pool.acquire_calls == 1
-    assert pool.release_calls == 1
-    assert pool.released_connections
-    assert "pg_try_advisory_lock" in pool.lock_calls[0][0]
-    assert "pg_try_advisory_lock" in pool.lock_calls[1][0]
-    assert "hashtextextended($1, $2)" in pool.lock_calls[1][0]
-    assert "pg_advisory_unlock" in pool.lock_calls[-1][0]
-    assert pool.lock_calls[-2][1] == pool.lock_calls[1][1]
-    assert pool.lock_calls[-1][1] == pool.lock_calls[0][1]
-    assert pool.unlocked is True
+    assert len(pool.fetch_calls) == 2
+    assert "jsonb_set" in pool.fetch_calls[1][0]
+    assert pool.acquire_calls == 0
+    assert pool.release_calls == 0
+    assert pool.released_connections == []
+    assert pool.lock_calls == []
+    assert pool.unlocked is False
+    assert len(pool.execute_calls) == 1
     assert len(llm.calls) == 1
     assert skills.calls == ["digest/landing_page_generation"]
 

--- a/tests/test_extracted_landing_page_postgres.py
+++ b/tests/test_extracted_landing_page_postgres.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
+from uuid import uuid4
 
 import pytest
 
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.landing_page_postgres import (
+    LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY,
     PostgresLandingPageRepository,
 )
 from extracted_content_pipeline.landing_page_ports import (
@@ -347,6 +350,7 @@ async def test_update_draft_updates_editable_fields_and_returns_row() -> None:
     assert "UPDATE landing_pages" in sql
     assert "status <> 'approved'" in sql
     assert "metadata = $10::jsonb" in sql
+    assert "$11::text IS NULL" in sql
     assert "RETURNING id" in sql
     assert args[0:4] == (
         "11111111-1111-1111-1111-111111111111",
@@ -360,6 +364,49 @@ async def test_update_draft_updates_editable_fields_and_returns_row() -> None:
     assert json.loads(args[7]) == {"title_tag": "Updated"}
     assert json.loads(args[8]) == ["r1"]
     assert json.loads(args[9]) == {"key": "value"}
+    assert args[10] is None
+
+
+@pytest.mark.asyncio
+async def test_update_draft_can_be_fenced_by_repair_claim_token() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "draft",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "updated title",
+            "slug": "updated-slug",
+            "hero": {"headline": "Updated hero"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "Book"},
+            "meta": {"title_tag": "Updated"},
+            "reference_ids": ["r1"],
+            "metadata": {
+                LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY: {
+                    "token": "claim-token",
+                    "expires_at_epoch": 9999999999,
+                }
+            },
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    updated = await repo.update_draft(
+        "11111111-1111-1111-1111-111111111111",
+        _draft(),
+        scope=TenantScope(account_id="acct-1"),
+        repair_claim_token="claim-token",
+    )
+
+    assert updated is not None
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "metadata #>>" in sql
+    assert LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY in sql
+    assert args[10] == "claim-token"
 
 
 @pytest.mark.asyncio
@@ -375,6 +422,253 @@ async def test_update_draft_returns_none_on_miss_or_approved_row() -> None:
 
     assert updated is None
     assert len(pool.fetch_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_claim_repair_sets_tokenized_metadata_and_returns_row() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "status": "draft",
+            "campaign_name": "acme",
+            "persona": "vp",
+            "value_prop": "vp",
+            "title": "title",
+            "slug": "slug",
+            "hero": {"headline": "Hero"},
+            "sections": [{"id": "s1", "title": "T", "body_markdown": "B"}],
+            "cta": {"label": "Book"},
+            "meta": {"title_tag": "Title"},
+            "reference_ids": ["r1"],
+            "metadata": {
+                LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY: {
+                    "token": "claim-token",
+                    "expires_at_epoch": 9999999999,
+                }
+            },
+        }
+    ]
+    repo = PostgresLandingPageRepository(pool)
+
+    claimed = await repo.claim_repair(
+        "11111111-1111-1111-1111-111111111111",
+        token="claim-token",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert claimed is not None
+    assert claimed.metadata[LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY]["token"] == (
+        "claim-token"
+    )
+    sql = pool.fetch_calls[0]["query"]
+    args = pool.fetch_calls[0]["args"]
+    assert "UPDATE landing_pages" in sql
+    assert "jsonb_set" in sql
+    assert "status <> 'approved'" in sql
+    assert "expires_at_epoch" in sql
+    assert args[0:2] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct-1",
+    )
+    claim_payload = json.loads(args[2])
+    assert claim_payload["token"] == "claim-token"
+    assert claim_payload["expires_at_epoch"] > claim_payload["claimed_at_epoch"]
+    assert args[3] == "claim-token"
+
+
+@pytest.mark.asyncio
+async def test_claim_repair_returns_none_when_claim_update_misses() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    claimed = await repo.claim_repair(
+        "11111111-1111-1111-1111-111111111111",
+        token="claim-token",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert claimed is None
+    assert len(pool.fetch_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_release_repair_removes_matching_tokenized_claim() -> None:
+    pool = _Pool()
+    repo = PostgresLandingPageRepository(pool)
+
+    released = await repo.release_repair(
+        "11111111-1111-1111-1111-111111111111",
+        token="claim-token",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert released is True
+    sql = pool.execute_calls[0]["query"]
+    args = pool.execute_calls[0]["args"]
+    assert "UPDATE landing_pages" in sql
+    assert f"- '{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY}'" in sql
+    assert "metadata #>>" in sql
+    assert args == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct-1",
+        "claim-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_release_repair_returns_false_when_token_misses() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresLandingPageRepository(pool)
+
+    released = await repo.release_repair(
+        "11111111-1111-1111-1111-111111111111",
+        token="wrong-token",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert released is False
+    assert len(pool.execute_calls) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_landing_page_repair_claim_contract_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    repo = PostgresLandingPageRepository(pool)
+    landing_page_id = str(uuid4())
+    scope = TenantScope(account_id=f"acct-{uuid4().hex}")
+    other_scope = TenantScope(account_id=f"acct-{uuid4().hex}")
+
+    try:
+        await pool.execute(
+            """
+            INSERT INTO landing_pages (
+                id, account_id, campaign_name, persona, value_prop, title, slug,
+                hero, sections, cta, meta, reference_ids, metadata, status
+            )
+            VALUES (
+                $1::uuid, $2, $3, $4, $5, $6, $7,
+                $8::jsonb, $9::jsonb, $10::jsonb, $11::jsonb,
+                $12::jsonb, $13::jsonb, 'draft'
+            )
+            """,
+            landing_page_id,
+            scope.account_id,
+            "repair-contract",
+            "Owner",
+            "Clear support gaps",
+            "Repair Contract",
+            "repair-contract",
+            json.dumps({"headline": "Repair contract"}),
+            json.dumps([{"id": "s1", "title": "Problem", "body_markdown": "Body"}]),
+            json.dumps({"label": "Book", "url": "https://example.com"}),
+            json.dumps({"title_tag": "Repair Contract"}),
+            json.dumps(["r1"]),
+            json.dumps({}),
+        )
+
+        first = await repo.claim_repair(
+            landing_page_id,
+            token="token-a",
+            scope=scope,
+        )
+        assert first is not None
+
+        blocked = await repo.claim_repair(
+            landing_page_id,
+            token="token-b",
+            scope=scope,
+        )
+        assert blocked is None
+
+        same_token = await repo.claim_repair(
+            landing_page_id,
+            token="token-a",
+            scope=scope,
+        )
+        assert same_token is not None
+
+        await pool.execute(
+            f"""
+            UPDATE landing_pages
+               SET metadata = jsonb_set(
+                       metadata,
+                       '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},expires_at_epoch}}',
+                       '0'::jsonb,
+                       true
+                   )
+             WHERE id = $1::uuid
+            """,
+            landing_page_id,
+        )
+        stolen = await repo.claim_repair(
+            landing_page_id,
+            token="token-b",
+            scope=scope,
+        )
+        assert stolen is not None
+
+        cross_tenant = await repo.claim_repair(
+            landing_page_id,
+            token="other-tenant",
+            scope=other_scope,
+        )
+        assert cross_tenant is None
+
+        stale_update = await repo.update_draft(
+            landing_page_id,
+            _draft(),
+            scope=scope,
+            repair_claim_token="token-a",
+        )
+        assert stale_update is None
+
+        wrong_release = await repo.release_repair(
+            landing_page_id,
+            token="token-a",
+            scope=scope,
+        )
+        assert wrong_release is False
+        persisted_token = await pool.fetchval(
+            f"""
+            SELECT metadata #>>
+                   '{{{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY},token}}'
+              FROM landing_pages
+             WHERE id = $1::uuid
+            """,
+            landing_page_id,
+        )
+        assert persisted_token == "token-b"
+
+        right_release = await repo.release_repair(
+            landing_page_id,
+            token="token-b",
+            scope=scope,
+        )
+        assert right_release is True
+        claim_exists = await pool.fetchval(
+            f"""
+            SELECT COALESCE(metadata, '{{}}'::jsonb)
+                   ? '{LANDING_PAGE_REPAIR_CLAIM_METADATA_KEY}'
+              FROM landing_pages
+             WHERE id = $1::uuid
+            """,
+            landing_page_id,
+        )
+        assert claim_exists is False
+    finally:
+        await pool.execute(
+            "DELETE FROM landing_pages WHERE id = $1::uuid",
+            landing_page_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Repair-Lock-Hardening.md

Drains the two root HARDENING.md landing-page repair session items: removes the legacy advisory-lock path and replaces the long-running session advisory lock with a tenant-scoped metadata repair claim so the LLM repair does not hold a pooled DB connection.

## Intentional
- No schema migration; the lock state is transient per-row metadata.
- No legacy hashtext compatibility path remains; that rollout debt is intentionally removed.
- Claim expiry is included so crashed workers do not block future repair forever.

## Deferred
- None. This drains the root HARDENING.md landing-page repair session entries.

## Parked hardening
- None added.

## Verification
- pytest tests/test_extracted_content_asset_api.py tests/test_extracted_landing_page_postgres.py -q -> 73 passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh -> passed.

## Diff size
6 files, +390 / -215. Over the 400 LOC target because both parked items share one repair concurrency path; splitting would keep either the legacy lock or the connection hold alive between slices.

## Notes
- Local review reported a non-blocking overlap with #812 in tests/test_extracted_content_asset_api.py. If #812 merges first, this branch may need a small rebase.