### PR TITLE
Show FAQ vocabulary gaps in execute results

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -2290,7 +2290,157 @@ function ExecutionStepSummary({
   if (['blog_post', 'report', 'landing_page', 'sales_brief'].includes(output)) {
     return <GeneratedAssetSummary result={result} generatedLabel="Assets generated" />
   }
+  if (output === 'faq_markdown') {
+    return <FAQMarkdownExecutionSummary result={result} />
+  }
   return null
+}
+
+function FAQMarkdownExecutionSummary({ result }: { result: Record<string, unknown> }) {
+  const generated = typeof result.generated === 'number' ? result.generated : null
+  const sourceCount =
+    typeof result.source_count === 'number' ? result.source_count : null
+  const ticketSourceCount =
+    typeof result.ticket_source_count === 'number'
+      ? result.ticket_source_count
+      : null
+  const warningCount = Array.isArray(result.warnings)
+    ? result.warnings.length
+    : null
+  const savedIds = Array.isArray(result.saved_ids)
+    ? result.saved_ids.filter((id): id is string => typeof id === 'string')
+    : []
+  const mappings = faqExecutionTermMappings(result.items)
+  const shownMappings = mappings.slice(0, 3)
+
+  if (
+    generated === null &&
+    sourceCount === null &&
+    ticketSourceCount === null &&
+    warningCount === null &&
+    savedIds.length === 0 &&
+    mappings.length === 0
+  ) {
+    return null
+  }
+
+  return (
+    <div className="mb-3 space-y-2 rounded-md border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-slate-300">
+      <div className="flex flex-wrap items-center gap-3">
+        {generated !== null && (
+          <span>
+            FAQ items:{' '}
+            <span className="font-medium text-slate-100">{generated}</span>
+          </span>
+        )}
+        {sourceCount !== null && (
+          <span>
+            Source rows:{' '}
+            <span className="font-medium text-slate-100">{sourceCount}</span>
+          </span>
+        )}
+        {ticketSourceCount !== null && (
+          <span>
+            Ticket sources:{' '}
+            <span className="font-medium text-slate-100">
+              {ticketSourceCount}
+            </span>
+          </span>
+        )}
+        {warningCount !== null && (
+          <span>
+            Warnings:{' '}
+            <span className="font-medium text-slate-100">{warningCount}</span>
+          </span>
+        )}
+        <span>
+          Vocabulary gaps:{' '}
+          <span className="font-medium text-slate-100">{mappings.length}</span>
+        </span>
+      </div>
+      {shownMappings.length > 0 && (
+        <ul className="space-y-1">
+          {shownMappings.map((mapping, index) => (
+            <li
+              key={`${mapping.customerTerm}-${mapping.documentationTerm}-${index}`}
+              className="rounded border border-slate-800 bg-slate-950/50 px-2 py-1"
+            >
+              <span className="font-medium text-slate-100">
+                {mapping.customerTerm || 'Customer term'}
+              </span>
+              {' -> '}
+              <span className="text-cyan-200">
+                {mapping.documentationTerm || 'Documentation term'}
+              </span>
+              <span className="ml-2 text-slate-500">
+                {faqMappingMeta(mapping).join(' · ')}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {mappings.length > shownMappings.length && (
+        <div className="text-slate-500">
+          +{mappings.length - shownMappings.length} more vocabulary gaps in raw
+          result details
+        </div>
+      )}
+      {savedIds.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span>Saved:</span>
+          {savedIds.map((id) => (
+            <span
+              key={id}
+              className="max-w-full break-all rounded bg-slate-950/60 px-1.5 py-0.5 font-mono text-slate-100"
+            >
+              {id}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type FAQExecutionTermMapping = {
+  customerTerm: string
+  documentationTerm: string
+  sourceIdCount: number | null
+  zeroResultSourceCount: number | null
+  opportunityScore: number | null
+}
+
+function faqExecutionTermMappings(value: unknown): FAQExecutionTermMapping[] {
+  return recordArray(value).flatMap((item) =>
+    recordArray(item.term_mappings)
+      .map((mapping) => ({
+        customerTerm: stringField(mapping, 'customer_term') ?? '',
+        documentationTerm: stringField(mapping, 'documentation_term') ?? '',
+        sourceIdCount: numberField(mapping, 'source_id_count'),
+        zeroResultSourceCount: numberField(mapping, 'zero_result_source_count'),
+        opportunityScore: numberField(mapping, 'opportunity_score'),
+      }))
+      .filter((mapping) => mapping.customerTerm || mapping.documentationTerm),
+  )
+}
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : []
+}
+
+function faqMappingMeta(mapping: FAQExecutionTermMapping): string[] {
+  return [
+    numberMeta(mapping.sourceIdCount, 'source'),
+    numberMeta(mapping.zeroResultSourceCount, 'zero-result'),
+    mapping.opportunityScore === null
+      ? ''
+      : `score ${mapping.opportunityScore}`,
+  ].filter(Boolean)
+}
+
+function numberMeta(value: number | null, label: string): string {
+  if (value === null) return ''
+  return `${value} ${label}${value === 1 ? '' : 's'}`
 }
 
 function GeneratedAssetSummary({
@@ -2812,6 +2962,14 @@ function stringField(
 ): string | null {
   const field = value[key]
   return typeof field === 'string' && field ? field : null
+}
+
+function numberField(
+  value: Record<string, unknown>,
+  key: string,
+): number | null {
+  const field = value[key]
+  return typeof field === 'number' && Number.isFinite(field) ? field : null
 }
 
 function executionDetailMessage(detail: unknown): string {

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Summary.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Summary.md
@@ -1,0 +1,75 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Summary
+
+## Why this slice exists
+
+Hosted FAQ runs can now accept vocabulary-gap inputs and generate mappings, but
+the execute result panel still hides that signal inside the raw JSON details.
+Operators need immediate confirmation that a hosted run found vocabulary gaps
+without opening the asset review drawer or expanding the full result payload.
+
+This slice adds the thinnest execute-result summary for FAQ Markdown
+vocabulary-gap output.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-execute-summary
+
+1. Render a dedicated FAQ Markdown execution summary when an executed step has
+   output `faq_markdown`.
+2. Show generated item count, source row count, ticket source count, warning
+   count, saved ids, and total vocabulary-gap mapping count.
+3. Show up to three vocabulary-gap mappings with customer term, documentation
+   term, source count, zero-result count, and opportunity score.
+4. Keep the raw JSON result details unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Summary.md` | Plan doc for this execute-result visibility slice. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Adds the FAQ execution summary and small result-parsing helpers. |
+
+## Mechanism
+
+The existing `ExecutionStepSummary` switch renders output-specific summaries
+before the raw JSON details. This slice adds a `faq_markdown` branch:
+
+```tsx
+faq_markdown result.items[].term_mappings -> summary chips + top mappings
+```
+
+The parser is defensive against unknown result shapes and uses the same
+record/list helper style already used by the execute panel.
+
+## Intentional
+
+- UI-only slice. No backend generator, API, persistence, CLI, or asset review
+  changes.
+- No new chart, drawer, or table abstraction; this is inline execute feedback.
+- Mapping list is capped at three entries to keep the execute panel compact.
+- Raw JSON remains available for full inspection.
+
+## Deferred
+
+- Full sortable/searchable vocabulary-gap table remains a later product slice.
+- Inline links from execute results to saved FAQ drafts remain separate.
+- Current `HARDENING.md` entries were scanned; they are landing-page repair
+  items and do not touch this FAQ execute-summary lane.
+
+## Verification
+
+- `npm run lint` from `atlas-intel-ui/` - passed.
+- `npm run build` from `atlas-intel-ui/` - initially failed because the first
+  implementation reused an asset-review-only `recordList` helper in
+  `ContentOpsNewRun`; fixed by adding a local `recordArray` helper, then
+  reran and passed.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| FAQ execute summary UI | ~80 |
+| Result parsing helpers | ~60 |
+| **Total** | ~215 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Execute-Summary.md

Hosted FAQ runs now accept vocabulary-gap inputs and generate mappings, but the execute result panel only exposed that signal inside raw JSON. This adds a FAQ-specific execute summary with item/source counts and top vocabulary-gap mappings before the raw result details.

## Intentional
- UI-only slice; no backend generator, API, persistence, CLI, or asset review changes.
- No new chart, drawer, or table abstraction.
- Mapping list is capped at three entries to keep execute feedback compact.
- Raw JSON remains available for full inspection.

## Deferred
- Full sortable/searchable vocabulary-gap table remains separate.
- Inline links from execute results to saved FAQ drafts remain separate.
- Existing HARDENING.md items are outside this FAQ execute-summary lane.

## Verification
- `npm run lint` from `atlas-intel-ui/` - passed.
- `npm run build` from `atlas-intel-ui/` - initially failed because the first implementation reused an asset-review-only `recordList` helper in `ContentOpsNewRun`; fixed by adding a local `recordArray` helper, then reran and passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed.

## Diff size
2 files, +233 / -0