### PR TITLE
Publish FAQ vocabulary-gap input contracts

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -296,6 +296,22 @@
       "placeholder": "/systems/ai-content-ops/intake",
       "asset": "landing_page",
       "group": "seo_geo_aeo"
+    },
+    "faq_documentation_terms": {
+      "key": "faq_documentation_terms",
+      "label": "Documentation terms",
+      "type": "string_list",
+      "placeholder": "Single sign-on setup\nData export guide",
+      "asset": "faq_markdown",
+      "group": "vocabulary_gap"
+    },
+    "faq_vocabulary_gap_rules": {
+      "key": "faq_vocabulary_gap_rules",
+      "label": "Vocabulary-gap rules",
+      "type": "nested_string_list",
+      "placeholder": "SSO, single sign-on\nexport, data export",
+      "asset": "faq_markdown",
+      "group": "vocabulary_gap"
     }
   }
 }

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -53,6 +53,7 @@ from ..reasoning_policy import (
     resolve_reasoning_policy,
 )
 from ..reasoning_signals import reasoning_validation_blocked_reason
+from ..ticket_faq_input_contract import ticket_faq_vocabulary_gap_input_contracts
 
 ExecutionServicesProvider = Callable[
     [],
@@ -131,6 +132,7 @@ def _build_static_catalog_payload() -> Mapping[str, Any]:
         "input_contracts": {
             LANDING_PAGE_QUALITY_REPAIR_INPUT: landing_page_quality_repair_input_contract(),
             **landing_page_seo_geo_aeo_input_contracts(),
+            **ticket_faq_vocabulary_gap_input_contracts(),
         },
     }
 

--- a/extracted_content_pipeline/ticket_faq_input_contract.py
+++ b/extracted_content_pipeline/ticket_faq_input_contract.py
@@ -1,0 +1,49 @@
+"""Ticket FAQ input contracts for hosted Content Ops control surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+TICKET_FAQ_INPUT_ASSET = "faq_markdown"
+TICKET_FAQ_VOCABULARY_GAP_INPUT_GROUP = "vocabulary_gap"
+
+FAQ_DOCUMENTATION_TERMS_INPUT = "faq_documentation_terms"
+FAQ_VOCABULARY_GAP_RULES_INPUT = "faq_vocabulary_gap_rules"
+
+_TICKET_FAQ_VOCABULARY_GAP_INPUT_CONTRACTS: tuple[dict[str, Any], ...] = (
+    {
+        "key": FAQ_DOCUMENTATION_TERMS_INPUT,
+        "label": "Documentation terms",
+        "type": "string_list",
+        "placeholder": "Single sign-on setup\nData export guide",
+    },
+    {
+        "key": FAQ_VOCABULARY_GAP_RULES_INPUT,
+        "label": "Vocabulary-gap rules",
+        "type": "nested_string_list",
+        "placeholder": "SSO, single sign-on\nexport, data export",
+    },
+)
+
+
+def ticket_faq_vocabulary_gap_input_contracts() -> dict[str, dict[str, Any]]:
+    """Return wire contracts for FAQ vocabulary-gap inputs."""
+
+    return {
+        item["key"]: {
+            **item,
+            "asset": TICKET_FAQ_INPUT_ASSET,
+            "group": TICKET_FAQ_VOCABULARY_GAP_INPUT_GROUP,
+        }
+        for item in _TICKET_FAQ_VOCABULARY_GAP_INPUT_CONTRACTS
+    }
+
+
+__all__ = [
+    "FAQ_DOCUMENTATION_TERMS_INPUT",
+    "FAQ_VOCABULARY_GAP_RULES_INPUT",
+    "TICKET_FAQ_INPUT_ASSET",
+    "TICKET_FAQ_VOCABULARY_GAP_INPUT_GROUP",
+    "ticket_faq_vocabulary_gap_input_contracts",
+]

--- a/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts.md
+++ b/plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts
+
+## Why this slice exists
+
+Hosted FAQ vocabulary-gap generation is now wired end to end, but the public
+control-surface catalog still does not describe the two FAQ-specific inputs the
+UI can send: `faq_documentation_terms` and `faq_vocabulary_gap_rules`.
+
+That leaves the UI labels/placeholders hardcoded and creates avoidable drift
+risk between backend request keys and frontend controls. This slice publishes
+the FAQ input contracts through the existing control-surface catalog.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-input-contracts
+
+1. Add backend FAQ input-contract metadata for documentation terms and
+   vocabulary-gap rules.
+2. Include those contracts in `GET /content-ops/control-surfaces`.
+3. Pin the catalog response in backend API coverage.
+4. Refresh the frontend catalog fixture so compile-time contract checks see the
+   new fields.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts.md` | Plan doc for this catalog contract slice. |
+| `extracted_content_pipeline/ticket_faq_input_contract.py` | Defines FAQ input contract metadata. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Adds FAQ contracts to the static control-surface catalog payload. |
+| `tests/test_extracted_content_control_surface_api.py` | Verifies the two FAQ input contracts in the catalog response. |
+| `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json` | Refreshes the frontend wire fixture with the new catalog contracts. |
+
+## Mechanism
+
+The control-surface API already composes static input contracts from dedicated
+contract modules:
+
+```python
+"input_contracts": {
+    LANDING_PAGE_QUALITY_REPAIR_INPUT: ...,
+    **landing_page_seo_geo_aeo_input_contracts(),
+}
+```
+
+This slice adds a parallel FAQ contract module and merges its two entries into
+that same static payload. No request parsing, generation, or UI behavior changes
+in this PR.
+
+## Intentional
+
+- Backend/catalog contract only. The UI continues to use its current hardcoded
+  FAQ labels/placeholders until the next slice consumes the catalog entries.
+- No generator, dispatcher, execute result, persistence, or CLI changes.
+- No new input type is introduced; the existing frontend contract type already
+  accepts string labels such as `string_list` and `nested_string_list`.
+
+## Deferred
+
+- Updating the Content Ops form to read FAQ labels/placeholders from these
+  catalog contracts remains the next UI slice.
+- Rich per-line validation metadata for vocabulary-gap rules remains separate.
+- Current `HARDENING.md` entries were scanned; they are landing-page repair
+  items and do not touch this FAQ catalog lane.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_describe_control_surfaces_route_returns_catalog_and_presets` - passed, 1 test.
+- `python -m py_compile extracted_content_pipeline/ticket_faq_input_contract.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` - passed.
+- `npm run build` from `atlas-intel-ui/` - passed; frontend contract fixtures compiled and Vite generated sitemap/prerender output.
+- `git diff --check` - passed.
+- `npm run lint` from `atlas-intel-ui/` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 1761 tests and 1 existing `torch`/`pynvml` warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| FAQ input contract module | ~45 |
+| API catalog merge | ~5 |
+| Backend test assertions | ~20 |
+| Frontend catalog fixture | ~20 |
+| **Total** | ~175 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -149,6 +149,22 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert input_contracts["secondary_keywords"]["type"] == "string_list"
     assert input_contracts["cta_url"]["asset"] == "landing_page"
     assert input_contracts["cta_url"]["placeholder"] == "/systems/ai-content-ops/intake"
+    assert input_contracts["faq_documentation_terms"] == {
+        "key": "faq_documentation_terms",
+        "label": "Documentation terms",
+        "type": "string_list",
+        "placeholder": "Single sign-on setup\nData export guide",
+        "asset": "faq_markdown",
+        "group": "vocabulary_gap",
+    }
+    assert input_contracts["faq_vocabulary_gap_rules"] == {
+        "key": "faq_vocabulary_gap_rules",
+        "label": "Vocabulary-gap rules",
+        "type": "nested_string_list",
+        "placeholder": "SSO, single sign-on\nexport, data export",
+        "asset": "faq_markdown",
+        "group": "vocabulary_gap",
+    }
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts.md

Hosted FAQ vocabulary-gap generation is wired end to end, but the public control-surface catalog did not describe the FAQ-specific inputs. This publishes `faq_documentation_terms` and `faq_vocabulary_gap_rules` as catalog input contracts and refreshes the frontend catalog fixture.

## Intentional
- Backend/catalog contract only; the UI consumes these contracts in a later slice.
- No generator, dispatcher, execute result, persistence, or CLI changes.
- No new request parsing behavior.

## Deferred
- Updating ContentOpsNewRun to read FAQ labels and placeholders from the catalog remains next.
- Rich per-line validation metadata for vocabulary-gap rules remains separate.
- Existing HARDENING.md items are outside this FAQ catalog lane.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_describe_control_surfaces_route_returns_catalog_and_presets` - passed, 1 test.
- `python -m py_compile extracted_content_pipeline/ticket_faq_input_contract.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` - passed.
- `npm run build` from `atlas-intel-ui/` - passed; frontend contract fixtures compiled and Vite generated sitemap/prerender output.
- `git diff --check` - passed.
- `npm run lint` from `atlas-intel-ui/` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 1761 tests and 1 existing torch/pynvml warning.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed.

## Diff size
5 files, +171 / -0