### PR TITLE
Read FAQ input labels from catalog

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:content-ops-input-display": "node --test scripts/content-ops-input-display.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/content-ops-input-display.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-input-display.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const source = readFileSync(
+  new URL('../src/domain/contentOps/inputDisplay.ts', import.meta.url),
+  'utf8',
+)
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+    verbatimModuleSyntax: true,
+  },
+}).outputText
+
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+const { inputContractDisplay } = await import(moduleUrl)
+
+test('inputContractDisplay prefers catalog label and placeholder', () => {
+  assert.deepEqual(
+    inputContractDisplay(
+      {
+        label: 'Catalog documentation terms',
+        placeholder: 'Catalog docs term one\nCatalog docs term two',
+      },
+      {
+        label: 'Fallback documentation terms',
+        placeholder: 'Fallback docs term',
+      },
+    ),
+    {
+      label: 'Catalog documentation terms',
+      placeholder: 'Catalog docs term one\nCatalog docs term two',
+    },
+  )
+})
+
+test('inputContractDisplay falls back when catalog placeholder is absent', () => {
+  assert.deepEqual(
+    inputContractDisplay(
+      {
+        label: 'Catalog vocabulary rules',
+      },
+      {
+        label: 'Fallback vocabulary rules',
+        placeholder: 'fallback term, canonical term',
+      },
+    ),
+    {
+      label: 'Catalog vocabulary rules',
+      placeholder: 'fallback term, canonical term',
+    },
+  )
+})

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -48,3 +48,6 @@ export {
   toWireIngestionInspectRequest,
   toWireRequest,
 } from './fromWire'
+
+export { inputContractDisplay } from './inputDisplay'
+export type { ContentOpsInputDisplayFallback } from './inputDisplay'

--- a/atlas-intel-ui/src/domain/contentOps/inputDisplay.ts
+++ b/atlas-intel-ui/src/domain/contentOps/inputDisplay.ts
@@ -1,0 +1,16 @@
+import type { ContentOpsInputContractView } from './types'
+
+export interface ContentOpsInputDisplayFallback {
+  label: string
+  placeholder: string
+}
+
+export function inputContractDisplay(
+  contract: Pick<ContentOpsInputContractView, 'label' | 'placeholder'> | undefined,
+  fallback: ContentOpsInputDisplayFallback,
+): ContentOpsInputDisplayFallback {
+  return {
+    label: contract?.label ?? fallback.label,
+    placeholder: contract?.placeholder ?? fallback.placeholder,
+  }
+}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -25,6 +25,7 @@ import {
   fromWirePlan,
   fromWirePreview,
   fromWireRequest,
+  inputContractDisplay,
   toWireIngestionInspectRequest,
   toWireIngestionImportRequest,
   toWireRequest,
@@ -100,6 +101,14 @@ const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const FAQ_MARKDOWN_OUTPUT = 'faq_markdown'
 const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
 const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
+const FAQ_DOCUMENTATION_TERMS_DISPLAY_FALLBACK = {
+  label: 'Documentation terms',
+  placeholder: 'Single sign-on setup\nData export guide',
+}
+const FAQ_VOCABULARY_GAP_RULES_DISPLAY_FALLBACK = {
+  label: 'Vocabulary-gap rules',
+  placeholder: 'SSO, single sign-on\nexport, data export',
+}
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_ORDER = [
   'target_keyword',
   'secondary_keywords',
@@ -198,6 +207,20 @@ export default function ContentOpsNewRun() {
     : ''
   const landingPageOutputSelected = request.outputs.includes('landing_page')
   const faqMarkdownOutputSelected = request.outputs.includes(FAQ_MARKDOWN_OUTPUT)
+  const faqDocumentationTermsContract = faqMarkdownOutputSelected
+    ? catalog.inputContracts[FAQ_DOCUMENTATION_TERMS_INPUT]
+    : undefined
+  const faqVocabularyGapRulesContract = faqMarkdownOutputSelected
+    ? catalog.inputContracts[FAQ_VOCABULARY_GAP_RULES_INPUT]
+    : undefined
+  const faqDocumentationTermsDisplay = inputContractDisplay(
+    faqDocumentationTermsContract,
+    FAQ_DOCUMENTATION_TERMS_DISPLAY_FALLBACK,
+  )
+  const faqVocabularyGapRulesDisplay = inputContractDisplay(
+    faqVocabularyGapRulesContract,
+    FAQ_VOCABULARY_GAP_RULES_DISPLAY_FALLBACK,
+  )
   const landingPageRepairAttemptContract = landingPageOutputSelected
     ? integerInputContract(catalog, LANDING_PAGE_QUALITY_REPAIR_INPUT)
     : null
@@ -908,7 +931,9 @@ export default function ContentOpsNewRun() {
               </div>
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
                 <label className="block text-sm">
-                  <span className="text-slate-300">Documentation terms</span>
+                  <span className="text-slate-300">
+                    {faqDocumentationTermsDisplay.label}
+                  </span>
                   <textarea
                     value={faqDocumentationTermsDraftValue(parsedInputsForControls)}
                     onChange={(e) =>
@@ -917,11 +942,13 @@ export default function ContentOpsNewRun() {
                     rows={4}
                     disabled={faqInputsDisabled}
                     className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    placeholder={'Single sign-on setup\nData export guide'}
+                    placeholder={faqDocumentationTermsDisplay.placeholder}
                   />
                 </label>
                 <label className="block text-sm">
-                  <span className="text-slate-300">Vocabulary-gap rules</span>
+                  <span className="text-slate-300">
+                    {faqVocabularyGapRulesDisplay.label}
+                  </span>
                   <textarea
                     value={faqVocabularyRulesDraftValue(parsedInputsForControls)}
                     onChange={(e) =>
@@ -930,7 +957,7 @@ export default function ContentOpsNewRun() {
                     rows={4}
                     disabled={faqInputsDisabled}
                     className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    placeholder={'SSO, single sign-on\nexport, data export'}
+                    placeholder={faqVocabularyGapRulesDisplay.placeholder}
                   />
                 </label>
               </div>

--- a/plans/PR-Content-Ops-FAQ-Catalog-Driven-Inputs.md
+++ b/plans/PR-Content-Ops-FAQ-Catalog-Driven-Inputs.md
@@ -1,0 +1,99 @@
+# PR-Content-Ops-FAQ-Catalog-Driven-Inputs
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Vocabulary-Gap-Input-Contracts published the hosted FAQ
+vocabulary-gap input contracts through `GET /content-ops/control-surfaces`, but
+the Content Ops new-run screen still renders those FAQ labels and placeholders
+from hardcoded UI literals.
+
+That leaves one last small drift point between the backend catalog and the UI.
+This slice consumes the catalog contracts in the existing FAQ controls.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-ui-controls
+
+1. Resolve the FAQ documentation-term and vocabulary-gap-rule contracts from the
+   fetched catalog when FAQ Markdown is selected.
+2. Render FAQ field labels and placeholders from those contracts, falling back
+   to the existing literals only if the catalog entry is absent.
+3. Preserve the existing text-area behavior that writes
+   `faq_documentation_terms` and `faq_vocabulary_gap_rules` into inputs JSON.
+4. Add focused coverage proving catalog labels/placeholders win over fallback
+   literals.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Catalog-Driven-Inputs.md` | Plan doc for this UI contract-consumption slice. |
+| `atlas-intel-ui/package.json` | Adds the focused Node test command. |
+| `atlas-intel-ui/scripts/content-ops-input-display.test.mjs` | Verifies catalog display metadata precedence. |
+| `atlas-intel-ui/src/domain/contentOps/inputDisplay.ts` | Provides the small display-metadata resolver used by the page. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Exports the display resolver through the domain barrel. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Reads FAQ labels/placeholders from catalog input contracts. |
+
+## Mechanism
+
+`ContentOpsNewRun` already has the normalized `catalog.inputContracts` map and
+already conditionally renders FAQ controls when `faq_markdown` is selected. This
+slice adds two small contract lookups:
+
+```ts
+const faqDocumentationTermsContract =
+  catalog.inputContracts[FAQ_DOCUMENTATION_TERMS_INPUT]
+const faqVocabularyGapRulesContract =
+  catalog.inputContracts[FAQ_VOCABULARY_GAP_RULES_INPUT]
+```
+
+The FAQ textareas continue to use the same draft-value and update helpers. Only
+display metadata moves from literals to the catalog.
+
+The precedence rule lives in a tiny pure helper so it can be covered by the
+existing Node `--test` pattern without introducing a frontend test framework:
+
+```ts
+inputContractDisplay(contract, fallback)
+```
+
+## Intentional
+
+- Fallback labels/placeholders remain in the UI so older or partial backend
+  catalogs still render usable controls.
+- No generic form renderer is introduced. The slice is the thinnest end-to-end
+  use of the new FAQ contracts, not a control-surface refactor.
+- No additional validation is added for `nested_string_list`; submit-time
+  backend validation remains the source of truth.
+- No Vitest/JSDOM setup is introduced for this one assertion. The test covers
+  the display precedence rule directly.
+
+## Deferred
+
+- A generic catalog-driven renderer for grouped input contracts is larger than
+  this slice and should be scoped separately if repeated input groups keep
+  growing.
+- Rich client-side validation for nested FAQ vocabulary rules remains a future
+  hardening item.
+- Current `HARDENING.md` entries were scanned; they are landing-page repair
+  items and do not touch this FAQ UI lane.
+
+## Verification
+
+- `npm run test:content-ops-input-display` from `atlas-intel-ui/` - passed,
+  2 tests.
+- `npm run lint` from `atlas-intel-ui/` - passed.
+- `npm run build` from `atlas-intel-ui/` - passed; frontend contract fixtures
+  compiled and Vite generated sitemap/prerender output.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| FAQ UI contract lookups/rendering | ~35 |
+| Display helper and export | ~25 |
+| Focused Node test and package script | ~50 |
+| **Total** | ~200 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Catalog-Driven-Inputs.md

The FAQ vocabulary-gap contracts are now published by the Content Ops catalog, but the new-run screen still duplicated their labels and placeholders. This slice consumes those catalog entries in the existing FAQ controls while preserving the same inputs JSON behavior, and adds focused coverage proving catalog metadata wins over fallback literals.

## Intentional
- Fallback labels/placeholders remain so older or partial backend catalogs still render usable controls.
- No generic form renderer is introduced; this is the thinnest UI consumption of the FAQ contracts.
- No extra client-side validation is added for nested vocabulary rules; backend validation remains the source of truth.
- No Vitest/JSDOM setup is introduced for one display-precedence assertion; the focused Node test covers the pure resolver.

## Deferred
- Generic grouped input rendering is larger than this slice and remains future work if repeated input groups keep growing.
- Rich client-side validation for nested FAQ vocabulary rules remains future hardening.

## Verification
- `npm run test:content-ops-input-display` from `atlas-intel-ui/` - passed, 2 tests.
- `npm run lint` from `atlas-intel-ui/` - passed.
- `npm run build` from `atlas-intel-ui/` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - passed.

## Diff size
6 files, +206 / -4