### PR TITLE
Close landing page SEO/GEO backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -1,7 +1,7 @@
 # AI Content Ops Deferred Backlog
 
 Created: 2026-05-11
-Last updated: 2026-05-20
+Last updated: 2026-05-23
 
 ## Purpose
 
@@ -64,6 +64,9 @@ The following items appear in older plan docs but are no longer active backlog:
 - Blog SEO/AEO and GEO save-time quality gates plus GEO repair loop.
 - Blog publish-level SEO/GEO/JSON-LD/crawler-visible article verification.
 - Atlas Intel blog readiness review and breakdown UI.
+- Landing-page SEO/AEO/GEO input contract, prompt consumption, save-time
+  readiness, review UI, draft edit/repair, public rendering,
+  sitemap/prerender, publish verification, and generation smoke coverage.
 
 ## Active Backlog
 
@@ -181,6 +184,18 @@ The original discovery audit now records the merged closeout chain:
 
 Do not take another Content Ops blog SEO/GEO slice unless it is driven by a
 new live-output failure, a UI/operator need, or a publish verifier regression.
+
+The landing-page SEO/AEO/GEO arc is also closed for the current product
+contract. The landing-page contract audit now records the implemented chain:
+
+- `docs/audits/ai_content_ops_landing_page_seo_aeo_geo_contract_2026-05-21.md`
+
+Do not take another Content Ops landing-page SEO/GEO slice unless it is driven
+by a new live-output failure, a UI/operator need, or a publish verifier
+regression. Historical plan-doc deferrals for landing-page input capture,
+prompt usage, readiness gating, review UI, edit, repair, public rendering,
+prerendering, and publish verification are stale after the merged closeout
+chain.
 
 The review-source readiness and Postgres smoke closeouts do not create a new
 active Content Ops implementation backlog. G2 can use the existing exporter,

--- a/plans/PR-Landing-Page-SEO-GEO-Backlog-Closeout.md
+++ b/plans/PR-Landing-Page-SEO-GEO-Backlog-Closeout.md
@@ -1,0 +1,63 @@
+# PR: Landing Page SEO/GEO Backlog Closeout
+
+## Why this slice exists
+
+The landing-page SEO/AEO/GEO implementation has now landed through input
+capture, prompt alignment, save-time readiness, review UI, draft edit/repair,
+public rendering, sitemap/prerender, publish verification, and generation smoke
+coverage. The active AI Content Ops deferred backlog still names the blog
+SEO/GEO closeout but does not explicitly close the equivalent landing-page arc.
+
+That leaves future sessions at risk of rediscovering stale landing-page
+deferrals from historical plan docs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-page-seo-geo-backlog-closeout
+
+1. Update the active AI Content Ops deferred backlog timestamp.
+2. Add landing-page SEO/AEO/GEO work to retired historical deferrals.
+3. Add a current-pick note that the landing-page SEO/AEO/GEO arc is closed for
+   the current product contract.
+4. Keep this docs-only; no runtime behavior changes.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Landing-Page-SEO-GEO-Backlog-Closeout.md` | Plan doc for this docs-only closeout. |
+| `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` | Mark landing-page SEO/AEO/GEO as closed in the active backlog. |
+
+## Mechanism
+
+The backlog already has a "Retired Historical Deferrals" list and a "Current
+Pick Recommendation" section that explicitly closes completed arcs. This slice
+adds the landing-page SEO/AEO/GEO chain to both places and points future work
+at live-output failures, operator needs, or publish-verifier regressions
+instead of stale historical deferrals.
+
+## Intentional
+
+- No runtime code changes.
+- No test changes beyond mechanical local review.
+- No claim that generated landing pages are guaranteed to rank or appear in AI
+  answer engines; this closeout is about implemented readiness and verification.
+
+## Deferred
+
+- Parked hardening: none. Root `HARDENING.md` has no landing-page backlog items.
+- Real operator acceptance testing for generated landing pages remains the next
+  practical product check, but it is not a docs backlog closeout change.
+
+## Verification
+
+- `git diff --check` -> passed.
+- Local PR review wrapper -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| Backlog update | ~30 |
+| **Total** | **~95** |


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-SEO-GEO-Backlog-Closeout.md

Closes the active AI Content Ops backlog entry for landing-page SEO/AEO/GEO now that the implementation chain has landed through input capture, prompt alignment, save-time readiness, review UI, edit/repair, public rendering, sitemap/prerender, publish verification, and generation smoke coverage.

## Intentional
- Docs-only backlog truthfulness update.
- No runtime, test, or product claim changes.
- No claim that generated landing pages are guaranteed to rank or appear in AI answer engines.

## Deferred
- Real operator acceptance testing remains a product check outside this backlog closeout.

## Parked hardening
- None. Root HARDENING.md has no landing-page backlog items.

## Verification
- git diff --check -> passed.
- Local PR review wrapper -> passed.

## Diff size
2 files, +79 / -1