### PR TITLE
Test hosted FAQ bulk source-material input

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -82,11 +82,24 @@ logger = logging.getLogger(__name__)
 _MAX_INPUT_KEYS = 50
 _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
-_MAX_INGESTION_ROWS = 500
+_MAX_INGESTION_ROWS = 1000
 _MAX_INGESTION_SAMPLE_LIMIT = 25
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
+_SOURCE_MATERIAL_ROW_LIST_KEYS = {
+    "sources",
+    "opportunities",
+    "complaints",
+    "search_logs",
+    "search_queries",
+    "support_tickets",
+    "tickets",
+    "cases",
+    "conversations",
+    "feedback",
+    "rows",
+}
 
 
 def _build_static_catalog_payload() -> Mapping[str, Any]:
@@ -1132,7 +1145,12 @@ def _ingestion_import_payload_to_mapping(payload: Any) -> dict[str, Any]:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 
 
-def _validate_input_shape(value: Any, *, depth: int) -> None:
+def _validate_input_shape(
+    value: Any,
+    *,
+    depth: int,
+    path: tuple[str, ...] = (),
+) -> None:
     if depth > _MAX_INPUT_DEPTH:
         raise ValueError("inputs are too deeply nested")
     if isinstance(value, Mapping):
@@ -1141,14 +1159,31 @@ def _validate_input_shape(value: Any, *, depth: int) -> None:
         for key, nested in value.items():
             if len(str(key)) > 100:
                 raise ValueError("inputs keys must be 100 characters or fewer")
-            _validate_input_shape(nested, depth=depth + 1)
+            _validate_input_shape(
+                nested,
+                depth=depth + 1,
+                path=(*path, str(key)),
+            )
     elif isinstance(value, (list, tuple)):
-        if len(value) > _MAX_INPUT_KEYS:
+        max_items = _input_array_max_items(path)
+        if len(value) > max_items:
             raise ValueError("inputs arrays are too large")
         for nested in value:
-            _validate_input_shape(nested, depth=depth + 1)
+            _validate_input_shape(nested, depth=depth + 1, path=(*path, "[]"))
     elif isinstance(value, str) and len(value) > _MAX_INPUT_STRING_CHARS:
         raise ValueError("inputs strings are too large")
+
+
+def _input_array_max_items(path: tuple[str, ...]) -> int:
+    if path == ("source_material",):
+        return _MAX_INGESTION_ROWS
+    if (
+        len(path) == 2
+        and path[0] == "source_material"
+        and path[1] in _SOURCE_MATERIAL_ROW_LIST_KEYS
+    ):
+        return _MAX_INGESTION_ROWS
+    return _MAX_INPUT_KEYS
 
 
 def _sanitize_execution_result(result: Mapping[str, Any]) -> dict[str, Any]:

--- a/extracted_content_pipeline/storage/migration_runner.py
+++ b/extracted_content_pipeline/storage/migration_runner.py
@@ -7,11 +7,16 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
+import re
 from typing import Any
 
 
 MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
 DEFAULT_MIGRATION_TABLE = "content_pipeline_schema_migrations"
+_NON_TRANSACTIONAL_SQL_RE = re.compile(
+    r"\b(?:CREATE|REINDEX|REFRESH\s+MATERIALIZED\s+VIEW)\b[^;]*\bCONCURRENTLY\b",
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 @dataclass(frozen=True)
@@ -103,19 +108,13 @@ async def apply_content_pipeline_migrations(
             if dry_run:
                 applied.append(entry)
                 continue
-            async with _transaction(conn):
+            if _requires_autocommit(migration.sql):
                 await conn.execute(migration.sql)
-                await conn.execute(
-                    f"""
-                    INSERT INTO {table} (version, checksum)
-                    VALUES ($1, $2)
-                    ON CONFLICT (version) DO UPDATE
-                       SET checksum = EXCLUDED.checksum,
-                           applied_at = NOW()
-                    """,
-                    migration.version,
-                    migration.checksum,
-                )
+                await _record_applied_migration(conn, table, migration)
+            else:
+                async with _transaction(conn):
+                    await conn.execute(migration.sql)
+                    await _record_applied_migration(conn, table, migration)
             applied.append(entry)
         return MigrationRunResult(
             applied=tuple(applied),
@@ -136,6 +135,24 @@ async def _ensure_migration_table(conn: Any, table: str) -> None:
         )
         """
     )
+
+
+async def _record_applied_migration(conn: Any, table: str, migration: MigrationFile) -> None:
+    await conn.execute(
+        f"""
+        INSERT INTO {table} (version, checksum)
+        VALUES ($1, $2)
+        ON CONFLICT (version) DO UPDATE
+           SET checksum = EXCLUDED.checksum,
+               applied_at = NOW()
+        """,
+        migration.version,
+        migration.checksum,
+    )
+
+
+def _requires_autocommit(sql: str) -> bool:
+    return bool(_NON_TRANSACTIONAL_SQL_RE.search(sql))
 
 
 async def _read_applied_versions(conn: Any, table: str, *, dry_run: bool) -> set[str]:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -57,6 +57,8 @@ _GENERIC_QUESTION_PHRASES = (
     "filed several complaints",
     "submitted a complaint",
     "filing this complaint",
+    "my complaint is about",
+    "our complaint is about",
     "this complaint is about",
 )
 _REDACTION_TOKEN_RE = re.compile(r"\bX{2,}\b", re.IGNORECASE)
@@ -122,6 +124,15 @@ DEFAULT_INTENT_RULES = (
     ("login reset", ("login reset", "password reset", "reset password", "reset my password")),
     ("email and profile updates", ("change my email", "update the email", "email address", "profile")),
     ("login and account access", ("login", "account access")),
+    ("communication and contact issues", (
+        "call at all hours",
+        "calling at all hours",
+        "various numbers",
+        "telephone calls",
+        "harass",
+        "harassed",
+        "harassment",
+    )),
     ("billing and payments", (
         "billing",
         "invoice",
@@ -220,6 +231,10 @@ _ACTION_RULES = (
     (("getting a credit card", "applied for a credit card", "credit card application", "activate card"), (
         "Gather the card application, offer, denial notice, account terms, or activation message tied to the issue.",
         "Ask the issuer to explain the decision, promotion, account status, or card record in writing before you reapply or activate anything.",
+    )),
+    (("communication and contact issues", "call at all hours", "calling at all hours", "various numbers", "telephone calls", "harass", "harassed", "harassment"), (
+        "Save the call log, message, notice, or contact record that shows when and how the company contacted you.",
+        "Ask the company in writing to explain the contact reason and update any communication preferences or dispute notes tied to the account.",
     )),
     (("export", "dashboard", "attribution", "analytics report", "download report", "report export"), (
         "Open the reporting or analytics area and choose the date range you need.",
@@ -627,8 +642,14 @@ def _item(
         snippets,
         " / ".join(_clean(row.get("source_title")) for row in display_rows if _clean(row.get("source_title"))),
     ))
-    question, question_source = _question(topic, display_rows)
-    summary = _summary(topic=topic, rows=display_rows, source_count=len(source_ids))
+    question, question_source, question_row = _question(topic, display_rows)
+    summary_rows = _rows_with_question_source_first(display_rows, question_row)
+    summary = _summary(
+        topic=topic,
+        rows=summary_rows,
+        source_count=len(source_ids),
+        question_source=question_source,
+    )
     steps = _article_steps(topic, action_context, support_contact=support_contact)
     escalation = _escalation_guidance(topic, action_context, support_contact=support_contact)
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
@@ -965,15 +986,29 @@ def _first_present(*rows: Mapping[str, Any], key: str) -> Any:
     return ""
 
 
-def _question(topic: str, rows: Sequence[Mapping[str, str]]) -> tuple[str, str]:
+def _question(
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+) -> tuple[str, str, Mapping[str, str] | None]:
     for row in rows:
         text = _question_text(row.get("text", ""))
         if text:
-            return (text, "customer_wording")
+            return (text, "customer_wording", row)
     policy_question = _policy_question(topic)
     if policy_question:
-        return (policy_question, "source_policy")
-    return (f"What are customers asking about {topic}?", "topic_fallback")
+        return (policy_question, "source_policy", None)
+    return (f"What are customers asking about {topic}?", "topic_fallback", None)
+
+
+def _rows_with_question_source_first(
+    rows: Sequence[Mapping[str, str]],
+    question_row: Mapping[str, str] | None,
+) -> tuple[Mapping[str, str], ...]:
+    if question_row is None or not rows or rows[0] is question_row:
+        return tuple(rows)
+    ordered = [question_row]
+    ordered.extend(row for row in rows if row is not question_row)
+    return tuple(ordered)
 
 
 def _question_text(value: Any) -> str:
@@ -1126,6 +1161,9 @@ def _looks_malformed_question(value: str) -> bool:
         return True
     if text.count('"') % 2:
         return True
+    letters = [character for character in text if character.isalpha()]
+    if len(letters) >= 5 and all(character.isupper() for character in letters):
+        return True
     return False
 
 
@@ -1246,14 +1284,31 @@ def _term_mapping_impact_line(mapping: Mapping[str, Any]) -> str:
     return f"({'; '.join(parts)}.)"
 
 
-def _summary(*, topic: str, rows: Sequence[Mapping[str, str]], source_count: int) -> str:
+def _summary(
+    *,
+    topic: str,
+    rows: Sequence[Mapping[str, str]],
+    source_count: int,
+    question_source: str,
+) -> str:
     issue = _topic_label(topic)
     example = _quote(rows[0].get("text", ""), limit=180) if rows else "the cited ticket evidence"
     if source_count > 1:
+        if question_source != "customer_wording":
+            return (
+                f"Customers are asking about {issue} across {source_count} ticket sources. "
+                f"Representative evidence includes {example}, so this FAQ should answer "
+                "the issue directly and tell users exactly what to try next."
+            )
         return (
             f"Customers are asking about {issue} across {source_count} ticket sources. "
             f"The clearest customer wording is {example}, so this FAQ should answer "
             "that request directly and tell users exactly what to try next."
+        )
+    if question_source != "customer_wording":
+        return (
+            f"A customer asked about {issue}: {example}. This FAQ should answer the "
+            "issue directly and tell the user exactly what to try next."
         )
     return (
         f"A customer asked about {issue}: {example}. This FAQ should answer the "
@@ -1286,6 +1341,11 @@ def _escalation_guidance(topic: str, evidence_text: str, *, support_contact: str
         return (
             f"{_support_sentence(support_contact)} if the servicer will not explain "
             "the payment, payoff, foreclosure, modification, escrow, or insurance issue in writing."
+        )
+    if any(term in text for term in ("communication and contact issues", "call at all hours", "calling at all hours", "various numbers", "telephone calls", "harass", "harassed", "harassment")):
+        return (
+            f"{_support_sentence(support_contact)} if the company keeps contacting "
+            "you after you ask for an explanation or correction in writing."
         )
     if topic in {"opening an account", "closing an account", "getting a credit card"} or any(
         term in text

--- a/plans/PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke.md
@@ -1,0 +1,165 @@
+# PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Vocab-Gap-IO-Smoke proved the hosted FAQ route accepts
+vocabulary-gap inputs and returns the expected mapped output. The next testing
+gap is confidence that the hosted input/output path also handles a larger
+uploaded source-material payload, not only a single-ticket example.
+
+This slice adds a thin 1,000-row hosted execute smoke and closes the failures
+surfaced while testing the real FAQ flow.
+
+Initial testing surfaced a real hosted input-path failure: direct
+inputs.source_material arrays were capped at 50 items because the generic
+input-shape validator reused `_MAX_INPUT_KEYS` for every array. The ingestion
+API validator was then raised to 1,000 rows because the product claim we need to
+prove is 500-1,000 ticket uploads, not only a 500-row ceiling.
+
+Follow-on testing surfaced three more real failures in this lane:
+
+1. The local DB lifecycle smoke could not run because the generated-asset table
+   was missing; applying migrations exposed that the migration runner wrapped
+   CREATE INDEX CONCURRENTLY in a transaction.
+2. The 1,000-row CFPB scale artifact passed checks but still emitted weak
+   customer-wording questions such as all-caps fragments and
+   `my complaint is about...` phrasing.
+3. A live CFPB smoke grouped unrelated call-behavior evidence with a billing
+   dispute.
+
+Those are fixed here because they directly affect the tested FAQ product proof.
+The resulting PR is over the 400 LOC soft cap because splitting would leave the
+current proof in a knowingly misleading state: hosted scale, DB lifecycle, and
+output quality all failed in the same real-flow test pass.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a hosted `/content-ops/execute` FAQ test with 1,000 inline support-ticket
+   rows.
+2. Assert the route completes, the FAQ result reports all 1,000 ticket sources,
+   output checks pass, and the generated FAQ item keeps source coverage.
+3. Keep the test deterministic by using generated in-test source rows and the
+   real `TicketFAQMarkdownService`.
+4. Allow direct inputs.source_material lists and recognized one-level
+   source_material bundle lists to use the existing `_MAX_INGESTION_ROWS` cap
+   and pin the 1,001-row rejection path.
+5. Allow packaged extracted migrations containing CONCURRENTLY to run outside
+   the per-migration transaction.
+6. Reject weak CFPB customer-question candidates and split contact/call
+   complaints away from billing disputes.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `extracted_content_pipeline/api/control_surfaces.py` | Raises direct and recognized one-level bundle source_material row-list caps to 1,000 while keeping descendant arrays at 50. |
+| `extracted_content_pipeline/storage/migration_runner.py` | Runs CONCURRENTLY migrations outside the transaction wrapper. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Rejects weak customer questions, aligns summaries with the question source row, and separates communication/contact issues. |
+| `plans/PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke.md` | Plan doc for this bulk hosted IO smoke slice. |
+| `tests/test_extracted_content_control_surface_api.py` | Pins the 1,001-row hosted source-material and ingestion rejection boundary plus scoped 50/1,000 array-cap behavior. |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | Adds the hosted 1,000-row FAQ route test. |
+| `tests/test_extracted_content_pipeline_migration_runner.py` | Covers non-transactional CONCURRENTLY migration execution. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Covers weak-question rejection and contact/billing split behavior. |
+
+## Mechanism
+
+The existing live execute harness calls the mounted `/content-ops/execute`
+endpoint directly with host-injected services. This slice reuses that shape and
+injects `ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService())`.
+
+The test builds 1,000 support-ticket rows in memory:
+
+```python
+source_material = [
+    {"ticket_id": f"ticket-bulk-{index}", ...}
+    for index in range(1000)
+]
+```
+
+The route should return a completed FAQ step whose result reports
+`ticket_source_count == 1000`, passing output checks, and a first FAQ item whose
+`source_ids` include the generated ticket IDs.
+
+The API validator keeps the existing 50-item cap for ordinary input arrays, but
+uses `_MAX_INGESTION_ROWS` when validating the direct source_material array or
+a recognized one-level source_material bundle list:
+
+```python
+max_items = _input_array_max_items(path)
+```
+
+List descendants append a synthetic path segment before recursion, so nested
+arrays under source_material do not inherit the 1,000-row row-list budget.
+
+The migration runner detects SQL that cannot run inside a transaction, such as
+CREATE INDEX CONCURRENTLY, executes that migration outside the transaction
+wrapper, and then records the applied migration.
+
+The FAQ generator keeps using source-policy questions when customer wording is
+not publishable. This slice expands that filter to reject all-caps fragments and
+`my complaint is about...` boilerplate, and it adds a communication/contact
+intent so call-behavior complaints do not collapse into billing disputes.
+
+## Intentional
+
+- No dispatcher or UI behavior changes.
+- The hosted request validator now accepts direct source_material arrays and
+  recognized one-level source_material bundle arrays up to 1,000 rows because
+  that is the confidence threshold being tested.
+- The generator behavior changes are limited to the weak output shapes surfaced
+  by the 1,000-row and live CFPB smokes.
+- The source rows are generated inside the test instead of checked into a new
+  fixture file.
+- The real DB migrations were applied locally as verification. The migration
+  state itself is not part of the repo diff.
+
+## Deferred
+
+- A browser file-upload test remains a future slice; this PR proves the hosted
+  execute route body, the CLI scale runner, and the DB lifecycle smoke.
+- Mixed-source hosted payload coverage remains separate; this slice focuses on
+  bulk row count through the route.
+- Current `HARDENING.md` entries were scanned; no root hardening items are
+  parked for this FAQ lane after the fixes in this slice.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_live_execute_route_handles_bulk_faq_source_material -q` - failed initially with HTTP 422 `inputs arrays are too large`, then passed after the source-material validation cap fix.
+- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py::test_live_execute_route_handles_bulk_faq_source_material tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_source_material_over_1000_as_422 tests/test_extracted_content_control_surface_api.py::test_ingestion_inspect_route_rejects_oversized_rows -q` - passed, 3 tests.
+- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_source_material_over_1000_as_422 tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_keeps_50_cap_for_non_source_material_arrays tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_accepts_source_material_bundle_1000_rows tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_keeps_50_cap_for_nested_source_material_arrays -q` - passed, 4 tests.
+- `python -m pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_rejects_all_caps_customer_question tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_rejects_complaint_about_as_customer_question tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_summarizes_customer_question_source_row -q` - passed, 3 tests.
+- `python -m pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_summarizes_customer_question_source_row tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_separates_contact_complaints_from_billing_disputes -q` - passed, 2 tests.
+- `python -m pytest tests/test_extracted_content_pipeline_migration_runner.py::test_apply_content_pipeline_migrations_runs_concurrent_index_outside_transaction tests/test_extracted_content_pipeline_migration_runner.py::test_apply_content_pipeline_migrations_applies_pending_files -q` - passed, 2 tests.
+- `python -m pytest tests/test_smoke_content_ops_faq_scale_run.py::test_faq_scale_smoke_writes_standard_artifacts -q` - passed, 4 tests.
+- `python scripts/run_extracted_content_pipeline_migrations.py --json` with the resolved local DB URL - initially failed with CREATE INDEX CONCURRENTLY cannot run inside a transaction block, then passed after the migration-runner fix: 20 applied, 8 skipped.
+- `python scripts/smoke_content_ops_faq_lifecycle.py --account-id acct-faq-db-smoke-20260523 --user-id user-faq-db-smoke --title "FAQ DB Lifecycle Smoke 2026-05-23" --output-result tmp/faq_lifecycle_smoke_20260523_after_migrations.json --json` - passed, `ok=true`, 4 source rows, 1 saved FAQ, draft export and published export present.
+- `python scripts/smoke_content_ops_faq_scale_run.py tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl --source-format jsonl --artifact-dir tmp/content_ops_faq_testing_20260523_scale1000_after_contact_fix --title 'CFPB 1,000 Row FAQ Test After Contact Fix 2026-05-23' --max-items 12 --max-evidence-per-item 5 --max-text-chars 1200 --default-field company_name=CFPB --default-field contact_email=cfpb-public-archive@example.invalid` - passed, 1,000/1,000 usable rows, 12 generated, 0 failed output checks, 0 warnings.
+- `python scripts/smoke_content_ops_cfpb_faq_markdown.py --limit 10 --max-rows-scanned 50 --title 'CFPB Live FAQ Smoke After Contact Fix 2026-05-23' --output-source-rows tmp/content_ops_faq_testing_20260523_live_cfpb_after_contact_fix/cfpb_sources.jsonl --output-markdown tmp/content_ops_faq_testing_20260523_live_cfpb_after_contact_fix/faq.md --json` - passed, 10/10 usable live CFPB rows, 4 generated FAQ items, 0 errors.
+- `python -m pytest tests/test_extracted_content_ops_live_execute_harness.py -q` - passed, 4 tests.
+- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_400 tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_rejects_source_material_over_1000_as_422 -q` - passed, 2 tests.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `git diff --check` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed, 1783 tests, 1 skipped, 1 existing `torch`/`pynvml` warning.
+- `bash scripts/local_pr_review.sh origin/main --allow-dirty` - pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 169 |
+| API validation boundary | 45 |
+| Hosted bulk route and boundary tests | 183 |
+| Migration runner and tests | 59 |
+| FAQ generator quality fixes and tests | 192 |
+| **Total** | 648 |
+
+This exceeds the 400 LOC soft cap because the same real-flow test pass surfaced
+inseparable hosted-scale, DB-lifecycle, and output-quality failures. Splitting
+the fixes would leave the open PR proving a 1,000-row FAQ path while known
+database and generated-output failures remained unresolved. Actual diff:
++612 / -25.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -641,7 +641,7 @@ async def test_ingestion_inspect_route_rejects_oversized_rows():
         await route.endpoint({
             "rows": [
                 {"target_id": f"opp-{index}"}
-                for index in range(501)
+                for index in range(1001)
             ],
         })
 
@@ -907,6 +907,133 @@ async def test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_
         exc.value.detail
         == "faq_vocabulary_gap_rules entries must include at least two terms"
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_rejects_source_material_over_1000_as_422():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=_CampaignService()
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": [
+                        {
+                            "source_type": "ticket",
+                            "text": f"Ticket row {index}",
+                        }
+                        for index in range(1001)
+                    ],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail[0]["msg"] == "Value error, inputs arrays are too large"
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_keeps_50_cap_for_non_source_material_arrays():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=_CampaignService()
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "faq_documentation_terms": [
+                        f"Documentation term {index}"
+                        for index in range(51)
+                    ],
+                    "source_material": [
+                        {
+                            "source_type": "ticket",
+                            "text": "How do I enable SSO?",
+                        }
+                    ],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail[0]["msg"] == "Value error, inputs arrays are too large"
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_accepts_source_material_bundle_1000_rows():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=service
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": {
+                    "support_tickets": [
+                        {
+                            "source_type": "ticket",
+                            "text": f"Ticket row {index}",
+                        }
+                        for index in range(1000)
+                    ],
+                },
+            },
+        }
+    )
+
+    assert payload["status"] == "completed"
+    assert len(service.calls[0]["kwargs"]["source_material"]["support_tickets"]) == 1000
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_keeps_50_cap_for_nested_source_material_arrays():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=_CampaignService()
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": [
+                        [
+                            {
+                                "source_type": "ticket",
+                                "text": f"Ticket row {index}",
+                            }
+                            for index in range(51)
+                        ]
+                    ],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail[0]["msg"] == "Value error, inputs arrays are too large"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -209,3 +209,57 @@ async def test_live_execute_route_accepts_faq_vocabulary_gap_inputs() -> None:
         item["term_mappings"][0]["documentation_term"]
         == "Single sign-on setup"
     )
+
+
+async def test_live_execute_route_handles_bulk_faq_source_material() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService(),
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+    )
+    source_material = [
+        {
+            "ticket_id": f"ticket-bulk-{index}",
+            "source_type": "support_ticket",
+            "subject": "SSO setup",
+            "message": "How do I enable SSO for my team?",
+            "pain_category": "authentication",
+        }
+        for index in range(1000)
+    ]
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "target_mode": "vendor_retention",
+        "outputs": ["faq_markdown"],
+        "limit": 5,
+        "require_quality_gates": False,
+        "inputs": {
+            "faq_title": "Hosted FAQ Bulk Smoke",
+            "source_material": source_material,
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert payload["plan"]["steps"][0]["config"]["max_items"] == 5
+
+    step = payload["steps"][0]
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+
+    result = step["result"]
+    assert result["generated"] == 1
+    assert result["source_count"] == 1000
+    assert result["ticket_source_count"] == 1000
+    assert all(result["output_checks"].values())
+    assert "Hosted FAQ Bulk Smoke" in result["markdown"]
+    assert "`ticket-bulk-0` - SSO setup" in result["markdown"]
+
+    item = result["items"][0]
+    assert item["frequency"] == 1000
+    assert item["evidence_count"] == 3
+    assert len(item["source_ids"]) == 1000
+    assert item["source_ids"][0] == "ticket-bulk-0"
+    assert item["source_ids"][-1] == "ticket-bulk-999"

--- a/tests/test_extracted_content_pipeline_migration_runner.py
+++ b/tests/test_extracted_content_pipeline_migration_runner.py
@@ -119,6 +119,24 @@ async def test_apply_content_pipeline_migrations_applies_pending_files(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_apply_content_pipeline_migrations_runs_concurrent_index_outside_transaction(tmp_path) -> None:
+    _write_migration(
+        tmp_path,
+        "001_concurrent_index.sql",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_example ON example(id);",
+    )
+    conn = _Conn()
+
+    result = await apply_content_pipeline_migrations(conn, migrations_dir=tmp_path)
+
+    assert [entry.version for entry in result.applied] == ["001_concurrent_index.sql"]
+    assert conn.transactions == 0
+    executed_sql = "\n".join(query for query, _ in conn.executed)
+    assert "CREATE INDEX CONCURRENTLY" in executed_sql
+    assert "INSERT INTO content_pipeline_schema_migrations" in executed_sql
+
+
+@pytest.mark.asyncio
 async def test_apply_content_pipeline_migrations_skips_applied_versions(tmp_path) -> None:
     _write_migration(tmp_path, "001_first.sql", "SELECT 1;")
     _write_migration(tmp_path, "002_second.sql", "SELECT 2;")

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2116,6 +2116,124 @@ def test_build_ticket_faq_markdown_rejects_complaint_process_boilerplate_questio
     assert "## 1. What should I do if my husband" not in result.markdown
 
 
+def test_build_ticket_faq_markdown_rejects_all_caps_customer_question() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "complaint",
+        "Product": "Credit card or prepaid card",
+        "Issue": "Advertising",
+        "evidence": [{
+            "text": (
+                "HOW WOULD I HAVE KNOWN? The promotional payment option was not "
+                "available on the statement."
+            ),
+            "source_id": "cfpb:3173636",
+            "source_type": "complaint",
+        }],
+    }])
+
+    assert result.items[0]["topic"] == "advertising"
+    assert result.items[0]["question"] == (
+        "What should I do if a financial product advertisement or offer seems wrong?"
+    )
+    assert result.items[0]["question_source"] == "source_policy"
+    assert "## 1. HOW WOULD I HAVE KNOWN?" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_rejects_complaint_about_as_customer_question() -> None:
+    result = build_ticket_faq_markdown([{
+        "source_type": "complaint",
+        "Product": "Checking or savings account",
+        "Issue": "Opening an account",
+        "evidence": [{
+            "text": (
+                "My complaint is about Capital One opening the Money Market Account "
+                "and getting the Bonus."
+            ),
+            "source_id": "cfpb:3172831",
+            "source_type": "complaint",
+        }],
+    }])
+
+    assert result.items[0]["topic"] == "opening an account"
+    assert result.items[0]["question"] == (
+        "What should I do if a bank will not open an account or says my account was opened incorrectly?"
+    )
+    assert result.items[0]["question_source"] == "source_policy"
+    assert "Capital One opening the Money Market Account" not in result.markdown.splitlines()[2]
+
+
+def test_build_ticket_faq_markdown_summarizes_customer_question_source_row() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "complaint",
+            "Product": "Credit card or prepaid card",
+            "Issue": "Problem with a purchase shown on your statement",
+            "evidence": [{
+                "text": "The charge is wrong on my statement.",
+                "source_id": "cfpb:3584679",
+                "source_type": "complaint",
+            }],
+        },
+        {
+            "source_type": "complaint",
+            "Product": "Credit card or prepaid card",
+            "Issue": "Problem with a purchase shown on your statement",
+            "evidence": [{
+                "text": (
+                    "How am I being held responsible for a package for which there "
+                    "is no proof that I received?"
+                ),
+                "source_id": "cfpb:3442136",
+                "source_type": "complaint",
+            }],
+        },
+    ])
+
+    assert result.items[0]["question"] == (
+        "How am I being held responsible for a package for which there is no proof that I received?"
+    )
+    assert result.items[0]["question_source"] == "customer_wording"
+    assert "The clearest customer wording is \"How am I being held responsible" in result.items[0]["summary"]
+    assert "The clearest customer wording is \"They call at all hours" not in result.items[0]["summary"]
+
+
+def test_build_ticket_faq_markdown_separates_contact_complaints_from_billing_disputes() -> None:
+    result = build_ticket_faq_markdown([
+        {
+            "source_type": "complaint",
+            "Product": "Student loan",
+            "Issue": "Dealing with your lender or servicer",
+            "evidence": [{
+                "text": "They call at all hours and on the weekends using various numbers.",
+                "source_id": "cfpb:3584679",
+                "source_type": "complaint",
+            }],
+        },
+        {
+            "source_type": "complaint",
+            "Product": "Credit card or prepaid card",
+            "Issue": "Problem with a purchase shown on your statement",
+            "evidence": [{
+                "text": (
+                    "How am I being held responsible for a package for which there "
+                    "is no proof that I received?"
+                ),
+                "source_id": "cfpb:3442136",
+                "source_type": "complaint",
+            }],
+        },
+    ])
+
+    assert [item["topic"] for item in result.items] == [
+        "billing and payments",
+        "communication and contact issues",
+    ]
+    assert result.items[0]["source_ids"] == ("cfpb:3442136",)
+    assert result.items[1]["source_ids"] == ("cfpb:3584679",)
+    assert "Save the call log" in result.items[1]["steps"][0]
+    assert "keeps contacting you" in result.items[1]["when_to_contact_support"]
+
+
 def test_build_ticket_faq_markdown_normalizes_source_type_and_keeps_unidentified_rows() -> None:
     result = build_ticket_faq_markdown([
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke.md

PR #820 proved the hosted FAQ vocabulary-gap seam. This slice now proves the hosted FAQ execute path with 1,000 direct source_material rows and fixes the real failures surfaced while testing that flow: the input cap, local DB migration runner failure on CREATE INDEX CONCURRENTLY, weak CFPB customer-question extraction, and contact/call complaints collapsing into billing evidence.

## Intentional
- No dispatcher or UI behavior changes.
- Ordinary input arrays keep the 50-item cap; source_material/ingestion rows now cap at 1,000.
- Local DB migrations were applied only as verification state, not repo state.

## Deferred
- Browser file-upload coverage remains a follow-up slice.
- Mixed-source hosted payload coverage remains separate.

## Verification
- Hosted 1,000-row FAQ route pytest passed.
- 1,001-row source_material and ingestion boundary pytest passed.
- FAQ generator weak-question and contact/billing split tests passed.
- Migration runner CONCURRENTLY test passed.
- Real local DB lifecycle smoke passed after migrations: generation, draft save, draft export, status update, published export.
- CFPB 1,000-row scale smoke with dataset-derived mock fields passed: 1,000/1,000 usable rows, 12 generated, 0 failed output checks, 0 warnings.
- Live CFPB FAQ smoke passed: 10/10 usable rows, 4 generated, 0 errors.
- Focused touched suites passed: live execute harness, control-surface API boundary tests, migration runner, FAQ Markdown, FAQ scale/lifecycle smokes.
- Extracted guardrails passed: validate_extracted_content_pipeline, forbid_atlas_reasoning_imports, audit_extracted_standalone, check_ascii_python, git diff --check.
- Full extracted CI mirror passed: 1788 passed, 1 skipped, 1 existing torch/pynvml warning.
- local_pr_review passed with --allow-dirty.

## Diff size
8 files, +494 / -25. Over the 400 LOC soft cap because one real-flow test pass surfaced inseparable hosted-scale, DB-lifecycle, and output-quality failures.