### PR TITLE
Test hosted FAQ bundle source-material scale

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Hosted-Bundle-IO-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Hosted-Bundle-IO-Smoke.md
@@ -1,0 +1,72 @@
+# PR-Content-Ops-FAQ-Hosted-Bundle-IO-Smoke
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Hosted-Bulk-IO-Smoke proved the hosted execute route can run
+1,000 direct FAQ source rows through the real generator, and separately proved
+the API input validator accepts 1,000 rows in the one-level
+`source_material.support_tickets` bundle shape. The remaining test gap is the
+real generator path for that bundle shape: a visitor or UI adapter can send the
+catalog-style bundle form and still get a grounded FAQ artifact at 1,000 rows.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a hosted execute smoke that sends
+   `inputs.source_material.support_tickets` with 1,000 support-ticket rows to
+   the real `TicketFAQMarkdownService`.
+2. Assert the output preserves the 1,000-row source count, passes output checks,
+   and retains first/last source IDs in the generated FAQ item.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Hosted-Bundle-IO-Smoke.md`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+
+## Mechanism
+
+The new test mirrors the direct-list bulk smoke but wraps the rows in the
+one-level bundle shape:
+
+```python
+"source_material": {"support_tickets": source_rows}
+```
+
+The route should normalize that bundle into FAQ rows, pass it through
+`TicketFAQMarkdownService`, and report 1,000 ticket sources in the compact
+result payload.
+
+## Intentional
+
+- This is test-only. The code path should already work after the validator and
+  generator fixes in the prior slices; the slice locks the behavior rather than
+  changing production code.
+- The test uses in-process route execution instead of a real HTTP server so the
+  assertion stays deterministic and cheap while still exercising the hosted
+  execute route contract.
+
+## Deferred
+
+- Real browser file-upload coverage remains deferred until the UI upload path is
+  the active slice; this test covers the API payload shape the UI adapter should
+  produce.
+- Real database lifecycle coverage remains in the existing smoke scripts rather
+  than CI unit tests to avoid making the package suite depend on local database
+  availability.
+
+## Verification
+
+- `pytest tests/test_extracted_content_ops_live_execute_harness.py -q` - 5 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 1818 passed, 1 skipped.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| Hosted bundle route test | ~55 |
+| **Total** | **~120** |
+
+Actual diff: +118 / -0.

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -263,3 +263,57 @@ async def test_live_execute_route_handles_bulk_faq_source_material() -> None:
     assert len(item["source_ids"]) == 1000
     assert item["source_ids"][0] == "ticket-bulk-0"
     assert item["source_ids"][-1] == "ticket-bulk-999"
+
+
+async def test_live_execute_route_handles_bulk_faq_source_material_bundle() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService(),
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+    )
+    support_tickets = [
+        {
+            "ticket_id": f"ticket-bundle-{index}",
+            "source_type": "support_ticket",
+            "subject": "Billing renewal question",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "billing",
+        }
+        for index in range(1000)
+    ]
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "target_mode": "vendor_retention",
+        "outputs": ["faq_markdown"],
+        "limit": 5,
+        "require_quality_gates": False,
+        "inputs": {
+            "faq_title": "Hosted FAQ Bundle Bulk Smoke",
+            "source_material": {"support_tickets": support_tickets},
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert payload["plan"]["steps"][0]["config"]["max_items"] == 5
+
+    step = payload["steps"][0]
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+
+    result = step["result"]
+    assert result["generated"] == 1
+    assert result["source_count"] == 1000
+    assert result["ticket_source_count"] == 1000
+    assert all(result["output_checks"].values())
+    assert "Hosted FAQ Bundle Bulk Smoke" in result["markdown"]
+    assert "`ticket-bundle-0` - Billing renewal question" in result["markdown"]
+
+    item = result["items"][0]
+    assert item["frequency"] == 1000
+    assert item["evidence_count"] == 3
+    assert len(item["source_ids"]) == 1000
+    assert item["source_ids"][0] == "ticket-bundle-0"
+    assert item["source_ids"][-1] == "ticket-bundle-999"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Hosted-Bundle-IO-Smoke.md

Proves the hosted `/content-ops/execute` FAQ path can process 1,000 support-ticket rows when the payload uses the catalog-style `inputs.source_material.support_tickets` bundle shape, not only the direct source-material list shape.

## Intentional
- Test-only slice; the production path should already work after the prior validator and generator fixes.
- Uses in-process route execution instead of a real HTTP server to keep the proof deterministic while still exercising the hosted execute contract.

## Deferred
- Browser file-upload coverage remains deferred until the UI upload path is the active slice.
- Real database lifecycle coverage remains in smoke scripts rather than CI unit tests.

## Verification
- `pytest tests/test_extracted_content_ops_live_execute_harness.py -q` - 5 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 1818 passed, 1 skipped.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed.

## Diff size
2 files, +126 / -0
