### PR TITLE
Test FAQ file input scale smoke

### DIFF
--- a/plans/PR-Content-Ops-FAQ-File-Input-Scale-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-File-Input-Scale-Smoke.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-FAQ-File-Input-Scale-Smoke
+
+## Why this slice exists
+
+The hosted FAQ path now has 1,000-row coverage for direct
+`inputs.source_material` lists and for one-level `source_material.support_tickets`
+bundles. The remaining input/output testing gap is the file-backed path that
+customers are most likely to use for SMB and mid-market ticket exports. This
+slice proves a 1,000-row source file flows through the existing FAQ scale-smoke
+script, source-file loader, CLI generator, artifact writer, and compact result
+payload.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a 1,000-row JSON bundle file smoke to the existing FAQ scale-smoke tests.
+2. Assert the input profile reports 1,000 raw and usable rows with no skipped
+   rows or missing source text.
+3. Assert the FAQ result and run summary preserve 1,000 rendered ticket sources,
+   pass output checks, and write the expected Markdown/result artifacts.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-File-Input-Scale-Smoke.md`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+The test writes a temporary JSON file in the same bundle shape supported by the
+source adapter:
+
+```json
+{"support_tickets": [{... 1000 rows ...}]}
+```
+
+It then calls `run_scale_smoke(...)`, which shells out to
+`scripts/build_extracted_ticket_faq_markdown.py`. That CLI loads the file through
+`load_source_campaign_opportunities_from_file(...)`, generates FAQ Markdown, and
+writes `faq.md`, `faq_result.json`, and `run_summary.json`.
+
+## Intentional
+
+- This is test-only. The production code already has the source-file loader and
+  FAQ CLI path; this slice locks the 1,000-row behavior instead of creating a new
+  ingestion path.
+- JSON bundle is used because it exercises the file-backed bundle parser and the
+  FAQ scale-smoke artifact contract in one cheap test. Existing small tests
+  already cover CSV, JSON array, and JSONL format selection.
+
+## Deferred
+
+- Browser upload coverage remains deferred until the UI upload path is active;
+  this slice proves the file artifact once it reaches the backend smoke/CLI
+  boundary.
+- Real database persistence remains in the lifecycle smoke lane rather than this
+  artifact-focused unit test lane.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_scale_run.py -q` - 19 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 1819 passed, 1 skipped.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| File-backed 1,000-row scale test | ~45 |
+| **Total** | **~115** |

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -136,6 +136,59 @@ def test_faq_scale_smoke_writes_standard_artifacts(
     )
 
 
+def test_faq_scale_smoke_processes_1000_row_json_bundle_file(tmp_path: Path) -> None:
+    source = tmp_path / "support_ticket_bundle.json"
+    source.write_text(
+        json.dumps({
+            "support_tickets": [
+                {
+                    "ticket_id": f"ticket-file-{index}",
+                    "source_type": "support_ticket",
+                    "subject": "Billing renewal question",
+                    "message": "How do I confirm my renewal invoice before payment?",
+                    "pain_category": "billing",
+                }
+                for index in range(1000)
+            ],
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code, summary = smoke.run_scale_smoke(
+        _args(
+            tmp_path,
+            path=source,
+            source_format="json",
+            title="Customer Ticket FAQ File Scale Smoke",
+        )
+    )
+
+    artifact_dir = tmp_path / "artifacts"
+    result = json.loads((artifact_dir / "faq_result.json").read_text(encoding="utf-8"))
+
+    assert code == 0
+    assert summary["ok"] is True
+    assert summary["input_profile"]["raw_row_count"] == 1000
+    assert summary["input_profile"]["raw_row_count_source"] == "json_bundle.support_tickets"
+    assert summary["input_profile"]["usable_source_count"] == 1000
+    assert summary["input_profile"]["skipped_row_count"] == 0
+    assert summary["input_profile"]["missing_source_text_count"] == 0
+    assert summary["faq_run_summary"]["weighted_source_volume"] == 1000
+    assert summary["faq_run_summary"]["source_channel_counts"]["support_tickets"] == 1000
+    assert summary["faq_run_summary"]["output_checks"]["failed"] == 0
+    assert result["status"] == "ok"
+    assert result["source_count"] == 1000
+    assert result["ticket_source_count"] == 1000
+    assert result["diagnostics"]["rendered_ticket_source_count"] == 1000
+    assert result["diagnostics"]["items"][0]["source_id_count"] == 1000
+    assert result["diagnostics"]["items"][0]["first_source_id"] == "ticket-file-0"
+    assert result["diagnostics"]["items"][0]["ticket_count"] == 1000
+    assert (artifact_dir / "faq.md").read_text(encoding="utf-8").startswith(
+        "# Customer Ticket FAQ File Scale Smoke"
+    )
+
+
 def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path) -> None:
     source = _write_ticket_csv(
         tmp_path,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-File-Input-Scale-Smoke.md

Proves the file-backed FAQ scale-smoke path can process a 1,000-row JSON support-ticket bundle through the existing source-file loader, FAQ CLI generator, artifact writer, and compact result payload.

## Intentional
- Test-only slice; production source-file loading and FAQ generation already exist.
- Uses JSON bundle input because existing small tests already cover CSV, JSON array, and JSONL format selection.

## Deferred
- Browser upload coverage remains deferred until the UI upload path is active.
- Real database persistence remains in the lifecycle smoke lane.

## Verification
- `pytest tests/test_smoke_content_ops_faq_scale_run.py -q` - 19 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 1819 passed, 1 skipped.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed.

## Diff size
2 files, +124 / -0
