### PR TITLE
Test FAQ lifecycle scale smoke

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Scale-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Scale-Smoke.md
@@ -1,0 +1,66 @@
+# PR-Content-Ops-FAQ-Lifecycle-Scale-Smoke
+
+## Why this slice exists
+
+The FAQ product now has 1,000-row proof for hosted direct input, hosted bundle
+input, and file-backed CLI/artifact generation. The next confidence gap is
+lifecycle behavior after generation: the artifact must persist as a reviewable
+FAQ draft, export as a draft, update review status, and export again after the
+status change without losing scale metadata.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a 1,000-row JSON support-ticket bundle lifecycle smoke test using the
+   existing lifecycle script and fake async pool.
+2. Assert generation persists one FAQ draft with 1,000 source rows and 1,000
+   ticket sources.
+3. Assert draft and reviewed exports preserve source counts, rendered item
+   source coverage, and review status.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Scale-Smoke.md`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+
+The test writes a temporary JSON file:
+
+```json
+{"support_tickets": [{... 1000 rows ...}]}
+```
+
+It then runs `run_faq_lifecycle_smoke(...)`, which uses the production
+source-file loader, `TicketFAQMarkdownService`, `PostgresTicketFAQRepository`,
+`export_ticket_faq_drafts(...)`, and status-update path. The test fakes only the
+async pool so CI does not require a live database.
+
+## Intentional
+
+- This is test-only. The lifecycle script and repository path already exist; the
+  slice locks scale behavior across that path.
+- The fake pool remains the right CI boundary. Real database execution stays in
+  smoke/manual environments where `EXTRACTED_DATABASE_URL` and migrations are
+  available.
+
+## Deferred
+
+- A live database 1,000-row lifecycle run is deferred to the manual smoke lane;
+  it should use the same script with a real `--database-url`.
+- Browser upload coverage remains deferred until the UI upload path is active.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` - 5 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 1820 passed, 1 skipped.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| Lifecycle 1,000-row scale test | ~55 |
+| **Total** | **~120** |

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -141,6 +142,68 @@ async def test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports(monke
     assert "# Customer Ticket FAQ" in payload["reviewed_export"]["rows"][0]["markdown"]
     assert pool.closed is True
     assert pool.execute_calls
+
+
+@pytest.mark.asyncio
+async def test_faq_lifecycle_smoke_persists_1000_row_json_bundle(monkeypatch, tmp_path):
+    pool = _Pool()
+    monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))
+    source = tmp_path / "support_ticket_bundle.json"
+    source.write_text(
+        json.dumps({
+            "support_tickets": [
+                {
+                    "ticket_id": f"ticket-lifecycle-{index}",
+                    "source_type": "support_ticket",
+                    "subject": "Billing renewal question",
+                    "message": "How do I confirm my renewal invoice before payment?",
+                    "pain_category": "billing",
+                }
+                for index in range(1000)
+            ],
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code, payload = await smoke.run_faq_lifecycle_smoke(
+        _args(
+            path=source,
+            source_format="json",
+            title="Customer Ticket FAQ Lifecycle Scale Smoke",
+            min_source_rows=1000,
+            export_limit=5,
+            default_field=[
+                "company_name=Acme Billing",
+                "contact_email=billing@example.com",
+                "vendor_name=Atlas Billing",
+            ],
+        )
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["source_rows"] == 1000
+    assert payload["saved_ids"] == ["faq-uuid-1"]
+    assert payload["generation"]["source_count"] == 1000
+    assert payload["generation"]["ticket_source_count"] == 1000
+    assert payload["generation"]["items"][0]["ticket_count"] == 1000
+    assert len(payload["generation"]["items"][0]["source_ids"]) == 1000
+    assert payload["generation"]["items"][0]["source_ids"][0] == "ticket-lifecycle-0"
+    assert payload["generation"]["items"][0]["source_ids"][-1] == "ticket-lifecycle-999"
+
+    draft = payload["draft_export"]["rows"][0]
+    reviewed = payload["reviewed_export"]["rows"][0]
+    assert draft["source_count"] == 1000
+    assert draft["ticket_source_count"] == 1000
+    assert draft["status"] == "draft"
+    assert draft["items"][0]["ticket_count"] == 1000
+    assert len(draft["items"][0]["source_ids"]) == 1000
+    assert reviewed["source_count"] == 1000
+    assert reviewed["ticket_source_count"] == 1000
+    assert reviewed["status"] == "published"
+    assert "# Customer Ticket FAQ Lifecycle Scale Smoke" in reviewed["markdown"]
+    assert pool.closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Scale-Smoke.md

Proves the 1,000-row FAQ file-input path survives the lifecycle after generation: source-file load, FAQ generation, repository persistence, draft export, review status update, and reviewed export.

## Intentional
- Test-only slice; production lifecycle script and repository path already exist.
- Uses the fake async pool for CI while preserving the real service, repository, export, and status-update path.
- Supplies realistic default company/contact/vendor metadata so the lifecycle smoke keeps its fail-closed ingestion-warning gate.

## Deferred
- Live database 1,000-row lifecycle execution remains in the manual smoke lane.
- Browser upload coverage remains deferred until the UI upload path is active.

## Verification
- `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` - 5 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 1820 passed, 1 skipped.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed.

## Diff size
2 files, +129 / -0
