### PR TITLE
Add Content Ops blog live generation smoke

### DIFF
--- a/atlas_brain/skills/digest/blog_post_generation.md
+++ b/atlas_brain/skills/digest/blog_post_generation.md
@@ -99,11 +99,11 @@ Return valid JSON with exactly these keys:
 
 1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, or review counts.
 2. **Chart placement**: Every `chart_id` listed in a section's `chart_ids` MUST appear exactly once in the content as `{{chart:chart-id}}` on its own line. Do not invent chart IDs that are not in `available_charts`.
-3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`).
+3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead.
 4. **Tone**: Authoritative but accessible. Data journalist style -- let the numbers tell the story. Avoid marketing fluff, superlatives, and filler.
 5. **Quotable phrases**: Where `quotable_phrases` are provided, weave 2-4 of them into the text as blockquotes (`> "quote" -- verified buyer`). Choose the most impactful ones.
 6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..."
-7. **Length**: 800-1500 words for the main content. Concise paragraphs (2-4 sentences each).
+7. **Length**: 1500-2200 words for the main content. Concise paragraphs (2-4 sentences each).
 8. **No CTA in content**: The frontend adds its own call-to-action section. End with a conclusion/verdict, not a sales pitch.
 9. **Formatting**: Use markdown headers (##), bold for key numbers, blockquotes for review excerpts, and bullet lists for comparisons. No HTML tags except tables.
 10. **SEO**: `seo_title` must be under 60 characters with the target keyword front-loaded. `seo_description` must be under 155 characters and include the target keyword. Use the target keyword naturally in H2 headings (2-3 times in the content, not forced). The display `title` can be longer and more natural -- it is the H1 on the page.

--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -337,6 +337,22 @@ available. Set `OPENROUTER_API_KEY` or
 `ATLAS_B2B_CHURN_OPENROUTER_API_KEY` for the pipeline-routed Claude provider.
 On success it prints the saved `landing_pages` draft id.
 
+To prove the live blog-post path too, run the same smoke with
+`--output blog_post`. The command upserts one account-scoped
+`blog_blueprints` row, then generates and persists one `blog_posts` draft with
+quality gates enabled:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+On success it prints the saved `blog_posts` draft id and the seeded blueprint
+id. Re-running the command refreshes the same smoke blueprint for that account.
+
 For hosted Content Ops execution, pass the same selling asset through request
 inputs so every generated campaign opportunity sees it in `opportunity_json`:
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -591,6 +591,21 @@ initialization and the pipeline LLM/OpenRouter credentials before testing the
 HTTP route. The provider route expects `OPENROUTER_API_KEY` or
 `ATLAS_B2B_CHURN_OPENROUTER_API_KEY` to be loaded in the host environment.
 
+Use the same smoke for the hosted blog-post path:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+Blog mode seeds one scoped `blog_blueprints` row, runs `blog_post` through the
+same executor path, and persists one `blog_posts` draft with quality gates on.
+If it reports that `blog_post` is not configured, check the same DB and provider
+settings first.
+
 CFPB complaint narratives are the public support-ticket-like smoke path. Use
 them when the host needs a non-review source before wiring CRM notes, call
 transcripts, support tickets, or case exports. The exporter keeps only rows

--- a/extracted_content_pipeline/skills/digest/blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/blog_post_generation.md
@@ -99,11 +99,11 @@ Return valid JSON with exactly these keys:
 
 1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, or review counts.
 2. **Chart placement**: Every `chart_id` listed in a section's `chart_ids` MUST appear exactly once in the content as `{{chart:chart-id}}` on its own line. Do not invent chart IDs that are not in `available_charts`.
-3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`).
+3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead.
 4. **Tone**: Authoritative but accessible. Data journalist style -- let the numbers tell the story. Avoid marketing fluff, superlatives, and filler.
 5. **Quotable phrases**: Where `quotable_phrases` are provided, weave 2-4 of them into the text as blockquotes (`> "quote" -- verified buyer`). Choose the most impactful ones.
 6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..."
-7. **Length**: 800-1500 words for the main content. Concise paragraphs (2-4 sentences each).
+7. **Length**: 1500-2200 words for the main content. Concise paragraphs (2-4 sentences each).
 8. **No CTA in content**: The frontend adds its own call-to-action section. End with a conclusion/verdict, not a sales pitch.
 9. **Formatting**: Use markdown headers (##), bold for key numbers, blockquotes for review excerpts, and bullet lists for comparisons. No HTML tags except tables.
 10. **SEO**: `seo_title` must be under 60 characters with the target keyword front-loaded. `seo_description` must be under 155 characters and include the target keyword. Use the target keyword naturally in H2 headings (2-3 times in the content, not forced). The display `title` can be longer and more natural -- it is the H1 on the page.

--- a/plans/PR-Content-Ops-Blog-Live-Generation-Smoke.md
+++ b/plans/PR-Content-Ops-Blog-Live-Generation-Smoke.md
@@ -1,0 +1,145 @@
+# PR: Content Ops Blog Live Generation Smoke
+
+## Why this slice exists
+
+PR #829 proved the live Content Ops landing-page path end to end: Atlas DB pool,
+pipeline-routed OpenRouter/Claude provider, packaged skill prompt, executor,
+quality gate, and persisted draft. Blog generation is wired through the same
+host services bundle, but the live path cannot be proved against an empty
+`blog_blueprints` table.
+
+This slice adds the thinnest real blog proof: seed one tenant-scoped blueprint,
+run `blog_post` through the same live executor path, and verify a saved
+`blog_posts` draft. While scoping the slice, the blog prompt/gate contract also
+showed a source mismatch: the prompt asked for 800-1500 words while the quality
+gate blocks under 1500 words. The live smoke should prove quality gates on, so
+this slice aligns the prompt with the gate instead of disabling quality checks.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-live-generation-smoke
+
+1. Extend `scripts/smoke_content_ops_live_generation.py` with an
+   `--output blog_post` mode.
+2. Seed one scoped `blog_blueprints` row before blog execution, using the
+   existing Postgres blueprint repository and a smoke-only topic-type filter so
+   the run consumes the row it just seeded.
+3. Keep the existing landing-page smoke behavior as the default.
+4. Verify configured services, execution status, saved ids, and seeded blueprint
+   ids in the smoke result.
+5. Align the blog generation prompt's word-count instruction with the existing
+   blog quality gate.
+6. Add CI-safe tests with fake services and a fake blueprint seed function.
+7. Document both live smoke modes in the README and host runbook.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Blog-Live-Generation-Smoke.md` | Plan doc for this slice. |
+| `scripts/smoke_content_ops_live_generation.py` | Add blog output mode, seeded blueprint setup, and output-aware validation. |
+| `tests/test_smoke_content_ops_live_generation.py` | Add blog smoke coverage while preserving landing-page coverage. |
+| `atlas_brain/skills/digest/blog_post_generation.md` | Align blog prompt length rule with the quality gate. |
+| `extracted_content_pipeline/skills/digest/blog_post_generation.md` | Synced extracted skill copy. |
+| `extracted_content_pipeline/README.md` | Document the blog live-generation smoke command. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Add the same operator runbook guidance. |
+
+## Mechanism
+
+The smoke command keeps `landing_page` as the default:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py --account-id acct_123
+```
+
+Blog mode is explicit:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+For `blog_post`, the command initializes the Atlas DB pool, builds the normal
+`build_content_ops_execution_services(enable_db_services=True)` bundle, checks
+that `blog_post` is configured, upserts one default blueprint through
+`PostgresBlogBlueprintRepository.save_blueprints()`, and then calls
+`execute_content_ops_from_mapping()` with:
+
+```python
+{
+    "outputs": ["blog_post"],
+    "target_mode": args.target_mode,
+    "limit": 1,
+    "require_quality_gates": True,
+    "inputs": {"topic": "..."},
+}
+```
+
+The default blueprint is scoped to the account id and uses a smoke-specific
+slug so repeated runs update the same smoke row for that account instead of
+creating a new unbounded queue. Blog mode also passes
+`inputs.filters.topic_type=content_ops_live_smoke`, matching the seeded
+blueprint's topic type, so newer unrelated unconsumed blueprints under the same
+target mode cannot steal the smoke run. Because the generator only persists
+drafts after passing the blog quality gate, a saved id with quality gates
+enabled is the live quality proof.
+
+## Intentional
+
+- One shared smoke script. The landing-page and blog modes exercise the same
+  host bundle and executor, so a second script would duplicate setup and
+  failure handling.
+- Blog seed is default for `--output blog_post`. The live database currently has
+  no blueprints, and seeding one row makes the smoke self-contained for
+  operators.
+- The default seed does not include source quotes or chart requirements. Those
+  are already covered in generator-level tests; the live smoke's job is to
+  prove provider/DB/executor/persistence with quality gates on.
+- The prompt length fix is included because the smoke would otherwise document
+  an operator path where the model is asked to produce output the quality gate
+  can reject.
+
+## Deferred
+
+- HTTP-level `/content-ops/execute` authenticated smoke remains a future PR
+  because it needs a real B2B session and route auth setup.
+- Custom operator-supplied blog blueprint JSON is deferred. The default seed is
+  enough to prove live wiring; custom fixtures can be added after this path is
+  stable.
+- Parked hardening: existing `ATLAS-HARDENING.md` items are for the older
+  Atlas blog/deep-dive content pipeline, not this Content Ops
+  `blog_blueprints` smoke path. They remain parked.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_live_generation.py -q` -> 5 passed.
+- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py` -> passed.
+- `pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_blog_generation.py -q` -> 32 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed.
+- `bash scripts/check_ascii_python.sh` -> passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -> refreshed 43 mapped files; source and extracted blog skill copies verified identical.
+- `python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_content_ops_blog_smoke --user-id codex-smoke --json` -> failed clearly before execution: `blog_post service is not configured`; this worktree has no provider key loaded.
+- `python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_content_ops_blog_smoke --user-id codex-smoke --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --json` -> passed; configured all LLM-backed outputs, seeded blueprint id `0b04a34c-0876-4255-ba6b-bfd31b90b5d5`, filtered execution to `topic_type=content_ops_live_smoke`, generated 1 blog post, quality gate passed, saved draft id `989ef0f9-060b-47c3-bf49-847614833212`.
+- Saved draft spot-check -> `blog_posts` row found for account `acct_content_ops_blog_smoke`, status `draft`, slug `content-ops-blog-live-smoke-acct-content-ops-blog-smoke`, target keyword `support ticket FAQ gaps`.
+- `bash scripts/run_extracted_pipeline_checks.sh` -> 1826 passed, 1 skipped.
+- `git diff --check` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~130 |
+| Smoke script | ~197 |
+| Tests | ~68 |
+| Prompt sync | ~8 |
+| Docs | ~31 |
+| **Total** | **~434** |
+
+This may land slightly over the 400 LOC soft cap because the slice needs the
+operator path, fake-backed CI coverage, docs, and the prompt/gate source fix to
+make the live smoke meaningful with quality gates enabled.

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test live Content Ops landing-page generation through host wiring."""
+"""Smoke-test live Content Ops generation through host wiring."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import json
 from pathlib import Path
+import re
 import sys
 from typing import Any, Awaitable, Callable, Mapping
 
@@ -21,7 +22,7 @@ except ImportError:  # pragma: no cover - optional host dependency
     load_dotenv = None
 
 
-DEFAULT_INPUTS: Mapping[str, Any] = {
+DEFAULT_LANDING_PAGE_INPUTS: Mapping[str, Any] = {
     "campaign_name": "FAQ Report",
     "offer": "Turn repeat support tickets into customer-ready FAQ answers",
     "audience": "10-50 person SaaS support team",
@@ -49,10 +50,15 @@ DEFAULT_INPUTS: Mapping[str, Any] = {
     "cta_label": "Upload Ticket CSV -- Free Analysis",
     "cta_url": "/systems/ai-content-ops/intake",
 }
+DEFAULT_BLOG_TOPIC = (
+    "Support ticket FAQ gaps: what 90 days of repeat tickets reveal"
+)
+DEFAULT_BLOG_TOPIC_TYPE = "content_ops_live_smoke"
 
 AsyncCallable = Callable[[], Awaitable[None]]
 ServicesFactory = Callable[[], Any]
 Executor = Callable[..., Awaitable[dict[str, Any]]]
+BlogBlueprintSeeder = Callable[[argparse.Namespace, Any], Awaitable[Mapping[str, Any]]]
 
 
 def _load_dotenv_files(extra_env_files: list[Path] | None = None) -> None:
@@ -68,16 +74,27 @@ def _load_dotenv_files(extra_env_files: list[Path] | None = None) -> None:
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Smoke-test live AI Content Ops landing-page generation through "
+            "Smoke-test live AI Content Ops generation through "
             "the host DB pool, packaged skills, and pipeline-routed LLM."
         )
     )
     parser.add_argument(
+        "--output",
+        choices=("landing_page", "blog_post"),
+        default="landing_page",
+        help="Content Ops output to smoke-test. Defaults to landing_page.",
+    )
+    parser.add_argument(
         "--account-id",
         required=True,
-        help="Tenant/account id used to scope the generated landing-page draft.",
+        help="Tenant/account id used to scope the generated draft.",
     )
     parser.add_argument("--user-id", default=None)
+    parser.add_argument(
+        "--target-mode",
+        default="vendor_retention",
+        help="Content Ops target_mode for blog blueprints and execution.",
+    )
     parser.add_argument(
         "--env-file",
         action="append",
@@ -91,7 +108,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--input-json",
         type=Path,
-        help="Optional JSON object merged over the default landing-page inputs.",
+        help="Optional JSON object merged over the default inputs.",
     )
     parser.add_argument(
         "--input",
@@ -154,15 +171,27 @@ def _parse_override(raw: str) -> tuple[str, Any]:
 def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
     if int(args.quality_repair_attempts) < 0:
         raise SystemExit("--quality-repair-attempts must be >= 0")
-    inputs = dict(DEFAULT_INPUTS)
+    output = str(args.output or "landing_page").strip() or "landing_page"
+    if output == "landing_page":
+        inputs = dict(DEFAULT_LANDING_PAGE_INPUTS)
+    elif output == "blog_post":
+        inputs = {
+            "topic": DEFAULT_BLOG_TOPIC,
+            "filters": {"topic_type": DEFAULT_BLOG_TOPIC_TYPE},
+        }
+    else:  # argparse enforces this for CLI callers; keep injected tests honest.
+        raise SystemExit(f"unsupported --output: {output}")
     if args.input_json:
         inputs.update(_load_json_object(args.input_json))
     for raw in args.input:
         key, value = _parse_override(str(raw))
         inputs[key] = value
-    inputs["landing_page_quality_repair_attempts"] = int(args.quality_repair_attempts)
+    if output == "landing_page":
+        inputs["landing_page_quality_repair_attempts"] = int(args.quality_repair_attempts)
     return {
-        "outputs": ["landing_page"],
+        "outputs": [output],
+        "target_mode": str(args.target_mode or "vendor_retention").strip()
+        or "vendor_retention",
         "limit": 1,
         "require_quality_gates": not bool(args.no_quality_gates),
         "inputs": inputs,
@@ -200,13 +229,14 @@ def _step_result(result: Mapping[str, Any], output: str) -> Mapping[str, Any] | 
 
 def _smoke_errors(
     *,
+    output: str,
     configured_outputs: tuple[str, ...],
     result: Mapping[str, Any] | None,
 ) -> list[str]:
     errors: list[str] = []
-    if "landing_page" not in configured_outputs:
+    if output not in configured_outputs:
         errors.append(
-            "landing_page service is not configured; check Atlas DB initialization "
+            f"{output} service is not configured; check Atlas DB initialization "
             "and pipeline LLM/OpenRouter credentials"
         )
         return errors
@@ -214,19 +244,141 @@ def _smoke_errors(
         return errors
     if result.get("status") != "completed":
         errors.append(f"execution status was {result.get('status')!r}, not 'completed'")
-    step = _step_result(result, "landing_page")
+    step = _step_result(result, output)
     if step is None:
-        errors.append("execution result did not include a landing_page step")
+        errors.append(f"execution result did not include a {output} step")
         return errors
     if step.get("status") != "completed":
-        errors.append(f"landing_page step status was {step.get('status')!r}")
+        errors.append(f"{output} step status was {step.get('status')!r}")
     step_payload = step.get("result") if isinstance(step.get("result"), Mapping) else {}
     if not step_payload.get("saved_ids"):
-        errors.append("landing_page generation did not return saved draft ids")
+        errors.append(f"{output} generation did not return saved draft ids")
     history = step_payload.get("quality_repair_history") or ()
     if history and isinstance(history[-1], Mapping) and not history[-1].get("passed"):
-        errors.append("landing_page quality gate did not pass")
+        errors.append(f"{output} quality gate did not pass")
     return errors
+
+
+def _account_slug(value: Any) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
+    return slug[:60].strip("-") or "acct"
+
+
+def _default_blog_blueprint_payload() -> dict[str, Any]:
+    return {
+        "topic": DEFAULT_BLOG_TOPIC,
+        "data_context": {
+            "review_period": "last 90 days",
+            "report_date": "2026-05-23",
+            "total_reviews_analyzed": 186,
+            "deep_enriched_count": 186,
+            "category": "support tickets",
+            "topic": "support tickets",
+            "_known_vendors": [],
+        },
+        "sections": [
+            {
+                "id": "repeat-ticket-patterns",
+                "heading": "What do repeat support tickets reveal?",
+                "goal": (
+                    "Explain why repeated setup, billing, and account-change "
+                    "questions show missing customer-facing answers."
+                ),
+                "key_stats": {
+                    "tickets_analyzed": 186,
+                    "repeat_question_count": 78,
+                    "repeat_question_rate": "42%",
+                },
+                "chart_ids": [],
+                "data_summary": (
+                    "Across 186 support tickets from the last 90 days, 78 "
+                    "tickets repeated a question another customer had already "
+                    "asked. Setup, billing, and account-change issues were the "
+                    "largest repeat clusters."
+                ),
+            },
+            {
+                "id": "faq-gap-priorities",
+                "heading": "Which FAQ gaps should a small team fix first?",
+                "goal": (
+                    "Rank the repeat-question clusters by volume and explain "
+                    "why the highest-volume issues should become FAQ entries."
+                ),
+                "key_stats": {
+                    "setup_questions": 31,
+                    "billing_questions": 24,
+                    "account_change_questions": 23,
+                },
+                "chart_ids": [],
+                "data_summary": (
+                    "Setup questions appeared 31 times, billing questions 24 "
+                    "times, and account-change questions 23 times. The first "
+                    "FAQ pass should start with those three clusters."
+                ),
+            },
+            {
+                "id": "publishable-answer-process",
+                "heading": "How should old tickets become customer-ready answers?",
+                "goal": (
+                    "Show the operational path from CSV upload to clustered "
+                    "questions, customer wording, draft answers, and review."
+                ),
+                "key_stats": {
+                    "source_window_days": 90,
+                    "draft_faq_entries": 12,
+                    "review_steps": 3,
+                },
+                "chart_ids": [],
+                "data_summary": (
+                    "The 90-day ticket CSV produces 12 first-pass FAQ entries. "
+                    "Each answer should preserve customer wording, summarize "
+                    "the support team's answer, and stay in review until the "
+                    "team approves it."
+                ),
+            },
+        ],
+        "available_charts": [],
+        "related_posts": [],
+        "grounded_vendors": [
+            "Support Tickets",
+            "Support Ticket FAQ",
+            "Support Ticket FAQ Gaps",
+            "FAQ Report",
+            "Help Center",
+        ],
+        "required_vendors": [],
+    }
+
+
+async def _seed_default_blog_blueprint(
+    args: argparse.Namespace,
+    scope: Any,
+) -> Mapping[str, Any]:
+    from atlas_brain.storage.database import get_db_pool  # noqa: PLC0415
+    from extracted_content_pipeline.blog_blueprint_postgres import (  # noqa: PLC0415
+        PostgresBlogBlueprintRepository,
+    )
+    from extracted_content_pipeline.blog_ports import BlogBlueprint  # noqa: PLC0415
+
+    account_slug = _account_slug(args.account_id)
+    slug = f"content-ops-blog-live-smoke-{account_slug}"
+    target_mode = str(args.target_mode or "vendor_retention").strip() or "vendor_retention"
+    blueprint = BlogBlueprint(
+        target_mode=target_mode,
+        topic_type=DEFAULT_BLOG_TOPIC_TYPE,
+        slug=slug,
+        suggested_title="Support Tickets: FAQ Gaps From 90 Days of Tickets",
+        payload=_default_blog_blueprint_payload(),
+    )
+    saved_ids = await PostgresBlogBlueprintRepository(
+        pool=get_db_pool()
+    ).save_blueprints((blueprint,), scope=scope)
+    return {
+        "saved_ids": list(saved_ids),
+        "slug": slug,
+        "target_mode": target_mode,
+        "topic_type": blueprint.topic_type,
+    }
 
 
 async def run_content_ops_live_generation_smoke(
@@ -237,6 +389,7 @@ async def run_content_ops_live_generation_smoke(
     services_factory: ServicesFactory | None = None,
     executor: Executor | None = None,
     tenant_scope_cls: Any = None,
+    blog_blueprint_seed_fn: BlogBlueprintSeeder | None = None,
 ) -> tuple[int, dict[str, Any]]:
     _load_dotenv_files(list(args.env_file or []))
     if (
@@ -255,24 +408,34 @@ async def run_content_ops_live_generation_smoke(
         ) = _resolve_runtime_dependencies()
 
     payload = _payload_from_args(args)
+    output = str(payload["outputs"][0])
     configured_outputs: tuple[str, ...] = ()
     execution_result: dict[str, Any] | None = None
+    seeded_blog_blueprint: Mapping[str, Any] | None = None
     errors: list[str] = []
     try:
         await init_database_fn()
         services = services_factory()
         configured_outputs = tuple(str(item) for item in services.configured_outputs())
         errors.extend(
-            _smoke_errors(configured_outputs=configured_outputs, result=None)
+            _smoke_errors(
+                output=output,
+                configured_outputs=configured_outputs,
+                result=None,
+            )
         )
         if not errors:
             scope = tenant_scope_cls(
                 account_id=str(args.account_id or "").strip(),
                 user_id=str(args.user_id or "").strip(),
             )
+            if output == "blog_post":
+                seeder = blog_blueprint_seed_fn or _seed_default_blog_blueprint
+                seeded_blog_blueprint = await seeder(args, scope)
             execution_result = await executor(payload, services=services, scope=scope)
             errors.extend(
                 _smoke_errors(
+                    output=output,
                     configured_outputs=configured_outputs,
                     result=execution_result,
                 )
@@ -289,6 +452,7 @@ async def run_content_ops_live_generation_smoke(
         "ok": not errors,
         "errors": errors,
         "configured_outputs": list(configured_outputs),
+        "seeded_blog_blueprint": dict(seeded_blog_blueprint or {}),
         "payload": payload,
         "execution": execution_result,
     }
@@ -306,7 +470,10 @@ def _print_result(result: Mapping[str, Any], *, as_json: bool) -> None:
         print(f"error: {error}")
     execution = result.get("execution")
     if isinstance(execution, Mapping):
-        step = _step_result(execution, "landing_page")
+        payload = result.get("payload") if isinstance(result.get("payload"), Mapping) else {}
+        outputs = payload.get("outputs") if isinstance(payload, Mapping) else ()
+        output = str(outputs[0]) if outputs else "landing_page"
+        step = _step_result(execution, output)
         step_payload = step.get("result") if isinstance(step, Mapping) else {}
         if isinstance(step_payload, Mapping):
             saved_ids = step_payload.get("saved_ids") or []

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -62,10 +62,27 @@ class _LandingPageService:
         }
 
 
+class _BlogPostService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        return {
+            "requested": 1,
+            "generated": 1,
+            "skipped": 0,
+            "saved_ids": ["blog-live-smoke-1"],
+            "errors": [],
+        }
+
+
 def _args(**overrides: Any) -> argparse.Namespace:
     values = {
+        "output": "landing_page",
         "account_id": "acct-live-smoke",
         "user_id": "user-live-smoke",
+        "target_mode": "vendor_retention",
         "env_file": [],
         "input_json": None,
         "input": [],
@@ -111,6 +128,58 @@ async def test_live_generation_smoke_executes_landing_page_through_real_executor
     assert call["campaign"].context["cta_url"] == "/custom-intake"
     assert call["campaign"].context["faq_questions"] == ["How long does it take?"]
     assert call["quality_repair_attempts"] == 1
+    assert call["quality_gates_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_seeds_and_executes_blog_post_through_real_executor() -> None:
+    lifecycle = _Lifecycle()
+    service = _BlogPostService()
+    seeded: list[dict[str, Any]] = []
+
+    async def _seed_blog_blueprint(args: argparse.Namespace, scope: TenantScope) -> dict[str, Any]:
+        seeded.append({"args": args, "scope": scope})
+        return {
+            "saved_ids": ["bp-live-smoke-1"],
+            "slug": "content-ops-blog-live-smoke-acct-live-smoke",
+            "target_mode": args.target_mode,
+            "topic_type": "complaint_roundup",
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="blog_post",
+            input=["topic=Support ticket FAQ gaps"],
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(blog_post=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        blog_blueprint_seed_fn=_seed_blog_blueprint,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["configured_outputs"] == ["blog_post"]
+    assert result["seeded_blog_blueprint"]["saved_ids"] == ["bp-live-smoke-1"]
+    assert result["execution"]["status"] == "completed"
+    assert result["execution"]["steps"][0]["result"]["saved_ids"] == [
+        "blog-live-smoke-1"
+    ]
+    assert lifecycle.initialized is True
+    assert lifecycle.closed is True
+    assert len(seeded) == 1
+    assert seeded[0]["scope"].account_id == "acct-live-smoke"
+    assert len(service.calls) == 1
+
+    call = service.calls[0]
+    assert call["scope"].account_id == "acct-live-smoke"
+    assert call["target_mode"] == "vendor_retention"
+    assert call["limit"] == 1
+    assert call["filters"] == {"topic_type": "content_ops_live_smoke"}
+    assert call["topic"] == "Support ticket FAQ gaps"
     assert call["quality_gates_enabled"] is True
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Live-Generation-Smoke.md

Adds a seeded blog_post mode to the live Content Ops generation smoke so we can prove the blog generator end to end against the real Atlas DB pool, pipeline-routed OpenRouter/Claude provider, executor, quality gate, and blog_posts persistence. The slice also aligns the blog prompt with the existing quality gate: 1500-2200 words, and no vague H2 headings like Conclusion/Summary that the GEO gate rejects.

## Intentional
- One shared live-generation smoke script covers both landing_page and blog_post so the two paths exercise the same host bundle and executor wiring.
- Blog mode seeds one scoped blog_blueprints row because the live DB may not already have unconsumed blueprints.
- The default seed avoids quote/chart requirements because those are already covered by generator-level tests; this smoke proves live provider/DB/executor/persistence with quality gates on.
- Prompt/gate alignment is included because quality-off live smoke would be misleading.

## Deferred
- HTTP-level authenticated /content-ops/execute smoke remains a future PR because it needs a real B2B session and route auth setup.
- Custom operator-supplied blog blueprint JSON is deferred until the default live path is stable.

## Parked hardening
- None. Existing ATLAS-HARDENING.md entries are for the older Atlas blog/deep-dive content pipeline, not this Content Ops blog_blueprints smoke path.

## Verification
- pytest tests/test_smoke_content_ops_live_generation.py -q -> 5 passed.
- python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py -> passed.
- pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_blog_generation.py -q -> 32 passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline -> refreshed 43 mapped files; source and extracted blog skill copies verified identical.
- python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_content_ops_blog_smoke --user-id codex-smoke --json -> failed clearly before execution: blog_post service is not configured.
- python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_content_ops_blog_smoke --user-id codex-smoke --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --json -> passed; seeded blueprint id 0b04a34c-0876-4255-ba6b-bfd31b90b5d5, saved blog draft id 989ef0f9-060b-47c3-bf49-847614833212.
- Saved draft spot-check -> blog_posts row found for account acct_content_ops_blog_smoke, status draft, slug content-ops-blog-live-smoke-acct-content-ops-blog-smoke, target keyword support ticket FAQ gaps.
- bash scripts/run_extracted_pipeline_checks.sh -> 1826 passed, 1 skipped.
- bash scripts/local_pr_review.sh origin/main -> passed.
- git diff --check -> passed.

## Diff size
7 files, +425 / -21