### PR TITLE
Add FAQ lifecycle console profile visibility

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Console-Profile.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Console-Profile.md
@@ -1,0 +1,64 @@
+# PR-Content-Ops-FAQ-Lifecycle-Console-Profile
+
+## Why this slice exists
+
+The FAQ lifecycle smoke now writes a structured `input_profile`, but the
+human-readable console output still hides it. Manual lifecycle runs, including
+future real-DB 1,000-row runs, should show the same compact row-count and warning
+summary that the scale smoke already shows. This slice shares the console
+formatter and uses it in lifecycle output.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Move the FAQ input-profile console formatter into the shared smoke profile
+   helper.
+2. Keep the scale smoke console output unchanged while using the shared
+   formatter.
+3. Add lifecycle console output for success and failure paths.
+4. Add tests for lifecycle console success and failure summaries.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Console-Profile.md`
+- `scripts/content_ops_faq_smoke_profile.py`
+- `scripts/smoke_content_ops_faq_lifecycle.py`
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+
+The shared helper exposes `console_input_profile(profile)`. The scale smoke
+delegates its existing private wrapper to the shared helper, and the lifecycle
+smoke includes that same string in `_print_payload(...)` for both pass and fail
+output.
+
+## Intentional
+
+- This is console visibility only. It does not change lifecycle pass/fail
+  behavior or JSON payload structure.
+- The scale smoke keeps its private wrapper for compatibility with existing
+  tests while moving implementation into the shared helper.
+
+## Deferred
+
+- Live database execution remains deferred because this environment has neither
+  `EXTRACTED_DATABASE_URL` nor `DATABASE_URL` set.
+- Browser upload coverage remains deferred until the UI upload path is active.
+
+## Verification
+
+- Passed: `pytest tests/test_smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_lifecycle.py -q` (28 passed)
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1830 passed, 1 skipped)
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| Shared console formatter | ~30 |
+| Lifecycle console tests | ~35 |
+| Smoke integrations | ~15 |
+| **Total** | **~150** |

--- a/scripts/content_ops_faq_smoke_profile.py
+++ b/scripts/content_ops_faq_smoke_profile.py
@@ -169,3 +169,26 @@ def resolve_source_format(path: Path, source_format: str) -> str:
     if path.suffix.lower() == ".jsonl":
         return "jsonl"
     return "json"
+
+
+def console_input_profile(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return "source_rows=unknown"
+    parts = [f"input_status={value.get('status') or 'unknown'}"]
+    usable = value.get("usable_source_count")
+    raw = value.get("raw_row_count")
+    if usable is not None or raw is not None:
+        parts.append(f"source_rows={_console_value(usable)}/{_console_value(raw)}")
+    for key, label in (
+        ("skipped_row_count", "skipped_rows"),
+        ("missing_source_text_count", "missing_source_text"),
+        ("warning_count", "warnings"),
+    ):
+        item = value.get(key)
+        if item not in (None, 0):
+            parts.append(f"{label}={item}")
+    return " ".join(parts)
+
+
+def _console_value(value: Any) -> str:
+    return str(value) if value is not None else "unknown"

--- a/scripts/smoke_content_ops_faq_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_lifecycle.py
@@ -33,6 +33,7 @@ from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
     PostgresTicketFAQRepository,
 )
 from content_ops_faq_smoke_profile import (  # noqa: E402
+    console_input_profile,
     empty_input_profile,
     input_profile_error,
     input_profile_from_loaded,
@@ -321,15 +322,16 @@ def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
         return
+    profile = console_input_profile(payload.get("input_profile"))
     if payload.get("ok"):
         print(
             "Content Ops FAQ lifecycle smoke passed: "
-            f"source_rows={payload.get('source_rows')} "
+            f"{profile} "
             f"saved_faqs={len(payload.get('saved_ids') or [])} "
             f"review_status={payload.get('review_status')}"
         )
         return
-    print("Content Ops FAQ lifecycle smoke failed:", file=sys.stderr)
+    print(f"Content Ops FAQ lifecycle smoke failed: {profile}", file=sys.stderr)
     for error in payload.get("errors") or []:
         print(f"- {error}", file=sys.stderr)
 

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -22,6 +22,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 FAQ_CLI = ROOT / "scripts/build_extracted_ticket_faq_markdown.py"
 
 from content_ops_faq_smoke_profile import (  # noqa: E402
+    console_input_profile,
     load_source_input_profile,
     raw_row_profile,
 )
@@ -248,22 +249,7 @@ def _print_scale_summary(summary: Mapping[str, Any]) -> None:
 
 
 def _console_input_profile(value: Any) -> str:
-    if not isinstance(value, Mapping):
-        return "source_rows=unknown"
-    parts = [f"input_status={value.get('status') or 'unknown'}"]
-    usable = value.get("usable_source_count")
-    raw = value.get("raw_row_count")
-    if usable is not None or raw is not None:
-        parts.append(f"source_rows={_console_value(usable)}/{_console_value(raw)}")
-    for key, label in (
-        ("skipped_row_count", "skipped_rows"),
-        ("missing_source_text_count", "missing_source_text"),
-        ("warning_count", "warnings"),
-    ):
-        item = value.get(key)
-        if item not in (None, 0):
-            parts.append(f"{label}={item}")
-    return " ".join(parts)
+    return console_input_profile(value)
 
 
 def _console_value(value: Any) -> str:

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -328,6 +328,59 @@ async def test_faq_lifecycle_smoke_marks_input_profile_error_on_load_failure(mon
     assert pool.closed is True
 
 
+def test_faq_lifecycle_print_payload_includes_input_profile(capsys) -> None:
+    smoke._print_payload(
+        {
+            "ok": True,
+            "input_profile": {
+                "status": "ok",
+                "usable_source_count": 1000,
+                "raw_row_count": 1000,
+                "warning_count": 0,
+            },
+            "saved_ids": ["faq-uuid-1"],
+            "review_status": "published",
+        },
+        as_json=False,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "Content Ops FAQ lifecycle smoke passed:" in captured.out
+    assert "input_status=ok" in captured.out
+    assert "source_rows=1000/1000" in captured.out
+    assert "saved_faqs=1" in captured.out
+    assert "review_status=published" in captured.out
+
+
+def test_faq_lifecycle_print_payload_includes_input_profile_on_failure(capsys) -> None:
+    smoke._print_payload(
+        {
+            "ok": False,
+            "input_profile": {
+                "status": "ok",
+                "usable_source_count": 46,
+                "raw_row_count": 1000,
+                "skipped_row_count": 954,
+                "missing_source_text_count": 954,
+                "warning_count": 954,
+            },
+            "errors": ["expected at least 500 source row(s), got 46"],
+        },
+        as_json=False,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Content Ops FAQ lifecycle smoke failed:" in captured.err
+    assert "input_status=ok" in captured.err
+    assert "source_rows=46/1000" in captured.err
+    assert "skipped_rows=954" in captured.err
+    assert "missing_source_text=954" in captured.err
+    assert "warnings=954" in captured.err
+    assert "- expected at least 500 source row(s), got 46" in captured.err
+
+
 def test_faq_lifecycle_smoke_rejects_invalid_args() -> None:
     args = _args(min_saved_faqs=0)
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Console-Profile.md

The FAQ lifecycle smoke now writes a structured input profile, but the human console output still hid the row-count and warning profile. This shares the scale smoke's compact formatter and prints it in lifecycle pass/fail output so manual 1,000-row and real-DB runs expose source density without opening JSON artifacts.

## Intentional
- Console visibility only; lifecycle pass/fail behavior and JSON payloads are unchanged.
- The scale smoke keeps its private wrapper while delegating implementation to the shared formatter.

## Deferred
- Live database execution remains deferred because this environment has neither EXTRACTED_DATABASE_URL nor DATABASE_URL set.
- Browser upload coverage remains deferred until the UI upload path is active.

## Verification
- `pytest tests/test_smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_lifecycle.py -q` (28 passed)
- `scripts/run_extracted_pipeline_checks.sh` (1830 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
5 files, +146 / -18
