### PR TITLE
Add FAQ lifecycle result summary

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Result-Summary.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Result-Summary.md
@@ -1,0 +1,83 @@
+# PR-Content-Ops-FAQ-Lifecycle-Result-Summary
+
+## Why this slice exists
+
+The FAQ lifecycle smoke can persist and review generated FAQ Markdown, and the
+scale smoke already has compact run-summary fields for large-upload triage. The
+lifecycle smoke still writes only the full payload: generation details, draft
+export rows, reviewed export rows, and errors. For a real 1,000-row database
+run, that makes the artifact harder to scan and pushes operators back into
+large nested payloads when they only need the source density, saved/exported row
+counts, output-check status, and review status.
+
+This slice adds a compact lifecycle summary beside the existing payload so the
+next real-DB 1,000-row run has a stable inspection point.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a compact `lifecycle_summary` block to the FAQ lifecycle smoke result.
+2. Include source/input-profile, saved count, export counts, output-checks, and
+   error count without duplicating Markdown bodies.
+3. Pin the summary for both successful 1,000-row lifecycle runs and fail-closed
+   preflight failures.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Result-Summary.md`
+- `scripts/smoke_content_ops_faq_lifecycle.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+
+The lifecycle script will build its existing payload as it does today, then
+attach `lifecycle_summary = _lifecycle_summary(payload)`. The helper reads only
+aggregate fields already present in the payload:
+
+```python
+{
+    "status": "ok" if payload["ok"] else "failed",
+    "source_rows": payload["source_rows"],
+    "input_profile": payload["input_profile"],
+    "saved_faq_count": len(payload["saved_ids"]),
+    "draft_export_count": len(payload["draft_export"]["rows"]),
+    "reviewed_export_count": len(payload["reviewed_export"]["rows"]),
+    "output_checks": payload["generation"]["output_checks"],
+}
+```
+
+Export row counts are derived through a tiny row-count helper so missing exports
+stay visible as `None` instead of being confused with zero exported rows.
+
+## Intentional
+
+- This is result visibility only. It does not change database writes, review
+  status updates, export behavior, console output, or pass/fail behavior.
+- The summary intentionally duplicates small aggregate values already present in
+  the full payload so large real-DB artifacts have a stable top-level readout.
+- No live database run is added to CI; the existing fake async pool remains the
+  test boundary.
+
+## Deferred
+
+- The real local DB 1,000-row lifecycle command remains the next manual test
+  once a database URL is available in this checkout.
+- A browser upload test remains deferred until the UI upload path is active.
+- Root `HARDENING.md` was scanned; no parked FAQ-lane item is required for this
+  slice to function.
+
+## Verification
+
+- Passed: `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` (9 passed)
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1831 passed, 1 skipped)
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Lifecycle summary helper | ~45 |
+| Lifecycle tests | ~30 |
+| **Total** | **~150** |

--- a/scripts/smoke_content_ops_faq_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_lifecycle.py
@@ -255,6 +255,7 @@ async def run_faq_lifecycle_smoke(args: argparse.Namespace) -> tuple[int, dict[s
         "review_status": str(args.review_status),
         "errors": errors,
     }
+    payload["lifecycle_summary"] = _lifecycle_summary(payload)
     if args.output_result:
         args.output_result.parent.mkdir(parents=True, exist_ok=True)
         args.output_result.write_text(
@@ -316,6 +317,41 @@ def _export_errors(
         if not str(row.get("markdown") or "").strip():
             errors.append(f"exported FAQ {saved_id} missing markdown")
     return errors
+
+
+def _lifecycle_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    generation = payload.get("generation")
+    generation_payload = generation if isinstance(generation, Mapping) else {}
+    items = generation_payload.get("items")
+    output_checks = generation_payload.get("output_checks")
+    return {
+        "status": "ok" if payload.get("ok") else "failed",
+        "source": payload.get("source"),
+        "source_format": payload.get("source_format"),
+        "source_rows": payload.get("source_rows"),
+        "input_profile": _mapping_or_none(payload.get("input_profile")),
+        "source_count": generation_payload.get("source_count"),
+        "ticket_source_count": generation_payload.get("ticket_source_count"),
+        "generated_item_count": len(items) if isinstance(items, list) else None,
+        "output_checks": _mapping_or_none(output_checks),
+        "saved_faq_count": len(payload.get("saved_ids") or []),
+        "draft_export_count": _export_row_count(payload.get("draft_export")),
+        "reviewed_export_count": _export_row_count(payload.get("reviewed_export")),
+        "review_status": payload.get("review_status"),
+        "error_count": len(payload.get("errors") or []),
+        "errors": list(payload.get("errors") or []),
+    }
+
+
+def _export_row_count(value: Any) -> int | None:
+    if not isinstance(value, Mapping):
+        return None
+    rows = value.get("rows")
+    return len(rows) if isinstance(rows, list) else None
+
+
+def _mapping_or_none(value: Any) -> dict[str, Any] | None:
+    return dict(value) if isinstance(value, Mapping) else None
 
 
 def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -211,6 +211,27 @@ async def test_faq_lifecycle_smoke_persists_1000_row_json_bundle(monkeypatch, tm
     assert len(payload["generation"]["items"][0]["source_ids"]) == 1000
     assert payload["generation"]["items"][0]["source_ids"][0] == "ticket-lifecycle-0"
     assert payload["generation"]["items"][0]["source_ids"][-1] == "ticket-lifecycle-999"
+    assert payload["lifecycle_summary"] == {
+        "status": "ok",
+        "source": str(source),
+        "source_format": "json",
+        "source_rows": 1000,
+        "input_profile": payload["input_profile"],
+        "source_count": 1000,
+        "ticket_source_count": 1000,
+        "generated_item_count": 1,
+        "output_checks": {
+            "uses_user_vocabulary": True,
+            "condensed": True,
+            "has_action_items": True,
+        },
+        "saved_faq_count": 1,
+        "draft_export_count": 1,
+        "reviewed_export_count": 1,
+        "review_status": "published",
+        "error_count": 0,
+        "errors": [],
+    }
 
     draft = payload["draft_export"]["rows"][0]
     reviewed = payload["reviewed_export"]["rows"][0]
@@ -290,6 +311,19 @@ async def test_faq_lifecycle_smoke_fails_closed_when_table_missing(monkeypatch):
     assert code == 1
     assert any("ticket_faq_markdown" in error for error in payload["errors"])
     assert payload["generation"] is None
+    assert payload["lifecycle_summary"]["status"] == "failed"
+    assert payload["lifecycle_summary"]["source_rows"] == 4
+    assert payload["lifecycle_summary"]["input_profile"] == payload["input_profile"]
+    assert payload["lifecycle_summary"]["source_count"] is None
+    assert payload["lifecycle_summary"]["ticket_source_count"] is None
+    assert payload["lifecycle_summary"]["generated_item_count"] is None
+    assert payload["lifecycle_summary"]["output_checks"] is None
+    assert payload["lifecycle_summary"]["saved_faq_count"] == 0
+    assert payload["lifecycle_summary"]["draft_export_count"] is None
+    assert payload["lifecycle_summary"]["reviewed_export_count"] is None
+    assert payload["lifecycle_summary"]["review_status"] == "published"
+    assert payload["lifecycle_summary"]["error_count"] == 1
+    assert payload["lifecycle_summary"]["errors"] == payload["errors"]
     assert len(pool.fetchval_calls) == 1
     assert pool.execute_calls == []
     assert pool.closed is True


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Result-Summary.md

The FAQ lifecycle smoke writes the full generation/export payload, but a real 1,000-row database run needs a stable compact readout. This adds `lifecycle_summary` beside the existing payload so operators can inspect source density, saved/exported row counts, output-check status, and review status without digging through full Markdown/export bodies.

## Intentional
- Result visibility only; database writes, exports, review updates, console output, and pass/fail behavior are unchanged.
- The summary duplicates small aggregate values already present in the full payload so large lifecycle artifacts have a stable top-level readout.
- No live database run is added to CI; the fake async pool remains the test boundary.

## Deferred
- Real local DB 1,000-row lifecycle execution remains the next manual test once a database URL is available in this checkout.
- Browser upload coverage remains deferred until the UI upload path is active.
- Root `HARDENING.md` was scanned; no parked FAQ-lane item is required for this slice.

## Verification
- `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` (9 passed)
- `scripts/run_extracted_pipeline_checks.sh` (1831 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +153 / -0
