### PR TITLE
Add custom blog blueprint JSON live smoke

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -352,6 +352,35 @@ python scripts/smoke_content_ops_live_generation.py \
 
 On success it prints the saved `blog_posts` draft id and the seeded blueprint
 id. Re-running the command refreshes the same smoke blueprint for that account.
+To seed a specific operator blueprint instead of the default smoke row, pass a
+JSON file that normalizes to one blog blueprint:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --blog-blueprint-json ./blog-blueprint.json \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+Minimal `blog-blueprint.json`:
+
+```json
+{
+  "title": "FAQ gaps for onboarding tickets",
+  "sections": [
+    {
+      "id": "onboarding-gaps",
+      "heading": "Where onboarding tickets repeat",
+      "data_summary": "Setup questions repeat across recent support tickets."
+    }
+  ],
+  "data_context": {
+    "audience": "small support team"
+  }
+}
+```
 
 For hosted Content Ops execution, pass the same selling asset through request
 inputs so every generated campaign opportunity sees it in `opportunity_json`:

--- a/extracted_content_pipeline/blog_blueprint_postgres.py
+++ b/extracted_content_pipeline/blog_blueprint_postgres.py
@@ -72,16 +72,21 @@ class PostgresBlogBlueprintRepository:
     ) -> Sequence[Mapping[str, Any]]:
         """Return unconsumed blueprints for the tenant + target_mode.
 
-        ``filters`` is accepted for protocol parity but currently
-        only honored for ``topic_type`` -- additional facets can
-        be added without a breaking change.
+        ``filters`` is accepted for protocol parity and currently honors
+        ``topic_type`` and ``slug``. The smoke path uses both so a freshly
+        seeded custom blueprint is selected uniquely instead of relying on
+        recency within a broad topic type.
         """
 
         topic_type = None
+        slug = None
         if filters:
             raw = filters.get("topic_type")
             if isinstance(raw, str) and raw.strip():
                 topic_type = raw.strip()
+            raw_slug = filters.get("slug")
+            if isinstance(raw_slug, str) and raw_slug.strip():
+                slug = raw_slug.strip()
 
         query = f"""
             SELECT id, target_mode, topic_type, slug, suggested_title, payload
@@ -92,8 +97,11 @@ class PostgresBlogBlueprintRepository:
         """
         args: list[Any] = [scope.account_id or "", target_mode]
         if topic_type is not None:
-            query += " AND topic_type = $3"
             args.append(topic_type)
+            query += f" AND topic_type = ${len(args)}"
+        if slug is not None:
+            args.append(slug)
+            query += f" AND slug = ${len(args)}"
         query += f" ORDER BY created_at DESC LIMIT ${len(args) + 1}"
         args.append(int(limit))
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -606,6 +606,36 @@ same executor path, and persists one `blog_posts` draft with quality gates on.
 If it reports that `blog_post` is not configured, check the same DB and provider
 settings first.
 
+To smoke a specific host-supplied blueprint, pass a JSON file that normalizes to
+exactly one blog blueprint:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --blog-blueprint-json ./blog-blueprint.json \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+Minimal `blog-blueprint.json`:
+
+```json
+{
+  "title": "FAQ gaps for onboarding tickets",
+  "sections": [
+    {
+      "id": "onboarding-gaps",
+      "heading": "Where onboarding tickets repeat",
+      "data_summary": "Setup questions repeat across recent support tickets."
+    }
+  ],
+  "data_context": {
+    "audience": "small support team"
+  }
+}
+```
+
 CFPB complaint narratives are the public support-ticket-like smoke path. Use
 them when the host needs a non-review source before wiring CRM notes, call
 transcripts, support tickets, or case exports. The exporter keeps only rows

--- a/plans/PR-Content-Ops-Blog-Blueprint-Json-Smoke.md
+++ b/plans/PR-Content-Ops-Blog-Blueprint-Json-Smoke.md
@@ -1,0 +1,130 @@
+# PR: Content Ops Blog Blueprint JSON Smoke
+
+## Why this slice exists
+
+PR #836 proved the hosted Content Ops `blog_post` path end to end with a
+default seeded blueprint. That proves the pipe works, but operators still cannot
+point the live smoke at a specific blog blueprint file before testing a real
+topic, audience, or content angle.
+
+This slice adds the thinnest operator-controlled proof: pass one custom blog
+blueprint JSON file to the same live smoke, seed it through the existing
+blueprint ingestion contract, execute the matching row, and verify the saved
+draft path still works.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-blueprint-json-smoke
+
+1. Add `--blog-blueprint-json` to
+   `scripts/smoke_content_ops_live_generation.py` for `--output blog_post`.
+2. Reuse `load_blog_blueprints_from_file()` so the smoke shares the existing
+   host blueprint schema instead of hand-parsing a second format.
+3. Require the custom file to normalize to exactly one blueprint for a
+   one-draft smoke run.
+4. Execute with the seeded blueprint's actual `topic_type` and `slug` filters so
+   a custom row cannot be skipped by the smoke-only default filter or displaced
+   by another row in the same topic type.
+5. Preserve the current default seeded blueprint when no custom file is passed.
+6. Add focused tests for the custom JSON path, invalid/multi-row input, and
+   default behavior.
+7. Document the operator command and minimal JSON shape in the README and host
+   runbook.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Blog-Blueprint-Json-Smoke.md` | Plan doc for this slice. |
+| `scripts/smoke_content_ops_live_generation.py` | Add custom blog blueprint JSON loading, validation, and seeded-filter alignment. |
+| `tests/test_smoke_content_ops_live_generation.py` | Cover custom JSON seeding and failure contracts. |
+| `extracted_content_pipeline/blog_blueprint_postgres.py` | Let blueprint reads filter by slug as well as topic type. |
+| `tests/test_extracted_blog_blueprint_postgres.py` | Lock the exact topic type plus slug read predicate. |
+| `extracted_content_pipeline/README.md` | Document the custom blog blueprint smoke option. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Add host-facing runbook guidance for the same option. |
+
+## Mechanism
+
+The existing default blog smoke still works:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+Operators can now pass one custom blueprint file:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_123 \
+  --blog-blueprint-json ./blog-blueprint.json \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+The smoke loads the file with `load_blog_blueprints_from_file()`, applying the
+CLI `target_mode` and the smoke topic type as defaults. It rejects files that
+produce zero or multiple blueprints because this smoke executes `limit=1` and
+should be deterministic.
+
+After saving the blueprint, the smoke updates `payload["inputs"]["filters"]` to
+the saved row's actual `topic_type` and `slug`. The Postgres repository now
+honors both filters, so the live smoke selects the exact row it just seeded
+instead of relying on recency within a topic type.
+
+## Intentional
+
+- This is a file-input smoke, not a new blueprint schema. The existing
+  `blog_blueprint_ingest` adapter remains the source of truth for accepted JSON
+  shapes.
+- The smoke still seeds only one blueprint. Bulk import is already covered by
+  `scripts/load_extracted_blog_blueprints.py`; live generation smoke should stay
+  deterministic.
+- The generated topic can still be overridden with `--input topic=...`. A
+  custom blueprint controls the source row; the per-run topic remains the
+  existing Content Ops input.
+
+## Deferred
+
+- HTTP-level `/content-ops/execute` authenticated smoke remains deferred because
+  it needs a real B2B session and route auth setup.
+- Bulk custom blueprint live smoke is deferred. Use the dedicated import CLI for
+  bulk loading, then run generation separately.
+- Parked hardening: existing `ATLAS-HARDENING.md` items are for the older Atlas
+  blog/deep-dive content pipeline, not this Content Ops `blog_blueprints` smoke
+  path. They were scanned and remain parked.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_live_generation.py -q` -> 8 passed.
+- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py` -> passed.
+- `git diff --check` -> passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed.
+- `bash scripts/check_ascii_python.sh` -> passed.
+- `pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_blog_blueprint_ingest.py -q` -> 21 passed.
+- `bash scripts/local_pr_review.sh origin/main` -> passed.
+- After review fix: `pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_blog_blueprint_postgres.py -q` -> 17 passed.
+- After review fix: `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py extracted_content_pipeline/blog_blueprint_postgres.py tests/test_extracted_blog_blueprint_postgres.py` -> passed.
+- After review fix: `git diff --check` -> passed.
+- After review fix: `bash scripts/validate_extracted_content_pipeline.sh` -> passed.
+- After review fix: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed.
+- After review fix: `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed.
+- After review fix: `bash scripts/check_ascii_python.sh` -> passed.
+- After review fix: `bash scripts/local_pr_review.sh origin/main` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~120 |
+| Smoke script | ~100 |
+| Repository | ~15 |
+| Tests | ~90 |
+| Docs | ~60 |
+| **Total** | **~385** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -111,6 +111,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional JSON object merged over the default inputs.",
     )
     parser.add_argument(
+        "--blog-blueprint-json",
+        type=Path,
+        help=(
+            "Optional custom blog blueprint JSON file for --output blog_post. "
+            "The file must normalize to exactly one blueprint."
+        ),
+    )
+    parser.add_argument(
         "--input",
         action="append",
         default=[],
@@ -350,6 +358,67 @@ def _default_blog_blueprint_payload() -> dict[str, Any]:
     }
 
 
+def _load_single_blog_blueprint_from_file(
+    path: Path,
+    *,
+    target_mode: str,
+) -> tuple[Any, list[dict[str, Any]]]:
+    from extracted_content_pipeline.blog_blueprint_ingest import (  # noqa: PLC0415
+        load_blog_blueprints_from_file,
+    )
+
+    try:
+        loaded = load_blog_blueprints_from_file(
+            path,
+            target_mode=target_mode,
+            topic_type=DEFAULT_BLOG_TOPIC_TYPE,
+        )
+    except OSError as exc:
+        raise ValueError(f"unable to read --blog-blueprint-json: {exc}") from exc
+    except ValueError as exc:
+        raise ValueError(f"invalid --blog-blueprint-json: {exc}") from exc
+    warnings = loaded.warning_dicts()
+    if len(loaded.blueprints) != 1:
+        warning_text = f"; warnings={json.dumps(warnings, sort_keys=True)}" if warnings else ""
+        raise ValueError(
+            "--blog-blueprint-json must load exactly one blueprint; "
+            f"loaded {len(loaded.blueprints)}{warning_text}"
+        )
+    blueprint = loaded.blueprints[0]
+    if str(blueprint.target_mode or "").strip() != target_mode:
+        raise ValueError(
+            "--blog-blueprint-json target_mode "
+            f"{blueprint.target_mode!r} does not match --target-mode {target_mode!r}"
+        )
+    return blueprint, warnings
+
+
+def _align_blog_payload_to_seed(
+    payload: dict[str, Any],
+    seeded_blog_blueprint: Mapping[str, Any],
+) -> None:
+    inputs = payload.get("inputs")
+    if not isinstance(inputs, dict):
+        return
+    topic_type = str(seeded_blog_blueprint.get("topic_type") or "").strip()
+    if topic_type:
+        filters = inputs.get("filters")
+        if not isinstance(filters, dict):
+            filters = {}
+            inputs["filters"] = filters
+        filters["topic_type"] = topic_type
+    slug = str(seeded_blog_blueprint.get("slug") or "").strip()
+    if slug:
+        filters = inputs.get("filters")
+        if not isinstance(filters, dict):
+            filters = {}
+            inputs["filters"] = filters
+        filters["slug"] = slug
+    seeded_topic = str(seeded_blog_blueprint.get("topic") or "").strip()
+    if seeded_topic and inputs.get("topic") == DEFAULT_BLOG_TOPIC:
+        inputs["topic"] = seeded_topic
+
+
 async def _seed_default_blog_blueprint(
     args: argparse.Namespace,
     scope: Any,
@@ -363,22 +432,38 @@ async def _seed_default_blog_blueprint(
     account_slug = _account_slug(args.account_id)
     slug = f"content-ops-blog-live-smoke-{account_slug}"
     target_mode = str(args.target_mode or "vendor_retention").strip() or "vendor_retention"
-    blueprint = BlogBlueprint(
-        target_mode=target_mode,
-        topic_type=DEFAULT_BLOG_TOPIC_TYPE,
-        slug=slug,
-        suggested_title="Support Tickets: FAQ Gaps From 90 Days of Tickets",
-        payload=_default_blog_blueprint_payload(),
-    )
+    custom_path = getattr(args, "blog_blueprint_json", None)
+    custom_warnings: list[dict[str, Any]] = []
+    custom_source = ""
+    if custom_path:
+        blueprint, custom_warnings = _load_single_blog_blueprint_from_file(
+            Path(custom_path),
+            target_mode=target_mode,
+        )
+        custom_source = str(custom_path)
+    else:
+        blueprint = BlogBlueprint(
+            target_mode=target_mode,
+            topic_type=DEFAULT_BLOG_TOPIC_TYPE,
+            slug=slug,
+            suggested_title="Support Tickets: FAQ Gaps From 90 Days of Tickets",
+            payload=_default_blog_blueprint_payload(),
+        )
     saved_ids = await PostgresBlogBlueprintRepository(
         pool=get_db_pool()
     ).save_blueprints((blueprint,), scope=scope)
-    return {
+    seeded = {
         "saved_ids": list(saved_ids),
-        "slug": slug,
-        "target_mode": target_mode,
+        "slug": blueprint.slug,
+        "target_mode": blueprint.target_mode,
         "topic_type": blueprint.topic_type,
+        "topic": blueprint.suggested_title,
     }
+    if custom_source:
+        seeded["source"] = custom_source
+    if custom_warnings:
+        seeded["warnings"] = custom_warnings
+    return seeded
 
 
 async def run_content_ops_live_generation_smoke(
@@ -432,6 +517,7 @@ async def run_content_ops_live_generation_smoke(
             if output == "blog_post":
                 seeder = blog_blueprint_seed_fn or _seed_default_blog_blueprint
                 seeded_blog_blueprint = await seeder(args, scope)
+                _align_blog_payload_to_seed(payload, seeded_blog_blueprint)
             execution_result = await executor(payload, services=services, scope=scope)
             errors.extend(
                 _smoke_errors(

--- a/tests/test_extracted_blog_blueprint_postgres.py
+++ b/tests/test_extracted_blog_blueprint_postgres.py
@@ -13,7 +13,7 @@ Test inventory (8 tests):
    is eligible for re-generation.
 3. `read_blog_blueprints` filters by account_id + target_mode
    + `consumed_at IS NULL` and applies the LIMIT.
-4. `read_blog_blueprints` honors the `topic_type` filter.
+4. `read_blog_blueprints` honors the `topic_type` and `slug` filters.
 5. `read_blog_blueprints` returns merged payload + row metadata
    so the generator sees a self-contained dict.
 6. `read_blog_blueprints` with no rows returns `()`
@@ -169,6 +169,35 @@ async def test_read_blog_blueprints_honors_topic_type_filter() -> None:
     # account_id, target_mode, topic_type, limit
     assert args == ("acct-1", "vendor_alternative", "pricing_pressure", 10)
     assert "topic_type = $3" in pool.fetch_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_read_blog_blueprints_honors_slug_filter_with_topic_type() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresBlogBlueprintRepository(pool=pool)
+
+    await repo.read_blog_blueprints(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_alternative",
+        limit=1,
+        filters={
+            "topic_type": "pricing_pressure",
+            "slug": "acme-pricing-pressure",
+        },
+    )
+
+    args = pool.fetch_calls[0]["args"]
+    assert args == (
+        "acct-1",
+        "vendor_alternative",
+        "pricing_pressure",
+        "acme-pricing-pressure",
+        1,
+    )
+    query = pool.fetch_calls[0]["query"]
+    assert "topic_type = $3" in query
+    assert "slug = $4" in query
 
 
 @pytest.mark.asyncio

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -85,6 +86,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "target_mode": "vendor_retention",
         "env_file": [],
         "input_json": None,
+        "blog_blueprint_json": None,
         "input": [],
         "quality_repair_attempts": 1,
         "no_quality_gates": False,
@@ -178,9 +180,76 @@ async def test_live_generation_smoke_seeds_and_executes_blog_post_through_real_e
     assert call["scope"].account_id == "acct-live-smoke"
     assert call["target_mode"] == "vendor_retention"
     assert call["limit"] == 1
-    assert call["filters"] == {"topic_type": "content_ops_live_smoke"}
+    assert call["filters"] == {
+        "topic_type": "complaint_roundup",
+        "slug": "content-ops-blog-live-smoke-acct-live-smoke",
+    }
     assert call["topic"] == "Support ticket FAQ gaps"
     assert call["quality_gates_enabled"] is True
+
+
+def test_blog_blueprint_json_loader_accepts_one_custom_blueprint(tmp_path: Path) -> None:
+    path = tmp_path / "blueprint.json"
+    path.write_text(
+        json.dumps({
+            "title": "FAQ gaps for onboarding tickets",
+            "sections": [{"id": "onboarding", "heading": "Onboarding gaps"}],
+            "data_context": {"audience": "small support team"},
+        }),
+        encoding="utf-8",
+    )
+
+    blueprint, warnings = smoke._load_single_blog_blueprint_from_file(
+        path,
+        target_mode="vendor_retention",
+    )
+
+    assert warnings == []
+    assert blueprint.target_mode == "vendor_retention"
+    assert blueprint.topic_type == "content_ops_live_smoke"
+    assert blueprint.slug == "faq-gaps-for-onboarding-tickets"
+    assert blueprint.suggested_title == "FAQ gaps for onboarding tickets"
+    assert blueprint.payload["sections"] == [
+        {"id": "onboarding", "heading": "Onboarding gaps"}
+    ]
+
+
+def test_blog_blueprint_json_loader_rejects_multiple_blueprints(tmp_path: Path) -> None:
+    path = tmp_path / "blueprints.json"
+    path.write_text(
+        json.dumps({
+            "blueprints": [
+                {"title": "First blueprint"},
+                {"title": "Second blueprint"},
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must load exactly one blueprint"):
+        smoke._load_single_blog_blueprint_from_file(
+            path,
+            target_mode="vendor_retention",
+        )
+
+
+def test_blog_payload_alignment_uses_seeded_topic_type_and_title() -> None:
+    payload = smoke._payload_from_args(_args(output="blog_post"))
+
+    smoke._align_blog_payload_to_seed(
+        payload,
+        {
+            "topic_type": "custom_smoke_topic",
+            "slug": "faq-gaps-for-onboarding-tickets",
+            "topic": "FAQ gaps for onboarding tickets",
+        },
+    )
+
+    assert payload["inputs"]["filters"] == {
+        "topic_type": "custom_smoke_topic",
+        "slug": "faq-gaps-for-onboarding-tickets",
+    }
+    assert payload["inputs"]["topic"] == "FAQ gaps for onboarding tickets"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Blog-Blueprint-Json-Smoke.md

Adds operator-controlled custom blog blueprint JSON support to the Content Ops live generation smoke. The smoke reuses the existing blog blueprint ingestion adapter, requires exactly one blueprint for deterministic `limit=1` generation, and executes with the seeded row's actual `topic_type` filter.

## Intentional
- Reuses `load_blog_blueprints_from_file()` instead of introducing a second smoke-only blueprint schema.
- Keeps the smoke to one seeded blueprint; bulk loading remains the job of `scripts/load_extracted_blog_blueprints.py`.
- Leaves per-run topic override on the existing `--input topic=...` path while defaulting to the seeded blueprint title when no topic override is supplied.

## Deferred
- HTTP-level authenticated `/content-ops/execute` smoke remains deferred.
- Bulk custom blueprint live smoke remains deferred to the import CLI plus separate generation.

## Parked hardening
- Existing `ATLAS-HARDENING.md` items were scanned and remain parked; they belong to the older Atlas blog/deep-dive pipeline, not this Content Ops smoke path.

## Verification
- `pytest tests/test_smoke_content_ops_live_generation.py -q` -> 8 passed.
- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py` -> passed.
- `git diff --check` -> passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed.
- `bash scripts/check_ascii_python.sh` -> passed.
- `pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_blog_blueprint_ingest.py -q` -> 21 passed.
- `bash scripts/local_pr_review.sh origin/main` -> passed.

## Diff size
5 files, +329 / -11
