### PR TITLE
Fix migration dry-run skip summary

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -35,13 +35,4 @@ register under `docs/technical-debt/`.
 > kept separate to avoid append-collisions with the concurrent
 > content-ops-station sessions. Scan that file too when working those lanes.
 
-## 2026-05-23
-
-### Extracted migration dry-run reports applied migrations as pending
-- File/location: `extracted_content_pipeline/storage/migration_runner.py` and `scripts/run_extracted_content_pipeline_migrations.py --dry-run --json`
-- Description: After the local extracted migrations were already applied, dry-run still reported `applied_count=28` with `status="dry_run"` while the actual non-dry run reported `applied_count=0`, `skipped_count=28`.
-- Why it matters: Operators can misread a dry-run as pending database work even when the migration table says the database is already current.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/faq-generator-io-tests
-- Found during: PR-Content-Ops-FAQ-Lifecycle-DB-1000-Run
+No parked items in the root hardening queue.

--- a/extracted_content_pipeline/storage/migration_runner.py
+++ b/extracted_content_pipeline/storage/migration_runner.py
@@ -85,7 +85,11 @@ async def apply_content_pipeline_migrations(
     async def _run(conn: Any) -> MigrationRunResult:
         if not dry_run:
             await _ensure_migration_table(conn, table)
-        applied_versions = await _read_applied_versions(conn, table, dry_run=dry_run)
+        applied_versions = await _read_applied_versions(
+            conn,
+            table,
+            missing_table_ok=dry_run,
+        )
         applied: list[MigrationRunEntry] = []
         skipped: list[MigrationRunEntry] = []
         for migration in migrations:
@@ -155,11 +159,27 @@ def _requires_autocommit(sql: str) -> bool:
     return bool(_NON_TRANSACTIONAL_SQL_RE.search(sql))
 
 
-async def _read_applied_versions(conn: Any, table: str, *, dry_run: bool) -> set[str]:
-    if dry_run:
-        return set()
-    rows = await conn.fetch(f"SELECT version FROM {table}")
+async def _read_applied_versions(
+    conn: Any,
+    table: str,
+    *,
+    missing_table_ok: bool = False,
+) -> set[str]:
+    try:
+        rows = await conn.fetch(f"SELECT version FROM {table}")
+    except Exception as exc:
+        if missing_table_ok and _is_undefined_table_error(exc):
+            return set()
+        raise
     return {str(_row_value(row, "version")) for row in rows if _row_value(row, "version")}
+
+
+def _is_undefined_table_error(exc: BaseException) -> bool:
+    if str(getattr(exc, "sqlstate", "") or "") == "42P01":
+        return True
+    if str(getattr(exc, "pgcode", "") or "") == "42P01":
+        return True
+    return exc.__class__.__name__ == "UndefinedTableError"
 
 
 async def _with_connection(

--- a/plans/PR-Content-Ops-Migration-Dry-Run-Skip-Summary.md
+++ b/plans/PR-Content-Ops-Migration-Dry-Run-Skip-Summary.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-Migration-Dry-Run-Skip-Summary
+
+## Why this slice exists
+
+The 1,000-row FAQ lifecycle database validation surfaced a misleading migration
+dry-run result: after the extracted Content Ops migrations were already applied,
+`run_extracted_content_pipeline_migrations.py --dry-run --json` still reported
+28 `dry_run` entries under `applied` and 0 skipped entries. The actual
+non-dry run correctly reported 0 applied and 28 skipped.
+
+That is a source-level correctness issue in the migration runner. Dry-run should
+not mutate the database, but it should still inspect the migration table when it
+exists so operators can distinguish pending migrations from already-applied
+ones.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Make dry-run read applied migration versions when the migration table exists.
+2. Keep first-run dry-run behavior safe when the migration table does not exist:
+   report all packaged migrations as pending without creating the table.
+3. Add regression tests for dry-run skipped/applied reporting.
+4. Remove the drained hardening item from `HARDENING.md`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Migration-Dry-Run-Skip-Summary.md`
+- `extracted_content_pipeline/storage/migration_runner.py`
+- `tests/test_extracted_content_pipeline_migration_runner.py`
+- `HARDENING.md`
+
+## Mechanism
+
+`apply_content_pipeline_migrations(..., dry_run=True)` will continue to avoid
+`_ensure_migration_table(...)`, migration SQL, and migration-record writes.
+Instead of returning an empty applied-version set, it will call
+`_read_applied_versions(..., missing_table_ok=True)`.
+
+If the migration table exists, dry-run can populate `skipped` for already
+applied versions and `applied` with `status="dry_run"` for pending versions. If
+the migration table does not exist yet, an undefined-table error is treated as
+an empty applied-version set so first-run dry-runs still report all migrations as
+pending.
+
+## Intentional
+
+- Dry-run still does not create tables, run migration SQL, or insert migration
+  records.
+- The missing-table fallback is narrow: only undefined-table errors are treated
+  as "no applied migrations yet"; other database errors still surface.
+- No CLI output schema change is needed. Existing `applied`, `skipped`,
+  `applied_count`, and `skipped_count` fields become accurate in dry-run mode.
+
+## Deferred
+
+- No new hardening is parked for this slice. The previous dry-run hardening item
+  is drained by this PR.
+- A containerized integration test against real Postgres remains deferred; the
+  fixture tests lock the runner contract without requiring a local DB in CI.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_content_pipeline_migration_runner.py -q` (11 passed)
+- Passed: local DB dry-run check after fix reported `applied_count=0`, `skipped_count=28`.
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1836 passed, 1 skipped)
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Migration runner | ~25 |
+| Tests | ~65 |
+| Hardening cleanup | ~10 |
+| **Total** | **~175** |

--- a/tests/test_extracted_content_pipeline_migration_runner.py
+++ b/tests/test_extracted_content_pipeline_migration_runner.py
@@ -41,8 +41,9 @@ class _Transaction:
 
 
 class _Conn:
-    def __init__(self, *, applied_versions=None) -> None:
+    def __init__(self, *, applied_versions=None, fetch_error: Exception | None = None) -> None:
         self.applied_versions = set(applied_versions or ())
+        self.fetch_error = fetch_error
         self.executed: list[tuple[str, tuple[object, ...]]] = []
         self.transactions = 0
 
@@ -54,6 +55,8 @@ class _Conn:
 
     async def fetch(self, query):
         self.executed.append((str(query), ()))
+        if self.fetch_error is not None:
+            raise self.fetch_error
         return [{"version": version} for version in sorted(self.applied_versions)]
 
     def transaction(self):
@@ -77,6 +80,10 @@ class _Pool:
 
     def acquire(self):
         return _Acquire(self.conn)
+
+
+class _UndefinedTableError(Exception):
+    sqlstate = "42P01"
 
 
 def _write_migration(root: Path, name: str, sql: str) -> None:
@@ -164,7 +171,52 @@ async def test_apply_content_pipeline_migrations_dry_run_does_not_execute_sql(tm
 
     assert result.dry_run is True
     assert [entry.status for entry in result.applied] == ["dry_run"]
-    assert conn.executed == []
+    assert len(conn.executed) == 1
+    assert "SELECT version FROM content_pipeline_schema_migrations" in conn.executed[0][0]
+    assert "CREATE TABLE example_one" not in "\n".join(query for query, _ in conn.executed)
+    assert conn.transactions == 0
+
+
+@pytest.mark.asyncio
+async def test_apply_content_pipeline_migrations_dry_run_reports_applied_versions_as_skipped(tmp_path) -> None:
+    _write_migration(tmp_path, "001_first.sql", "SELECT 1;")
+    _write_migration(tmp_path, "002_second.sql", "SELECT 2;")
+    conn = _Conn(applied_versions={"001_first.sql"})
+
+    result = await apply_content_pipeline_migrations(
+        conn,
+        migrations_dir=tmp_path,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert [entry.version for entry in result.skipped] == ["001_first.sql"]
+    assert [entry.status for entry in result.skipped] == ["skipped"]
+    assert [entry.version for entry in result.applied] == ["002_second.sql"]
+    assert [entry.status for entry in result.applied] == ["dry_run"]
+    executed_sql = "\n".join(query for query, _ in conn.executed)
+    assert "SELECT 1;" not in executed_sql
+    assert "SELECT 2;" not in executed_sql
+    assert "INSERT INTO content_pipeline_schema_migrations" not in executed_sql
+    assert conn.transactions == 0
+
+
+@pytest.mark.asyncio
+async def test_apply_content_pipeline_migrations_dry_run_treats_missing_table_as_no_applied_versions(tmp_path) -> None:
+    _write_migration(tmp_path, "001_first.sql", "SELECT 1;")
+    conn = _Conn(fetch_error=_UndefinedTableError("missing migration table"))
+
+    result = await apply_content_pipeline_migrations(
+        conn,
+        migrations_dir=tmp_path,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.skipped == ()
+    assert [entry.version for entry in result.applied] == ["001_first.sql"]
+    assert [entry.status for entry in result.applied] == ["dry_run"]
+    assert conn.transactions == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Migration-Dry-Run-Skip-Summary.md

The 1,000-row FAQ lifecycle DB run surfaced that migration dry-run output reported already-applied migrations as pending. This fixes the runner at the source: dry-run now reads the migration table when it exists, reports applied versions under `skipped`, and still avoids schema writes, migration SQL, and migration-record inserts.

## Intentional
- Dry-run now performs a read-only migration-table query so `applied_count` / `skipped_count` are accurate.
- Missing migration tables are treated as no applied versions only for dry-run undefined-table errors.
- CLI JSON shape is unchanged; existing fields become accurate in dry-run mode.

## Deferred
- Containerized Postgres integration coverage remains deferred; fixture coverage locks the runner contract for this slice.
- No hardening remains parked for this item; the previous `HARDENING.md` entry is drained.

## Verification
- `pytest tests/test_extracted_content_pipeline_migration_runner.py -q` (11 passed)
- Local DB dry-run check after fix reported `applied_count=0`, `skipped_count=28`
- `scripts/run_extracted_pipeline_checks.sh` (1836 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
4 files, +157 / -17
