### PR TITLE
Align blog GEO repair and prompt guidance

### DIFF
--- a/atlas_brain/skills/digest/blog_post_generation.md
+++ b/atlas_brain/skills/digest/blog_post_generation.md
@@ -187,6 +187,7 @@ Start each section with a direct answer in the first 40-60 words. AI engines ext
 
 ### Self-Contained Sections
 Each H2 section should be independently citable (200-500 words). An AI engine should be able to extract any single section and present it as a complete answer without needing context from other sections.
+At least two H2 sections must start with a 40-120 word answer paragraph that names the exact `target_keyword` or clearest named subject. This makes the section understandable when it is quoted by itself.
 
 ### Question-Format H2s
 Where natural, phrase H2 headings as questions that match real search queries. Example: "What Are the Most Common Logitech Mouse Problems?" rather than "Logitech Complaint Analysis."
@@ -199,6 +200,7 @@ Include date references and "as of [month year]" anchoring in key claims. AI eng
 
 ### Entity Clarity
 Use full brand/product names on first mention in each section, not abbreviations. AI engines need unambiguous entity references to cite correctly.
+When `target_keyword` is provided, include that exact phrase in the display `title` and repeat it naturally in the first answer paragraph. If no `target_keyword` is provided, put the clearest named subject from the topic, category, product, or vendor in the title or first answer paragraph. The subject should be clear in the opening 40-60 words so readers and answer engines immediately know what the article is about.
 
 ### Structured Comparisons
 Use HTML tables for any 2+ item comparison. AI engines extract tabular data more reliably than prose comparisons.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -49,6 +49,7 @@ class BlogPostGenerationConfig:
     temperature: float = 0.3
     quality_policy: QualityPolicy | None = None
     quality_gates_enabled: bool = True
+    quality_repair_attempts: int = 2
     parse_retry_attempts: int = 1
     parse_retry_response_excerpt_chars: int = 800
 
@@ -144,17 +145,95 @@ def _blog_quality_repair_user_prompt(
     previous_json: str,
 ) -> str:
     blocker_text = "\n".join(f"- {item}" for item in blockers)
+    guidance = _blog_quality_repair_guidance(blockers)
     return (
         f"{base_prompt}\n\n"
         "The previous blog JSON parsed, but it failed the blog quality gate.\n"
         "Quality blockers:\n"
         f"{blocker_text}\n\n"
+        f"Repair instructions:\n{guidance}\n\n"
         "Return the full blog JSON object again. Keep the valid fields that already "
         "worked, but revise the draft so it fixes every blocker above. Do not return "
         "commentary, markdown fences, or partial JSON.\n\n"
         "Previous parsed JSON:\n"
         f"{previous_json}"
     )
+
+
+def _blog_quality_repair_guidance(blockers: Sequence[str]) -> str:
+    """Translate gate blocker codes into concrete blog-edit instructions."""
+
+    instructions: list[str] = []
+    for blocker in blockers:
+        code = str(blocker or "").strip()
+        if code.startswith("content_too_short:"):
+            instructions.append(
+                "- Expand `content` to at least 1500 words and keep it in the "
+                "1500-2200 word range. Add useful H2 sections and supporting "
+                "paragraphs instead of filler."
+            )
+        elif code.startswith("seo_title_too_long:"):
+            instructions.append(
+                "- Shorten `seo_title` to 60 characters or fewer while keeping "
+                "the target keyword near the front."
+            )
+        elif code == "geo_entity_clarity_missing":
+            instructions.append(
+                "- Update the display `title` to include the exact current "
+                "`target_keyword` string from the previous JSON. Also repeat "
+                "that exact phrase naturally in the first 40-60 words of `content`."
+            )
+        elif code == "geo_citable_section_structure_missing":
+            instructions.append(
+                "- Make at least two H2 sections independently citable. Each of "
+                "those sections must start with a 40-120 word answer paragraph "
+                "that includes the exact `target_keyword` or clearest named subject."
+            )
+        elif code == "geo_citation_safety_failed":
+            instructions.append(
+                "- Remove unresolved placeholders, placeholder links, unknown chart "
+                "placeholders, and unsupported claims. Keep only claims grounded in "
+                "the blueprint data, source wording, or visible chart IDs."
+            )
+    if not instructions:
+        instructions.append(
+            "- Fix each blocker directly while preserving the required blog JSON "
+            "schema and the factual constraints from the blueprint."
+        )
+    return "\n".join(dict.fromkeys(instructions))
+
+
+def _normalize_blog_metadata(
+    parsed: Mapping[str, Any],
+    *,
+    quality_policy: QualityPolicy | None,
+) -> dict[str, Any]:
+    """Apply deterministic metadata limits before quality validation."""
+
+    normalized = dict(parsed)
+    seo_title = str(normalized.get("seo_title") or "").strip()
+    seo_title_max = 60
+    if quality_policy is not None:
+        raw_max = quality_policy.thresholds.get("seo_title_max_chars")
+        if isinstance(raw_max, (int, float)) and not isinstance(raw_max, bool):
+            seo_title_max = int(raw_max)
+    if seo_title and len(seo_title) > seo_title_max:
+        normalized["seo_title"] = _truncate_text_at_word_boundary(
+            seo_title,
+            max_chars=seo_title_max,
+        )
+    return normalized
+
+
+def _truncate_text_at_word_boundary(value: str, *, max_chars: int) -> str:
+    limit = max(1, int(max_chars))
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    trimmed = text[:limit].rstrip()
+    if " " in trimmed:
+        trimmed = trimmed.rsplit(" ", 1)[0].rstrip()
+    return trimmed or text[:limit].rstrip()
 
 
 class BlogPostGenerationService:
@@ -210,6 +289,7 @@ class BlogPostGenerationService:
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        quality_repair_attempts: int | None = None,
         topic: str | None = None,
     ) -> BlogPostGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
@@ -240,6 +320,14 @@ class BlogPostGenerationService:
             if quality_gates_enabled is None
             else bool(quality_gates_enabled)
         )
+        resolved_quality_repair_attempts = (
+            self._config.quality_repair_attempts
+            if quality_repair_attempts is None
+            else int(quality_repair_attempts)
+        )
+        if not resolved_quality_gates_enabled:
+            resolved_quality_repair_attempts = 0
+        resolved_quality_repair_attempts = max(0, resolved_quality_repair_attempts)
         # PR-Blog-Topic-Per-Call: operator-supplied topic for this run.
         # Empty string when None so prompt substitution is a clean no-op.
         resolved_topic = (topic or "").strip()
@@ -282,41 +370,63 @@ class BlogPostGenerationService:
                 skipped += 1
                 errors.append({"blueprint_id": blueprint_id, "reason": "unparseable_response"})
                 continue
+            parsed = _normalize_blog_metadata(
+                parsed,
+                quality_policy=self._config.quality_policy,
+            )
             quality = self._quality_check(
                 parsed,
                 blueprint=blueprint,
                 quality_gates_enabled=resolved_quality_gates_enabled,
             )
             if not quality["passed"]:
-                try:
-                    repaired = await self._repair_quality_once(
-                        prompt_template,
-                        parsed=parsed,
-                        quality=quality,
-                        blueprint=blueprint,
-                        target_mode=target_mode,
-                        temperature=resolved_temperature,
-                        max_tokens=resolved_max_tokens,
-                        parse_retry_attempts=resolved_parse_retry_attempts,
-                        topic=resolved_topic,
-                    )
-                except Exception as exc:
-                    skipped += 1
-                    errors.append({
-                        "blueprint_id": blueprint_id,
-                        "reason": "quality_repair_failed",
-                        "error": str(exc),
-                    })
-                    continue
-                if repaired:
-                    repaired_quality = self._quality_check(
+                repair_failed = False
+                for repair_attempt_no in range(1, resolved_quality_repair_attempts + 1):
+                    try:
+                        repaired = await self._repair_quality_once(
+                            prompt_template,
+                            parsed=parsed,
+                            quality=quality,
+                            blueprint=blueprint,
+                            target_mode=target_mode,
+                            temperature=resolved_temperature,
+                            max_tokens=resolved_max_tokens,
+                            quality_repair_attempt_no=repair_attempt_no,
+                            topic=resolved_topic,
+                        )
+                    except Exception as exc:
+                        skipped += 1
+                        errors.append({
+                            "blueprint_id": blueprint_id,
+                            "reason": "quality_repair_failed",
+                            "error": str(exc),
+                            "error_type": type(exc).__name__,
+                        })
+                        repair_failed = True
+                        break
+                    if not repaired:
+                        skipped += 1
+                        errors.append({
+                            "blueprint_id": blueprint_id,
+                            "reason": "quality_repair_unparseable",
+                            "blockers": quality["blockers"],
+                            "quality_repair_attempt_no": repair_attempt_no,
+                        })
+                        repair_failed = True
+                        break
+                    parsed = _normalize_blog_metadata(
                         repaired,
+                        quality_policy=self._config.quality_policy,
+                    )
+                    quality = self._quality_check(
+                        parsed,
                         blueprint=blueprint,
                         quality_gates_enabled=resolved_quality_gates_enabled,
                     )
-                    quality = repaired_quality
-                    if repaired_quality["passed"]:
-                        parsed = repaired
+                    if quality["passed"]:
+                        break
+                if repair_failed:
+                    continue
                 if not quality["passed"]:
                     skipped += 1
                     errors.append({
@@ -445,16 +555,13 @@ class BlogPostGenerationService:
         target_mode: str,
         temperature: float,
         max_tokens: int,
-        parse_retry_attempts: int,
+        quality_repair_attempt_no: int,
         topic: str = "",
     ) -> dict[str, Any] | None:
         blockers = tuple(str(item) for item in quality.get("blockers") or () if item)
         if not blockers:
             return None
         parse_attempts_used = int(parsed.get("_parse_attempts") or 1)
-        retries_used_for_parsing = max(0, parse_attempts_used - 1)
-        if retries_used_for_parsing >= max(0, int(parse_retry_attempts or 0)):
-            return None
         system_prompt, base_user_prompt = _blog_generation_prompts(
             prompt_template,
             blueprint=blueprint,
@@ -479,8 +586,8 @@ class BlogPostGenerationService:
                 "blueprint_id": _blueprint_id(blueprint),
                 "skill_name": self._config.skill_name,
                 "asset_type": "blog_post",
-                "attempt_no": parse_attempts_used + 1,
-                "quality_repair_attempt_no": 1,
+                "attempt_no": parse_attempts_used + quality_repair_attempt_no,
+                "quality_repair_attempt_no": quality_repair_attempt_no,
             },
         )
         repaired = parse_blog_post_response(response.content)

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -511,6 +511,7 @@ async def _dispatch_blog_post(
             step.config, "parse_retry_response_excerpt_chars"
         ),
         quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
+        quality_repair_attempts=_step_config_int(step.config, "quality_repair_attempts"),
         topic=_step_config_text(step.config, "topic"),
     )
 

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -374,6 +374,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "max_tokens": config.max_tokens,
                 "temperature": config.temperature,
                 "quality_gates_enabled": request.require_quality_gates,
+                "quality_repair_attempts": config.quality_repair_attempts,
                 "parse_retry_attempts": config.parse_retry_attempts,
                 "parse_retry_response_excerpt_chars": config.parse_retry_response_excerpt_chars,
                 "topic": request.inputs.get("topic"),

--- a/extracted_content_pipeline/skills/digest/blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/blog_post_generation.md
@@ -187,6 +187,7 @@ Start each section with a direct answer in the first 40-60 words. AI engines ext
 
 ### Self-Contained Sections
 Each H2 section should be independently citable (200-500 words). An AI engine should be able to extract any single section and present it as a complete answer without needing context from other sections.
+At least two H2 sections must start with a 40-120 word answer paragraph that names the exact `target_keyword` or clearest named subject. This makes the section understandable when it is quoted by itself.
 
 ### Question-Format H2s
 Where natural, phrase H2 headings as questions that match real search queries. Example: "What Are the Most Common Logitech Mouse Problems?" rather than "Logitech Complaint Analysis."
@@ -199,6 +200,7 @@ Include date references and "as of [month year]" anchoring in key claims. AI eng
 
 ### Entity Clarity
 Use full brand/product names on first mention in each section, not abbreviations. AI engines need unambiguous entity references to cite correctly.
+When `target_keyword` is provided, include that exact phrase in the display `title` and repeat it naturally in the first answer paragraph. If no `target_keyword` is provided, put the clearest named subject from the topic, category, product, or vendor in the title or first answer paragraph. The subject should be clear in the opening 40-60 words so readers and answer engines immediately know what the article is about.
 
 ### Structured Comparisons
 Use HTML tables for any 2+ item comparison. AI engines extract tabular data more reliably than prose comparisons.

--- a/plans/PR-Blog-GEO-Entity-Prompt-Alignment.md
+++ b/plans/PR-Blog-GEO-Entity-Prompt-Alignment.md
@@ -1,0 +1,106 @@
+# PR: Blog GEO Entity Prompt Alignment
+
+## Why this slice exists
+
+The custom blog live smoke proved the seeded blueprint path, LLM routing, and
+draft persistence path, but the draft failed the blog quality gate with
+`geo_entity_clarity_missing`. The generated article was coherent, but it did
+not mention the exact target keyword or named subject early enough for the
+existing GEO entity-clarity validator, which checks the title plus the opening
+body window.
+
+This slice aligns the blog-generation and quality-repair path with the existing
+validator contract instead of weakening the gate.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-geo-prompt-alignment
+
+1. Require exact `target_keyword` / subject clarity in the blog prompt.
+2. Add targeted repair guidance for observed SEO/AEO/GEO blocker codes.
+3. Decouple blog quality-repair attempts from parse-retry attempts.
+4. Normalize overlong SEO titles before validation.
+5. Thread blog repair-attempt count through plan and executor config.
+6. Sync the extracted Content Ops skill copy and add focused tests.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-GEO-Entity-Prompt-Alignment.md` | Plan doc for this slice. |
+| `atlas_brain/skills/digest/blog_post_generation.md` | Source prompt guidance for early subject clarity. |
+| `extracted_content_pipeline/skills/digest/blog_post_generation.md` | Synced extracted prompt copy. |
+| `extracted_content_pipeline/blog_generation.py` | Targeted quality-repair guidance, SEO title normalization, and multiple repair attempts for gate blocker codes. |
+| `extracted_content_pipeline/generation_plan.py` | Include blog repair-attempt count in the step config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Pass blog repair-attempt count into the service. |
+| `tests/test_atlas_content_ops_infrastructure.py` | Regression coverage for the host-shipped prompt text. |
+| `tests/test_extracted_blog_generation.py` | Regression coverage for the quality-repair prompt guidance. |
+| `tests/test_extracted_content_generation_plan.py` | Regression coverage for the blog step config. |
+| `tests/test_extracted_content_ops_execution.py` | Regression coverage for executor dispatch wiring. |
+
+## Mechanism
+
+The blog GEO validator checks the display title plus opening body window for
+topic terms from `target_keyword` and blueprint context. The prompt now tells
+the model to put the exact phrase there, and the real-disk skill-store test pins
+that instruction.
+
+The repair prompt expands known blocker codes into concrete edits while keeping
+the raw blocker list for auditability. Blog generation now has its own
+`quality_repair_attempts` config, emits it in the plan, and passes it through
+execution so a blocker introduced by the first repair can receive a second
+repair. Mechanical SEO-title length misses are trimmed before validation;
+content-level blockers stay in the LLM repair path.
+
+## Intentional
+
+- No quality-gate code change. The gate is doing the right source-level check;
+  the generation and repair prompts were underspecified.
+- No live Sonnet test. Future live validation will use the Haiku override file
+  so testing does not spend against the expensive model family.
+- No broad prompt rewrite. This is a narrow alignment with the failures observed
+  in the custom blog smoke.
+- The blog repair-attempt default is 2. That gives the service one follow-up
+  after the initial repair without opening an unbounded retry loop.
+- SEO title normalization is deterministic because the quality gate already
+  enforces a hard character maximum; this avoids spending an LLM repair attempt
+  on a one-character title miss.
+
+## Deferred
+
+- Haiku live smokes on this branch exposed the blocker sequence fixed here:
+  short content / overlong SEO title / missing entity clarity, then missing
+  citable H2 structure, then citation-safety failure after the one-attempt loop.
+  The final live run still did not save a draft; further debugging should
+  inspect the failed candidate body instead of continuing blind prompt
+  iteration.
+- Parked hardening: existing `ATLAS-HARDENING.md` items are for the older
+  deep-dive blog lane and do not touch this Content Ops blog prompt/readiness
+  contract. They remain parked.
+
+## Verification
+
+- Haiku live smokes with `/tmp/atlas-haiku-override.env` -> no saved draft yet; blockers progressed through the prompt/repair gaps listed in Deferred.
+- pytest `tests/test_extracted_blog_generation.py` `tests/test_atlas_content_ops_infrastructure.py` `tests/test_extracted_content_generation_plan.py` `tests/test_extracted_content_ops_execution.py` -q -> 136 passed.
+- bash `extracted/_shared/scripts/sync_extracted.sh` extracted_content_pipeline -> refreshed 43 mapped files.
+- bash `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- python `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` extracted_content_pipeline -> passed.
+- python `scripts/audit_extracted_standalone.py` --fail-on-debt -> passed.
+- bash `scripts/check_ascii_python.sh` -> passed.
+- bash `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~105 |
+| Prompt sync | ~8 |
+| Repair prompt/loop | ~175 |
+| Plan/dispatch wiring | ~6 |
+| Tests | ~155 |
+| **Total** | **~449** |
+
+This is over the 400 LOC soft cap because the live-smoke repair path and PR
+review both exposed source-level integration issues in the same loop:
+prompt/gate alignment, bounded multi-attempt repair, deterministic metadata
+normalization, dispatch wiring, and debuggable repair-failure attribution.

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -62,6 +62,18 @@ def test_host_skill_store_returns_existing_skill_content() -> None:
     assert len(prompt) > 0
 
 
+def test_blog_generation_prompt_requires_early_entity_clarity() -> None:
+    """Blog prompt stays aligned with the GEO entity-clarity gate."""
+
+    store = build_content_ops_skill_store()
+    prompt = store.get_prompt("digest/blog_post_generation")
+    assert isinstance(prompt, str)
+    assert "include that exact phrase in the display `title`" in prompt
+    assert "repeat it naturally in the first answer paragraph" in prompt
+    assert "At least two H2 sections must start with a 40-120 word answer paragraph" in prompt
+    assert "opening 40-60 words" in prompt
+
+
 def test_host_skill_store_falls_back_to_packaged_skills() -> None:
     """Codex P2 fix: skills that the extracted services depend on
     by default (e.g. `digest/landing_page_generation`,

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -7,6 +7,8 @@ import pytest
 from extracted_content_pipeline.blog_generation import (
     BlogPostGenerationConfig,
     BlogPostGenerationService,
+    _blog_quality_repair_guidance,
+    _normalize_blog_metadata,
     parse_blog_post_response,
 )
 from extracted_content_pipeline.blog_ports import BlogPostDraft
@@ -226,6 +228,27 @@ def test_parse_blog_post_response_returns_none_when_required_fields_missing() ->
     assert parsed["content"] == ""
 
 
+def test_normalize_blog_metadata_trims_overlong_seo_title() -> None:
+    parsed = json.loads(_valid_blog_json(seo_title="A" * 61))
+
+    normalized = _normalize_blog_metadata(parsed, quality_policy=None)
+
+    assert len(normalized["seo_title"]) == 60
+    assert normalized["seo_title"] == "A" * 60
+
+
+def test_blog_quality_repair_guidance_explains_citation_safety() -> None:
+    guidance = _blog_quality_repair_guidance([
+        "seo_title_too_long:61_chars_max_60",
+        "geo_citation_safety_failed",
+    ])
+
+    assert "Shorten `seo_title` to 60 characters or fewer" in guidance
+    assert "Remove unresolved placeholders" in guidance
+    assert "unsupported claims" in guidance
+    assert "visible chart IDs" in guidance
+
+
 @pytest.mark.asyncio
 async def test_generate_persists_blog_drafts_via_ports() -> None:
     service, blueprints, blog_posts, llm, skills = _service()
@@ -273,6 +296,7 @@ async def test_generate_blocks_low_quality_posts_without_saving() -> None:
         responses=[_valid_blog_json(content="Too short.")],
         config=BlogPostGenerationConfig(
             parse_retry_attempts=0,
+            quality_repair_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 70},
@@ -303,6 +327,7 @@ async def test_generate_blocks_missing_seo_aeo_fields_without_saving() -> None:
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
             parse_retry_attempts=0,
+            quality_repair_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
@@ -337,6 +362,7 @@ async def test_generate_blocks_missing_geo_contract_without_saving() -> None:
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
             parse_retry_attempts=0,
+            quality_repair_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
@@ -392,7 +418,81 @@ async def test_generate_repairs_geo_quality_block_with_retry_budget() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_does_not_repair_quality_block_without_retry_budget() -> None:
+async def test_generate_quality_repair_prompt_explains_known_blockers() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["title"] = "Buyer Shortlists Are Changing"
+    payload["seo_title"] = "A" * 61
+    payload["content"] = (
+        "## Why are buyer shortlists changing?\n\n"
+        "Buyers are comparing renewal costs before they commit to another contract."
+    )
+    service, _blueprints, _blog_posts, llm, _skills = _service(
+        responses=[json.dumps(payload), _valid_blog_json()],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            )
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 1
+    assert len(llm.calls) == 2
+    retry_prompt = llm.calls[1]["messages"][1].content
+    assert "Quality blockers:" in retry_prompt
+    assert "content_too_short:" in retry_prompt
+    assert "geo_entity_clarity_missing" in retry_prompt
+    assert "geo_citable_section_structure_missing" in retry_prompt
+    assert "Expand `content` to at least 1500 words" in retry_prompt
+    assert "include the exact current `target_keyword` string" in retry_prompt
+    assert "repeat that exact phrase naturally" in retry_prompt
+    assert "Make at least two H2 sections independently citable" in retry_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_multiple_quality_repair_attempts() -> None:
+    first_payload = json.loads(_valid_blog_json())
+    first_payload["content"] = (
+        "## Why are buyer shortlists changing?\n\n"
+        "Buyers are comparing renewal costs before they commit to another contract."
+    )
+    second_payload = json.loads(_valid_blog_json())
+    second_payload["title"] = "Buyer Shortlist Changes"
+    second_payload["content"] = (
+        _valid_content()
+        .replace("HubSpot pricing pressure", "Buyer renewal pressure")
+        .replace("HubSpot pricing evidence", "Buyer renewal evidence")
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        responses=[
+            json.dumps(first_payload),
+            json.dumps(second_payload),
+            _valid_blog_json(),
+        ],
+        config=BlogPostGenerationConfig(
+            quality_repair_attempts=2,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 1
+    assert result.errors == ()
+    assert len(llm.calls) == 3
+    assert llm.calls[1]["metadata"]["quality_repair_attempt_no"] == 1
+    assert llm.calls[2]["metadata"]["quality_repair_attempt_no"] == 2
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["generation_quality_repair_attempts"] == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_repair_quality_block_without_repair_budget() -> None:
     payload = json.loads(_valid_blog_json())
     payload["content"] = (
         "## How is HubSpot pricing pressure changing shortlists?\n\n"
@@ -403,6 +503,7 @@ async def test_generate_does_not_repair_quality_block_without_retry_budget() -> 
         responses=[json.dumps(payload), _valid_blog_json()],
         config=BlogPostGenerationConfig(
             parse_retry_attempts=0,
+            quality_repair_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
@@ -416,6 +517,36 @@ async def test_generate_does_not_repair_quality_block_without_retry_budget() -> 
     assert result.skipped == 1
     assert result.errors[0]["reason"] == "quality_blocked"
     assert len(llm.calls) == 1
+    assert blog_posts.saved == []
+
+
+@pytest.mark.asyncio
+async def test_generate_reports_unparseable_quality_repair_response() -> None:
+    payload = json.loads(_valid_blog_json())
+    payload["content"] = (
+        "## How is HubSpot pricing pressure changing shortlists?\n\n"
+        "HubSpot pricing pressure changes shortlists because buyers compare "
+        "renewal terms before they commit to another contract."
+    )
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        responses=[json.dumps(payload), "not valid repair json"],
+        config=BlogPostGenerationConfig(
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
+        ),
+    )
+
+    result = await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["blueprint_id"] == "bp-1"
+    assert result.errors[0]["reason"] == "quality_repair_unparseable"
+    assert "geo_citable_section_structure_missing" in result.errors[0]["blockers"]
+    assert result.errors[0]["quality_repair_attempt_no"] == 1
+    assert len(llm.calls) == 2
     assert blog_posts.saved == []
 
 
@@ -454,6 +585,7 @@ async def test_generate_quality_repair_failure_skips_one_blueprint_not_batch() -
         "blueprint_id": "bp-1",
         "reason": "quality_repair_failed",
         "error": "repair backend timeout",
+        "error_type": "RuntimeError",
     },)
     assert len(llm.calls) == 3
     assert blog_posts.saved[0]["drafts"][0].slug == "hubspot-pricing-pressure-2"
@@ -467,6 +599,7 @@ async def test_generate_routes_missing_content_to_quality_blocked_not_unparseabl
         responses=[json.dumps(payload)],
         config=BlogPostGenerationConfig(
             parse_retry_attempts=0,
+            quality_repair_attempts=0,
             quality_policy=QualityPolicy(
                 name="blog_post",
                 thresholds={"min_words": 20, "target_words": 20, "pass_score": 70},
@@ -578,6 +711,10 @@ async def test_generate_per_call_llm_tuning_overrides_win_over_construction_conf
             temperature=0.3,
             max_tokens=4096,
             parse_retry_attempts=0,
+            quality_policy=QualityPolicy(
+                name="blog_post",
+                thresholds={"min_words": 20, "target_words": 20, "pass_score": 0},
+            ),
         ),
     )
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -296,6 +296,7 @@ def test_plan_maps_blog_to_blog_generation_service():
         "max_tokens": 4096,
         "temperature": 0.3,
         "quality_gates_enabled": True,
+        "quality_repair_attempts": 2,
         "parse_retry_attempts": 1,
         "parse_retry_response_excerpt_chars": 800,
         "topic": "Churn pressure",

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -59,6 +59,7 @@ class _OpportunityService:
         temperature: float | None = None,
         max_tokens: int | None = None,
         parse_retry_attempts: int | None = None,
+        quality_repair_attempts: int | None = None,
         quality_revalidation_enabled: bool | None = None,
         quality_prompt_proof_term_limit: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
@@ -78,6 +79,7 @@ class _OpportunityService:
             "temperature": temperature,
             "max_tokens": max_tokens,
             "parse_retry_attempts": parse_retry_attempts,
+            "quality_repair_attempts": quality_repair_attempts,
             "quality_revalidation_enabled": quality_revalidation_enabled,
             "quality_prompt_proof_term_limit": quality_prompt_proof_term_limit,
             "parse_retry_response_excerpt_chars": parse_retry_response_excerpt_chars,
@@ -1224,6 +1226,7 @@ async def test_execute_threads_topic_into_blog_post_dispatcher() -> None:
 
     call = blog.calls[0]
     assert call["topic"] == "Renewal pricing pressure"
+    assert call["quality_repair_attempts"] == 2
     assert call["extras"] == {}
 
 


### PR DESCRIPTION
Plan: plans/PR-Blog-GEO-Entity-Prompt-Alignment.md

The custom Content Ops blog live smoke generated coherent drafts but repeatedly failed the existing blog quality gate. This PR aligns the blog prompt and repair path with the SEO/AEO/GEO validators instead of weakening the gate.

## Intentional
- Keep the quality gate unchanged; the failures are in generation/repair alignment.
- Use Haiku for live testing; no Sonnet live tests were run after the model-cost concern.
- Keep the repair loop bounded at 2 quality attempts.
- Deterministically trim overlong SEO titles before validation because the title max is a mechanical metadata rule.
- Repair failures now preserve debuggable attribution: unparseable repair output gets `quality_repair_unparseable`, and repair exceptions include `error_type`.

## Deferred
- Haiku live smokes still have not produced a saved draft. The final live blocker set before the attribution fix was citation-safety related, so the next debug slice should inspect the failed candidate body instead of continuing blind prompt iteration.
- Existing ATLAS-HARDENING.md deep-dive entries remain parked because they do not touch this Content Ops blog prompt/readiness contract.

## Parked hardening
- None added.

## Verification
- pytest tests/test_extracted_blog_generation.py tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py -q -> 136 passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline -> refreshed 43 mapped files.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh -> passed.
- Haiku live smokes using /tmp/atlas-haiku-override.env -> no saved draft yet; blockers exposed and shaped this PRs fixes.

## Diff size
10 files, +404 / -32