### PR TITLE
Add FAQ lifecycle summary JSON output

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-JSON.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-JSON.md
@@ -1,0 +1,72 @@
+# PR-Content-Ops-FAQ-Lifecycle-Summary-JSON
+
+## Why this slice exists
+
+The real 1,000-row FAQ database lifecycle run passed, but `--json` printed the
+entire lifecycle payload to stdout, including exported rows and full Markdown.
+That made the operator output thousands of lines long even though the useful
+readout was already available in `lifecycle_summary`.
+
+This slice adds a compact machine-readable stdout mode for lifecycle smokes so
+large runs can write the full payload to `--output-result` while printing only
+the summary needed for triage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add a `--summary-json` CLI flag to `scripts/smoke_content_ops_faq_lifecycle.py`.
+2. Make `--summary-json` print `payload["lifecycle_summary"]` only.
+3. Keep existing `--json` full-payload behavior unchanged.
+4. Add focused print tests for summary JSON success and failure output.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Summary-JSON.md`
+- `scripts/smoke_content_ops_faq_lifecycle.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+
+The parser adds `--summary-json` beside the existing `--json` flag. `_main`
+passes both flags to `_print_payload(...)`.
+
+`_print_payload(...)` keeps the current ordering:
+
+1. `--json`: print the full payload exactly as today.
+2. `--summary-json`: print only the `lifecycle_summary` mapping.
+3. no JSON flag: print the compact human console line.
+
+`--json` wins if both flags are passed, preserving the existing full-payload
+contract for callers that already use it.
+
+## Intentional
+
+- No lifecycle generation, persistence, export, review, or result payload shape
+  changes.
+- `--output-result` still writes the full payload; `--summary-json` only changes
+  stdout.
+- `--json` remains backward compatible and still prints the full payload.
+
+## Deferred
+
+- A similar summary-only stdout mode for other Postgres smoke scripts remains
+  deferred until those scripts show the same large-output problem.
+- Root `HARDENING.md` was scanned; no parked FAQ-lane item is required for this
+  slice.
+
+## Verification
+
+- Passed: `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` (12 passed)
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
+- Passed: live local DB smoke with `--summary-json`; stdout equaled `lifecycle_summary` and omitted full export payloads while `--output-result` kept the full result.
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| CLI flag and printer | ~25 |
+| Tests | ~85 |
+| **Total** | **~180** |

--- a/scripts/smoke_content_ops_faq_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_lifecycle.py
@@ -105,6 +105,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--output-result", type=Path, default=None)
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Print only lifecycle_summary as JSON; --output-result still writes the full payload.",
+    )
     parser.add_argument("--database-url", default=_default_database_url())
     return parser.parse_args(argv)
 
@@ -354,9 +359,25 @@ def _mapping_or_none(value: Any) -> dict[str, Any] | None:
     return dict(value) if isinstance(value, Mapping) else None
 
 
-def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+def _print_payload(
+    payload: Mapping[str, Any],
+    *,
+    as_json: bool,
+    summary_json: bool = False,
+) -> None:
     if as_json:
         print(json.dumps(dict(payload), indent=2, sort_keys=True, default=str))
+        return
+    if summary_json:
+        summary = payload.get("lifecycle_summary")
+        print(
+            json.dumps(
+                summary if isinstance(summary, Mapping) else {},
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+        )
         return
     profile = console_input_profile(payload.get("input_profile"))
     if payload.get("ok"):
@@ -377,7 +398,11 @@ async def _main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     _validate_args(args)
     code, payload = await run_faq_lifecycle_smoke(args)
-    _print_payload(payload, as_json=bool(args.json))
+    _print_payload(
+        payload,
+        as_json=bool(args.json),
+        summary_json=bool(args.summary_json),
+    )
     return code
 
 

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -415,6 +415,85 @@ def test_faq_lifecycle_print_payload_includes_input_profile_on_failure(capsys) -
     assert "- expected at least 500 source row(s), got 46" in captured.err
 
 
+def test_faq_lifecycle_print_payload_summary_json(capsys) -> None:
+    smoke._print_payload(
+        {
+            "ok": True,
+            "lifecycle_summary": {
+                "status": "ok",
+                "source_rows": 1000,
+                "saved_faq_count": 1,
+                "draft_export_count": 1,
+                "reviewed_export_count": 1,
+            },
+            "reviewed_export": {
+                "rows": [
+                    {
+                        "markdown": "# full markdown body should not print",
+                    }
+                ]
+            },
+        },
+        as_json=False,
+        summary_json=True,
+    )
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert captured.err == ""
+    assert output == {
+        "status": "ok",
+        "source_rows": 1000,
+        "saved_faq_count": 1,
+        "draft_export_count": 1,
+        "reviewed_export_count": 1,
+    }
+    assert "full markdown body" not in captured.out
+
+
+def test_faq_lifecycle_print_payload_summary_json_on_failure(capsys) -> None:
+    smoke._print_payload(
+        {
+            "ok": False,
+            "lifecycle_summary": {
+                "status": "failed",
+                "source_rows": 46,
+                "error_count": 1,
+                "errors": ["expected at least 500 source row(s), got 46"],
+            },
+            "errors": ["expected at least 500 source row(s), got 46"],
+        },
+        as_json=False,
+        summary_json=True,
+    )
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert captured.err == ""
+    assert output["status"] == "failed"
+    assert output["source_rows"] == 46
+    assert output["error_count"] == 1
+    assert output["errors"] == ["expected at least 500 source row(s), got 46"]
+
+
+def test_faq_lifecycle_print_payload_full_json_wins_over_summary_json(capsys) -> None:
+    smoke._print_payload(
+        {
+            "ok": True,
+            "lifecycle_summary": {"status": "ok"},
+            "reviewed_export": {"rows": [{"markdown": "# full markdown"}]},
+        },
+        as_json=True,
+        summary_json=True,
+    )
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert captured.err == ""
+    assert output["lifecycle_summary"] == {"status": "ok"}
+    assert output["reviewed_export"]["rows"][0]["markdown"] == "# full markdown"
+
+
 def test_faq_lifecycle_smoke_rejects_invalid_args() -> None:
     args = _args(min_saved_faqs=0)
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Summary-JSON.md

The real 1,000-row FAQ database lifecycle run passed, but full `--json` stdout included exported rows and Markdown bodies. This adds a compact machine-readable `--summary-json` stdout mode so large runs can keep the full payload in `--output-result` while printing only `lifecycle_summary` for triage.

## Intentional
- Lifecycle generation, persistence, export, review behavior, and result payload shape are unchanged.
- `--json` remains the full-payload output mode and wins if both JSON flags are passed.
- `--output-result` still writes the full lifecycle payload.

## Deferred
- Similar summary-only output for other Postgres smoke scripts remains deferred until those scripts show the same large-output problem.
- Root `HARDENING.md` was scanned; no parked FAQ-lane item is required for this slice.

## Verification
- `pytest tests/test_smoke_content_ops_faq_lifecycle.py -q` (12 passed)
- Live local DB smoke with `--summary-json`; stdout equaled `lifecycle_summary` and omitted full export payloads while `--output-result` kept the full result.
- `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +178 / -2