### PR TITLE
Add FAQ lifecycle artifact runner

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Artifact-Runner.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Artifact-Runner.md
@@ -1,0 +1,95 @@
+# PR-Content-Ops-FAQ-Lifecycle-Artifact-Runner
+
+## Why this slice exists
+
+The FAQ lifecycle smoke can now print compact `--summary-json`, but a real
+500-row or 1,000-row database run still requires a long hand-built command and
+manual redirection to preserve the stdout, stderr, full payload, and compact
+summary as separate artifacts.
+
+This slice adds the thinnest repeatable operator wrapper around the existing
+database lifecycle smoke. It does not create a second lifecycle path; it runs
+the product smoke command and writes a small artifact bundle that makes input
+density, output checks, persistence, export, review status, and failure type
+visible after each run.
+
+This is slightly over the 400 LOC target because it introduces a new executable
+and its artifact/failure contract tests together; splitting the tests from the
+runner would leave the operator command without reviewable behavior proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-io-tests
+
+1. Add `scripts/smoke_content_ops_faq_lifecycle_run.py`.
+2. Have the wrapper invoke `scripts/smoke_content_ops_faq_lifecycle.py` with
+   `--output-result` and `--summary-json`.
+3. Capture stdout, stderr, lifecycle result JSON, compact summary JSON, and
+   run summary JSON artifacts under an operator-provided
+   artifact directory.
+4. Add focused tests for success, lifecycle failure, and hard CLI failure
+   artifact behavior.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Artifact-Runner.md`
+- `scripts/smoke_content_ops_faq_lifecycle_run.py`
+- `tests/test_smoke_content_ops_faq_lifecycle_run.py`
+
+## Mechanism
+
+The new wrapper is a subprocess runner, matching the established shape of
+`scripts/smoke_content_ops_faq_scale_run.py`.
+
+It builds the existing lifecycle command with:
+
+```bash
+--output-result <artifact-dir>/lifecycle_result.json --summary-json
+```
+
+Then it captures process stdout and stderr, parses the compact summary stdout
+when available, parses the full result payload when available, and writes a
+small run summary JSON file with:
+
+- exit code and `ok`
+- source path and source format
+- artifact paths and sizes
+- parsed `lifecycle_summary`
+- parsed full lifecycle result
+- failure classification for missing result, lifecycle errors, or raw CLI
+  errors
+
+## Intentional
+
+- No lifecycle generation, repository, export, review, or source-ingestion logic
+  changes.
+- The wrapper does not bypass the existing smoke; the existing script remains
+  the single execution path.
+- No database fixture is checked in; live DB verification stays in the manual
+  smoke lane.
+
+## Deferred
+
+- Documentation snippets for every 500/1,000-row operator command are deferred
+  until the next real DB run confirms the final artifact names.
+- Root `HARDENING.md` was scanned; no same-lane parked item is required for
+  this slice.
+
+## Verification
+
+- Passed: `pytest tests/test_smoke_content_ops_faq_lifecycle_run.py -q` (4 passed)
+- Passed: live local DB smoke with the checked-in support-ticket CSV; the runner
+  wrote the run summary, lifecycle result, compact summary stdout, raw stdout,
+  and raw stderr artifacts, and the parsed summary reported
+  `status=ok`, `source_rows=4`, `saved_faq_count=1`.
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Wrapper script | ~226 |
+| Tests | ~135 |
+| **Total** | **~456** |

--- a/scripts/smoke_content_ops_faq_lifecycle_run.py
+++ b/scripts/smoke_content_ops_faq_lifecycle_run.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Run the FAQ lifecycle smoke and capture standard artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIFECYCLE_CLI = ROOT / "scripts/smoke_content_ops_faq_lifecycle.py"
+DEFAULT_SOURCE_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+RESERVED_LIFECYCLE_FLAGS = ("--output-result", "--json", "--summary-json")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run FAQ lifecycle smoke with artifact capture. Lifecycle flags such "
+            "as --account-id, --source-format, and --min-source-rows pass through."
+        )
+    )
+    parser.add_argument("path", type=Path, nargs="?", default=DEFAULT_SOURCE_PATH)
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    args, lifecycle_args = parser.parse_known_args(argv)
+    args.lifecycle_args = lifecycle_args
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, summary = run_lifecycle_artifact_smoke(args)
+    _print_run_summary(summary)
+    return code
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    reserved = [
+        value
+        for value in args.lifecycle_args
+        if any(value == flag or value.startswith(f"{flag}=") for flag in RESERVED_LIFECYCLE_FLAGS)
+    ]
+    if reserved:
+        raise SystemExit(
+            "lifecycle artifact runner owns these flags: "
+            + ", ".join(sorted(set(reserved)))
+        )
+
+
+def run_lifecycle_artifact_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    artifact_dir = Path(args.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    result_path = artifact_dir / "lifecycle_result.json"
+    summary_stdout_path = artifact_dir / "summary_stdout.json"
+    stdout_path = artifact_dir / "stdout.txt"
+    stderr_path = artifact_dir / "stderr.txt"
+    run_summary_path = artifact_dir / "run_summary.json"
+    command = [
+        sys.executable,
+        str(LIFECYCLE_CLI),
+        str(args.path),
+        *[str(value) for value in args.lifecycle_args],
+        "--output-result",
+        str(result_path),
+        "--summary-json",
+    ]
+    started = time.monotonic()
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    elapsed_seconds = time.monotonic() - started
+    stdout_path.write_text(completed.stdout, encoding="utf-8")
+    stderr_path.write_text(completed.stderr, encoding="utf-8")
+    result_payload = _read_json(result_path)
+    summary_stdout = _parse_stdout_summary(completed.stdout)
+    if summary_stdout is not None:
+        summary_stdout_path.write_text(
+            json.dumps(summary_stdout, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    artifacts = {
+        "result": result_path,
+        "summary_stdout": summary_stdout_path,
+        "stdout": stdout_path,
+        "stderr": stderr_path,
+        "summary": run_summary_path,
+    }
+    summary = {
+        "ok": completed.returncode == 0,
+        "exit_code": completed.returncode,
+        "source": str(args.path),
+        "command": command,
+        "timing": {"elapsed_seconds": round(elapsed_seconds, 6)},
+        "artifacts": _artifact_paths(artifacts),
+        "lifecycle_summary": _lifecycle_summary(result_payload, summary_stdout),
+        "failure": _failure_summary(
+            returncode=completed.returncode,
+            result_payload=result_payload,
+            summary_stdout=summary_stdout,
+            stderr=completed.stderr,
+        ),
+        "result": result_payload,
+    }
+    _write_summary(run_summary_path, summary, artifacts)
+    return completed.returncode, summary
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _parse_stdout_summary(stdout: str) -> dict[str, Any] | None:
+    try:
+        data = json.loads(stdout.strip())
+    except json.JSONDecodeError:
+        return None
+    return dict(data) if isinstance(data, Mapping) else None
+
+
+def _lifecycle_summary(
+    result_payload: dict[str, Any] | None,
+    summary_stdout: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if isinstance(summary_stdout, dict):
+        return summary_stdout
+    if isinstance(result_payload, dict) and isinstance(result_payload.get("lifecycle_summary"), Mapping):
+        return dict(result_payload["lifecycle_summary"])
+    return None
+
+
+def _artifact_paths(paths: Mapping[str, Path]) -> dict[str, str | None]:
+    return {
+        name: str(path) if path.exists() or name == "summary" else None
+        for name, path in paths.items()
+    }
+
+
+def _artifact_details(paths: Mapping[str, Path]) -> dict[str, dict[str, Any]]:
+    return {
+        name: {
+            "path": str(path),
+            "exists": path.exists(),
+            "bytes": path.stat().st_size if path.exists() else None,
+        }
+        for name, path in paths.items()
+    }
+
+
+def _write_summary(
+    summary_path: Path,
+    summary: dict[str, Any],
+    artifact_paths: Mapping[str, Path],
+) -> None:
+    details = _artifact_details(artifact_paths)
+    details["summary"]["exists"] = True
+    details["summary"]["bytes"] = None
+    summary["artifact_details"] = details
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _failure_summary(
+    *,
+    returncode: int,
+    result_payload: dict[str, Any] | None,
+    summary_stdout: dict[str, Any] | None,
+    stderr: str,
+) -> dict[str, Any] | None:
+    if returncode == 0:
+        return None
+    errors = _payload_errors(result_payload) or _payload_errors(summary_stdout)
+    return {
+        "type": "lifecycle_error" if errors else "missing_result",
+        "errors": errors,
+        "stderr_tail": _text_tail(stderr),
+        "summary_status": summary_stdout.get("status") if isinstance(summary_stdout, dict) else None,
+    }
+
+
+def _payload_errors(value: dict[str, Any] | None) -> list[str]:
+    errors = value.get("errors") if isinstance(value, dict) else None
+    return [str(error) for error in errors] if isinstance(errors, list) else []
+
+
+def _text_tail(value: str, *, max_chars: int = 4000, max_lines: int = 20) -> str:
+    lines = value.strip().splitlines()
+    text = "\n".join(lines[-max_lines:])
+    return text[-max_chars:] if len(text) > max_chars else text
+
+
+def _print_run_summary(summary: Mapping[str, Any]) -> None:
+    artifacts = summary.get("artifacts") if isinstance(summary.get("artifacts"), Mapping) else {}
+    lifecycle_summary = summary.get("lifecycle_summary")
+    status = lifecycle_summary.get("status") if isinstance(lifecycle_summary, Mapping) else "unknown"
+    source_rows = lifecycle_summary.get("source_rows") if isinstance(lifecycle_summary, Mapping) else "unknown"
+    saved_faqs = lifecycle_summary.get("saved_faq_count") if isinstance(lifecycle_summary, Mapping) else "unknown"
+    message = (
+        f"status={status} source_rows={source_rows} saved_faqs={saved_faqs} "
+        f"summary={artifacts.get('summary')}"
+    )
+    if summary.get("ok") is True:
+        print(f"Content Ops FAQ lifecycle artifact smoke passed: {message}")
+        return
+    failure = summary.get("failure") if isinstance(summary.get("failure"), Mapping) else {}
+    print(
+        "Content Ops FAQ lifecycle artifact smoke failed: "
+        f"{message} failure={failure.get('type') or 'unknown'}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_faq_lifecycle_run.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle_run.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_lifecycle_run.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_lifecycle_run", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+SUPPORT_TICKET_CSV = ROOT / "extracted_content_pipeline/examples/support_ticket_sources.csv"
+
+
+def _args(tmp_path: Path, lifecycle_args: list[str] | None = None):
+    return argparse.Namespace(
+        path=SUPPORT_TICKET_CSV,
+        artifact_dir=tmp_path / "artifacts",
+        lifecycle_args=lifecycle_args or ["--account-id", "acct-smoke"],
+    )
+
+
+def _result_path(command: list[str]) -> Path:
+    return Path(command[command.index("--output-result") + 1])
+
+
+def test_lifecycle_artifact_smoke_writes_standard_artifacts(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+    lifecycle_summary = {"status": "ok", "source_rows": 1000, "saved_faq_count": 1}
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        _result_path(command).write_text(
+            json.dumps({"ok": True, "saved_ids": ["faq-uuid-1"], "lifecycle_summary": lifecycle_summary}) + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(lifecycle_summary) + "\n", stderr="")
+
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    code, summary = smoke.run_lifecycle_artifact_smoke(
+        _args(tmp_path, ["--account-id", "acct-smoke", "--min-source-rows", "1000"])
+    )
+
+    artifact_dir = tmp_path / "artifacts"
+    saved_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
+    command, kwargs = calls[0]
+    assert code == 0
+    assert summary["failure"] is None
+    assert saved_summary["lifecycle_summary"] == lifecycle_summary
+    assert json.loads((artifact_dir / "summary_stdout.json").read_text(encoding="utf-8")) == lifecycle_summary
+    assert json.loads((artifact_dir / "lifecycle_result.json").read_text(encoding="utf-8"))["saved_ids"] == ["faq-uuid-1"]
+    assert saved_summary["artifact_details"]["summary_stdout"]["exists"] is True
+    assert saved_summary["artifact_details"]["result"]["bytes"] > 0
+    assert kwargs == {"check": False, "capture_output": True, "text": True}
+    assert command[command.index("--min-source-rows") + 1] == "1000"
+    assert "--summary-json" in command
+
+
+def test_lifecycle_artifact_smoke_classifies_lifecycle_failure(monkeypatch, tmp_path: Path) -> None:
+    errors = ["expected at least 500 source row(s), got 46"]
+    lifecycle_summary = {"status": "failed", "source_rows": 46, "errors": errors}
+
+    def fake_run(command, **kwargs):
+        _result_path(command).write_text(
+            json.dumps({"ok": False, "errors": errors, "lifecycle_summary": lifecycle_summary}) + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout=json.dumps(lifecycle_summary) + "\n",
+            stderr="Content Ops FAQ lifecycle smoke failed\n",
+        )
+
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    code, summary = smoke.run_lifecycle_artifact_smoke(_args(tmp_path))
+
+    assert code == 1
+    assert summary["failure"]["type"] == "lifecycle_error"
+    assert summary["failure"]["errors"] == errors
+    assert summary["failure"]["summary_status"] == "failed"
+
+
+def test_lifecycle_artifact_smoke_classifies_hard_cli_failure(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 2, stdout="", stderr="Missing --database-url\n")
+
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    code, summary = smoke.run_lifecycle_artifact_smoke(_args(tmp_path))
+
+    artifact_dir = tmp_path / "artifacts"
+    assert code == 2
+    assert summary["result"] is None
+    assert summary["lifecycle_summary"] is None
+    assert summary["failure"]["type"] == "missing_result"
+    assert "Missing --database-url" in summary["failure"]["stderr_tail"]
+    assert not (artifact_dir / "summary_stdout.json").exists()
+    assert json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))["artifact_details"]["summary_stdout"]["exists"] is False
+
+
+def test_lifecycle_artifact_smoke_main_and_reserved_flag_guard(monkeypatch, tmp_path: Path, capsys) -> None:
+    lifecycle_summary = {"status": "ok", "source_rows": 4, "saved_faq_count": 1}
+
+    def fake_run(command, **kwargs):
+        _result_path(command).write_text(
+            json.dumps({"ok": True, "lifecycle_summary": lifecycle_summary}) + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(lifecycle_summary) + "\n", stderr="")
+
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    code = smoke.main([
+        str(SUPPORT_TICKET_CSV),
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--account-id",
+        "acct-smoke",
+    ])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "Content Ops FAQ lifecycle artifact smoke passed:" in captured.out
+    assert f"summary={tmp_path / 'artifacts' / 'run_summary.json'}" in captured.out
+    with pytest.raises(SystemExit, match="artifact runner owns"):
+        smoke._validate_args(_args(tmp_path, ["--json"]))


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Artifact-Runner.md

The FAQ lifecycle smoke now has compact summary stdout, but real 500/1,000-row DB runs still need repeatable artifact capture. This adds a thin wrapper that delegates to the existing lifecycle smoke and writes raw stdout/stderr, compact summary stdout, full lifecycle result, and a run summary artifact.

## Intentional
- The wrapper delegates lifecycle execution to the existing smoke script and only owns artifact capture.
- Database-backed lifecycle generation, persistence, export, review, and source ingestion are unchanged.
- The PR is slightly over the 400 LOC target because it ships the new executable and its artifact/failure contract tests together.

## Deferred
- Documentation snippets for 500/1,000-row operator commands are deferred until the next real DB run confirms final artifact names.
- Root `HARDENING.md` was scanned; no same-lane parked item is required for this slice.

## Verification
- `pytest tests/test_smoke_content_ops_faq_lifecycle_run.py -q` (4 passed)
- Live local DB smoke with checked-in support-ticket CSV; parsed summary reported `status=ok`, `source_rows=4`, `saved_faq_count=1`.
- `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +457 / -0