### PR TITLE
Document FAQ lifecycle summary JSON smoke

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -262,7 +262,8 @@ python scripts/smoke_content_ops_faq_lifecycle.py \
   --source-format csv \
   --account-id acct_123 \
   --review-status published \
-  --json
+  --output-result tmp/faq_lifecycle_result.json \
+  --summary-json
 ```
 
 If Atlas already has scraped B2B review rows, export one reliable source as
@@ -1096,7 +1097,7 @@ python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign
 python scripts/smoke_extracted_content_ops_execution.py --outputs email_campaign,landing_page --with-reasoning --reasoning-provider postgres-fixture --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs signal_extraction --source-vendor HubSpot --source-max-text-chars 400 --json
 python scripts/smoke_extracted_content_ops_execution.py --outputs faq_markdown --source-type support_ticket --source-title "login reset" --json
-python scripts/smoke_content_ops_faq_lifecycle.py --account-id acct_123 --review-status published --json
+python scripts/smoke_content_ops_faq_lifecycle.py --account-id acct_123 --review-status published --output-result tmp/faq_lifecycle_result.json --summary-json
 ```
 
 This validates the full campaign preset and the deterministic source-material

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -274,7 +274,8 @@ python scripts/smoke_content_ops_faq_lifecycle.py \
   --source-format csv \
   --account-id acct_123 \
   --review-status published \
-  --json
+  --output-result tmp/faq_lifecycle_result.json \
+  --summary-json
 ```
 
 The source adapter copies `review_text`, `transcript`, `complaint`, `message`,
@@ -1175,7 +1176,8 @@ python scripts/smoke_extracted_content_ops_execution.py \
 python scripts/smoke_content_ops_faq_lifecycle.py \
   --account-id acct_123 \
   --review-status published \
-  --json
+  --output-result tmp/faq_lifecycle_result.json \
+  --summary-json
 ```
 
 The smoke uses fake generated-asset services plus the deterministic FAQ

--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Docs.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Docs.md
@@ -1,0 +1,65 @@
+# PR-Content-Ops-FAQ-Lifecycle-Summary-Docs
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Lifecycle-Summary-JSON added `--summary-json` so large FAQ
+lifecycle database runs can keep stdout compact while writing the full payload
+to disk. The operator docs still show `--json`, which prints the full exported
+Markdown payload to stdout and recreates the noisy-output problem the code slice
+fixed.
+
+This slice updates the existing lifecycle smoke examples to use the compact
+summary mode that is already on main.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-docs
+
+1. Update the extracted package README lifecycle smoke examples.
+2. Update the host install runbook lifecycle smoke examples.
+3. Keep the docs focused on the already-shipped `--summary-json` flow.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Docs.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/docs/host_install_runbook.md`
+
+## Mechanism
+
+Lifecycle smoke examples now pass an `--output-result` file path together with
+`--summary-json`. This preserves the full result payload on disk and prints only the compact
+`lifecycle_summary` object to stdout.
+
+## Intentional
+
+- Docs only; no lifecycle code, database code, or source-ingestion behavior
+  changes.
+- This does not document the unmerged artifact runner from PR #850.
+
+## Deferred
+
+- Full artifact-runner runbook snippets remain deferred until the artifact
+  runner lands on main.
+- Root `HARDENING.md` was scanned; no same-lane parked item is required for this
+  docs slice.
+
+## Verification
+
+- Passed: grep sweep confirmed the lifecycle smoke examples now use
+  `--summary-json` with `--output-result`.
+- Passed: live local DB smoke using the documented `--output-result` +
+  `--summary-json` pattern; stdout equaled `lifecycle_summary`, reported
+  `status=ok`, `source_rows=4`, `saved_faq_count=1`, and the full result file
+  retained `reviewed_export`.
+- Passed: `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
+- Pending: `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| README examples | ~7 |
+| Host runbook examples | ~4 |
+| **Total** | **~76** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Docs.md

The FAQ lifecycle smoke supports compact `--summary-json`, but the operator docs still showed full `--json` stdout. This updates the README and host install runbook examples to write the full payload to `--output-result` while printing only the lifecycle summary.

## Intentional
- Docs only; lifecycle execution, database, and source-ingestion behavior are unchanged.
- This documents the already-merged `--summary-json` flow, not the unmerged artifact runner.

## Deferred
- Full artifact-runner runbook snippets remain deferred until the artifact runner lands on main.
- Root `HARDENING.md` was scanned; no same-lane parked item is required for this docs slice.

## Verification
- Grep sweep confirmed lifecycle smoke examples now use `--summary-json` with `--output-result`.
- Live local DB smoke using the documented pattern; stdout equaled `lifecycle_summary`, reported `status=ok`, `source_rows=4`, `saved_faq_count=1`, and the full result retained `reviewed_export`.
- `scripts/run_extracted_pipeline_checks.sh` (1839 passed, 1 skipped)
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +72 / -4