### PR TITLE
Add blog repair failure diagnostics

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -37,6 +37,7 @@ from extracted_quality_gate.types import QualityInput, QualityPolicy
 # call-site target_mode (e.g. "vendor_retention") is an unrelated
 # tenant-scope concept.
 _BLOG_REASONING_TARGET_MODE = "blog_blueprint"
+_BLOG_FAILURE_EXCERPT_CHARS = 1500
 
 
 @dataclass(frozen=True)
@@ -236,6 +237,32 @@ def _truncate_text_at_word_boundary(value: str, *, max_chars: int) -> str:
     return trimmed or text[:limit].rstrip()
 
 
+def _blog_failure_candidate_snapshot(
+    parsed: Mapping[str, Any],
+    *,
+    excerpt_chars: int = _BLOG_FAILURE_EXCERPT_CHARS,
+) -> dict[str, Any]:
+    """Return bounded diagnostics for a parsed draft that cannot be saved."""
+
+    content = str(parsed.get("content") or "").strip()
+    limit = max(1, int(excerpt_chars))
+    return {
+        "title": str(parsed.get("title") or "").strip(),
+        "slug": str(parsed.get("slug") or "").strip(),
+        "seo_title": str(parsed.get("seo_title") or "").strip(),
+        "target_keyword": str(parsed.get("target_keyword") or "").strip(),
+        "topic_type": str(parsed.get("topic_type") or "").strip(),
+        "word_count": len(content.split()),
+        "generation_parse_attempts": parsed.get("_parse_attempts"),
+        "generation_quality_repair_attempts": (
+            parsed.get("_quality_repair_attempts") or 0
+        ),
+        "content_excerpt_head": content[:limit],
+        "content_excerpt_tail": content[-limit:] if len(content) > limit else "",
+        "content_truncated": len(content) > limit,
+    }
+
+
 class BlogPostGenerationService:
     """Generate blog-post drafts through product-owned ports."""
 
@@ -411,6 +438,7 @@ class BlogPostGenerationService:
                             "reason": "quality_repair_unparseable",
                             "blockers": quality["blockers"],
                             "quality_repair_attempt_no": repair_attempt_no,
+                            "failed_candidate": _blog_failure_candidate_snapshot(parsed),
                         })
                         repair_failed = True
                         break
@@ -433,6 +461,7 @@ class BlogPostGenerationService:
                         "blueprint_id": blueprint_id,
                         "reason": "quality_blocked",
                         "blockers": quality["blockers"],
+                        "failed_candidate": _blog_failure_candidate_snapshot(parsed),
                     })
                     continue
             if _has_prompt_reasoning_context(blueprint):

--- a/plans/PR-Blog-Repair-Failure-Diagnostics.md
+++ b/plans/PR-Blog-Repair-Failure-Diagnostics.md
@@ -1,0 +1,87 @@
+# PR: Blog Repair Failure Diagnostics
+
+## Why this slice exists
+
+PR #847 made the Content Ops blog repair loop debuggable enough to distinguish
+exception, unparseable repair, and still-blocked quality outcomes. The live
+Haiku smoke still did not save a draft, though, and the final blocker was
+`geo_citation_safety_failed`. The current error payload reports blocker codes
+but not the final generated candidate, so the next operator cannot tell whether
+the model produced a placeholder link, unsupported claim, bad chart reference,
+or another citation-safety trigger.
+
+This slice adds bounded failed-candidate diagnostics to the existing error
+payload instead of saving a bad draft or guessing with more prompt edits.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-repair-failure-diagnostics
+
+1. Attach a bounded `failed_candidate` snapshot when a parsed blog draft remains
+   quality-blocked after repair attempts.
+2. Attach the same snapshot when a repair response is unparseable, using the
+   candidate that was sent into the failed repair.
+3. Keep diagnostics small and structured: metadata, word count, parse/repair
+   attempts, and bounded head/tail content excerpts.
+4. Add focused tests for both diagnostic paths.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Blog-Repair-Failure-Diagnostics.md` | Plan doc for this slice. |
+| `extracted_content_pipeline/blog_generation.py` | Add failed-candidate snapshot helper and wire it into repair failure errors. |
+| `tests/test_extracted_blog_generation.py` | Assert diagnostics are present and bounded for quality-blocked and repair-unparseable paths. |
+
+## Mechanism
+
+The failed-candidate snapshot helper extracts a small diagnostic object from the
+parsed candidate:
+
+- `title`, `slug`, `seo_title`, `target_keyword`, `topic_type`
+- `word_count`
+- `generation_parse_attempts`, `generation_quality_repair_attempts`
+- `content_excerpt_head`, `content_excerpt_tail`, `content_truncated`
+
+The generator attaches that object to:
+
+- `quality_blocked` after all repair attempts parse but still fail the gate.
+- `quality_repair_unparseable` when the repair LLM response does not parse, so
+  the operator can inspect the candidate that was sent into the failed repair.
+
+The helper does not save the failed draft and does not include the full body.
+
+## Intentional
+
+- No quality-gate change. The gate still decides whether a draft can be saved.
+- No live prompt iteration in this slice. The point is to make the next live
+  run explain the failure.
+- No DB persistence for failed candidates. The diagnostics live in the execution
+  result only.
+
+## Deferred
+
+- Running the Haiku live smoke after this lands is the next slice. It should use
+  `/tmp/atlas-haiku-override.env` and inspect `failed_candidate` if the draft is
+  still blocked.
+- Parked hardening: existing `ATLAS-HARDENING.md` items are for older deep-dive
+  blog generator/content issues and do not touch this Content Ops blog
+  diagnostics path. They remain parked.
+
+## Verification
+
+- pytest `tests/test_extracted_blog_generation.py` -q -> 33 passed.
+- bash `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- python `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` extracted_content_pipeline -> passed.
+- python `scripts/audit_extracted_standalone.py` --fail-on-debt -> passed.
+- bash `scripts/check_ascii_python.sh` -> passed.
+- bash `scripts/local_pr_review.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Generator | ~45 |
+| Tests | ~35 |
+| **Total** | **~160** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -7,6 +7,7 @@ import pytest
 from extracted_content_pipeline.blog_generation import (
     BlogPostGenerationConfig,
     BlogPostGenerationService,
+    _blog_failure_candidate_snapshot,
     _blog_quality_repair_guidance,
     _normalize_blog_metadata,
     parse_blog_post_response,
@@ -247,6 +248,26 @@ def test_blog_quality_repair_guidance_explains_citation_safety() -> None:
     assert "Remove unresolved placeholders" in guidance
     assert "unsupported claims" in guidance
     assert "visible chart IDs" in guidance
+
+
+def test_blog_failure_candidate_snapshot_is_bounded() -> None:
+    parsed = json.loads(_valid_blog_json(content="alpha " * 200))
+    parsed["_parse_attempts"] = 2
+    parsed["_quality_repair_attempts"] = 1
+
+    snapshot = _blog_failure_candidate_snapshot(parsed, excerpt_chars=25)
+
+    assert snapshot["title"] == "HubSpot Pricing Pressure Is Changing Buyer Shortlists"
+    assert snapshot["slug"] == "hubspot-pricing-pressure"
+    assert snapshot["seo_title"] == "HubSpot Pricing Pressure"
+    assert snapshot["target_keyword"] == "hubspot pricing pressure"
+    assert snapshot["topic_type"] == "vendor_alternative"
+    assert snapshot["word_count"] == 200
+    assert snapshot["generation_parse_attempts"] == 2
+    assert snapshot["generation_quality_repair_attempts"] == 1
+    assert snapshot["content_excerpt_head"] == ("alpha " * 200)[:25]
+    assert snapshot["content_excerpt_tail"] == ("alpha " * 200).strip()[-25:]
+    assert snapshot["content_truncated"] is True
 
 
 @pytest.mark.asyncio
@@ -516,6 +537,10 @@ async def test_generate_does_not_repair_quality_block_without_repair_budget() ->
     assert result.generated == 0
     assert result.skipped == 1
     assert result.errors[0]["reason"] == "quality_blocked"
+    assert result.errors[0]["failed_candidate"]["title"] == (
+        "HubSpot Pricing Pressure Is Changing Buyer Shortlists"
+    )
+    assert result.errors[0]["failed_candidate"]["word_count"] == 24
     assert len(llm.calls) == 1
     assert blog_posts.saved == []
 
@@ -546,6 +571,10 @@ async def test_generate_reports_unparseable_quality_repair_response() -> None:
     assert result.errors[0]["reason"] == "quality_repair_unparseable"
     assert "geo_citable_section_structure_missing" in result.errors[0]["blockers"]
     assert result.errors[0]["quality_repair_attempt_no"] == 1
+    assert result.errors[0]["failed_candidate"]["title"] == (
+        "HubSpot Pricing Pressure Is Changing Buyer Shortlists"
+    )
+    assert result.errors[0]["failed_candidate"]["word_count"] == 24
     assert len(llm.calls) == 2
     assert blog_posts.saved == []
 


### PR DESCRIPTION
Plan: plans/PR-Blog-Repair-Failure-Diagnostics.md

Adds bounded failed-candidate diagnostics to Content Ops blog quality failures so the next live Haiku smoke can show what the blocked candidate actually contained without saving a failed draft.

## Intentional
- No quality-gate change.
- No failed-draft persistence.
- Diagnostics are bounded to structured metadata plus head/tail excerpts.

## Deferred
- Re-run the Haiku live smoke after this merges and inspect `failed_candidate` if the draft remains blocked.
- Existing ATLAS-HARDENING.md deep-dive entries remain parked; they do not touch this diagnostics path.

## Parked hardening
- None added.

## Verification
- pytest tests/test_extracted_blog_generation.py -q -> 33 passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh -> passed.

## Diff size
3 files, +145 / -0