### PR TITLE
Record FAQ lifecycle summary JSON validation

### DIFF
--- a/docs/extraction/validation/content_ops_faq_lifecycle_db_1000_row_run_2026-05-23.md
+++ b/docs/extraction/validation/content_ops_faq_lifecycle_db_1000_row_run_2026-05-23.md
@@ -169,6 +169,89 @@ Maximum resident set size: 40988 KB
 Exit status: 0
 ```
 
+## Summary JSON Rerun
+
+After `--summary-json` landed, the same 1,000-row source artifact was rerun
+through the real local database lifecycle path using compact stdout plus a full
+result artifact.
+
+Command:
+
+```bash
+EXTRACTED_DATABASE_URL="$(python - <<'PY'
+from atlas_brain.storage.config import db_settings
+print(db_settings.dsn)
+PY
+)" /usr/bin/time -v -o tmp/faq_lifecycle_summary_validation_20260523/time.txt \
+  python scripts/smoke_content_ops_faq_lifecycle.py \
+  tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl \
+  --source-format jsonl \
+  --account-id acct-faq-db-summary-validation-20260523 \
+  --user-id user-faq-db-summary-validation \
+  --title 'CFPB 1,000 Row FAQ DB Summary JSON Validation 2026-05-23' \
+  --min-source-rows 1000 \
+  --min-saved-faqs 1 \
+  --export-limit 5 \
+  --max-text-chars 1200 \
+  --default-field company_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --default-field vendor_name=CFPB \
+  --output-result tmp/faq_lifecycle_summary_validation_20260523/result.json \
+  --summary-json > tmp/faq_lifecycle_summary_validation_20260523/stdout_summary.json
+```
+
+Artifact syntax checks:
+
+```bash
+python -m json.tool tmp/faq_lifecycle_summary_validation_20260523/stdout_summary.json
+python -m json.tool tmp/faq_lifecycle_summary_validation_20260523/result.json
+```
+
+Observed result:
+
+```json
+{
+  "draft_export_count": 1,
+  "error_count": 0,
+  "errors": [],
+  "generated_item_count": 8,
+  "output_checks": {
+    "condensed": true,
+    "has_action_items": true,
+    "uses_user_vocabulary": true
+  },
+  "review_status": "published",
+  "reviewed_export_count": 1,
+  "saved_faq_count": 1,
+  "source_count": 1000,
+  "source_format": "jsonl",
+  "source_rows": 1000,
+  "status": "ok",
+  "ticket_source_count": 1000
+}
+```
+
+Additional observed values:
+
+- `stdout_summary.json` exactly matched `result.json.lifecycle_summary`.
+- Full result artifact retained `reviewed_export`.
+- Normalization warning count: `0`.
+- Question sources: `source_policy=8`.
+- Ticket counts by item: `[633, 166, 111, 57, 8, 6, 6, 13]`.
+- Result artifact size: `230K`.
+- Summary stdout artifact size: `807B`.
+
+Timing:
+
+```text
+Elapsed wall time: 0:01.21
+Maximum resident set size: 41508 KB
+Exit status: 0
+```
+
+No new issues surfaced in the summary JSON rerun. The compact stdout path kept
+operator output small while preserving the full lifecycle payload for audit.
+
 ## Issues Surfaced
 
 ### FAQLIFE1000-1 - Migration dry-run reports already-applied migrations as pending

--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Validation.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Validation.md
@@ -1,0 +1,64 @@
+# PR-Content-Ops-FAQ-Lifecycle-Summary-Validation
+
+## Why this slice exists
+
+The FAQ lifecycle smoke now supports compact `--summary-json` output, and the
+docs are being updated to recommend that operator pattern. The existing
+1,000-row database validation note still records the older full `--json` stdout
+run, so it does not prove the current large-run triage flow.
+
+This slice reruns the real local database lifecycle proof with 1,000 CFPB-derived
+support-ticket rows using `--summary-json` plus `--output-result`, then records
+the observed result and any surfaced issues.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-validation
+
+1. Run the existing FAQ lifecycle smoke against the local Atlas Postgres DB with
+   1,000 source rows.
+2. Record the compact summary JSON behavior in the validation note.
+3. Acknowledge whether the run surfaced new issues.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Validation.md`
+- `docs/extraction/validation/content_ops_faq_lifecycle_db_1000_row_run_2026-05-23.md`
+
+## Mechanism
+
+The validation command uses the existing lifecycle smoke only, with an
+`--output-result` path and `--summary-json`. The full payload stays in the
+result artifact while stdout is redirected to a separate compact summary JSON
+file. The validation note records parsed summary fields, output-check status,
+artifact paths, and any new issue observed during the run.
+
+## Intentional
+
+- Documentation/validation record only; no generator, repository, migration, or
+  lifecycle code changes.
+- This slice does not depend on the unmerged artifact-runner PR.
+
+## Deferred
+
+- Full artifact-runner validation remains deferred until the artifact runner
+  lands on main.
+- Root `HARDENING.md` was scanned; no same-lane parked item is required before
+  this validation run.
+
+## Verification
+
+- Passed: real local DB 1,000-row lifecycle smoke with `--summary-json`.
+- Passed: parsed saved stdout/result JSON artifacts; stdout exactly matched
+  `result.lifecycle_summary`, full result retained `reviewed_export`, and the
+  compact summary reported `status=ok`, `source_rows=1000`,
+  `saved_faq_count=1`, `error_count=0`.
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~64 |
+| Validation note update | ~83 |
+| **Total** | **~147** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Summary-Validation.md

The existing 1,000-row DB lifecycle validation still recorded the older full `--json` stdout path. This reruns the real local DB lifecycle with 1,000 CFPB-derived support-ticket rows using the merged `--summary-json` plus `--output-result` pattern and records the observed result.

## Intentional
- Documentation and validation record only; lifecycle execution, repository, migration, and source-ingestion behavior are unchanged.
- This validation uses the existing lifecycle smoke and does not depend on the unmerged artifact-runner PR.

## Deferred
- Full artifact-runner validation remains deferred until the artifact runner lands on main.
- Root `HARDENING.md` was scanned; no same-lane parked item is required before this validation run.

## Verification
- Real local DB 1,000-row lifecycle smoke with `--summary-json` exited 0.
- Parsed saved stdout/result JSON artifacts; stdout exactly matched `result.lifecycle_summary`, full result retained `reviewed_export`, and compact summary reported `status=ok`, `source_rows=1000`, `saved_faq_count=1`, `error_count=0`.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
2 files, +147 / -0