### PR TITLE
Fix blog draft save on blocked slugs

### DIFF
--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+import logging
 from typing import Any, Mapping, Sequence
 
 from .blog_ports import BlogPostDraft
@@ -17,6 +18,8 @@ from .storage._jsonb_helpers import (
 
 
 _METADATA_KEY = "_metadata"
+_MAX_SLUG_ATTEMPTS = 5
+logger = logging.getLogger(__name__)
 
 
 def _draft_data_context(draft: BlogPostDraft, scope: TenantScope) -> JsonDict:
@@ -80,6 +83,29 @@ def _optional_text(value: Any) -> str | None:
     return text or None
 
 
+def _slug_part(value: Any, *, fallback: str) -> str:
+    chars: list[str] = []
+    previous_dash = False
+    for char in str(value or "").strip().lower():
+        if "a" <= char <= "z" or "0" <= char <= "9":
+            chars.append(char)
+            previous_dash = False
+        elif chars and not previous_dash:
+            chars.append("-")
+            previous_dash = True
+    slug = "".join(chars).strip("-")
+    return slug or fallback
+
+
+def _fallback_slug(base_slug: str, account_id: str, attempt: int) -> str:
+    suffix = _slug_part(account_id, fallback="draft")[:40].strip("-") or "draft"
+    if attempt > 1:
+        suffix = f"{suffix}-{attempt}"
+    base = _slug_part(base_slug, fallback="blog-post")
+    max_base_length = max(1, 180 - len(suffix) - 1)
+    return f"{base[:max_base_length].strip('-')}-{suffix}"
+
+
 def _metadata_json_list(metadata: Mapping[str, Any], key: str) -> tuple[bool, list[Any]]:
     if key not in metadata:
         return False, []
@@ -125,82 +151,113 @@ class PostgresBlogPostRepository:
         saved: list[str] = []
         account_id = scope.account_id or ""
         for draft in drafts:
-            data_context = _draft_data_context(draft, scope)
-            has_secondary_keywords, secondary_keywords = _metadata_json_list(
-                draft.metadata,
-                "secondary_keywords",
+            blog_post_id = await self._save_draft_with_slug(
+                draft,
+                scope=scope,
+                slug=draft.slug,
             )
-            has_faq, faq = _metadata_json_list(draft.metadata, "faq")
-            blog_post_id = await self.pool.fetchval(
-                """
-                INSERT INTO blog_posts (
-                    account_id, slug, title, description, topic_type,
-                    tags, content, charts, data_context, status,
-                    llm_model, source_report_date,
-                    seo_title, seo_description, target_keyword,
-                    secondary_keywords, faq
+            attempt = 1
+            while not blog_post_id and attempt < _MAX_SLUG_ATTEMPTS:
+                blog_post_id = await self._save_draft_with_slug(
+                    draft,
+                    scope=scope,
+                    slug=_fallback_slug(draft.slug, account_id, attempt),
                 )
-                VALUES (
-                    $1, $2, $3, $4, $5,
-                    $6::jsonb, $7, $8::jsonb, $9::jsonb, 'draft',
-                    $10, $11,
-                    $12, $13, $14, $15::jsonb, $16::jsonb
-                )
-                ON CONFLICT (slug) DO UPDATE SET
-                    account_id = EXCLUDED.account_id,
-                    title = EXCLUDED.title,
-                    description = EXCLUDED.description,
-                    topic_type = EXCLUDED.topic_type,
-                    tags = EXCLUDED.tags,
-                    content = EXCLUDED.content,
-                    charts = EXCLUDED.charts,
-                    data_context = EXCLUDED.data_context,
-                    status = EXCLUDED.status,
-                    llm_model = EXCLUDED.llm_model,
-                    source_report_date = EXCLUDED.source_report_date,
-                    seo_title = COALESCE(EXCLUDED.seo_title, blog_posts.seo_title),
-                    seo_description = COALESCE(
-                        EXCLUDED.seo_description,
-                        blog_posts.seo_description
-                    ),
-                    target_keyword = COALESCE(
-                        EXCLUDED.target_keyword,
-                        blog_posts.target_keyword
-                    ),
-                    secondary_keywords = CASE
-                        WHEN $17 THEN EXCLUDED.secondary_keywords
-                        ELSE blog_posts.secondary_keywords
-                    END,
-                    faq = CASE
-                        WHEN $18 THEN EXCLUDED.faq
-                        ELSE blog_posts.faq
-                    END
-                WHERE blog_posts.status != 'published'
-                  AND blog_posts.account_id = EXCLUDED.account_id
-                RETURNING id
-                """,
-                account_id,
-                draft.slug,
-                draft.title,
-                draft.description,
-                draft.topic_type,
-                json_dump_jsonb(list(draft.tags or ())),
-                draft.content,
-                json_dump_jsonb([dict(chart) for chart in draft.charts or ()]),
-                json_dump_jsonb(data_context),
-                str(draft.metadata.get("generation_model") or "") or None,
-                _source_report_date(data_context.get("source_report_date")),
-                _optional_text(draft.metadata.get("seo_title")),
-                _optional_text(draft.metadata.get("seo_description")),
-                _optional_text(draft.metadata.get("target_keyword")),
-                json_dump_jsonb(secondary_keywords),
-                json_dump_jsonb(faq),
-                has_secondary_keywords,
-                has_faq,
-            )
+                attempt += 1
             if blog_post_id:
                 saved.append(str(blog_post_id))
+            else:
+                logger.warning(
+                    "blog_post_draft_save_exhausted_slug_attempts",
+                    extra={
+                        "account_id": account_id,
+                        "slug": draft.slug,
+                        "attempts": _MAX_SLUG_ATTEMPTS,
+                    },
+                )
         return tuple(saved)
+
+    async def _save_draft_with_slug(
+        self,
+        draft: BlogPostDraft,
+        *,
+        scope: TenantScope,
+        slug: str,
+    ) -> Any:
+        account_id = scope.account_id or ""
+        data_context = _draft_data_context(draft, scope)
+        has_secondary_keywords, secondary_keywords = _metadata_json_list(
+            draft.metadata,
+            "secondary_keywords",
+        )
+        has_faq, faq = _metadata_json_list(draft.metadata, "faq")
+        return await self.pool.fetchval(
+            """
+            INSERT INTO blog_posts (
+                account_id, slug, title, description, topic_type,
+                tags, content, charts, data_context, status,
+                llm_model, source_report_date,
+                seo_title, seo_description, target_keyword,
+                secondary_keywords, faq
+            )
+            VALUES (
+                $1, $2, $3, $4, $5,
+                $6::jsonb, $7, $8::jsonb, $9::jsonb, 'draft',
+                $10, $11,
+                $12, $13, $14, $15::jsonb, $16::jsonb
+            )
+            ON CONFLICT (slug) DO UPDATE SET
+                account_id = EXCLUDED.account_id,
+                title = EXCLUDED.title,
+                description = EXCLUDED.description,
+                topic_type = EXCLUDED.topic_type,
+                tags = EXCLUDED.tags,
+                content = EXCLUDED.content,
+                charts = EXCLUDED.charts,
+                data_context = EXCLUDED.data_context,
+                status = EXCLUDED.status,
+                llm_model = EXCLUDED.llm_model,
+                source_report_date = EXCLUDED.source_report_date,
+                seo_title = COALESCE(EXCLUDED.seo_title, blog_posts.seo_title),
+                seo_description = COALESCE(
+                    EXCLUDED.seo_description,
+                    blog_posts.seo_description
+                ),
+                target_keyword = COALESCE(
+                    EXCLUDED.target_keyword,
+                    blog_posts.target_keyword
+                ),
+                secondary_keywords = CASE
+                    WHEN $17 THEN EXCLUDED.secondary_keywords
+                    ELSE blog_posts.secondary_keywords
+                END,
+                faq = CASE
+                    WHEN $18 THEN EXCLUDED.faq
+                    ELSE blog_posts.faq
+                END
+            WHERE blog_posts.status != 'published'
+              AND blog_posts.account_id = EXCLUDED.account_id
+            RETURNING id
+            """,
+            account_id,
+            slug,
+            draft.title,
+            draft.description,
+            draft.topic_type,
+            json_dump_jsonb(list(draft.tags or ())),
+            draft.content,
+            json_dump_jsonb([dict(chart) for chart in draft.charts or ()]),
+            json_dump_jsonb(data_context),
+            str(draft.metadata.get("generation_model") or "") or None,
+            _source_report_date(data_context.get("source_report_date")),
+            _optional_text(draft.metadata.get("seo_title")),
+            _optional_text(draft.metadata.get("seo_description")),
+            _optional_text(draft.metadata.get("target_keyword")),
+            json_dump_jsonb(secondary_keywords),
+            json_dump_jsonb(faq),
+            has_secondary_keywords,
+            has_faq,
+        )
 
     async def list_drafts(
         self,

--- a/plans/PR-Blog-Draft-Slug-Fallback.md
+++ b/plans/PR-Blog-Draft-Slug-Fallback.md
@@ -1,0 +1,73 @@
+# PR-Blog-Draft-Slug-Fallback
+
+Ownership lane: `content-ops/blog-live-smoke`
+
+## Why this slice exists
+
+The live Haiku blog smoke generated one draft and passed quality checks, but
+returned no saved draft ids. The generated slug already existed under another
+smoke account, and `blog_posts.slug` is globally unique. The extracted blog
+repository intentionally avoided cross-tenant overwrites, but it silently
+reported no save instead of storing the new tenant's draft under a safe alternate
+slug.
+
+## Scope (this PR)
+
+1. Make `PostgresBlogPostRepository.save_drafts` retry blocked slug writes with a
+   deterministic tenant-scoped fallback slug.
+2. Preserve the existing guard that prevents cross-tenant or published-row
+   overwrites.
+3. Update focused repository tests to prove the live-smoke failure mode returns a
+   saved draft id.
+4. Warn if every bounded fallback attempt is still blocked, so a future shortfall
+   does not become another silent save mismatch.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_post_postgres.py`
+- `tests/test_extracted_blog_post_postgres.py`
+- `plans/PR-Blog-Draft-Slug-Fallback.md`
+
+## Mechanism
+
+`save_drafts` still attempts the requested draft slug first. If Postgres returns
+no id because the global slug conflict was blocked by the scoped `WHERE`, the
+repository retries with `"{base_slug}-{account_slug}"` and then numbered
+variants. The same insert/upsert SQL is used for every attempt, so the tenant and
+published-row safety guard remains load-bearing. If every bounded attempt is
+blocked, the repository leaves the draft unsaved and emits a warning with the
+base slug, account id, and attempt count.
+
+## Intentional
+
+- No schema migration in this slice. The legacy table has a global slug
+  uniqueness contract, and older blog writers still use `ON CONFLICT (slug)`.
+- No cross-tenant overwrite. A blocked slug becomes an alternate slug for the new
+  draft, not an update to the existing row.
+
+## Deferred
+
+- Parked hardening: none.
+- Replacing the legacy global slug uniqueness model with a composite
+  account/slug contract would be a broader migration and caller audit. This PR
+  fixes the current production save path without changing public slug semantics.
+
+## Verification
+
+- `pytest tests/test_extracted_blog_post_postgres.py -q` - 9 passed.
+- `python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_content_ops_custom_blog_smoke_haiku_diagnostics --user-id codex-smoke --blog-blueprint-json /tmp/atlas-custom-blog-blueprint.json --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file /tmp/atlas-haiku-override.env --output-result /tmp/atlas-custom-blog-smoke-haiku-diagnostics-result-after-fallback.json --json` - passed and returned saved draft id `7ff3c7b9-e6e5-476c-8a73-47d55d3e3adc`.
+- Export check for `acct_content_ops_custom_blog_smoke_haiku_diagnostics` - confirmed draft slug `how-support-tickets-become-faq-answers-customers-can-actually-find-acct-content-ops-custom-blog-smoke-haiku`.
+- Extracted content pipeline validation wrapper - passed.
+- Extracted reasoning-import guard - passed.
+- Extracted standalone audit with debt failure enabled - passed.
+- Extracted Python ASCII check - passed.
+- Extracted content pipeline sync wrapper - passed.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Blog Postgres repository slug fallback + warning | ~130 LOC |
+| Repository tests | ~50 LOC |
+| Plan doc | ~80 LOC |
+| **Total** | **~325 LOC** |

--- a/tests/test_extracted_blog_post_postgres.py
+++ b/tests/test_extracted_blog_post_postgres.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import date
 
 import pytest
@@ -93,16 +94,59 @@ async def test_save_drafts_persists_scope_metadata_and_returns_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_save_drafts_skips_cross_tenant_slug_conflict() -> None:
+async def test_save_drafts_retries_cross_tenant_slug_conflict_with_scope_slug() -> None:
     pool = _Pool()
-    pool.fetchval_results = [None]
+    pool.fetchval_results = [None, "blog-post-uuid-2"]
     repo = PostgresBlogPostRepository(pool)
 
     saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-b"))
 
-    assert saved == ()
+    assert saved == ("blog-post-uuid-2",)
+    assert len(pool.fetchval_calls) == 2
+    assert pool.fetchval_calls[0]["args"][1] == "acme-pricing-pressure"
+    assert pool.fetchval_calls[1]["args"][1] == "acme-pricing-pressure-acct-b"
     sql = pool.fetchval_calls[0]["query"]
     assert "blog_posts.account_id = EXCLUDED.account_id" in sql
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_uses_numbered_scope_slug_when_first_fallback_conflicts() -> None:
+    pool = _Pool()
+    pool.fetchval_results = [None, None, "blog-post-uuid-3"]
+    repo = PostgresBlogPostRepository(pool)
+
+    saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-b"))
+
+    assert saved == ("blog-post-uuid-3",)
+    assert pool.fetchval_calls[1]["args"][1] == "acme-pricing-pressure-acct-b"
+    assert pool.fetchval_calls[2]["args"][1] == "acme-pricing-pressure-acct-b-2"
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_warns_when_slug_retries_are_exhausted(caplog) -> None:
+    pool = _Pool()
+    pool.fetchval_results = [None, None, None, None, None]
+    repo = PostgresBlogPostRepository(pool)
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="extracted_content_pipeline.blog_post_postgres",
+    ):
+        saved = await repo.save_drafts([_draft()], scope=TenantScope(account_id="acct-b"))
+
+    assert saved == ()
+    assert [call["args"][1] for call in pool.fetchval_calls] == [
+        "acme-pricing-pressure",
+        "acme-pricing-pressure-acct-b",
+        "acme-pricing-pressure-acct-b-2",
+        "acme-pricing-pressure-acct-b-3",
+        "acme-pricing-pressure-acct-b-4",
+    ]
+    warning = caplog.records[0]
+    assert warning.message == "blog_post_draft_save_exhausted_slug_attempts"
+    assert warning.account_id == "acct-b"
+    assert warning.slug == "acme-pricing-pressure"
+    assert warning.attempts == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Blog-Draft-Slug-Fallback.md

Live Haiku blog generation passed quality but returned no saved draft ids when the generated slug was already owned by another account. This PR keeps the existing scoped upsert guard and retries blocked writes with deterministic tenant-scoped fallback slugs so the new draft saves without overwriting the existing row. Review feedback also added an exhaustion warning and a focused test for the all-attempts-blocked path.

## Intentional
- Keep the legacy global `blog_posts.slug` uniqueness contract; older blog writers still rely on `ON CONFLICT (slug)`.
- Preserve the cross-tenant/published-row overwrite guard and solve the failure by changing the new draft slug.
- Use deterministic account-derived suffixes so repeat runs update the same tenant-specific draft instead of creating random duplicates.

## Deferred
- Broader account/slug schema migration is deferred because it needs a legacy writer and public slug audit.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_blog_post_postgres.py -q` - 9 passed.
- Live Haiku smoke with `/tmp/atlas-custom-blog-blueprint.json` - passed and returned saved draft id `7ff3c7b9-e6e5-476c-8a73-47d55d3e3adc`.
- Export check confirmed fallback slug `how-support-tickets-become-faq-answers-customers-can-actually-find-acct-content-ops-custom-blog-smoke-haiku`.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
- `bash scripts/local_pr_review.sh` - passed.

## Diff size
3 files, +248 / -74.
