### PR TITLE
Add landing page failure diagnostics

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -68,6 +68,8 @@ from extracted_quality_gate.types import QualityInput, QualityPolicy
 
 
 _TARGET_MODE = "marketing_campaign"
+_LANDING_PAGE_FAILURE_EXCERPT_CHARS = 240
+_LANDING_PAGE_FAILURE_MAX_SECTIONS = 6
 
 
 @dataclass(frozen=True)
@@ -333,6 +335,7 @@ class LandingPageGenerationService:
             )
 
         parsed: dict[str, Any] | None = None
+        last_parsed_candidate: dict[str, Any] | None = None
         quality: dict[str, Any] = {"passed": False, "blockers": (), "repair_issues": ()}
         quality_blockers: tuple[str, ...] = ()
         quality_repair_history: list[dict[str, Any]] = []
@@ -372,6 +375,10 @@ class LandingPageGenerationService:
                     error["quality_blockers"] = quality_blockers
                 if quality_repair_history:
                     error["quality_repair_history"] = tuple(quality_repair_history)
+                if last_parsed_candidate is not None:
+                    error["failed_candidate"] = _landing_page_failure_candidate_snapshot(
+                        last_parsed_candidate
+                    )
                 return LandingPageGenerationResult(
                     requested=1,
                     generated=0,
@@ -402,6 +409,7 @@ class LandingPageGenerationService:
                 **parsed,
                 "_quality_repair_history": tuple(quality_repair_history),
             }
+            last_parsed_candidate = parsed
             if quality["passed"]:
                 break
             quality_blockers = tuple(str(item) for item in quality["repair_issues"])
@@ -417,6 +425,7 @@ class LandingPageGenerationService:
                     "blockers": tuple(str(item) for item in quality["blockers"]),
                     "quality_repair_attempts": repair_limit,
                     "quality_repair_history": tuple(quality_repair_history),
+                    "failed_candidate": _landing_page_failure_candidate_snapshot(parsed),
                 },),
                 quality_repair_history=tuple(quality_repair_history),
             )
@@ -557,6 +566,7 @@ class LandingPageGenerationService:
         total_usage: dict[str, Any] = {}
         total_parse_attempts = 0
         parsed: dict[str, Any] | None = None
+        last_parsed_candidate: dict[str, Any] | None = None
         campaign_payload: dict[str, Any] = campaign.as_dict()
         for repair_attempt_no in range(1, repair_limit + 1):
             campaign_payload = {
@@ -588,17 +598,22 @@ class LandingPageGenerationService:
                     quality_repair_history=tuple(quality_repair_history),
                 )
             if not parsed:
+                error: dict[str, Any] = {
+                    "landing_page_id": draft.id,
+                    "reason": "unparseable_response",
+                    "blockers": quality_blockers,
+                    "quality_blockers": quality_blockers,
+                    "quality_repair_history": tuple(quality_repair_history),
+                }
+                if last_parsed_candidate is not None:
+                    error["failed_candidate"] = _landing_page_failure_candidate_snapshot(
+                        last_parsed_candidate
+                    )
                 return LandingPageGenerationResult(
                     requested=1,
                     generated=0,
                     skipped=1,
-                    errors=({
-                        "landing_page_id": draft.id,
-                        "reason": "unparseable_response",
-                        "blockers": quality_blockers,
-                        "quality_blockers": quality_blockers,
-                        "quality_repair_history": tuple(quality_repair_history),
-                    },),
+                    errors=(error,),
                     quality_repair_history=tuple(quality_repair_history),
                 )
             total_usage = accumulate_usage(total_usage, parsed.get("_usage"))
@@ -623,6 +638,7 @@ class LandingPageGenerationService:
                 **parsed,
                 "_quality_repair_history": tuple(quality_repair_history),
             }
+            last_parsed_candidate = parsed
             if quality["passed"]:
                 break
             quality_blockers = tuple(str(item) for item in quality["repair_issues"])
@@ -638,6 +654,9 @@ class LandingPageGenerationService:
                     "blockers": tuple(str(item) for item in quality["blockers"]),
                     "quality_repair_attempts": repair_limit,
                     "quality_repair_history": tuple(quality_repair_history),
+                    "failed_candidate": _landing_page_failure_candidate_snapshot(
+                        parsed or last_parsed_candidate or {}
+                    ),
                 },),
                 quality_repair_history=tuple(quality_repair_history),
             )
@@ -878,6 +897,88 @@ def _quality_repair_history_row(
         "blockers": tuple(str(item) for item in quality.get("blockers") or ()),
         "repair_issues": tuple(
             str(item) for item in quality.get("repair_issues") or ()
+        ),
+    }
+
+
+def _clip_failure_text(value: Any, *, max_chars: int) -> str:
+    text = str(value or "").strip()
+    limit = max(1, int(max_chars))
+    if len(text) <= limit:
+        return text
+    trimmed = text[:limit].rstrip()
+    if " " in trimmed:
+        trimmed = trimmed.rsplit(" ", 1)[0].rstrip()
+    return trimmed or text[:limit].rstrip()
+
+
+def _landing_page_failure_candidate_snapshot(
+    parsed: Mapping[str, Any],
+    *,
+    excerpt_chars: int = _LANDING_PAGE_FAILURE_EXCERPT_CHARS,
+) -> dict[str, Any]:
+    """Return bounded diagnostics for a parsed landing page that cannot save."""
+
+    hero = parsed.get("hero") if isinstance(parsed.get("hero"), Mapping) else {}
+    cta = parsed.get("cta") if isinstance(parsed.get("cta"), Mapping) else {}
+    meta = parsed.get("meta") if isinstance(parsed.get("meta"), Mapping) else {}
+    raw_sections = parsed.get("sections")
+    sections = (
+        list(raw_sections)
+        if isinstance(raw_sections, Sequence)
+        and not isinstance(raw_sections, (str, bytes, bytearray))
+        else []
+    )
+    return {
+        "title": str(parsed.get("title") or "").strip(),
+        "slug": str(parsed.get("slug") or "").strip(),
+        "hero_headline": str(hero.get("headline") or "").strip(),
+        "hero_subheadline": str(hero.get("subheadline") or "").strip(),
+        "cta_label": str(cta.get("label") or "").strip(),
+        "cta_url": str(cta.get("url") or "").strip(),
+        "meta_title_tag": str(meta.get("title_tag") or "").strip(),
+        "section_count": len(sections),
+        "sections": tuple(
+            _landing_page_failure_section_snapshot(
+                section,
+                excerpt_chars=excerpt_chars,
+            )
+            for section in sections[:_LANDING_PAGE_FAILURE_MAX_SECTIONS]
+            if isinstance(section, Mapping)
+        ),
+        "sections_truncated": len(sections) > _LANDING_PAGE_FAILURE_MAX_SECTIONS,
+        "generation_parse_attempts": parsed.get("_parse_attempts"),
+        "generation_quality_repair_attempts": (
+            parsed.get("_quality_repair_attempts") or 0
+        ),
+    }
+
+
+def _landing_page_failure_section_snapshot(
+    section: Mapping[str, Any],
+    *,
+    excerpt_chars: int,
+) -> dict[str, Any]:
+    metadata = (
+        section.get("metadata")
+        if isinstance(section.get("metadata"), Mapping)
+        else {}
+    )
+    summary = str(metadata.get("answer_summary") or "").strip()
+    body = str(section.get("body_markdown") or "").strip()
+    return {
+        "id": str(section.get("id") or "").strip(),
+        "title": str(section.get("title") or "").strip(),
+        "kind": normalize_landing_page_section_kind(metadata.get("kind")),
+        "primary_question": str(metadata.get("primary_question") or "").strip(),
+        "answer_summary_word_count": len(summary.split()),
+        "answer_summary_excerpt": _clip_failure_text(
+            summary,
+            max_chars=excerpt_chars,
+        ),
+        "body_excerpt_head": _clip_failure_text(body, max_chars=excerpt_chars),
+        "body_starts_with_answer_summary": (
+            bool(summary) and _normalized_startswith(body, summary)
         ),
     }
 

--- a/plans/PR-Landing-Page-Failure-Diagnostics.md
+++ b/plans/PR-Landing-Page-Failure-Diagnostics.md
@@ -1,0 +1,69 @@
+# PR-Landing-Page-Failure-Diagnostics
+
+Ownership lane: `content-ops/landing-page-live-smoke`
+
+## Why this slice exists
+
+The Haiku landing-page live smoke can fail the save path because the landing
+quality gate blocks on `geo_readiness:section_semantics`. The blocked result
+currently reports only the missing check and repair history, not the candidate
+section metadata/body shape that caused the miss. A no-gate inspection run
+showed another candidate can pass readiness, so changing prompts without seeing
+the failed candidate would be guesswork.
+
+## Scope (this PR)
+
+1. Add a bounded landing-page failed-candidate snapshot for parsed candidates
+   that fail quality after all repair attempts.
+2. Include the same snapshot when a repair response is unparseable after a
+   previous parsed candidate existed.
+3. Cover the diagnostics with focused landing-page generation tests.
+
+### Files touched
+
+- `extracted_content_pipeline/landing_page_generation.py`
+- `tests/test_extracted_landing_page_generation.py`
+- `plans/PR-Landing-Page-Failure-Diagnostics.md`
+
+## Mechanism
+
+The generator already carries the last parsed landing-page JSON through the
+quality and repair loop. This PR adds a small helper that extracts safe, bounded
+fields from that parsed object: title, slug, hero headline, CTA, meta title,
+section count, section kinds/titles/questions, answer summary lengths, body
+starts, and repair attempt metadata. Quality-blocked and repair-unparseable
+errors include that snapshot.
+
+## Intentional
+
+- The snapshot is diagnostic only; it does not relax any quality gate or save
+  blocked drafts.
+- Body excerpts are capped so failed live outputs do not dump whole landing-page
+  drafts into operational logs.
+- No prompt changes in this slice. The live failure needs better observability
+  before we change the generation contract.
+
+## Deferred
+
+- Parked hardening: none.
+- Fixing the actual `geo_readiness:section_semantics` recurrence is the next
+  slice once diagnostics show the offending section shape.
+
+## Verification
+
+- `pytest tests/test_extracted_landing_page_generation.py -q` - 38 passed.
+- Live Haiku landing-page smoke with quality gates enabled - passed and returned saved draft id `f83fab79-762d-46d6-885a-37f5df5eb1e4`.
+- Extracted content pipeline validation wrapper - passed.
+- Extracted reasoning-import guard - passed.
+- Extracted standalone audit with debt failure enabled - passed.
+- Extracted Python ASCII check - passed.
+- Extracted content pipeline sync wrapper - passed.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Landing-page generator diagnostics | ~80 LOC |
+| Focused tests | ~55 LOC |
+| Plan doc | ~60 LOC |
+| **Total** | **~195 LOC** |

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -593,6 +593,38 @@ async def test_generate_skips_when_shared_readiness_blocks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_quality_blocked_error_includes_failed_candidate_snapshot() -> None:
+    response = json.loads(_valid_response())
+    response["sections"][0]["title"] = "Benefits"
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[json.dumps(response)],
+        config=LandingPageGenerationConfig(quality_repair_attempts=0),
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert landing_pages.saved == []
+    error = result.errors[0]
+    assert error["reason"] == "quality_blocked"
+    assert "geo_readiness:section_semantics" in error["blockers"]
+    snapshot = error["failed_candidate"]
+    assert snapshot["title"] == "Acme Q3: Stop Renewal Surprises"
+    assert snapshot["slug"] == "acme-q3-launch"
+    assert snapshot["hero_headline"] == "Stop renewal surprises"
+    assert snapshot["cta_url"] == "/demo"
+    assert snapshot["section_count"] == 3
+    assert snapshot["sections_truncated"] is False
+    first_section = snapshot["sections"][0]
+    assert first_section["title"] == "Benefits"
+    assert first_section["kind"] == "problem"
+    assert first_section["primary_question"] == "Why do renewal surprises cause churn?"
+    assert first_section["answer_summary_word_count"] >= 6
+    assert first_section["body_starts_with_answer_summary"] is True
+
+
+@pytest.mark.asyncio
 async def test_generate_repairs_quality_blocked_response_once_and_persists() -> None:
     """Parsed JSON that fails the quality gate gets one targeted repair pass."""
     bad_response = json.dumps({
@@ -924,6 +956,10 @@ async def test_generate_reports_quality_blockers_when_repair_response_will_not_p
     assert result.errors[0]["reason"] == "unparseable_response"
     assert any("no_cta" in blocker for blocker in result.errors[0]["quality_blockers"])
     assert result.errors[0]["quality_repair_history"] == result.quality_repair_history
+    snapshot = result.errors[0]["failed_candidate"]
+    assert snapshot["title"] == "ok"
+    assert snapshot["section_count"] == 1
+    assert snapshot["sections"][0]["title"] == "T"
     assert len(result.quality_repair_history) == 1
     assert result.quality_repair_history[0]["attempt"] == 0
     assert result.quality_repair_history[0]["passed"] is False


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-Failure-Diagnostics.md

A gated Haiku landing-page smoke intermittently blocked on `geo_readiness:section_semantics`, but the error only exposed the missing check, not the generated candidate shape. This PR adds bounded failed-candidate snapshots to landing-page quality-blocked and repair-unparseable paths so the next prompt/repair fix can be based on the actual section metadata/body output.

## Intentional
- Diagnostics only; no quality gate relaxation and no blocked draft persistence.
- Body excerpts are capped so operational errors do not dump complete generated pages.
- No prompt changes in this slice. We should inspect the failing candidate before changing the generation contract.

## Deferred
- Fixing recurring `geo_readiness:section_semantics` failures is deferred until diagnostics show the offending section shape.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_landing_page_generation.py -q` - 38 passed.
- Live Haiku landing-page smoke with quality gates enabled - passed and returned saved draft id `f83fab79-762d-46d6-885a-37f5df5eb1e4`.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
- `bash scripts/local_pr_review.sh` - passed.

## Diff size
3 files, +213 / -7.
