### PR TITLE
Record FAQ lifecycle 500-row validation

### DIFF
--- a/docs/extraction/validation/content_ops_faq_lifecycle_db_500_row_run_2026-05-23.md
+++ b/docs/extraction/validation/content_ops_faq_lifecycle_db_500_row_run_2026-05-23.md
@@ -1,0 +1,124 @@
+# Content Ops FAQ DB Lifecycle 500-Row Run - 2026-05-23
+
+## Summary
+
+The FAQ lifecycle smoke passed against the local Atlas Postgres database with
+500 CFPB-derived support-ticket source rows. The run exercised the full
+database-backed lifecycle:
+
+1. Load JSONL source rows.
+2. Generate FAQ Markdown.
+3. Persist the generated FAQ draft.
+4. Export the draft.
+5. Update the draft to `published`.
+6. Export the reviewed row.
+
+The command exited `0`, saved one FAQ row, exported one draft row, exported one
+published row, and reported all output checks passing.
+
+## Source Data
+
+- Source seed artifact: `tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl`
+- 500-row source artifact: `tmp/faq_lifecycle_500_validation_20260523/cfpb_500_source_rows.jsonl`
+- Source rows: `500`
+- Source format: `jsonl`
+- Source fixture command:
+
+```bash
+head -n 500 tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl \
+  > tmp/faq_lifecycle_500_validation_20260523/cfpb_500_source_rows.jsonl
+```
+
+## Database
+
+The run used the Atlas local database settings derived from
+`atlas_brain.storage.config.db_settings`. The DSN was passed through
+`EXTRACTED_DATABASE_URL` at command runtime and was not printed or checked in.
+
+## Command
+
+```bash
+EXTRACTED_DATABASE_URL="$(python - <<'PY'
+from atlas_brain.storage.config import db_settings
+print(db_settings.dsn)
+PY
+)" /usr/bin/time -v -o tmp/faq_lifecycle_500_validation_20260523/time.txt \
+  python scripts/smoke_content_ops_faq_lifecycle.py \
+  tmp/faq_lifecycle_500_validation_20260523/cfpb_500_source_rows.jsonl \
+  --source-format jsonl \
+  --account-id acct-faq-db-500-validation-20260523 \
+  --user-id user-faq-db-500-validation \
+  --title 'CFPB 500 Row FAQ DB Lifecycle Validation 2026-05-23' \
+  --min-source-rows 500 \
+  --min-saved-faqs 1 \
+  --export-limit 5 \
+  --max-text-chars 1200 \
+  --default-field company_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --default-field vendor_name=CFPB \
+  --output-result tmp/faq_lifecycle_500_validation_20260523/result.json \
+  --summary-json > tmp/faq_lifecycle_500_validation_20260523/stdout_summary.json
+```
+
+Artifact syntax checks:
+
+```bash
+python -m json.tool tmp/faq_lifecycle_500_validation_20260523/stdout_summary.json
+python -m json.tool tmp/faq_lifecycle_500_validation_20260523/result.json
+```
+
+## Result
+
+Compact lifecycle summary:
+
+```json
+{
+  "draft_export_count": 1,
+  "error_count": 0,
+  "errors": [],
+  "generated_item_count": 8,
+  "output_checks": {
+    "condensed": true,
+    "has_action_items": true,
+    "uses_user_vocabulary": true
+  },
+  "review_status": "published",
+  "reviewed_export_count": 1,
+  "saved_faq_count": 1,
+  "source_count": 500,
+  "source_format": "jsonl",
+  "source_rows": 500,
+  "status": "ok",
+  "ticket_source_count": 500
+}
+```
+
+Additional observed values:
+
+- `stdout_summary.json` exactly matched `result.json.lifecycle_summary`.
+- Full result artifact retained `reviewed_export`.
+- Normalization warning count: `0`.
+- Question sources: `source_policy=8`.
+- Ticket counts by item: `[322, 87, 50, 26, 4, 2, 2, 7]`.
+- Result artifact size: `182K`.
+- Summary stdout artifact size: `818B`.
+
+Timing:
+
+```text
+Elapsed wall time: 0:00.64
+Maximum resident set size: 36144 KB
+Exit status: 0
+```
+
+## Issues Surfaced
+
+No new issues surfaced in the 500-row lifecycle run. The compact stdout path
+kept operator output small while preserving the full lifecycle payload for
+audit.
+
+## Conclusion
+
+The real local database lifecycle proof passed at 500 source rows. Together with
+the 1,000-row lifecycle proof, this covers the common upload-size confidence
+range requested for the FAQ product wedge.

--- a/plans/PR-Content-Ops-FAQ-Lifecycle-500-Validation.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-500-Validation.md
@@ -1,0 +1,66 @@
+# PR-Content-Ops-FAQ-Lifecycle-500-Validation
+
+## Why this slice exists
+
+The FAQ product needs confidence signals at common SMB and mid-market upload
+sizes, not only at the 1,000-row upper proof point. The current main branch has
+1,000-row FAQ generator and lifecycle coverage, but no separate validation note
+for a 500-row database lifecycle run.
+
+This slice runs the real local database FAQ lifecycle against 500 CFPB-derived
+support-ticket rows and records the observed result. The goal is evidence, not a
+new code path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-validation
+
+1. Build a 500-row local fixture from the existing CFPB-derived 1,000-row JSONL
+   source artifact.
+2. Run the existing FAQ lifecycle smoke against the local Atlas Postgres DB with
+   500 source rows.
+3. Add a validation note with the observed lifecycle summary, timing, and issue
+   status.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-500-Validation.md`
+- `docs/extraction/validation/content_ops_faq_lifecycle_db_500_row_run_2026-05-23.md`
+
+## Mechanism
+
+The run uses the existing lifecycle smoke with the documented compact-output
+pattern: `--output-result` writes the full lifecycle payload and
+`--summary-json` writes compact stdout. The validation note records parsed
+summary fields, artifact paths, timing, and any issues surfaced.
+
+## Intentional
+
+- Documentation/validation record only; no generator, repository, migration, or
+  lifecycle code changes.
+- The 500-row source fixture is generated under `tmp/` and is not checked in.
+- This slice does not depend on the unmerged artifact-runner PR.
+
+## Deferred
+
+- Full artifact-runner validation remains deferred until the artifact runner
+  lands on main.
+- Root `HARDENING.md` was scanned; no same-lane parked item is required before
+  this validation run.
+
+## Verification
+
+- Passed: real local DB 500-row lifecycle smoke with `--summary-json`.
+- Passed: parsed saved stdout/result JSON artifacts; stdout exactly matched
+  `result.lifecycle_summary`, full result retained `reviewed_export`, and the
+  compact summary reported `status=ok`, `source_rows=500`,
+  `saved_faq_count=1`, `error_count=0`.
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~66 |
+| Validation note | ~124 |
+| **Total** | **~190** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-500-Validation.md

This records a real local DB FAQ lifecycle run at 500 CFPB-derived support-ticket rows, complementing the existing 1,000-row proof with a common SMB/mid-market upload size. The run uses the existing lifecycle smoke with `--summary-json` plus `--output-result`.

## Intentional
- Documentation and validation record only; lifecycle execution, repository, migration, and source-ingestion behavior are unchanged.
- The 500-row source fixture is generated under `tmp/` and is not checked in.
- This slice does not depend on the unmerged artifact-runner PR.

## Deferred
- Full artifact-runner validation remains deferred until the artifact runner lands on main.
- Root `HARDENING.md` was scanned; no same-lane parked item is required before this validation run.

## Verification
- Real local DB 500-row lifecycle smoke with `--summary-json` exited 0.
- Parsed saved stdout/result JSON artifacts; stdout exactly matched `result.lifecycle_summary`, full result retained `reviewed_export`, and compact summary reported `status=ok`, `source_rows=500`, `saved_faq_count=1`, `error_count=0`.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
2 files, +190 / -0