### PR TITLE
Record FAQ scale stress probe

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,9 +30,27 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-23
+
+### FAQSTRESS-2 - FAQ lifecycle concurrency needs DB pressure limits and failure artifacts
+- File/location: `scripts/smoke_content_ops_faq_lifecycle.py::_create_pool`, `atlas_brain/_content_ops_services.py::build_content_ops_execution_services`, hosted FAQ execution path.
+- Description: Real Postgres-backed concurrency probe passed through 50 simultaneous 10,000-row lifecycle runs, but 100 simultaneous 5,000-row runs produced 97 successes and 3 `asyncpg.exceptions.TooManyConnectionsError` failures. The failed smoke processes exited before writing `--output-result`.
+- Why it matters: concurrent customer uploads can exhaust database connection slots unless hosted FAQ execution has bounded concurrency, queue backpressure, request limits, or equivalent controls; missing failure artifacts also make saturation harder to diagnose.
+- Effort: M
+- Category: correctness
+- Owner/session: content-ops/faq-generator-validation
+- Found during: PR-Content-Ops-FAQ-Scale-Stress-Probe
+
+### FAQSTRESS-1 - FAQ large uploads need async/job boundary or explicit hosted limits
+- File/location: `scripts/smoke_content_ops_faq_scale_run.py`, `scripts/smoke_content_ops_faq_lifecycle.py`, hosted FAQ upload/execution path.
+- Description: Real CFPB-derived stress probe passed correctness through 50,000 rows, but 50k deterministic generation took 1:49.48 and 590,612 KB RSS; the DB lifecycle took 1:05.32 and 681,848 KB RSS. This is batch-safe but not request/response-safe.
+- Why it matters: large customer uploads can tie up request workers and memory unless the hosted path uses explicit row/file limits, background jobs, queue backpressure, or similar controls.
+- Effort: M
+- Category: correctness
+- Owner/session: content-ops/faq-generator-validation
+- Found during: PR-Content-Ops-FAQ-Scale-Stress-Probe
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent
 > content-ops-station sessions. Scan that file too when working those lanes.
-
-No parked items in the root hardening queue.

--- a/docs/extraction/validation/content_ops_faq_scale_stress_probe_2026-05-23.md
+++ b/docs/extraction/validation/content_ops_faq_scale_stress_probe_2026-05-23.md
@@ -1,0 +1,200 @@
+# Content Ops FAQ Scale Stress Probe - 2026-05-23
+
+## Summary
+
+The deterministic FAQ generator and Postgres-backed FAQ lifecycle were stress
+tested with real CFPB-derived support-ticket source rows at 2,000, 5,000,
+10,000, 25,000, and 50,000 rows.
+
+Correctness held through 50,000 rows:
+
+- deterministic generator exit code: `0` at every tested size
+- database lifecycle exit code: `0` at every tested size
+- output checks: `condensed=true`, `has_action_items=true`,
+  `uses_user_vocabulary=true`
+- normalization warnings: `0`
+- lifecycle saved one FAQ draft, exported the draft, updated it to `published`,
+  and exported the reviewed row
+
+The first weaknesses are operational, not FAQ correctness:
+
+- the 50,000-row run is too slow and memory-heavy for a synchronous
+  request/response path
+- the real Postgres-backed lifecycle starts failing under high concurrency when
+  connection slots saturate
+
+Those hardening items are parked in `HARDENING.md`.
+
+## Source Data
+
+- Archive: `/home/juan-canfield/Downloads/archive (1)/rows.csv`
+- Extractor: `scripts/export_content_ops_cfpb_sources.py`
+- Source type: `support_ticket`
+- Metadata defaults used to suppress CFPB fixture noise:
+  - `company_name=CFPB`
+  - `contact_email=cfpb-public-archive@example.invalid`
+  - `vendor_name=CFPB`
+
+Generated local fixtures:
+
+| Rows | Source artifact | Rows scanned | Size |
+|---:|---|---:|---:|
+| 2,000 | `tmp/faq_scale_stress_20260523/cfpb_2000_source_rows.jsonl` | 69,155 | 3.8 MB |
+| 5,000 | `tmp/faq_scale_stress_20260523/cfpb_5000_source_rows.jsonl` | 69,155 | 10.1 MB |
+| 10,000 | `tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl` | 69,155 | 20.2 MB |
+| 25,000 | `tmp/faq_scale_stress_20260523/cfpb_25000_source_rows.jsonl` | 102,311 | 50.7 MB |
+| 50,000 | `tmp/faq_scale_stress_20260523/cfpb_50000_source_rows.jsonl` | 156,985 | 101.8 MB |
+
+## Deterministic Generator Results
+
+Command shape:
+
+```bash
+/usr/bin/time -v -o tmp/faq_scale_stress_20260523/scale_<rows>_time.txt \
+  python scripts/smoke_content_ops_faq_scale_run.py \
+  tmp/faq_scale_stress_20260523/cfpb_<rows>_source_rows.jsonl \
+  --source-format jsonl \
+  --artifact-dir tmp/faq_scale_stress_20260523/scale_<rows> \
+  --title 'CFPB <rows> Row FAQ Scale Stress' \
+  --max-items 12 \
+  --max-evidence-per-item 5 \
+  --max-text-chars 1200 \
+  --default-field company_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --default-field vendor_name=CFPB
+```
+
+| Rows | Exit | Generated | Failed checks | Elapsed | Max RSS |
+|---:|---:|---:|---|---:|---:|
+| 2,000 | 0 | 12 | `[]` | 0:03.94 | 36,040 KB |
+| 5,000 | 0 | 12 | `[]` | 0:10.02 | 66,136 KB |
+| 10,000 | 0 | 12 | `[]` | 0:20.32 | 138,724 KB |
+| 25,000 | 0 | 12 | `[]` | 0:51.68 | 321,148 KB |
+| 50,000 | 0 | 12 | `[]` | 1:49.48 | 590,612 KB |
+
+The generated Markdown stayed around 29 KB because `max_items=12` and
+`max_evidence_per_item=5` bound the output size. Runtime and memory still grew
+with input size because the source file is fully loaded and grouped before
+rendering.
+
+## Database Lifecycle Results
+
+Command shape:
+
+```bash
+EXTRACTED_DATABASE_URL="$(python - <<'PY'
+from atlas_brain.storage.config import db_settings
+print(db_settings.dsn)
+PY
+)" /usr/bin/time -v -o tmp/faq_scale_stress_20260523/lifecycle_<rows>_time.txt \
+  python scripts/smoke_content_ops_faq_lifecycle.py \
+  tmp/faq_scale_stress_20260523/cfpb_<rows>_source_rows.jsonl \
+  --source-format jsonl \
+  --account-id acct-faq-stress-<rows>-20260523 \
+  --user-id user-faq-stress \
+  --title 'CFPB <rows> Row FAQ DB Lifecycle Stress 2026-05-23' \
+  --min-source-rows <rows> \
+  --min-saved-faqs 1 \
+  --export-limit 5 \
+  --max-text-chars 1200 \
+  --default-field company_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --default-field vendor_name=CFPB \
+  --output-result tmp/faq_scale_stress_20260523/lifecycle_<rows>_result.json \
+  --summary-json > tmp/faq_scale_stress_20260523/lifecycle_<rows>_stdout_summary.json
+```
+
+| Rows | Exit | Saved | Draft export | Reviewed export | Elapsed | Max RSS | Result size |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 2,000 | 0 | 1 | 1 | 1 | 0:02.51 | 52,676 KB | 314 KB |
+| 5,000 | 0 | 1 | 1 | 1 | 0:06.23 | 84,732 KB | 566 KB |
+| 10,000 | 0 | 1 | 1 | 1 | 0:13.07 | 167,620 KB | 986 KB |
+| 25,000 | 0 | 1 | 1 | 1 | 0:32.59 | 374,108 KB | 2.2 MB |
+| 50,000 | 0 | 1 | 1 | 1 | 1:05.32 | 681,848 KB | 4.2 MB |
+
+For every lifecycle run:
+
+- `stdout_summary.json` exactly matched `result.json.lifecycle_summary`
+- `source_count` equaled the requested row count
+- `ticket_source_count` equaled the requested row count
+- `error_count=0`
+- normalization warning count was `0`
+- question source counts were `source_policy=8`
+
+## Concurrent Lifecycle Results
+
+The concurrency probe launched independent
+`scripts/smoke_content_ops_faq_lifecycle.py` processes with unique account IDs,
+the real database URL from `atlas_brain.storage.config.db_settings.dsn`, and
+the same CFPB fixture defaults used by the single-worker runs.
+
+Host headroom before the final probe:
+
+- memory: 61 GiB total, 39 GiB available
+- Postgres `max_connections=100`
+- active Postgres connections before the final probe: `6`
+
+| Scenario | Source rows per run | Successes | Failures | Wall time | Failure mode |
+|---|---:|---:|---:|---:|---|
+| 5 concurrent runs | 5,000 | 5 | 0 | 6.65s | none |
+| 10 concurrent runs | 10,000 | 10 | 0 | 14.77s | none |
+| 20 concurrent runs | 10,000 | 20 | 0 | 23.36s | none |
+| 50 concurrent runs | 10,000 | 50 | 0 | 55.82s | none |
+| 100 concurrent runs | 5,000 | 97 | 3 | 50.84s | `TooManyConnectionsError` |
+
+The 100-way run produced three fast failures at indexes 92, 93, and 94:
+
+```text
+asyncpg.exceptions.TooManyConnectionsError: remaining connection slots are reserved for roles with the SUPERUSER attribute
+```
+
+Those failed processes returned exit code `1` and did not write their requested
+`--output-result` artifacts. The failure occurs while creating the script-local
+asyncpg pool, before `run_faq_lifecycle_smoke()` builds its payload and writes
+the result JSON.
+
+## Issues Surfaced
+
+### FAQSTRESS-1 - Large uploads need an async/job boundary or explicit limit
+
+At 50,000 rows, the deterministic generator still passed all checks, but the
+run took `1:49.48` and used `590,612 KB` RSS. The full DB lifecycle also passed,
+but took `1:05.32` and used `681,848 KB` RSS. This is acceptable as an operator
+batch smoke, but not as a synchronous web request path.
+
+Impact: without an async job boundary, upload limits, or backpressure, large
+uploads can tie up request workers and memory even when the deterministic
+generator eventually succeeds.
+
+Resolution: parked in `HARDENING.md`. The probe's goal was to find and record
+the weakness, not to introduce a job runner in this slice.
+
+### FAQSTRESS-2 - Concurrent lifecycle runs can exhaust DB connections
+
+At 100 concurrent 5,000-row lifecycle runs, 97 completed successfully and 3
+failed with `asyncpg.exceptions.TooManyConnectionsError`. The hosted service
+factory uses the host's existing shared pool, so this exact smoke shape is not
+the production wiring. The production requirement still stands: hosted FAQ
+execution needs bounded concurrency, queue backpressure, or explicit request
+limits so customer traffic cannot consume all database connection slots.
+
+The smoke also exposed a visibility gap: pool creation failures bypass
+`--output-result`, leaving only stderr for failed runs. That should be fixed in
+the smoke harness before relying on it as an automated survivability probe.
+
+Resolution: parked in `HARDENING.md`. The next slice should add result-artifact
+visibility for lifecycle pool creation failures or introduce the reusable
+concurrency probe, depending on which path we want to automate first.
+
+## Conclusion
+
+The current deterministic FAQ path survives real-data uploads through 50,000
+rows without output-check or lifecycle correctness failures. It also survives
+up to 50 concurrent 10,000-row lifecycle runs on this host. The first observed
+failure appears at 100 concurrent 5,000-row lifecycle runs, where Postgres
+connection slots saturate.
+
+The production hardening requirement is operational: large uploads need
+explicit limits and/or background job execution, and concurrent hosted FAQ
+execution needs bounded database pressure before this flow is exposed as a
+synchronous hosted upload endpoint.

--- a/plans/PR-Content-Ops-FAQ-Scale-Stress-Probe.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Stress-Probe.md
@@ -1,0 +1,89 @@
+# PR-Content-Ops-FAQ-Scale-Stress-Probe
+
+## Why this slice exists
+
+The FAQ generator and database lifecycle now have real 500-row and 1,000-row
+proofs. The next survivability question is where the deterministic path starts
+to bend under larger customer uploads.
+
+This slice intentionally pushes larger real CFPB-derived support-ticket files
+through the existing generator and database lifecycle smokes, then adds
+concurrent lifecycle probes to find the first operational failure mode. It
+records the observed limits, failures, timing, memory, and issue status.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-validation
+
+1. Generate larger local JSONL source-row fixtures from the local CFPB archive.
+2. Run existing deterministic FAQ generator smokes at increasing row counts.
+3. Run existing Postgres-backed FAQ lifecycle smokes at increasing row counts
+   when the generator run passes.
+4. Run concurrent Postgres-backed FAQ lifecycle probes to pressure the shared
+   database ceiling.
+5. Add a validation note with the commands, observed results, and any surfaced
+   issues.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Stress-Probe.md`
+- `docs/extraction/validation/content_ops_faq_scale_stress_probe_2026-05-23.md`
+- `HARDENING.md`
+
+## Mechanism
+
+The probe uses the existing scripts only:
+
+- CFPB row conversion reuses `cfpb_row_to_source_row`.
+- FAQ generation uses `scripts/smoke_content_ops_faq_scale_run.py`.
+- DB lifecycle uses `scripts/smoke_content_ops_faq_lifecycle.py`.
+- Concurrent probes launch the same lifecycle smoke with unique account IDs and
+  temp-only result paths.
+
+The validation note records exact row counts, concurrency levels, elapsed time,
+peak RSS when available, output checks, warning counts, and each issue that
+appears.
+
+## Intentional
+
+- Documentation/validation record only; no generator, repository, migration, or
+  lifecycle code changes.
+- Temporary large fixtures and result artifacts stay under `tmp/` and are not
+  checked in.
+- This slice does not depend on the unmerged artifact-runner PR.
+- The concurrency harness is temp-only. This PR records the observed behavior
+  without adding a reusable load-test runner.
+
+## Deferred
+
+- Hosted limits, async job execution, and bounded DB concurrency are deferred to
+  hardening slices. This PR is the evidence slice that identifies the limits.
+- The lifecycle smoke visibility fix for pool-creation failures is deferred to
+  the next slice because the probe itself completed and the failure is recorded.
+
+## Verification
+
+- Passed: generated 2,000, 5,000, 10,000, 25,000, and 50,000 row
+  CFPB-derived JSONL fixtures from the local archive.
+- Passed: deterministic FAQ scale smokes at 2k, 5k, 10k, 25k, and 50k rows;
+  all exited `0` with output checks passing.
+- Passed: Postgres-backed lifecycle smokes at 2k, 5k, 10k, 25k, and 50k rows;
+  all exited `0`, saved one FAQ, exported draft/reviewed rows, and reported
+  `error_count=0`.
+- Passed: concurrent lifecycle probes at 5x5k, 10x10k, 20x10k, and 50x10k.
+- Failed as expected under saturation: 100x5k returned 97 successes and 3
+  `asyncpg.exceptions.TooManyConnectionsError` failures.
+- Parked: 50k uploads are batch-safe but not request/response-safe without
+  hosted limits or an async job boundary.
+- Parked: 100-way lifecycle pressure can exhaust DB connections and failed
+  pool creation does not write the requested result artifact.
+- Passed: `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~89 |
+| Validation note | ~200 |
+| HARDENING entries | ~22 |
+| **Total** | **~311** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Stress-Probe.md

This records a real CFPB-derived stress probe across 2k/5k/10k/25k/50k rows through the deterministic FAQ generator and Postgres-backed lifecycle, then adds concurrent lifecycle pressure probes. Correctness held through 50k and through 50 concurrent 10k lifecycle runs, but the run surfaces operational hardening issues: 50k is batch-safe rather than request/response-safe, and 100 concurrent 5k lifecycle runs can exhaust Postgres connection slots.

## Intentional
- Documentation and validation record only; generator, lifecycle, repository, and migration behavior are unchanged.
- Temporary large fixtures and result artifacts stay under tmp/ and are not checked in.
- The concurrency harness is temp-only; this PR records behavior without adding a reusable load-test runner.
- This slice does not depend on the unmerged artifact-runner PR.

## Deferred
- Hosted upload limits / async job boundary are parked in HARDENING.md as FAQSTRESS-1.
- Bounded DB concurrency / queue backpressure and lifecycle pool-creation failure artifacts are parked in HARDENING.md as FAQSTRESS-2.

## Verification
- Generated 2k, 5k, 10k, 25k, and 50k CFPB-derived JSONL fixtures from the local archive.
- Deterministic FAQ scale smokes passed at 2k/5k/10k/25k/50k.
- Postgres-backed lifecycle smokes passed at 2k/5k/10k/25k/50k.
- Concurrent lifecycle probes passed at 5x5k, 10x10k, 20x10k, and 50x10k.
- 100x5k lifecycle pressure returned 97 successes and 3 `asyncpg.exceptions.TooManyConnectionsError` failures, now logged.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +309 / -2