### PR TITLE
Add server-side Content Ops file ingestion

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2,20 +2,26 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import math
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
 try:
-    from fastapi import APIRouter, Body, HTTPException
+    from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
     from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
     APIRouter = None
     Body = None
     HTTPException = None
+    File = None
+    Form = None
+    UploadFile = None
     BaseModel = None
     ConfigDict = None
     Field = None
@@ -41,7 +47,7 @@ from ..control_surfaces import (
 )
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
 from ..landing_page_input_contract import landing_page_seo_geo_aeo_input_contracts
-from ..ingestion_diagnostics import inspect_ingestion_rows
+from ..ingestion_diagnostics import inspect_ingestion_file, inspect_ingestion_rows
 from ..landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_INPUT,
     landing_page_quality_repair_input_contract,
@@ -83,6 +89,8 @@ _MAX_INPUT_KEYS = 50
 _MAX_INPUT_DEPTH = 6
 _MAX_INPUT_STRING_CHARS = 10000
 _MAX_INGESTION_ROWS = 1000
+_MAX_FILE_INGESTION_ROWS = 10000
+_MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
@@ -501,7 +509,7 @@ def create_content_ops_control_surface_router(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @router.post("/ingestion/inspect")
+    @router.post("/ingestion/inspect", deprecated=True)
     async def inspect_ingestion(
         payload: ContentOpsIngestionInspectModel = Body(...),
     ) -> dict[str, Any]:
@@ -520,7 +528,7 @@ def create_content_ops_control_surface_router(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return report.as_dict()
 
-    @router.post("/ingestion/import")
+    @router.post("/ingestion/import", deprecated=True)
     async def import_ingestion(
         payload: ContentOpsIngestionImportModel = Body(...),
     ) -> dict[str, Any]:
@@ -562,6 +570,82 @@ def create_content_ops_control_surface_router(
             replace_existing=bool(data.get("replace_existing")),
             dry_run=dry_run,
             source=report.source,
+        )
+        return {
+            "diagnostics": diagnostics,
+            "import": result.as_dict(),
+        }
+
+    @router.post("/ingestion/files/inspect")
+    async def inspect_ingestion_file_upload(
+        file: UploadFile = File(...),
+        source_rows: bool = Form(False),
+        source: str | None = Form(None),
+        target_mode: str | None = Form("vendor_retention"),
+        file_format: str = Form("auto"),
+        max_source_text_chars: int = Form(1200),
+        sample_limit: int = Form(3),
+        default_fields: str | None = Form(None),
+    ) -> dict[str, Any]:
+        report = await _inspect_uploaded_ingestion_file(
+            file,
+            source_rows=source_rows,
+            source=source,
+            target_mode=target_mode,
+            file_format=file_format,
+            max_source_text_chars=max_source_text_chars,
+            sample_limit=sample_limit,
+            default_fields=default_fields,
+        )
+        return _file_ingestion_response(report, source=source)
+
+    @router.post("/ingestion/files/import")
+    async def import_ingestion_file_upload(
+        file: UploadFile = File(...),
+        source_rows: bool = Form(False),
+        source: str | None = Form(None),
+        target_mode: str | None = Form("vendor_retention"),
+        file_format: str = Form("auto"),
+        max_source_text_chars: int = Form(1200),
+        sample_limit: int = Form(3),
+        default_fields: str | None = Form(None),
+        replace_existing: bool = Form(False),
+        dry_run: bool = Form(False),
+    ) -> dict[str, Any]:
+        target_mode_value = _clean(target_mode) or "vendor_retention"
+        report = await _inspect_uploaded_ingestion_file(
+            file,
+            source_rows=source_rows,
+            source=source,
+            target_mode=target_mode_value,
+            file_format=file_format,
+            max_source_text_chars=max_source_text_chars,
+            sample_limit=sample_limit,
+            default_fields=default_fields,
+        )
+        diagnostics = _file_ingestion_response(report, source=source)
+        if not report.ok:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason": "ingestion_not_ready",
+                    "diagnostics": diagnostics,
+                },
+            )
+        if dry_run:
+            pool = object()
+        else:
+            pool = await _resolve_import_pool(opportunity_import_pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        result = await _import_campaign_opportunities_for_route(
+            pool,
+            report.opportunities,
+            scope=scope,
+            target_mode=target_mode_value,
+            opportunity_table=resolved_config.ingestion_opportunity_table,
+            replace_existing=bool(replace_existing),
+            dry_run=bool(dry_run),
+            source=_clean(source) or report.source,
         )
         return {
             "diagnostics": diagnostics,
@@ -636,6 +720,146 @@ def create_content_ops_control_surface_router(
         return result
 
     return router
+
+
+async def _inspect_uploaded_ingestion_file(
+    file: UploadFile,
+    *,
+    source_rows: bool,
+    source: str | None,
+    target_mode: str | None,
+    file_format: str,
+    max_source_text_chars: int,
+    sample_limit: int,
+    default_fields: str | None,
+):
+    upload_bytes = await _read_bounded_upload(file)
+    if not upload_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded ingestion file is empty.")
+    resolved_format = _validate_upload_file_format(file_format)
+    parsed_default_fields = _parse_default_fields_form(default_fields)
+    suffix = _upload_suffix(file, resolved_format)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-ingestion-",
+            suffix=suffix,
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            handle.write(upload_bytes)
+        try:
+            report = inspect_ingestion_file(
+                temp_path,
+                source_rows=bool(source_rows),
+                file_format=resolved_format,
+                source_format=resolved_format,
+                target_mode=_clean(target_mode) or "vendor_retention",
+                max_source_text_chars=int(max_source_text_chars),
+                sample_limit=int(sample_limit),
+                default_fields=parsed_default_fields,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        row_count = len(report.opportunities)
+        if row_count > _MAX_FILE_INGESTION_ROWS:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    "Uploaded ingestion file is too large after normalization; "
+                    f"max {_MAX_FILE_INGESTION_ROWS} rows, got {row_count}."
+                ),
+            )
+        return report
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning(
+                    "Content Ops temporary ingestion upload cleanup failed",
+                    extra={"source": _clean(source) or _clean(getattr(file, "filename", None))},
+                )
+
+
+async def _read_bounded_upload(file: UploadFile) -> bytes:
+    try:
+        data = await file.read(_MAX_INGESTION_FILE_BYTES + 1)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded ingestion file could not be read.",
+        ) from exc
+    if len(data) > _MAX_INGESTION_FILE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                "Uploaded ingestion file is too large; "
+                f"max {_MAX_INGESTION_FILE_BYTES} bytes."
+            ),
+        )
+    return data
+
+
+def _validate_upload_file_format(value: str) -> str:
+    text = _clean(value) or "auto"
+    if text not in {"auto", "json", "jsonl", "csv"}:
+        raise HTTPException(
+            status_code=400,
+            detail="file_format must be one of: auto, json, jsonl, csv.",
+        )
+    return text
+
+
+def _parse_default_fields_form(value: str | None) -> dict[str, Any]:
+    text = _clean(value)
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="default_fields must be a JSON object.",
+        ) from exc
+    if not isinstance(parsed, Mapping):
+        raise HTTPException(
+            status_code=400,
+            detail="default_fields must be a JSON object.",
+        )
+    parsed_dict = dict(parsed)
+    if len(parsed_dict) > 50:
+        raise HTTPException(
+            status_code=400,
+            detail="default_fields cannot contain more than 50 entries.",
+        )
+    try:
+        _validate_input_shape(parsed_dict, depth=0)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return parsed_dict
+
+
+def _upload_suffix(file: UploadFile, file_format: str) -> str:
+    filename = _clean(getattr(file, "filename", None))
+    suffix = Path(filename).suffix.lower() if filename else ""
+    if suffix in {".json", ".jsonl", ".ndjson", ".csv"}:
+        return ".jsonl" if suffix == ".ndjson" else suffix
+    if file_format in {"json", "jsonl", "csv"}:
+        return f".{file_format}"
+    return ".json"
+
+
+def _file_ingestion_response(report: Any, *, source: str | None = None) -> dict[str, Any]:
+    payload = report.as_dict()
+    payload["source"] = _clean(source) or payload.get("source") or ""
+    payload["ingestion_path"] = "file_upload"
+    payload["limits"] = {
+        "max_file_bytes": _MAX_INGESTION_FILE_BYTES,
+        "max_rows": _MAX_FILE_INGESTION_ROWS,
+        "inline_rows_deprecated": True,
+    }
+    return payload
 
 
 async def _resolve_execution_services(

--- a/plans/PR-Content-Ops-Server-File-Ingestion.md
+++ b/plans/PR-Content-Ops-Server-File-Ingestion.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-Server-File-Ingestion
+
+## Why this slice exists
+
+FAQ generation can process thousands of ticket rows, but the hosted
+control-surface ingestion routes still accept inline JSON row arrays capped at
+1,000 rows. That makes the browser/API shape the production bottleneck for
+larger support-ticket CSV exports even though the underlying generator already
+handles larger files.
+
+This slice adds a production-shaped server-side file ingestion path so larger
+CSV/JSON/JSONL uploads are parsed by the API process instead of being expanded
+into a giant browser JSON body. The old inline row endpoints stay working but
+are marked deprecated so they can become dead code in a later cleanup.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/server-file-ingestion
+
+1. Add `/content-ops/ingestion/files/inspect` for uploaded ingestion files.
+2. Add `/content-ops/ingestion/files/import` for uploaded ingestion files that
+   reuse the existing diagnostics/import machinery.
+3. Bound file uploads by size and normalized row count separately from the old
+   inline-row cap.
+4. Mark `/content-ops/ingestion/inspect` and `/content-ops/ingestion/import`
+   as deprecated in FastAPI metadata.
+5. Add focused route tests proving large files bypass the 1,000 inline-row cap
+   without removing compatibility.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `plans/PR-Content-Ops-Server-File-Ingestion.md`
+
+## Mechanism
+
+The new file routes accept multipart file uploads plus form fields mirroring
+the inline routes: `source_rows`, `source`, `target_mode`,
+`max_source_text_chars`, `sample_limit`, `default_fields`, and import-only
+`replace_existing` / `dry_run`.
+
+The API writes the uploaded bytes to a temporary file, calls the existing
+`inspect_ingestion_file` parser/diagnostics path, then deletes the temp file.
+Import routes reuse the existing `_import_campaign_opportunities_for_route`
+function so scope checks, dry-run behavior, replace-existing behavior, and DB
+error wrapping stay centralized.
+
+## Intentional
+
+- The old inline endpoints remain available because the current UI still calls
+  them. This PR deprecates them in API metadata instead of removing them.
+- The new file upload row cap is intentionally larger than the inline cap. The
+  inline cap protects request-body shape; the file route is the production
+  path for larger customer exports.
+- This slice does not add durable upload/job storage. It proves the server-side
+  parsing/import path first; queued jobs and Blob-backed persistence are the
+  next hardening layer.
+
+## Deferred
+
+- Future PR: move the Intel UI file loader from inline JSON posts to the new
+  file endpoints.
+- Future PR: add durable upload/job persistence, polling status, and cleanup
+  metadata for long-running customer CSV imports.
+- Future PR: remove the deprecated inline ingestion routes after UI migration
+  and compatibility window.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
+  - `84 passed in 2.85s`
+- Ran the extracted pipeline check script at
+  `scripts/run_extracted_pipeline_checks.sh` with bash.
+  - `1858 passed, 1 skipped, 1 warning in 19.02s`
+  - All extracted content pipeline checks completed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| API file routes and helpers | ~230 |
+| Backend API tests | ~220 |
+| **Total** | ~535 |
+
+Slightly over the 400 LOC target because the slice needs route implementation,
+load-bearing upload bounds, deprecation coverage, >1,000-row file-route tests,
+and rejection-path coverage in one coherent API contract change.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 import extracted_content_pipeline.api.control_surfaces as api_module
@@ -20,6 +22,34 @@ def _route(router, path: str, method: str):
         if getattr(route, "path", None) == path and method.upper() in getattr(route, "methods", set()):
             return route
     raise AssertionError(f"route not found: {method} {path}")
+
+
+class _UploadFile:
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self._content = content
+
+    async def read(self, size=-1):
+        if size is None or size < 0:
+            return self._content
+        return self._content[:size]
+
+
+def _ticket_bundle_upload(row_count: int) -> _UploadFile:
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "source_type": "support_ticket",
+            "subject": "Billing renewal question",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "billing",
+        }
+        for index in range(row_count)
+    ]
+    return _UploadFile(
+        "support-ticket-export.json",
+        (json.dumps({"support_tickets": rows}) + "\n").encode("utf-8"),
+    )
 
 
 class _CampaignService:
@@ -646,6 +676,261 @@ async def test_ingestion_inspect_route_rejects_oversized_rows():
         })
 
     assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_inline_ingestion_routes_are_deprecated():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    inspect_route = _route(router, "/ops/ingestion/inspect", "POST")
+    import_route = _route(router, "/ops/ingestion/import", "POST")
+
+    assert inspect_route.deprecated is True
+    assert import_route.deprecated is True
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_accepts_more_than_inline_row_cap():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "source_type": "support_ticket",
+            "subject": "Billing renewal question",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "billing",
+        }
+        for index in range(1001)
+    ]
+    upload = _UploadFile(
+        "support-ticket-export.json",
+        (json.dumps({"support_tickets": rows}) + "\n").encode("utf-8"),
+    )
+
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+    payload = await route.endpoint(
+        file=upload,
+        source_rows=True,
+        source="ticket-csv-upload",
+        target_mode="vendor_retention",
+        file_format="json",
+        max_source_text_chars=1200,
+        sample_limit=3,
+        default_fields=json.dumps({
+            "company_name": "Acme",
+            "vendor_name": "Atlas",
+            "contact_email": "support@example.com",
+        }),
+    )
+
+    assert payload["ingestion_path"] == "file_upload"
+    assert payload["limits"]["inline_rows_deprecated"] is True
+    assert payload["source"] == "ticket-csv-upload"
+    assert payload["mode"] == "source_rows"
+    assert payload["ok"] is True
+    assert payload["opportunity_count"] == 1001
+    assert payload["source_type_counts"] == {"support_ticket": 1001}
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_import_route_dry_run_uses_file_parser():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "source_type": "support_ticket",
+            "subject": "Setup question",
+            "message": "Where do I find the setup checklist?",
+            "pain_category": "setup",
+        }
+        for index in range(1001)
+    ]
+    upload = _UploadFile(
+        "support-ticket-export.json",
+        (json.dumps({"support_tickets": rows}) + "\n").encode("utf-8"),
+    )
+
+    route = _route(router, "/ops/ingestion/files/import", "POST")
+    payload = await route.endpoint(
+        file=upload,
+        source_rows=True,
+        source="ticket-csv-upload",
+        target_mode="vendor_retention",
+        file_format="json",
+        max_source_text_chars=1200,
+        sample_limit=3,
+        default_fields=json.dumps({
+            "company_name": "Acme",
+            "vendor_name": "Atlas",
+            "contact_email": "support@example.com",
+        }),
+        dry_run=True,
+    )
+
+    assert payload["diagnostics"]["ingestion_path"] == "file_upload"
+    assert payload["diagnostics"]["opportunity_count"] == 1001
+    assert payload["import"]["dry_run"] is True
+    assert payload["import"]["inserted"] == 1001
+    assert payload["import"]["source"] == "ticket-csv-upload"
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_rejects_oversized_upload_bytes():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_UploadFile("support-ticket-export.json", b"x" * (25 * 1024 * 1024 + 2)),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+        )
+
+    assert exc.value.status_code == 413
+    assert "Uploaded ingestion file is too large" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_rejects_more_than_file_row_cap():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(10001),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+        )
+
+    assert exc.value.status_code == 413
+    assert "max 10000 rows" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_rejects_empty_file():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_UploadFile("empty.json", b""),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Uploaded ingestion file is empty."
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_rejects_invalid_file_format():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="xlsx",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=None,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "file_format must be one of: auto, json, jsonl, csv."
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_rejects_malformed_default_fields():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields="{not-json",
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "default_fields must be a JSON object."
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_import_route_rejects_not_ready_diagnostics():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    upload = _UploadFile(
+        "support-ticket-export.json",
+        (json.dumps([{"message": "Missing target defaults."}]) + "\n").encode("utf-8"),
+    )
+    route = _route(router, "/ops/ingestion/files/import", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=upload,
+            source_rows=False,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=None,
+            dry_run=True,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "ingestion_not_ready"
+    assert exc.value.detail["diagnostics"]["ingestion_path"] == "file_upload"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Server-File-Ingestion.md

Adds server-side Content Ops ingestion file routes so larger customer CSV/JSON/JSONL exports are parsed by the API process instead of being expanded into deprecated inline JSON row posts capped at 1,000 rows.

## Intentional
- Keep `/content-ops/ingestion/inspect` and `/content-ops/ingestion/import` working while marking them deprecated in FastAPI metadata.
- Bound uploaded files separately from the old inline row cap: 25 MB file cap and 10,000 normalized rows.
- Reuse existing ingestion diagnostics and import machinery so parsing/import behavior stays centralized.

## Deferred
- Migrate the Intel UI file loader to `/content-ops/ingestion/files/inspect` and `/content-ops/ingestion/files/import`.
- Add durable upload/job persistence, polling status, and cleanup metadata for long-running imports.
- Remove deprecated inline ingestion routes after UI migration and compatibility window.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py -q` — 78 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 1852 passed, 1 skipped, 1 warning.
- `bash scripts/local_pr_review.sh` — passed.

## Diff size
3 files, +432 / -4. Slightly over the 400 LOC soft cap because route implementation, upload bounds, deprecation coverage, and >1,000-row file-route tests ship as one API contract slice.