### PR TITLE
Write FAQ lifecycle setup failure results

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Lifecycle-Setup-Failure-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Lifecycle-Setup-Failure-Result.md
@@ -1,0 +1,69 @@
+# PR-Content-Ops-FAQ-Lifecycle-Setup-Failure-Result
+
+## Why this slice exists
+
+The FAQ scale stress probe found that `scripts/smoke_content_ops_faq_lifecycle.py`
+does not write `--output-result` when database pool creation fails. In the
+100-way lifecycle pressure run, `TooManyConnectionsError` failures left only
+stderr, which is too weak for automated survivability probes.
+
+This slice makes that failure mode visible without changing FAQ generation,
+repository behavior, migrations, or hosted runtime limits.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-validation
+
+1. Keep the existing lifecycle success path unchanged.
+2. Route database pool acquisition failures through the same lifecycle payload
+   and result-file writing path used by in-flow failures.
+3. Add focused regression coverage for a setup failure with `--output-result`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Lifecycle-Setup-Failure-Result.md`
+- `scripts/smoke_content_ops_faq_lifecycle.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+
+`run_faq_lifecycle_smoke()` will initialize its default failure state before it
+attempts `_create_pool()`. If `_create_pool()` raises, the function records the
+exception in `errors`, builds the normal compact `lifecycle_summary`, writes
+`args.output_result` when requested, and returns exit code `1`.
+
+The success path still closes the pool and still writes the same payload shape.
+
+## Intentional
+
+- No retry, backoff, semaphore, queue, or connection-pool sizing change in this
+  slice; those are runtime hardening decisions, not result visibility.
+- CLI argument validation failures remain command-line validation failures.
+  This slice targets runtime setup failures after arguments have validated.
+- The result payload stays compact and does not add traceback bodies.
+
+## Deferred
+
+- Bounded hosted FAQ concurrency and async/background job execution stay
+  deferred to hardening slices.
+- A reusable concurrent FAQ load-test runner is deferred; the current need is
+  making existing smoke failures machine-readable.
+
+## Verification
+
+- Passed: pytest focused lifecycle smoke tests:
+  `tests/test_smoke_content_ops_faq_lifecycle.py` (`13 passed`).
+- Passed: extracted pipeline validation bundle:
+  `scripts/run_extracted_pipeline_checks.sh`
+  (`1850 passed, 1 skipped` for extracted_content_pipeline; extracted
+  reasoning checks also passed).
+- Pending: local PR review.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~69 |
+| Lifecycle smoke script | ~14 |
+| Lifecycle smoke tests | ~32 |
+| **Total** | **~115** |

--- a/scripts/smoke_content_ops_faq_lifecycle.py
+++ b/scripts/smoke_content_ops_faq_lifecycle.py
@@ -134,7 +134,7 @@ def _validate_args(args: argparse.Namespace) -> None:
 async def run_faq_lifecycle_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     default_fields = parse_default_fields_or_exit(args.default_field)
     source_path = Path(args.path)
-    pool = await _create_pool(str(args.database_url))
+    pool = None
     errors: list[str] = []
     source_rows = 0
     saved_ids: list[str] = []
@@ -145,6 +145,7 @@ async def run_faq_lifecycle_smoke(args: argparse.Namespace) -> tuple[int, dict[s
     input_profile = empty_input_profile(status="not_started")
     try:
         try:
+            pool = await _create_pool(str(args.database_url))
             if not await _relation_exists(pool, "ticket_faq_markdown"):
                 errors.append(
                     "required Content Ops table missing: ticket_faq_markdown. "
@@ -238,14 +239,15 @@ async def run_faq_lifecycle_smoke(args: argparse.Namespace) -> tuple[int, dict[s
                         expected_status=str(args.review_status),
                     )
                 )
-        except Exception as exc:  # pragma: no cover - exercised by live hosts
+        except Exception as exc:
             errors.append(f"{type(exc).__name__}: {exc}")
     finally:
-        close = getattr(pool, "close", None)
-        if close is not None:
-            maybe_awaitable = close()
-            if hasattr(maybe_awaitable, "__await__"):
-                await maybe_awaitable
+        if pool is not None:
+            close = getattr(pool, "close", None)
+            if close is not None:
+                maybe_awaitable = close()
+                if hasattr(maybe_awaitable, "__await__"):
+                    await maybe_awaitable
     payload = {
         "ok": not errors,
         "source": str(source_path),

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -330,6 +330,38 @@ async def test_faq_lifecycle_smoke_fails_closed_when_table_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_faq_lifecycle_smoke_writes_result_when_pool_creation_fails(
+    monkeypatch, tmp_path
+):
+    async def fail_create_pool(*_args, **_kwargs):
+        raise RuntimeError("database connection slots exhausted")
+
+    result_path = tmp_path / "lifecycle_failure.json"
+    monkeypatch.setattr(smoke, "_create_pool", fail_create_pool)
+
+    code, payload = await smoke.run_faq_lifecycle_smoke(
+        _args(output_result=result_path)
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["source"] == str(SUPPORT_TICKET_CSV)
+    assert payload["source_rows"] == 0
+    assert payload["input_profile"]["status"] == "not_started"
+    assert payload["generation"] is None
+    assert payload["draft_export"] is None
+    assert payload["reviewed_export"] is None
+    assert payload["saved_ids"] == []
+    assert payload["errors"] == ["RuntimeError: database connection slots exhausted"]
+    assert payload["lifecycle_summary"]["status"] == "failed"
+    assert payload["lifecycle_summary"]["source_rows"] == 0
+    assert payload["lifecycle_summary"]["error_count"] == 1
+    assert payload["lifecycle_summary"]["errors"] == payload["errors"]
+    assert result_path.exists()
+    assert json.loads(result_path.read_text(encoding="utf-8")) == payload
+
+
+@pytest.mark.asyncio
 async def test_faq_lifecycle_smoke_reports_review_status_miss(monkeypatch):
     pool = _Pool(update_hits=False)
     monkeypatch.setattr(smoke, "_create_pool", lambda *_args, **_kwargs: _return_pool(pool))


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Lifecycle-Setup-Failure-Result.md

The FAQ concurrency stress probe found that database pool creation failures can exit the lifecycle smoke before `--output-result` is written. This keeps success behavior unchanged while routing runtime setup failures through the same compact lifecycle payload/result-file path used by in-flow failures.

## Intentional
- No retry, backoff, semaphore, queue, or connection-pool sizing change in this slice.
- CLI argument validation failures remain command-line validation failures.
- The result payload stays compact and does not add traceback bodies.

## Deferred
- Bounded hosted FAQ concurrency and async/background job execution stay deferred to hardening slices.
- A reusable concurrent FAQ load-test runner is deferred.

## Verification
- Focused lifecycle smoke tests: `13 passed`.
- Extracted pipeline validation bundle: `1850 passed, 1 skipped`; extracted reasoning checks also passed.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +109 / -6