### PR TITLE
Add Content Ops execute concurrency gate

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import math
@@ -237,6 +238,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_falsification_conservative: bool = True
     structured_reasoning_drop_falsified: bool = False
     ingestion_opportunity_table: str = "campaign_opportunities"
+    execute_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
@@ -274,6 +276,8 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_top_thesis_limit must be positive")
         if self.structured_reasoning_max_continuations < 0:
             raise ValueError("structured_reasoning_max_continuations must be non-negative")
+        if self.execute_max_concurrency <= 0:
+            raise ValueError("execute_max_concurrency must be positive")
         if not isinstance(
             self.structured_reasoning_falsification_rules,
             Sequence,
@@ -302,6 +306,25 @@ class ContentOpsControlSurfaceApiConfig:
                 )
         if not str(self.ingestion_opportunity_table or "").strip():
             raise ValueError("ingestion_opportunity_table is required")
+
+
+class _ExecuteConcurrencyGate:
+    def __init__(self, max_concurrency: int) -> None:
+        self.max_concurrency = int(max_concurrency)
+        self._in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> bool:
+        async with self._lock:
+            if self._in_flight >= self.max_concurrency:
+                return False
+            self._in_flight += 1
+            return True
+
+    async def release(self) -> None:
+        async with self._lock:
+            if self._in_flight > 0:
+                self._in_flight -= 1
 
 
 @dataclass(frozen=True)
@@ -469,6 +492,7 @@ def create_content_ops_control_surface_router(
 
     _require_fastapi()
     resolved_config = config or ContentOpsControlSurfaceApiConfig()
+    execute_gate = _ExecuteConcurrencyGate(resolved_config.execute_max_concurrency)
     router = APIRouter(
         prefix=resolved_config.prefix,
         tags=list(resolved_config.tags),
@@ -656,68 +680,79 @@ def create_content_ops_control_surface_router(
     async def execute_generation(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
-        if execution_services_provider is None:
-            raise HTTPException(
-                status_code=503,
-                detail="Content Ops execution services are not configured.",
-            )
-        services = await _resolve_execution_services(execution_services_provider)
-        if services is None:
-            raise HTTPException(
-                status_code=503,
-                detail="Content Ops execution services are not configured.",
-            )
-        # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
-        # per-request reasoning provider and derive a reasoning-aware
-        # bundle. The base services from execution_services_provider
-        # are not mutated; the derivation rebinds reasoning on each
-        # opt-in service via with_reasoning_context().
-        #
-        # Gate on whether the kwarg was supplied at router construction,
-        # not on the resolved value -- when a host wires a per-request
-        # provider that returns None for tenant-policy reasons, the
-        # bundle is derived with reasoning rebound to None (predictable,
-        # no leak of construction-time reasoning). When the kwarg was
-        # never supplied, leave the host-baked reasoning alone.
         payload_mapping = _payload_to_mapping(payload)
-        if reasoning_context_provider is not None:
-            if _clean(payload_mapping.get("reasoning_preset")):
-                logger.info(
-                    "Content Ops reasoning_preset ignored because host provider is configured"
-                )
-            reasoning_context = await _resolve_reasoning_context(
-                reasoning_context_provider
+        if not await execute_gate.acquire():
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "reason": "content_ops_execute_at_capacity",
+                    "max_concurrency": execute_gate.max_concurrency,
+                },
             )
-            services = services.with_reasoning_context(reasoning_context)
-        else:
-            reasoning_groups = await _structured_reasoning_contexts(
-                payload_mapping,
-                config=resolved_config,
-                services=services,
-                llm_provider=llm_provider,
-            )
-            for reasoning_context, reasoning_outputs in reasoning_groups:
-                services = services.with_reasoning_context(
-                    reasoning_context,
-                    outputs=reasoning_outputs,
-                )
-        scope = await _resolve_scope(scope_provider)
         try:
-            result = await execute_content_ops_from_mapping(
-                payload_mapping,
-                services=services,
-                scope=scope,
-            )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        result = _sanitize_execution_result(result)
-        if result["status"] == "blocked":
-            raise HTTPException(status_code=400, detail=result)
-        if result["status"] == "failed":
-            raise HTTPException(status_code=502, detail=result)
-        if result["status"] == "partial":
-            raise HTTPException(status_code=207, detail=result)
-        return result
+            if execution_services_provider is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Content Ops execution services are not configured.",
+                )
+            services = await _resolve_execution_services(execution_services_provider)
+            if services is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Content Ops execution services are not configured.",
+                )
+            # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
+            # per-request reasoning provider and derive a reasoning-aware
+            # bundle. The base services from execution_services_provider
+            # are not mutated; the derivation rebinds reasoning on each
+            # opt-in service via with_reasoning_context().
+            #
+            # Gate on whether the kwarg was supplied at router construction,
+            # not on the resolved value -- when a host wires a per-request
+            # provider that returns None for tenant-policy reasons, the
+            # bundle is derived with reasoning rebound to None (predictable,
+            # no leak of construction-time reasoning). When the kwarg was
+            # never supplied, leave the host-baked reasoning alone.
+            if reasoning_context_provider is not None:
+                if _clean(payload_mapping.get("reasoning_preset")):
+                    logger.info(
+                        "Content Ops reasoning_preset ignored because host provider is configured"
+                    )
+                reasoning_context = await _resolve_reasoning_context(
+                    reasoning_context_provider
+                )
+                services = services.with_reasoning_context(reasoning_context)
+            else:
+                reasoning_groups = await _structured_reasoning_contexts(
+                    payload_mapping,
+                    config=resolved_config,
+                    services=services,
+                    llm_provider=llm_provider,
+                )
+                for reasoning_context, reasoning_outputs in reasoning_groups:
+                    services = services.with_reasoning_context(
+                        reasoning_context,
+                        outputs=reasoning_outputs,
+                    )
+            scope = await _resolve_scope(scope_provider)
+            try:
+                result = await execute_content_ops_from_mapping(
+                    payload_mapping,
+                    services=services,
+                    scope=scope,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            result = _sanitize_execution_result(result)
+            if result["status"] == "blocked":
+                raise HTTPException(status_code=400, detail=result)
+            if result["status"] == "failed":
+                raise HTTPException(status_code=502, detail=result)
+            if result["status"] == "partial":
+                raise HTTPException(status_code=207, detail=result)
+            return result
+        finally:
+            await execute_gate.release()
 
     return router
 

--- a/plans/PR-Content-Ops-Execute-Concurrency-Gate.md
+++ b/plans/PR-Content-Ops-Execute-Concurrency-Gate.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-Execute-Concurrency-Gate
+
+## Why this slice exists
+
+The FAQ stress probe showed correctness holds at large row counts, but hosted
+execution still needs survivability controls. The API already caps inline
+`source_material` uploads at 1,000 rows; the next source-level issue is
+concurrent `/content-ops/execute` traffic.
+
+This slice adds a thin request-level concurrency gate at the hosted execute
+route so excess execute requests fail fast instead of piling onto database and
+worker resources.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator-validation
+
+1. Add a router-local execute concurrency limit to
+   `ContentOpsControlSurfaceApiConfig`.
+2. Apply that limit around the `/execute` route's runtime work.
+3. Return a machine-readable `429` overload response when the gate is full.
+4. Add focused API tests that prove overload rejection and release behavior.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Execute-Concurrency-Gate.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Mechanism
+
+The control-surface router factory constructs one in-memory gate per router
+instance. The execute endpoint validates the request body, attempts to
+enter the gate, and returns `429` with `reason=content_ops_execute_at_capacity`
+when the gate is full. A `finally` block releases the slot after success,
+partial failure, or exception.
+
+The default is intentionally small and configurable. This is a per-process
+guard, not a distributed queue.
+
+## Intentional
+
+- No async job runner, retry/backoff, distributed queue, or database pool
+  tuning in this slice.
+- No new row-count cap; the route already limits inline `source_material` to
+  1,000 rows.
+- The gate covers all `/execute` outputs, not only FAQ, because the shared route
+  and shared database pool are the constrained resources.
+
+## Deferred
+
+- Cross-process/global admission control remains deferred until there is a
+  deployed multi-worker topology to target.
+- Background job execution for large uploads remains deferred to a later
+  hardening slice.
+
+## Verification
+
+- Passed: focused control-surface API tests:
+  `tests/test_extracted_content_control_surface_api.py` (`86 passed` after
+  rebasing over PR #861).
+- Passed: extracted pipeline validation bundle:
+  `scripts/run_extracted_pipeline_checks.sh` (`1860 passed, 1 skipped`;
+  extracted reasoning checks also passed).
+- Passed: post-rebase `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~73 |
+| Control-surface API | ~151 |
+| API tests | ~66 |
+| **Total** | **~291** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import pytest
@@ -64,6 +65,25 @@ class _CampaignService:
             "filters": dict(filters or {}),
             "kwargs": dict(kwargs),
         })
+        return {"generated": 1, "saved_ids": ["draft-1"]}
+
+
+class _BlockingCampaignService(_CampaignService):
+    def __init__(self):
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def generate(self, *, scope, target_mode, limit=None, filters=None, **kwargs):
+        self.calls.append({
+            "scope": scope,
+            "target_mode": target_mode,
+            "limit": limit,
+            "filters": dict(filters or {}),
+            "kwargs": dict(kwargs),
+        })
+        self.started.set()
+        await self.release.wait()
         return {"generated": 1, "saved_ids": ["draft-1"]}
 
 
@@ -1134,6 +1154,47 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["target_mode"] == "vendor_retention"
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_rejects_when_concurrency_gate_is_full():
+    service = _BlockingCampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            execute_max_concurrency=1,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(campaign=service),
+    )
+    route = _route(router, "/ops/execute", "POST")
+    request = {
+        "outputs": ["email_campaign"],
+        "inputs": {
+            "target_account": "Acme",
+            "offer": "Churn audit",
+        },
+    }
+
+    first = asyncio.create_task(route.endpoint(request))
+    await asyncio.wait_for(service.started.wait(), timeout=1)
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(request)
+
+    assert exc.value.status_code == 429
+    assert exc.value.detail == {
+        "reason": "content_ops_execute_at_capacity",
+        "max_concurrency": 1,
+    }
+    assert len(service.calls) == 1
+
+    service.release.set()
+    first_payload = await first
+    assert first_payload["status"] == "completed"
+
+    second_payload = await route.endpoint(request)
+    assert second_payload["status"] == "completed"
+    assert len(service.calls) == 2
 
 
 @pytest.mark.asyncio
@@ -2232,6 +2293,11 @@ def test_content_ops_config_stores_output_pack_names_immutably():
 
     with pytest.raises(TypeError):
         config.structured_reasoning_output_pack_names["blog_post"] = "other_pack"  # type: ignore[index]
+
+
+def test_content_ops_config_rejects_invalid_execute_concurrency():
+    with pytest.raises(ValueError, match="execute_max_concurrency must be positive"):
+        ContentOpsControlSurfaceApiConfig(execute_max_concurrency=0)
 
 
 def test_content_ops_config_rejects_invalid_falsification_rules_shape():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Execute-Concurrency-Gate.md

This adds a router-local fail-fast concurrency gate around `/content-ops/execute`. The API already caps inline source_material uploads at 1,000 rows; this slice protects the hosted execution seam from concurrent request pressure by returning a machine-readable 429 when the execute gate is full.

## Intentional
- No async job runner, retry/backoff, distributed queue, or database pool tuning in this slice.
- No new row-count cap; inline source_material is already capped at 1,000 rows.
- The gate covers all `/execute` outputs because the route and database pool are shared resources.
- Rebased over #861; file-ingestion routes and execute concurrency gate now coexist in the same control-surface module.

## Deferred
- Cross-process/global admission control remains deferred until there is a deployed multi-worker topology to target.
- Background job execution for large uploads remains deferred to a later hardening slice.

## Verification
- Focused control-surface API tests after rebasing over #861: `86 passed`.
- Extracted pipeline validation bundle after rebasing over #861: `1860 passed, 1 skipped`; extracted reasoning checks also passed.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +233 / -58