### PR TITLE
Route Content Ops UI file ingestion through upload endpoints

### DIFF
--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -7,8 +7,10 @@
  *   GET  /content-ops/control-surfaces
  *   POST /content-ops/preview
  *   POST /content-ops/plan
- *   POST /content-ops/ingestion/inspect
- *   POST /content-ops/ingestion/import
+ *   POST /content-ops/ingestion/files/inspect
+ *   POST /content-ops/ingestion/files/import
+ *   POST /content-ops/ingestion/inspect (deprecated inline fallback)
+ *   POST /content-ops/ingestion/import (deprecated inline fallback)
  *   POST /content-ops/execute
  *   GET  /content-assets/{asset}/drafts
  *   GET  /content-assets/{asset}/drafts/export
@@ -137,6 +139,23 @@ export interface ContentOpsIngestionImportRequest
   extends ContentOpsIngestionInspectRequest {
   replace_existing?: boolean                         // default false
   dry_run?: boolean                                  // default false
+}
+
+export interface ContentOpsIngestionFileInspectRequest {
+  file: File
+  source_rows?: boolean
+  source?: string | null
+  target_mode?: string | null
+  file_format?: 'auto' | 'json' | 'jsonl' | 'csv'
+  max_source_text_chars?: number
+  sample_limit?: number
+  default_fields?: Record<string, unknown>
+}
+
+export interface ContentOpsIngestionFileImportRequest
+  extends ContentOpsIngestionFileInspectRequest {
+  replace_existing?: boolean
+  dry_run?: boolean
 }
 
 export interface ContentOpsIngestionWarning {
@@ -494,6 +513,70 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return rawJson<T>(res)
 }
 
+async function postMultipart<T>(path: string, body: FormData): Promise<T> {
+  const url = `${BASE}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: authHeaders(),
+      body,
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+  return rawJson<T>(res)
+}
+
+function ingestionFileFormData(
+  body: ContentOpsIngestionFileInspectRequest,
+): FormData {
+  const formData = new FormData()
+  formData.set('file', body.file)
+  appendOptionalBoolean(formData, 'source_rows', body.source_rows)
+  appendOptionalString(formData, 'source', body.source)
+  appendOptionalString(formData, 'target_mode', body.target_mode)
+  appendOptionalString(formData, 'file_format', body.file_format)
+  appendOptionalNumber(
+    formData,
+    'max_source_text_chars',
+    body.max_source_text_chars,
+  )
+  appendOptionalNumber(formData, 'sample_limit', body.sample_limit)
+  if (body.default_fields) {
+    formData.set('default_fields', JSON.stringify(body.default_fields))
+  }
+  return formData
+}
+
+function appendOptionalString(
+  formData: FormData,
+  key: string,
+  value: string | null | undefined,
+): void {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (text) formData.set(key, text)
+}
+
+function appendOptionalNumber(
+  formData: FormData,
+  key: string,
+  value: number | null | undefined,
+): void {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    formData.set(key, String(value))
+  }
+}
+
+function appendOptionalBoolean(
+  formData: FormData,
+  key: string,
+  value: boolean | null | undefined,
+): void {
+  if (typeof value === 'boolean') formData.set(key, String(value))
+}
+
 function queryString(params: GeneratedAssetListParams): string {
   const search = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
@@ -746,7 +829,17 @@ export function inspectContentOpsIngestion(
   return postJson<ContentOpsIngestionDiagnosticsResponse>('/ingestion/inspect', body)
 }
 
-/** POST /content-ops/ingestion/import -- import inspected opportunity/source rows. */
+/** POST /content-ops/ingestion/files/inspect -- inspect an uploaded ingestion file. */
+export function inspectContentOpsIngestionFile(
+  body: ContentOpsIngestionFileInspectRequest,
+): Promise<ContentOpsIngestionDiagnosticsResponse> {
+  return postMultipart<ContentOpsIngestionDiagnosticsResponse>(
+    '/ingestion/files/inspect',
+    ingestionFileFormData(body),
+  )
+}
+
+/** POST /content-ops/ingestion/import -- deprecated inline compatibility path. */
 export async function importContentOpsIngestion(
   body: ContentOpsIngestionImportRequest,
 ): Promise<ContentOpsIngestionImportOutcome> {
@@ -758,7 +851,30 @@ export async function importContentOpsIngestion(
       body: JSON.stringify(body),
     })
   const res = await withRefreshOn401(doFetch)
+  return ingestionImportOutcomeFromResponse(res)
+}
 
+/** POST /content-ops/ingestion/files/import -- import an uploaded ingestion file. */
+export async function importContentOpsIngestionFile(
+  body: ContentOpsIngestionFileImportRequest,
+): Promise<ContentOpsIngestionImportOutcome> {
+  const url = `${BASE}/ingestion/files/import`
+  const formData = ingestionFileFormData(body)
+  appendOptionalBoolean(formData, 'replace_existing', body.replace_existing)
+  appendOptionalBoolean(formData, 'dry_run', body.dry_run)
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: formData,
+    })
+  const res = await withRefreshOn401(doFetch)
+  return ingestionImportOutcomeFromResponse(res)
+}
+
+async function ingestionImportOutcomeFromResponse(
+  res: Response,
+): Promise<ContentOpsIngestionImportOutcome> {
   if (res.status === 200) {
     return {
       kind: 'success',

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -13,7 +13,9 @@ import {
   executeContentOpsRun,
   fetchContentOpsControlSurfaces,
   importContentOpsIngestion,
+  importContentOpsIngestionFile,
   inspectContentOpsIngestion,
+  inspectContentOpsIngestionFile,
   planContentOpsRun,
   previewContentOpsRun,
 } from '../api/contentOps'
@@ -86,7 +88,7 @@ type IngestionFileLoadState =
   | { kind: 'idle' }
   | { kind: 'loading' }
   | { kind: 'error'; message: string }
-  | { kind: 'success'; filename: string; count: number }
+  | { kind: 'success'; filename: string; size: number }
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_ROWS_JSON = '[\n  \n]'
@@ -166,6 +168,9 @@ export default function ContentOpsNewRun() {
   const [ingestionReplaceExisting, setIngestionReplaceExisting] = useState(false)
   const [ingestionFileLoadState, setIngestionFileLoadState] =
     useState<IngestionFileLoadState>({ kind: 'idle' })
+  const [selectedIngestionFile, setSelectedIngestionFile] = useState<File | null>(
+    null,
+  )
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
   const [planState, setPlanState] = useState<PlanState>({ kind: 'idle' })
   const [executionState, setExecutionState] = useState<ExecutionState>({
@@ -263,9 +268,6 @@ export default function ContentOpsNewRun() {
     ingestionInspectRequestIdRef.current += 1
     ingestionImportRequestIdRef.current += 1
     ingestionFileLoadRequestIdRef.current += 1
-    setIngestionFileLoadState((prev) =>
-      prev.kind === 'loading' ? prev : { kind: 'idle' },
-    )
     setIngestionInspectState((prev) =>
       prev.kind === 'idle' ? prev : { kind: 'idle' },
     )
@@ -503,11 +505,13 @@ export default function ContentOpsNewRun() {
 
   const handleInspectIngestion = async () => {
     const requestId = ++ingestionInspectRequestIdRef.current
-    const parsed = parseIngestionRowsJson(ingestionRowsJson)
-    if (!parsed.ok) {
+    const parsedRows = selectedIngestionFile
+      ? null
+      : parseIngestionRowsJson(ingestionRowsJson)
+    if (parsedRows && !parsedRows.ok) {
       setIngestionInspectState({
         kind: 'invalid_input',
-        message: parsed.message,
+        message: parsedRows.message,
       })
       return
     }
@@ -521,20 +525,32 @@ export default function ContentOpsNewRun() {
       })
       return
     }
+    const inlineRows = parsedRows?.ok ? parsedRows.rows : []
 
     setIngestionInspectState({ kind: 'submitting' })
     try {
-      const wire = await inspectContentOpsIngestion(
-        toWireIngestionInspectRequest({
-          rows: parsed.rows,
-          sourceRows: ingestionSourceRows,
-          source: ingestionSource.trim() || null,
-          targetMode: request.targetMode,
-          maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-          sampleLimit: INGESTION_SAMPLE_LIMIT,
-          defaultFields: parsedDefaultFields.fields,
-        }),
-      )
+      const wire = selectedIngestionFile
+        ? await inspectContentOpsIngestionFile({
+            file: selectedIngestionFile,
+            source_rows: ingestionSourceRows,
+            source: ingestionSource.trim() || null,
+            target_mode: request.targetMode,
+            file_format: 'auto',
+            max_source_text_chars: INGESTION_MAX_SOURCE_TEXT_CHARS,
+            sample_limit: INGESTION_SAMPLE_LIMIT,
+            default_fields: parsedDefaultFields.fields,
+          })
+        : await inspectContentOpsIngestion(
+            toWireIngestionInspectRequest({
+              rows: inlineRows,
+              sourceRows: ingestionSourceRows,
+              source: ingestionSource.trim() || null,
+              targetMode: request.targetMode,
+              maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
+              sampleLimit: INGESTION_SAMPLE_LIMIT,
+              defaultFields: parsedDefaultFields.fields,
+            }),
+          )
       if (requestId !== ingestionInspectRequestIdRef.current) return
       setIngestionInspectState({
         kind: 'success',
@@ -552,11 +568,13 @@ export default function ContentOpsNewRun() {
   const handleImportIngestion = async () => {
     const requestId = ++ingestionImportRequestIdRef.current
     const inspectRequestId = ++ingestionInspectRequestIdRef.current
-    const parsed = parseIngestionRowsJson(ingestionRowsJson)
-    if (!parsed.ok) {
+    const parsedRows = selectedIngestionFile
+      ? null
+      : parseIngestionRowsJson(ingestionRowsJson)
+    if (parsedRows && !parsedRows.ok) {
       setIngestionImportState({
         kind: 'invalid_input',
-        message: parsed.message,
+        message: parsedRows.message,
       })
       return
     }
@@ -570,22 +588,36 @@ export default function ContentOpsNewRun() {
       })
       return
     }
+    const inlineRows = parsedRows?.ok ? parsedRows.rows : []
 
     setIngestionImportState({ kind: 'submitting' })
     try {
-      const outcome = await importContentOpsIngestion(
-        toWireIngestionImportRequest({
-          rows: parsed.rows,
-          sourceRows: ingestionSourceRows,
-          source: ingestionSource.trim() || null,
-          targetMode: request.targetMode,
-          maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-          sampleLimit: INGESTION_SAMPLE_LIMIT,
-          defaultFields: parsedDefaultFields.fields,
-          replaceExisting: ingestionReplaceExisting,
-          dryRun: ingestionDryRun,
-        }),
-      )
+      const outcome = selectedIngestionFile
+        ? await importContentOpsIngestionFile({
+            file: selectedIngestionFile,
+            source_rows: ingestionSourceRows,
+            source: ingestionSource.trim() || null,
+            target_mode: request.targetMode,
+            file_format: 'auto',
+            max_source_text_chars: INGESTION_MAX_SOURCE_TEXT_CHARS,
+            sample_limit: INGESTION_SAMPLE_LIMIT,
+            default_fields: parsedDefaultFields.fields,
+            replace_existing: ingestionReplaceExisting,
+            dry_run: ingestionDryRun,
+          })
+        : await importContentOpsIngestion(
+            toWireIngestionImportRequest({
+              rows: inlineRows,
+              sourceRows: ingestionSourceRows,
+              source: ingestionSource.trim() || null,
+              targetMode: request.targetMode,
+              maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
+              sampleLimit: INGESTION_SAMPLE_LIMIT,
+              defaultFields: parsedDefaultFields.fields,
+              replaceExisting: ingestionReplaceExisting,
+              dryRun: ingestionDryRun,
+            }),
+          )
       if (requestId !== ingestionImportRequestIdRef.current) return
       if (outcome.kind === 'success') {
         setIngestionImportState({
@@ -631,31 +663,16 @@ export default function ContentOpsNewRun() {
     event.currentTarget.value = ''
     if (!file) return
 
-    const requestId = ++ingestionFileLoadRequestIdRef.current
+    ingestionFileLoadRequestIdRef.current += 1
     setIngestionFileLoadState({ kind: 'loading' })
-    try {
-      const text = await file.text()
-      if (requestId !== ingestionFileLoadRequestIdRef.current) return
-      const parsed = parseIngestionFileRows(file.name, text)
-      if (!parsed.ok) {
-        setIngestionFileLoadState({ kind: 'error', message: parsed.message })
-        return
-      }
-      setIngestionRowsJson(JSON.stringify(parsed.rows, null, 2))
-      setIngestionSource(file.name)
-      markIngestionStale()
-      setIngestionFileLoadState({
-        kind: 'success',
-        filename: file.name,
-        count: parsed.rows.length,
-      })
-    } catch (err) {
-      if (requestId !== ingestionFileLoadRequestIdRef.current) return
-      setIngestionFileLoadState({
-        kind: 'error',
-        message: err instanceof Error ? err.message : String(err),
-      })
-    }
+    setSelectedIngestionFile(file)
+    setIngestionSource(file.name)
+    markIngestionStale()
+    setIngestionFileLoadState({
+      kind: 'success',
+      filename: file.name,
+      size: file.size,
+    })
   }
 
   return (
@@ -1103,6 +1120,8 @@ export default function ContentOpsNewRun() {
           <textarea
             value={ingestionRowsJson}
             onChange={(e) => {
+              setSelectedIngestionFile(null)
+              setIngestionFileLoadState({ kind: 'idle' })
               setIngestionRowsJson(e.target.value)
               markIngestionStale()
             }}
@@ -1477,10 +1496,19 @@ function IngestionFileLoadResult({ state }: { state: IngestionFileLoadState }) {
   }
   return (
     <div className="mt-3 rounded-md border border-slate-700 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
-      Loaded {state.count} row{state.count === 1 ? '' : 's'} from{' '}
-      <span className="font-mono text-slate-100">{state.filename}</span>.
+      Selected{' '}
+      <span className="font-mono text-slate-100">{state.filename}</span>{' '}
+      ({formatBytes(state.size)}) for server-side inspection.
     </div>
   )
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return 'unknown size'
+  if (value < 1024) return `${value} B`
+  const kib = value / 1024
+  if (kib < 1024) return `${kib.toFixed(1)} KB`
+  return `${(kib / 1024).toFixed(1)} MB`
 }
 
 function IngestionImportResult({ state }: { state: IngestionImportState }) {
@@ -1963,129 +1991,6 @@ function parseIngestionDefaultFieldsJson(
     return { ok: false, message: 'Fallback fields must be a JSON object.' }
   }
   return { ok: true, fields: { ...parsed } }
-}
-
-function parseIngestionFileRows(
-  filename: string,
-  text: string,
-): ParsedIngestionRows {
-  if (!text.trim()) {
-    return { ok: false, message: 'File is empty.' }
-  }
-  const lowerFilename = filename.toLowerCase()
-  if (lowerFilename.endsWith('.jsonl') || lowerFilename.endsWith('.ndjson')) {
-    const rows: unknown[] = []
-    for (const [index, line] of text.split(/\r?\n/).entries()) {
-      if (!line.trim()) continue
-      try {
-        rows.push(JSON.parse(line))
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return { ok: false, message: `Line ${index + 1}: ${message}` }
-      }
-    }
-    return normalizeIngestionRows(rows)
-  }
-  if (lowerFilename.endsWith('.csv')) {
-    return parseIngestionCsvRows(text)
-  }
-  return parseIngestionRowsJson(text)
-}
-
-function parseIngestionCsvRows(text: string): ParsedIngestionRows {
-  const parsed = parseCsv(text)
-  if (!parsed.ok) return parsed
-  const [header, ...bodyRows] = parsed.rows
-  if (!header || header.length === 0) {
-    return { ok: false, message: 'CSV must include a header row.' }
-  }
-  const columns = header.map((value) => value.trim())
-  const seenColumns = new Set<string>()
-  for (const [index, column] of columns.entries()) {
-    if (!column) {
-      return { ok: false, message: `CSV header ${index + 1} is empty.` }
-    }
-    if (seenColumns.has(column)) {
-      return { ok: false, message: `CSV header "${column}" is duplicated.` }
-    }
-    seenColumns.add(column)
-  }
-
-  const normalizedRows: Array<Record<string, unknown>> = []
-  for (const [index, row] of bodyRows.entries()) {
-    if (!row.some((value) => value.trim())) continue
-    if (row.length > columns.length) {
-      return {
-        ok: false,
-        message: `CSV row ${index + 2} has ${row.length} fields but only ${columns.length} headers.`,
-      }
-    }
-    const out: Record<string, unknown> = {}
-    for (const [index, column] of columns.entries()) {
-      out[column] = row[index] ?? ''
-    }
-    normalizedRows.push(out)
-  }
-  if (normalizedRows.length === 0) {
-    return { ok: false, message: 'Provide at least one row to inspect.' }
-  }
-  return normalizeIngestionRows(normalizedRows)
-}
-
-function parseCsv(text: string): { ok: true; rows: string[][] } | { ok: false; message: string } {
-  const rows: string[][] = []
-  let row: string[] = []
-  let field = ''
-  let inQuotes = false
-  let justClosedQuote = false
-
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index]
-    const nextChar = text[index + 1]
-    if (char === '"') {
-      if (inQuotes && nextChar === '"') {
-        field += '"'
-        index += 1
-      } else if (inQuotes) {
-        inQuotes = false
-        justClosedQuote = true
-      } else if (!field) {
-        inQuotes = true
-      } else {
-        return { ok: false, message: `Unexpected quote at character ${index + 1}.` }
-      }
-      continue
-    }
-    if (char === ',' && !inQuotes) {
-      row.push(field)
-      field = ''
-      justClosedQuote = false
-      continue
-    }
-    if ((char === '\n' || char === '\r') && !inQuotes) {
-      row.push(field)
-      rows.push(row)
-      row = []
-      field = ''
-      justClosedQuote = false
-      if (char === '\r' && nextChar === '\n') {
-        index += 1
-      }
-      continue
-    }
-    if (justClosedQuote) {
-      return { ok: false, message: `Unexpected character after closing quote at character ${index + 1}.` }
-    }
-    field += char
-  }
-  if (inQuotes) {
-    return { ok: false, message: 'CSV contains an unterminated quoted field.' }
-  }
-  if (field || row.length > 0 || justClosedQuote) {
-    row.push(field)
-    rows.push(row)
-  }
-  return { ok: true, rows }
 }
 
 function extractIngestionRows(value: unknown): ParsedIngestionRows {

--- a/plans/PR-Content-Ops-UI-File-Ingestion.md
+++ b/plans/PR-Content-Ops-UI-File-Ingestion.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-UI-File-Ingestion
+
+## Why this slice exists
+
+PR #861 added server-side file ingestion routes so large customer CSV/JSON/JSONL
+exports no longer need to be expanded into inline browser JSON posts. The New
+Run UI still parses loaded files into the `rows` textarea and submits them to
+the now-deprecated inline ingestion endpoints, so customer ticket exports over
+the inline cap can still fail from the UI.
+
+This slice moves the file-loaded path to the new multipart file endpoints while
+leaving pasted/manual rows on the deprecated inline path for compatibility.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/ui-file-ingestion
+
+1. Add frontend API wrappers for:
+   - `POST /content-ops/ingestion/files/inspect`
+   - `POST /content-ops/ingestion/files/import`
+2. Keep the old inline wrappers available but document them as deprecated.
+3. Update `ContentOpsNewRun` so loaded files are retained as `File` objects and
+   submitted through the file endpoints.
+4. Keep pasted JSON rows working through the inline compatibility path.
+
+### Files touched
+
+- `plans/PR-Content-Ops-UI-File-Ingestion.md`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+
+## Mechanism
+
+The API adapter builds `FormData` with the selected `File`, `source_rows`,
+`source`, `target_mode`, `max_source_text_chars`, `sample_limit`,
+`default_fields`, and import-only `replace_existing` / `dry_run`. It does not
+set `Content-Type`, letting the browser provide the multipart boundary.
+
+`ContentOpsNewRun` stores the loaded file separately from the manual rows
+textarea. Inspect/import choose the file route when a file is selected and the
+inline route otherwise. Editing the rows textarea clears the selected file and
+returns the operator to the manual compatibility path.
+
+## Intentional
+
+- Manual pasted rows still use the deprecated inline endpoints because the UI
+  still needs a low-friction row editor for small/debug payloads.
+- No backend files are touched. PR #864 is open against backend control-surface
+  files, so this slice avoids that ownership lane.
+- No durable job/upload polling yet. This slice only wires the existing
+  server-side file routes into the UI.
+
+## Deferred
+
+- Future PR: remove the inline UI path after a compatibility window.
+- Future PR: add durable upload/job status once the backend grows a job model.
+- Future PR: show backend upload limits from catalog/config instead of hardcoded
+  route behavior.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run build` from `atlas-intel-ui/`
+  - TypeScript build passed.
+  - Vite production build passed.
+- `npm run lint` from `atlas-intel-ui/`
+  - Passed.
+- `npm run test:content-ops-input-display` from `atlas-intel-ui/`
+  - `2` tests passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| API wrappers | ~160 |
+| New Run UI wiring | ~270 changed, mostly deleting client-side file parsing |
+| **Total** | ~520 changed |
+
+Over the 400 LOC target because the UI migration removes the old client-side
+CSV/JSONL parser, adds multipart wrappers, and keeps manual inline rows as a
+compatibility path in one coherent screen/API contract update.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-UI-File-Ingestion.md

Moves the Content Ops New Run file-loaded ingestion path from deprecated inline JSON row posts to the server-side multipart file ingestion endpoints added in #861. Manual pasted rows remain on the inline compatibility path.

## Intentional
- File uploads now stay as `File` objects and use `/content-ops/ingestion/files/inspect` and `/content-ops/ingestion/files/import`.
- Manual pasted rows still use the deprecated inline endpoints until a later compatibility cleanup.
- No backend files are touched because PR #864 owns the overlapping backend control-surface lane.

## Deferred
- Remove the inline UI path after a compatibility window.
- Add durable upload/job status once the backend has a job model.
- Surface backend upload limits from catalog/config in a later slice.

## Parked hardening
- None.

## Verification
- `npm run build` from `atlas-intel-ui/` — passed.
- `npm run lint` from `atlas-intel-ui/` — passed.
- `npm run test:content-ops-input-display` from `atlas-intel-ui/` — 2 passed.
- `bash scripts/local_pr_review.sh` — passed.

## Diff size
3 files, +289 / -186. Over the 400 LOC soft cap because this removes the old client-side file parser, adds multipart wrappers, and keeps manual inline rows as a compatibility path in one coherent screen/API contract update.