### PR TITLE
Add Content Ops UI file ingestion routing tests

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:content-ops-ingestion-routing": "node --test scripts/content-ops-ingestion-routing.test.mjs",
     "test:content-ops-input-display": "node --test scripts/content-ops-input-display.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+function loadContentOpsApiModule() {
+  const source = readFileSync(
+    new URL('../src/api/contentOps.ts', import.meta.url),
+    'utf8',
+  )
+    .replace(
+      "import { tryRefreshToken } from '../auth/AuthContext'\n",
+      'const tryRefreshToken = async () => null\n',
+    )
+    .replace(
+      "import { API_BASE } from './config'\n",
+      `const API_BASE = '${API_ORIGIN}'\n`,
+    )
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  importContentOpsIngestion,
+  importContentOpsIngestionFile,
+  inspectContentOpsIngestion,
+  inspectContentOpsIngestionFile,
+} = await loadContentOpsApiModule()
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+function diagnosticsPayload() {
+  return {
+    ok: true,
+    mode: 'source_rows',
+    source: 'tickets.csv',
+    opportunity_count: 2,
+    warning_count: 0,
+    warning_counts: {},
+    missing_field_counts: {},
+    source_type_counts: { ticket: 2 },
+    samples: [],
+    warnings: [],
+  }
+}
+
+function importPayload() {
+  return {
+    diagnostics: diagnosticsPayload(),
+    import: {
+      inserted: 2,
+      skipped: 0,
+      dry_run: false,
+      replace_existing: true,
+      target_ids: ['ticket-1', 'ticket-2'],
+      warnings: [],
+      source: 'tickets.csv',
+    },
+  }
+}
+
+function assertAuthHeader(headers) {
+  assert.equal(headers.Authorization, 'Bearer test-token')
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('uploaded file inspect uses multipart file endpoint', async () => {
+  const calls = installFetchResponder(diagnosticsPayload())
+  const file = new File(['subject,body\nSetup,How do I set this up?\n'], 'tickets.csv', {
+    type: 'text/csv',
+  })
+
+  await inspectContentOpsIngestionFile({
+    file,
+    source_rows: true,
+    source: 'tickets.csv',
+    target_mode: 'vendor_retention',
+    file_format: 'csv',
+    max_source_text_chars: 900,
+    sample_limit: 5,
+    default_fields: { company_name: 'Acme' },
+  })
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/ingestion/files/inspect`,
+  )
+  assert.equal(init.method, 'POST')
+  assertAuthHeader(init.headers)
+  assert.equal(init.headers['Content-Type'], undefined)
+  assert.ok(init.body instanceof FormData)
+  assert.equal(init.body.get('file').name, 'tickets.csv')
+  assert.equal(init.body.get('source_rows'), 'true')
+  assert.equal(init.body.get('source'), 'tickets.csv')
+  assert.equal(init.body.get('target_mode'), 'vendor_retention')
+  assert.equal(init.body.get('file_format'), 'csv')
+  assert.equal(init.body.get('max_source_text_chars'), '900')
+  assert.equal(init.body.get('sample_limit'), '5')
+  assert.equal(
+    init.body.get('default_fields'),
+    JSON.stringify({ company_name: 'Acme' }),
+  )
+})
+
+test('inline inspect uses deprecated JSON compatibility endpoint', async () => {
+  const calls = installFetchResponder(diagnosticsPayload())
+
+  await inspectContentOpsIngestion({
+    rows: [{ target_id: 'ticket-1', text: 'How do I set this up?' }],
+    source_rows: true,
+    source: 'manual-paste',
+    target_mode: 'vendor_retention',
+    max_source_text_chars: 900,
+    sample_limit: 5,
+    default_fields: { company_name: 'Acme' },
+  })
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(url, `${API_ORIGIN}/api/v1/content-ops/ingestion/inspect`)
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), {
+    rows: [{ target_id: 'ticket-1', text: 'How do I set this up?' }],
+    source_rows: true,
+    source: 'manual-paste',
+    target_mode: 'vendor_retention',
+    max_source_text_chars: 900,
+    sample_limit: 5,
+    default_fields: { company_name: 'Acme' },
+  })
+})
+
+test('uploaded file import uses multipart file endpoint', async () => {
+  const calls = installFetchResponder(importPayload())
+  const file = new File(['subject,body\nBilling,Why was I charged?\n'], 'tickets.csv', {
+    type: 'text/csv',
+  })
+
+  const outcome = await importContentOpsIngestionFile({
+    file,
+    source_rows: true,
+    source: 'tickets.csv',
+    target_mode: 'vendor_retention',
+    file_format: 'csv',
+    max_source_text_chars: 1200,
+    sample_limit: 3,
+    default_fields: { company_name: 'Acme' },
+    replace_existing: true,
+    dry_run: false,
+  })
+
+  assert.equal(outcome.kind, 'success')
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/ingestion/files/import`,
+  )
+  assert.equal(init.method, 'POST')
+  assertAuthHeader(init.headers)
+  assert.equal(init.headers['Content-Type'], undefined)
+  assert.ok(init.body instanceof FormData)
+  assert.equal(init.body.get('file').name, 'tickets.csv')
+  assert.equal(init.body.get('replace_existing'), 'true')
+  assert.equal(init.body.get('dry_run'), 'false')
+})
+
+test('inline import uses deprecated JSON compatibility endpoint', async () => {
+  const calls = installFetchResponder(importPayload())
+
+  const outcome = await importContentOpsIngestion({
+    rows: [{ target_id: 'ticket-2', text: 'Why was I charged?' }],
+    source_rows: true,
+    source: 'manual-paste',
+    target_mode: 'vendor_retention',
+    max_source_text_chars: 1200,
+    sample_limit: 3,
+    default_fields: { company_name: 'Acme' },
+    replace_existing: true,
+    dry_run: false,
+  })
+
+  assert.equal(outcome.kind, 'success')
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(url, `${API_ORIGIN}/api/v1/content-ops/ingestion/import`)
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), {
+    rows: [{ target_id: 'ticket-2', text: 'Why was I charged?' }],
+    source_rows: true,
+    source: 'manual-paste',
+    target_mode: 'vendor_retention',
+    max_source_text_chars: 1200,
+    sample_limit: 3,
+    default_fields: { company_name: 'Acme' },
+    replace_existing: true,
+    dry_run: false,
+  })
+})

--- a/plans/PR-Content-Ops-UI-File-Ingestion-Tests.md
+++ b/plans/PR-Content-Ops-UI-File-Ingestion-Tests.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-UI-File-Ingestion-Tests
+
+## Why this slice exists
+
+PR #865 routed selected ingestion files through the new server-side upload
+endpoints, while keeping pasted/manual rows on the deprecated inline fallback.
+The reviewer called out that the new UI path did not have a direct frontend
+test proving the split. This slice adds that regression coverage without
+changing production behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/ui-file-ingestion-tests
+
+1. Add a focused adapter-level Node test for Content Ops ingestion routing.
+2. Prove uploaded files use multipart `/ingestion/files/inspect` and
+   `/ingestion/files/import`.
+3. Prove inline rows still use JSON `/ingestion/inspect` and
+   `/ingestion/import`.
+4. Add an npm script so the test can run independently.
+
+### Files touched
+
+- `plans/PR-Content-Ops-UI-File-Ingestion-Tests.md`
+- `atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs`
+- `atlas-intel-ui/package.json`
+
+## Mechanism
+
+The test transpiles `src/api/contentOps.ts` in-process, stubs the API base,
+local storage, and `fetch`, then invokes the public adapter functions. Captured
+fetch calls assert the URL, method, body type, headers, and important request
+fields.
+
+This avoids a brittle DOM-level form test while still proving the production
+adapter will send `File` payloads over multipart requests and inline rows over
+JSON.
+
+## Intentional
+
+- No React component test in this slice. The route split lives in the API
+  adapter, and PR #865 already made the screen call those adapter functions.
+- No source-code changes. This is a regression test for shipped behavior.
+- The test stubs imports from auth/config because it is verifying request
+  construction, not auth refresh behavior.
+
+## Deferred
+
+- Parked hardening considered: `FAQSTRESS-1` and `FAQSTRESS-2` in
+  `HARDENING.md`. They remain parked because they are hosted-runtime scale and
+  DB pressure work, not required for this UI adapter test slice. The merged
+  execute concurrency gate partially mitigates `FAQSTRESS-2`, but a background
+  job boundary or deploy-aware admission control remains a separate hardening
+  slice.
+
+## Verification
+
+- Passed: focused UI adapter routing test:
+  `npm run test:content-ops-ingestion-routing` (`4 passed`).
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| UI adapter test | ~250 |
+| Package script | ~1 |
+| **Total** | **~321** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-UI-File-Ingestion-Tests.md

Adds frontend adapter regression coverage proving selected ingestion files use multipart /ingestion/files/* routes while inline/manual rows stay on the deprecated JSON compatibility endpoints.

## Intentional
- No production source changes; this is route-split coverage for behavior shipped in PR #865.
- No React component test in this slice; the route split is verified at the API adapter boundary.
- Auth/config imports are stubbed because the test verifies request construction, not token refresh behavior.

## Deferred
- FAQSTRESS-1 and FAQSTRESS-2 remain parked as hosted-runtime scale work. The merged execute concurrency gate partially mitigates FAQSTRESS-2, but background job execution or deploy-aware admission control remains a separate hardening slice.

## Parked hardening
- None added in this slice.

## Verification
- npm run test:content-ops-ingestion-routing
- npm run build
- npm run lint
- bash scripts/local_pr_review.sh

## Diff size
3 files, +321 / -0