### PR TITLE
Run FastAPI route tests in extracted CI

### DIFF
--- a/.github/workflows/extracted_pipeline_checks.yml
+++ b/.github/workflows/extracted_pipeline_checks.yml
@@ -3,6 +3,7 @@ name: Extracted Pipeline Checks
 on:
   pull_request:
     paths:
+      - ".github/workflows/extracted_pipeline_checks.yml"
       - "extracted_content_pipeline/**"
       - "extracted_reasoning_core/**"
       - "atlas_brain/reasoning/state.py"
@@ -42,6 +43,7 @@ on:
       - "tests/test_smoke_content_ops_live_generation.py"
       - "tests/test_extracted_vendor_briefing_*.py"
       - "tests/test_extracted_content_pipeline_reasoning_*.py"
+      - "tests/test_extracted_pipeline_route_ci_contract.py"
       - "tests/test_extracted_reasoning_core_*.py"
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
@@ -60,6 +62,7 @@ on:
       - "extracted/_shared/scripts/forbid_atlas_reasoning_imports.py"
   push:
     paths:
+      - ".github/workflows/extracted_pipeline_checks.yml"
       - "extracted_content_pipeline/**"
       - "extracted_reasoning_core/**"
       - "atlas_brain/reasoning/state.py"
@@ -99,6 +102,7 @@ on:
       - "tests/test_smoke_content_ops_live_generation.py"
       - "tests/test_extracted_vendor_briefing_*.py"
       - "tests/test_extracted_content_pipeline_reasoning_*.py"
+      - "tests/test_extracted_pipeline_route_ci_contract.py"
       - "tests/test_extracted_reasoning_core_*.py"
       - "tests/test_atlas_reasoning_state_*.py"
       - "tests/test_atlas_reasoning_port_adapters.py"
@@ -144,7 +148,7 @@ jobs:
         # pydantic-settings; this is purely the cross-boundary seam test.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown
+          python -m pip install pytest pytest-asyncio beautifulsoup4 httpx PyJWT pyyaml pydantic-settings markdown fastapi python-multipart
 
       - name: Run extracted pipeline checks
         run: bash scripts/run_extracted_pipeline_checks.sh

--- a/plans/PR-Extracted-Fastapi-Route-CI.md
+++ b/plans/PR-Extracted-Fastapi-Route-CI.md
@@ -1,0 +1,79 @@
+# PR-Extracted-Fastapi-Route-CI
+
+## Why this slice exists
+
+PR #866 enrolled Content Ops uploaded-file route tests in extracted pipeline CI,
+but reviewer follow-up noted a broader gap: the dependency-light extracted CI
+lane collects FastAPI route tests and skips them because the workflow does not
+install FastAPI. That means route assertions can pass locally while the main
+extracted gate only proves collection, not behavior.
+
+This slice makes the extracted pipeline gate actually execute the route tests
+that already live in the runner.
+
+## Scope (this PR)
+
+Ownership lane: extracted-pipeline/route-ci
+
+1. Add the missing FastAPI multipart dependencies to the extracted pipeline
+   workflow install step.
+2. Add a small contract test so route-test CI dependencies and runner
+   enrollment cannot drift apart silently.
+3. Enroll that contract test in the extracted pipeline runner/path filters.
+
+### Files touched
+
+- `.github/workflows/extracted_pipeline_checks.yml`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_pipeline_route_ci_contract.py`
+- `plans/PR-Extracted-Fastapi-Route-CI.md`
+
+## Mechanism
+
+The workflow install command gains `fastapi` and `python-multipart`. FastAPI is
+required by the route modules, and `python-multipart` is required for route
+registration that uses `File(...)` and `Form(...)`.
+
+The new contract test reads the workflow and extracted runner as text. It
+asserts:
+
+- the extracted workflow install step includes `fastapi`;
+- the same install step includes `python-multipart`;
+- the extracted runner includes the uploaded-file route smoke test;
+- the extracted runner includes the control-surface route API test.
+
+## Intentional
+
+- No route code changes. The behavior already exists; the gap is CI
+  dependency coverage.
+- No broad `tests/**` workflow path glob. This repo intentionally enrolls
+  extracted files explicitly, and this slice follows that pattern.
+- The contract test is text-based rather than importing CI YAML machinery; the
+  check is about a concrete workflow command and runner list.
+
+## Deferred
+
+- A broader workflow normalization/refactor remains out of scope. If more
+  dependency lanes diverge, that should be a separate CI maintenance slice.
+- Non-dry-run uploaded-file import against local Postgres remains the next
+  backend validation slice after this CI gate is real.
+
+## Verification
+
+- Focused CI contract + route tests:
+  - `python -m pytest tests/test_extracted_pipeline_route_ci_contract.py tests/test_smoke_content_ops_ingestion_file_route.py tests/test_extracted_content_control_surface_api.py -q`
+  - `91 passed`
+- Extracted pipeline runner passed for `scripts/run_extracted_pipeline_checks.sh`:
+  - `1866 passed, 1 skipped, 1 warning`
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Passed before commit; rerun after commit before push.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Workflow dependency/path enrollment | ~6 |
+| Runner enrollment | ~1 |
+| Contract test | ~35 |
+| **Total** | ~122 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -94,6 +94,7 @@ pytest \
   tests/test_extracted_campaign_single_pass_reasoning.py \
   tests/test_extracted_campaign_multi_pass_reasoning_provider.py \
   tests/test_extracted_content_pipeline_migration_runner.py \
+  tests/test_extracted_pipeline_route_ci_contract.py \
   tests/test_extracted_pipeline_notify.py \
   tests/test_extracted_content_pipeline_reasoning_archetypes.py \
   tests/test_extracted_content_pipeline_reasoning_temporal.py \

--- a/tests/test_extracted_pipeline_route_ci_contract.py
+++ b/tests/test_extracted_pipeline_route_ci_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/extracted_pipeline_checks.yml"
+RUNNER = ROOT / "scripts/run_extracted_pipeline_checks.sh"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _workflow_install_command() -> str:
+    text = _read(WORKFLOW)
+    for match in re.finditer(r"python -m pip install (?P<packages>[^\n]+)", text):
+        packages = match.group("packages")
+        if "pytest" in packages.split():
+            return packages
+    raise AssertionError("extracted workflow must install test dependencies")
+
+
+def test_extracted_pipeline_installs_fastapi_route_dependencies() -> None:
+    packages = set(_workflow_install_command().split())
+
+    assert "fastapi" in packages
+    assert "python-multipart" in packages
+
+
+def test_extracted_pipeline_runner_includes_route_tests() -> None:
+    runner = _read(RUNNER)
+
+    assert "tests/test_extracted_content_control_surface_api.py" in runner
+    assert "tests/test_smoke_content_ops_ingestion_file_route.py" in runner


### PR DESCRIPTION
Plan: plans/PR-Extracted-Fastapi-Route-CI.md

PR #866 enrolled Content Ops route tests in extracted pipeline CI, but the dependency-light CI lane collected and skipped them because FastAPI was not installed. This slice installs the missing FastAPI multipart dependencies and adds a small contract test so route-test dependencies and runner enrollment cannot drift apart silently.

## Intentional
- No route code changes; the behavior exists already and the gap is CI dependency coverage.
- Keeps explicit extracted workflow path filters rather than adding a broad tests glob.
- The contract test is text-based because it verifies a concrete workflow install command and runner list.

## Deferred
- Broader workflow normalization remains out of scope.
- Non-dry-run uploaded-file import against local Postgres remains the next backend validation slice.

## Verification
- python -m pytest tests/test_extracted_pipeline_route_ci_contract.py tests/test_smoke_content_ops_ingestion_file_route.py tests/test_extracted_content_control_surface_api.py -q — 91 passed.
- bash scripts/run_extracted_pipeline_checks.sh — 1866 passed, 1 skipped, 1 warning.
- bash scripts/local_pr_review.sh --allow-dirty — passed.

## Diff size
4 files, +121 / -1