### PR TITLE
Expose Content Ops ingestion limits in catalog

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -165,6 +165,24 @@
     "manual",
     "existing_evidence"
   ],
+  "ingestion_limits": {
+    "inline_rows": {
+      "max_rows": 1000,
+      "deprecated": true
+    },
+    "file_upload": {
+      "max_file_bytes": 26214400,
+      "max_rows": 10000,
+      "supported_formats": [
+        "auto",
+        "json",
+        "jsonl",
+        "csv"
+      ]
+    },
+    "max_source_text_chars": 10000,
+    "max_sample_limit": 25
+  },
   "reasoning": {
     "configured": true,
     "source": "db",

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -99,7 +99,22 @@ export interface ContentOpsCatalogResponse {
       | Record<string, ContentOpsReasoningCapabilityStatus>
   }
   ingestion_profiles: string[]
+  ingestion_limits: ContentOpsIngestionLimits
   input_contracts: Record<string, ContentOpsInputContract>
+}
+
+export interface ContentOpsIngestionLimits {
+  inline_rows: {
+    max_rows: number
+    deprecated: boolean
+  }
+  file_upload: {
+    max_file_bytes: number
+    max_rows: number
+    supported_formats: string[]
+  }
+  max_source_text_chars: number
+  max_sample_limit: number
 }
 
 export interface ContentOpsReasoningCapabilityStatus {

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../api/contentOps'
 import type {
   ContentOpsCatalog,
+  ContentOpsIngestionLimits,
   ContentOpsIngestionDiagnostics,
   ContentOpsIngestionImportRequest,
   ContentOpsIngestionImportResponse,
@@ -112,12 +113,31 @@ export function fromWireCatalog(
       capabilities: copyReasoningCapabilities(wire.reasoning.capabilities),
     },
     ingestionProfiles: [...wire.ingestion_profiles],
+    ingestionLimits: fromWireIngestionLimits(wire.ingestion_limits),
     inputContracts: Object.fromEntries(
       Object.entries(wire.input_contracts ?? {}).map(([key, contract]) => [
         key,
         fromWireInputContract(contract),
       ]),
     ),
+  }
+}
+
+function fromWireIngestionLimits(
+  wire: ContentOpsCatalogResponse['ingestion_limits'],
+): ContentOpsIngestionLimits {
+  return {
+    inlineRows: {
+      maxRows: wire.inline_rows.max_rows,
+      deprecated: wire.inline_rows.deprecated,
+    },
+    fileUpload: {
+      maxFileBytes: wire.file_upload.max_file_bytes,
+      maxRows: wire.file_upload.max_rows,
+      supportedFormats: [...wire.file_upload.supported_formats],
+    },
+    maxSourceTextChars: wire.max_source_text_chars,
+    maxSampleLimit: wire.max_sample_limit,
   }
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -72,7 +72,22 @@ export interface ContentOpsCatalog {
       | Record<string, ReasoningCapabilityStatus>
   }
   ingestionProfiles: string[]
+  ingestionLimits: ContentOpsIngestionLimits
   inputContracts: Record<string, ContentOpsInputContractView>
+}
+
+export interface ContentOpsIngestionLimits {
+  inlineRows: {
+    maxRows: number
+    deprecated: boolean
+  }
+  fileUpload: {
+    maxFileBytes: number
+    maxRows: number
+    supportedFormats: string[]
+  }
+  maxSourceTextChars: number
+  maxSampleLimit: number
 }
 
 export interface ReasoningCapabilityStatus {

--- a/docs/frontend/content_ops_frontend_contract.md
+++ b/docs/frontend/content_ops_frontend_contract.md
@@ -104,6 +104,7 @@ top-level `execution.{configured,configured_outputs}` /
 | `ControlSurfacePreset` | `control_surfaces.py:33-40` | `id`, `label`, `outputs`, `description` |
 | `ContentOpsRequest` | `control_surfaces.py:43-55` | `target_mode`, `preset`, `outputs`, `limit`, `max_cost_usd`, `inputs`, `ingestion_profile`, `require_quality_gates`, `allow_unimplemented_outputs` |
 | `ContentOpsIngestionDiagnostics` | `ingestion_diagnostics.py:28-57` | `ok`, counts, bounded samples, and row warnings from file or inline ingestion inspection |
+| `ContentOpsIngestionLimits` | `control_surfaces.py` catalog response | inline row cap/deprecation, file upload byte/row caps, upload formats, sample/text caps |
 | `ContentOpsIngestionImportResult` | `control_surfaces.py` import route response | `inserted`, `skipped`, `dry_run`, `replace_existing`, `target_ids`, `warnings`, `source` |
 | `ControlSurfacePreview` | `control_surfaces.py:58-90` | `can_run`, `outputs`, `estimated_cost_usd`, `missing_inputs`, `blocked_outputs`, `warnings`, `normalized_request` |
 | `GenerationPlanStep` | `generation_plan.py:28-45` | `output`, `runner`, `status`, `config`, `reason` |

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -93,6 +93,7 @@ _MAX_INGESTION_ROWS = 1000
 _MAX_FILE_INGESTION_ROWS = 10000
 _MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
+_UPLOAD_FILE_FORMATS = ("auto", "json", "jsonl", "csv")
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
@@ -151,6 +152,19 @@ def _build_static_catalog_payload() -> Mapping[str, Any]:
             "manual",
             "existing_evidence",
         ),
+        "ingestion_limits": {
+            "inline_rows": {
+                "max_rows": _MAX_INGESTION_ROWS,
+                "deprecated": True,
+            },
+            "file_upload": {
+                "max_file_bytes": _MAX_INGESTION_FILE_BYTES,
+                "max_rows": _MAX_FILE_INGESTION_ROWS,
+                "supported_formats": _UPLOAD_FILE_FORMATS,
+            },
+            "max_source_text_chars": _MAX_INPUT_STRING_CHARS,
+            "max_sample_limit": _MAX_INGESTION_SAMPLE_LIMIT,
+        },
         "input_contracts": {
             LANDING_PAGE_QUALITY_REPAIR_INPUT: landing_page_quality_repair_input_contract(),
             **landing_page_seo_geo_aeo_input_contracts(),
@@ -194,6 +208,17 @@ def _compose_describe_response(
         },
         "reasoning": dict(reasoning_status),
         "ingestion_profiles": list(static["ingestion_profiles"]),
+        "ingestion_limits": {
+            "inline_rows": dict(static["ingestion_limits"]["inline_rows"]),
+            "file_upload": {
+                **static["ingestion_limits"]["file_upload"],
+                "supported_formats": list(
+                    static["ingestion_limits"]["file_upload"]["supported_formats"]
+                ),
+            },
+            "max_source_text_chars": static["ingestion_limits"]["max_source_text_chars"],
+            "max_sample_limit": static["ingestion_limits"]["max_sample_limit"],
+        },
         "input_contracts": {
             key: dict(value)
             for key, value in static["input_contracts"].items()
@@ -838,7 +863,7 @@ async def _read_bounded_upload(file: UploadFile) -> bytes:
 
 def _validate_upload_file_format(value: str) -> str:
     text = _clean(value) or "auto"
-    if text not in {"auto", "json", "jsonl", "csv"}:
+    if text not in _UPLOAD_FILE_FORMATS:
         raise HTTPException(
             status_code=400,
             detail="file_format must be one of: auto, json, jsonl, csv.",

--- a/plans/PR-Content-Ops-Ingestion-Limits-Catalog.md
+++ b/plans/PR-Content-Ops-Ingestion-Limits-Catalog.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-Ingestion-Limits-Catalog
+
+## Why this slice exists
+
+The Content Ops API now has two ingestion paths: multipart uploaded files for
+customer CSV/JSON/JSONL exports and deprecated inline JSON rows for pasted or
+manual rows. The backend enforces separate limits for each path, but
+`GET /content-ops/control-surfaces` only exposes `ingestion_profiles`.
+
+This leaves the UI and docs without a machine-readable source of truth for file
+size, row caps, sample limits, and inline deprecation status. This slice adds a
+small catalog contract for those limits.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/ingestion-limits-catalog
+
+1. Add `ingestion_limits` to the control-surface catalog response.
+2. Include inline-row limits, file-upload limits, shared text/sample caps, and
+   supported upload formats.
+3. Thread the new wire field through frontend API/domain types and fixtures.
+4. Add focused backend and frontend contract coverage.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Ingestion-Limits-Catalog.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+- `docs/frontend/content_ops_frontend_contract.md`
+
+## Mechanism
+
+The static catalog payload now includes immutable ingestion-limit metadata:
+
+```json
+{
+  "ingestion_limits": {
+    "inline_rows": { "max_rows": 1000, "deprecated": true },
+    "file_upload": {
+      "max_file_bytes": 26214400,
+      "max_rows": 10000,
+      "supported_formats": ["auto", "json", "jsonl", "csv"]
+    },
+    "max_source_text_chars": 10000,
+    "max_sample_limit": 25
+  }
+}
+```
+
+`_compose_describe_response` reprojects this metadata into fresh dict/list
+objects per request, preserving the static-cache non-aliasing contract.
+
+## Intentional
+
+- No UI rendering in this slice. The UI can consume the new domain field in a
+  follow-up without hardcoding caps.
+- No route behavior changes. This only exposes limits that already exist.
+- The deprecated inline path remains listed because pasted/manual row ingestion
+  still uses it.
+
+## Deferred
+
+- Future PR: render file upload limits in `ContentOpsNewRun`.
+- Future PR: remove inline compatibility after an operator compatibility
+  window.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: focused control-surface catalog/limits pytest (`4 passed`).
+- Passed: full control-surface API pytest:
+  `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
+  (`86 passed`).
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: `git diff --check`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Backend catalog + tests | ~45 |
+| Frontend types/mapper/fixture | ~70 |
+| Contract docs | ~5 |
+| **Total** | **~200** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -228,6 +228,19 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
         "manual",
         "existing_evidence",
     ]
+    assert payload["ingestion_limits"] == {
+        "inline_rows": {
+            "max_rows": 1000,
+            "deprecated": True,
+        },
+        "file_upload": {
+            "max_file_bytes": 25 * 1024 * 1024,
+            "max_rows": 10000,
+            "supported_formats": ["auto", "json", "jsonl", "csv"],
+        },
+        "max_source_text_chars": 10000,
+        "max_sample_limit": 25,
+    }
 
 
 @pytest.mark.asyncio
@@ -481,12 +494,16 @@ async def test_describe_control_surfaces_returns_independent_dict_per_call():
     first["outputs"][0]["required_inputs"].append("injected_field")
     first["presets"][0]["outputs"].append("injected_output")
     first["ingestion_profiles"].append("injected_profile")
+    first["ingestion_limits"]["inline_rows"]["max_rows"] = 999999
+    first["ingestion_limits"]["file_upload"]["supported_formats"].append("yaml")
 
     second = await route.endpoint()
     assert second["outputs"][0]["label"] != "MUTATED"
     assert "injected_field" not in second["outputs"][0]["required_inputs"]
     assert "injected_output" not in second["presets"][0]["outputs"]
     assert "injected_profile" not in second["ingestion_profiles"]
+    assert second["ingestion_limits"]["inline_rows"]["max_rows"] == 1000
+    assert "yaml" not in second["ingestion_limits"]["file_upload"]["supported_formats"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ingestion-Limits-Catalog.md

Expose the existing Content Ops ingestion limits through the control-surface catalog so the UI has one machine-readable source of truth for inline deprecation, file upload bytes/row caps, supported upload formats, and sample/text caps.

## Intentional
- No UI rendering in this slice; this only adds the frontend contract/domain field for a follow-up to consume.
- No route behavior changes; the exposed limits already exist in backend validation.
- The deprecated inline path remains listed because pasted/manual row ingestion still uses it.

## Deferred
- Future PR: render file upload limits in ContentOpsNewRun.
- Future PR: remove inline compatibility after an operator compatibility window.

## Parked hardening
- None.

## Verification
- Focused control-surface catalog/limits pytest: 4 passed.
- Full control-surface API pytest: python -m pytest tests/test_extracted_content_control_surface_api.py -q (86 passed).
- UI build: npm run build.
- UI lint: npm run lint.
- git diff --check.
- Local PR review: bash scripts/local_pr_review.sh.

## Diff size
8 files, +203 / -1