### PR TITLE
Add Content Ops file route Postgres write smoke

### DIFF
--- a/plans/PR-Content-Ops-File-Route-Postgres-Smoke.md
+++ b/plans/PR-Content-Ops-File-Route-Postgres-Smoke.md
@@ -1,0 +1,85 @@
+# PR-Content-Ops-File-Route-Postgres-Smoke
+
+## Why this slice exists
+
+PR #866 added a dry-run uploaded-file route smoke, and PR #871 made route tests
+execute in extracted CI. The remaining backend proof is the production-shaped
+write path: uploaded source rows should flow through
+`/content-ops/ingestion/files/import`, resolve a real import pool provider, and
+persist normalized opportunities instead of only exercising `dry_run=True`.
+
+This slice extends the existing route smoke with an explicit write mode so
+reviewers can run the same command against local Postgres and get a compact
+artifact on success or failure.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add opt-in non-dry-run support to the uploaded-file route smoke.
+2. Require account scope and database URL only when write mode is selected.
+3. Preserve the current dry-run default and compact result output.
+4. Add focused tests for write-mode validation and pool-provider wiring.
+
+### Files touched
+
+- `scripts/smoke_content_ops_ingestion_file_route.py`
+- `tests/test_smoke_content_ops_ingestion_file_route.py`
+- `plans/PR-Content-Ops-File-Route-Postgres-Smoke.md`
+
+## Mechanism
+
+The script keeps `dry_run=True` by default. A new `--write` flag flips the route
+call to `dry_run=False`, creates an asyncpg pool from `--database-url`,
+`EXTRACTED_DATABASE_URL`, `DATABASE_URL`, or Atlas local DB settings, wires that
+pool into `create_content_ops_control_surface_router` through
+`opportunity_import_pool_provider`, and supplies a `TenantScope` from
+`--account-id` / `--user-id`.
+
+The response payload now includes `dry_run`, `account_id`, `user_id`,
+`replace_existing`, and `opportunity_table` so the artifact tells reviewers
+which execution mode and scope were used. Pool creation or route failures still
+write the same compact failure payload when `--output-result` is provided.
+
+## Intentional
+
+- Write mode is explicit. The default remains side-effect-free so the smoke is
+  safe in CI and for quick local checks.
+- No DB migrations or table creation are added. The smoke validates the route
+  against the existing `campaign_opportunities` import path.
+- No UI code is touched. The UI upload lane is separate.
+
+## Deferred
+
+- A checked-in live Postgres validation record is deferred until this smoke is
+  reviewed; this PR ships the reusable command and deterministic tests first.
+- Background jobs, durable upload storage, and cross-process admission control
+  remain parked in `HARDENING.md` under the existing FAQ scale/concurrency
+  entries.
+
+## Verification
+
+- Focused route smoke/API tests:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_extracted_content_control_surface_api.py -q`
+  - `92 passed`
+- Compile check passed for `scripts/smoke_content_ops_ingestion_file_route.py`.
+- Live local Postgres uploaded-file route smoke:
+  - `python scripts/smoke_content_ops_ingestion_file_route.py tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl --source-format jsonl --source cfpb-route-postgres-1000 --min-source-rows 1000 --default-field company_name=CFPB --default-field vendor_name=CFPB --default-field contact_email=cfpb-public-archive@example.invalid --write --account-id acct-file-route-postgres-20260523 --user-id user-file-route-postgres --replace-existing --output-result tmp/content_ops_file_route_postgres_smoke_20260523_1000.json --json`
+  - Exit `0`; `dry_run=false`, `opportunity_count=1000`,
+    `inserted=1000`, `warning_count=0`, `missing_field_counts={}`.
+- Database count check:
+  - `campaign_opportunities` rows for
+    `acct-file-route-postgres-20260523` / `vendor_retention`: `1000`.
+- Extracted pipeline runner passed for `scripts/run_extracted_pipeline_checks.sh`:
+  - `1869 passed, 1 skipped, 1 warning`
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Smoke script | ~100 |
+| Smoke tests | ~132 |
+| **Total** | ~317 |

--- a/scripts/smoke_content_ops_ingestion_file_route.py
+++ b/scripts/smoke_content_ops_ingestion_file_route.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 from pathlib import Path
 import sys
 import time
@@ -20,9 +21,15 @@ from extracted_content_pipeline.api.control_surfaces import (  # noqa: E402
     ContentOpsControlSurfaceApiConfig,
     create_content_ops_control_surface_router,
 )
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     parse_default_fields_or_exit,
 )
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional host dependency.
+    load_dotenv = None
 
 
 _REQUIRED_DEFAULT_FIELDS = ("company_name", "vendor_name", "contact_email")
@@ -63,6 +70,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "The smoke requires company_name, vendor_name, and contact_email."
         ),
     )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist rows through the route instead of using dry_run=True.",
+    )
+    parser.add_argument("--account-id", default=None)
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--opportunity-table", default="campaign_opportunities")
+    parser.add_argument("--replace-existing", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -107,6 +124,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "uploaded source-row smoke requires default fields: " + ", ".join(missing)
         )
+    if bool(args.write):
+        if not str(args.account_id or "").strip():
+            raise SystemExit("--account-id is required when --write is selected")
+        if not str(args.database_url or "").strip():
+            raise SystemExit(
+                "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
+            )
+    if not str(args.opportunity_table or "").strip():
+        raise SystemExit("--opportunity-table is required")
 
 
 async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
@@ -119,6 +145,11 @@ async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]
         "source_path": str(args.path),
         "source_format": str(args.source_format),
         "source": str(args.source),
+        "dry_run": not bool(args.write),
+        "account_id": str(args.account_id or "").strip() or None,
+        "user_id": str(args.user_id or "").strip() or None,
+        "opportunity_table": str(args.opportunity_table),
+        "replace_existing": bool(args.replace_existing),
         "min_source_rows": int(args.min_source_rows),
         "elapsed_seconds": None,
         "status_code": None,
@@ -126,9 +157,14 @@ async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]
         "import": None,
         "errors": [],
     }
+    pool = None
     try:
+        if args.write:
+            pool = await _create_pool(str(args.database_url))
         router = create_content_ops_control_surface_router(
             config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+            opportunity_import_pool_provider=(lambda: pool) if pool is not None else None,
+            scope_provider=_scope_provider(args) if args.write else None,
         )
         route = _route(router, route_path, "POST")
         response = await route.endpoint(
@@ -140,8 +176,8 @@ async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]
             max_source_text_chars=int(args.max_source_text_chars),
             sample_limit=int(args.sample_limit),
             default_fields=json.dumps(defaults, sort_keys=True),
-            replace_existing=False,
-            dry_run=True,
+            replace_existing=bool(args.replace_existing),
+            dry_run=not bool(args.write),
         )
     except Exception as exc:
         status_code = getattr(exc, "status_code", 500)
@@ -153,6 +189,9 @@ async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]
         }
         payload["elapsed_seconds"] = round(time.monotonic() - started, 6)
         return 1, payload
+    finally:
+        if pool is not None:
+            await _close_pool(pool)
 
     diagnostics = _diagnostics_summary(response.get("diagnostics"))
     import_summary = _import_summary(response.get("import"))
@@ -160,6 +199,7 @@ async def run_route_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]
         diagnostics=diagnostics,
         import_summary=import_summary,
         min_source_rows=int(args.min_source_rows),
+        expected_dry_run=not bool(args.write),
     )
     payload = {
         **base_payload,
@@ -219,6 +259,7 @@ def _result_errors(
     diagnostics: Mapping[str, Any] | None,
     import_summary: Mapping[str, Any] | None,
     min_source_rows: int,
+    expected_dry_run: bool,
 ) -> list[str]:
     errors: list[str] = []
     if not diagnostics or not diagnostics.get("ok"):
@@ -226,12 +267,63 @@ def _result_errors(
     opportunity_count = int((diagnostics or {}).get("opportunity_count") or 0)
     if opportunity_count < min_source_rows:
         errors.append(f"expected at least {min_source_rows} source row(s), got {opportunity_count}")
-    if not import_summary or not import_summary.get("dry_run"):
-        errors.append("file import route did not return a dry-run import result")
+    actual_dry_run = bool((import_summary or {}).get("dry_run"))
+    if actual_dry_run is not bool(expected_dry_run):
+        errors.append(
+            "file import route returned dry_run="
+            f"{str(actual_dry_run).lower()}, expected {str(expected_dry_run).lower()}"
+        )
     inserted = int((import_summary or {}).get("inserted") or 0)
     if inserted < min_source_rows:
         errors.append(f"expected at least {min_source_rows} inserted row(s), got {inserted}")
     return errors
+
+
+def _scope_provider(args: argparse.Namespace):
+    scope = TenantScope(
+        account_id=str(args.account_id or "").strip() or None,
+        user_id=str(args.user_id or "").strip() or None,
+    )
+    return lambda: scope
+
+
+def _default_database_url() -> str | None:
+    _load_dotenv_files()
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    dsn = str(getattr(db_settings, "dsn", "") or "").strip()
+    return dsn or None
+
+
+async def _create_pool(database_url: str):
+    _load_dotenv_files()
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency.
+        raise RuntimeError(
+            "asyncpg is required for --write; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _close_pool(pool: Any) -> None:
+    close = getattr(pool, "close", None)
+    if close is None:
+        return
+    maybe_awaitable = close()
+    if hasattr(maybe_awaitable, "__await__"):
+        await maybe_awaitable
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
 
 
 def _compact_detail(value: Any) -> Any:

--- a/tests/test_smoke_content_ops_ingestion_file_route.py
+++ b/tests/test_smoke_content_ops_ingestion_file_route.py
@@ -66,6 +66,52 @@ def _default_args(path: Path, result_path: Path) -> list[str]:
     ]
 
 
+class _Transaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.executed = []
+
+    def transaction(self):
+        return _Transaction()
+
+    async def execute(self, query, *args):
+        self.executed.append((str(query), args))
+        return "EXECUTE"
+
+
+class _Acquire:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _Pool:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+        self.closed = False
+        self.is_initialized = True
+
+    def acquire(self):
+        return _Acquire(self.connection)
+
+    async def close(self):
+        self.closed = True
+
+
 def test_file_route_smoke_writes_success_result_for_cfpb_rows(tmp_path: Path) -> None:
     module = _load_script_module()
     source_path = tmp_path / "cfpb_rows.jsonl"
@@ -117,3 +163,89 @@ def test_file_route_smoke_requires_public_dataset_defaults(tmp_path: Path) -> No
 
     assert "vendor_name" in str(exc.value)
     assert "contact_email" in str(exc.value)
+
+
+def test_file_route_smoke_write_mode_requires_account_id(tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    _write_cfpb_rows(source_path, 1)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main([
+            *_default_args(source_path, tmp_path / "result.json"),
+            "--write",
+            "--database-url",
+            "postgresql://atlas@localhost:5433/atlas",
+        ])
+
+    assert "--account-id is required" in str(exc.value)
+
+
+def test_file_route_smoke_write_mode_uses_pool_provider(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    _write_cfpb_rows(source_path, 3)
+    connection = _Connection()
+    pool = _Pool(connection)
+
+    async def create_pool(database_url: str):
+        assert database_url == "postgresql://atlas@localhost:5433/atlas"
+        return pool
+
+    monkeypatch.setattr(module, "_create_pool", create_pool)
+
+    code = module.main([
+        *_default_args(source_path, result_path),
+        "--write",
+        "--account-id",
+        "acct-route-write",
+        "--user-id",
+        "user-route-write",
+        "--database-url",
+        "postgresql://atlas@localhost:5433/atlas",
+        "--replace-existing",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["dry_run"] is False
+    assert payload["account_id"] == "acct-route-write"
+    assert payload["import"]["dry_run"] is False
+    assert payload["import"]["inserted"] == 3
+    assert payload["import"]["replace_existing"] is True
+    assert pool.closed is True
+    assert any("DELETE FROM" in query for query, _args in connection.executed)
+    insert_args = [args for query, args in connection.executed if "INSERT INTO" in query]
+    assert len(insert_args) == 3
+    assert {args[0] for args in insert_args} == {"acct-route-write"}
+
+
+def test_file_route_smoke_write_mode_writes_pool_failure(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    _write_cfpb_rows(source_path, 1)
+
+    async def create_pool(database_url: str):
+        del database_url
+        raise RuntimeError("pool unavailable")
+
+    monkeypatch.setattr(module, "_create_pool", create_pool)
+
+    code = module.main([
+        *_default_args(source_path, result_path),
+        "--write",
+        "--account-id",
+        "acct-route-write",
+        "--database-url",
+        "postgresql://atlas@localhost:5433/atlas",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["dry_run"] is False
+    assert payload["status_code"] == 500
+    assert payload["errors"] == ["RuntimeError: pool unavailable"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Route-Postgres-Smoke.md

This extends the uploaded-file route smoke with explicit write mode so reviewers can validate non-dry-run Postgres persistence through the real /content-ops/ingestion/files/import route. Dry-run remains the default; --write is required before the script creates a DB pool or persists rows.

## Intentional
- Dry-run remains the default; --write is required for database side effects.
- No route code, migrations, UI code, or background job machinery changes in this slice.
- The deterministic tests use a fake asyncpg-shaped pool; the live local verification used real Postgres and is recorded in the plan.

## Deferred
- Checked-in live validation record and larger write-scale runs remain follow-up validation slices.
- Durable upload jobs and cross-process admission control remain parked in HARDENING.md.

## Verification
- python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_extracted_content_control_surface_api.py -q — 92 passed.
- Live local Postgres uploaded-file route smoke — exit 0; dry_run=false, opportunity_count=1000, inserted=1000, warning_count=0, missing_field_counts={}. Result written to tmp/content_ops_file_route_postgres_smoke_20260523_1000.json.
- Database count check for acct-file-route-postgres-20260523/vendor_retention — 1000 rows.
- bash scripts/run_extracted_pipeline_checks.sh — 1869 passed, 1 skipped, 1 warning.
- bash scripts/local_pr_review.sh --allow-dirty — passed after rebasing on current origin/main.

## Diff size
3 files, +313 / -4