### PR TITLE
Plan: plans/PR-Blog-SEO-Keywords-Marketing-Automation.md

### DIFF
--- a/atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts
@@ -116,7 +116,7 @@ const post: BlogPost = {
   seo_title: 'Brevo Reviews: Pricing Pain & Churn Signals',
   seo_description: 'Brevo reviews show pricing complaints and support gaps. See what 38 enriched reviews reveal about churn signals and buyer intent in marketing automation.',
   target_keyword: 'Brevo reviews',
-  secondary_keywords: ["Brevo pricing complaints", "Brevo vs ActiveCampaign", "marketing automation software reviews"],
+  secondary_keywords: ["Brevo pricing complaints", "Brevo vs ActiveCampaign", "marketing automation software reviews", "Brevo vs Sendinblue"],
   faq: [
   {
     "question": "What are the main complaints about Brevo?",

--- a/atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts
@@ -116,7 +116,7 @@ const post: BlogPost = {
   seo_title: 'Mailchimp Reviews: 1,184 User Insights on Pricing & Features',
   seo_description: 'Analysis of 1,184 Mailchimp reviews reveals pricing backlash, UX strengths, and integration gaps. See what real users report about this marketing automation platform.',
   target_keyword: 'Mailchimp reviews',
-  secondary_keywords: ["Mailchimp pricing", "Mailchimp vs alternatives", "marketing automation software comparison"],
+  secondary_keywords: ["Mailchimp pricing", "Mailchimp vs alternatives", "marketing automation software comparison", "Mailchimp too expensive", "Mailchimp price increase"],
   faq: [
   {
     "question": "What are the most common complaints about Mailchimp?",

--- a/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
@@ -108,7 +108,7 @@ const post: BlogPost = {
   seo_title: 'Marketing Automation Landscape 2026 | 5 Vendors',
   seo_description: 'Marketing automation landscape analysis of 5 vendors across 640 reviews. See churn urgency, pricing pressure, and switching patterns in 2026.',
   target_keyword: 'marketing automation landscape',
-  secondary_keywords: ["marketing automation software comparison", "marketing automation vendors 2026", "marketing automation churn signals"],
+  secondary_keywords: ["marketing automation software comparison", "marketing automation vendors 2026", "marketing automation churn signals", "marketing automation cost", "marketing automation pricing"],
   faq: [
   {
     "question": "Which marketing automation vendors face the highest churn risk?",

--- a/atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts
@@ -92,7 +92,7 @@ const post: BlogPost = {
   seo_title: 'Switch to Klaviyo: Migration Guide from 5 Platforms',
   seo_description: 'Why teams switch to Klaviyo from Mailchimp, Flodesk, MailerLite & more. Migration triggers, integration considerations, and practical switching advice from 638 reviews.',
   target_keyword: 'switch to Klaviyo',
-  secondary_keywords: ["Klaviyo migration", "Mailchimp to Klaviyo", "Klaviyo alternatives"],
+  secondary_keywords: ["Klaviyo migration", "Mailchimp to Klaviyo", "Klaviyo alternatives", "Klaviyo vs Omnisend", "Klaviyo vs Mailchimp", "Klaviyo too expensive"],
   faq: [
   {
     "question": "Which platforms do most Klaviyo users migrate from?",

--- a/plans/PR-Blog-SEO-Keywords-Marketing-Automation.md
+++ b/plans/PR-Blog-SEO-Keywords-Marketing-Automation.md
@@ -1,0 +1,72 @@
+# PR-Blog-SEO-Keywords-Marketing-Automation
+
+Ownership lane: `content-ops/blog-seo-keywords-marketing-automation`
+
+## Why this slice exists
+
+First full-category batch of the business-buyer SEO-keyword sweep (the method was
+proven on two mini-samples; sample-wins shipped in #868). This slice runs the
+validated pipeline — mine allowlist `review_text` -> frustration-framed Google
+autocomplete demand-check -> intent-classify -> keep only buyer/churn/comparison/cost
+winners — across the Marketing Automation category and commits the validated wins.
+
+## Scope (this PR)
+
+8 validated keyword additions appended to `secondary_keywords` across 4 of the 5 MA
+posts. Additive only; no `target_keyword` or prose changes.
+
+- mailchimp-deep-dive: `Mailchimp too expensive`, `Mailchimp price increase`
+- switch-to-klaviyo: `Klaviyo vs Omnisend`, `Klaviyo vs Mailchimp`, `Klaviyo too expensive`
+- brevo-deep-dive: `Brevo vs Sendinblue`
+- marketing-automation-landscape: `marketing automation cost`, `marketing automation pricing`
+
+top-complaint-every-marketing-automation is intentionally NOT edited (no new validated
+win; its existing vendor-complaint keywords are appropriate, and adding the landscape's
+cost terms would self-cannibalize).
+
+### Files touched
+
+- `plans/PR-Blog-SEO-Keywords-Marketing-Automation.md`
+- `atlas-churn-ui/src/content/blog/mailchimp-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/brevo-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts`
+
+## Mechanism
+
+Each edit appends entries to the existing `secondary_keywords` string array on one
+line, applied via an assert-exact-match script (1 match per file required). Casing
+matches each post's own convention.
+
+## Intentional
+
+- **Only autocomplete-validated, right-intent terms committed.** Rejected the highest
+  raw signal `mailchimp api` (df 53) as a developer/how-to trap, and `mailchimp
+  learning curve` (autocomplete returned nothing — Mailchimp is the easy tool).
+- **Additive, `target_keyword` untouched** — same discipline as #868; primary-target
+  changes wait on volume validation.
+
+## Deferred
+
+- **Volume magnitude** — autocomplete proves searched, not rank; promotion to
+  `target_keyword` waits on Search Console / a keyword tool.
+- **Remaining business-buyer categories** (~6: CRM, Project Management, Communication,
+  E-commerce, Helpdesk, HR/HCM) and the technical light-touch pass. Per-category
+  records kept in the seo-geo-aeo-blog-post skill scripts dir (outside this repo).
+
+Parked hardening: none new.
+
+## Verification
+
+- All 4 edits applied via assert-exact-match (1 match/file); `git diff` shows 4 posts,
+  8 additions, single-line array changes only; no `target_keyword`/prose lines.
+- Each committed keyword has a recorded autocomplete result (per-category record in the
+  skill scripts dir).
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 4 post files (1 line each, +/-) | ~8 |
+| Plan doc | ~70 |
+| **Total** | **~78** |


### PR DESCRIPTION
## Intentional

First full-category batch of the business-buyer SEO-keyword sweep (method proven on
two mini-samples; sample-wins shipped in #868). Validated pipeline: mine allowlist
\`review_text\` → frustration-framed Google autocomplete → intent-classify.

8 validated additions to \`secondary_keywords\` across 4 of 5 Marketing Automation posts:

| Post | Added |
|---|---|
| mailchimp-deep-dive | \`Mailchimp too expensive\`, \`Mailchimp price increase\` |
| switch-to-klaviyo | \`Klaviyo vs Omnisend\`, \`Klaviyo vs Mailchimp\`, \`Klaviyo too expensive\` |
| brevo-deep-dive | \`Brevo vs Sendinblue\` |
| marketing-automation-landscape | \`marketing automation cost\`, \`marketing automation pricing\` |

Each confirmed a real search via Google autocomplete with buyer/churn/comparison/cost
intent. Rejected: \`mailchimp api\` (df 53, the top raw signal — developer/how-to trap)
and \`mailchimp learning curve\` (autocomplete NONE; Mailchimp is the easy tool, so
learning-curve isn't searched for it). top-complaint-every-marketing-automation is
intentionally untouched (no new validated win; padding it would self-cannibalize the
landscape post's cost terms).

## Deferred

- **Volume magnitude** — autocomplete proves searched, not rank; \`target_keyword\`
  promotion waits on Search Console / a keyword tool.
- **Remaining categories** — ~6 business-buyer (CRM, Project Management, Communication,
  E-commerce, Helpdesk, HR/HCM) + technical light-touch. Per-category records in the
  seo-geo-aeo-blog-post skill scripts dir.

## Verification

- Edits applied via assert-exact-match script (1 match/file); \`git diff\` = 4 posts, 8
  additions, single-line array changes only. No \`target_keyword\`/prose lines.
- Pre-push gates PASS (plan-shape, files-touched, diff-size, drift, plan/code, whitespace).

## Diff size

| Area | LOC |
|---|---:|
| 4 post files | ~8 |
| Plan doc | ~72 |
| **Total** | **~80** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)