### PR TITLE
Plan: plans/PR-Blog-SEO-Keywords-CRM.md

### DIFF
--- a/atlas-churn-ui/src/content/blog/best-crm-for-51-200-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/best-crm-for-51-200-2026-04.ts
@@ -129,7 +129,7 @@ const post: BlogPost = {
   seo_title: 'Best CRM for 51-200 Teams: 8 Vendors Compared (1163 Reviews)',
   seo_description: 'Compare 8 CRM tools for 51-200 teams using 1163 real reviews. See ratings, pain patterns, and honest fit recommendations for Close, Copper, Freshsales, and more.',
   target_keyword: 'best CRM software for 51-200 teams',
-  secondary_keywords: ["CRM comparison for mid-size teams", "CRM reviews 51-200 employees", "CRM buyer's guide"],
+  secondary_keywords: ["CRM comparison for mid-size teams", "CRM reviews 51-200 employees", "CRM buyer's guide", "CRM implementation cost", "CRM setup cost"],
   faq: [
   {
     "question": "Which CRM is best for teams of 51-200 employees?",

--- a/atlas-churn-ui/src/content/blog/close-vs-zoho-crm-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/close-vs-zoho-crm-2026-04.ts
@@ -102,7 +102,7 @@ const post: BlogPost = {
   seo_title: 'Close vs Zoho CRM 2026: 102 Reviews Compared',
   seo_description: 'Analysis of 102 Close and Zoho CRM reviews. Compare urgency scores, pain categories, and buyer segment patterns to see which CRM fits your needs.',
   target_keyword: 'close vs zoho crm',
-  secondary_keywords: ["close crm reviews", "zoho crm alternatives", "close vs zoho comparison"],
+  secondary_keywords: ["close crm reviews", "zoho crm alternatives", "close vs zoho comparison", "close crm pricing"],
   faq: [
   {
     "question": "What are the main differences between Close and Zoho CRM?",

--- a/atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts
@@ -116,7 +116,7 @@ const post: BlogPost = {
   seo_title: 'Copper Reviews 2026: 1619 User Experiences Analyzed',
   seo_description: 'Analysis of 1619 Copper reviews reveals Google integration strengths and customization pain points. See what drives satisfaction and frustration.',
   target_keyword: 'copper reviews',
-  secondary_keywords: ["copper crm reviews", "copper vs salesforce", "copper crm complaints", "copper google integration"],
+  secondary_keywords: ["copper crm reviews", "copper vs salesforce", "copper crm complaints", "copper google integration", "copper crm pricing"],
   faq: [
   {
     "question": "What are the main strengths of Copper according to reviewers?",

--- a/atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-03.ts
@@ -116,7 +116,7 @@ const post: BlogPost = {
   seo_title: 'HubSpot Reviews 2026: 1648 User Sentiment Analysis',
   seo_description: 'Analysis of 1648 HubSpot reviews from G2, Capterra, Reddit, and Trustpilot. See what drives teams away, what they praise, and how it compares to alternatives.',
   target_keyword: 'hubspot reviews',
-  secondary_keywords: ["hubspot marketing hub reviews", "hubspot crm reviews", "hubspot pricing complaints", "hubspot alternatives"],
+  secondary_keywords: ["hubspot marketing hub reviews", "hubspot crm reviews", "hubspot pricing complaints", "hubspot alternatives", "hubspot too expensive", "hubspot vs salesforce"],
   faq: [
   {
     "question": "What are the top complaints about HubSpot?",

--- a/atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-04.ts
@@ -116,7 +116,7 @@ const post: BlogPost = {
   seo_title: 'HubSpot Reviews 2026: 1680 User Experiences Analyzed',
   seo_description: 'Analysis of 1680 HubSpot reviews: pricing pain, integration strengths, and where reviewer sentiment splits. See what drives satisfaction and frustration.',
   target_keyword: 'hubspot reviews',
-  secondary_keywords: ["hubspot crm reviews", "hubspot pricing complaints", "hubspot vs salesforce", "hubspot alternatives"],
+  secondary_keywords: ["hubspot crm reviews", "hubspot pricing complaints", "hubspot vs salesforce", "hubspot alternatives", "hubspot too expensive"],
   faq: [
   {
     "question": "What are the most common complaints about HubSpot?",

--- a/atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts
@@ -117,7 +117,7 @@ const post: BlogPost = {
   seo_title: 'Insightly Reviews: 200 CRM Users on Support & Usability',
   seo_description: 'Analysis of 200 Insightly CRM reviews reveals support friction after one year, dashboard strengths, and storage limitations that trigger evaluation cycles.',
   target_keyword: 'Insightly reviews',
-  secondary_keywords: ["Insightly CRM support", "Insightly usability", "Insightly pricing complaints"],
+  secondary_keywords: ["Insightly CRM support", "Insightly usability", "Insightly pricing complaints", "Insightly vs Zoho CRM"],
   faq: [
   {
     "question": "What do reviewers like most about Insightly CRM?",

--- a/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts
@@ -122,7 +122,7 @@ const post: BlogPost = {
   seo_title: 'Pipedrive Reviews: Deep Dive Analysis of 262 User Reports',
   seo_description: 'Analysis of 262 Pipedrive reviews reveals billing friction and support quality concerns alongside strong onboarding and integration praise. Data from G2, Reddit, and verified platforms.',
   target_keyword: 'Pipedrive reviews',
-  secondary_keywords: ["Pipedrive CRM feedback", "Pipedrive pricing complaints", "Pipedrive support issues"],
+  secondary_keywords: ["Pipedrive CRM feedback", "Pipedrive pricing complaints", "Pipedrive support issues", "Pipedrive vs HubSpot", "Pipedrive pricing"],
   faq: [
   {
     "question": "What do Pipedrive users complain about most?",

--- a/atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts
@@ -122,7 +122,7 @@ const post: BlogPost = {
   seo_title: 'Zoho CRM Reviews 2026: 429 User Experiences Analyzed',
   seo_description: 'Analysis of 429 Zoho CRM reviews: strengths, weaknesses, pain points, and buyer profiles. See what users praise and where complaints cluster.',
   target_keyword: 'zoho crm reviews',
-  secondary_keywords: ["zoho crm pricing", "zoho crm vs hubspot", "zoho crm complaints"],
+  secondary_keywords: ["zoho crm pricing", "zoho crm vs hubspot", "zoho crm complaints", "zoho crm vs salesforce"],
   faq: [
   {
     "question": "What are the main complaints about Zoho CRM?",

--- a/plans/PR-Blog-SEO-Keywords-CRM.md
+++ b/plans/PR-Blog-SEO-Keywords-CRM.md
@@ -1,0 +1,80 @@
+# PR-Blog-SEO-Keywords-CRM
+
+Ownership lane: `content-ops/blog-seo-keywords-crm`
+
+## Why this slice exists
+
+Second full-category batch of the business-buyer SEO-keyword sweep (after Marketing
+Automation #874; method proven on the mini-samples + #868). Covers the remaining CRM
+posts (salesforce-deep-dive + crm-landscape already shipped in #868). Same validated
+pipeline: mine allowlist `review_text` -> frustration-framed Google autocomplete ->
+intent-classify -> keep buyer/churn/comparison/cost winners.
+
+## Scope (this PR)
+
+11 validated keyword additions appended to `secondary_keywords` across 8 CRM posts.
+Additive only; no `target_keyword` or prose changes.
+
+- hubspot-deep-dive-2026-03: `hubspot too expensive`, `hubspot vs salesforce`
+- hubspot-deep-dive-2026-04: `hubspot too expensive`
+- zoho-crm-deep-dive: `zoho crm vs salesforce`
+- pipedrive-deep-dive: `Pipedrive vs HubSpot`, `Pipedrive pricing`
+- close-vs-zoho-crm: `close crm pricing`
+- copper-deep-dive: `copper crm pricing`
+- insightly-deep-dive: `Insightly vs Zoho CRM`
+- best-crm-for-51-200: `CRM implementation cost`, `CRM setup cost`
+
+### Files touched
+
+- `plans/PR-Blog-SEO-Keywords-CRM.md`
+- `atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-03.ts`
+- `atlas-churn-ui/src/content/blog/hubspot-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/zoho-crm-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/pipedrive-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/close-vs-zoho-crm-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/copper-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/insightly-deep-dive-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/best-crm-for-51-200-2026-04.ts`
+
+## Mechanism
+
+Each edit appends entries to the existing `secondary_keywords` array on one line,
+applied via an assert-exact-match script (1 match per file). Casing matches each post.
+
+## Intentional
+
+- **Copper rescued via direct autocomplete, not mining.** The Copper review-text scope
+  is contaminated by the metal (commodity/mining text), so mined phrases are unusable;
+  `copper crm pricing` was validated by probing autocomplete directly. Same handling
+  for the sparse Close scope.
+- **Rejected** `hubspot learning curve` (career/course-collision; HubSpot is the easy
+  tool) and `best crm for small business` for the 51-200 post (segment mismatch).
+- **Additive, `target_keyword` untouched** — same discipline as #868/#874.
+
+## Deferred
+
+- **Volume magnitude** — autocomplete proves searched, not rank; primary-target
+  promotion waits on Search Console / a keyword tool.
+- **Remaining business-buyer categories** (~5: Project Management, Communication,
+  E-commerce, Helpdesk, HR/HCM) + technical light-touch. Per-category records in the
+  seo-geo-aeo-blog-post skill scripts dir.
+- **switch-to-salesforce / switch-to-zoho-crm / top-complaint-every-crm /
+  hubspot-vs-power-bi / insightly-vs-zoho-crm** — no new validated win (existing
+  comparison/migration keyword already present or is the target_keyword).
+
+Parked hardening: none new.
+
+## Verification
+
+- All 8 edits applied via assert-exact-match (1 match/file); `git diff` shows 8 posts,
+  11 additions, single-line array changes only; no `target_keyword`/prose lines.
+- Each committed keyword has a recorded autocomplete result (per-category record in the
+  skill scripts dir).
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 8 post files (1 line each, +/-) | ~16 |
+| Plan doc | ~78 |
+| **Total** | **~94** |


### PR DESCRIPTION
## Intentional

Second full-category batch of the business-buyer SEO-keyword sweep (after Marketing
Automation #874). 11 validated additions to \`secondary_keywords\` across 8 CRM posts:

| Post | Added |
|---|---|
| hubspot-deep-dive-2026-03 | \`hubspot too expensive\`, \`hubspot vs salesforce\` |
| hubspot-deep-dive-2026-04 | \`hubspot too expensive\` |
| zoho-crm-deep-dive | \`zoho crm vs salesforce\` |
| pipedrive-deep-dive | \`Pipedrive vs HubSpot\`, \`Pipedrive pricing\` |
| close-vs-zoho-crm | \`close crm pricing\` |
| copper-deep-dive | \`copper crm pricing\` |
| insightly-deep-dive | \`Insightly vs Zoho CRM\` |
| best-crm-for-51-200 | \`CRM implementation cost\`, \`CRM setup cost\` |

Method notes worth surfacing:
- **Copper rescued via direct autocomplete.** The Copper review-text scope is
  contaminated by the *metal* ("copper price environment", "gold price", "exploration
  costs"), so mined phrases are unusable — `copper crm pricing` was validated by probing
  autocomplete directly ("how much does copper crm cost"). Same approach for the sparse
  Close scope.
- **Rejected** `hubspot learning curve` (career/course-collision — HubSpot's the easy
  tool) and `best crm for small business` for the 51-200 post (segment mismatch).
- Comparison terms keep being the most-often-missing strong keyword (Pipedrive had none).

## Deferred

- **Volume magnitude** — autocomplete proves searched, not rank; \`target_keyword\`
  promotion waits on Search Console / a keyword tool.
- **Remaining categories** — ~5 business-buyer (Project Management, Communication,
  E-commerce, Helpdesk, HR/HCM) + technical light-touch.
- **No-add posts** (honest): switch-to-salesforce (wrong-direction terms), switch-to-zoho,
  insightly-vs-zoho, top-complaint-every-crm, hubspot-vs-power-bi — existing comparison/
  migration keyword already present or is the target_keyword.

## Verification

- Edits via assert-exact-match (1 match/file); \`git diff\` = 8 posts, 11 additions,
  single-line array changes only; no \`target_keyword\`/prose lines.
- Pre-push gates PASS.

## Diff size

| Area | LOC |
|---|---:|
| 8 post files | ~16 |
| Plan doc | ~80 |
| **Total** | **~96** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)