### PR TITLE
Render Content Ops upload limits in new-run UI

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:content-ops-ingestion-limits": "node --test scripts/content-ops-ingestion-limits.test.mjs",
     "test:content-ops-ingestion-routing": "node --test scripts/content-ops-ingestion-routing.test.mjs",
     "test:content-ops-input-display": "node --test scripts/content-ops-input-display.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const source = readFileSync(
+  new URL('../src/domain/contentOps/fromWire.ts', import.meta.url),
+  'utf8',
+)
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+    verbatimModuleSyntax: true,
+  },
+}).outputText
+
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+const { fromWireCatalog } = await import(moduleUrl)
+
+const catalogFixture = JSON.parse(
+  readFileSync(
+    new URL('../src/api/__fixtures__/contentOps/catalog.json', import.meta.url),
+    'utf8',
+  ),
+)
+
+test('fromWireCatalog maps ingestion limits from wire to domain shape', () => {
+  assert.deepEqual(fromWireCatalog(catalogFixture).ingestionLimits, {
+    inlineRows: {
+      maxRows: 1000,
+      deprecated: true,
+    },
+    fileUpload: {
+      maxFileBytes: 25 * 1024 * 1024,
+      maxRows: 10000,
+      supportedFormats: ['auto', 'json', 'jsonl', 'csv'],
+    },
+    maxSourceTextChars: 10000,
+    maxSampleLimit: 25,
+  })
+})
+
+test('fromWireCatalog copies ingestion limit supported formats', () => {
+  const first = fromWireCatalog(catalogFixture)
+  first.ingestionLimits.fileUpload.supportedFormats.push('yaml')
+
+  assert.deepEqual(fromWireCatalog(catalogFixture).ingestionLimits.fileUpload.supportedFormats, [
+    'auto',
+    'json',
+    'jsonl',
+    'csv',
+  ])
+})

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -94,8 +94,7 @@ const DEFAULT_INPUTS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_ROWS_JSON = '[\n  \n]'
 const DEFAULT_INGESTION_DEFAULT_FIELDS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_SOURCE = 'manual'
-const INGESTION_SAMPLE_LIMIT = 5
-const INGESTION_MAX_SOURCE_TEXT_CHARS = 1200
+const INGESTION_RESULT_DISPLAY_LIMIT = 5
 const LANDING_PAGE_QUALITY_REPAIR_INPUT =
   'landing_page_quality_repair_attempts'
 const LANDING_PAGE_INPUT_ASSET = 'landing_page'
@@ -536,8 +535,8 @@ export default function ContentOpsNewRun() {
             source: ingestionSource.trim() || null,
             target_mode: request.targetMode,
             file_format: 'auto',
-            max_source_text_chars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-            sample_limit: INGESTION_SAMPLE_LIMIT,
+            max_source_text_chars: catalog.ingestionLimits.maxSourceTextChars,
+            sample_limit: catalog.ingestionLimits.maxSampleLimit,
             default_fields: parsedDefaultFields.fields,
           })
         : await inspectContentOpsIngestion(
@@ -546,8 +545,8 @@ export default function ContentOpsNewRun() {
               sourceRows: ingestionSourceRows,
               source: ingestionSource.trim() || null,
               targetMode: request.targetMode,
-              maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-              sampleLimit: INGESTION_SAMPLE_LIMIT,
+              maxSourceTextChars: catalog.ingestionLimits.maxSourceTextChars,
+              sampleLimit: catalog.ingestionLimits.maxSampleLimit,
               defaultFields: parsedDefaultFields.fields,
             }),
           )
@@ -599,8 +598,8 @@ export default function ContentOpsNewRun() {
             source: ingestionSource.trim() || null,
             target_mode: request.targetMode,
             file_format: 'auto',
-            max_source_text_chars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-            sample_limit: INGESTION_SAMPLE_LIMIT,
+            max_source_text_chars: catalog.ingestionLimits.maxSourceTextChars,
+            sample_limit: catalog.ingestionLimits.maxSampleLimit,
             default_fields: parsedDefaultFields.fields,
             replace_existing: ingestionReplaceExisting,
             dry_run: ingestionDryRun,
@@ -611,8 +610,8 @@ export default function ContentOpsNewRun() {
               sourceRows: ingestionSourceRows,
               source: ingestionSource.trim() || null,
               targetMode: request.targetMode,
-              maxSourceTextChars: INGESTION_MAX_SOURCE_TEXT_CHARS,
-              sampleLimit: INGESTION_SAMPLE_LIMIT,
+              maxSourceTextChars: catalog.ingestionLimits.maxSourceTextChars,
+              sampleLimit: catalog.ingestionLimits.maxSampleLimit,
               defaultFields: parsedDefaultFields.fields,
               replaceExisting: ingestionReplaceExisting,
               dryRun: ingestionDryRun,
@@ -1051,6 +1050,7 @@ export default function ContentOpsNewRun() {
               </button>
             </div>
           </div>
+          <IngestionLimitsSummary limits={catalog.ingestionLimits} />
           <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
             <label className="block text-sm sm:col-span-2">
               <span className="text-slate-300">Source label</span>
@@ -1456,7 +1456,7 @@ function IngestionInspectResult({ state }: { state: IngestionInspectState }) {
       {diagnostics.warnings.length > 0 && (
         <Section label="Warnings">
           <ul className="ml-4 list-disc text-xs text-amber-100">
-            {diagnostics.warnings.slice(0, INGESTION_SAMPLE_LIMIT).map((warning, i) => (
+            {diagnostics.warnings.slice(0, INGESTION_RESULT_DISPLAY_LIMIT).map((warning, i) => (
               <li key={`${warning.code}-${warning.rowIndex ?? i}-${warning.field ?? ''}`}>
                 {warning.code}: {warning.message}
               </li>
@@ -1471,6 +1471,63 @@ function IngestionInspectResult({ state }: { state: IngestionInspectState }) {
           </pre>
         </Section>
       )}
+    </div>
+  )
+}
+
+function IngestionLimitsSummary({
+  limits,
+}: {
+  limits: ContentOpsCatalog['ingestionLimits']
+}) {
+  return (
+    <div className="mb-3 rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
+      <div className="flex flex-wrap gap-x-5 gap-y-1">
+        <span>
+          Upload:{' '}
+          <span className="text-slate-100">
+            {formatBytes(limits.fileUpload.maxFileBytes)}
+          </span>{' '}
+          or{' '}
+          <span className="text-slate-100">
+            {formatCount(limits.fileUpload.maxRows)}
+          </span>{' '}
+          rows
+        </span>
+        <span>
+          Formats:{' '}
+          <span className="text-slate-100">
+            {formatUploadFormats(limits.fileUpload.supportedFormats)}
+          </span>
+        </span>
+        {supportsAutoDetection(limits.fileUpload.supportedFormats) && (
+          <span>
+            Detection: <span className="text-slate-100">Auto</span>
+          </span>
+        )}
+        <span>
+          Inline JSON:{' '}
+          <span className="text-slate-100">
+            {formatCount(limits.inlineRows.maxRows)}
+          </span>{' '}
+          rows
+          {limits.inlineRows.deprecated ? ' (deprecated)' : ''}
+        </span>
+        <span>
+          Source text:{' '}
+          <span className="text-slate-100">
+            {formatCount(limits.maxSourceTextChars)}
+          </span>{' '}
+          chars
+        </span>
+        <span>
+          Samples:{' '}
+          <span className="text-slate-100">
+            {formatCount(limits.maxSampleLimit)}
+          </span>{' '}
+          rows
+        </span>
+      </div>
     </div>
   )
 }
@@ -1511,6 +1568,23 @@ function formatBytes(value: number): string {
   return `${(kib / 1024).toFixed(1)} MB`
 }
 
+function formatCount(value: number): string {
+  if (!Number.isFinite(value)) return 'unknown'
+  return value.toLocaleString('en-US')
+}
+
+function formatUploadFormats(formats: string[]): string {
+  const concreteFormats = formats.filter((format) => format !== 'auto')
+  if (concreteFormats.length === 0) return 'server-detected'
+  return concreteFormats
+    .map((format) => (format === 'auto' ? 'Auto' : format.toUpperCase()))
+    .join(', ')
+}
+
+function supportsAutoDetection(formats: string[]): boolean {
+  return formats.includes('auto')
+}
+
 function IngestionImportResult({ state }: { state: IngestionImportState }) {
   if (state.kind === 'idle' || state.kind === 'submitting') {
     return null
@@ -1543,7 +1617,7 @@ function IngestionImportResult({ state }: { state: IngestionImportState }) {
           <Section label="Blocking diagnostics">
             <ul className="ml-4 list-disc text-xs text-amber-100">
               {state.diagnostics.warnings
-                .slice(0, INGESTION_SAMPLE_LIMIT)
+                .slice(0, INGESTION_RESULT_DISPLAY_LIMIT)
                 .map((warning, i) => (
                   <li key={`${warning.code}-${warning.rowIndex ?? i}-${warning.field ?? ''}`}>
                     {warning.code}: {warning.message}
@@ -1572,14 +1646,14 @@ function IngestionImportResult({ state }: { state: IngestionImportState }) {
       {result.targetIds.length > 0 && (
         <Section label="Target ids">
           <div className="break-all font-mono text-[11px] text-slate-300">
-            {result.targetIds.slice(0, INGESTION_SAMPLE_LIMIT).join(', ')}
+            {result.targetIds.slice(0, INGESTION_RESULT_DISPLAY_LIMIT).join(', ')}
           </div>
         </Section>
       )}
       {result.warnings.length > 0 && (
         <Section label="Import warnings">
           <ul className="ml-4 list-disc text-xs text-amber-100">
-            {result.warnings.slice(0, INGESTION_SAMPLE_LIMIT).map((warning, i) => (
+            {result.warnings.slice(0, INGESTION_RESULT_DISPLAY_LIMIT).map((warning, i) => (
               <li key={`${warning.code}-${warning.rowIndex ?? i}-${warning.field ?? ''}`}>
                 {warning.code}: {warning.message}
               </li>

--- a/plans/PR-Content-Ops-Upload-Limits-UI.md
+++ b/plans/PR-Content-Ops-Upload-Limits-UI.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-Upload-Limits-UI
+
+## Why this slice exists
+
+The Content Ops new-run page lets operators upload CSV/JSON/JSONL ingestion
+files, but the upload surface only says "Load JSON/JSONL/CSV". Operators have
+to discover byte caps, row caps, source-text truncation, and inline deprecation
+by trial, error, or backend errors.
+
+PR #872 exposes those limits through the control-surface catalog. This slice
+uses that catalog-backed contract in the UI so the upload surface displays the
+real backend limits without hardcoded duplicate caps.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-limits-ui
+
+1. Render a compact ingestion-limits summary in `ContentOpsNewRun`.
+2. Source the display from `catalog.ingestionLimits`.
+3. Align inspect/import request caps with `catalog.ingestionLimits` so the
+   banner matches the actual submitted request.
+4. Treat `auto` as server detection mode in the UI rather than listing it as a
+   concrete file format.
+5. Add small formatting helpers and a focused mapper test for the new
+   catalog-backed limits.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Upload-Limits-UI.md`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/package.json`
+- `atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs`
+
+## Mechanism
+
+The page already builds a domain catalog with `fromWireCatalog`. The new
+`catalog.ingestionLimits` field contains:
+
+- upload byte cap
+- upload row cap
+- supported upload formats
+- deprecated inline row cap
+- source text and sample caps
+
+The ingestion inspector section will render those values near the file upload
+controls. Formatting stays local to the page and only transforms numbers into
+operator-readable text. The display filters `auto` out of the concrete format
+list and renders it separately as automatic server detection.
+
+The inspect/import handlers also submit `maxSourceTextChars` and
+`maxSampleLimit` from the same catalog-backed limits. The separate local result
+display truncation remains capped at 5 rows so large diagnostics do not flood
+the page.
+
+## Intentional
+
+- This does not add client-side file rejection because the backend remains the
+  canonical enforcement point.
+- This does not remove the inline JSON textarea yet. Inline ingestion is marked
+  deprecated in the displayed limits, but compatibility remains.
+- This PR is stacked on #872 because it consumes the new catalog field.
+
+## Deferred
+
+- Future PR: remove inline compatibility after the operator compatibility
+  window.
+- Future PR: add client-side preflight rejection only if operators need faster
+  feedback for large local files.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: ingestion-limits mapper test:
+  `npm run test:content-ops-ingestion-limits` (`2 passed`).
+- Passed: `git diff --check`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| UI display, request caps + helpers | ~85 |
+| Mapper test + npm script | ~55 |
+| **Total** | **~220** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Upload-Limits-UI.md

Render the catalog-backed ingestion limits from #872 in the Content Ops new-run ingestion inspector so operators can see upload byte caps, row caps, supported formats, inline deprecation, source-text cap, and sample cap before inspecting/importing rows. Inspect/import now submit the same catalog-backed source-text and sample caps shown in the banner.

## Intentional
- Backend remains the canonical enforcement point; this PR does not add client-side file rejection.
- The UI treats auto as server detection mode, not as a concrete upload format.
- Inline ingestion remains available but is displayed as deprecated through the catalog-backed limit metadata.

## Deferred
- Future PR: remove inline compatibility after the operator compatibility window.
- Future PR: add client-side preflight rejection only if operators need faster feedback for large local files.

## Parked hardening
- None.

## Verification
- npm run test:content-ops-ingestion-limits (2 passed).
- npm run build.
- npm run lint.
- git diff --check.
- bash scripts/local_pr_review.sh.

## Diff size
4 files, +230 / -14