### PR TITLE
Record Content Ops file route 10k Postgres validation

### DIFF
--- a/docs/extraction/validation/content_ops_file_route_postgres_10000_row_run_2026-05-23.md
+++ b/docs/extraction/validation/content_ops_file_route_postgres_10000_row_run_2026-05-23.md
@@ -1,0 +1,242 @@
+# Content Ops File Route Postgres 10,000-Row Run - 2026-05-23
+
+## Summary
+
+The uploaded-file Content Ops route passed a non-dry-run write against the
+local Atlas Postgres database with 10,000 CFPB-derived support-ticket source
+rows. This exercises the production-shaped file ingestion path at the current
+route cap:
+
+1. Read the uploaded JSONL source-row file.
+2. Parse it through `/content-ops/ingestion/files/import`.
+3. Apply public-dataset default fields for customer-style metadata.
+4. Resolve a real Postgres import pool provider.
+5. Persist normalized campaign opportunities under a scoped account.
+6. Rerun with `--replace-existing` and confirm the scoped row count stays
+   stable.
+
+The command exited `0`, inserted 10,000 opportunities, reported zero warnings,
+and wrote a compact result artifact.
+
+## Source Data
+
+- Source artifact: `tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`
+- Source rows: `10,000`
+- Source format: `jsonl`
+- File size: `21M`
+- Route limit exercised: `max_rows=10000`
+- Source type after normalization: `support_ticket=10000`
+
+## Database
+
+The run used Atlas local database settings derived from
+`atlas_brain.storage.config.db_settings`:
+
+- host: `localhost`
+- port: `5433`
+- database: `atlas`
+- user: `atlas`
+- password: not set
+
+The DSN was derived at runtime and was not printed or checked in.
+
+## Commands
+
+Environment check:
+
+```bash
+python - <<'PY'
+from atlas_brain.storage.config import db_settings
+print("derived_dsn_present=", bool(db_settings.dsn))
+print("host=", db_settings.host)
+print("port=", db_settings.port)
+print("database=", db_settings.database)
+print("user=", db_settings.user)
+print("password_set=", bool(db_settings.password))
+PY
+```
+
+Source file check:
+
+```bash
+wc -l tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl
+ls -lh tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl
+```
+
+Route write smoke:
+
+```bash
+/usr/bin/time -v python scripts/smoke_content_ops_ingestion_file_route.py \
+  tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl \
+  --source-format jsonl \
+  --source cfpb-route-postgres-10000 \
+  --min-source-rows 10000 \
+  --default-field company_name=CFPB \
+  --default-field vendor_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --write \
+  --account-id acct-file-route-postgres-10000-20260523 \
+  --user-id user-file-route-postgres \
+  --replace-existing \
+  --output-result tmp/content_ops_file_route_postgres_smoke_20260523_10000.json \
+  --json
+```
+
+Saved artifact syntax check:
+
+```bash
+python -m json.tool tmp/content_ops_file_route_postgres_smoke_20260523_10000.json
+```
+
+Scoped database count and sample check:
+
+```bash
+python - <<'PY'
+import asyncio, json
+from atlas_brain.storage.config import db_settings
+
+ACCOUNT = "acct-file-route-postgres-10000-20260523"
+
+async def main():
+    import asyncpg
+    pool = await asyncpg.create_pool(dsn=db_settings.dsn, min_size=1, max_size=1)
+    try:
+        count = await pool.fetchval(
+            """
+            SELECT count(*)
+              FROM campaign_opportunities
+             WHERE account_id = $1
+               AND target_mode = $2
+            """,
+            ACCOUNT,
+            "vendor_retention",
+        )
+        sample = await pool.fetchrow(
+            """
+            SELECT target_id,
+                   company_name,
+                   vendor_name,
+                   contact_email,
+                   raw_payload->>'source_type' AS source_type,
+                   jsonb_array_length(evidence) AS evidence_count
+              FROM campaign_opportunities
+             WHERE account_id = $1
+               AND target_mode = $2
+             ORDER BY target_id
+             LIMIT 1
+            """,
+            ACCOUNT,
+            "vendor_retention",
+        )
+        print(json.dumps({"count": count, "sample": dict(sample)}, sort_keys=True))
+    finally:
+        await pool.close()
+
+asyncio.run(main())
+PY
+```
+
+Idempotency rerun:
+
+```bash
+/usr/bin/time -v python scripts/smoke_content_ops_ingestion_file_route.py \
+  tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl \
+  --source-format jsonl \
+  --source cfpb-route-postgres-10000 \
+  --min-source-rows 10000 \
+  --default-field company_name=CFPB \
+  --default-field vendor_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --write \
+  --account-id acct-file-route-postgres-10000-20260523 \
+  --user-id user-file-route-postgres \
+  --replace-existing \
+  --output-result tmp/content_ops_file_route_postgres_smoke_20260523_10000_rerun.json \
+  --json
+```
+
+## Result
+
+The first route write smoke wrote:
+
+```text
+tmp/content_ops_file_route_postgres_smoke_20260523_10000.json
+```
+
+Compact route result:
+
+```json
+{
+  "account_id": "acct-file-route-postgres-10000-20260523",
+  "dry_run": false,
+  "errors": [],
+  "inserted": 10000,
+  "missing_field_counts": {},
+  "ok": true,
+  "opportunity_count": 10000,
+  "replace_existing": true,
+  "source_type_counts": {
+    "support_ticket": 10000
+  },
+  "status_code": 200,
+  "target_id_count": 10000,
+  "warning_count": 0
+}
+```
+
+Timing:
+
+```text
+Elapsed wall time: 0:04.83
+Maximum resident set size: 154556 KB
+Exit status: 0
+```
+
+Database confirmation:
+
+```json
+{
+  "count": 10000,
+  "sample": {
+    "company_name": "CFPB",
+    "contact_email": "cfpb-public-archive@example.invalid",
+    "evidence_count": 1,
+    "source_type": "support_ticket",
+    "target_id": "cfpb:3134827",
+    "vendor_name": "EQUIFAX, INC."
+  }
+}
+```
+
+The sample `vendor_name` came from the CFPB source row, which correctly
+overrode the fallback default. Public-dataset `company_name` and
+`contact_email` defaults filled the campaign-required metadata fields.
+
+Idempotency rerun:
+
+```json
+{
+  "count_after_rerun": 10000
+}
+```
+
+The rerun exited `0`, inserted 10,000 rows after the scoped
+`--replace-existing` delete, and left the scoped row count at 10,000 rather
+than accumulating duplicates.
+
+## Issues Surfaced
+
+No product issue surfaced.
+
+One validation-query mistake happened during manual verification: the first
+sample query selected a non-existent `source` column from
+`campaign_opportunities`. The corrected query reads `source_type` from
+`raw_payload`. This did not affect the route smoke, persisted rows, or result
+artifact, so no `HARDENING.md` entry was added.
+
+## Conclusion
+
+The uploaded-file route write path is now validated at the current 10,000-row
+cap against local Postgres. The route accepted the file, normalized all rows,
+persisted all rows under the scoped account, wrote a compact artifact, and
+reran idempotently with `--replace-existing`.

--- a/plans/PR-Content-Ops-File-Route-Postgres-10k-Validation.md
+++ b/plans/PR-Content-Ops-File-Route-Postgres-10k-Validation.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-File-Route-Postgres-10k-Validation
+
+## Why this slice exists
+
+PR #873 added an explicit `--write` mode to the uploaded-file route smoke and
+proved a 1,000-row local Postgres write. The file route's production cap is
+10,000 normalized rows, so the next confidence slice is to run the same real
+route write at the cap and record the evidence.
+
+This slice is validation only. It should not change product code unless the
+10,000-row route write exposes a blocker that prevents the flow from working.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Run the uploaded-file route smoke in `--write` mode against local Postgres
+   with 10,000 CFPB-derived source rows.
+2. Confirm the route response, saved result artifact, and database count agree.
+3. Document the command, result, timing, and any surfaced issues.
+4. Park non-blocking findings in `HARDENING.md` only if the run exposes them.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_file_route_postgres_10000_row_run_2026-05-23.md`
+- `plans/PR-Content-Ops-File-Route-Postgres-10k-Validation.md`
+
+## Mechanism
+
+Use `scripts/smoke_content_ops_ingestion_file_route.py` with:
+
+- `tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`;
+- `--write`;
+- `--replace-existing`;
+- a unique account id for this validation slice;
+- mocked public-dataset defaults for `company_name`, `vendor_name`, and
+  `contact_email`.
+
+After the route smoke returns, query `campaign_opportunities` for the scoped
+account and `vendor_retention` target mode. The doc records the compact result
+summary and the database count without checking in temporary output artifacts
+or database credentials.
+
+## Intentional
+
+- No code changes planned. This is a real-flow validation slice.
+- The run uses a unique account id and `--replace-existing` so reruns are
+  idempotent for the scoped validation rows.
+- The local DSN is derived from Atlas settings at runtime and is not printed or
+  checked in.
+
+## Deferred
+
+- Concurrent uploaded-file write pressure is deferred until the single-run
+  10,000-row cap path is recorded.
+- Background jobs, durable upload storage, and cross-process admission control
+  remain separate hardening work if pressure testing shows they are needed.
+- No `HARDENING.md` entry was added because no product issue surfaced.
+
+## Verification
+
+- Environment check: local Atlas DB settings derived from
+  `atlas_brain.storage.config.db_settings`; host `localhost`, port `5433`,
+  database `atlas`, user `atlas`, password not set.
+- Source file check:
+  - `10000 tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`
+  - File size: `21M`
+- Uploaded-file route write smoke:
+  - `python scripts/smoke_content_ops_ingestion_file_route.py tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl --source-format jsonl --source cfpb-route-postgres-10000 --min-source-rows 10000 --default-field company_name=CFPB --default-field vendor_name=CFPB --default-field contact_email=cfpb-public-archive@example.invalid --write --account-id acct-file-route-postgres-10000-20260523 --user-id user-file-route-postgres --replace-existing --output-result tmp/content_ops_file_route_postgres_smoke_20260523_10000.json --json`
+  - Exit `0`; `dry_run=false`, `opportunity_count=10000`,
+    `inserted=10000`, `warning_count=0`, `missing_field_counts={}`.
+  - Elapsed `0:04.83`; maximum RSS `154556 KB`.
+- Saved artifact syntax check passed for
+  `tmp/content_ops_file_route_postgres_smoke_20260523_10000.json`.
+- Database count/sample check:
+  - Scoped `campaign_opportunities` count: `10000`.
+  - Sample row retained `target_id`, default `company_name` and
+    `contact_email`, source `vendor_name`, `source_type=support_ticket`, and
+    one evidence item.
+- Idempotency rerun:
+  - Exit `0`; scoped count after rerun stayed `10000`.
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~91 |
+| Validation record | ~242 |
+| **Total** | ~333 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Route-Postgres-10k-Validation.md

This records a validation-only run of the uploaded-file route write path at the current 10,000-row route cap. The run used CFPB-derived source rows, wrote through /content-ops/ingestion/files/import with --write and --replace-existing, confirmed the compact result artifact, queried local Postgres for the scoped count/sample, and reran to prove idempotency.

## Intentional
- Documentation and validation record only; no product code changes.
- Uses a unique account id with --replace-existing so reruns are scoped and idempotent.
- The local DSN is derived at runtime and is not printed or checked in.

## Deferred
- Concurrent uploaded-file write pressure remains a follow-up validation slice.
- Background jobs, durable upload storage, and cross-process admission control remain separate hardening work if pressure testing shows they are needed.
- No HARDENING.md entry was added because no product issue surfaced.

## Verification
- Environment check: local Atlas DB settings derived from atlas_brain.storage.config.db_settings; host localhost, port 5433, database atlas, user atlas, password not set.
- Source file check: 10,000 rows, 21M file.
- Uploaded-file route write smoke: exit 0; dry_run=false, opportunity_count=10000, inserted=10000, warning_count=0, missing_field_counts={}; elapsed 0:04.83, max RSS 154556 KB.
- Saved artifact syntax check passed for tmp/content_ops_file_route_postgres_smoke_20260523_10000.json.
- Database count/sample check: scoped campaign_opportunities count=10000; sample retained target_id, default company_name/contact_email, source vendor_name, source_type=support_ticket, evidence_count=1.
- Idempotency rerun: exit 0; scoped count_after_rerun=10000.
- bash scripts/local_pr_review.sh --allow-dirty — passed.

## Diff size
2 files, +333 / -0