### PR TITLE
Preflight Content Ops ingestion file size in UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
@@ -3,20 +3,27 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import ts from 'typescript'
 
-const source = readFileSync(
-  new URL('../src/domain/contentOps/fromWire.ts', import.meta.url),
-  'utf8',
-)
-const compiled = ts.transpileModule(source, {
-  compilerOptions: {
-    module: ts.ModuleKind.ES2022,
-    target: ts.ScriptTarget.ES2022,
-    verbatimModuleSyntax: true,
-  },
-}).outputText
+async function loadTsModule(path) {
+  const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
 
-const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
-const { fromWireCatalog } = await import(moduleUrl)
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const { fromWireCatalog } = await loadTsModule(
+  '../src/domain/contentOps/fromWire.ts',
+)
+const {
+  contentOpsIngestionFilePreflightError,
+  formatContentOpsBytes,
+} = await loadTsModule('../src/domain/contentOps/ingestionLimits.ts')
 
 const catalogFixture = JSON.parse(
   readFileSync(
@@ -45,10 +52,64 @@ test('fromWireCatalog copies ingestion limit supported formats', () => {
   const first = fromWireCatalog(catalogFixture)
   first.ingestionLimits.fileUpload.supportedFormats.push('yaml')
 
-  assert.deepEqual(fromWireCatalog(catalogFixture).ingestionLimits.fileUpload.supportedFormats, [
-    'auto',
-    'json',
-    'jsonl',
-    'csv',
-  ])
+  assert.deepEqual(
+    fromWireCatalog(catalogFixture).ingestionLimits.fileUpload.supportedFormats,
+    ['auto', 'json', 'jsonl', 'csv'],
+  )
+})
+
+test('contentOpsIngestionFilePreflightError rejects oversized uploads', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsIngestionFilePreflightError(
+      {
+        name: 'tickets.csv',
+        size: limits.fileUpload.maxFileBytes + 1,
+      },
+      limits,
+    ),
+    'tickets.csv is 25.0 MB. Upload files must be 25.0 MB or smaller.',
+  )
+})
+
+test('contentOpsIngestionFilePreflightError accepts files at the byte cap', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsIngestionFilePreflightError(
+      {
+        name: 'tickets.csv',
+        size: limits.fileUpload.maxFileBytes,
+      },
+      limits,
+    ),
+    null,
+  )
+})
+
+test('contentOpsIngestionFilePreflightError fails open when cap is not finite', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsIngestionFilePreflightError(
+      {
+        name: 'tickets.csv',
+        size: limits.fileUpload.maxFileBytes + 1,
+      },
+      {
+        ...limits,
+        fileUpload: {
+          ...limits.fileUpload,
+          maxFileBytes: Number.NaN,
+        },
+      },
+    ),
+    null,
+  )
+})
+
+test('formatContentOpsBytes formats byte caps for operators', () => {
+  assert.equal(formatContentOpsBytes(25 * 1024 * 1024), '25.0 MB')
+  assert.equal(formatContentOpsBytes(512), '512 B')
 })

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -32,6 +32,11 @@ export type {
 } from './types'
 
 export {
+  contentOpsIngestionFilePreflightError,
+  formatContentOpsBytes,
+} from './ingestionLimits'
+
+export {
   fromWireCatalog,
   fromWireExecution,
   fromWireIngestionDiagnostics,

--- a/atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts
+++ b/atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts
@@ -1,0 +1,29 @@
+import type { ContentOpsIngestionLimits } from './types'
+
+export interface ContentOpsIngestionFileSelection {
+  name: string
+  size: number
+}
+
+export function contentOpsIngestionFilePreflightError(
+  file: ContentOpsIngestionFileSelection,
+  limits: ContentOpsIngestionLimits,
+): string | null {
+  const maxFileBytes = limits.fileUpload.maxFileBytes
+  if (
+    Number.isFinite(file.size) &&
+    Number.isFinite(maxFileBytes) &&
+    file.size > maxFileBytes
+  ) {
+    return `${file.name} is ${formatContentOpsBytes(file.size)}. Upload files must be ${formatContentOpsBytes(maxFileBytes)} or smaller.`
+  }
+  return null
+}
+
+export function formatContentOpsBytes(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return 'unknown size'
+  if (value < 1024) return `${value} B`
+  const kib = value / 1024
+  if (kib < 1024) return `${kib.toFixed(1)} KB`
+  return `${(kib / 1024).toFixed(1)} MB`
+}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -20,6 +20,8 @@ import {
   previewContentOpsRun,
 } from '../api/contentOps'
 import {
+  contentOpsIngestionFilePreflightError,
+  formatContentOpsBytes,
   fromWireCatalog,
   fromWireExecution,
   fromWireIngestionDiagnostics,
@@ -661,6 +663,21 @@ export default function ContentOpsNewRun() {
     const file = event.currentTarget.files?.[0]
     event.currentTarget.value = ''
     if (!file) return
+
+    const preflightError = contentOpsIngestionFilePreflightError(
+      file,
+      catalog.ingestionLimits,
+    )
+    if (preflightError) {
+      ingestionFileLoadRequestIdRef.current += 1
+      setSelectedIngestionFile(null)
+      setIngestionFileLoadState({
+        kind: 'error',
+        message: preflightError,
+      })
+      markIngestionStale()
+      return
+    }
 
     ingestionFileLoadRequestIdRef.current += 1
     setIngestionFileLoadState({ kind: 'loading' })
@@ -1486,7 +1503,7 @@ function IngestionLimitsSummary({
         <span>
           Upload:{' '}
           <span className="text-slate-100">
-            {formatBytes(limits.fileUpload.maxFileBytes)}
+            {formatContentOpsBytes(limits.fileUpload.maxFileBytes)}
           </span>{' '}
           or{' '}
           <span className="text-slate-100">
@@ -1555,17 +1572,9 @@ function IngestionFileLoadResult({ state }: { state: IngestionFileLoadState }) {
     <div className="mt-3 rounded-md border border-slate-700 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
       Selected{' '}
       <span className="font-mono text-slate-100">{state.filename}</span>{' '}
-      ({formatBytes(state.size)}) for server-side inspection.
+      ({formatContentOpsBytes(state.size)}) for server-side inspection.
     </div>
   )
-}
-
-function formatBytes(value: number): string {
-  if (!Number.isFinite(value) || value < 0) return 'unknown size'
-  if (value < 1024) return `${value} B`
-  const kib = value / 1024
-  if (kib < 1024) return `${kib.toFixed(1)} KB`
-  return `${(kib / 1024).toFixed(1)} MB`
 }
 
 function formatCount(value: number): string {

--- a/plans/PR-Content-Ops-Upload-Preflight.md
+++ b/plans/PR-Content-Ops-Upload-Preflight.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-Upload-Preflight
+
+## Why this slice exists
+
+The new-run page can now display the backend upload limits from the control
+surface catalog, but selecting an oversized local file still marks it as
+selected and waits for the server to reject it during inspect/import.
+
+That is unnecessary work for operators and avoidable network load. This slice
+uses the same catalog-backed limits to reject obviously oversized files in the
+browser before they become the selected ingestion file.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-preflight
+
+1. Add a small domain helper for ingestion file selection preflight.
+2. Check selected file size against `catalog.ingestionLimits.fileUpload`.
+3. Show the existing file-load error state when a file is too large.
+4. Keep backend validation authoritative and unchanged.
+5. Extend the ingestion-limits frontend test with preflight coverage.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Upload-Preflight.md`
+- `atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs`
+
+## Mechanism
+
+`contentOpsIngestionFilePreflightError(file, limits)` returns a human-readable
+error string when the selected file exceeds the catalog-backed byte cap. The
+React file handler calls the helper before setting `selectedIngestionFile`.
+
+The helper accepts a file-like `{ name, size }` object so the test can exercise
+the behavior without a browser or React test harness.
+
+## Intentional
+
+- This only preflights file size. Row count and parse validity still require
+  server inspection because the browser should not parse large operator files
+  just to duplicate backend logic.
+- This does not change inspect/import API calls or backend enforcement.
+- This PR builds on #876's catalog-backed limits UI and keeps the same
+  ingestion-limits frontend test as the focused coverage surface.
+
+## Deferred
+
+- Future PR: remove inline compatibility after the operator compatibility
+  window.
+- Future PR: add extension/MIME preflight only if operators repeatedly upload
+  unsupported formats.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: ingestion-limits mapper/preflight test:
+  `npm run test:content-ops-ingestion-limits` (`6 passed`).
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: `git diff --check`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Domain helper + export | ~30 |
+| UI handler change | ~20 |
+| Test additions | ~60 |
+| **Total** | **~190** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Upload-Preflight.md

Use the catalog-backed Content Ops ingestion file byte limit to reject obviously oversized local uploads before the operator selects the file for inspect/import.

## Intentional
- Backend validation remains authoritative.
- This only preflights file size; row count and parse validity still require server inspection.
- No inspect/import API behavior changes.
- Backend boundary parity verified: server rejects only files larger than the byte cap, so exactly-at-cap is allowed in both UI and backend.

## Deferred
- Future PR: remove inline compatibility after the operator compatibility window.
- Future PR: add extension/MIME preflight only if unsupported uploads become common.

## Parked hardening
- None.

## Verification
- npm run test:content-ops-ingestion-limits (6 passed).
- npm run build.
- npm run lint.
- git diff --check.
- bash scripts/local_pr_review.sh.

## Diff size
5 files, +207 / -29