### PR TITLE
Record Content Ops file route concurrency validation

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-23
+
+### FILECONCURRENCY-1 - Uploaded-file write pressure needs bounded DB concurrency
+- File/location: `scripts/smoke_content_ops_ingestion_file_route.py`, hosted `/content-ops/ingestion/files/import` write path.
+- Description: Local Postgres pressure validation passed at 5 concurrent 10,000-row writes, 20 concurrent 1,000-row writes, and 100 concurrent 1,000-row writes, but 150 concurrent 1,000-row write processes produced 141 successes and 9 `asyncpg.exceptions.TooManyConnectionsError` failures during pool creation.
+- Why it matters: concurrent customer uploads can exhaust database connection slots unless hosted file-route writes use bounded concurrency, queue backpressure, async jobs, or a shared pool/admission-control layer.
+- Effort: M
+- Category: correctness
+- Owner/session: content-ops/backend-file-ingestion-validation
+- Found during: PR-Content-Ops-File-Route-Concurrency-Validation
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/docs/extraction/validation/content_ops_file_route_concurrency_validation_2026-05-23.md
+++ b/docs/extraction/validation/content_ops_file_route_concurrency_validation_2026-05-23.md
@@ -1,0 +1,152 @@
+# Content Ops File Route Concurrency Validation - 2026-05-23
+
+## Summary
+
+The uploaded-file route write path was pressure-tested against local Atlas
+Postgres with concurrent CFPB-derived source-row uploads. Correctness held
+through:
+
+- 5 concurrent 10,000-row route writes;
+- 20 concurrent 1,000-row route writes;
+- 100 concurrent 1,000-row route writes.
+
+At 150 concurrent 1,000-row route writes, the route surfaced the expected
+database connection ceiling: 141 runs succeeded and 9 failed during pool
+creation with `asyncpg.exceptions.TooManyConnectionsError`.
+
+This is a resource/backpressure finding, not a parsing or persistence
+correctness failure. Successful runs persisted the expected row counts under
+their scoped accounts with zero ingestion warnings.
+
+## Source Data
+
+10,000-row cap fixture:
+
+- `tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`
+- Rows: `10,000`
+
+1,000-row fixture:
+
+- `tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl`
+- Rows: `1,000`
+
+Both fixtures use source-row mode with these fallback fields:
+
+```text
+company_name=CFPB
+vendor_name=CFPB
+contact_email=cfpb-public-archive@example.invalid
+```
+
+## Database
+
+The run used Atlas local database settings derived from
+`atlas_brain.storage.config.db_settings`:
+
+- host: `localhost`
+- port: `5433`
+- database: `atlas`
+- user: `atlas`
+- password: not set
+
+Observed local Postgres connection settings:
+
+```json
+{
+  "max_connections": "100",
+  "superuser_reserved_connections": "3"
+}
+```
+
+## Commands
+
+Each process ran `scripts/smoke_content_ops_ingestion_file_route.py` with
+`--write`, `--replace-existing`, a unique `account_id`, and an
+`--output-result` path under:
+
+```text
+tmp/content_ops_file_route_concurrency_20260523/
+```
+
+Example shape:
+
+```bash
+python scripts/smoke_content_ops_ingestion_file_route.py \
+  tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl \
+  --source-format jsonl \
+  --source cfpb-route-concurrency-100x1000 \
+  --min-source-rows 1000 \
+  --default-field company_name=CFPB \
+  --default-field vendor_name=CFPB \
+  --default-field contact_email=cfpb-public-archive@example.invalid \
+  --write \
+  --account-id acct-file-route-concurrency-100x1000-20260523-1 \
+  --user-id user-file-route-concurrency \
+  --replace-existing \
+  --output-result tmp/content_ops_file_route_concurrency_20260523/100x1000/result_1.json \
+  --json
+```
+
+## Results
+
+| Probe | Source rows per run | Concurrent processes | Successes | Failures | Inserted rows | Warnings | Elapsed | Max RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| 5x10000 | 10,000 | 5 | 5 | 0 | 50,000 | 0 | 0:05.93 | 154,760 KB |
+| 20x1000 | 1,000 | 20 | 20 | 0 | 20,000 | 0 | 0:01.69 | 65,868 KB |
+| 100x1000 | 1,000 | 100 | 100 | 0 | 100,000 | 0 | 0:07.85 | 66,028 KB |
+| 150x1000 | 1,000 | 150 | 141 | 9 | 141,000 | 0 | 0:12.49 | 66,280 KB |
+
+Database row counts matched successful run counts:
+
+```json
+{"accounts": 5, "batch": "5x10000", "rows": 50000}
+{"accounts": 20, "batch": "20x1000", "rows": 20000}
+{"accounts": 100, "batch": "100x1000", "rows": 100000}
+{"accounts": 141, "batch": "150x1000", "rows": 141000}
+```
+
+## Failure Shape
+
+The 150-way probe produced 9 compact failure artifacts. Example:
+
+```json
+{
+  "account_id": "acct-file-route-concurrency-150x1000-20260523-22",
+  "detail": null,
+  "diagnostics": null,
+  "dry_run": false,
+  "errors": [
+    "TooManyConnectionsError: None"
+  ],
+  "import": null,
+  "ok": false,
+  "status_code": 500
+}
+```
+
+The failure happens before route diagnostics/import work because the smoke must
+create a database pool before wiring `opportunity_import_pool_provider`.
+Successful runs in the same batch wrote all expected rows and warning counts
+remained zero.
+
+## Issues Surfaced
+
+### FILECONCURRENCY-1 - Uploaded-file write pressure needs bounded DB concurrency
+
+At 150 concurrent 1,000-row route-write processes, 9 processes failed during
+pool creation with `TooManyConnectionsError`. The local database reports
+`max_connections=100` and `superuser_reserved_connections=3`, so hosted
+uploaded-file writes need admission control before this route is exposed to
+unbounded concurrent customer uploads.
+
+Resolution: parked in `HARDENING.md`. The single-run and moderate concurrent
+flows work, and fixing hosted queue/backpressure is larger than a validation
+record.
+
+## Conclusion
+
+The uploaded-file route write path is correct through the current 10,000-row
+file cap and through 100 simultaneous 1,000-row writes on local Postgres. The
+first observed ceiling is connection pressure at 150 simultaneous write
+processes. That ceiling is now logged as hardening work for bounded hosted
+write concurrency or background job admission control.

--- a/plans/PR-Content-Ops-File-Route-Concurrency-Validation.md
+++ b/plans/PR-Content-Ops-File-Route-Concurrency-Validation.md
@@ -1,0 +1,91 @@
+# PR-Content-Ops-File-Route-Concurrency-Validation
+
+## Why this slice exists
+
+PR #878 proved a single uploaded-file route write at the 10,000-row cap. The
+next survivability question is whether the same route write path stays correct
+under concurrent customer-style uploads, and where it starts to show resource
+pressure.
+
+This slice records progressive local Postgres pressure probes for the
+uploaded-file route write smoke. It is validation only unless the concurrent
+flow cannot be exercised.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Run multiple concurrent `--write` route-smoke processes against local
+   Postgres using CFPB-derived source-row fixtures.
+2. Confirm success counts, DB row counts, and failure modes for each pressure
+   level.
+3. Document timing, memory, and any surfaced issues.
+4. Park non-blocking hardening issues in `HARDENING.md` if the pressure run
+   exposes resource ceilings.
+
+### Files touched
+
+- `docs/extraction/validation/content_ops_file_route_concurrency_validation_2026-05-23.md`
+- `plans/PR-Content-Ops-File-Route-Concurrency-Validation.md`
+- `HARDENING.md`
+
+## Mechanism
+
+Use the existing `scripts/smoke_content_ops_ingestion_file_route.py` command in
+`--write` mode with unique account ids per process and `--replace-existing`.
+Run progressive batches:
+
+- smaller concurrent 1,000-row writes to exercise request/process pressure;
+- concurrent 10,000-row writes to exercise the current route cap under load;
+- a higher-concurrency probe only if earlier runs pass cleanly.
+
+Each process writes its compact JSON result under `tmp/`. After each batch,
+summarize exit codes and query `campaign_opportunities` for the scoped account
+prefix so the database state matches the result artifacts.
+
+## Intentional
+
+- No reusable load-test runner in this slice. The pressure commands are
+  validation evidence; if repeated often, a future slice can promote them into a
+  checked-in harness.
+- No product code changes unless the route write path cannot be exercised.
+- Rows are scoped by unique account prefixes and use `--replace-existing` so
+  reruns are isolated and idempotent per account.
+
+## Deferred
+
+- Background jobs, durable upload storage, and cross-process admission control
+  remain separate hardening work if this pressure test shows they are needed.
+- Cleanup tooling for validation rows remains out of scope unless DB bloat
+  becomes a blocker.
+
+## Verification
+
+- 5 concurrent 10,000-row writes:
+  - 5 successes, 0 failures, 50,000 inserted rows, 0 warnings.
+  - Elapsed `0:05.93`; max RSS `154760 KB`.
+- 20 concurrent 1,000-row writes:
+  - 20 successes, 0 failures, 20,000 inserted rows, 0 warnings.
+  - Elapsed `0:01.69`; max RSS `65868 KB`.
+- 100 concurrent 1,000-row writes:
+  - 100 successes, 0 failures, 100,000 inserted rows, 0 warnings.
+  - Elapsed `0:07.85`; max RSS `66028 KB`.
+- 150 concurrent 1,000-row writes:
+  - 141 successes, 9 failures, 141,000 inserted rows, 0 warnings.
+  - Failure mode: `TooManyConnectionsError: None` during pool creation.
+  - Elapsed `0:12.49`; max RSS `66280 KB`.
+- Database count checks matched successful run counts for all four probes.
+- Local Postgres settings: `max_connections=100`,
+  `superuser_reserved_connections=3`.
+- `FILECONCURRENCY-1` parked in `HARDENING.md`.
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Validation record | ~150 |
+| HARDENING entry | ~10 |
+| **Total** | ~255 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Route-Concurrency-Validation.md

Records the hosted Content Ops uploaded-file route concurrency validation using the real Postgres write path. The passing probes show the route can handle 5 concurrent 10k-row uploads, 20 concurrent 1k-row uploads, and 100 concurrent 1k-row uploads; the 150 concurrent 1k-row probe surfaced a Postgres connection ceiling, now logged as FILECONCURRENCY-1.

## Intentional
- Documentation and hardening-log slice only; no product code changes are bundled into the validation record.
- The 150x1000 failure is recorded as a real surfaced issue instead of hidden by lowering the test ceiling.
- The validation uses unique accounts and `--replace-existing` so database row counts are easy to verify.

## Deferred
- FILECONCURRENCY-1 tracks bounded DB concurrency, queue backpressure, async jobs, or a shared pool/admission-control layer for hosted file uploads.
- Reusable load-runner automation and DB cleanup tooling are left for a later hardening slice.

## Verification
- 5x10000 concurrent write probe: 5 successes, 0 failures, 50,000 rows inserted.
- 20x1000 concurrent write probe: 20 successes, 0 failures, 20,000 rows inserted.
- 100x1000 concurrent write probe: 100 successes, 0 failures, 100,000 rows inserted.
- 150x1000 concurrent write probe: 141 successes, 9 TooManyConnections failures, 141,000 rows inserted; issue logged as FILECONCURRENCY-1.
- Confirmed Postgres validation counts and settings: max_connections=100, superuser_reserved_connections=3.
- `bash scripts/local_pr_review.sh --allow-dirty`

## Diff size
3 files, +254 / -0