### PR TITLE
Add Content Ops file import admission gate

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -264,6 +264,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_drop_falsified: bool = False
     ingestion_opportunity_table: str = "campaign_opportunities"
     execute_max_concurrency: int = 8
+    ingestion_import_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
         if not str(self.prefix or "").strip().startswith("/"):
@@ -303,6 +304,8 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_max_continuations must be non-negative")
         if self.execute_max_concurrency <= 0:
             raise ValueError("execute_max_concurrency must be positive")
+        if self.ingestion_import_max_concurrency <= 0:
+            raise ValueError("ingestion_import_max_concurrency must be positive")
         if not isinstance(
             self.structured_reasoning_falsification_rules,
             Sequence,
@@ -518,6 +521,9 @@ def create_content_ops_control_surface_router(
     _require_fastapi()
     resolved_config = config or ContentOpsControlSurfaceApiConfig()
     execute_gate = _ExecuteConcurrencyGate(resolved_config.execute_max_concurrency)
+    ingestion_import_gate = _ExecuteConcurrencyGate(
+        resolved_config.ingestion_import_max_concurrency
+    )
     router = APIRouter(
         prefix=resolved_config.prefix,
         tags=list(resolved_config.tags),
@@ -605,15 +611,11 @@ def create_content_ops_control_surface_router(
                 },
             )
         dry_run = bool(data.get("dry_run"))
-        if dry_run:
-            pool = object()
-        else:
-            pool = await _resolve_import_pool(opportunity_import_pool_provider)
-        scope = await _resolve_scope(scope_provider)
-        result = await _import_campaign_opportunities_for_route(
-            pool,
+        result = await _import_ingestion_rows_with_admission(
             report.opportunities,
-            scope=scope,
+            import_gate=ingestion_import_gate,
+            pool_provider=opportunity_import_pool_provider,
+            scope_provider=scope_provider,
             target_mode=target_mode,
             opportunity_table=resolved_config.ingestion_opportunity_table,
             replace_existing=bool(data.get("replace_existing")),
@@ -681,15 +683,11 @@ def create_content_ops_control_surface_router(
                     "diagnostics": diagnostics,
                 },
             )
-        if dry_run:
-            pool = object()
-        else:
-            pool = await _resolve_import_pool(opportunity_import_pool_provider)
-        scope = await _resolve_scope(scope_provider)
-        result = await _import_campaign_opportunities_for_route(
-            pool,
+        result = await _import_ingestion_rows_with_admission(
             report.opportunities,
-            scope=scope,
+            import_gate=ingestion_import_gate,
+            pool_provider=opportunity_import_pool_provider,
+            scope_provider=scope_provider,
             target_mode=target_mode_value,
             opportunity_table=resolved_config.ingestion_opportunity_table,
             replace_existing=bool(replace_existing),
@@ -1240,6 +1238,56 @@ async def _resolve_import_pool(provider: PoolProvider | None) -> Any:
             detail="Content Ops ingestion import database is unavailable.",
         )
     return pool
+
+
+async def _import_ingestion_rows_with_admission(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    import_gate: _ExecuteConcurrencyGate,
+    pool_provider: PoolProvider | None,
+    scope_provider: ScopeProvider | None,
+    target_mode: str,
+    opportunity_table: str,
+    replace_existing: bool,
+    dry_run: bool,
+    source: str | None,
+) -> Any:
+    if dry_run:
+        scope = await _resolve_scope(scope_provider)
+        return await _import_campaign_opportunities_for_route(
+            object(),
+            rows,
+            scope=scope,
+            target_mode=target_mode,
+            opportunity_table=opportunity_table,
+            replace_existing=replace_existing,
+            dry_run=True,
+            source=source,
+        )
+
+    if not await import_gate.acquire():
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "reason": "content_ops_ingestion_import_at_capacity",
+                "max_concurrency": import_gate.max_concurrency,
+            },
+        )
+    try:
+        pool = await _resolve_import_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        return await _import_campaign_opportunities_for_route(
+            pool,
+            rows,
+            scope=scope,
+            target_mode=target_mode,
+            opportunity_table=opportunity_table,
+            replace_existing=replace_existing,
+            dry_run=False,
+            source=source,
+        )
+    finally:
+        await import_gate.release()
 
 
 async def _import_campaign_opportunities_for_route(

--- a/plans/PR-Content-Ops-File-Import-Admission-Gate.md
+++ b/plans/PR-Content-Ops-File-Import-Admission-Gate.md
@@ -1,0 +1,105 @@
+# PR-Content-Ops-File-Import-Admission-Gate
+
+## Why this slice exists
+
+The uploaded-file route now has live write and scale validation, but the
+concurrency probe surfaced the next production risk: enough simultaneous
+non-dry-run imports can pressure the host database connection pool. The
+production app mounts the Content Ops routes with the shared Atlas DB pool, so
+the source-level mitigation belongs at the route layer before an import request
+resolves or acquires the pool.
+
+This slice adds a bounded admission gate for hosted ingestion imports. It is the
+smallest end-to-end source fix for the surfaced issue: one active import can
+hold the gate, a second write receives a deterministic 429, and dry-run
+inspection/import paths remain side-effect-free.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a configurable `ingestion_import_max_concurrency` limit to
+   `ContentOpsControlSurfaceApiConfig`.
+2. Apply that limit to non-dry-run ingestion imports before resolving the import
+   pool provider.
+3. Wire both the legacy JSON import route and uploaded-file import route through
+   the same admission helper.
+4. Add focused route tests for config validation and file-upload admission
+   behavior.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `plans/PR-Content-Ops-File-Import-Admission-Gate.md`
+
+## Mechanism
+
+`create_content_ops_control_surface_router` will instantiate a second
+`_ExecuteConcurrencyGate` using the new
+`ContentOpsControlSurfaceApiConfig.ingestion_import_max_concurrency` value.
+Non-dry-run import routes will enter a shared helper before resolving
+`opportunity_import_pool_provider` or scope. If the gate is full, the route
+raises:
+
+```python
+HTTPException(
+    status_code=429,
+    detail={
+        "reason": "content_ops_ingestion_import_at_capacity",
+        "max_concurrency": ingestion_import_gate.max_concurrency,
+    },
+)
+```
+
+The helper releases the gate in `finally` after the import succeeds or fails.
+`dry_run=True` bypasses the gate and still uses the existing object-backed dry
+run path.
+
+## Intentional
+
+- This is an in-process route admission gate for the hosted app's shared pool,
+  not a distributed queue. Cross-process queueing and durable background jobs
+  are larger product-hardening work.
+- The default limit is conservative and configurable instead of derived from
+  Postgres `max_connections`; the extracted package should not inspect host DB
+  settings.
+- The smoke harness's 150-process pool-creation ceiling is not fixed here. That
+  harness creates one asyncpg pool per process, which is a different shape from
+  the hosted app's shared pool.
+
+## Deferred
+
+- Cross-process backpressure, durable import jobs, and shared queue visibility
+  remain follow-up production hardening.
+- A reusable in-process load runner that proves shared-pool admission against a
+  real DB is deferred until after this route contract is in place.
+
+## Verification
+
+- Focused route tests:
+  - `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
+  - `88 passed`
+- Extracted package gauntlet:
+  - `bash scripts/validate_extracted_content_pipeline.sh`
+  - Passed.
+  - `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - Passed.
+  - `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Passed.
+  - `bash scripts/check_ascii_python.sh`
+  - Passed.
+  - `bash scripts/run_extracted_pipeline_checks.sh`
+  - `1871 passed, 1 skipped, 1 warning`
+- Local PR review:
+  - `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 105 |
+| Router admission gate | 80 |
+| Route tests | 96 |
+| Total | 281 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -819,6 +819,97 @@ async def test_ingestion_file_import_route_dry_run_uses_file_parser():
 
 
 @pytest.mark.asyncio
+async def test_ingestion_file_import_route_rejects_when_import_gate_is_full():
+    pool = _Pool()
+    provider_started = asyncio.Event()
+    provider_release = asyncio.Event()
+    provider_calls = 0
+
+    async def pool_provider():
+        nonlocal provider_calls
+        provider_calls += 1
+        provider_started.set()
+        await provider_release.wait()
+        return pool
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            ingestion_import_max_concurrency=1,
+        ),
+        opportunity_import_pool_provider=pool_provider,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    route = _route(router, "/ops/ingestion/files/import", "POST")
+    first = asyncio.create_task(
+        route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+            dry_run=False,
+        )
+    )
+    await asyncio.wait_for(provider_started.wait(), timeout=1)
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+            dry_run=False,
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.detail == {
+        "reason": "content_ops_ingestion_import_at_capacity",
+        "max_concurrency": 1,
+    }
+    assert provider_calls == 1
+
+    provider_release.set()
+    first_payload = await first
+    assert first_payload["import"]["inserted"] == 1
+    assert provider_calls == 1
+
+    second_payload = await route.endpoint(
+        file=_ticket_bundle_upload(1),
+        source_rows=True,
+        source="ticket-csv-upload",
+        target_mode="vendor_retention",
+        file_format="json",
+        max_source_text_chars=1200,
+        sample_limit=3,
+        default_fields=json.dumps({
+            "company_name": "Acme",
+            "vendor_name": "Atlas",
+            "contact_email": "support@example.com",
+        }),
+        dry_run=False,
+    )
+    assert second_payload["import"]["inserted"] == 1
+    assert provider_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_ingestion_file_inspect_route_rejects_oversized_upload_bytes():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
@@ -2315,6 +2406,11 @@ def test_content_ops_config_stores_output_pack_names_immutably():
 def test_content_ops_config_rejects_invalid_execute_concurrency():
     with pytest.raises(ValueError, match="execute_max_concurrency must be positive"):
         ContentOpsControlSurfaceApiConfig(execute_max_concurrency=0)
+
+
+def test_content_ops_config_rejects_invalid_ingestion_import_concurrency():
+    with pytest.raises(ValueError, match="ingestion_import_max_concurrency must be positive"):
+        ContentOpsControlSurfaceApiConfig(ingestion_import_max_concurrency=0)
 
 
 def test_content_ops_config_rejects_invalid_falsification_rules_shape():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Import-Admission-Gate.md

Adds a bounded admission gate for non-dry-run Content Ops ingestion imports before the route resolves the host import pool. Both the legacy JSON import route and uploaded-file import route use the same helper, so a second write receives a deterministic 429 while another import is holding the gate.

## Intentional
- This is an in-process hosted-route admission gate for the shared Atlas DB pool, not a distributed queue or durable job system.
- Dry-run imports bypass the gate and preserve the existing side-effect-free behavior.
- The smoke harness 150-process pool-creation ceiling is not changed here because that harness creates one asyncpg pool per process.

## Deferred
- Cross-process backpressure, durable import jobs, and shared queue visibility remain follow-up production hardening.
- A real-DB in-process load runner that proves shared-pool admission is deferred until after this route contract is in place.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py -q` -> 88 passed
- `bash scripts/validate_extracted_content_pipeline.sh` -> passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -> passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -> passed
- `bash scripts/check_ascii_python.sh` -> passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 1871 passed, 1 skipped, 1 warning
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed

## Diff size
3 files, +265 / -16