### PR TITLE
Preflight Content Ops inline row cap in UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs
@@ -22,7 +22,9 @@ const { fromWireCatalog } = await loadTsModule(
 )
 const {
   contentOpsIngestionFilePreflightError,
+  contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
+  formatContentOpsCount,
 } = await loadTsModule('../src/domain/contentOps/ingestionLimits.ts')
 
 const catalogFixture = JSON.parse(
@@ -109,7 +111,45 @@ test('contentOpsIngestionFilePreflightError fails open when cap is not finite', 
   )
 })
 
+test('contentOpsInlineRowsPreflightError rejects oversized inline rows', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsInlineRowsPreflightError(limits.inlineRows.maxRows + 1, limits),
+    'Inline JSON has 1,001 rows. Inline ingestion accepts 1,000 rows or fewer. Use a CSV, JSON, or JSONL file for larger imports.',
+  )
+})
+
+test('contentOpsInlineRowsPreflightError accepts inline rows at the cap', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsInlineRowsPreflightError(limits.inlineRows.maxRows, limits),
+    null,
+  )
+})
+
+test('contentOpsInlineRowsPreflightError fails open when cap is not finite', () => {
+  const limits = fromWireCatalog(catalogFixture).ingestionLimits
+
+  assert.equal(
+    contentOpsInlineRowsPreflightError(limits.inlineRows.maxRows + 1, {
+      ...limits,
+      inlineRows: {
+        ...limits.inlineRows,
+        maxRows: Number.NaN,
+      },
+    }),
+    null,
+  )
+})
+
 test('formatContentOpsBytes formats byte caps for operators', () => {
   assert.equal(formatContentOpsBytes(25 * 1024 * 1024), '25.0 MB')
   assert.equal(formatContentOpsBytes(512), '512 B')
+})
+
+test('formatContentOpsCount formats row caps for operators', () => {
+  assert.equal(formatContentOpsCount(1000), '1,000')
+  assert.equal(formatContentOpsCount(Number.NaN), 'unknown')
 })

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -33,7 +33,9 @@ export type {
 
 export {
   contentOpsIngestionFilePreflightError,
+  contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
+  formatContentOpsCount,
 } from './ingestionLimits'
 
 export {

--- a/atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts
+++ b/atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts
@@ -20,10 +20,30 @@ export function contentOpsIngestionFilePreflightError(
   return null
 }
 
+export function contentOpsInlineRowsPreflightError(
+  rowCount: number,
+  limits: ContentOpsIngestionLimits,
+): string | null {
+  const maxRows = limits.inlineRows.maxRows
+  if (
+    Number.isFinite(rowCount) &&
+    Number.isFinite(maxRows) &&
+    rowCount > maxRows
+  ) {
+    return `Inline JSON has ${formatContentOpsCount(rowCount)} rows. Inline ingestion accepts ${formatContentOpsCount(maxRows)} rows or fewer. Use a CSV, JSON, or JSONL file for larger imports.`
+  }
+  return null
+}
+
 export function formatContentOpsBytes(value: number): string {
   if (!Number.isFinite(value) || value < 0) return 'unknown size'
   if (value < 1024) return `${value} B`
   const kib = value / 1024
   if (kib < 1024) return `${kib.toFixed(1)} KB`
   return `${(kib / 1024).toFixed(1)} MB`
+}
+
+export function formatContentOpsCount(value: number): string {
+  if (!Number.isFinite(value)) return 'unknown'
+  return value.toLocaleString('en-US')
 }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -21,6 +21,7 @@ import {
 } from '../api/contentOps'
 import {
   contentOpsIngestionFilePreflightError,
+  contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
   fromWireCatalog,
   fromWireExecution,
@@ -516,6 +517,19 @@ export default function ContentOpsNewRun() {
       })
       return
     }
+    const inlineRowsPreflightError = parsedRows?.ok
+      ? contentOpsInlineRowsPreflightError(
+          parsedRows.rows.length,
+          catalog.ingestionLimits,
+        )
+      : null
+    if (inlineRowsPreflightError) {
+      setIngestionInspectState({
+        kind: 'invalid_input',
+        message: inlineRowsPreflightError,
+      })
+      return
+    }
     const parsedDefaultFields = parseIngestionDefaultFieldsJson(
       ingestionDefaultFieldsJson,
     )
@@ -576,6 +590,19 @@ export default function ContentOpsNewRun() {
       setIngestionImportState({
         kind: 'invalid_input',
         message: parsedRows.message,
+      })
+      return
+    }
+    const inlineRowsPreflightError = parsedRows?.ok
+      ? contentOpsInlineRowsPreflightError(
+          parsedRows.rows.length,
+          catalog.ingestionLimits,
+        )
+      : null
+    if (inlineRowsPreflightError) {
+      setIngestionImportState({
+        kind: 'invalid_input',
+        message: inlineRowsPreflightError,
       })
       return
     }

--- a/plans/PR-Content-Ops-Inline-Row-Preflight.md
+++ b/plans/PR-Content-Ops-Inline-Row-Preflight.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-Inline-Row-Preflight
+
+## Why this slice exists
+
+The Content Ops new-run page still supports deprecated inline JSON rows for
+manual/pasted ingestion. The backend enforces the inline row cap from the
+control-surface catalog, but the UI currently parses and submits oversized
+inline payloads before the server rejects them.
+
+After #880, uploaded files get catalog-backed preflight for obvious local
+limits. This slice applies the same pattern to inline rows without touching the
+file-upload path or backend behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/inline-row-preflight
+
+1. Add a small domain helper for inline row-count preflight.
+2. Check parsed inline rows against `catalog.ingestionLimits.inlineRows.maxRows`.
+3. Use the existing invalid-input states for inspect/import when inline rows
+   exceed the cap.
+4. Keep backend validation authoritative and unchanged.
+5. Extend the ingestion-limits frontend test with inline row-count coverage.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Inline-Row-Preflight.md`
+- `atlas-intel-ui/src/domain/contentOps/ingestionLimits.ts`
+- `atlas-intel-ui/src/domain/contentOps/index.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-ingestion-limits.test.mjs`
+
+## Mechanism
+
+`contentOpsInlineRowsPreflightError(rowCount, limits)` returns a readable error
+when a parsed inline JSON payload exceeds the catalog-backed inline row cap.
+`ContentOpsNewRun` calls it after JSON parsing and before inspect/import
+submission.
+
+The helper fails open if either the row count or cap is non-finite. That keeps
+the backend as the final authority if the catalog shape is ever unavailable or
+malformed.
+
+## Intentional
+
+- This does not revive or expand inline ingestion; the path remains deprecated.
+- This only preflights parsed inline row count. File row count and parse
+  validity still belong to server-side inspection.
+- This does not change API requests or backend enforcement.
+
+## Deferred
+
+- Future PR: remove inline compatibility after the operator compatibility
+  window.
+- Future PR: add extension/MIME preflight only if unsupported uploads become
+  common.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: ingestion-limits mapper/preflight test:
+  `npm run test:content-ops-ingestion-limits` (`10 passed`).
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: `git diff --check`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Domain helper + export | ~30 |
+| UI handler change | ~25 |
+| Test additions | ~45 |
+| **Total** | **~180** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Inline-Row-Preflight.md

Use the catalog-backed Content Ops inline row cap to reject oversized pasted/manual JSON rows before inspect/import submits the deprecated inline path.

## Intentional
- Backend validation remains authoritative.
- Inline ingestion remains deprecated; this only avoids known oversized submissions while compatibility exists.
- File row count and parse validity stay server-side.
- No API or backend behavior changes.

## Deferred
- Future PR: remove inline compatibility after the operator compatibility window.
- Future PR: add extension/MIME preflight only if unsupported uploads become common.

## Parked hardening
- None.

## Verification
- npm run test:content-ops-ingestion-limits (10 passed).
- npm run build.
- npm run lint.
- git diff --check.
- bash scripts/local_pr_review.sh.

## Diff size
5 files, +165 / -0