### PR TITLE
Label deprecated Content Ops inline rows field

### DIFF
--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1161,19 +1161,32 @@ export default function ContentOpsNewRun() {
               placeholder='{"company_name": "Acme", "contact_email": "ops@example.com"}'
             />
           </label>
-          <textarea
-            value={ingestionRowsJson}
-            onChange={(e) => {
-              setSelectedIngestionFile(null)
-              setIngestionFileLoadState({ kind: 'idle' })
-              setIngestionRowsJson(e.target.value)
-              markIngestionStale()
-            }}
-            rows={5}
-            spellCheck={false}
-            className="w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs text-slate-200 focus:border-cyan-500 focus:outline-none"
-            placeholder='[{"company_name": "Acme", "vendor": "HubSpot", "email": "ops@example.com"}]'
-          />
+          <label className="block text-sm">
+            <span className="flex flex-wrap items-center gap-2 text-slate-300">
+              Inline rows JSON
+              <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-200">
+                Deprecated
+              </span>
+              {selectedIngestionFile && (
+                <span className="text-xs text-slate-500">
+                  Ignored while an uploaded file is selected
+                </span>
+              )}
+            </span>
+            <textarea
+              value={ingestionRowsJson}
+              onChange={(e) => {
+                setSelectedIngestionFile(null)
+                setIngestionFileLoadState({ kind: 'idle' })
+                setIngestionRowsJson(e.target.value)
+                markIngestionStale()
+              }}
+              rows={5}
+              spellCheck={false}
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs text-slate-200 focus:border-cyan-500 focus:outline-none"
+              placeholder='[{"company_name": "Acme", "vendor": "HubSpot", "email": "ops@example.com"}]'
+            />
+          </label>
           <IngestionFileLoadResult state={ingestionFileLoadState} />
           <IngestionInspectResult state={ingestionInspectState} />
           <IngestionImportResult state={ingestionImportState} />

--- a/plans/PR-Content-Ops-Inline-Row-Label.md
+++ b/plans/PR-Content-Ops-Inline-Row-Label.md
@@ -1,0 +1,61 @@
+# PR-Content-Ops-Inline-Row-Label
+
+## Why this slice exists
+
+The Content Ops new-run page now supports real file uploads and keeps pasted
+inline JSON rows only as a deprecated compatibility path. The upload limits
+summary says inline JSON is deprecated, and #886 preflights the inline row cap,
+but the actual inline rows textarea is unlabeled.
+
+That makes the operator surface ambiguous: a selected file takes precedence, but
+the old textarea still looks like an equal primary input. This slice labels the
+inline field clearly and shows when file upload is the active source.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/inline-row-label
+
+1. Add a visible label for the inline rows JSON textarea.
+2. Mark the inline field as deprecated in the field label.
+3. Show that inline rows are ignored while an uploaded file is selected.
+4. Keep inspect/import behavior unchanged.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Inline-Row-Label.md`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+
+## Mechanism
+
+The UI wraps the existing inline rows textarea in a labeled block and renders a
+small state note when `selectedIngestionFile` is present. The textarea remains
+editable because editing it intentionally clears the selected file and returns
+to the deprecated inline path.
+
+## Intentional
+
+- No API changes.
+- No new validation; row-count preflight already landed in #886.
+- No removal of inline compatibility in this slice.
+
+## Deferred
+
+- Future PR: remove inline compatibility after the operator compatibility
+  window.
+- Future PR: add richer upload/job status after the backend grows a job model.
+- Parked hardening: none.
+
+## Verification
+
+- Passed: UI build: `npm run build`.
+- Passed: UI lint: `npm run lint`.
+- Passed: `git diff --check`.
+- Passed: local PR review via `scripts/local_pr_review.sh`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| UI label/state copy | ~20 |
+| **Total** | **~90** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Inline-Row-Label.md

Label the deprecated inline rows JSON textarea in the Content Ops new-run ingestion UI and show when it is ignored because an uploaded file is selected.

## Intentional
- No API or validation changes.
- Inline compatibility remains available.
- Editing inline rows still clears the selected file and returns to the inline path.

## Deferred
- Future PR: remove inline compatibility after the operator compatibility window.
- Future PR: add richer upload/job status after backend job support exists.

## Parked hardening
- None.

## Verification
- npm run build.
- npm run lint.
- git diff --check.
- bash scripts/local_pr_review.sh.

## Diff size
2 files, +87 / -13