### PR TITLE
Add Content Ops file import in-process load runner

### DIFF
--- a/plans/PR-Content-Ops-File-Import-Inprocess-Load.md
+++ b/plans/PR-Content-Ops-File-Import-Inprocess-Load.md
@@ -1,0 +1,102 @@
+# PR-Content-Ops-File-Import-Inprocess-Load
+
+## Why this slice exists
+
+PR-Content-Ops-File-Import-Admission-Gate added an in-process admission gate for
+non-dry-run ingestion imports. The next proof should exercise the real route in
+the hosted shape: many uploaded-file import calls inside one app process, using
+one shared pool provider, where excess requests receive deterministic 429
+responses instead of creating more database pools.
+
+This closes the validation gap left by the older 150-process smoke. That smoke
+is still useful for pressure discovery, but each process creates its own asyncpg
+pool, so it cannot prove shared-pool admission behavior.
+
+This slice is over the 400 LOC target because the runner needs to be reusable,
+reviewable, and safe to run against a real database: it includes CLI validation,
+shared-pool setup, async fan-out, compact failure artifacts, and deterministic
+fake-pool tests. Splitting the tests from the runner would ship an unverified
+load tool, which is not useful for this hardening lane.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a same-process uploaded-file import load runner script.
+2. Share one import pool across all route calls in the script.
+3. Allow callers to configure total concurrency and route import admission
+   concurrency.
+4. Emit a compact JSON result that counts successes, 429 admission responses,
+   unexpected failures, and inserted rows.
+5. Add deterministic tests with a fake slow pool to prove the runner observes
+   gate-full 429 responses and writes its artifact.
+
+### Files touched
+
+- `scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py`
+- `tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py`
+- `plans/PR-Content-Ops-File-Import-Inprocess-Load.md`
+
+## Mechanism
+
+The new script builds the Content Ops control-surface router once with
+`ContentOpsControlSurfaceApiConfig.ingestion_import_max_concurrency` set from
+the CLI. It creates one asyncpg pool from the existing database URL resolution
+helper and passes that same pool through `opportunity_import_pool_provider` for
+every route call.
+
+It then launches `N` async tasks against `/ops/ingestion/files/import` with the
+same uploaded file bytes and `dry_run=False`. Per-call results are compacted to
+status code, elapsed time, inserted count, and error reason. The overall result
+is successful only when:
+
+1. at least the configured minimum number of imports succeed,
+2. at least the configured minimum number of calls return the expected 429
+   admission response, and
+3. no unexpected non-429 failures occur.
+
+## Intentional
+
+- This is a validation runner, not product code. It proves the route contract
+  introduced by the previous slice.
+- The runner does not add a queue or retry behavior. Queueing remains product
+  hardening, not required to prove bounded admission.
+- The default expected 429 count is conservative and caller-configurable because
+  row count, database speed, and host scheduling affect how many concurrent
+  calls collide while the gate is held.
+
+## Deferred
+
+- Cross-process or multi-worker admission remains a later production-hardening
+  slice.
+- Cleanup tooling for rows inserted during load validation is left out; callers
+  should use a unique account id per run.
+- Durable background import jobs remain deferred until after synchronous route
+  behavior is fully characterized.
+
+## Verification
+
+- Focused runner tests:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py -q`
+  - `3 passed`
+- Live shared-pool route load:
+  - `python scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl --source-format jsonl --source cfpb-route-inprocess-load-20260523 --min-source-rows 1000 --default-field company_name=CFPB --default-field vendor_name=CFPB --default-field contact_email=cfpb-public-archive@example.invalid --account-id acct-file-route-inprocess-load-20260523 --user-id user-file-route-inprocess-load --concurrency 8 --import-max-concurrency 2 --min-successes 1 --expect-at-capacity-min 1 --output-result tmp/content_ops_file_route_inprocess_load_20260523.json --json`
+  - Exit `0`; `2` successes, `6` admission 429 responses, `0`
+    unexpected failures, `2000` rows inserted.
+  - DB verification for `acct-file-route-inprocess-load-20260523` /
+    `vendor_retention`: `2000` rows, `1000` distinct target IDs.
+- Extracted route smoke/API tests:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_extracted_content_control_surface_api.py -q`
+  - `97 passed`
+- Local PR review:
+  - `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 105 |
+| Load runner script | 370 |
+| Runner tests | 235 |
+| Total | 710 |

--- a/scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py
+++ b/scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Run concurrent uploaded-file imports through one shared route pool."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from extracted_content_pipeline.api.control_surfaces import (  # noqa: E402
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    parse_default_fields_or_exit,
+)
+from smoke_content_ops_ingestion_file_route import (  # noqa: E402
+    _LocalUploadFile,
+    _close_pool,
+    _compact_detail,
+    _create_pool,
+    _default_database_url,
+    _diagnostics_summary,
+    _import_summary,
+)
+
+
+_EXPECTED_AT_CAPACITY_REASON = "content_ops_ingestion_import_at_capacity"
+_REQUIRED_DEFAULT_FIELDS = ("company_name", "vendor_name", "contact_email")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run concurrent /content-ops/ingestion/files/import writes inside "
+            "one process using one shared import pool."
+        )
+    )
+    parser.add_argument("path", type=Path, help="Source-row JSON, JSONL, or CSV file.")
+    parser.add_argument("--source-format", choices=("auto", "json", "jsonl", "csv"), default="auto")
+    parser.add_argument("--source", default="content-ops-file-route-inprocess-load")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--min-source-rows", type=int, default=1)
+    parser.add_argument("--max-source-text-chars", type=int, default=1200)
+    parser.add_argument("--sample-limit", type=int, default=1)
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata for public/source-row files. Repeat as key=value. "
+            "The load runner requires company_name, vendor_name, and contact_email."
+        ),
+    )
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--opportunity-table", default="campaign_opportunities")
+    parser.add_argument("--replace-existing", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--import-max-concurrency", type=int, default=2)
+    parser.add_argument("--min-successes", type=int, default=1)
+    parser.add_argument("--expect-at-capacity-min", type=int, default=1)
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, payload = asyncio.run(run_inprocess_load(args))
+    if args.output_result is not None:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print(
+            "ok={ok} successes={successes} at_capacity={at_capacity} "
+            "failures={failures} inserted={inserted}".format(
+                ok=str(payload["ok"]).lower(),
+                successes=summary["successes"],
+                at_capacity=summary["at_capacity"],
+                failures=summary["unexpected_failures"],
+                inserted=summary["inserted"],
+            )
+        )
+    return code
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not args.path.exists():
+        raise SystemExit(f"source file not found: {args.path}")
+    if int(args.min_source_rows) < 1:
+        raise SystemExit("--min-source-rows must be positive")
+    if int(args.max_source_text_chars) < 1:
+        raise SystemExit("--max-source-text-chars must be positive")
+    if int(args.sample_limit) < 0:
+        raise SystemExit("--sample-limit must be non-negative")
+    if int(args.concurrency) < 1:
+        raise SystemExit("--concurrency must be positive")
+    if int(args.import_max_concurrency) < 1:
+        raise SystemExit("--import-max-concurrency must be positive")
+    if int(args.min_successes) < 0:
+        raise SystemExit("--min-successes must be non-negative")
+    if int(args.expect_at_capacity_min) < 0:
+        raise SystemExit("--expect-at-capacity-min must be non-negative")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not str(args.database_url or "").strip():
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if not str(args.opportunity_table or "").strip():
+        raise SystemExit("--opportunity-table is required")
+    defaults = parse_default_fields_or_exit(args.default_field)
+    missing = [field for field in _REQUIRED_DEFAULT_FIELDS if not str(defaults.get(field) or "").strip()]
+    if missing:
+        raise SystemExit(
+            "uploaded source-row load runner requires default fields: "
+            + ", ".join(missing)
+        )
+
+
+async def run_inprocess_load(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    started = time.monotonic()
+    pool = None
+    route_path = "/ops/ingestion/files/import"
+    source_bytes = args.path.read_bytes()
+    defaults = parse_default_fields_or_exit(args.default_field)
+    base_payload = {
+        "ok": False,
+        "route": route_path,
+        "source_path": str(args.path),
+        "source_format": str(args.source_format),
+        "source": str(args.source),
+        "account_id": str(args.account_id or "").strip(),
+        "user_id": str(args.user_id or "").strip() or None,
+        "opportunity_table": str(args.opportunity_table),
+        "replace_existing": bool(args.replace_existing),
+        "concurrency": int(args.concurrency),
+        "import_max_concurrency": int(args.import_max_concurrency),
+        "min_successes": int(args.min_successes),
+        "expect_at_capacity_min": int(args.expect_at_capacity_min),
+        "elapsed_seconds": None,
+        "summary": None,
+        "results": [],
+        "errors": [],
+    }
+    try:
+        pool = await _create_pool(str(args.database_url))
+        router = create_content_ops_control_surface_router(
+            config=ContentOpsControlSurfaceApiConfig(
+                prefix="/ops",
+                tags=("ops",),
+                ingestion_opportunity_table=str(args.opportunity_table),
+                ingestion_import_max_concurrency=int(args.import_max_concurrency),
+            ),
+            opportunity_import_pool_provider=lambda: pool,
+            scope_provider=_scope_provider(args),
+        )
+        route = _route(router, route_path, "POST")
+        start_event = asyncio.Event()
+        tasks = [
+            asyncio.create_task(
+                _run_one_import(
+                    index=index,
+                    route=route,
+                    start_event=start_event,
+                    source_bytes=source_bytes,
+                    filename=args.path.name,
+                    defaults=defaults,
+                    args=args,
+                )
+            )
+            for index in range(int(args.concurrency))
+        ]
+        start_event.set()
+        results = await asyncio.gather(*tasks)
+    except Exception as exc:
+        payload = {
+            **base_payload,
+            "summary": _empty_summary(),
+            "errors": [f"{type(exc).__name__}: {exc}"],
+        }
+        payload["elapsed_seconds"] = round(time.monotonic() - started, 6)
+        return 1, payload
+    finally:
+        if pool is not None:
+            await _close_pool(pool)
+
+    summary = _summarize_results(results)
+    errors = _load_errors(
+        summary,
+        min_successes=int(args.min_successes),
+        expect_at_capacity_min=int(args.expect_at_capacity_min),
+    )
+    payload = {
+        **base_payload,
+        "ok": not errors,
+        "summary": summary,
+        "results": results,
+        "errors": errors,
+    }
+    payload["elapsed_seconds"] = round(time.monotonic() - started, 6)
+    return (0 if payload["ok"] else 1), payload
+
+
+async def _run_one_import(
+    *,
+    index: int,
+    route: Any,
+    start_event: asyncio.Event,
+    source_bytes: bytes,
+    filename: str,
+    defaults: Mapping[str, Any],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    await start_event.wait()
+    started = time.monotonic()
+    try:
+        response = await route.endpoint(
+            file=_LocalUploadFile(filename, source_bytes),
+            source_rows=True,
+            source=str(args.source),
+            target_mode=str(args.target_mode),
+            file_format=str(args.source_format),
+            max_source_text_chars=int(args.max_source_text_chars),
+            sample_limit=int(args.sample_limit),
+            default_fields=json.dumps(dict(defaults), sort_keys=True),
+            replace_existing=bool(args.replace_existing),
+            dry_run=False,
+        )
+    except Exception as exc:
+        status_code = int(getattr(exc, "status_code", 500) or 500)
+        detail = _compact_detail(getattr(exc, "detail", str(exc)))
+        reason = _detail_reason(detail)
+        return {
+            "index": index,
+            "ok": False,
+            "status_code": status_code,
+            "reason": reason,
+            "detail": detail,
+            "elapsed_seconds": round(time.monotonic() - started, 6),
+        }
+
+    diagnostics = _diagnostics_summary(response.get("diagnostics"))
+    import_summary = _import_summary(response.get("import"))
+    inserted = int((import_summary or {}).get("inserted") or 0)
+    return {
+        "index": index,
+        "ok": True,
+        "status_code": 200,
+        "reason": None,
+        "inserted": inserted,
+        "diagnostics": diagnostics,
+        "import": import_summary,
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def _route(router: Any, path: str, method: str) -> Any:
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method.upper() in getattr(route, "methods", set()):
+            return route
+    raise RuntimeError(f"route not found: {method} {path}")
+
+
+def _scope_provider(args: argparse.Namespace):
+    scope = TenantScope(
+        account_id=str(args.account_id or "").strip() or None,
+        user_id=str(args.user_id or "").strip() or None,
+    )
+    return lambda: scope
+
+
+def _summarize_results(results: list[Mapping[str, Any]]) -> dict[str, Any]:
+    successes = [item for item in results if item.get("ok")]
+    at_capacity = [
+        item
+        for item in results
+        if int(item.get("status_code") or 0) == 429
+        and item.get("reason") == _EXPECTED_AT_CAPACITY_REASON
+    ]
+    unexpected_failures = [
+        item
+        for item in results
+        if not item.get("ok") and item not in at_capacity
+    ]
+    return {
+        "successes": len(successes),
+        "at_capacity": len(at_capacity),
+        "unexpected_failures": len(unexpected_failures),
+        "inserted": sum(int(item.get("inserted") or 0) for item in successes),
+        "status_counts": _count_by(results, "status_code"),
+        "reason_counts": _count_by(
+            [item for item in results if item.get("reason")],
+            "reason",
+        ),
+    }
+
+
+def _empty_summary() -> dict[str, Any]:
+    return {
+        "successes": 0,
+        "at_capacity": 0,
+        "unexpected_failures": 0,
+        "inserted": 0,
+        "status_counts": {},
+        "reason_counts": {},
+    }
+
+
+def _load_errors(
+    summary: Mapping[str, Any],
+    *,
+    min_successes: int,
+    expect_at_capacity_min: int,
+) -> list[str]:
+    errors: list[str] = []
+    successes = int(summary.get("successes") or 0)
+    at_capacity = int(summary.get("at_capacity") or 0)
+    unexpected_failures = int(summary.get("unexpected_failures") or 0)
+    if successes < min_successes:
+        errors.append(f"expected at least {min_successes} success(es), got {successes}")
+    if at_capacity < expect_at_capacity_min:
+        errors.append(
+            "expected at least "
+            f"{expect_at_capacity_min} admission 429 response(s), got {at_capacity}"
+        )
+    if unexpected_failures:
+        errors.append(f"unexpected failure count: {unexpected_failures}")
+    return errors
+
+
+def _count_by(items: list[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        value = str(item.get(key) or "").strip()
+        if value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _detail_reason(detail: Any) -> str | None:
+    if isinstance(detail, Mapping):
+        text = str(detail.get("reason") or "").strip()
+        return text or None
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py
+++ b/scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py
@@ -156,6 +156,7 @@ async def run_inprocess_load(args: argparse.Namespace) -> tuple[int, dict[str, A
         "replace_existing": bool(args.replace_existing),
         "concurrency": int(args.concurrency),
         "import_max_concurrency": int(args.import_max_concurrency),
+        "min_source_rows": int(args.min_source_rows),
         "min_successes": int(args.min_successes),
         "expect_at_capacity_min": int(args.expect_at_capacity_min),
         "elapsed_seconds": None,
@@ -208,6 +209,7 @@ async def run_inprocess_load(args: argparse.Namespace) -> tuple[int, dict[str, A
     summary = _summarize_results(results)
     errors = _load_errors(
         summary,
+        min_source_rows=int(args.min_source_rows),
         min_successes=int(args.min_successes),
         expect_at_capacity_min=int(args.expect_at_capacity_min),
     )
@@ -330,13 +332,20 @@ def _empty_summary() -> dict[str, Any]:
 def _load_errors(
     summary: Mapping[str, Any],
     *,
+    min_source_rows: int,
     min_successes: int,
     expect_at_capacity_min: int,
 ) -> list[str]:
     errors: list[str] = []
     successes = int(summary.get("successes") or 0)
     at_capacity = int(summary.get("at_capacity") or 0)
+    inserted = int(summary.get("inserted") or 0)
     unexpected_failures = int(summary.get("unexpected_failures") or 0)
+    if inserted < min_source_rows:
+        errors.append(
+            "expected at least "
+            f"{min_source_rows} inserted source row(s), got {inserted}"
+        )
     if successes < min_successes:
         errors.append(f"expected at least {min_successes} success(es), got {successes}")
     if at_capacity < expect_at_capacity_min:

--- a/tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py
+++ b/tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+import extracted_content_pipeline.api.control_surfaces as api_module
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "smoke_content_ops_ingestion_file_route_inprocess_load.py"
+
+pytestmark = pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "smoke_content_ops_ingestion_file_route_inprocess_load",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module: {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_cfpb_rows(path: Path, row_count: int) -> None:
+    rows = (
+        {
+            "complaint_id": f"cfpb-{index}",
+            "product": "Credit reporting or other personal consumer reports",
+            "issue": "Incorrect information on your report",
+            "consumer_complaint_narrative": (
+                "My credit report still shows an account I already disputed "
+                "and I need help understanding the next step."
+            ),
+        }
+        for index in range(row_count)
+    )
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _default_args(path: Path, result_path: Path) -> list[str]:
+    return [
+        str(path),
+        "--source-format",
+        "jsonl",
+        "--source",
+        "cfpb-route-inprocess-load-test",
+        "--min-source-rows",
+        "3",
+        "--default-field",
+        "company_name=CFPB Public Archive",
+        "--default-field",
+        "vendor_name=CFPB",
+        "--default-field",
+        "contact_email=cfpb-public-archive@example.invalid",
+        "--account-id",
+        "acct-route-inprocess-load",
+        "--database-url",
+        "postgresql://atlas@localhost:5433/atlas",
+        "--output-result",
+        str(result_path),
+    ]
+
+
+class _Transaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _Connection:
+    def __init__(self, delay_seconds: float = 0.02) -> None:
+        self.delay_seconds = delay_seconds
+        self.executed = []
+
+    def transaction(self):
+        return _Transaction()
+
+    async def execute(self, query, *args):
+        await asyncio.sleep(self.delay_seconds)
+        self.executed.append((str(query), args))
+        return "EXECUTE"
+
+
+class _Acquire:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _Pool:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+        self.closed = False
+        self.is_initialized = True
+
+    def acquire(self):
+        return _Acquire(self.connection)
+
+    async def close(self):
+        self.closed = True
+
+
+def test_inprocess_load_runner_writes_admission_gate_result(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    _write_cfpb_rows(source_path, 3)
+    connection = _Connection()
+    pool = _Pool(connection)
+
+    async def create_pool(database_url: str):
+        assert database_url == "postgresql://atlas@localhost:5433/atlas"
+        return pool
+
+    monkeypatch.setattr(module, "_create_pool", create_pool)
+
+    code = module.main([
+        *_default_args(source_path, result_path),
+        "--concurrency",
+        "3",
+        "--import-max-concurrency",
+        "1",
+        "--min-successes",
+        "1",
+        "--expect-at-capacity-min",
+        "1",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["concurrency"] == 3
+    assert payload["import_max_concurrency"] == 1
+    assert payload["summary"]["successes"] == 1
+    assert payload["summary"]["at_capacity"] == 2
+    assert payload["summary"]["unexpected_failures"] == 0
+    assert payload["summary"]["inserted"] == 3
+    assert payload["summary"]["status_counts"] == {"200": 1, "429": 2}
+    assert payload["summary"]["reason_counts"] == {
+        "content_ops_ingestion_import_at_capacity": 2
+    }
+    assert pool.closed is True
+    insert_args = [args for query, args in connection.executed if "INSERT INTO" in query]
+    assert len(insert_args) == 3
+    assert {args[0] for args in insert_args} == {"acct-route-inprocess-load"}
+
+
+def test_inprocess_load_runner_fails_when_expected_429_missing(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    _write_cfpb_rows(source_path, 1)
+    pool = _Pool(_Connection(delay_seconds=0))
+
+    async def create_pool(database_url: str):
+        del database_url
+        return pool
+
+    monkeypatch.setattr(module, "_create_pool", create_pool)
+
+    code = module.main([
+        *_default_args(source_path, result_path),
+        "--min-source-rows",
+        "1",
+        "--concurrency",
+        "1",
+        "--import-max-concurrency",
+        "1",
+        "--min-successes",
+        "1",
+        "--expect-at-capacity-min",
+        "1",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["summary"]["successes"] == 1
+    assert payload["summary"]["at_capacity"] == 0
+    assert payload["errors"] == [
+        "expected at least 1 admission 429 response(s), got 0"
+    ]
+
+
+def test_inprocess_load_runner_requires_database_url(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    _write_cfpb_rows(source_path, 1)
+    monkeypatch.setattr(module, "_default_database_url", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main([
+            str(source_path),
+            "--source-format",
+            "jsonl",
+            "--default-field",
+            "company_name=CFPB Public Archive",
+            "--default-field",
+            "vendor_name=CFPB",
+            "--default-field",
+            "contact_email=cfpb-public-archive@example.invalid",
+            "--account-id",
+            "acct-route-inprocess-load",
+            "--database-url",
+            "",
+        ])
+
+    assert "Missing --database-url" in str(exc.value)
+

--- a/tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py
+++ b/tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py
@@ -204,6 +204,42 @@ def test_inprocess_load_runner_fails_when_expected_429_missing(monkeypatch, tmp_
     ]
 
 
+def test_inprocess_load_runner_fails_when_inserted_rows_below_minimum(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    _write_cfpb_rows(source_path, 1)
+    pool = _Pool(_Connection(delay_seconds=0))
+
+    async def create_pool(database_url: str):
+        del database_url
+        return pool
+
+    monkeypatch.setattr(module, "_create_pool", create_pool)
+
+    code = module.main([
+        *_default_args(source_path, result_path),
+        "--concurrency",
+        "1",
+        "--import-max-concurrency",
+        "1",
+        "--min-successes",
+        "1",
+        "--expect-at-capacity-min",
+        "0",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["min_source_rows"] == 3
+    assert payload["summary"]["successes"] == 1
+    assert payload["summary"]["inserted"] == 1
+    assert payload["errors"] == [
+        "expected at least 3 inserted source row(s), got 1"
+    ]
+
+
 def test_inprocess_load_runner_requires_database_url(monkeypatch, tmp_path: Path) -> None:
     module = _load_script_module()
     source_path = tmp_path / "cfpb_rows.jsonl"
@@ -228,4 +264,3 @@ def test_inprocess_load_runner_requires_database_url(monkeypatch, tmp_path: Path
         ])
 
     assert "Missing --database-url" in str(exc.value)
-


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Import-Inprocess-Load.md

Adds a same-process uploaded-file import load runner that exercises many `/content-ops/ingestion/files/import` calls through one shared route pool. This proves the admission-gate shape merged in #884: excess concurrent writes return deterministic 429 responses instead of opening more database pools.

## Intentional
- This is validation tooling, not product queueing or retry behavior.
- The runner uses one shared import pool inside one process; the older process-fanout smoke remains useful for cross-process pressure discovery.
- The diff is over 400 LOC because the reusable runner includes CLI validation, async fan-out, compact artifacts, and deterministic fake-pool tests in the same slice.

## Deferred
- Cross-process and multi-worker admission remain future production hardening.
- Cleanup tooling for rows inserted during load validation is left to callers using unique account ids.
- Durable background import jobs remain deferred until synchronous route behavior is fully characterized.

## Verification
- `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py -q` -> 3 passed
- Live shared-pool route load with 8 concurrent 1k-row uploads and import gate 2 -> 2 successes, 6 admission 429 responses, 0 unexpected failures, 2000 rows inserted
- DB verification for `acct-file-route-inprocess-load-20260523` / `vendor_retention` -> 2000 rows, 1000 distinct target IDs
- `python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_extracted_content_control_surface_api.py -q` -> 97 passed
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed

## Diff size
3 files, +702 / -0