### PR TITLE
Close Content Ops file concurrency hardening item

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-23
-
-### FILECONCURRENCY-1 - Uploaded-file write pressure needs bounded DB concurrency
-- File/location: `scripts/smoke_content_ops_ingestion_file_route.py`, hosted `/content-ops/ingestion/files/import` write path.
-- Description: Local Postgres pressure validation passed at 5 concurrent 10,000-row writes, 20 concurrent 1,000-row writes, and 100 concurrent 1,000-row writes, but 150 concurrent 1,000-row write processes produced 141 successes and 9 `asyncpg.exceptions.TooManyConnectionsError` failures during pool creation.
-- Why it matters: concurrent customer uploads can exhaust database connection slots unless hosted file-route writes use bounded concurrency, queue backpressure, async jobs, or a shared pool/admission-control layer.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/backend-file-ingestion-validation
-- Found during: PR-Content-Ops-File-Route-Concurrency-Validation
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-File-Concurrency-Hardening-Close.md
+++ b/plans/PR-Content-Ops-File-Concurrency-Hardening-Close.md
@@ -1,0 +1,68 @@
+# PR-Content-Ops-File-Concurrency-Hardening-Close
+
+## Why this slice exists
+
+`HARDENING.md` still lists `FILECONCURRENCY-1` even though the source fix and
+the hosted-shape proof are now merged:
+
+1. `PR-Content-Ops-File-Import-Admission-Gate` added the in-process route
+   admission gate before import requests resolve or acquire the database pool.
+2. `PR-Content-Ops-File-Import-Inprocess-Load` proved concurrent uploaded-file
+   imports use one shared pool and return deterministic 429 admission responses
+   when the gate is full.
+
+Leaving the item parked makes the active hardening queue look stale and can
+send the next session back into work that is already closed.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Remove the closed `FILECONCURRENCY-1` item from root `HARDENING.md`.
+2. Keep the blog/deep-dive hardening pointer intact.
+
+### Files touched
+
+- `HARDENING.md`
+- `plans/PR-Content-Ops-File-Concurrency-Hardening-Close.md`
+
+## Mechanism
+
+This is a register-only update. The code-level mitigation remains in
+`extracted_content_pipeline/api/control_surfaces.py`, and the reusable proof
+remains in `scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py`.
+The hardening queue is updated to reflect that the parked item has been drained
+by the already-merged implementation and validation slices.
+
+## Intentional
+
+- This PR does not remove the older process-based smoke runner. It still helps
+  discover multi-process pressure, but it is not the hosted shared-pool shape.
+- This PR does not claim cross-process or durable queueing is done. Those are
+  separate production-hardening follow-ups named in the merged plan docs.
+
+## Deferred
+
+- Cross-process backpressure, durable import jobs, and shared queue visibility
+  remain deferred by `PR-Content-Ops-File-Import-Admission-Gate` and
+  `PR-Content-Ops-File-Import-Inprocess-Load`.
+- Parked hardening: none.
+
+## Verification
+
+- Register spot-check:
+  - `git show origin/main:HARDENING.md | sed -n '1,220p'`
+  - Confirmed `FILECONCURRENCY-1` was the only root parked item in this
+    ownership lane.
+- Merged mitigation/proof spot-check:
+  - `git log --oneline --decorate -8 origin/main`
+  - Confirmed `PR-Content-Ops-File-Import-Admission-Gate` and
+    `PR-Content-Ops-File-Import-Inprocess-Load` are both on `origin/main`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 68 |
+| Hardening register | 11 |
+| Total | 79 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Concurrency-Hardening-Close.md

Closes the stale FILECONCURRENCY-1 root hardening entry now that the in-process import admission gate and shared-pool load proof are both merged on main. This is a register-only cleanup so future sessions do not repeat closed backend file-ingestion hardening work.

## Intentional
- Does not remove the older process-based smoke runner; it remains useful for multi-process pressure discovery.
- Does not claim cross-process backpressure or durable queueing is complete; those remain separate product-hardening follow-ups.

## Deferred
- Cross-process backpressure, durable import jobs, and shared queue visibility remain deferred by the merged admission-gate and in-process-load plans.

## Parked hardening
- None. This PR drains the only root HARDENING.md item in the content-ops/backend-file-ingestion-validation lane.

## Verification
- bash scripts/local_pr_review.sh --allow-dirty
- git show origin/main:HARDENING.md | sed -n '1,220p'\n- git log --oneline --decorate -8 origin/main\n\n## Diff size\n2 files, +68 / -11