### PR TITLE
Record Content Ops file cross-process hardening

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-23
+
+### FILECONCURRENCY-2 - Uploaded-file imports need cross-process admission
+- File/location: Hosted `/content-ops/ingestion/files/import` deployment topology; in-process runner lives at `scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py`.
+- Description: The shared-pool route gate and in-process load runner prove one-router admission, but multi-worker or multi-process deployments can still admit one gate window per process unless backed by a distributed queue, shared semaphore, or job boundary.
+- Why it matters: Production deployments with multiple app workers can multiply the configured import concurrency and pressure Postgres even though each worker is locally bounded.
+- Effort: L
+- Category: correctness
+- Owner/session: content-ops/backend-file-ingestion-validation
+- Found during: PR-Content-Ops-File-Cross-Process-Hardening-Register
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-File-Cross-Process-Hardening-Register.md
+++ b/plans/PR-Content-Ops-File-Cross-Process-Hardening-Register.md
@@ -1,0 +1,62 @@
+# PR-Content-Ops-File-Cross-Process-Hardening-Register
+
+## Why this slice exists
+
+The uploaded-file import path now has an in-process admission gate and a
+same-process load runner that proves shared-pool behavior. That closes the
+original database-pool pressure issue for one hosted router process.
+
+One deployment risk remains: a multi-worker or multi-process host can still
+create one admission window per process. That is not solved by the in-process
+gate, and it should stay visible as future production hardening instead of
+being hidden by the closed `FILECONCURRENCY-1` item.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a narrower `FILECONCURRENCY-2` root hardening item for cross-process /
+   multi-worker uploaded-file import admission.
+2. Leave the merged `PR-Content-Ops-File-Concurrency-Hardening-Close` plan doc
+   unchanged.
+
+### Files touched
+
+- `HARDENING.md`
+- `plans/PR-Content-Ops-File-Cross-Process-Hardening-Register.md`
+
+## Mechanism
+
+This is a register-only slice. `FILECONCURRENCY-2` records that the current
+route-level gate is process-local and names the production topology that still
+needs a distributed queue, shared semaphore, or durable job boundary before
+high-concurrency multi-worker uploads can be called fully hardened.
+
+## Intentional
+
+- No product code changes. The current synchronous route still functions, and
+  the remaining concern depends on deployment topology.
+- No claim that durable imports are implemented. This PR records the remaining
+  production-hardening gap so it is owned explicitly.
+
+## Deferred
+
+- Cross-process import admission, durable import jobs, and queue visibility
+  remain future production-hardening work.
+- Parked hardening: `FILECONCURRENCY-2`.
+
+## Verification
+
+- Hardening register spot-check:
+  - Confirmed `HARDENING.md` contains `FILECONCURRENCY-2`.
+- Plan/code consistency and local review:
+  - `bash scripts/local_pr_review.sh --allow-dirty`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 62 |
+| Hardening register | 11 |
+| Total | 73 |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Cross-Process-Hardening-Register.md

Records the remaining uploaded-file import production-hardening gap after the in-process admission gate and shared-pool load proof landed. The current gate is process-local, so multi-worker or multi-process deployments still need an explicit future queue/shared-admission design.

## Intentional
- Register-only slice; no product code changes.
- Leaves the merged #890 plan doc unchanged and records the remaining risk in a new plan.

## Deferred
- Cross-process import admission, durable import jobs, and queue visibility remain future production-hardening work.

## Parked hardening
- Added `FILECONCURRENCY-2` for cross-process / multi-worker uploaded-file import admission.

## Verification
- bash scripts/local_pr_review.sh --allow-dirty

## Diff size
2 files, +72 / -0