### PR TITLE
Add Content Ops import admission provider

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -83,6 +83,7 @@ ReasoningStatusProvider = Callable[
 ]
 LLMProvider = Callable[[], Any | Awaitable[Any]]
 PoolProvider = Callable[[], Any | Awaitable[Any]]
+ImportAdmissionProvider = Callable[[], Any | Awaitable[Any]]
 
 logger = logging.getLogger(__name__)
 
@@ -502,6 +503,7 @@ def create_content_ops_control_surface_router(
     reasoning_status_provider: ReasoningStatusProvider | None = None,
     llm_provider: LLMProvider | None = None,
     opportunity_import_pool_provider: PoolProvider | None = None,
+    ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
     """Create host-mounted AI Content Ops control-surface routes.
@@ -614,6 +616,7 @@ def create_content_ops_control_surface_router(
         result = await _import_ingestion_rows_with_admission(
             report.opportunities,
             import_gate=ingestion_import_gate,
+            import_gate_provider=ingestion_import_admission_provider,
             pool_provider=opportunity_import_pool_provider,
             scope_provider=scope_provider,
             target_mode=target_mode,
@@ -686,6 +689,7 @@ def create_content_ops_control_surface_router(
         result = await _import_ingestion_rows_with_admission(
             report.opportunities,
             import_gate=ingestion_import_gate,
+            import_gate_provider=ingestion_import_admission_provider,
             pool_provider=opportunity_import_pool_provider,
             scope_provider=scope_provider,
             target_mode=target_mode_value,
@@ -1244,6 +1248,7 @@ async def _import_ingestion_rows_with_admission(
     rows: Sequence[Mapping[str, Any]],
     *,
     import_gate: _ExecuteConcurrencyGate,
+    import_gate_provider: ImportAdmissionProvider | None,
     pool_provider: PoolProvider | None,
     scope_provider: ScopeProvider | None,
     target_mode: str,
@@ -1265,13 +1270,11 @@ async def _import_ingestion_rows_with_admission(
             source=source,
         )
 
-    if not await import_gate.acquire():
+    active_gate = await _resolve_import_admission_gate(import_gate_provider, import_gate)
+    if not await _acquire_import_admission(active_gate):
         raise HTTPException(
             status_code=429,
-            detail={
-                "reason": "content_ops_ingestion_import_at_capacity",
-                "max_concurrency": import_gate.max_concurrency,
-            },
+            detail=_import_admission_capacity_detail(active_gate),
         )
     try:
         pool = await _resolve_import_pool(pool_provider)
@@ -1287,7 +1290,78 @@ async def _import_ingestion_rows_with_admission(
             source=source,
         )
     finally:
-        await import_gate.release()
+        await _release_import_admission(active_gate)
+
+
+async def _resolve_import_admission_gate(
+    provider: ImportAdmissionProvider | None,
+    default_gate: _ExecuteConcurrencyGate,
+) -> Any:
+    if provider is None:
+        return default_gate
+    try:
+        gate = await _resolve_provider(provider)
+    except Exception as exc:
+        logger.warning(
+            "Content Ops ingestion import admission provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import admission is unavailable.",
+        ) from exc
+    if gate is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import admission is unavailable.",
+        )
+    return gate
+
+
+async def _acquire_import_admission(gate: Any) -> bool:
+    acquire = getattr(gate, "acquire", None)
+    if not callable(acquire):
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import admission is unavailable.",
+        )
+    try:
+        result = acquire()
+        if hasattr(result, "__await__"):
+            result = await result
+    except Exception as exc:
+        logger.warning(
+            "Content Ops ingestion import admission acquire failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops ingestion import admission is unavailable.",
+        ) from exc
+    return bool(result)
+
+
+async def _release_import_admission(gate: Any) -> None:
+    release = getattr(gate, "release", None)
+    if not callable(release):
+        return
+    try:
+        result = release()
+        if hasattr(result, "__await__"):
+            await result
+    except Exception as exc:
+        logger.warning(
+            "Content Ops ingestion import admission release failed",
+            extra={"error_type": type(exc).__name__},
+        )
+
+
+def _import_admission_capacity_detail(gate: Any) -> dict[str, Any]:
+    detail: dict[str, Any] = {"reason": "content_ops_ingestion_import_at_capacity"}
+    max_concurrency = getattr(gate, "max_concurrency", None)
+    if max_concurrency is not None:
+        detail["max_concurrency"] = int(max_concurrency)
+    return detail
 
 
 async def _import_campaign_opportunities_for_route(

--- a/plans/PR-Content-Ops-Import-Admission-Provider.md
+++ b/plans/PR-Content-Ops-Import-Admission-Provider.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-Import-Admission-Provider
+
+## Why this slice exists
+
+`FILECONCURRENCY-2` tracks the remaining uploaded-file import risk: the current
+route gate is process-local. A multi-worker host can multiply the configured
+admission window because each process owns its own in-memory gate.
+
+The extracted package should not hard-code Redis, Postgres advisory locks, or a
+durable queue implementation. The source fix is to move the shared-admission
+decision to a host-owned provider seam while keeping the existing in-process
+gate as the safe default.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a host-injected ingestion import admission provider to the Content Ops
+   control-surface router.
+2. Use the provider before resolving the import pool for non-dry-run legacy and
+   uploaded-file imports.
+3. Preserve the current process-local gate when no provider is configured.
+4. Add focused route tests for custom admission denial and release behavior.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `plans/PR-Content-Ops-Import-Admission-Provider.md`
+
+## Mechanism
+
+`create_content_ops_control_surface_router(...)` gains an optional
+`ingestion_import_admission_provider`. The provider returns a gate-like object
+with async or sync `acquire()` and `release()` methods. Non-dry-run import
+routes resolve that gate before the database pool is resolved.
+
+When no provider is supplied, the existing `_ExecuteConcurrencyGate` remains the
+default. When a provider denies admission, the route still returns the existing
+machine-readable 429 reason:
+`content_ops_ingestion_import_at_capacity`.
+
+## Intentional
+
+- No Redis/Postgres queue implementation in this slice. The extracted package
+  exposes the production seam; hosts choose the distributed backend.
+- Dry-run imports still bypass admission because they do not write.
+- Existing response shape and default local behavior stay compatible.
+
+## Deferred
+
+- A concrete Atlas-host distributed admission provider remains future work.
+- Durable background import jobs and queue visibility remain parked under
+  `FILECONCURRENCY-2`.
+- Parked hardening: `FILECONCURRENCY-2` remains open because this slice adds the
+  seam but not a deployed shared gate.
+
+## Verification
+
+- Focused control-surface tests:
+  - `python -m pytest tests/test_extracted_content_control_surface_api.py -q`
+  - `92 passed`
+- Router factory caller smoke tests:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_extracted_content_ops_live_execute_harness.py -q`
+  - `15 passed`
+- Local PR review:
+  - `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Router admission provider seam | 86 |
+| Route tests | 173 |
+| Total | 335 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -155,6 +155,34 @@ class _PoolWithAcquire:
         return _Acquire(self.connection)
 
 
+class _AdmissionGate:
+    def __init__(
+        self,
+        *,
+        allowed=True,
+        max_concurrency=1,
+        fail_acquire=False,
+        fail_release=False,
+    ):
+        self.allowed = allowed
+        self.max_concurrency = max_concurrency
+        self.fail_acquire = fail_acquire
+        self.fail_release = fail_release
+        self.acquire_calls = 0
+        self.release_calls = 0
+
+    async def acquire(self):
+        self.acquire_calls += 1
+        if self.fail_acquire:
+            raise RuntimeError("admission backend unavailable")
+        return self.allowed
+
+    async def release(self):
+        self.release_calls += 1
+        if self.fail_release:
+            raise RuntimeError("admission backend release failed")
+
+
 @pytest.mark.asyncio
 async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     router = create_content_ops_control_surface_router()
@@ -907,6 +935,151 @@ async def test_ingestion_file_import_route_rejects_when_import_gate_is_full():
     )
     assert second_payload["import"]["inserted"] == 1
     assert provider_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_import_route_uses_custom_admission_before_pool_provider():
+    gate = _AdmissionGate(allowed=False, max_concurrency=3)
+    provider_calls = 0
+
+    async def pool_provider():
+        nonlocal provider_calls
+        provider_calls += 1
+        return _Pool()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=pool_provider,
+        ingestion_import_admission_provider=lambda: gate,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    route = _route(router, "/ops/ingestion/files/import", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+            dry_run=False,
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.detail == {
+        "reason": "content_ops_ingestion_import_at_capacity",
+        "max_concurrency": 3,
+    }
+    assert gate.acquire_calls == 1
+    assert gate.release_calls == 0
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_import_route_treats_custom_admission_acquire_failure_as_503():
+    gate = _AdmissionGate(fail_acquire=True)
+    provider_calls = 0
+
+    async def pool_provider():
+        nonlocal provider_calls
+        provider_calls += 1
+        return _Pool()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=pool_provider,
+        ingestion_import_admission_provider=lambda: gate,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    route = _route(router, "/ops/ingestion/files/import", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            file=_ticket_bundle_upload(1),
+            source_rows=True,
+            source="ticket-csv-upload",
+            target_mode="vendor_retention",
+            file_format="json",
+            max_source_text_chars=1200,
+            sample_limit=3,
+            default_fields=json.dumps({
+                "company_name": "Acme",
+                "vendor_name": "Atlas",
+                "contact_email": "support@example.com",
+            }),
+            dry_run=False,
+        )
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Content Ops ingestion import admission is unavailable."
+    assert gate.acquire_calls == 1
+    assert gate.release_calls == 0
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_releases_custom_admission_after_success():
+    gate = _AdmissionGate(allowed=True)
+    pool = _Pool()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=lambda: pool,
+        ingestion_import_admission_provider=lambda: gate,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    route = _route(router, "/ops/ingestion/import", "POST")
+
+    payload = await route.endpoint({
+        "dry_run": False,
+        "source": "operator-upload",
+        "rows": [{
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "evidence": [{"quote": "Renewal process is too manual."}],
+        }],
+    })
+
+    assert payload["import"]["inserted"] == 1
+    assert gate.acquire_calls == 1
+    assert gate.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ingestion_import_route_keeps_success_when_custom_admission_release_fails():
+    gate = _AdmissionGate(allowed=True, fail_release=True)
+    pool = _Pool()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        opportunity_import_pool_provider=lambda: pool,
+        ingestion_import_admission_provider=lambda: gate,
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+    route = _route(router, "/ops/ingestion/import", "POST")
+
+    payload = await route.endpoint({
+        "dry_run": False,
+        "source": "operator-upload",
+        "rows": [{
+            "target_id": "opp-1",
+            "company_name": "Acme",
+            "vendor_name": "HubSpot",
+            "evidence": [{"quote": "Renewal process is too manual."}],
+        }],
+    })
+
+    assert payload["import"]["inserted"] == 1
+    assert gate.acquire_calls == 1
+    assert gate.release_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Import-Admission-Provider.md

Adds a host-owned admission-provider seam for non-dry-run Content Ops ingestion imports. The route still defaults to the existing process-local gate, but hosts can now inject a distributed/shared gate before the import pool is resolved.

## Intentional
- No Redis/Postgres queue implementation in the extracted package. The package exposes the production seam; hosts choose the distributed backend.
- Dry-run imports still bypass admission because they do not write.
- Existing router callers remain compatible because the new provider is optional.

## Deferred
- Atlas-host distributed admission provider, durable import jobs, and queue visibility remain under `FILECONCURRENCY-2`.

## Parked hardening
- `FILECONCURRENCY-2` remains open; this PR adds the provider seam but does not deploy a shared gate.

## Verification
- python -m pytest tests/test_extracted_content_control_surface_api.py -q
- python -m pytest tests/test_smoke_content_ops_ingestion_file_route.py tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_extracted_content_ops_live_execute_harness.py -q
- bash scripts/validate_extracted_content_pipeline.sh
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- python scripts/audit_extracted_standalone.py --fail-on-debt
- bash scripts/check_ascii_python.sh
- bash scripts/local_pr_review.sh --allow-dirty

## Diff size
3 files, +227 / -6