### PR TITLE
Add Content Ops file multiprocess load probe

### DIFF
--- a/plans/PR-Content-Ops-File-Multiprocess-Load-Probe.md
+++ b/plans/PR-Content-Ops-File-Multiprocess-Load-Probe.md
@@ -1,0 +1,102 @@
+# PR-Content-Ops-File-Multiprocess-Load-Probe
+
+## Why this slice exists
+
+`FILECONCURRENCY-2` is now parked for the remaining uploaded-file import
+deployment risk: the route admission gate is process-local. The previous
+in-process runner proved one router process uses one shared pool and returns
+deterministic 429 responses when its local gate is full. It does not prove what
+happens when multiple app processes each own a separate route gate.
+
+This slice adds the thinnest reusable probe for that topology. It fans out the
+already-merged in-process load runner across multiple child processes and
+summarizes the aggregate admitted writes, 429 responses, and unexpected
+failures. That gives reviewers and future sessions a concrete way to reproduce
+the remaining risk before deciding whether to build distributed admission or a
+durable import job boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a multiprocess uploaded-file import load probe script.
+2. Reuse `scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py` as
+   the per-process worker.
+3. Emit one parent JSON result plus child result artifacts.
+4. Add deterministic tests for command construction, aggregate classification,
+   and artifact writing without requiring Postgres.
+
+### Files touched
+
+- `scripts/smoke_content_ops_ingestion_file_route_multiprocess_load.py`
+- `tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py`
+- `plans/PR-Content-Ops-File-Multiprocess-Load-Probe.md`
+
+## Mechanism
+
+The parent script launches `--processes N` child Python processes. Each child
+runs the existing in-process load runner with its own account id suffix and its
+own output JSON path. The parent waits for all children, reads their compact
+JSON results, and summarizes:
+
+- child process count,
+- child exit codes,
+- total successes,
+- total admission 429 responses,
+- total unexpected failures,
+- total inserted rows,
+- per-child artifact paths.
+
+The probe exits successfully only if every child exits successfully and the
+aggregate meets caller-provided minimums for total successes and total
+admission 429 responses.
+
+## Intentional
+
+- This is validation tooling, not a product fix. The parked hardening item still
+  owns distributed admission / durable job behavior.
+- The parent does not parse database credentials or open a database connection.
+  It passes through the same database URL option/env behavior used by the
+  existing child runner.
+- Each child gets a unique account id suffix so live runs can verify inserted
+  rows without write collisions between processes.
+
+## Deferred
+
+- Distributed semaphore, shared queue, durable import jobs, and queue
+  observability remain parked under `FILECONCURRENCY-2`.
+- Automatic database cleanup is left out; live runs should use unique account
+  ids, as the existing validation scripts do.
+
+## Verification
+
+- Focused probe tests:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py -q`
+  - `4 passed`
+- Live multiprocess probe:
+  - `python scripts/smoke_content_ops_ingestion_file_route_multiprocess_load.py tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl --source-format jsonl --source cfpb-route-multiprocess-load-20260523 --min-source-rows 1000 --default-field company_name=CFPB --default-field vendor_name=CFPB --default-field contact_email=cfpb-public-archive@example.invalid --account-id acct-file-route-multiprocess-load-20260523 --user-id user-file-route-multiprocess-load --processes 3 --child-concurrency 2 --child-import-max-concurrency 1 --child-min-successes 1 --child-expect-at-capacity-min 1 --min-total-successes 3 --expect-total-at-capacity-min 3 --output-dir tmp/content_ops_file_route_multiprocess_load_20260523 --output-result tmp/content_ops_file_route_multiprocess_load_20260523/result.json --json`
+  - Exit `0`; `3` child processes, `3` successes, `3` admission 429
+    responses, `0` unexpected failures, `3000` rows inserted.
+  - DB verification for `acct-file-route-multiprocess-load-20260523-p%` /
+    `vendor_retention`: `3` accounts, `3000` rows, `1000` distinct target IDs.
+- Focused load-runner suite and compile check:
+  - `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py -q`
+  - `8 passed`
+  - Python compile check passed for the multiprocess probe script.
+- Local PR review:
+  - `bash scripts/local_pr_review.sh --allow-dirty`
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 96 |
+| Multiprocess probe script | 360 |
+| Probe tests | 241 |
+| Total | 703 |
+
+The diff is over the 400 LOC target because the probe needs a real CLI,
+subprocess fan-out, child artifact management, aggregate validation, and
+deterministic fake-subprocess tests to be useful as production-hardening
+evidence.

--- a/scripts/smoke_content_ops_ingestion_file_route_multiprocess_load.py
+++ b/scripts/smoke_content_ops_ingestion_file_route_multiprocess_load.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Fan out uploaded-file import load across child processes."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    parse_default_fields_or_exit,
+)
+from smoke_content_ops_ingestion_file_route_inprocess_load import (  # noqa: E402
+    _default_database_url,
+)
+
+
+_CHILD_SCRIPT = SCRIPTS / "smoke_content_ops_ingestion_file_route_inprocess_load.py"
+_REQUIRED_DEFAULT_FIELDS = ("company_name", "vendor_name", "contact_email")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run multiple in-process uploaded-file import load probes as child "
+            "processes to expose process-local admission behavior."
+        )
+    )
+    parser.add_argument("path", type=Path, help="Source-row JSON, JSONL, or CSV file.")
+    parser.add_argument("--source-format", choices=("auto", "json", "jsonl", "csv"), default="auto")
+    parser.add_argument("--source", default="content-ops-file-route-multiprocess-load")
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--min-source-rows", type=int, default=1)
+    parser.add_argument("--max-source-text-chars", type=int, default=1200)
+    parser.add_argument("--sample-limit", type=int, default=1)
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help=(
+            "Fallback metadata for public/source-row files. Repeat as key=value. "
+            "The multiprocess probe requires company_name, vendor_name, and contact_email."
+        ),
+    )
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--user-id", default=None)
+    parser.add_argument("--opportunity-table", default="campaign_opportunities")
+    parser.add_argument("--replace-existing", action="store_true")
+    parser.add_argument("--database-url", default=_default_database_url())
+    parser.add_argument("--processes", type=int, default=2)
+    parser.add_argument("--child-concurrency", type=int, default=2)
+    parser.add_argument("--child-import-max-concurrency", type=int, default=1)
+    parser.add_argument("--child-min-successes", type=int, default=1)
+    parser.add_argument("--child-expect-at-capacity-min", type=int, default=1)
+    parser.add_argument("--min-total-successes", type=int, default=1)
+    parser.add_argument("--expect-total-at-capacity-min", type=int, default=1)
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "tmp" / "content_ops_file_route_multiprocess_load")
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    code, payload = asyncio.run(run_multiprocess_load(args))
+    if args.output_result is not None:
+        args.output_result.parent.mkdir(parents=True, exist_ok=True)
+        args.output_result.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print(
+            "ok={ok} processes={processes} successes={successes} "
+            "at_capacity={at_capacity} failures={failures} inserted={inserted}".format(
+                ok=str(payload["ok"]).lower(),
+                processes=summary["processes"],
+                successes=summary["successes"],
+                at_capacity=summary["at_capacity"],
+                failures=summary["unexpected_failures"],
+                inserted=summary["inserted"],
+            )
+        )
+    return code
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not args.path.exists():
+        raise SystemExit(f"source file not found: {args.path}")
+    if int(args.min_source_rows) < 1:
+        raise SystemExit("--min-source-rows must be positive")
+    if int(args.max_source_text_chars) < 1:
+        raise SystemExit("--max-source-text-chars must be positive")
+    if int(args.sample_limit) < 0:
+        raise SystemExit("--sample-limit must be non-negative")
+    if int(args.processes) < 1:
+        raise SystemExit("--processes must be positive")
+    if int(args.child_concurrency) < 1:
+        raise SystemExit("--child-concurrency must be positive")
+    if int(args.child_import_max_concurrency) < 1:
+        raise SystemExit("--child-import-max-concurrency must be positive")
+    if int(args.child_min_successes) < 0:
+        raise SystemExit("--child-min-successes must be non-negative")
+    if int(args.child_expect_at_capacity_min) < 0:
+        raise SystemExit("--child-expect-at-capacity-min must be non-negative")
+    if int(args.min_total_successes) < 0:
+        raise SystemExit("--min-total-successes must be non-negative")
+    if int(args.expect_total_at_capacity_min) < 0:
+        raise SystemExit("--expect-total-at-capacity-min must be non-negative")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if not str(args.database_url or "").strip():
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if not str(args.opportunity_table or "").strip():
+        raise SystemExit("--opportunity-table is required")
+    defaults = parse_default_fields_or_exit(args.default_field)
+    missing = [field for field in _REQUIRED_DEFAULT_FIELDS if not str(defaults.get(field) or "").strip()]
+    if missing:
+        raise SystemExit(
+            "uploaded source-row multiprocess probe requires default fields: "
+            + ", ".join(missing)
+        )
+
+
+async def run_multiprocess_load(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    started = time.monotonic()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    child_specs = [
+        _child_spec(args, index=index)
+        for index in range(int(args.processes))
+    ]
+    child_results = await asyncio.gather(
+        *[
+            _run_child_process(spec["command"], result_path=spec["result_path"])
+            for spec in child_specs
+        ]
+    )
+    summary = _summarize_children(child_results)
+    errors = _load_errors(
+        summary,
+        min_total_successes=int(args.min_total_successes),
+        expect_total_at_capacity_min=int(args.expect_total_at_capacity_min),
+    )
+    payload = {
+        "ok": not errors,
+        "source_path": str(args.path),
+        "source": str(args.source),
+        "processes": int(args.processes),
+        "child_concurrency": int(args.child_concurrency),
+        "child_import_max_concurrency": int(args.child_import_max_concurrency),
+        "account_id": str(args.account_id).strip(),
+        "output_dir": str(args.output_dir),
+        "summary": summary,
+        "children": child_results,
+        "errors": errors,
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+    }
+    return (0 if payload["ok"] else 1), payload
+
+
+def _child_spec(args: argparse.Namespace, *, index: int) -> dict[str, Any]:
+    result_path = args.output_dir / f"child_{index + 1}.json"
+    account_id = f"{str(args.account_id).strip()}-p{index + 1}"
+    source = f"{str(args.source).strip()}-p{index + 1}"
+    command = _child_command(
+        args,
+        index=index,
+        result_path=result_path,
+        account_id=account_id,
+        source=source,
+    )
+    return {
+        "index": index,
+        "account_id": account_id,
+        "source": source,
+        "result_path": result_path,
+        "command": command,
+    }
+
+
+def _child_command(
+    args: argparse.Namespace,
+    *,
+    index: int,
+    result_path: Path,
+    account_id: str,
+    source: str,
+) -> list[str]:
+    del index
+    command = [
+        sys.executable,
+        str(_CHILD_SCRIPT),
+        str(args.path),
+        "--source-format",
+        str(args.source_format),
+        "--source",
+        source,
+        "--target-mode",
+        str(args.target_mode),
+        "--min-source-rows",
+        str(int(args.min_source_rows)),
+        "--max-source-text-chars",
+        str(int(args.max_source_text_chars)),
+        "--sample-limit",
+        str(int(args.sample_limit)),
+        "--account-id",
+        account_id,
+        "--opportunity-table",
+        str(args.opportunity_table),
+        "--database-url",
+        str(args.database_url),
+        "--concurrency",
+        str(int(args.child_concurrency)),
+        "--import-max-concurrency",
+        str(int(args.child_import_max_concurrency)),
+        "--min-successes",
+        str(int(args.child_min_successes)),
+        "--expect-at-capacity-min",
+        str(int(args.child_expect_at_capacity_min)),
+        "--output-result",
+        str(result_path),
+    ]
+    if str(args.user_id or "").strip():
+        command.extend(["--user-id", str(args.user_id).strip()])
+    if bool(args.replace_existing):
+        command.append("--replace-existing")
+    for item in args.default_field:
+        command.extend(["--default-field", str(item)])
+    return command
+
+
+async def _run_child_process(command: list[str], *, result_path: Path) -> dict[str, Any]:
+    started = time.monotonic()
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    payload = _load_child_payload(result_path)
+    summary = payload.get("summary") if isinstance(payload, Mapping) else None
+    return {
+        "result_path": str(result_path),
+        "returncode": int(process.returncode or 0),
+        "ok": bool(payload.get("ok")) if isinstance(payload, Mapping) else False,
+        "summary": dict(summary or {}),
+        "stdout_tail": _tail(stdout.decode("utf-8", errors="replace")),
+        "stderr_tail": _tail(stderr.decode("utf-8", errors="replace")),
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def _load_child_payload(result_path: Path) -> Mapping[str, Any]:
+    if not result_path.exists():
+        return {
+            "ok": False,
+            "summary": {},
+            "errors": [f"missing child result: {result_path}"],
+        }
+    try:
+        value = json.loads(result_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "summary": {},
+            "errors": [f"invalid child result JSON: {exc}"],
+        }
+    if not isinstance(value, Mapping):
+        return {
+            "ok": False,
+            "summary": {},
+            "errors": ["child result JSON was not an object"],
+        }
+    return value
+
+
+def _summarize_children(children: list[Mapping[str, Any]]) -> dict[str, Any]:
+    return {
+        "processes": len(children),
+        "successful_processes": sum(1 for child in children if child.get("ok")),
+        "failed_processes": sum(1 for child in children if not child.get("ok")),
+        "successes": sum(_summary_int(child, "successes") for child in children),
+        "at_capacity": sum(_summary_int(child, "at_capacity") for child in children),
+        "unexpected_failures": sum(
+            _summary_int(child, "unexpected_failures") for child in children
+        ),
+        "inserted": sum(_summary_int(child, "inserted") for child in children),
+        "returncode_counts": _count_by(children, "returncode"),
+    }
+
+
+def _summary_int(child: Mapping[str, Any], key: str) -> int:
+    summary = child.get("summary")
+    if not isinstance(summary, Mapping):
+        return 0
+    return int(summary.get(key) or 0)
+
+
+def _load_errors(
+    summary: Mapping[str, Any],
+    *,
+    min_total_successes: int,
+    expect_total_at_capacity_min: int,
+) -> list[str]:
+    errors: list[str] = []
+    failed_processes = int(summary.get("failed_processes") or 0)
+    unexpected_failures = int(summary.get("unexpected_failures") or 0)
+    successes = int(summary.get("successes") or 0)
+    at_capacity = int(summary.get("at_capacity") or 0)
+    if failed_processes:
+        errors.append(f"failed child process count: {failed_processes}")
+    if unexpected_failures:
+        errors.append(f"unexpected child failure count: {unexpected_failures}")
+    if successes < min_total_successes:
+        errors.append(
+            f"expected at least {min_total_successes} total success(es), got {successes}"
+        )
+    if at_capacity < expect_total_at_capacity_min:
+        errors.append(
+            "expected at least "
+            f"{expect_total_at_capacity_min} total admission 429 response(s), got {at_capacity}"
+        )
+    return errors
+
+
+def _count_by(items: list[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        raw = item.get(key)
+        value = "" if raw is None else str(raw).strip()
+        if value:
+            counts[value] = counts.get(value, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _tail(text: str, *, max_chars: int = 800) -> str:
+    stripped = text.strip()
+    if len(stripped) <= max_chars:
+        return stripped
+    return stripped[-max_chars:]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py
+++ b/tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "smoke_content_ops_ingestion_file_route_multiprocess_load.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "smoke_content_ops_ingestion_file_route_multiprocess_load",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module: {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_cfpb_rows(path: Path, row_count: int) -> None:
+    rows = (
+        {
+            "complaint_id": f"cfpb-{index}",
+            "product": "Credit reporting or other personal consumer reports",
+            "issue": "Incorrect information on your report",
+            "consumer_complaint_narrative": (
+                "My credit report still shows an account I already disputed "
+                "and I need help understanding the next step."
+            ),
+        }
+        for index in range(row_count)
+    )
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _default_args(path: Path, result_path: Path, output_dir: Path) -> list[str]:
+    return [
+        str(path),
+        "--source-format",
+        "jsonl",
+        "--source",
+        "cfpb-route-multiprocess-load-test",
+        "--min-source-rows",
+        "3",
+        "--default-field",
+        "company_name=CFPB Public Archive",
+        "--default-field",
+        "vendor_name=CFPB",
+        "--default-field",
+        "contact_email=cfpb-public-archive@example.invalid",
+        "--account-id",
+        "acct-route-multiprocess-load",
+        "--database-url",
+        "postgresql://atlas@localhost:5433/atlas",
+        "--output-dir",
+        str(output_dir),
+        "--output-result",
+        str(result_path),
+    ]
+
+
+def test_multiprocess_load_builds_child_command(tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    output_dir = tmp_path / "children"
+    _write_cfpb_rows(source_path, 3)
+    args = module._parse_args([
+        *_default_args(source_path, result_path, output_dir),
+        "--processes",
+        "2",
+        "--child-concurrency",
+        "4",
+        "--child-import-max-concurrency",
+        "2",
+        "--replace-existing",
+    ])
+
+    spec = module._child_spec(args, index=1)
+    command = spec["command"]
+
+    assert spec["account_id"] == "acct-route-multiprocess-load-p2"
+    assert spec["source"] == "cfpb-route-multiprocess-load-test-p2"
+    assert str(module._CHILD_SCRIPT) in command
+    assert command[command.index("--account-id") + 1] == "acct-route-multiprocess-load-p2"
+    assert command[command.index("--source") + 1] == "cfpb-route-multiprocess-load-test-p2"
+    assert command[command.index("--concurrency") + 1] == "4"
+    assert command[command.index("--import-max-concurrency") + 1] == "2"
+    assert command[command.index("--database-url") + 1] == "postgresql://atlas@localhost:5433/atlas"
+    assert "--replace-existing" in command
+    assert command.count("--default-field") == 3
+
+
+def test_multiprocess_load_writes_aggregate_result(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    output_dir = tmp_path / "children"
+    _write_cfpb_rows(source_path, 3)
+
+    async def run_child(command, *, result_path):
+        account_id = command[command.index("--account-id") + 1]
+        child_payload = {
+            "ok": True,
+            "summary": {
+                "successes": 1,
+                "at_capacity": 1,
+                "unexpected_failures": 0,
+                "inserted": 3,
+            },
+        }
+        result_path.write_text(json.dumps(child_payload) + "\n", encoding="utf-8")
+        return {
+            "result_path": str(result_path),
+            "returncode": 0,
+            "ok": True,
+            "summary": dict(child_payload["summary"]),
+            "stdout_tail": f"account={account_id}",
+            "stderr_tail": "",
+            "elapsed_seconds": 0.01,
+        }
+
+    monkeypatch.setattr(module, "_run_child_process", run_child)
+
+    code = module.main([
+        *_default_args(source_path, result_path, output_dir),
+        "--processes",
+        "2",
+        "--child-concurrency",
+        "2",
+        "--child-import-max-concurrency",
+        "1",
+        "--min-total-successes",
+        "2",
+        "--expect-total-at-capacity-min",
+        "2",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["summary"] == {
+        "processes": 2,
+        "successful_processes": 2,
+        "failed_processes": 0,
+        "successes": 2,
+        "at_capacity": 2,
+        "unexpected_failures": 0,
+        "inserted": 6,
+        "returncode_counts": {"0": 2},
+    }
+    assert len(payload["children"]) == 2
+    assert (output_dir / "child_1.json").exists()
+    assert (output_dir / "child_2.json").exists()
+
+
+def test_multiprocess_load_fails_on_child_failure(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    result_path = tmp_path / "result.json"
+    output_dir = tmp_path / "children"
+    _write_cfpb_rows(source_path, 3)
+
+    async def run_child(command, *, result_path):
+        account_id = command[command.index("--account-id") + 1]
+        failed = account_id.endswith("-p2")
+        summary = {
+            "successes": 0 if failed else 1,
+            "at_capacity": 0 if failed else 1,
+            "unexpected_failures": 1 if failed else 0,
+            "inserted": 0 if failed else 3,
+        }
+        return {
+            "result_path": str(result_path),
+            "returncode": 1 if failed else 0,
+            "ok": not failed,
+            "summary": summary,
+            "stdout_tail": "",
+            "stderr_tail": "TooManyConnectionsError" if failed else "",
+            "elapsed_seconds": 0.01,
+        }
+
+    monkeypatch.setattr(module, "_run_child_process", run_child)
+
+    code = module.main([
+        *_default_args(source_path, result_path, output_dir),
+        "--processes",
+        "2",
+        "--min-total-successes",
+        "2",
+        "--expect-total-at-capacity-min",
+        "2",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["summary"]["failed_processes"] == 1
+    assert payload["summary"]["unexpected_failures"] == 1
+    assert payload["errors"] == [
+        "failed child process count: 1",
+        "unexpected child failure count: 1",
+        "expected at least 2 total success(es), got 1",
+        "expected at least 2 total admission 429 response(s), got 1",
+    ]
+
+
+def test_multiprocess_load_requires_database_url(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    source_path = tmp_path / "cfpb_rows.jsonl"
+    _write_cfpb_rows(source_path, 1)
+    monkeypatch.setattr(module, "_default_database_url", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        module.main([
+            str(source_path),
+            "--source-format",
+            "jsonl",
+            "--default-field",
+            "company_name=CFPB Public Archive",
+            "--default-field",
+            "vendor_name=CFPB",
+            "--default-field",
+            "contact_email=cfpb-public-archive@example.invalid",
+            "--account-id",
+            "acct-route-multiprocess-load",
+            "--database-url",
+            "",
+        ])
+
+    assert "Missing --database-url" in str(exc.value)
+


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-File-Multiprocess-Load-Probe.md

Adds a process-fanout uploaded-file import load probe that reuses the in-process runner as each child process. This makes the FILECONCURRENCY-2 deployment-topology risk reproducible: each child process has its own local admission gate, so aggregate admitted writes scale by process count.

## Intentional
- Validation tooling only; no product route or queue behavior changes.
- Each child uses a unique account suffix so live DB verification avoids process write collisions.
- The diff is over 400 LOC because the reusable probe includes CLI validation, subprocess fan-out, child artifact management, aggregate validation, and deterministic fake-subprocess tests.

## Deferred
- Distributed semaphore, shared queue, durable import jobs, and queue visibility remain parked under FILECONCURRENCY-2.
- Automatic database cleanup is left out; live runs should use unique account ids.

## Verification
- `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py -q` -> 4 passed
- Live multiprocess probe with 3 child processes, child concurrency 2, child gate 1 -> 3 successes, 3 admission 429 responses, 0 unexpected failures, 3000 rows inserted
- DB verification for `acct-file-route-multiprocess-load-20260523-p%` / `vendor_retention` -> 3 accounts, 3000 rows, 1000 distinct target IDs
- `python -m pytest tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py -q` -> 8 passed
- Python compile check passed for the multiprocess probe script
- `bash scripts/local_pr_review.sh --allow-dirty` -> passed

## Diff size
3 files, +703 / -0