### PR TITLE
PR-Content-Ops-Host-Import-Admission-Provider

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,11 +32,11 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-23
 
-### FILECONCURRENCY-2 - Uploaded-file imports need cross-process admission
-- File/location: Hosted `/content-ops/ingestion/files/import` deployment topology; in-process runner lives at `scripts/smoke_content_ops_ingestion_file_route_inprocess_load.py`.
-- Description: The shared-pool route gate and in-process load runner prove one-router admission, but multi-worker or multi-process deployments can still admit one gate window per process unless backed by a distributed queue, shared semaphore, or job boundary.
-- Why it matters: Production deployments with multiple app workers can multiply the configured import concurrency and pressure Postgres even though each worker is locally bounded.
-- Effort: L
+### FILECONCURRENCY-2 - Uploaded-file imports need hosted multiprocess proof
+- File/location: Hosted `/content-ops/ingestion/files/import` deployment topology; host provider lives at `atlas_brain/_content_ops_import_admission.py`.
+- Description: Atlas now has a Postgres advisory-lock admission provider for shared cross-process capacity, but the remaining production hardening is a live Atlas-mounted multiprocess proof plus durable background job/queue visibility.
+- Why it matters: Production deployments need evidence that the mounted host route stays bounded across workers and enough job visibility to diagnose long-running imports.
+- Effort: M
 - Category: correctness
 - Owner/session: content-ops/backend-file-ingestion-validation
 - Found during: PR-Content-Ops-File-Cross-Process-Hardening-Register

--- a/atlas_brain/_content_ops_import_admission.py
+++ b/atlas_brain/_content_ops_import_admission.py
@@ -1,0 +1,131 @@
+"""Host-owned shared admission for Content Ops ingestion imports."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .storage.database import get_db_pool
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+
+CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE = 1_096_047_443
+
+
+class ContentOpsPostgresImportAdmissionGate:
+    """Bound non-dry-run Content Ops imports across Atlas app processes."""
+
+    def __init__(
+        self,
+        *,
+        pool_provider: PoolProvider,
+        max_concurrency: int,
+        namespace: int = CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE,
+    ) -> None:
+        if max_concurrency <= 0:
+            raise ValueError("max_concurrency must be positive")
+        self.max_concurrency = max_concurrency
+        self._pool_provider = pool_provider
+        self._namespace = namespace
+        self._pool: Any | None = None
+        self._connection: Any | None = None
+        self._slot: int | None = None
+
+    async def acquire(self) -> bool:
+        """Acquire one advisory-lock slot, returning False when full."""
+
+        if self._connection is not None:
+            return True
+
+        pool = await _resolve_pool(self._pool_provider)
+        connection = await _maybe_await(pool.acquire())
+        try:
+            for slot in range(self.max_concurrency):
+                acquired = await _maybe_await(
+                    connection.fetchval(
+                        "SELECT pg_try_advisory_lock($1::int, $2::int)",
+                        self._namespace,
+                        slot,
+                    )
+                )
+                if bool(acquired):
+                    self._pool = pool
+                    self._connection = connection
+                    self._slot = slot
+                    return True
+        except BaseException:
+            await _release_connection(pool, connection)
+            raise
+
+        await _release_connection(pool, connection)
+        return False
+
+    async def release(self) -> None:
+        """Release a held advisory-lock slot and return its connection."""
+
+        if self._connection is None:
+            return
+
+        pool = self._pool
+        connection = self._connection
+        slot = self._slot
+        self._pool = None
+        self._connection = None
+        self._slot = None
+
+        unlock_error: BaseException | None = None
+        try:
+            unlocked = await _maybe_await(
+                connection.fetchval(
+                    "SELECT pg_advisory_unlock($1::int, $2::int)",
+                    self._namespace,
+                    slot,
+                )
+            )
+            if not bool(unlocked):
+                raise RuntimeError("Content Ops import advisory lock was not held")
+        except Exception as exc:
+            unlock_error = exc
+            await _close_connection(connection)
+        finally:
+            if pool is not None:
+                await _release_connection(pool, connection)
+        if unlock_error is not None:
+            raise unlock_error
+
+
+def build_content_ops_import_admission_gate(
+    *,
+    max_concurrency: int,
+    pool_provider: PoolProvider = get_db_pool,
+) -> ContentOpsPostgresImportAdmissionGate:
+    """Build a fresh host admission gate for one import request."""
+
+    return ContentOpsPostgresImportAdmissionGate(
+        pool_provider=pool_provider,
+        max_concurrency=max_concurrency,
+    )
+
+
+async def _resolve_pool(provider: PoolProvider) -> Any:
+    pool = await _maybe_await(provider())
+    if pool is None:
+        raise RuntimeError("Content Ops import admission database pool is unavailable")
+    return pool
+
+
+async def _release_connection(pool: Any, connection: Any) -> None:
+    await _maybe_await(pool.release(connection))
+
+
+async def _close_connection(connection: Any) -> None:
+    close = getattr(connection, "close", None)
+    if callable(close):
+        await _maybe_await(close())
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -154,7 +154,11 @@ router.include_router(b2b_challenger_claims_router)
 # is logged as disabled and existing routes keep serving.
 try:
     from extracted_content_pipeline.api.control_surfaces import (
+        ContentOpsControlSurfaceApiConfig,
         create_content_ops_control_surface_router,
+    )
+    from .._content_ops_import_admission import (
+        build_content_ops_import_admission_gate,
     )
     from extracted_content_pipeline.api.generated_assets import (
         create_generated_asset_router,
@@ -193,7 +197,9 @@ try:
         set_current_auth_user(user)
         return user
 
+    content_ops_config = ContentOpsControlSurfaceApiConfig()
     content_ops_router = create_content_ops_control_surface_router(
+        config=content_ops_config,
         dependencies=[Depends(_capture_content_ops_auth_user)],
         execution_services_provider=lambda: (
             build_content_ops_execution_services(enable_db_services=True)
@@ -202,6 +208,11 @@ try:
         reasoning_context_provider=select_content_ops_reasoning_context_provider,
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
         opportunity_import_pool_provider=get_db_pool,
+        ingestion_import_admission_provider=lambda: (
+            build_content_ops_import_admission_gate(
+                max_concurrency=content_ops_config.ingestion_import_max_concurrency
+            )
+        ),
     )
     router.include_router(content_ops_router)
     content_assets_router = create_generated_asset_router(

--- a/plans/PR-Content-Ops-Host-Import-Admission-Provider.md
+++ b/plans/PR-Content-Ops-Host-Import-Admission-Provider.md
@@ -1,0 +1,69 @@
+# PR-Content-Ops-Host-Import-Admission-Provider
+
+## Why this slice exists
+`FILECONCURRENCY-2` tracks the remaining Content Ops uploaded-file import risk:
+the extracted route now exposes a host admission provider seam, but Atlas still
+mounts the router without a shared provider. In a multi-worker deployment that
+means each process can still admit its own local import window.
+
+This slice wires the Atlas host to a Postgres advisory-lock-backed admission
+gate so non-dry-run file imports share one bounded capacity window across app
+processes.
+
+## Scope (this PR)
+Ownership lane: content-ops/backend-file-ingestion-validation
+
+1. Add a host-owned Content Ops import admission gate backed by Postgres
+   session advisory locks.
+2. Wire that provider into the Atlas-mounted Content Ops control-surface
+   router.
+3. Add focused unit tests for admission success, capacity denial, release, and
+   invalid capacity.
+4. Narrow the parked hardening item to the remaining durable-job/load-proofing
+   work after the shared provider is wired.
+
+### Files touched
+
+- `atlas_brain/_content_ops_import_admission.py`
+- `atlas_brain/api/__init__.py`
+- `tests/test_atlas_content_ops_import_admission.py`
+- `HARDENING.md`
+- `plans/PR-Content-Ops-Host-Import-Admission-Provider.md`
+
+## Mechanism
+`ContentOpsPostgresImportAdmissionGate.acquire()` obtains one host database
+connection and tries `pg_try_advisory_lock(namespace, slot)` for slots from `0`
+through `max_concurrency - 1`.
+
+The first successful slot is held on the same connection until `release()`
+calls `pg_advisory_unlock(namespace, slot)` and returns the connection to the
+pool. If no slot is available, the gate releases the connection immediately and
+returns `False`, letting the existing extracted route return its 429
+`content_ops_ingestion_import_at_capacity` response.
+
+## Intentional
+- The gate uses Postgres advisory locks rather than adding Redis or a durable
+  queue because Atlas already requires the database for write-mode imports.
+- The lock is session-scoped and intentionally holds one pool connection while
+  the import runs; advisory locks require the same connection for unlock.
+- The provider returns a fresh gate per request so a held connection/slot never
+  leaks between unrelated requests.
+
+## Deferred
+- Durable background import jobs and queue visibility remain parked; this slice
+  bounds concurrent writers but does not add async job orchestration.
+- A live multi-process smoke that exercises the Atlas-mounted provider remains a
+  follow-up. Existing route-level load probes exercise the extracted route seam,
+  not the host provider.
+- Parked hardening: `FILECONCURRENCY-2 - Uploaded-file imports need hosted
+  multiprocess proof`.
+
+## Verification
+- Focused host admission tests: `python -m pytest tests/test_atlas_content_ops_import_admission.py -q` (`7 passed`)
+- Import-route seam regression: `python -m pytest tests/test_extracted_content_control_surface_api.py -q` (`92 passed`)
+- Local PR review: `bash scripts/local_pr_review.sh --allow-dirty` (`passed`)
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Total | 397 |

--- a/tests/test_atlas_content_ops_import_admission.py
+++ b/tests/test_atlas_content_ops_import_admission.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from atlas_brain._content_ops_import_admission import (
+    CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE,
+    ContentOpsPostgresImportAdmissionGate,
+    build_content_ops_import_admission_gate,
+)
+
+
+class _Connection:
+    def __init__(self, try_results: list[bool], *, unlock_result: bool = True) -> None:
+        self.try_results = try_results
+        self.unlock_result = unlock_result
+        self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.closed = False
+
+    async def fetchval(self, query: str, *args: object) -> bool:
+        self.fetchval_calls.append((query, args))
+        if "pg_try_advisory_lock" in query:
+            if not self.try_results:
+                raise AssertionError("Unexpected advisory lock attempt")
+            return self.try_results.pop(0)
+        if "pg_advisory_unlock" in query:
+            return self.unlock_result
+        raise AssertionError(f"Unexpected query: {query}")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Pool:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+        self.acquire_count = 0
+        self.released: list[_Connection] = []
+
+    async def acquire(self) -> _Connection:
+        self.acquire_count += 1
+        return self.connection
+
+    async def release(self, connection: _Connection) -> None:
+        self.released.append(connection)
+
+
+@pytest.mark.asyncio
+async def test_import_admission_gate_acquires_first_available_slot() -> None:
+    connection = _Connection([False, True])
+    pool = _Pool(connection)
+    gate = ContentOpsPostgresImportAdmissionGate(
+        pool_provider=lambda: pool,
+        max_concurrency=3,
+    )
+
+    acquired = await gate.acquire()
+
+    assert acquired is True
+    assert pool.acquire_count == 1
+    assert pool.released == []
+    assert connection.fetchval_calls == [
+        (
+            "SELECT pg_try_advisory_lock($1::int, $2::int)",
+            (CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE, 0),
+        ),
+        (
+            "SELECT pg_try_advisory_lock($1::int, $2::int)",
+            (CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE, 1),
+        ),
+    ]
+
+    await gate.release()
+
+    assert pool.released == [connection]
+    assert connection.fetchval_calls[-1] == (
+        "SELECT pg_advisory_unlock($1::int, $2::int)",
+        (CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE, 1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_admission_gate_denies_when_all_slots_are_full() -> None:
+    connection = _Connection([False, False])
+    pool = _Pool(connection)
+    gate = ContentOpsPostgresImportAdmissionGate(
+        pool_provider=lambda: pool,
+        max_concurrency=2,
+    )
+
+    acquired = await gate.acquire()
+
+    assert acquired is False
+    assert pool.acquire_count == 1
+    assert pool.released == [connection]
+    assert connection.fetchval_calls == [
+        (
+            "SELECT pg_try_advisory_lock($1::int, $2::int)",
+            (CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE, 0),
+        ),
+        (
+            "SELECT pg_try_advisory_lock($1::int, $2::int)",
+            (CONTENT_OPS_IMPORT_ADVISORY_LOCK_NAMESPACE, 1),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        RuntimeError("database unavailable"),
+        asyncio.CancelledError(),
+    ],
+)
+@pytest.mark.asyncio
+async def test_import_admission_gate_releases_connection_when_try_fails(
+    exception: BaseException,
+) -> None:
+    class _FailingConnection(_Connection):
+        async def fetchval(self, query: str, *args: object) -> bool:
+            self.fetchval_calls.append((query, args))
+            raise exception
+
+    connection = _FailingConnection([])
+    pool = _Pool(connection)
+    gate = ContentOpsPostgresImportAdmissionGate(
+        pool_provider=lambda: pool,
+        max_concurrency=1,
+    )
+
+    with pytest.raises(type(exception)):
+        await gate.acquire()
+
+    assert pool.released == [connection]
+
+
+@pytest.mark.asyncio
+async def test_import_admission_gate_closes_connection_when_unlock_fails() -> None:
+    connection = _Connection([True], unlock_result=False)
+    pool = _Pool(connection)
+    gate = ContentOpsPostgresImportAdmissionGate(
+        pool_provider=lambda: pool,
+        max_concurrency=1,
+    )
+
+    assert await gate.acquire() is True
+
+    with pytest.raises(RuntimeError, match="advisory lock was not held"):
+        await gate.release()
+
+    assert connection.closed is True
+    assert pool.released == [connection]
+
+
+def test_import_admission_gate_rejects_invalid_capacity() -> None:
+    with pytest.raises(ValueError, match="max_concurrency must be positive"):
+        ContentOpsPostgresImportAdmissionGate(
+            pool_provider=lambda: object(),
+            max_concurrency=0,
+        )
+
+
+def test_import_admission_provider_returns_fresh_gate_per_request() -> None:
+    gate_one = build_content_ops_import_admission_gate(
+        max_concurrency=2,
+        pool_provider=lambda: object(),
+    )
+    gate_two = build_content_ops_import_admission_gate(
+        max_concurrency=2,
+        pool_provider=lambda: object(),
+    )
+
+    assert gate_one is not gate_two
+    assert gate_one.max_concurrency == 2
+    assert gate_two.max_concurrency == 2


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Host-Import-Admission-Provider.md

Atlas now has the extracted route seam for import admission, but the hosted Content Ops router still mounted without a shared provider. This wires write-mode Content Ops file imports to a host-owned Postgres advisory-lock gate so multiple app processes share one bounded import capacity window. The gate now also returns the acquired pool connection if advisory-lock acquisition is cancelled before returning to the route.

## Intentional
- Use Postgres advisory locks because write-mode imports already require the host database.
- Hold one database pool connection per active import because session-scoped advisory locks must unlock on the same connection.
- Return a fresh gate per request so held lock slots and connections do not leak across imports.
- Catch `BaseException` during advisory-lock acquisition so request cancellation still returns the pool connection.

## Deferred
- Durable background import jobs and queue visibility remain parked under FILECONCURRENCY-2.
- Atlas-mounted live multiprocess proof remains a follow-up.

## Parked hardening
- FILECONCURRENCY-2 - Uploaded-file imports need hosted multiprocess proof.

## Verification
- `python -m pytest tests/test_atlas_content_ops_import_admission.py -q` (`7 passed`)
- `python -m pytest tests/test_extracted_content_control_surface_api.py -q` (`92 passed`)
- `python -m pytest tests/test_atlas_content_ops_import_admission.py tests/test_extracted_content_control_surface_api.py -q` (`99 passed`)
- `bash scripts/local_pr_review.sh --allow-dirty` (`passed`, estimate/actual 397)
- Local reviewer pre-GitHub verdict: LGTM before the GitHub review fix; GitHub review MAJOR addressed in latest push.

## Diff size
5 files, +392 / -5