### PR TITLE
Plan: plans/PR-Blog-Headlines-Landscapes.md

### DIFF
--- a/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'helpdesk-landscape-2026-04',
-  title: 'Helpdesk Landscape 2026: 5 Vendors Compared by Real User Data',
+  title: 'Helpdesk Landscape 2026: 5 Vendors on Cost, Churn & Support Pain (352 Reviews)',
   description: 'Compare Freshdesk, Zendesk, Help Scout, HappyFox, and Zoho Desk across 352 enriched reviews. See churn urgency, pain patterns, and strengths/weaknesses in the 2026 helpdesk market.',
   date: '2026-04-07',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/hr-hcm-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/hr-hcm-landscape-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'hr-hcm-landscape-2026-04',
-  title: 'HR / HCM Landscape 2026: 4 Vendors Compared by Real User Data',
+  title: 'HR / HCM Landscape 2026: 4 Vendors on Cost, Support & Fit (306 Churn Signals)',
   description: 'A data-backed comparison of BambooHR, Gusto, Rippling, and Workday based on 306 churn signals and public reviews from March–April 2026. See which vendors face the highest churn risk and what pain patterns recur across the HR / HCM market.',
   date: '2026-04-07',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'marketing-automation-landscape-2026-04',
-  title: 'Marketing Automation Landscape 2026: 5 Vendors Compared by Real User Data',
+  title: 'Marketing Automation Landscape 2026: 5 Vendors on Pricing, Churn & Real Pain (640 Reviews)',
   description: 'Compare ActiveCampaign, Brevo, GetResponse, Klaviyo, and Mailchimp across 640 enriched reviews. Discover churn signals, pricing pressure, and which vendors face the highest replacement risk.',
   date: '2026-04-07',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/project-management-landscape-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/project-management-landscape-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'project-management-landscape-2026-04',
-  title: 'Project Management Landscape 2026: 10 Vendors Compared by Real User Data',
+  title: 'Project Management Landscape 2026: 10 Vendors on Cost, Complexity & Pain (1,464 Churn Signals)',
   description: 'A data-driven comparison of 10 project management vendors based on 1,464 churn signals from verified reviews and community platforms. See which tools face the highest churn risk and what pain patterns recur across the category.',
   date: '2026-04-07',
   author: 'Churn Signals Team',

--- a/plans/PR-Blog-Headlines-Landscapes.md
+++ b/plans/PR-Blog-Headlines-Landscapes.md
@@ -1,0 +1,65 @@
+# PR-Blog-Headlines-Landscapes
+
+Ownership lane: `content-ops/blog-headlines-landscapes`
+
+## Why this slice exists
+
+Headlines phase, scaling slice 3 / final (after sample #892, deep-dives #896, vs #897).
+Rewrites the 4 category-landscape posts whose titles use the dry "N Vendors Compared by
+Real User Data" pattern, matching the approved crm-landscape style ("N Vendors on
+{axes} (count)"). The other landscape posts (b2b-software ×2, communication) already
+carry a count/finding and are left as-is.
+
+## Scope (this PR)
+
+4 `title` rewrites. No `seo_title`/body changes. Each leads with the buyer axes (cost
+from the validated keyword + churn + a category-specific pain) and surfaces the count.
+
+### Files touched
+
+- `plans/PR-Blog-Headlines-Landscapes.md`
+- `atlas-churn-ui/src/content/blog/helpdesk-landscape-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/hr-hcm-landscape-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/marketing-automation-landscape-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/project-management-landscape-2026-04.ts`
+
+## Mechanism
+
+Each edit replaces one `title:` line via an assert-exact-match script (1 match per file).
+The vendor count (5/4/5/10) is preserved from the old title. The added count is taken
+from each post's own description **with the correct unit** — verified: helpdesk "352
+enriched reviews" → "(352 Reviews)"; hr-hcm "306 churn signals" → "(306 Churn Signals)";
+marketing-automation "640 enriched reviews" → "(640 Reviews)"; project-management "1,464
+churn signals" → "(1,464 Churn Signals)". Reviews and churn signals are NOT conflated.
+
+## Intentional
+
+- **Cost axis = each post's validated keyword** (help desk software cost / HR software
+  cost / marketing automation cost / project management software cost).
+- **Correct metric unit per post** — the two posts that count churn signals say "Churn
+  Signals", the two that count reviews say "Reviews"; this avoids the reviews-vs-signals
+  conflation that the earlier correctness audit fixed elsewhere.
+- **`seo_title` untouched**; b2b-software/communication landscapes left as-is (already
+  carry a count).
+
+## Deferred
+
+- Headline scaling is complete after this slice. Intentionally-untouched (already punchy):
+  top-complaint posts, why-teams-leave posts, finding-led deep-dives, switch posts, the
+  two cross-category "Urgency Gap" vs-posts, b2b-software/communication landscapes.
+
+Parked hardening: none new.
+
+## Verification
+
+- All 4 edits applied via assert-exact-match (1 match/file); `git diff` = 4 `title`
+  lines only; vendor counts preserved; added counts match each description's figure +
+  unit.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 4 post files (title) | ~8 |
+| Plan doc | ~52 |
+| **Total** | **~60** |


### PR DESCRIPTION
## Intentional

Headlines scaling slice 3 / final (after #892, #896, #897). 4 landscape titles rewritten
from the dry "N Vendors Compared by Real User Data" pattern to axis-led:

| Post | New title |
|---|---|
| helpdesk-landscape | Helpdesk Landscape 2026: 5 Vendors on Cost, Churn & Support Pain (352 Reviews) |
| hr-hcm-landscape | HR / HCM Landscape 2026: 4 Vendors on Cost, Support & Fit (306 Churn Signals) |
| marketing-automation-landscape | Marketing Automation Landscape 2026: 5 Vendors on Pricing, Churn & Real Pain (640 Reviews) |
| project-management-landscape | Project Management Landscape 2026: 10 Vendors on Cost, Complexity & Pain (1,464 Churn Signals) |

Vendor counts preserved (5/4/5/10). The added count comes from each post's own description
**with the correct unit** — reviews vs churn signals are NOT conflated (the two posts that
count signals say "Churn Signals", the two that count reviews say "Reviews"). Cost axis =
each post's validated keyword.

## Deferred

Headline scaling **complete** after this. Intentionally untouched (already punchy):
top-complaint posts, why-teams-leave posts, finding-led deep-dives, switch posts, the
cross-category "Urgency Gap" vs-posts, b2b-software/communication landscapes.

## Verification

- Assert-exact-match (1/file); `git diff` = 4 `title` lines only; added counts match each
  description's figure + unit. Pre-push gates PASS.

## Diff size

| Area | LOC |
|---|---:|
| 4 post files | ~8 |
| Plan doc | ~52 |
| **Total** | **~60** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)