### PR TITLE
Plan: plans/PR-Blog-Headlines-Switch.md

### DIFF
--- a/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-clickup-2026-03.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-clickup-2026-03',
-  title: 'Migration Guide: Why Teams Are Switching to ClickUp',
+  title: 'Switching to ClickUp: What 645 Reviews Reveal About Why Teams Migrate',
   description: 'Analysis of 645 enriched reviews showing migration patterns to ClickUp. Where teams are coming from, what triggers the switch, and what to expect during migration.',
   date: '2026-03-29',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-klaviyo-2026-04',
-  title: 'Migration Guide: Why Teams Are Switching to Klaviyo from 5 Competitor Platforms',
+  title: 'Switching to Klaviyo: Why Teams Leave Mailchimp, Flodesk & MailerLite (638 Reviews)',
   description: 'Analysis of 638 Klaviyo reviews reveals why teams migrate from Mailchimp, Flodesk, MailerLite, Shopify Emails, and other platforms. Covers migration triggers, practical considerations, and what to expect when switching.',
   date: '2026-04-07',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-sentinelone-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-sentinelone-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-sentinelone-2026-04',
-  title: 'Migration Guide: Why Teams Are Switching to SentinelOne',
+  title: 'Switching to SentinelOne: What 488 Reviews Reveal About the Migration',
   description: 'A practical migration guide based on 488 SentinelOne reviews. Learn which competitors users are leaving, what triggers the switch, and what to expect during migration.',
   date: '2026-04-10',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-shopify-2026-03',
-  title: 'Migration Guide: Why Teams Are Switching to Shopify (93 Switching Stories Analyzed)',
+  title: 'Switching to Shopify: 93 Migration Stories Across 1,503 Reviews',
   description: 'Analysis of 93 migration signals across 1,503 enriched reviews. Where teams come from, what triggers the switch, and what the transition looks like based on reviewer experiences.',
   date: '2026-03-29',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-shopify-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-shopify-2026-04',
-  title: 'Migration Guide: Why Teams Are Switching to Shopify from 3 Competitor Platforms',
+  title: 'Switching to Shopify: What 2,383 Reviews Reveal About Why Teams Migrate',
   description: 'Analysis of 2383 Shopify reviews reveals 3 primary competitor sources driving inbound migrations. This guide covers the pain categories triggering switches, practical migration considerations, and what to expect when moving to Shopify.',
   date: '2026-04-08',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-woocommerce-2026-04',
-  title: 'Migration Guide: Why Teams Are Switching to WooCommerce',
+  title: 'Switching to WooCommerce: What 1,467 Reviews Reveal About Why Teams Migrate',
   description: 'Analysis of inbound migration patterns to WooCommerce based on 1467 reviews. What drives teams to switch, where they come from, and what to expect during migration.',
   date: '2026-04-03',
   author: 'Churn Signals Team',

--- a/atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts
+++ b/atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts
@@ -2,7 +2,7 @@ import type { BlogPost } from './index'
 
 const post: BlogPost = {
   slug: 'switch-to-zoho-crm-2026-04',
-  title: 'Migration Guide: Why Teams Are Switching to Zoho CRM from 4 Competitor Platforms',
+  title: 'Switching to Zoho CRM: 4 Migration Sources Across 963 Reviews',
   description: 'Analysis of 963 Zoho CRM reviews reveals 4 documented migration sources and the pain categories driving platform switches. Includes practical migration considerations, integration patterns, and support experience patterns from paying customers.',
   date: '2026-04-10',
   author: 'Churn Signals Team',

--- a/plans/PR-Blog-Headlines-Switch.md
+++ b/plans/PR-Blog-Headlines-Switch.md
@@ -1,0 +1,69 @@
+# PR-Blog-Headlines-Switch
+
+Ownership lane: `content-ops/blog-headlines-switch`
+
+## Why this slice exists
+
+Headlines phase, scaling slice 4 / final (after sample #892, deep-dives #896, vs #897,
+landscapes #898). Rewrites the high-N switch posts from the dry "Migration Guide: Why
+Teams Are Switching to X" pattern to the approved punchier "Switching to X" style with
+the review count surfaced. The two very low-N switch posts (switch-to-asana = 3 migrations,
+switch-to-salesforce = 3 sources) are intentionally LEFT in their modest framing to avoid
+overstating thin data.
+
+## Scope (this PR)
+
+7 `title` rewrites. No `seo_title`/body changes. Drops the "Migration Guide:" prefix,
+leads with "Switching to X", surfaces each post's review count (from its description) and
+names source platforms only where the description names them.
+
+### Files touched
+
+- `plans/PR-Blog-Headlines-Switch.md`
+- `atlas-churn-ui/src/content/blog/switch-to-clickup-2026-03.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-klaviyo-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-sentinelone-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-shopify-2026-03.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-shopify-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-woocommerce-2026-04.ts`
+- `atlas-churn-ui/src/content/blog/switch-to-zoho-crm-2026-04.ts`
+
+## Mechanism
+
+Each edit replaces one `title:` line via an assert-exact-match script (1 match per file).
+Counts are taken from each post's own description and verified: clickup-03 "645 enriched
+reviews", klaviyo "638 Klaviyo reviews", sentinelone "488 SentinelOne reviews", shopify-03
+"93 migration signals across 1,503 enriched reviews", shopify-04 "2383 Shopify reviews",
+woocommerce "1467 reviews", zoho-crm "963 Zoho CRM reviews".
+
+## Intentional
+
+- **Sources named only when the description names them** — Klaviyo's "Mailchimp, Flodesk &
+  MailerLite" are verbatim from its description. The others use a generic "why teams
+  migrate" framing rather than asserting unverified source platforms.
+- **Low-N posts left modest** — switch-to-asana / switch-to-salesforce keep "Migration
+  Guide" framing (3 migrations / 3 sources); a punchy headline would overstate.
+- **`seo_title` untouched.**
+
+## Deferred
+
+- **Headline phase COMPLETE** after this slice. Total rewritten across the phase: sample
+  (5) + deep-dives (16) + vs (10) + landscapes (4) + switch (7) = 42 posts. Left as-is
+  (already punchy): top-complaint (7), why-teams-leave (3), finding-led deep-dives (13),
+  b2b-software/communication landscapes, urgency-gap vs-posts, low-N switch posts (2).
+- Next roadmap phase: phased publish (then post-publish GSC volume refinement).
+
+Parked hardening: none new.
+
+## Verification
+
+- All 7 edits applied via assert-exact-match (1 match/file); `git diff` = 7 `title` lines
+  only; each surfaced count matches the post's description figure.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 7 post files (title) | ~14 |
+| Plan doc | ~58 |
+| **Total** | **~72** |


### PR DESCRIPTION
## Intentional

Headlines scaling slice 4 / final (after #892, #896, #897, #898). 7 high-N switch-post
titles rewritten from the dry "Migration Guide: Why Teams Are Switching to X" to the
punchier "Switching to X" style:

| Post | New title |
|---|---|
| switch-to-clickup-2026-03 | Switching to ClickUp: What 645 Reviews Reveal About Why Teams Migrate |
| switch-to-klaviyo | Switching to Klaviyo: Why Teams Leave Mailchimp, Flodesk & MailerLite (638 Reviews) |
| switch-to-sentinelone | Switching to SentinelOne: What 488 Reviews Reveal About the Migration |
| switch-to-shopify-2026-03 | Switching to Shopify: 93 Migration Stories Across 1,503 Reviews |
| switch-to-shopify-2026-04 | Switching to Shopify: What 2,383 Reviews Reveal About Why Teams Migrate |
| switch-to-woocommerce | Switching to WooCommerce: What 1,467 Reviews Reveal About Why Teams Migrate |
| switch-to-zoho-crm | Switching to Zoho CRM: 4 Migration Sources Across 963 Reviews |

Counts taken from each post's own description (verified). **Sources named only where the
description names them** (Klaviyo's Mailchimp/Flodesk/MailerLite are verbatim); others use
a generic "why teams migrate" framing to avoid asserting unverified sources. **Low-N posts
(switch-to-asana = 3 migrations, switch-to-salesforce = 3 sources) intentionally left in
modest "Migration Guide" framing** per the thin-data call.

## Deferred

**Headline phase COMPLETE.** 42 posts rewritten total (sample 5 + deep-dives 16 + vs 10 +
landscapes 4 + switch 7). Already-punchy posts left as-is (top-complaint, why-teams-leave,
finding-led deep-dives, etc.). Next roadmap phase: phased publish → post-publish GSC volume
refinement.

## Verification

- Assert-exact-match (1/file); `git diff` = 7 `title` lines only; each count matches its
  description. Pre-push gates PASS.

## Diff size

| Area | LOC |
|---|---:|
| 7 post files | ~14 |
| Plan doc | ~58 |
| **Total** | **~72** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)