### PR TITLE
Wire Content Ops input providers into API routes

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -38,6 +38,10 @@ from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
 )
+from ..content_ops_input_provider import (
+    ContentOpsInputProvider,
+    merge_content_ops_input_package,
+)
 from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
@@ -84,6 +88,7 @@ ReasoningStatusProvider = Callable[
 LLMProvider = Callable[[], Any | Awaitable[Any]]
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ImportAdmissionProvider = Callable[[], Any | Awaitable[Any]]
+InputProvider = ContentOpsInputProvider
 
 logger = logging.getLogger(__name__)
 
@@ -502,6 +507,7 @@ def create_content_ops_control_surface_router(
     reasoning_context_provider: ReasoningContextProvider | None = None,
     reasoning_status_provider: ReasoningStatusProvider | None = None,
     llm_provider: LLMProvider | None = None,
+    input_provider: InputProvider | None = None,
     opportunity_import_pool_provider: PoolProvider | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     dependencies: Sequence[Any] | None = None,
@@ -555,14 +561,24 @@ def create_content_ops_control_surface_router(
     async def preview_generation(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
-        return preview_from_mapping(_payload_to_mapping(payload))
+        payload_mapping = await _payload_with_input_provider(
+            _payload_to_mapping(payload, exclude_unset=input_provider is not None),
+            input_provider=input_provider,
+            scope_provider=scope_provider,
+        )
+        return preview_from_mapping(payload_mapping)
 
     @router.post("/plan")
     async def plan_generation(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
         try:
-            return build_generation_plan_from_mapping(_payload_to_mapping(payload))
+            payload_mapping = await _payload_with_input_provider(
+                _payload_to_mapping(payload, exclude_unset=input_provider is not None),
+                input_provider=input_provider,
+                scope_provider=scope_provider,
+            )
+            return build_generation_plan_from_mapping(payload_mapping)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -707,7 +723,7 @@ def create_content_ops_control_surface_router(
     async def execute_generation(
         payload: ContentOpsRequestModel = Body(...),
     ) -> dict[str, Any]:
-        payload_mapping = _payload_to_mapping(payload)
+        payload_mapping = _payload_to_mapping(payload, exclude_unset=input_provider is not None)
         if not await execute_gate.acquire():
             raise HTTPException(
                 status_code=429,
@@ -728,6 +744,12 @@ def create_content_ops_control_surface_router(
                     status_code=503,
                     detail="Content Ops execution services are not configured.",
                 )
+            scope = await _resolve_scope(scope_provider)
+            payload_mapping = await _payload_with_input_provider(
+                payload_mapping,
+                input_provider=input_provider,
+                scope=scope,
+            )
             # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
             # per-request reasoning provider and derive a reasoning-aware
             # bundle. The base services from execution_services_provider
@@ -761,7 +783,6 @@ def create_content_ops_control_surface_router(
                         reasoning_context,
                         outputs=reasoning_outputs,
                     )
-            scope = await _resolve_scope(scope_provider)
             try:
                 result = await execute_content_ops_from_mapping(
                     payload_mapping,
@@ -958,6 +979,39 @@ async def _resolve_reasoning_context(
             detail="Content Ops reasoning context provider is unavailable.",
         ) from exc
     return value
+
+
+async def _payload_with_input_provider(
+    payload: Mapping[str, Any],
+    *,
+    input_provider: InputProvider | None,
+    scope_provider: ScopeProvider | None = None,
+    scope: TenantScope | None = None,
+) -> dict[str, Any]:
+    if input_provider is None:
+        return dict(payload)
+    resolved_scope = scope
+    if resolved_scope is None:
+        resolved_scope = await _resolve_scope(scope_provider)
+    try:
+        package = input_provider.build_content_ops_input_package(
+            scope=resolved_scope or TenantScope(),
+            request=payload,
+        )
+        if hasattr(package, "__await__"):
+            package = await package
+        return merge_content_ops_input_package(payload, package)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Content Ops input provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops input provider is unavailable.",
+        ) from exc
 
 
 async def _structured_reasoning_contexts(
@@ -1524,11 +1578,13 @@ def _clean_sequence(value: Any) -> tuple[str, ...]:
     return tuple(cleaned)
 
 
-def _payload_to_mapping(payload: Any) -> dict[str, Any]:
+def _payload_to_mapping(payload: Any, *, exclude_unset: bool = False) -> dict[str, Any]:
     if BaseModel is not None and isinstance(payload, ContentOpsRequestModel):
-        return payload.model_dump()
+        return payload.model_dump(exclude_unset=exclude_unset)
     try:
-        return ContentOpsRequestModel.model_validate(payload).model_dump()
+        return ContentOpsRequestModel.model_validate(payload).model_dump(
+            exclude_unset=exclude_unset
+        )
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 

--- a/plans/PR-Content-Ops-Input-Provider-API-Wiring.md
+++ b/plans/PR-Content-Ops-Input-Provider-API-Wiring.md
@@ -1,0 +1,98 @@
+# PR: Content Ops Input Provider API Wiring
+
+## Why this slice exists
+
+PR #899 added the pure input-provider contract, but hosted preview, plan, and
+execute routes still use the raw request body directly. That means ingestion
+providers can build a normalized input package, but the API layer has no place
+to apply it before the existing control surface runs.
+
+This slice wires the configured input provider into the hosted API path without
+creating a new content layer. The provider only supplies the same
+`ContentOpsRequest.inputs` shape the existing preview/plan/execute code already
+understands.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/input-provider-api-wiring
+
+1. Add an optional `input_provider` argument to
+   `create_content_ops_control_surface_router`.
+2. Apply the provider package before `/preview`, `/plan`, and `/execute` run the
+   existing control surface.
+3. Resolve tenant scope once for execute and reuse it for provider handoff and
+   generation execution.
+4. Support both sync and async provider implementations.
+5. Keep request/operator inputs authoritative over provider defaults.
+6. Return a bounded `503` if the provider fails or returns an invalid package.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Input-Provider-API-Wiring.md` | Plan doc for this slice. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Wire optional input provider into preview/plan/execute. |
+| `tests/test_extracted_content_control_surface_api.py` | Route-level coverage for provider merge, sync/async providers, scope, and failure handling. |
+
+## Mechanism
+
+The router factory accepts `input_provider`. When configured, each request body
+is converted to a mapping, the tenant scope is resolved, and the provider's
+`build_content_ops_input_package(scope=..., request=...)` result is merged under
+the request via `merge_content_ops_input_package(...)`.
+
+The provider merge uses only explicitly supplied request fields. This matters
+because the API model expands omitted fields to defaults such as `outputs=[]`;
+those defaults must not erase provider-selected outputs.
+
+The merge happens before:
+
+- `preview_from_mapping(...)`;
+- `build_generation_plan_from_mapping(...)`;
+- structured reasoning selection and `execute_content_ops_from_mapping(...)`.
+
+This keeps the existing control surface, plan builder, and generators as the
+source of truth.
+
+## Intentional
+
+- No new public route. This only wires the existing hosted routes.
+- No FAQ implementation. FAQ remains owned by the existing FAQ generator lane.
+- No automatic provider discovery. Hosts configure the provider explicitly.
+- Provider failures are treated as service unavailability, not user validation
+  errors, because the provider is host-owned infrastructure.
+- Explicitly empty request values such as `outputs=[]` and `inputs={}` are
+  treated like omitted values by the existing request-normalization path; this
+  slice preserves that behavior so hosts use non-empty request fields when they
+  intend to override provider defaults.
+
+## Deferred
+
+- Future PR: `PR-Content-Ops-Ticket-Input-Package` can implement a concrete
+  provider that maps uploaded support-ticket imports into `source_material`,
+  landing-page context, and blog topic/filter inputs.
+- Future PR owned by the FAQ session: standalone FAQ article output contract.
+- Parked hardening: none.
+
+## Verification
+
+- `py_compile` for `extracted_content_pipeline/api/control_surfaces.py` and
+  `tests/test_extracted_content_control_surface_api.py` -> passed.
+- `pytest` for `tests/test_extracted_content_control_surface_api.py`,
+  `tests/test_extracted_content_ops_input_provider.py`,
+  `tests/test_extracted_content_control_surfaces.py`, and
+  `tests/test_extracted_content_generation_plan.py` -> 173 passed.
+- `scripts/validate_extracted_content_pipeline.sh` -> passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` for
+  `extracted_content_pipeline` -> passed.
+- `scripts/audit_extracted_standalone.py` with `--fail-on-debt` -> passed.
+- `scripts/check_ascii_python.sh` -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~100 |
+| API wiring | ~70 |
+| Tests | ~155 |
+| **Total** | **~325** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -9,6 +9,7 @@ from extracted_content_pipeline.api.control_surfaces import (
     create_content_ops_control_surface_router,
 )
 from extracted_content_pipeline.campaign_ports import CampaignReasoningContext
+from extracted_content_pipeline.content_ops_input_provider import ContentOpsInputPackage
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
 
 
@@ -66,6 +67,34 @@ class _CampaignService:
             "kwargs": dict(kwargs),
         })
         return {"generated": 1, "saved_ids": ["draft-1"]}
+
+
+class _SyncInputProvider:
+    def __init__(self, package: ContentOpsInputPackage):
+        self.package = package
+        self.calls = []
+
+    def build_content_ops_input_package(self, *, scope, request=None):
+        self.calls.append({"scope": scope, "request": dict(request or {})})
+        return self.package
+
+
+class _AsyncInputProvider(_SyncInputProvider):
+    async def build_content_ops_input_package(self, *, scope, request=None):
+        self.calls.append({"scope": scope, "request": dict(request or {})})
+        return self.package
+
+
+class _FailingInputProvider:
+    def build_content_ops_input_package(self, *, scope, request=None):
+        del scope, request
+        raise RuntimeError("postgres://user:secret@example/internal")
+
+
+class _HTTPFailingInputProvider:
+    def build_content_ops_input_package(self, *, scope, request=None):
+        del scope, request
+        raise api_module.HTTPException(status_code=400, detail="bad ticket payload")
 
 
 class _BlockingCampaignService(_CampaignService):
@@ -626,6 +655,99 @@ async def test_plan_generation_route_returns_execution_plan():
     assert payload["steps"][0]["runner"] == "CampaignGenerationService.generate"
     assert payload["steps"][0]["status"] == "runnable"
     assert payload["preview"]["can_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_applies_sync_input_provider():
+    provider = _SyncInputProvider(
+        ContentOpsInputPackage(
+            provider="ticket_upload",
+            outputs=("landing_page",),
+            inputs={
+                "audience": "10-50 person SaaS teams",
+                "offer": "Provider offer",
+            },
+        )
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=provider,
+        scope_provider=lambda: {"account_id": " acct-1 "},
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint({
+        "inputs": {
+            "offer": "Operator offer",
+        },
+    })
+
+    assert payload["can_run"] is True
+    assert payload["outputs"] == ["landing_page"]
+    assert payload["missing_inputs"] == []
+    assert provider.calls[0]["scope"].account_id == "acct-1"
+    assert provider.calls[0]["request"]["inputs"]["offer"] == "Operator offer"
+
+
+@pytest.mark.asyncio
+async def test_plan_generation_route_applies_async_input_provider():
+    provider = _AsyncInputProvider(
+        ContentOpsInputPackage(
+            provider="ticket_upload",
+            outputs=("faq_markdown",),
+            inputs={
+                "source_material": [{
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                    "text": "How do I export my dashboard?",
+                }],
+            },
+        )
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=provider,
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    payload = await route.endpoint({})
+
+    assert payload["can_execute"] is True
+    assert payload["steps"][0]["output"] == "faq_markdown"
+    assert payload["steps"][0]["runner"] == "TicketFAQMarkdownService.generate"
+    assert provider.calls[0]["scope"].account_id is None
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_wraps_input_provider_failure(caplog):
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=_FailingInputProvider(),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({"outputs": ["landing_page"]})
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Content Ops input provider is unavailable."
+    assert "postgres://" not in str(exc.value.detail)
+    assert "postgres://" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_passes_through_input_provider_http_exception():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=_HTTPFailingInputProvider(),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({"outputs": ["landing_page"]})
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "bad ticket payload"
 
 
 @pytest.mark.asyncio
@@ -1435,6 +1557,43 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["target_mode"] == "vendor_retention"
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_applies_input_provider_before_generation():
+    service = _CampaignService()
+    provider = _SyncInputProvider(
+        ContentOpsInputPackage(
+            provider="ticket_upload",
+            outputs=("email_campaign",),
+            inputs={
+                "target_account": "Provider account",
+                "offer": "Provider offer",
+                "filters": {"status": "provider"},
+            },
+        )
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(campaign=service),
+        input_provider=provider,
+        scope_provider=lambda: {"account_id": " acct-1 "},
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint({
+        "inputs": {
+            "offer": "Operator offer",
+            "filters": {"status": "operator"},
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert provider.calls[0]["scope"].account_id == "acct-1"
+    assert service.calls[0]["scope"].account_id == "acct-1"
+    assert service.calls[0]["filters"] == {"status": "operator"}
+    assert service.calls[0]["target_mode"] == "vendor_retention"
+    assert service.calls[0]["limit"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Input-Provider-API-Wiring.md

Wires the optional Content Ops input provider into the existing hosted preview, plan, and execute routes so upstream ingestion layers can supply normalized inputs before the current control surface runs.

## Intentional
- No new public route; this applies providers to existing preview/plan/execute routes.
- No FAQ implementation; FAQ remains owned by the FAQ generator lane.
- No automatic provider discovery; hosts configure the provider explicitly.
- Provider failures return bounded 503s because the provider is host-owned infrastructure.

## Deferred
- Future PR: PR-Content-Ops-Ticket-Input-Package can map uploaded support tickets into source_material, landing-page context, and blog topic/filter inputs.
- Future PR owned by FAQ session: standalone FAQ article output contract.

## Parked hardening
- None.

## Verification
- py_compile for extracted_content_pipeline/api/control_surfaces.py and tests/test_extracted_content_control_surface_api.py: passed.
- pytest tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py -q: 172 passed.
- bash scripts/validate_extracted_content_pipeline.sh: passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline: passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt: passed.
- bash scripts/check_ascii_python.sh: passed.
- bash scripts/local_pr_review.sh --allow-dirty: passed. Used --allow-dirty only because unrelated import-lane files and audit docs exist in the shared checkout.

## Diff size
3 files, +294 / -7