### PR TITLE
Plan: plans/PR-Blog-B2B-Complaint-Conflation.md

### DIFF
--- a/atlas-churn-ui/src/content/blog/top-complaint-every-b2b-software-2026-03.ts
+++ b/atlas-churn-ui/src/content/blog/top-complaint-every-b2b-software-2026-03.ts
@@ -74,13 +74,13 @@ const post: BlogPost = {
   "booking_url": "https://churnsignals.co"
 },
   seo_title: 'B2B Software Complaints 2026: Top Issues by Vendor',
-  seo_description: 'Analysis of 9,137 complaints across 54 B2B software vendors from 9,137 reviews. See each tool\'s #1 weakness based on reviewer data.',
+  seo_description: 'Analysis of 9,137 reviews across 54 B2B software vendors. See each tool\'s #1 weakness based on reviewer data.',
   target_keyword: 'b2b software complaints',
   secondary_keywords: ["salesforce complaints", "notion problems", "zendesk alternatives", "b2b software reviews"],
   faq: [
   {
     "question": "What is the most common complaint about B2B software in 2026?",
-    "answer": "Based on 9,137 complaints across 9,137 reviews, pricing concerns dominate the complaint landscape, with 114.4 mentions and stable high volume. Feature gaps are accelerating (+50% recent vs. prior period), while support quality shows an 86% decline in recent mentions."
+    "answer": "Based on 9,137 reviews, pricing concerns dominate the complaint landscape, with 114.4 mentions and stable high volume. Feature gaps are accelerating (+50% recent vs. prior period), while support quality shows an 86% decline in recent mentions."
   },
   {
     "question": "Which B2B software vendors have the highest complaint urgency?",
@@ -97,12 +97,12 @@ const post: BlogPost = {
 ],
   related_slugs: ["b2b-software-landscape-2026-03", "notion-vs-salesforce-2026-03", "jira-vs-trello-2026-03"],
   content: `<p><em>Methodology note: This analysis reflects self-selected feedback from Public B2B software review platforms collected between 2026-02-25 to 2026-03-29. It captures reviewer perception, not a census of all users.</em></p>
-<p>Every B2B software tool has flaws. This analysis examines 9,137 complaints across 54 vendors, drawn from 9,137 enriched reviews collected between February 25 and March 29, 2026. The data comes from public review platforms including G2, Capterra, TrustRadius, Reddit, and Trustpilot—7,985 verified reviews and 18,350 community-sourced reviews.</p>
+<p>Every B2B software tool has flaws. This analysis examines complaints across 54 vendors, drawn from 9,137 enriched reviews collected between February 25 and March 29, 2026. The data comes from public review platforms including G2, Capterra, TrustRadius, Reddit, and Trustpilot.</p>
 <p>The goal is simple: show you each vendor's biggest weakness based on what reviewers actually say, not marketing claims. No vendor gets a pass. If a tool's top complaint is pricing, we say so. If it's feature gaps, we say so. If reviewers report support erosion, we say so.</p>
 <p>This is not a hit piece on any single vendor. It is a comparative analysis that acknowledges the reality every software buyer faces: <strong>there is no perfect tool.</strong> The question is which set of trade-offs fits your situation.</p>
 <p>Sample size context: 9,137 reviews is a high-confidence dataset. The patterns described here reflect consistent themes across thousands of reviewer experiences, not isolated anecdotes. Where complaint volumes are lower (under 100 reviews for a specific vendor), we note it explicitly.</p>
 <h2 id="the-landscape-at-a-glance">The Landscape at a Glance</h2>
-<p>The B2B software category shows a stable market regime with 54 vendors analyzed. Total complaint volume: 9,137. Average urgency across all complaints: 1.9/10. This low urgency average reflects that most complaints describe frustrations rather than blocking issues—but the distribution varies significantly by vendor.</p>
+<p>The B2B software category shows a stable market regime with 54 vendors analyzed across 9,137 reviews. Average urgency across all complaints: 1.9/10. This low urgency average reflects that most complaints describe frustrations rather than blocking issues—but the distribution varies significantly by vendor.</p>
 <p>{{chart:vendor-urgency}}</p>
 <p>Pricing concerns dominate the category with 114.4 total mentions and stable high volume (6 recent mentions in the current window). Feature gaps are accelerating: 3 recent mentions versus 2 in the prior period, a 50% increase. Support quality shows an 86% decline in recent mentions (1 recent versus 7 prior), removing what was once a key retention lever for many vendors.</p>
 <p>The synthesis assessment labels this pattern a <strong>price squeeze</strong>: pricing dissatisfaction remains high while support quality erodes, and feature gaps accelerate. The causal trigger: "Pricing complaints accelerated in recent window, with 6 recent mentions against a declining support baseline (1 recent vs. 7 prior), while feature gaps (3 recent, accelerating from 2 prior) compound buyer frustration."</p>
@@ -184,7 +184,7 @@ const post: BlogPost = {
 <p><strong>The bottom line:</strong> Every B2B software tool has a #1 complaint. The vendors that succeed are not the ones without flaws—they are the ones whose flaws matter least to their target buyers. Use this analysis to identify which trade-offs fit your situation, then evaluate accordingly.</p>
 <p>For a broader view of how these vendors compare across the category, see the <a href="/blog/b2b-software-landscape-2026-03">B2B Software Landscape 2026</a>, which examines 17 vendors across 9,137 reviews.</p>
 <h2 id="methodology-note">Methodology Note</h2>
-<p>This analysis draws on 9,137 enriched reviews from G2, Capterra, TrustRadius, PeerSpot, Gartner Peer Insights, Software Advice, Trustpilot, and Reddit, collected between February 25 and March 29, 2026. The dataset includes 7,985 verified reviews from structured review platforms and 18,350 community-sourced reviews from Reddit and other forums.</p>
+<p>This analysis draws on 9,137 enriched reviews from G2, Capterra, TrustRadius, PeerSpot, Gartner Peer Insights, Software Advice, Trustpilot, and Reddit, collected between February 25 and March 29, 2026.</p>
 <p>Reviews are a self-selected sample that overrepresents strong opinions. The patterns described here reflect reviewer sentiment, not universal product truth. Where sample sizes are smaller (under 100 reviews for a specific vendor), we note it explicitly. Urgency scores measure the intensity of reviewer frustration, not the objective severity of issues.</p>
 <p>The "other" complaint category encompasses issues that do not fit neatly into pricing, features, support, or UX buckets. This includes workflow friction, integration quirks, administrative overhead, and edge-case limitations. The breadth of "other" complaints varies by vendor complexity—platforms like Azure and Salesforce show more diverse "other" complaints than single-purpose tools like Close.</p>
 <p>For questions about methodology or data sources, see the full <a href="/blog/b2b-software-landscape-2026-03">B2B Software Landscape 2026</a> report.</p>`,

--- a/plans/PR-Blog-B2B-Complaint-Conflation.md
+++ b/plans/PR-Blog-B2B-Complaint-Conflation.md
@@ -1,0 +1,70 @@
+# PR-Blog-B2B-Complaint-Conflation
+
+Ownership lane: `content-ops/blog-b2b-complaint-conflation`
+
+## Why this slice exists
+
+Pre-launch correctness patch. `top-complaint-every-b2b-software-2026-03` presented
+**9,137 as both the complaint count AND the review count** ("9,137 complaints across
+9,137 reviews", "Total complaint volume: 9,137") — an artifact of the #859 stale-count
+fix collapsing the old distinct "11,399 complaints / 26,335 reviews" both to 9,137. It
+also still carried the stale "7,985 verified + 18,350 community-sourced reviews"
+breakdown (= 26,335), contradicting the corrected 9,137 figure.
+
+## Scope (this PR)
+
+Make the post numerically coherent: 9,137 means **reviews** consistently (the figure
+#859 established and DB-grounded), drop the duplicated "complaints" count, and remove the
+stale 26,335 verified/community breakdown. **No new numbers invented.**
+
+5 lines changed in `top-complaint-every-b2b-software-2026-03.ts`:
+- seo_description: "9,137 complaints across 54 vendors from 9,137 reviews" → "9,137 reviews across 54 vendors"
+- FAQ answer: "Based on 9,137 complaints across 9,137 reviews" → "Based on 9,137 reviews"
+- content intro: "examines 9,137 complaints across 54 vendors" → "examines complaints across 54 vendors"; dropped "—7,985 verified reviews and 18,350 community-sourced reviews"
+- landscape-at-a-glance: "Total complaint volume: 9,137." → "54 vendors analyzed across 9,137 reviews."
+- methodology footer: dropped "The dataset includes 7,985 verified reviews … and 18,350 community-sourced reviews."
+
+### Files touched
+
+- `plans/PR-Blog-B2B-Complaint-Conflation.md`
+- `atlas-churn-ui/src/content/blog/top-complaint-every-b2b-software-2026-03.ts`
+
+## Mechanism
+
+Exact-match substring replacements (assert 1 match each), substrings chosen to avoid the
+apostrophe in "tool's". Verified after: zero remaining "9,137 complaints"/"complaints
+across 9,137", zero "Total complaint volume", zero 7,985/18,350/26,335; all 8 surviving
+9,137 mentions are review-context.
+
+## Intentional
+
+- **9,137 kept as the single, accurate figure** (reviews) rather than inventing a distinct
+  complaint count — the generator's model is total_complaints = enriched_reviews, so a
+  separate complaint count was always redundant/misleading here. Qualitative complaint
+  analysis (pricing dominates, urgency, etc.) is unchanged.
+- **Stale 26,335 breakdown removed, not relabeled** — it contradicts 9,137 and no verified
+  verified/community split for the corrected scope is available (same "drop the unfounded
+  number" discipline used on the Copper 928 fix).
+- **D6 (#802) NOT included** — that item is already MERGED (zoho G2→Slashdot attribution);
+  the earlier "D6 open" flag was stale memory.
+
+## Deferred
+
+- The post's methodology still lists some non-allowlist sources (Capterra/TrustRadius/
+  Trustpilot) — a separate parked item (methodology-declares-non-allowlist-sources), out
+  of scope here.
+
+Parked hardening: none new.
+
+## Verification
+
+- 5 edits applied via assert-exact-match; `git diff` = 1 file, 5 lines; grep confirms no
+  conflation, no stale breakdown, no "Total complaint volume" line remain.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| 1 post file | ~10 |
+| Plan doc | ~55 |
+| **Total** | **~65** |


### PR DESCRIPTION
## Intentional

Pre-launch correctness patch. `top-complaint-every-b2b-software-2026-03` presented **9,137
as both the complaint count AND the review count** ("9,137 complaints across 9,137 reviews",
"Total complaint volume: 9,137") — an artifact of the #859 stale-count fix collapsing the
old distinct "11,399 complaints / 26,335 reviews" both to 9,137. It also still carried the
stale "7,985 verified + 18,350 community" breakdown (= 26,335), contradicting 9,137.

Fix — 9,137 means **reviews** consistently; dropped the duplicated complaint count and the
stale 26,335 breakdown. **No new numbers invented.** 5 lines changed:

| Where | Before → After |
|---|---|
| seo_description | "9,137 complaints across … from 9,137 reviews" → "9,137 reviews across 54 vendors" |
| FAQ answer | "Based on 9,137 complaints across 9,137 reviews" → "Based on 9,137 reviews" |
| content intro | "examines 9,137 complaints across 54 vendors" → "examines complaints across 54 vendors"; dropped "—7,985 verified … 18,350 community" |
| at-a-glance | "Total complaint volume: 9,137." → "54 vendors analyzed across 9,137 reviews." |
| methodology | dropped "The dataset includes 7,985 verified … and 18,350 community-sourced reviews." |

Qualitative complaint analysis (pricing dominates, urgency, etc.) unchanged. Stale 26,335
breakdown removed, not relabeled (no verified split available — same discipline as the
Copper-928 fix).

**D6 (#802) is NOT in this PR — it's already MERGED** (zoho G2→Slashdot attribution); the
earlier "D6 open" note was stale.

## Verification

- 5 exact-match edits; grep confirms zero "9,137 complaints"/"complaints across 9,137",
  zero "Total complaint volume", zero 7,985/18,350/26,335; all surviving 9,137 mentions are
  review-context. Pre-push gates PASS.

## Diff size

| Area | LOC |
|---|---:|
| 1 post file | ~10 |
| Plan doc | ~55 |
| **Total** | **~65** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)