### PR TITLE
PR-Atlas-Workflow-Phase-Contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Required sections, in this order:
 | Section | Purpose |
 |---|---|
 | **Why this slice exists** | What's broken / what's missing / what audit item this closes. Tie to a prior plan, audit finding, or a concrete user request. |
-| **Scope (this PR)** | The narrow surface this PR touches. Start with `Slice phase: <phase>.` Numbered list of intent. List of files in a "Files touched" subsection. |
+| **Scope (this PR)** | The narrow surface this PR touches. Start with an `Ownership lane: <lane>` line, then a `Slice phase: <phase>` line, then a numbered list of intent and a "Files touched" subsection. |
 | **Mechanism** | Short prose (and code stub if helpful) explaining *how* the change works -- enough that the reviewer doesn't have to reverse-engineer it from the diff. |
 | **Intentional** | Things that look wrong but aren't -- explicit trade-offs and rejected alternatives ("no `warnings.warn` shim because ..."). Saves reviewer cycles. |
 | **Deferred** | Things explicitly punted to a follow-up slice. Each item should name the future PR or describe what would unlock it. Include "Parked hardening: none" or list the `HARDENING.md` entries added by this slice. |
@@ -372,8 +372,9 @@ Before LGTM, the reviewer confirms:
 
 - [ ] CI green (extracted-checks ✅, Vercel ✅).
 - [ ] Plan doc has all 7 required sections.
-- [ ] Plan, PR body, and commit message name a `Slice phase`, and the
-      diff matches that phase.
+- [ ] Plan and PR body name a `Slice phase`, and the diff matches that
+      phase. The squash commit message carries the phase from the PR body
+      at merge.
 - [ ] Diff size matches the plan's estimate (or the overage is
       justified in **Why**).
 - [ ] No regressions in the named test sweep.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Required sections, in this order:
 | Section | Purpose |
 |---|---|
 | **Why this slice exists** | What's broken / what's missing / what audit item this closes. Tie to a prior plan, audit finding, or a concrete user request. |
-| **Scope (this PR)** | The narrow surface this PR touches. Numbered list of intent. List of files in a "Files touched" subsection. |
+| **Scope (this PR)** | The narrow surface this PR touches. Start with `Slice phase: <phase>.` Numbered list of intent. List of files in a "Files touched" subsection. |
 | **Mechanism** | Short prose (and code stub if helpful) explaining *how* the change works -- enough that the reviewer doesn't have to reverse-engineer it from the diff. |
 | **Intentional** | Things that look wrong but aren't -- explicit trade-offs and rejected alternatives ("no `warnings.warn` shim because ..."). Saves reviewer cycles. |
 | **Deferred** | Things explicitly punted to a follow-up slice. Each item should name the future PR or describe what would unlock it. Include "Parked hardening: none" or list the `HARDENING.md` entries added by this slice. |
@@ -39,6 +39,7 @@ Mirror the plan-doc framing in the PR description:
 
 ```
 Plan: plans/PR-<Slice-Name>.md
+Slice phase: <phase>
 
 <one-paragraph why>
 
@@ -60,9 +61,9 @@ N files, +X / -Y
 
 ### 1c. Commit message
 
-Same `Plan: ...` lead line + Intentional / Deferred / Parked
-hardening sections as the PR body. Squash-merge collapses to one
-canonical commit at merge time.
+Same `Plan: ...` and `Slice phase: ...` lead lines + Intentional /
+Deferred / Parked hardening sections as the PR body. Squash-merge
+collapses to one canonical commit at merge time.
 
 ### 1d. Diff budget
 
@@ -108,7 +109,8 @@ The reviewer should produce something like:
 
 **Plan-doc compliance:** Why / Scope / Mechanism / Files touched /
 Intentional / Deferred / Verification -- matches AGENTS.md framework.
-Parked hardening is named in Deferred or explicitly marked none.
+Slice phase is named and matches the PR's scope. Parked hardening is
+named in Deferred or explicitly marked none.
 
 **Defensible trade-offs (no action needed):**
 - <decision> -- <why it's the right call>
@@ -197,9 +199,28 @@ as the final enforcement layer, not the first reviewer.
 
 ### 3d. Thin-slice and hardening triage
 
-Build the thinnest end-to-end version that exercises the real flow. A
-slice is done only when the builder demonstrates the behavior with a
-concrete test, script, artifact, or command output.
+Every plan names a slice phase in `Scope (this PR)`, and the PR body
+and commit message repeat it. Use these standard phases:
+
+| Phase | Use when |
+|---|---|
+| `Vertical slice` | Building the thinnest end-to-end product path that proves the real flow. |
+| `Functional validation` | Proving the finished flow works on representative inputs and outputs. |
+| `Robust testing` | Pushing scale, concurrency, failure, and integration edges after the flow works. |
+| `Production hardening` | Closing survivability, observability, security, durability, and operational gaps found during validation or robust testing. |
+| `Product polish` | Improving UX, copy, defaults, and ergonomics after the core behavior is proven. |
+| `Workflow/process` | Changing repo workflow, review contracts, audits, or developer tooling rather than product behavior. |
+
+The normal product order is `Vertical slice` -> `Functional validation`
+-> `Robust testing` -> `Production hardening` -> `Product polish`.
+Small corrections can happen out of order, but the plan must name why
+the phase is appropriate now. If implementation changes the phase,
+update the plan and PR body before review.
+
+For a `Vertical slice`, build the thinnest end-to-end version that
+exercises the real flow. A slice is done only when the builder
+demonstrates the behavior with a concrete test, script, artifact, or
+command output.
 
 Only fix inline what the slice cannot function without. Required
 inline fixes include:
@@ -227,7 +248,9 @@ include what shipped, how it was demonstrated, and what was parked in
 
 At the start of each slice, scan `HARDENING.md` for entries touching
 the same ownership lane or files. Fix only entries that are required for
-the slice to function; otherwise leave them parked and mention the
+the slice to function. For `Robust testing` and `Production hardening`
+phases, promote relevant parked entries into the PR scope when they are
+the reason the slice exists. Otherwise leave them parked and mention the
 reason in `Deferred` if they were considered. Periodically drain or
 promote stale entries into the debt register so `HARDENING.md` remains a
 working queue, not an archive.
@@ -349,6 +372,8 @@ Before LGTM, the reviewer confirms:
 
 - [ ] CI green (extracted-checks ✅, Vercel ✅).
 - [ ] Plan doc has all 7 required sections.
+- [ ] Plan, PR body, and commit message name a `Slice phase`, and the
+      diff matches that phase.
 - [ ] Diff size matches the plan's estimate (or the overage is
       justified in **Why**).
 - [ ] No regressions in the named test sweep.

--- a/plans/PR-Atlas-Workflow-Phase-Contract.md
+++ b/plans/PR-Atlas-Workflow-Phase-Contract.md
@@ -34,10 +34,14 @@ Slice phase: Workflow/process.
 ## Mechanism
 
 `AGENTS.md` gains a lightweight phase label instead of a new required
-section, preserving the seven-section plan shape while making phase
-visible in the highest-signal places:
+section. The existing `Ownership lane` line stays first, then the phase
+line follows it, preserving the seven-section plan shape while making
+phase visible in the highest-signal places:
 
 ```md
+Ownership lane: content-ops/faq-generator
+Slice phase: Vertical slice
+
 Plan: plans/PR-<Slice-Name>.md
 Slice phase: <Vertical slice | Functional validation | Robust testing |
 Production hardening | Product polish | Workflow/process>
@@ -72,6 +76,6 @@ LGTM gate.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~70 |
-| AGENTS workflow contract | ~43 |
-| **Total** | ~113 |
+| Plan doc | ~75 |
+| AGENTS workflow contract | ~45 |
+| **Total** | ~120 |

--- a/plans/PR-Atlas-Workflow-Phase-Contract.md
+++ b/plans/PR-Atlas-Workflow-Phase-Contract.md
@@ -1,0 +1,77 @@
+# PR-Atlas-Workflow-Phase-Contract
+
+## Why this slice exists
+
+The Atlas workflow already requires thin end-to-end slices and parks
+non-blocking hardening work in `HARDENING.md`, but it does not require
+each PR to name where it sits in the feature lifecycle. That leaves
+parallel sessions deciding "by ear" whether a PR is feature work,
+validation, robust testing, hardening, or polish, which makes scope drift
+and cross-session collisions harder to catch before review.
+
+This slice makes the lifecycle explicit in the PR contract so builders,
+reviewers, and operators can tell what kind of work a PR is doing before
+reading the diff.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow
+
+Slice phase: Workflow/process.
+
+1. Require every plan doc, PR body, and commit message to name the slice
+   phase.
+2. Define the standard phase names and their intended order.
+3. Extend thin-slice triage so robust-testing and production-hardening
+   slices intentionally pull required parked work forward.
+4. Extend reviewer checks so the verdict confirms phase/scope alignment.
+
+### Files touched
+
+- `AGENTS.md`
+- `plans/PR-Atlas-Workflow-Phase-Contract.md`
+
+## Mechanism
+
+`AGENTS.md` gains a lightweight phase label instead of a new required
+section, preserving the seven-section plan shape while making phase
+visible in the highest-signal places:
+
+```md
+Plan: plans/PR-<Slice-Name>.md
+Slice phase: <Vertical slice | Functional validation | Robust testing |
+Production hardening | Product polish | Workflow/process>
+```
+
+The builder workflow explains the lifecycle order and how the phase
+affects triage. Reviewer checklist updates make the phase part of the
+LGTM gate.
+
+## Intentional
+
+- No mechanical audit script update in this slice. The contract change is
+  useful immediately, and automated enforcement can land separately after
+  reviewers have used the wording once.
+- The existing seven required plan sections stay unchanged. A phase line is
+  less disruptive than introducing an eighth required heading across all
+  plan-shape checks.
+- `Workflow/process` is included so repo-contract changes like this one do
+  not have to pretend they are product validation or production hardening.
+
+## Deferred
+
+- Future PR: add `scripts/local_pr_review.sh` enforcement that the plan doc
+  and PR body include a recognized `Slice phase:` value.
+- Parked hardening: none.
+
+## Verification
+
+- `bash scripts/local_pr_review.sh --allow-dirty`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| AGENTS workflow contract | ~43 |
+| **Total** | ~113 |


### PR DESCRIPTION
Plan: plans/PR-Atlas-Workflow-Phase-Contract.md
Slice phase: Workflow/process

This slice makes the repo-wide feature lifecycle explicit in the PR contract: each plan, PR body, and commit message names whether the work is a vertical slice, functional validation, robust testing, production hardening, product polish, or workflow/process change. That gives parallel sessions and reviewers a simple scope check before reading the diff.

## Intentional
- Keep the existing seven-section plan shape and add phase as a required line instead of a new heading.
- Defer mechanical enforcement until the wording has landed and reviewers can use it once.
- Include Workflow/process so repo-contract changes do not have to pretend they are product hardening.

## Deferred
- Future PR can teach local_pr_review to enforce recognized Slice phase values.

## Parked hardening
- None.

## Verification
- bash scripts/local_pr_review.sh --allow-dirty
- Pre-push hook reran local_pr_review on push and passed.

## Diff size
2 files, +111 / -9