### PR TITLE
PR-Atlas-Slice-Phase-Audit

### DIFF
--- a/plans/PR-Atlas-Slice-Phase-Audit.md
+++ b/plans/PR-Atlas-Slice-Phase-Audit.md
@@ -1,0 +1,87 @@
+# PR-Atlas-Slice-Phase-Audit
+
+## Why this slice exists
+
+PR-Atlas-Workflow-Phase-Contract made `Slice phase` part of the Atlas
+PR contract, but enforcement is still manual. That leaves builders and
+reviewers dependent on memory exactly where the contract is supposed to
+reduce cross-session drift.
+
+This slice closes the deferred follow-up by teaching the existing
+cross-session PR audit to validate phase metadata for new plan docs and
+the current PR body.
+
+The diff is over the 400 LOC soft cap because the audit change needs
+fixture coverage for plan parsing, current-PR body parsing, mismatch
+handling, other-PR advisory behavior, real-form normalization, existing
+ownership-lane behavior, and the code-block false-positive that surfaced
+in #904.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow
+
+Slice phase: Workflow/process.
+
+1. Validate that newly added PR plan files contain a recognized
+   `Slice phase` in `Scope (this PR)`.
+2. Validate the current PR body, when one exists, contains a recognized
+   `Slice phase` matching the branch plan.
+3. Keep other open PR body phase issues as warnings so legacy/open PRs do
+   not block unrelated branches.
+4. Add fixture tests for missing, invalid, mismatched, and valid phase
+   metadata, plus the existing whole-doc ownership-lane behavior.
+
+### Files touched
+
+- `scripts/audit_pr_session_drift.py`
+- `tests/test_audit_pr_session_drift.py`
+- `plans/PR-Atlas-Slice-Phase-Audit.md`
+
+## Mechanism
+
+The existing drift audit already:
+
+- collects new plan docs,
+- extracts ownership metadata,
+- reads open PR bodies through `gh`, and
+- runs inside `scripts/local_pr_review.sh`.
+
+This slice extends that flow with `Slice phase` parsing. Plan-doc
+metadata is extracted only from the Scope section so illustrative examples
+elsewhere in the plan cannot trigger false failures. Current PR body
+metadata is blocking because it is the branch under review; other open PR
+body phase problems are warnings to avoid blocking a new branch on older
+PRs that predate this contract.
+
+## Intentional
+
+- No new audit script. Reusing the existing drift audit avoids another
+  local-review step and keeps PR metadata checks together.
+- No hard failure for other open PR bodies that are missing phase metadata.
+  That would make a builder responsible for legacy PRs outside the slice.
+- Existing ownership-lane parsing stays whole-document in this slice. Moving
+  the lane parser to Scope-only would be a separate migration, not part of
+  phase enforcement.
+- No structured front-matter migration in this slice. The current contract
+  is line-based; the richer metadata block remains a future option.
+
+## Deferred
+
+- Future PR: consider replacing first-line Scope metadata with a structured
+  metadata block if more labels are added.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_audit_pr_session_drift.py -q` - 22 passed.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Audit script | ~130 |
+| Tests | ~260 |
+| Plan doc | ~84 |
+| **Total** | ~474 |

--- a/scripts/audit_pr_session_drift.py
+++ b/scripts/audit_pr_session_drift.py
@@ -16,6 +16,21 @@ from typing import Any, Iterable, Sequence
 
 LANE_RE = re.compile(r"^\s*Ownership lane:\s*`?([^`\n]+?)`?\s*$", re.IGNORECASE | re.MULTILINE)
 LANE_VALUE_RE = re.compile(r"^[a-z0-9][a-z0-9._/-]*[a-z0-9]$")
+SLICE_PHASE_RE = re.compile(r"^\s*Slice phase:\s*`?([^`\n]+?)`?\s*$", re.IGNORECASE | re.MULTILINE)
+SCOPE_SECTION_RE = re.compile(
+    r"^##\s+Scope(?:\s+\(this PR\))?\s*$\n?(.*?)(?=^##\s+|\Z)",
+    re.IGNORECASE | re.MULTILINE | re.DOTALL,
+)
+VALID_SLICE_PHASES = frozenset(
+    {
+        "vertical slice",
+        "functional validation",
+        "robust testing",
+        "production hardening",
+        "product polish",
+        "workflow/process",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -27,6 +42,8 @@ class OpenPullRequest:
     url: str
     files: frozenset[str]
     ownership_lanes: frozenset[str]
+    slice_phases: frozenset[str]
+    slice_phase_errors: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -36,11 +53,14 @@ class DriftReport:
     base_overlap: frozenset[str]
     open_pr_overlaps: tuple[tuple[OpenPullRequest, frozenset[str]], ...]
     branch_ownership_lanes: frozenset[str]
+    branch_slice_phases: frozenset[str]
     open_pr_lane_overlaps: tuple[tuple[OpenPullRequest, frozenset[str]], ...]
     github_status: str
     github_warnings: tuple[str, ...]
     path_errors: tuple[str, ...]
     ownership_errors: tuple[str, ...]
+    phase_errors: tuple[str, ...]
+    current_pr_phase_errors: tuple[str, ...]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -70,6 +90,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if (
         report.path_errors
         or report.ownership_errors
+        or report.phase_errors
+        or report.current_pr_phase_errors
         or report.base_overlap
         or report.open_pr_lane_overlaps
     ):
@@ -82,7 +104,9 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
     base = git_stdout(["merge-base", "HEAD", base_ref])
     branch_files = changed_files([base, "HEAD"], triple_dot=True)
     base_files = changed_files([base, base_ref], triple_dot=False)
-    branch_ownership_lanes, ownership_errors = branch_ownership(added_plan_docs(base))
+    plan_docs = added_plan_docs(base)
+    branch_ownership_lanes, ownership_errors = branch_ownership(plan_docs)
+    branch_slice_phases, phase_errors = collect_branch_slice_phases(plan_docs)
 
     path_errors: list[str] = []
     path_errors.extend(validate_paths(branch_files, "branch diff"))
@@ -91,6 +115,7 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
     base_overlap = frozenset(branch_files & base_files)
     open_pr_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
     open_pr_lane_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
+    current_pr_phase_errors: list[str] = []
     github_status = "skipped (--skip-github)"
     github_warnings: list[str] = []
 
@@ -100,7 +125,21 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
         current_branch = current_head_ref()
         current_oid = current_head_oid()
         for pr in prs:
-            if pr.head_ref == current_branch or (pr.head_oid and pr.head_oid == current_oid):
+            is_current_pr = pr.head_ref == current_branch or (pr.head_oid and pr.head_oid == current_oid)
+            if is_current_pr:
+                current_pr_phase_errors.extend(pr.slice_phase_errors)
+                if branch_slice_phases and not pr.slice_phases:
+                    current_pr_phase_errors.append("current PR body: missing Slice phase")
+                elif (
+                    branch_slice_phases
+                    and pr.slice_phases
+                    and branch_slice_phases.isdisjoint(pr.slice_phases)
+                ):
+                    current_pr_phase_errors.append(
+                        "current PR body Slice phase "
+                        f"{format_values(pr.slice_phases)} does not match branch plan phase(s) "
+                        f"{format_values(branch_slice_phases)}"
+                    )
                 continue
             overlap = frozenset(branch_files & pr.files)
             if overlap:
@@ -115,11 +154,14 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
         base_overlap=base_overlap,
         open_pr_overlaps=tuple(open_pr_overlaps),
         branch_ownership_lanes=branch_ownership_lanes,
+        branch_slice_phases=branch_slice_phases,
         open_pr_lane_overlaps=tuple(open_pr_lane_overlaps),
         github_status=github_status,
         github_warnings=tuple(github_warnings),
         path_errors=tuple(path_errors),
         ownership_errors=tuple(ownership_errors),
+        phase_errors=tuple(phase_errors),
+        current_pr_phase_errors=tuple(current_pr_phase_errors),
     )
 
 
@@ -172,6 +214,25 @@ def branch_ownership(plan_docs: set[str]) -> tuple[frozenset[str], tuple[str, ..
     return frozenset(lanes), tuple(errors)
 
 
+def collect_branch_slice_phases(plan_docs: set[str]) -> tuple[frozenset[str], tuple[str, ...]]:
+    phases: set[str] = set()
+    errors: list[str] = []
+    if not plan_docs:
+        return frozenset(), tuple()
+
+    for plan_doc in plan_docs:
+        text = git_stdout(["show", f"HEAD:{plan_doc}"])
+        doc_phases, doc_errors = extract_plan_slice_phases(text, source=plan_doc)
+        phases.update(doc_phases)
+        errors.extend(doc_errors)
+        if not doc_phases and not doc_errors:
+            errors.append(f"{plan_doc}: missing Slice phase")
+
+    if not phases and plan_docs:
+        errors.append("changed PR plan docs must declare a Slice phase")
+    return frozenset(phases), tuple(errors)
+
+
 def extract_ownership_lanes(text: str, *, source: str) -> tuple[frozenset[str], tuple[str, ...]]:
     lanes: set[str] = set()
     errors: list[str] = []
@@ -185,6 +246,34 @@ def extract_ownership_lanes(text: str, *, source: str) -> tuple[frozenset[str], 
             continue
         lanes.add(lane)
     return frozenset(lanes), tuple(errors)
+
+
+def extract_plan_slice_phases(text: str, *, source: str) -> tuple[frozenset[str], tuple[str, ...]]:
+    return extract_slice_phases(scope_section(text), source=source)
+
+
+def extract_slice_phases(text: str, *, source: str) -> tuple[frozenset[str], tuple[str, ...]]:
+    phases: set[str] = set()
+    errors: list[str] = []
+    for raw_phase in SLICE_PHASE_RE.findall(text):
+        phase = normalize_slice_phase(raw_phase)
+        if phase not in VALID_SLICE_PHASES:
+            errors.append(
+                f"{source}: invalid Slice phase {raw_phase!r}; "
+                f"use one of: {', '.join(sorted(VALID_SLICE_PHASES))}"
+            )
+            continue
+        phases.add(phase)
+    return frozenset(phases), tuple(errors)
+
+
+def normalize_slice_phase(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().rstrip(".").lower())
+
+
+def scope_section(text: str) -> str:
+    match = SCOPE_SECTION_RE.search(text)
+    return match.group(1) if match else ""
 
 
 def load_open_pull_requests(base_ref: str) -> tuple[str, tuple[OpenPullRequest, ...], tuple[str, ...]]:
@@ -236,7 +325,14 @@ def load_open_pull_requests(base_ref: str) -> tuple[str, tuple[OpenPullRequest, 
 
 
 def load_open_pull_request_files(number: int, row: dict[str, Any]) -> tuple[OpenPullRequest, tuple[str, ...]]:
-    fallback = open_pr_from_row(number, row, files=frozenset(), ownership_lanes=frozenset())
+    fallback = open_pr_from_row(
+        number,
+        row,
+        files=frozenset(),
+        ownership_lanes=frozenset(),
+        slice_phases=frozenset(),
+        slice_phase_errors=(),
+    )
     result = subprocess.run(
         ["gh", "pr", "view", str(number), "--json", "files,body"],
         check=False,
@@ -259,12 +355,15 @@ def load_open_pull_request_files(number: int, row: dict[str, Any]) -> tuple[Open
     }
     body = str(payload.get("body", "") or "")
     lanes, lane_errors = extract_ownership_lanes(body, source=f"PR #{number} body")
-    warnings = tuple(lane_errors)
+    phases, phase_errors = extract_slice_phases(body, source=f"PR #{number} body")
+    warnings = tuple(lane_errors + phase_errors)
     return open_pr_from_row(
         number,
         row,
         files=frozenset(path for path in files if path),
         ownership_lanes=lanes if not lane_errors else frozenset(),
+        slice_phases=phases if not phase_errors else frozenset(),
+        slice_phase_errors=phase_errors,
     ), warnings
 
 
@@ -274,6 +373,8 @@ def open_pr_from_row(
     *,
     files: frozenset[str],
     ownership_lanes: frozenset[str],
+    slice_phases: frozenset[str],
+    slice_phase_errors: tuple[str, ...],
 ) -> OpenPullRequest:
     return OpenPullRequest(
         number=number,
@@ -283,6 +384,8 @@ def open_pr_from_row(
         url=str(row.get("url", "")).strip(),
         files=files,
         ownership_lanes=ownership_lanes,
+        slice_phases=slice_phases,
+        slice_phase_errors=slice_phase_errors,
     )
 
 
@@ -308,6 +411,7 @@ def render_report(base_ref: str, report: DriftReport) -> None:
     print(f"branch changed files: {len(report.branch_files)}")
     print(f"base changed files since branch point: {len(report.base_files)}")
     print(f"branch ownership lanes: {', '.join(sorted(report.branch_ownership_lanes)) or 'none'}")
+    print(f"branch slice phases: {', '.join(sorted(report.branch_slice_phases)) or 'none'}")
     print(f"GitHub open PR check: {report.github_status}")
     if report.github_warnings:
         print()
@@ -325,6 +429,18 @@ def render_report(base_ref: str, report: DriftReport) -> None:
         print()
         print("DRIFT: ownership lane contract failed")
         for error in report.ownership_errors:
+            print(f"- {error}")
+
+    if report.phase_errors:
+        print()
+        print("DRIFT: slice phase contract failed")
+        for error in report.phase_errors:
+            print(f"- {error}")
+
+    if report.current_pr_phase_errors:
+        print()
+        print("DRIFT: current PR body slice phase contract failed")
+        for error in report.current_pr_phase_errors:
             print(f"- {error}")
 
     if report.base_overlap:
@@ -362,10 +478,16 @@ def render_report(base_ref: str, report: DriftReport) -> None:
     if (
         not report.path_errors
         and not report.ownership_errors
+        and not report.phase_errors
+        and not report.current_pr_phase_errors
         and not report.base_overlap
         and not report.open_pr_lane_overlaps
     ):
         print("OK: no blocking drift detected")
+
+
+def format_values(values: Iterable[str]) -> str:
+    return ", ".join(sorted(values)) or "none"
 
 
 def current_head_ref() -> str:

--- a/tests/test_audit_pr_session_drift.py
+++ b/tests/test_audit_pr_session_drift.py
@@ -83,6 +83,153 @@ def test_cli_ignores_open_pr_for_current_branch(tmp_path: Path) -> None:
     assert "OK: no blocking drift detected" in result.stdout
 
 
+def test_cli_fails_when_current_pr_body_missing_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 20,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/20",
+            }
+        ],
+        files={20: [path]},
+        bodies={20: "Plan: plans/PR-Current.md\n\nOwnership lane: atlas-workflow\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 1
+    assert "current PR body slice phase contract failed" in result.stdout
+    assert "current PR body: missing Slice phase" in result.stdout
+
+
+def test_cli_fails_when_current_pr_body_slice_phase_is_invalid(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 21,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/21",
+            }
+        ],
+        files={21: [path]},
+        bodies={21: "Plan: plans/PR-Current.md\n\nSlice phase: Discovery\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 1
+    assert "invalid Slice phase 'Discovery'" in result.stdout
+
+
+def test_cli_fails_when_current_pr_body_slice_phase_mismatches_plan(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 22,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/22",
+            }
+        ],
+        files={22: [path]},
+        bodies={22: "Plan: plans/PR-Current.md\n\nSlice phase: Robust testing\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 1
+    assert "does not match branch plan phase(s) workflow/process" in result.stdout
+
+
+def test_cli_accepts_current_pr_body_matching_plan_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 23,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/23",
+            }
+        ],
+        files={23: [path]},
+        bodies={23: "Plan: plans/PR-Current.md\n\nSlice phase: Workflow/process\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_accepts_mixed_case_period_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Vertical Slice.\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 24,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/24",
+            }
+        ],
+        files={24: [path]},
+        bodies={24: "Plan: plans/PR-Current.md\n\nSlice phase: vertical slice.\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "branch slice phases: vertical slice" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
 def test_cli_warns_for_unsafe_open_pr_file_path(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path)
     _commit(repo, "README.md", "branch\n")
@@ -111,7 +258,7 @@ def test_cli_fails_when_changed_plan_doc_missing_ownership_lane(tmp_path: Path) 
     _commit(
         repo,
         "plans/PR-No-Lane.md",
-        "# PR-No-Lane\n\n## Why this slice exists\n\nTest.\n",
+        "# PR-No-Lane\n\n## Scope (this PR)\n\nSlice phase: Workflow/process\n",
     )
 
     result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
@@ -119,6 +266,69 @@ def test_cli_fails_when_changed_plan_doc_missing_ownership_lane(tmp_path: Path) 
     assert result.returncode == 1
     assert "ownership lane contract failed" in result.stdout
     assert "plans/PR-No-Lane.md: missing Ownership lane" in result.stdout
+
+
+def test_cli_keeps_existing_whole_doc_ownership_lane_parsing(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Top-Lane.md",
+        "# PR-Top-Lane\n\nOwnership lane: atlas-workflow\n\n"
+        "## Scope (this PR)\n\nSlice phase: Workflow/process\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "branch ownership lanes: atlas-workflow" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_fails_when_changed_plan_doc_missing_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-No-Phase.md",
+        "# PR-No-Phase\n\n## Scope (this PR)\n\nOwnership lane: atlas-workflow\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 1
+    assert "slice phase contract failed" in result.stdout
+    assert "plans/PR-No-Phase.md: missing Slice phase" in result.stdout
+
+
+def test_cli_fails_when_changed_plan_doc_has_invalid_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Bad-Phase.md",
+        "# PR-Bad-Phase\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Exploratory cleanup\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 1
+    assert "invalid Slice phase 'Exploratory cleanup'" in result.stdout
+
+
+def test_cli_reads_plan_metadata_only_from_scope_section(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Scope-Metadata.md",
+        "# PR-Scope-Metadata\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n\n"
+        "## Mechanism\n\n```md\nSlice phase: <phase>\n```\n",
+    )
+
+    result = _run(repo, ["python", "scripts/audit_pr_session_drift.py", "--skip-github"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "invalid Ownership lane '<lane>'" not in result.stdout
+    assert "invalid Slice phase '<phase>'" not in result.stdout
 
 
 def test_cli_allows_modified_legacy_plan_doc_without_ownership_lane(tmp_path: Path) -> None:
@@ -149,7 +359,7 @@ def test_cli_fails_when_open_pr_claims_same_ownership_lane(tmp_path: Path) -> No
     _commit(
         repo,
         "plans/PR-Current.md",
-        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n",
     )
     gh_bin = _write_fake_gh(
         tmp_path,
@@ -162,7 +372,7 @@ def test_cli_fails_when_open_pr_claims_same_ownership_lane(tmp_path: Path) -> No
             }
         ],
         files={15: ["README.md"]},
-        bodies={15: "Plan: plans/PR-Other.md\n\nOwnership lane: content-ops/faq-generator\n"},
+        bodies={15: "Plan: plans/PR-Other.md\n\nOwnership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n"},
     )
 
     result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
@@ -178,7 +388,7 @@ def test_cli_allows_open_pr_with_different_ownership_lane(tmp_path: Path) -> Non
     _commit(
         repo,
         "plans/PR-Current.md",
-        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n",
     )
     gh_bin = _write_fake_gh(
         tmp_path,
@@ -191,7 +401,7 @@ def test_cli_allows_open_pr_with_different_ownership_lane(tmp_path: Path) -> Non
             }
         ],
         files={16: ["atlas-intel-ui/src/pages/Landing.tsx"]},
-        bodies={16: "Ownership lane: content-ops/landing-seo-geo\n"},
+        bodies={16: "Ownership lane: content-ops/landing-seo-geo\n\nSlice phase: Workflow/process\n"},
     )
 
     result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
@@ -231,7 +441,7 @@ def test_cli_warns_for_malformed_lane_in_other_pr_body(tmp_path: Path) -> None:
     _commit(
         repo,
         "plans/PR-Current.md",
-        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n",
     )
     gh_bin = _write_fake_gh(
         tmp_path,
@@ -244,7 +454,7 @@ def test_cli_warns_for_malformed_lane_in_other_pr_body(tmp_path: Path) -> None:
             }
         ],
         files={18: ["README.md"]},
-        bodies={18: "Ownership lane: Content Ops!\n"},
+        bodies={18: "Ownership lane: Content Ops!\n\nSlice phase: Workflow/process\n"},
     )
 
     result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
@@ -254,13 +464,43 @@ def test_cli_warns_for_malformed_lane_in_other_pr_body(tmp_path: Path) -> None:
     assert "PR #18 body: invalid Ownership lane" in result.stdout
 
 
+def test_cli_treats_other_pr_invalid_slice_phase_as_advisory(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path)
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n",
+    )
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 77,
+                "title": "Legacy bad phase",
+                "headRefName": "claude/legacy",
+                "url": "https://github.test/pr/77",
+            }
+        ],
+        files={77: ["README.md"]},
+        bodies={77: "Ownership lane: content-ops/other-lane\n\nSlice phase: Discovery\n"},
+    )
+
+    result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "WARN: GitHub metadata skipped or malformed" in result.stdout
+    assert "PR #77 body: invalid Slice phase" in result.stdout
+    assert "OK: no blocking drift detected" in result.stdout
+
+
 def test_cli_ignores_current_pr_by_head_oid_when_detached(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path, branch="claude/current")
     path = "plans/PR-Current.md"
     _commit(
         repo,
         path,
-        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n",
+        "# PR-Current\n\n## Scope (this PR)\n\nOwnership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n",
     )
     head_oid = _git_stdout(repo, "rev-parse", "HEAD")
     _git(repo, "checkout", "--detach", "HEAD")
@@ -276,7 +516,7 @@ def test_cli_ignores_current_pr_by_head_oid_when_detached(tmp_path: Path) -> Non
             }
         ],
         files={19: [path]},
-        bodies={19: "Ownership lane: content-ops/faq-generator\n"},
+        bodies={19: "Ownership lane: content-ops/faq-generator\n\nSlice phase: Workflow/process\n"},
     )
 
     result = _run_with_path(repo, gh_bin, ["python", "scripts/audit_pr_session_drift.py"])


### PR DESCRIPTION
Plan: plans/PR-Atlas-Slice-Phase-Audit.md
Slice phase: Workflow/process

This slice turns the new phase workflow contract into a mechanical gate. The existing cross-session drift audit now validates recognized Slice phase metadata for new plan docs and, once the PR exists, the current PR body. Other open PR body phase problems stay advisory so legacy/open branches do not block unrelated work.

## Intentional
- Reuse scripts/audit_pr_session_drift.py instead of adding a parallel local-review checker.
- Parse plan Slice phase metadata from Scope only so examples elsewhere in the plan cannot become false contract inputs.
- Keep existing ownership-lane parsing whole-document; narrowing that parser would be a separate migration.
- Treat current PR body phase failures as blocking while keeping other open PR body phase issues advisory.

## Deferred
- Future PR can consider structured Scope metadata if more labels are added.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_audit_pr_session_drift.py -q — 22 passed
- bash scripts/local_pr_review.sh --allow-dirty — passed
- Pre-push hook reran local_pr_review and passed

## Diff size
3 files, +462 / -13