### PR TITLE
PR-Atlas-Local-Review-CI

### DIFF
--- a/.github/workflows/pre_push_audit.yml
+++ b/.github/workflows/pre_push_audit.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pre-push-audit:
     runs-on: ubuntu-latest
@@ -24,5 +28,7 @@ jobs:
         run: |
           git remote set-head origin --auto || git remote set-head origin main
 
-      - name: Run pre-push audit wrapper
-        run: bash scripts/pre_push_audit.sh
+      - name: Run local PR review bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/local_pr_review.sh

--- a/plans/PR-Atlas-Local-Review-CI.md
+++ b/plans/PR-Atlas-Local-Review-CI.md
@@ -1,0 +1,83 @@
+# PR-Atlas-Local-Review-CI
+
+## Why this slice exists
+
+AGENTS.md says GitHub Actions should run the same local review wrapper
+after a PR opens, but the current workflow still runs only
+`scripts/pre_push_audit.sh`. That means the CI gate misses checks that
+live only in `scripts/local_pr_review.sh`, including the just-landed
+current-PR `Slice phase` body validation.
+
+This slice makes CI enforce the same mechanical bundle builders run
+locally.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow
+
+Slice phase: Workflow/process.
+
+1. Run `scripts/local_pr_review.sh` from the pre-push audit workflow
+   instead of the narrower pre-push wrapper.
+2. Provide `GH_TOKEN` in that workflow so the drift audit can read open
+   PR metadata through `gh`.
+3. Make current-PR detection work in detached GitHub Actions checkouts by
+   honoring `GITHUB_HEAD_REF`.
+4. Add a fixture proving `GITHUB_HEAD_REF` identifies the current PR even
+   when `git branch --show-current` is empty.
+
+### Files touched
+
+- `.github/workflows/pre_push_audit.yml`
+- `scripts/audit_pr_session_drift.py`
+- `tests/test_audit_pr_session_drift.py`
+- `plans/PR-Atlas-Local-Review-CI.md`
+
+## Mechanism
+
+The workflow keeps its name and trigger surface, but its audit step calls
+the `scripts/local_pr_review.sh` wrapper. That wrapper already runs
+`scripts/pre_push_audit.sh`, then adds drift, cross-layer caller,
+plan/code consistency, and whitespace checks.
+
+`audit_pr_session_drift.py` currently identifies the current PR by local
+branch name or matching head SHA. In GitHub Actions pull-request checkouts
+the repository can be detached, so the local branch name may be empty and
+the checked-out SHA may be a synthetic merge commit. Reading
+`GITHUB_HEAD_REF` first gives the audit the PR head branch that GitHub
+already exposes.
+
+## Intentional
+
+- No workflow rename in this slice. Keeping the existing "Pre-push Audit"
+  workflow avoids branch-protection churn while strengthening the command it
+  runs.
+- No new audit script. `local_pr_review.sh` remains the single mechanical PR
+  review wrapper.
+- The workflow grants only `contents: read` and `pull-requests: read` so
+  `gh` metadata reads do not depend on public-repo defaults; no write
+  permissions are added.
+- Cross-session drift overlap remains blocking in CI. A PR may need to rebase
+  when main or another open same-lane PR moves, but this is the intended
+  collision signal for the workflow arc.
+
+## Deferred
+
+- Future PR: consider renaming the workflow/job from "Pre-push Audit" to
+  "Local PR Review" if branch protection and reviewer expectations allow it.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_audit_pr_session_drift.py -q` - 23 passed.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Workflow | ~10 |
+| Drift audit | ~8 |
+| Tests | ~45 |
+| Plan doc | ~75 |
+| **Total** | ~138 |

--- a/scripts/audit_pr_session_drift.py
+++ b/scripts/audit_pr_session_drift.py
@@ -491,6 +491,9 @@ def format_values(values: Iterable[str]) -> str:
 
 
 def current_head_ref() -> str:
+    github_head_ref = os.environ.get("GITHUB_HEAD_REF", "").strip()
+    if github_head_ref:
+        return github_head_ref
     result = subprocess.run(
         ["git", "branch", "--show-current"],
         check=False,

--- a/tests/test_audit_pr_session_drift.py
+++ b/tests/test_audit_pr_session_drift.py
@@ -83,6 +83,42 @@ def test_cli_ignores_open_pr_for_current_branch(tmp_path: Path) -> None:
     assert "OK: no blocking drift detected" in result.stdout
 
 
+def test_cli_uses_github_head_ref_for_current_pr_when_detached(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    path = "plans/PR-Current.md"
+    _commit(
+        repo,
+        path,
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    _git(repo, "checkout", "--detach", "HEAD")
+    gh_bin = _write_fake_gh(
+        tmp_path,
+        prs=[
+            {
+                "number": 25,
+                "title": "Current PR",
+                "headRefName": "claude/current",
+                "url": "https://github.test/pr/25",
+            }
+        ],
+        files={25: [path]},
+        bodies={25: "Plan: plans/PR-Current.md\n\nOwnership lane: atlas-workflow\n"},
+    )
+
+    result = _run_with_path(
+        repo,
+        gh_bin,
+        ["python", "scripts/audit_pr_session_drift.py"],
+        extra_env={"GITHUB_HEAD_REF": "claude/current"},
+    )
+
+    assert result.returncode == 1
+    assert "current PR body slice phase contract failed" in result.stdout
+    assert "current PR body: missing Slice phase" in result.stdout
+
+
 def test_cli_fails_when_current_pr_body_missing_slice_phase(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path, branch="claude/current")
     path = "plans/PR-Current.md"
@@ -616,8 +652,14 @@ def _run_with_path(
     repo: Path,
     bin_dir: Path,
     args: list[str],
+    *,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        **(extra_env or {}),
+    }
     return subprocess.run(
         args,
         cwd=repo,


### PR DESCRIPTION
Plan: plans/PR-Atlas-Local-Review-CI.md
Slice phase: Workflow/process

This slice makes the GitHub pre-push audit workflow run the same local PR review bundle builders run locally. That closes the gap where CI ran pre_push_audit only and missed local_pr_review-only checks, including current-PR Slice phase body validation.

## Intentional
- Keep the existing Pre-push Audit workflow name to avoid branch-protection churn while strengthening the command it runs.
- Grant only contents: read and pull-requests: read so gh metadata reads do not depend on public-repo defaults.
- Detect the current PR from GITHUB_HEAD_REF in detached GitHub Actions checkouts.
- Keep cross-session drift overlap blocking in CI; a PR may need to rebase when main or another same-lane PR moves, but that is the intended collision signal.

## Deferred
- Future PR can rename the workflow/job from Pre-push Audit to Local PR Review if branch protection and reviewer expectations allow it.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_audit_pr_session_drift.py -q — 23 passed
- bash scripts/local_pr_review.sh --allow-dirty — passed
- Pre-push hook reran local_pr_review and passed

## Diff size
4 files, +137 / -3