### PR TITLE
Validate support-ticket input provider route parity

### DIFF
--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime
 from typing import Any
 
 from .campaign_source_adapters import source_material_to_source_rows
@@ -131,6 +132,7 @@ def build_support_ticket_input_package(
 
     source_period = f"Last {window_days} days of support tickets"
     faq_questions = _ticket_questions(normalized_rows)
+    faq_source_types = _source_types(normalized_rows)
     resolved_secondary_keywords = tuple(secondary_keywords or (
         "customer support FAQ",
         "reduce repeat support tickets",
@@ -144,8 +146,7 @@ def build_support_ticket_input_package(
 
     inputs = {
         "source_material": normalized_rows,
-        "faq_window_days": window_days,
-        "faq_source_types": ["support_ticket"],
+        "faq_source_types": faq_source_types,
         "faq_title": campaign_name,
         "topic": "Support-ticket questions customers keep asking",
         "filters": {"topic_type": "content_ops_support_ticket_faq"},
@@ -168,6 +169,8 @@ def build_support_ticket_input_package(
         "cta_label": cta_label,
         "cta_url": cta_url,
     }
+    if _all_rows_have_dates(normalized_rows):
+        inputs["faq_window_days"] = window_days
 
     return ContentOpsInputPackage(
         provider=_clean(provider) or "support_ticket_upload",
@@ -268,6 +271,41 @@ def _ticket_questions(rows: Sequence[Mapping[str, Any]], *, limit: int = 6) -> l
             if len(questions) >= limit:
                 return questions
     return questions
+
+
+def _source_types(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    source_types: list[str] = []
+    for row in rows:
+        source_type = _clean(row.get("source_type"))
+        if source_type and source_type not in source_types:
+            source_types.append(source_type)
+    return source_types or ["support_ticket"]
+
+
+def _all_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
+    return bool(rows) and all(
+        _parse_ticket_source_date(row.get("created_at")) is not None
+        for row in rows
+    )
+
+
+def _parse_ticket_source_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = _clean(value)
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).date()
+    except ValueError:
+        pass
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
 
 
 def _first_question(value: Any) -> str:

--- a/plans/PR-Support-Ticket-Input-Provider-Route-Parity.md
+++ b/plans/PR-Support-Ticket-Input-Provider-Route-Parity.md
@@ -1,0 +1,99 @@
+# PR: Support Ticket Input Provider Route Parity
+
+## Why this slice exists
+
+The support-ticket input provider is now the handoff point between host-owned
+ticket ingestion and Content Ops generation. The provider has direct adapter
+tests and one preview-route canary, but the route surface that matters to users
+is broader: `/content-ops/preview`, `/content-ops/plan`, and
+`/content-ops/execute` should all apply the same provider-built support-ticket
+package before they validate, plan, or run generation.
+
+This slice adds focused functional validation for that route parity. It does not
+add generator behavior or host upload wiring.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/input-provider-ticket-package
+
+Slice phase: Functional validation
+
+1. Keep the existing preview-route support-ticket provider test.
+2. Fix the support-ticket package so FAQ source-type filters match the
+   normalized rows they will be applied to.
+3. Avoid applying a strict FAQ date-window filter when the uploaded ticket rows
+   do not contain row dates; the source-period context still says the upload is
+   the last 90 days.
+4. Add a plan-route test proving provider-generated FAQ Report defaults produce
+   a runnable `faq_markdown` generation plan.
+5. Add an execute-route test proving the deterministic `faq_markdown` service
+   can run from provider-expanded support-ticket material.
+
+### Files touched
+
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_support_ticket_input_provider.py`
+- `plans/PR-Support-Ticket-Input-Provider-Route-Parity.md`
+
+## Mechanism
+
+The tests use the existing `create_content_ops_control_surface_router(...)`
+input-provider seam and `SupportTicketInputProvider(source_material_loader=...)`.
+The loader asserts tenant scope and request payload shape where useful, then
+returns in-memory ticket rows.
+
+The package now derives `faq_source_types` from normalized source rows instead
+of hardcoding `support_ticket`, because hosts can pass source rows labeled
+`ticket`, `case`, or another supported ticket-source alias. It only includes
+`faq_window_days` when every normalized row has a parseable `created_at` value,
+because otherwise the FAQ Markdown service treats the value as a strict
+evidence date filter and drops undated or malformed-date CSV rows even when the
+upload itself represents the last 90 days.
+
+The plan-route test calls the mounted `/ops/plan` endpoint directly and checks
+that the provider package resolves to the `TicketFAQMarkdownService.generate`
+runner. The execute-route test injects a `ContentOpsExecutionServices` bundle
+with the deterministic FAQ Markdown service and verifies the generated markdown
+contains the ticket question.
+
+## Intentional
+
+- No Atlas host changes. Host wiring is covered separately in
+  `PR-Content-Ops-Host-Ticket-Input-Provider`.
+- No LLM-backed output execution. `faq_markdown` is deterministic and gives the
+  provider route path an end-to-end execution canary without model cost.
+- No standalone FAQ article contract. That remains owned by the FAQ session.
+- The date-window change is limited to the support-ticket input package. Direct
+  `faq_window_days` callers still get the existing strict date filter.
+- Mixed dated/undated support-ticket uploads omit the strict window filter and
+  favor keeping customer evidence over applying a partial window. The
+  `source_period` text still carries the upload's intended last-90-days context.
+
+## Deferred
+
+- Future PR owned by the host wiring lane: add Atlas API route tests once the
+  host provider mount lands.
+- Future PR owned by the ingestion lane: test persisted upload/import lookup
+  when a loader contract exists.
+- Parked hardening: none.
+
+## Verification
+
+- `py_compile` for changed Python files - passed.
+- `pytest tests/test_extracted_support_ticket_input_provider.py tests/test_extracted_support_ticket_input_package.py -q` - 26 passed.
+- `scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `scripts/check_ascii_python.sh` - passed.
+- `scripts/local_pr_review.sh` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Package source-type/date-window fix | ~45 |
+| Package regression tests | ~55 |
+| Route parity tests | ~55 |
+| **Total** | **~240** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -23,12 +23,14 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
             "Subject": "How do I change my login email?",
             "Description": "I cannot find where to update the email on my account.",
             "Pain Category": "profile updates",
+            "Created At": "2026-05-01",
         },
         {
             "ticket_id": "ticket-2",
             "subject": "Export dashboard",
             "description": "Where do I export the dashboard before renewal?",
             "source_url": "https://example.test/tickets/2",
+            "created_at": "2026-05-02",
         },
     ])
 
@@ -65,6 +67,7 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
         "company_name": "Acme Logistics",
         "vendor_name": "HelpDeskPro",
         "pain_category": "profile updates",
+        "created_at": "2026-05-01",
     }
     assert package.metadata["included_row_count"] == 2
 
@@ -101,6 +104,69 @@ def test_support_ticket_bundle_inherits_parent_fields_and_comment_text() -> None
         }
     ]
     assert package.inputs["faq_questions"] == ["Can I automate demo follow-up?"]
+
+
+def test_support_ticket_input_package_derives_faq_source_types_from_rows() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "source_type": "ticket",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+        },
+        {
+            "ticket_id": "ticket-2",
+            "source_type": "support_ticket",
+            "subject": "Export dashboard",
+            "message": "Where do I export the dashboard?",
+        },
+    ])
+
+    assert package.inputs["faq_source_types"] == ["ticket", "support_ticket"]
+
+
+def test_support_ticket_input_package_omits_window_filter_without_row_dates() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+        }
+    ])
+
+    assert "faq_window_days" not in package.inputs
+    assert package.inputs["source_period"] == "Last 90 days of support tickets"
+
+
+def test_support_ticket_input_package_omits_window_filter_without_parseable_row_dates() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+            "created_at": "last week",
+        }
+    ])
+
+    assert "faq_window_days" not in package.inputs
+
+
+def test_support_ticket_input_package_omits_window_filter_for_mixed_date_rows() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "Login email change",
+            "message": "How do I change my email address?",
+            "created_at": "2026-05-02T12:00:00Z",
+        },
+        {
+            "ticket_id": "ticket-2",
+            "subject": "Export dashboard",
+            "message": "Where do I export the dashboard?",
+        },
+    ])
+
+    assert "faq_window_days" not in package.inputs
 
 
 def test_support_ticket_input_package_accepts_single_mapping_comment_thread() -> None:

--- a/tests/test_extracted_support_ticket_input_provider.py
+++ b/tests/test_extracted_support_ticket_input_provider.py
@@ -11,12 +11,14 @@ from extracted_content_pipeline.control_surfaces import (
     preview_control_surface,
     request_from_mapping,
 )
+from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
 from extracted_content_pipeline.content_ops_input_provider import (
     content_ops_payload_from_input_package,
 )
 from extracted_content_pipeline.support_ticket_input_provider import (
     SupportTicketInputProvider,
 )
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
 
 
 def _ticket_rows() -> list[dict[str, str]]:
@@ -186,3 +188,53 @@ async def test_support_ticket_input_provider_wires_into_preview_route() -> None:
     assert payload["can_run"] is True
     assert payload["outputs"] == ["landing_page"]
     assert payload["missing_inputs"] == []
+
+
+@pytest.mark.asyncio
+async def test_support_ticket_input_provider_wires_into_plan_route() -> None:
+    calls: list[dict[str, object]] = []
+
+    def loader(scope: TenantScope, request):
+        calls.append({"scope": scope, "request": request})
+        return _ticket_rows()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=SupportTicketInputProvider(source_material_loader=loader),
+        scope_provider=lambda: {"account_id": "acct-plan"},
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    payload = await route.endpoint({"outputs": ["faq_markdown"]})
+
+    assert payload["can_execute"] is True
+    assert payload["steps"][0]["output"] == "faq_markdown"
+    assert payload["steps"][0]["runner"] == "TicketFAQMarkdownService.generate"
+    assert payload["preview"]["can_run"] is True
+    assert calls[0]["scope"] == TenantScope(account_id="acct-plan")
+
+
+@pytest.mark.asyncio
+async def test_support_ticket_input_provider_wires_into_execute_route() -> None:
+    def loader(scope: TenantScope, request):
+        assert scope.account_id == "acct-execute"
+        assert request == {"outputs": ("faq_markdown",)}
+        return _ticket_rows()
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService(),
+        ),
+        input_provider=SupportTicketInputProvider(source_material_loader=loader),
+        scope_provider=lambda: {"account_id": "acct-execute"},
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint({"outputs": ["faq_markdown"]})
+
+    assert payload["status"] == "completed"
+    assert payload["steps"][0]["output"] == "faq_markdown"
+    assert payload["steps"][0]["status"] == "completed"
+    assert payload["steps"][0]["result"]["generated"] == 1
+    assert "How do I change my login email?" in payload["steps"][0]["result"]["markdown"]


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Input-Provider-Route-Parity.md
Slice phase: Functional validation

Add route-level validation that the support-ticket input provider works through Content Ops preview, plan, and execute paths. The execute canary exposed two source-level package issues, so this also fixes FAQ source-type filters to match normalized rows and avoids applying a strict date-window filter when uploaded ticket rows do not include row dates.

## Intentional
- No Atlas host changes; host mounting is covered by PR #909.
- No LLM-backed output execution; faq_markdown is deterministic and keeps this validation cost-free.
- No standalone FAQ article contract; that remains owned by the FAQ session.
- The date-window change is limited to support-ticket input packages. Direct faq_window_days callers still get the existing strict date filter.

## Deferred
- Atlas host API route tests can follow after the host provider mount lands.
- Persisted upload/import lookup tests remain with the ingestion lane.

## Parked hardening
- None.

## Verification
- py_compile for changed Python files: passed
- pytest tests/test_extracted_support_ticket_input_provider.py tests/test_extracted_support_ticket_input_package.py -q: 24 passed
- scripts/validate_extracted_content_pipeline.sh: passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline: passed
- python scripts/audit_extracted_standalone.py --fail-on-debt: passed
- scripts/check_ascii_python.sh: passed
- bash scripts/local_pr_review.sh: passed

## Diff size
4 files, +200 / -2