### PR TITLE
PR-Content-Ops-FAQ-Scale-Gates

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Scale-Gates.md
+++ b/plans/PR-Content-Ops-FAQ-Scale-Gates.md
@@ -1,0 +1,85 @@
+# PR-Content-Ops-FAQ-Scale-Gates
+
+## Why this slice exists
+
+The FAQ generator has been manually stress-tested through 50,000 real
+CFPB-derived support-ticket rows, and the scale smoke already captures the
+right diagnostics in its run summary. The remaining testing gap is that an
+operator cannot ask the smoke to fail if the loaded row volume or rendered
+ticket-source coverage is below the promised scale.
+
+This slice turns those manual JSON checks into explicit scale gates so future
+500, 1,000, 10,000, and 50,000 row generation proofs can be demonstrated by the
+script exit code and summary artifact.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+Slice phase: Robust testing.
+
+1. Add optional minimum raw-row and FAQ ticket-source gates to
+   `scripts/smoke_content_ops_faq_scale_run.py`.
+2. Add an optional gate requiring every accepted ticket source to be represented
+   in generated FAQ items.
+3. Include scale-gate results in the run summary and make gate failures return a
+   non-zero smoke exit.
+4. Add focused tests for passing and failing scale-gate runs.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Scale-Gates.md`
+- `scripts/smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+
+## Mechanism
+
+The scale smoke still runs the existing FAQ CLI and reads the compact FAQ result
+payload. After the CLI exits, the wrapper evaluates optional
+scale gates against:
+
+- `input_profile.raw_row_count`
+- `result.ticket_source_count`
+- `result.diagnostics.rendered_ticket_source_count`
+
+When a gate fails, the smoke writes the same artifact set, marks the summary as
+failed with failure.type=scale_gates, and exits 1. CLI failures and FAQ
+output-check failures keep their existing behavior.
+
+## Intentional
+
+- No FAQ generation behavior changes. This is a robust-testing harness slice,
+  not a ranking or rendering change.
+- No checked-in large fixture. The existing synthetic test rows prove the gate
+  logic; real 50,000-row CFPB artifacts stay local operator artifacts.
+- No new hosted route or database dependency. The scale smoke remains an
+  offline deterministic proof.
+
+## Deferred
+
+- Production hardening for async/background execution remains covered by the
+  existing stress validation and closeout docs; this slice only strengthens the
+  repeatable test harness.
+- A hosted route smoke can reuse these gate semantics once #909 or a later
+  host-input slice exposes the full support-ticket source flow.
+- Parked hardening: none.
+
+## Verification
+
+- Focused pytest command passed: python -m pytest
+  tests/test_smoke_content_ops_faq_scale_run.py -q. Result: 25 passed.
+- Py compile command passed for the scale-smoke script and focused test file.
+- Scale-gated smoke command passed against
+  extracted_content_pipeline/examples/support_ticket_sources.csv with minimum
+  raw rows 4, minimum ticket rows 4, and all-ticket-source rendering required.
+  The run summary reported scale_gates.passed=true.
+- Local PR review command passed: bash scripts/local_pr_review.sh --allow-dirty.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 85 |
+| Scale smoke gates | 142 |
+| Tests | 156 |
+| **Total** | 383 |

--- a/scripts/smoke_content_ops_faq_scale_run.py
+++ b/scripts/smoke_content_ops_faq_scale_run.py
@@ -44,6 +44,21 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--support-contact")
     parser.add_argument("--default-field", action="append", default=[])
     parser.add_argument("--allow-output-check-failures", action="store_true")
+    parser.add_argument(
+        "--min-raw-source-rows",
+        type=int,
+        help="Fail unless the source file profile sees at least this many raw rows.",
+    )
+    parser.add_argument(
+        "--min-ticket-source-rows",
+        type=int,
+        help="Fail unless the FAQ result accepts at least this many ticket source rows.",
+    )
+    parser.add_argument(
+        "--require-all-ticket-sources-rendered",
+        action="store_true",
+        help="Fail unless every accepted ticket source is represented in FAQ items.",
+    )
     return parser.parse_args(argv)
 
 
@@ -66,6 +81,10 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--window-days must be positive")
     if args.as_of_date and args.window_days is None:
         raise SystemExit("--as-of-date requires --window-days")
+    if args.min_raw_source_rows is not None and args.min_raw_source_rows < 1:
+        raise SystemExit("--min-raw-source-rows must be positive")
+    if args.min_ticket_source_rows is not None and args.min_ticket_source_rows < 1:
+        raise SystemExit("--min-ticket-source-rows must be positive")
 
 
 def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
@@ -85,6 +104,14 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     stderr_path.write_text(completed.stderr, encoding="utf-8")
     result_payload = _read_json(result_path)
     faq_run_summary = _faq_run_summary(result_payload)
+    scale_gates = _scale_gate_summary(
+        args,
+        input_profile=input_profile,
+        result_payload=result_payload,
+    )
+    smoke_exit_code = completed.returncode
+    if completed.returncode == 0 and scale_gates["failed"]:
+        smoke_exit_code = 1
     artifact_paths = {
         "markdown": markdown_path,
         "result": result_path,
@@ -93,8 +120,9 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "summary": summary_path,
     }
     summary = {
-        "ok": completed.returncode == 0,
-        "exit_code": completed.returncode,
+        "ok": smoke_exit_code == 0,
+        "exit_code": smoke_exit_code,
+        "faq_cli_exit_code": completed.returncode,
         "source": str(args.path),
         "source_format": args.source_format,
         "command": command,
@@ -109,21 +137,24 @@ def run_scale_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         },
         "artifact_details": _artifact_details(artifact_paths),
         "faq_run_summary": faq_run_summary,
+        "scale_gates": scale_gates,
         "failure": _failure_summary(
-            returncode=completed.returncode,
+            returncode=smoke_exit_code,
+            cli_returncode=completed.returncode,
             result_payload=result_payload,
+            scale_gates=scale_gates,
             stderr=completed.stderr,
         ),
         "result": result_payload,
     }
     _write_summary(summary_path, summary, artifact_paths)
     if (
-        completed.returncode != 0
+        smoke_exit_code != 0
         and bool(args.allow_output_check_failures)
         and _is_output_check_failure(result_payload)
     ):
         return 0, summary
-    return completed.returncode, summary
+    return smoke_exit_code, summary
 
 
 def _faq_run_summary(result_payload: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -284,14 +315,114 @@ def _console_faq_run_summary(value: Any) -> str:
     return " ".join(parts)
 
 
+def _scale_gate_summary(
+    args: argparse.Namespace,
+    *,
+    input_profile: dict[str, Any],
+    result_payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    gates: list[dict[str, Any]] = []
+    if args.min_raw_source_rows is not None:
+        gates.append(
+            _minimum_gate(
+                name="min_raw_source_rows",
+                actual=_scale_gate_integer_or_none(input_profile.get("raw_row_count")),
+                expected=int(args.min_raw_source_rows),
+            )
+        )
+    if args.min_ticket_source_rows is not None:
+        gates.append(
+            _minimum_gate(
+                name="min_ticket_source_rows",
+                actual=_scale_gate_integer_or_none(
+                    result_payload.get("ticket_source_count")
+                    if isinstance(result_payload, dict)
+                    else None
+                ),
+                expected=int(args.min_ticket_source_rows),
+            )
+        )
+    if args.require_all_ticket_sources_rendered:
+        ticket_source_count = _scale_gate_integer_or_none(
+            result_payload.get("ticket_source_count")
+            if isinstance(result_payload, dict)
+            else None
+        )
+        diagnostics = (
+            result_payload.get("diagnostics")
+            if isinstance(result_payload, dict)
+            else None
+        )
+        rendered_ticket_source_count = _scale_gate_integer_or_none(
+            diagnostics.get("rendered_ticket_source_count")
+            if isinstance(diagnostics, dict)
+            else None
+        )
+        gates.append(
+            {
+                "name": "all_ticket_sources_rendered",
+                "passed": (
+                    ticket_source_count is not None
+                    and rendered_ticket_source_count is not None
+                    and rendered_ticket_source_count == ticket_source_count
+                ),
+                "expected": ticket_source_count,
+                "actual": rendered_ticket_source_count,
+            }
+        )
+    failed = [gate for gate in gates if gate.get("passed") is not True]
+    return {
+        "configured": bool(gates),
+        "passed": not failed,
+        "failed": failed,
+        "gates": gates,
+    }
+
+
+def _minimum_gate(
+    *,
+    name: str,
+    actual: int | None,
+    expected: int,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": actual is not None and actual >= expected,
+        "expected": expected,
+        "actual": actual,
+    }
+
+
+def _scale_gate_integer_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _failure_summary(
     *,
     returncode: int,
+    cli_returncode: int,
     result_payload: dict[str, Any] | None,
+    scale_gates: dict[str, Any],
     stderr: str,
 ) -> dict[str, Any] | None:
     if returncode == 0:
         return None
+    failed_scale_gates = scale_gates.get("failed")
+    if cli_returncode == 0 and isinstance(failed_scale_gates, list) and failed_scale_gates:
+        return {
+            "type": "scale_gates",
+            "exit_code": returncode,
+            "result_status": (
+                result_payload.get("status") if isinstance(result_payload, dict) else None
+            ),
+            "failed_scale_gates": [dict(gate) for gate in failed_scale_gates],
+            "stderr_tail": _text_tail(stderr),
+        }
     failed_checks: list[str] = []
     result_status = None
     output_check_details: list[dict[str, Any]] = []

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -49,6 +49,9 @@ def _args(tmp_path: Path, **overrides):
         "support_contact": None,
         "default_field": [],
         "allow_output_check_failures": False,
+        "min_raw_source_rows": None,
+        "min_ticket_source_rows": None,
+        "require_all_ticket_sources_rendered": False,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -118,6 +121,12 @@ def test_faq_scale_smoke_writes_standard_artifacts(
     assert saved_summary["faq_run_summary"]["generated"] == result["generated"]
     assert saved_summary["faq_run_summary"]["weighted_source_volume"] == 4
     assert saved_summary["faq_run_summary"]["output_checks"]["failed"] == 0
+    assert saved_summary["scale_gates"] == {
+        "configured": False,
+        "passed": True,
+        "failed": [],
+        "gates": [],
+    }
     assert saved_summary["source_format"] == fmt
     assert saved_summary["input_profile"]["status"] == "ok"
     assert saved_summary["input_profile"]["raw_row_count"] == 4
@@ -161,6 +170,9 @@ def test_faq_scale_smoke_processes_1000_row_json_bundle_file(tmp_path: Path) -> 
             path=source,
             source_format="json",
             title="Customer Ticket FAQ File Scale Smoke",
+            min_raw_source_rows=1000,
+            min_ticket_source_rows=1000,
+            require_all_ticket_sources_rendered=True,
         )
     )
 
@@ -177,6 +189,29 @@ def test_faq_scale_smoke_processes_1000_row_json_bundle_file(tmp_path: Path) -> 
     assert summary["faq_run_summary"]["weighted_source_volume"] == 1000
     assert summary["faq_run_summary"]["source_channel_counts"]["support_tickets"] == 1000
     assert summary["faq_run_summary"]["output_checks"]["failed"] == 0
+    assert summary["scale_gates"]["configured"] is True
+    assert summary["scale_gates"]["passed"] is True
+    assert summary["scale_gates"]["failed"] == []
+    assert summary["scale_gates"]["gates"] == [
+        {
+            "name": "min_raw_source_rows",
+            "passed": True,
+            "expected": 1000,
+            "actual": 1000,
+        },
+        {
+            "name": "min_ticket_source_rows",
+            "passed": True,
+            "expected": 1000,
+            "actual": 1000,
+        },
+        {
+            "name": "all_ticket_sources_rendered",
+            "passed": True,
+            "expected": 1000,
+            "actual": 1000,
+        },
+    ]
     assert result["status"] == "ok"
     assert result["source_count"] == 1000
     assert result["ticket_source_count"] == 1000
@@ -187,6 +222,94 @@ def test_faq_scale_smoke_processes_1000_row_json_bundle_file(tmp_path: Path) -> 
     assert (artifact_dir / "faq.md").read_text(encoding="utf-8").startswith(
         "# Customer Ticket FAQ File Scale Smoke"
     )
+
+
+def test_faq_scale_smoke_fails_minimum_scale_gates(tmp_path: Path) -> None:
+    source = _write_source(tmp_path, "jsonl")
+
+    code, summary = smoke.run_scale_smoke(
+        _args(
+            tmp_path,
+            path=source,
+            source_format="jsonl",
+            min_raw_source_rows=5,
+            min_ticket_source_rows=5,
+        )
+    )
+
+    failed = summary["scale_gates"]["failed"]
+    assert code == 1
+    assert summary["ok"] is False
+    assert summary["faq_cli_exit_code"] == 0
+    assert summary["failure"]["type"] == "scale_gates"
+    assert [gate["name"] for gate in failed] == [
+        "min_raw_source_rows",
+        "min_ticket_source_rows",
+    ]
+    assert failed[0]["actual"] == 4
+    assert failed[0]["expected"] == 5
+    assert failed[1]["actual"] == 4
+    assert failed[1]["expected"] == 5
+    assert summary["failure"]["failed_scale_gates"] == failed
+    assert (tmp_path / "artifacts" / "faq_result.json").exists()
+    assert (tmp_path / "artifacts" / "run_summary.json").exists()
+
+
+def test_faq_scale_gate_detects_unrendered_ticket_sources(tmp_path: Path) -> None:
+    summary = smoke._scale_gate_summary(
+        _args(tmp_path, require_all_ticket_sources_rendered=True),
+        input_profile={"raw_row_count": 4},
+        result_payload={
+            "ticket_source_count": 4,
+            "diagnostics": {"rendered_ticket_source_count": 2},
+        },
+    )
+
+    assert summary["configured"] is True
+    assert summary["passed"] is False
+    assert summary["failed"] == [
+        {
+            "name": "all_ticket_sources_rendered",
+            "passed": False,
+            "expected": 4,
+            "actual": 2,
+        }
+    ]
+
+
+def test_faq_scale_gates_fail_closed_when_metrics_are_missing(tmp_path: Path) -> None:
+    summary = smoke._scale_gate_summary(
+        _args(
+            tmp_path,
+            min_raw_source_rows=1,
+            min_ticket_source_rows=1,
+            require_all_ticket_sources_rendered=True,
+        ),
+        input_profile={"raw_row_count": None},
+        result_payload={},
+    )
+
+    assert summary["passed"] is False
+    assert summary["failed"] == [
+        {
+            "name": "min_raw_source_rows",
+            "passed": False,
+            "expected": 1,
+            "actual": None,
+        },
+        {
+            "name": "min_ticket_source_rows",
+            "passed": False,
+            "expected": 1,
+            "actual": None,
+        },
+        {
+            "name": "all_ticket_sources_rendered",
+            "passed": False,
+            "expected": None,
+            "actual": None,
+        },
+    ]
 
 
 def test_faq_scale_smoke_preserves_fail_closed_exit_and_artifacts(tmp_path: Path) -> None:
@@ -239,6 +362,36 @@ def test_faq_scale_smoke_can_allow_output_check_failures(tmp_path: Path) -> None
     assert code == 0
     assert summary["ok"] is False
     assert summary["exit_code"] == 1
+    assert summary["faq_cli_exit_code"] == 1
+
+
+def test_faq_scale_smoke_does_not_allow_scale_gate_failures(
+    tmp_path: Path,
+) -> None:
+    source = _write_source(tmp_path, "jsonl")
+
+    code, summary = smoke.run_scale_smoke(
+        _args(
+            tmp_path,
+            path=source,
+            source_format="jsonl",
+            allow_output_check_failures=True,
+            min_raw_source_rows=5,
+        )
+    )
+
+    assert code == 1
+    assert summary["ok"] is False
+    assert summary["faq_cli_exit_code"] == 0
+    assert summary["failure"]["type"] == "scale_gates"
+    assert summary["failure"]["failed_scale_gates"] == [
+        {
+            "name": "min_raw_source_rows",
+            "passed": False,
+            "expected": 5,
+            "actual": 4,
+        }
+    ]
 
 
 def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> None:
@@ -248,6 +401,7 @@ def test_faq_scale_smoke_does_not_allow_hard_cli_failures(tmp_path: Path) -> Non
 
     assert code != 0
     assert summary["ok"] is False
+    assert summary["faq_cli_exit_code"] != 0
     assert summary["result"] is None
     assert summary["faq_run_summary"] is None
     assert summary["input_profile"]["status"] == "error"
@@ -424,6 +578,8 @@ def _mapping_shape(value: object, path: str = "") -> object:
     ({"max_text_chars": 0}, "--max-text-chars must be positive"),
     ({"window_days": 0}, "--window-days must be positive"),
     ({"as_of_date": "2026-05-01"}, "--as-of-date requires --window-days"),
+    ({"min_raw_source_rows": 0}, "--min-raw-source-rows must be positive"),
+    ({"min_ticket_source_rows": 0}, "--min-ticket-source-rows must be positive"),
 ])
 def test_faq_scale_smoke_rejects_invalid_args(
     tmp_path: Path,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Scale-Gates.md
Slice phase: Robust testing

Add explicit FAQ scale-smoke gates for raw row volume, accepted ticket-source volume, and full rendered ticket-source coverage. This turns the large generation proof from manual JSON inspection into script-enforced behavior: the smoke writes the same artifacts, reports scale_gates in the summary, and exits non-zero when a requested scale promise is not met.

## Intentional
- No FAQ generation behavior changes; this only hardens the offline scale smoke harness.
- No checked-in large fixture. The focused tests cover the gate logic; real 50,000-row CFPB artifacts stay local operator artifacts.
- No hosted route or database dependency in this slice.

## Deferred
- Hosted route scale-gate reuse can follow once the support-ticket host input flow lands.
- Async/background production hardening remains in the existing stress closeout path.
- Parked hardening: none.

## Verification
- python -m pytest tests/test_smoke_content_ops_faq_scale_run.py -q: 25 passed.
- python -m py_compile scripts/smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_scale_run.py: passed.
- python scripts/smoke_content_ops_faq_scale_run.py extracted_content_pipeline/examples/support_ticket_sources.csv --artifact-dir tmp/faq_scale_gate_smoke_20260523 --min-raw-source-rows 4 --min-ticket-source-rows 4 --require-all-ticket-sources-rendered: passed; summary reported scale_gates.passed=true.
- bash scripts/local_pr_review.sh --allow-dirty: passed.

## Diff size
3 files, +377 / -5