### PR TITLE
Document Content Ops support-ticket input provider handoff

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -252,6 +252,21 @@ The same artifact can run through the Content Ops execution seam by selecting
 When the host wires `PostgresTicketFAQRepository`, execution also persists the
 Markdown document into `ticket_faq_markdown` and returns `saved_ids`.
 
+Support-ticket exports can also enter Content Ops through the input-provider
+handoff instead of being sent as ad hoc request fields. The
+`support_ticket_input_package` builder normalizes already-loaded ticket rows or
+`support_tickets` bundles into `source_material`, FAQ defaults, landing-page SEO
+context, and blog-planning inputs. `SupportTicketInputProvider` wraps that
+builder behind the generic `ContentOpsInputProvider` protocol so hosts can pass
+fixed in-memory source material or a tenant/request-aware loader.
+
+Atlas mounts a host-owned support-ticket provider on the `/content-ops` control
+surface. It no-ops for empty or generic source material and expands only
+support-ticket-shaped rows or bundles, leaving unrelated source-based workflows
+unchanged. File parsing, persisted upload lookup, and import-row lookup remain
+host/ingestion responsibilities; by the time data reaches the provider, it
+should already be loaded as source material.
+
 To prove the persisted review lifecycle in one command, run the FAQ lifecycle
 smoke. It generates from source rows, exports the saved draft, updates it to a
 host-defined review status, and exports the reviewed row:

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -69,6 +69,15 @@ source of truth for what remains.
   is also available as `faq_markdown` in the AI Content Ops control-surface
   execution path and can persist drafts through `PostgresTicketFAQRepository`
   when DB services are enabled.
+- `support_ticket_input_package` and `support_ticket_input_provider` package
+  already-loaded support-ticket rows or `support_tickets` bundles into the
+  generic Content Ops request shape. The package supplies `source_material`,
+  FAQ Markdown defaults, landing-page SEO/GEO/AEO context, and blog-planning
+  inputs; the provider exposes the same handoff through the
+  `ContentOpsInputProvider` protocol for host-owned loaders. Atlas mounts a
+  host adapter on `/content-ops` that expands only support-ticket-shaped source
+  material and no-ops for empty or generic evidence. File parsing and persisted
+  import lookup remain owned by host ingestion.
 - `campaign_postgres_export` provides a read-only draft export path over
   generated `b2b_campaigns` rows so hosts can review JSON/CSV outputs without
   handwritten SQL.

--- a/plans/PR-Content-Ops-Input-Provider-Docs-Closeout.md
+++ b/plans/PR-Content-Ops-Input-Provider-Docs-Closeout.md
@@ -1,0 +1,68 @@
+# PR: Content Ops Input Provider Docs Closeout
+
+## Why this slice exists
+
+The support-ticket input-provider path now has the core implementation pieces:
+the extracted input package, the extracted provider adapter, the Atlas host
+mount, and route-level validation. The package README and STATUS still mostly
+describe inline `source_material` and FAQ Markdown generation, which leaves the
+new provider handoff under-documented for future sessions.
+
+This slice updates docs only. It does not change generation, ingestion, or FAQ
+article behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/input-provider-ticket-package
+
+Slice phase: Product polish
+
+1. Document that support-ticket source material can be packaged into Content Ops
+   defaults for FAQ Markdown, landing pages, and blog planning.
+2. Document the host-owned `ContentOpsInputProvider` handoff and the Atlas host
+   mount at a high level.
+3. Clarify that file parsing and persisted import lookup remain host/ingestion
+   responsibilities, not generator responsibilities.
+
+### Files touched
+
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/STATUS.md`
+- `plans/PR-Content-Ops-Input-Provider-Docs-Closeout.md`
+
+## Mechanism
+
+The README gains a short support-ticket input-provider note near the existing
+support-ticket example flow. STATUS gains a bullet under the component inventory
+summarizing the package/provider/host handoff and the ownership boundary.
+
+## Intentional
+
+- No code changes. This is a documentation closeout after the implementation
+  slices landed.
+- No standalone FAQ article promises. That work remains owned by the FAQ
+  session.
+- No upload/import lookup contract. Ingestion owns loading persisted files or
+  import rows before handing source material to Content Ops.
+
+## Deferred
+
+- Future PR owned by the ingestion lane: document persisted import lookup once
+  the loader contract exists.
+- Future PR owned by the FAQ session: document standalone FAQ article output
+  once that contract exists.
+- Parked hardening: none.
+
+## Verification
+
+- `git diff --check` - passed.
+- `scripts/local_pr_review.sh` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| README | ~25 |
+| STATUS | ~15 |
+| **Total** | **~105** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Input-Provider-Docs-Closeout.md
Slice phase: Product polish

Document the support-ticket input-provider handoff now that the package, provider, host mount, and route validation have landed.

## Intentional
- Docs only.
- No standalone FAQ article promises.
- No upload/import lookup contract.

## Deferred
- Persisted import lookup docs remain with the ingestion lane.
- Standalone FAQ article output docs remain with the FAQ session.

## Parked hardening
- None.

## Verification
- git diff --check: passed
- bash scripts/local_pr_review.sh: passed

## Diff size
3 files, +92 / -0