### PR TITLE
Park FAQSCALE-1: large synchronous FAQ generation needs hosted limits

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,6 +32,15 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-23
 
+### FAQSCALE-1 - Large synchronous FAQ generation needs hosted limits / backpressure / background execution
+- File/location: Hosted FAQ generation path (deterministic generator `extracted_content_pipeline/ticket_faq_markdown.py` via the `/content-ops` execute route); offline proof harness `scripts/smoke_content_ops_faq_scale_run.py`.
+- Description: A gated 50,000-row deterministic FAQ run completes correctly but synchronously, taking ~1:41.86 wall and ~593 MB RSS on one core (recorded in `docs/extraction/validation/content_ops_faq_50k_gated_validation_2026-05-23.md` and the earlier `content_ops_faq_scale_stress_probe_2026-05-23.md`). Hosted paths have no explicit upload-size limit, backpressure, or background-job execution for large uploads, and no bound on concurrent large runs.
+- Why it matters: Exposing large uploads as synchronous customer requests would tie up a worker for ~100s and ~600 MB per run with no concurrency bound -- a latency/availability and memory-pressure risk. Limits / backpressure / background execution should land before large uploads are offered as a synchronous hosted endpoint.
+- Effort: M
+- Category: correctness
+- Owner/session: content-ops/faq-generation-scale
+- Found during: PR-Content-Ops-FAQ-50K-Gated-Validation (#914); previously noted in the FAQ scale stress probe.
+
 ### FILECONCURRENCY-2 - Uploaded-file imports need hosted multiprocess proof
 - File/location: Hosted `/content-ops/ingestion/files/import` deployment topology; host provider lives at `atlas_brain/_content_ops_import_admission.py`.
 - Description: Atlas now has a Postgres advisory-lock admission provider for shared cross-process capacity, but the remaining production hardening is a live Atlas-mounted multiprocess proof plus durable background job/queue visibility.


### PR DESCRIPTION
Slice phase: Workflow/process

Parks **FAQSCALE-1** in `HARDENING.md`: large synchronous FAQ generation runs correctly but ties up a worker (~1:41.86 wall, ~593 MB RSS on one core for 50k rows, per #914's gated validation and the earlier scale stress probe) with no hosted upload-size limit, backpressure, background-job execution, or concurrency bound. Records it as a tracked queue item rather than prose spread across validation docs.

## Intentional
- HARDENING.md bookkeeping only — a single parked-debt entry, no code and no plan doc.
- Category: correctness · Effort: M · Owner: content-ops/faq-generation-scale.
- Filed on its own branch (not #914) because #914 declares "Parked hardening: none".

## Deferred
- The actual hosting limits / backpressure / background execution are the parked work itself.
- Parked hardening: this PR *is* the parking entry.

## Verification
- Entry matches the HARDENING.md format (FILECONCURRENCY-2 sibling).
- Pre-push `local_pr_review.sh` passed.

## Diff size
1 file, +9 / -0

🤖 Generated with [Claude Code](https://claude.com/claude-code)