### PR TITLE
PR-Atlas-Support-Ticket-FAQ-Execute-Cap

### DIFF
--- a/plans/PR-Atlas-Support-Ticket-FAQ-Execute-Cap.md
+++ b/plans/PR-Atlas-Support-Ticket-FAQ-Execute-Cap.md
@@ -1,0 +1,72 @@
+# PR-Atlas-Support-Ticket-FAQ-Execute-Cap
+
+## Why this slice exists
+
+PR #912 proved the Atlas-mounted Content Ops preview and plan routes apply the
+support-ticket input provider. The remaining thin route-level validation gap is
+execute: the host should prove a support-ticket request can reach the real
+deterministic FAQ generator through the API route at the synchronous 1,000-row
+cap, without a database or model provider.
+
+This slice closes that gap with one focused host-route test.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+Slice phase: Functional validation.
+
+1. Add one Atlas host execute-route test that wires:
+   - `build_content_ops_input_provider()`
+   - `create_content_ops_control_surface_router(...)`
+   - real `TicketFAQMarkdownService`
+2. Send 1,000 inline support-ticket rows through `/content-ops/execute` using
+   only the deterministic `faq_markdown` output.
+3. Assert the route returns completed FAQ output with 1,000 accepted and
+   rendered ticket sources, passing output checks, and no saved IDs.
+
+### Files touched
+
+- `plans/PR-Atlas-Support-Ticket-FAQ-Execute-Cap.md`
+- `tests/test_atlas_content_ops_input_provider.py`
+
+## Mechanism
+
+The test constructs the extracted Content Ops control-surface router in-memory
+with the Atlas support-ticket input provider and a `ContentOpsExecutionServices`
+bundle containing `TicketFAQMarkdownService()`. It then calls the route endpoint
+directly with 1,000 support-ticket rows under `inputs.source_material` and
+`outputs=["faq_markdown"]`.
+
+The explicit output keeps the route focused on the deterministic FAQ service
+instead of requiring landing-page or blog services.
+
+## Intentional
+
+- No production code changes.
+- No database assertion. Persistence is already covered by FAQ lifecycle smokes;
+  this route proof keeps the service repository-free.
+- No 50,000-row hosted route run. The synchronous route cap is 1,000 rows; larger
+  uploads remain a background-job/product slice.
+
+## Deferred
+
+- Hosted persisted FAQ execute proof can follow with a fake or local Postgres
+  repository if reviewers need route-level `saved_ids`.
+- Public/help-center FAQ rendering remains outside this route-validation slice.
+- Parked hardening: none.
+
+## Verification
+
+- Focused host input-provider pytest passed after rebase: 11 passed, 1 warning.
+- Related support-ticket provider pytest sweep passed after rebase: 37 passed, 1 warning.
+- Py compile passed for the host input-provider test file.
+- Local PR review passed: `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 80 |
+| Host route test | 70 |
+| **Total** | 150 |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -8,6 +8,7 @@ import sys
 
 import pytest
 
+import extracted_content_pipeline.api.control_surfaces as api_module
 from atlas_brain._content_ops_input_provider import build_content_ops_input_provider
 from extracted_content_pipeline.api.control_surfaces import (
     ContentOpsControlSurfaceApiConfig,
@@ -294,6 +295,59 @@ def test_api_aggregator_wires_content_ops_input_provider() -> None:
 
     assert provider.__class__.__name__ == "_AtlasSupportTicketInputProvider"
     assert package.inputs["faq_questions"] == ["Where is my invoice?"]
+
+
+@pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+@pytest.mark.asyncio
+async def test_execute_route_generates_support_ticket_faq_at_inline_cap() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=build_content_ops_input_provider(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService()
+        ),
+        scope_provider=lambda: {"account_id": "acct-route-faq"},
+    )
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "subject": "Billing renewal question",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "billing",
+        }
+        for index in range(1000)
+    ]
+
+    route = _router_route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "outputs": ["faq_markdown"],
+        "inputs": {
+            "source_material": {
+                "support_tickets": rows,
+            },
+        },
+    })
+
+    step = payload["steps"][0]
+    result = step["result"]
+    assert payload["status"] == "completed"
+    assert payload["errors"] == []
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+    assert result["source_count"] == 1000
+    assert result["ticket_source_count"] == 1000
+    assert result["generated"] == 1
+    assert result["output_checks"] == {
+        "condensed": True,
+        "has_action_items": True,
+        "uses_user_vocabulary": True,
+    }
+    assert result["saved_ids"] == []
+    assert result["items"][0]["ticket_count"] == 1000
+    assert len(result["items"][0]["source_ids"]) == 1000
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Plan: plans/PR-Atlas-Support-Ticket-FAQ-Execute-Cap.md
Slice phase: Functional validation

Add host execute-route proof for deterministic support-ticket FAQ generation at the 1,000-row synchronous cap. The test wires the Atlas support-ticket input provider, extracted control-surface router, and real TicketFAQMarkdownService, then executes faq_markdown without DB/model services.

## Intentional
- No production code changes.
- No database assertion; this route proof keeps the service repository-free.
- No 50,000-row hosted route run; the synchronous route cap is 1,000 rows.

## Deferred
- Hosted persisted FAQ execute proof can follow with a fake or local Postgres repository if reviewers need route-level saved_ids.
- Public/help-center FAQ rendering remains outside this route-validation slice.
- Parked hardening: none.

## Verification
- python -m pytest tests/test_atlas_content_ops_input_provider.py -q: 10 passed, 1 warning.
- python -m pytest tests/test_atlas_content_ops_input_provider.py tests/test_extracted_support_ticket_input_provider.py tests/test_extracted_support_ticket_input_package.py -q: 36 passed, 1 warning.
- python -m py_compile tests/test_atlas_content_ops_input_provider.py: passed.
- bash scripts/local_pr_review.sh --allow-dirty: passed.
- bash scripts/local_pr_review.sh after rebase: passed.

## Diff size
2 files, +142 / -0
