### PR TITLE
Prove support-ticket provider execute route

### DIFF
--- a/plans/PR-Atlas-Support-Ticket-Provider-Execute-Proof.md
+++ b/plans/PR-Atlas-Support-Ticket-Provider-Execute-Proof.md
@@ -1,0 +1,81 @@
+# PR-Atlas-Support-Ticket-Provider-Execute-Proof
+
+## Why this slice exists
+
+The support-ticket input-provider chain had route proof for preview and plan,
+but the session had not locked the final provider-backed execute handoff. A
+real support-ticket CSV should move through the Atlas provider, the
+Content Ops execute route, and the FAQ Markdown generator without a DB or LLM
+dependency.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add a focused execute-route regression test for the Atlas support-ticket
+   input provider.
+2. Use the packaged support-ticket CSV fixture instead of synthetic inline-only
+   rows.
+3. Keep the execution services offline and narrowly scoped to FAQ Markdown so
+   this slice proves the provider handoff without spending model calls.
+
+### Files touched
+
+- `tests/test_atlas_content_ops_input_provider.py`
+- `plans/PR-Atlas-Support-Ticket-Provider-Execute-Proof.md`
+
+## Mechanism
+
+The new test creates a Content Ops control-surface router with:
+
+- `input_provider=build_content_ops_input_provider()`
+- `execution_services_provider` configured with `TicketFAQMarkdownService`
+- a tenant scope provider
+
+It posts the repository support-ticket CSV rows to `/content-ops/execute` with
+`outputs=["faq_markdown"]`, then asserts the route completes, the provider
+normalizes all four ticket rows, and the FAQ output checks pass.
+
+## Intentional
+
+- This does not call the production Atlas-mounted execute route because that
+  route resolves DB-backed services. The goal here is to prove the provider
+  handoff into execute/generation with controlled offline services.
+- This does not add new FAQ generation behavior. FAQ implementation remains
+  owned by the FAQ lane.
+- This keeps the fixture small and committed. Larger CFPB-derived artifacts
+  remain local validation fixtures rather than new repository data.
+
+## Deferred
+
+- Full 1,000+ row CFPB execution should use the file-ingestion or persisted
+  import path. Inline source material is bounded by the control-surface request
+  model and can reject very large real rows before the provider runs.
+- Persisted import lookup remains with the file-ingestion/backend validation
+  lane.
+- Parked hardening: none.
+
+## Verification
+
+- Python compile check for `tests/test_atlas_content_ops_input_provider.py` -
+  passed.
+- Pytest focused provider suite: `tests/test_atlas_content_ops_input_provider.py`
+  - 10 passed, 1 warning.
+- Manual provider-backed route smoke with
+  `extracted_content_pipeline/examples/support_ticket_sources.csv`: preview
+  runnable, plan executable, FAQ execute completed, 4 ticket rows accepted,
+  all output checks true.
+- Manual provider-backed route smoke with the local CFPB-derived 1,000-row
+  fixture showed inline execute works through 900 rows and rejects 999+ rows
+  with the existing request-size guard.
+- FAQ scale smoke against the local CFPB 1,000-row artifact - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Execute-route provider test | ~75 |
+| **Total** | **~150** |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import csv
 import importlib
 import importlib.util
+from pathlib import Path
 import sys
 
 import pytest
 
 from atlas_brain._content_ops_input_provider import build_content_ops_input_provider
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
 from extracted_content_pipeline.content_ops_input_provider import (
     merge_content_ops_input_package,
 )
@@ -15,6 +22,10 @@ from extracted_content_pipeline.control_surfaces import (
     preview_control_surface,
     request_from_mapping,
 )
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _fresh_api_package():
@@ -32,6 +43,17 @@ def _route(api_pkg, path: str):
     return route
 
 
+def _router_route(router, path: str, method: str):
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method.upper() in getattr(
+            route,
+            "methods",
+            set(),
+        ):
+            return route
+    raise AssertionError(f"Route {method.upper()} {path!r} not mounted")
+
+
 def _ticket_payload() -> dict[str, object]:
     return {
         "inputs": {
@@ -43,6 +65,12 @@ def _ticket_payload() -> dict[str, object]:
             ]
         }
     }
+
+
+def _support_ticket_csv_rows() -> list[dict[str, str]]:
+    path = ROOT / "extracted_content_pipeline" / "examples" / "support_ticket_sources.csv"
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
 
 
 def test_atlas_content_ops_input_provider_noops_without_source_material() -> None:
@@ -307,3 +335,50 @@ async def test_api_plan_route_applies_support_ticket_input_provider() -> None:
         "landing_page",
         "blog_post",
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_route_generates_faq_from_support_ticket_input_provider() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        input_provider=build_content_ops_input_provider(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService(),
+        ),
+        scope_provider=lambda: TenantScope(
+            account_id="acct-support-ticket-execute",
+            user_id="user-support-ticket-execute",
+        ),
+    )
+    route = _router_route(router, "/content-ops/execute", "POST")
+
+    payload = await route.endpoint({
+        "outputs": ["faq_markdown"],
+        "limit": 3,
+        "require_quality_gates": False,
+        "inputs": {
+            "source_material": _support_ticket_csv_rows(),
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert payload["plan"]["steps"][0]["runner"] == "TicketFAQMarkdownService.generate"
+
+    step = payload["steps"][0]
+    result = step["result"]
+
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+    assert result["source_count"] == 4
+    assert result["ticket_source_count"] == 4
+    assert result["generated"] == 2
+    assert result["output_checks"] == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+    }
+    assert "FAQ Report" in result["markdown"]
+    assert result["items"][0]["source_ids"] == (
+        "ticket-northstar-1",
+        "ticket-northstar-2",
+    )


### PR DESCRIPTION
Plan: plans/PR-Atlas-Support-Ticket-Provider-Execute-Proof.md
Slice phase: Functional validation

Adds a focused execute-route regression test proving the Atlas support-ticket input provider can feed the Content Ops execute path and FAQ Markdown generator using the packaged support-ticket CSV fixture.

## Intentional
- Uses offline FAQ execution services instead of the production DB-backed Atlas execute route.
- Does not change FAQ generation behavior or claim FAQ session ownership.
- Keeps larger CFPB-derived artifacts as local validation fixtures instead of committed test data.

## Deferred
- Full 1,000+ row CFPB execution belongs on the file-ingestion or persisted-import path because inline source material is request-size bounded.
- Persisted import lookup remains with the file-ingestion/backend validation lane.

## Parked hardening
- None.

## Verification
- Python compile check for tests/test_atlas_content_ops_input_provider.py passed.
- pytest tests/test_atlas_content_ops_input_provider.py -q: 10 passed, 1 warning.
- Manual provider-backed support-ticket CSV route smoke passed.
- Manual CFPB inline route smoke passed through 900 rows and rejected 999+ rows at the request-size guard.
- CFPB 1,000-row FAQ scale smoke passed: 1,000 ticket rows, 12 generated FAQ items, all 3 output checks passed.
- bash scripts/local_pr_review.sh passed.

## Diff size
2 files, +156 / -0