### PR TITLE
PR-Content-Ops-Execute-Limits-Describe

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -171,6 +171,10 @@ def _build_static_catalog_payload() -> Mapping[str, Any]:
             "max_source_text_chars": _MAX_INPUT_STRING_CHARS,
             "max_sample_limit": _MAX_INGESTION_SAMPLE_LIMIT,
         },
+        "execute_limits": {
+            "max_source_material_rows": _MAX_INGESTION_ROWS,
+            "large_upload_strategy": "background_or_offline",
+        },
         "input_contracts": {
             LANDING_PAGE_QUALITY_REPAIR_INPUT: landing_page_quality_repair_input_contract(),
             **landing_page_seo_geo_aeo_input_contracts(),
@@ -187,6 +191,7 @@ def _compose_describe_response(
     static: Mapping[str, Any],
     configured_outputs: frozenset[str],
     execution_configured: bool,
+    execute_max_concurrency: int,
     reasoning_status: Mapping[str, Any],
 ) -> dict[str, Any]:
     # Re-project the cached static template into a fresh dict tree so
@@ -211,6 +216,15 @@ def _compose_describe_response(
         "execution": {
             "configured": execution_configured,
             "configured_outputs": sorted(configured_outputs),
+            "limits": {
+                "max_concurrency": execute_max_concurrency,
+                "max_source_material_rows": static["execute_limits"][
+                    "max_source_material_rows"
+                ],
+                "large_upload_strategy": static["execute_limits"][
+                    "large_upload_strategy"
+                ],
+            },
         },
         "reasoning": dict(reasoning_status),
         "ingestion_profiles": list(static["ingestion_profiles"]),
@@ -554,6 +568,7 @@ def create_content_ops_control_surface_router(
             static=_STATIC_CATALOG_PAYLOAD,
             configured_outputs=configured_outputs,
             execution_configured=execution_services is not None,
+            execute_max_concurrency=execute_gate.max_concurrency,
             reasoning_status=reasoning_status,
         )
 

--- a/plans/PR-Content-Ops-Execute-Limits-Describe.md
+++ b/plans/PR-Content-Ops-Execute-Limits-Describe.md
@@ -1,0 +1,86 @@
+# PR-Content-Ops-Execute-Limits-Describe
+
+## Why this slice exists
+
+The FAQ generator has now been proved offline at 50,000 rows and the hosted
+execute route is being proved at the current 1,000-row synchronous cap. The cap
+exists in request validation, but clients only discover it by failing a request
+or reading code/tests. That creates room for drift across sessions and for
+frontends to imply large synchronous uploads are safe when the production-safe
+path is bounded execution or background work.
+
+This slice makes the existing execute-route limits visible through
+`/content-ops/control-surfaces`. It does not raise limits or add background job
+execution.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/control-surfaces
+
+Slice phase: Production hardening.
+
+1. Add an `execution.limits` object to the control-surfaces describe response.
+2. Surface the current synchronous execute concurrency and source-material row
+   cap from existing constants/config.
+3. Add focused API tests that lock the response shape and prove the values do
+   not alias the cached static catalog payload.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Execute-Limits-Describe.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+
+## Mechanism
+
+The static catalog payload already carries ingestion limits. This slice adds a
+small static `execute` limits block for `max_source_material_rows`, then
+projects it into the existing per-request `execution` response along with
+`ContentOpsControlSurfaceApiConfig.execute_max_concurrency`.
+
+Expected response shape:
+
+```json
+"execution": {
+  "configured": true,
+  "configured_outputs": ["faq_markdown"],
+  "limits": {
+    "max_concurrency": 8,
+    "max_source_material_rows": 1000,
+    "large_upload_strategy": "background_or_offline"
+  }
+}
+```
+
+## Intentional
+
+- No execute-route behavior changes. This only publishes limits that already
+  exist.
+- No background queue in this PR. That remains the production solution for
+  uploads larger than the synchronous cap.
+- No frontend work. Clients can consume this contract in a separate lane.
+
+## Deferred
+
+- Background/durable execution for large FAQ uploads remains tracked by
+  `FAQSCALE-1` in `HARDENING.md`.
+- Route-level persisted FAQ execution proof remains a separate functional
+  validation slice after PR #916 review.
+
+## Verification
+
+- Focused API pytest passed: 98 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` passed.
+- `bash scripts/check_ascii_python.sh` passed.
+- `bash scripts/local_pr_review.sh --allow-dirty` passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Control-surface response | 15 |
+| API tests | 44 |
+| Plan doc | 81 |
+| **Total** | 140 |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -18,6 +18,12 @@ pytestmark = pytest.mark.skipif(
     reason="fastapi is not installed in this test environment",
 )
 
+_DEFAULT_EXECUTION_LIMITS = {
+    "max_concurrency": 8,
+    "max_source_material_rows": 1000,
+    "large_upload_strategy": "background_or_offline",
+}
+
 
 def _route(router, path: str, method: str):
     for route in router.routes:
@@ -276,7 +282,11 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert outputs["faq_markdown"]["reasoning_requirement"] == "absent"
-    assert payload["execution"] == {"configured": False, "configured_outputs": []}
+    assert payload["execution"] == {
+        "configured": False,
+        "configured_outputs": [],
+        "limits": dict(_DEFAULT_EXECUTION_LIMITS),
+    }
     assert payload["reasoning"] == {"configured": False}
     assert "email_only" in preset_ids
     assert "lead_gen_campaign" in preset_ids
@@ -323,6 +333,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
             "report",
             "signal_extraction",
         ],
+        "limits": dict(_DEFAULT_EXECUTION_LIMITS),
     }
     assert outputs["email_campaign"]["execution_configured"] is True
     assert outputs["email_campaign"]["can_execute"] is True
@@ -338,6 +349,21 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
 
 
 @pytest.mark.asyncio
+async def test_describe_control_surfaces_reports_configured_execute_concurrency():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(execute_max_concurrency=3)
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["execution"]["limits"] == {
+        **_DEFAULT_EXECUTION_LIMITS,
+        "max_concurrency": 3,
+    }
+
+
+@pytest.mark.asyncio
 async def test_describe_control_surfaces_reports_reasoning_provider_status():
     router = create_content_ops_control_surface_router(
         reasoning_context_provider=lambda: object()
@@ -346,7 +372,11 @@ async def test_describe_control_surfaces_reports_reasoning_provider_status():
     route = _route(router, "/content-ops/control-surfaces", "GET")
     payload = await route.endpoint()
 
-    assert payload["execution"] == {"configured": False, "configured_outputs": []}
+    assert payload["execution"] == {
+        "configured": False,
+        "configured_outputs": [],
+        "limits": dict(_DEFAULT_EXECUTION_LIMITS),
+    }
     assert payload["reasoning"] == {"configured": True}
 
 
@@ -509,6 +539,7 @@ async def test_describe_control_surfaces_requires_generate_method_for_readiness(
     assert payload["execution"] == {
         "configured": True,
         "configured_outputs": ["report"],
+        "limits": dict(_DEFAULT_EXECUTION_LIMITS),
     }
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
@@ -526,7 +557,11 @@ async def test_describe_control_surfaces_ignores_invalid_execution_provider_resu
     payload = await route.endpoint()
 
     outputs = {item["id"]: item for item in payload["outputs"]}
-    assert payload["execution"] == {"configured": False, "configured_outputs": []}
+    assert payload["execution"] == {
+        "configured": False,
+        "configured_outputs": [],
+        "limits": dict(_DEFAULT_EXECUTION_LIMITS),
+    }
     assert payload["reasoning"] == {"configured": False}
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
@@ -553,6 +588,7 @@ async def test_describe_control_surfaces_returns_independent_dict_per_call():
     first["ingestion_profiles"].append("injected_profile")
     first["ingestion_limits"]["inline_rows"]["max_rows"] = 999999
     first["ingestion_limits"]["file_upload"]["supported_formats"].append("yaml")
+    first["execution"]["limits"]["max_source_material_rows"] = 999999
 
     second = await route.endpoint()
     assert second["outputs"][0]["label"] != "MUTATED"
@@ -561,6 +597,7 @@ async def test_describe_control_surfaces_returns_independent_dict_per_call():
     assert "injected_profile" not in second["ingestion_profiles"]
     assert second["ingestion_limits"]["inline_rows"]["max_rows"] == 1000
     assert "yaml" not in second["ingestion_limits"]["file_upload"]["supported_formats"]
+    assert second["execution"]["limits"]["max_source_material_rows"] == 1000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Execute-Limits-Describe.md
Slice phase: Production hardening

Surface the existing Content Ops execute-route limits in the `/content-ops/control-surfaces` describe response so clients can discover the synchronous concurrency and source-material row cap before submitting FAQ generation requests.

## Intentional
- No execute-route behavior changes; this only publishes existing limits.
- No background queue in this PR; large-upload execution remains parked under FAQSCALE-1.
- No frontend work; clients can consume this contract in a separate lane.

## Deferred
- Background/durable execution for large FAQ uploads remains tracked by FAQSCALE-1 in HARDENING.md.
- Route-level persisted FAQ execution proof remains a separate functional validation slice after PR #916 review.

## Verification
- python -m pytest tests/test_extracted_content_control_surface_api.py -q: 98 passed.
- bash scripts/validate_extracted_content_pipeline.sh: passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline: passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt: passed.
- bash scripts/check_ascii_python.sh: passed.
- bash scripts/local_pr_review.sh --allow-dirty: passed.

## Diff size
3 files, +141 / -3
