### PR TITLE
PR-Content-Ops-Marketing-Claim-Audit

### DIFF
--- a/plans/PR-Content-Ops-Marketing-Claim-Audit.md
+++ b/plans/PR-Content-Ops-Marketing-Claim-Audit.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-Marketing-Claim-Audit
+
+## Why this slice exists
+Support Ticket Deflection copy is moving in parallel with FAQ generator work.
+The product can support strong claims, but public copy must not drift into live
+integrations, auto-publishing, guaranteed reduction, semantic clustering, cost
+ranking without cost data, or hosted unlimited/50k synchronous uploads.
+
+This slice adds a local audit so product/landing-page docs can be checked before
+PR review. Review follow-up tightened the audit so it fails loud on empty scan
+scopes, reports unreadable files as audit errors, and catches the named support
+platform/doc-site claims used in the funnel.
+
+## Scope (this PR)
+Ownership lane: content-ops/product-positioning
+
+Slice phase: Workflow/process.
+
+1. Add a script that scans repo-relative Markdown/text paths for prohibited
+   Support Ticket Deflection claims.
+2. Emit file/line/code diagnostics for each unsafe claim.
+3. Fail loud when no Markdown/text files are scanned or a candidate file cannot
+   be read.
+4. Add fixture tests for happy path, unsafe claims, named platform/doc targets,
+   allow comments, path-safety rejection, and `main()` success/error exits.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Marketing-Claim-Audit.md`
+- `scripts/audit_content_ops_marketing_claims.py`
+- `tests/test_audit_content_ops_marketing_claims.py`
+
+## Mechanism
+
+`scripts/audit_content_ops_marketing_claims.py` accepts repo-relative files or
+directories, defaults to `docs/products`, walks Markdown/text files, and reports
+unsafe claim lines. `claim-audit: allow <reason>` permits quoted anti-patterns.
+The allow marker must live in a trailing HTML comment with a substantive reason.
+Absolute paths, `..` traversal, empty scan scopes, missing paths, and files that
+resolve outside the repository are rejected.
+
+The script returns:
+
+- `0` when at least one file was scanned and no unsupported claim was found.
+- `1` when unsupported claim findings were found.
+- `2` when the audit could not reliably scan the requested scope.
+
+## Intentional
+
+- No existing product copy is changed in this slice.
+- The audit is phrase-based, not a semantic classifier. It catches known risky
+  claims cheaply and deterministically.
+- Denial copy can still match the phrase rules. Authors should use the explicit
+  allow comment for quoted anti-patterns or honest "we do not support X" copy.
+- The script is not wired into the global local PR review yet; teams can run it
+  against candidate marketing docs first, then we can promote it if it earns its
+  keep.
+
+## Deferred
+
+- Updating or landing the in-progress ticket-deflection GTM doc remains with the
+  product-copy session that created it.
+- CI/local-review integration for this audit is a later workflow slice.
+- Adding a richer claim policy file is deferred until the first rule churn
+  appears.
+
+## Verification
+
+- Audit unit tests passed: 10 passed.
+- Py compile passed for the audit script and tests.
+- Audit against tracked `docs/products` files passed and reported scanned file
+  count.
+- Local PR review passed: `bash scripts/local_pr_review.sh --allow-dirty`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Audit script | 274 |
+| Tests | 251 |
+| **Total** | 613 |
+
+Actual diff after review fixes is expected to exceed the 400 LOC target because
+the review identified correctness gaps in the first version of this audit: dead
+guaranteed-deflection phrasing, missing named platform targets, empty scan
+success, read-error behavior, and missing `main()` exit coverage. Splitting the
+fixes would leave a known-false-green audit open.

--- a/scripts/audit_content_ops_marketing_claims.py
+++ b/scripts/audit_content_ops_marketing_claims.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Audit Content Ops marketing copy for unsupported ticket-deflection claims."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PATHS = ("docs/products",)
+TEXT_SUFFIXES = {".md", ".mdx", ".txt"}
+ALLOW_MARKER = "claim-audit: allow"
+ALLOW_COMMENT_RE = re.compile(
+    r"<!--\s*claim-audit:\s*allow\s+(?P<reason>[^<>]+?)\s*-->",
+    re.IGNORECASE,
+)
+HELPDESK_PLATFORMS = (
+    r"zendesk|intercom|gorgias|freshdesk|help scout|"
+    r"salesforce service cloud|hubspot(?: service hub)?|shopify|front|"
+    r"jira service management"
+)
+PUBLISH_TARGETS = r"help[- ]?center|knowledge base|docs site|documentation site"
+
+
+@dataclass(frozen=True)
+class ClaimRule:
+    code: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+@dataclass(frozen=True)
+class ClaimFinding:
+    path: Path
+    line_no: int
+    code: str
+    message: str
+    line: str
+
+
+@dataclass(frozen=True)
+class ClaimAuditError:
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class ClaimAuditReport:
+    scanned_files: tuple[Path, ...]
+    findings: tuple[ClaimFinding, ...]
+    errors: tuple[ClaimAuditError, ...]
+
+
+RULES: tuple[ClaimRule, ...] = (
+    ClaimRule(
+        code="AUTO_PUBLISH",
+        pattern=re.compile(
+            r"\b(auto[- ]?publish(?:es|ing)?|automatically publish(?:es|ing)?|"
+            rf"publish(?:es)? (?:directly )?to (?:your )?(?:{PUBLISH_TARGETS})|"
+            rf"updates? (?:your )?(?:{PUBLISH_TARGETS}))\b",
+            re.IGNORECASE,
+        ),
+        message="Do not claim automatic help-center publishing.",
+    ),
+    ClaimRule(
+        code="LIVE_HELPDESK_INTEGRATION",
+        pattern=re.compile(
+            rf"\b(connect(?:s|ed)? (?:to )?(?:{HELPDESK_PLATFORMS})|"
+            rf"(?:native )?(?:{HELPDESK_PLATFORMS}) integration)\b",
+            re.IGNORECASE,
+        ),
+        message="Do not claim live help-desk integrations until built.",
+    ),
+    ClaimRule(
+        code="GUARANTEED_DEFLECTION",
+        pattern=re.compile(
+            r"\b(guarantee(?:d|s)? (?:a )?(?:ticket )?(?:reduction|deflection)|"
+            r"(?:cut|reduce|deflect) (?:support )?ticket(?: volume|s)? by \d+%|"
+            r"\d+% (?:fewer|less) (?:support )?tickets?)(?=$|[^A-Za-z0-9_])",
+            re.IGNORECASE,
+        ),
+        message="Do not claim guaranteed ticket-volume outcomes.",
+    ),
+    ClaimRule(
+        code="SEMANTIC_CLUSTERING",
+        pattern=re.compile(
+            r"\b(semantic clustering|semantically cluster(?:s|ed|ing)?|"
+            r"embedding(?:s)?[- ]?based clustering)\b",
+            re.IGNORECASE,
+        ),
+        message="Use intent/repeated-issue grouping unless semantic clustering lands.",
+    ),
+    ClaimRule(
+        code="COST_RANKING",
+        pattern=re.compile(
+            r"\b(rank(?:s|ed|ing)? by cost|cost[- ]?rank(?:s|ed|ing)?|"
+            r"support cost ranking)\b",
+            re.IGNORECASE,
+        ),
+        message="Do not claim cost ranking without imported cost/handle-time data.",
+    ),
+    ClaimRule(
+        code="UNBOUNDED_HOSTED_UPLOADS",
+        pattern=re.compile(
+            r"\b(unlimited (?:ticket|upload|row)s?|"
+            r"(?:hosted|self[- ]?serve|synchronous)[^.\n]{0,80}"
+            r"(?:50,?000|fifty thousand)|"
+            r"(?:50,?000|fifty thousand)[^.\n]{0,80}"
+            r"(?:hosted|self[- ]?serve|synchronous))\b",
+            re.IGNORECASE,
+        ),
+        message="Do not claim unbounded or 50k hosted synchronous uploads.",
+    ),
+)
+
+
+def _display_path(path: Path, *, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
+def _resolve_repo_path(value: str, *, root: Path) -> Path:
+    if not value.strip():
+        raise ValueError("path cannot be blank")
+    candidate = Path(value)
+    if candidate.is_absolute():
+        raise ValueError(f"absolute paths are not allowed: {value}")
+    if ".." in candidate.parts:
+        raise ValueError(f"path traversal is not allowed: {value}")
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository root: {value}") from exc
+    return resolved
+
+
+def _iter_files(paths: Sequence[str], *, root: Path) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for raw_path in paths:
+        path = _resolve_repo_path(raw_path, root=root)
+        if not path.exists():
+            raise ValueError(f"path does not exist: {raw_path}")
+        if path.is_file():
+            if path.suffix.lower() in TEXT_SUFFIXES:
+                files.append(path)
+            continue
+        for child in sorted(path.rglob("*")):
+            if child.is_file() and child.suffix.lower() in TEXT_SUFFIXES:
+                files.append(child)
+    return tuple(dict.fromkeys(files))
+
+
+def _allowed(line: str) -> bool:
+    match = ALLOW_COMMENT_RE.search(line)
+    if match is None:
+        return False
+    reason = match.group("reason").strip()
+    words = re.findall(r"[A-Za-z0-9]+", reason)
+    return len(reason) >= 12 and len(words) >= 2
+
+
+def audit_file(path: Path, *, root: Path) -> tuple[ClaimFinding, ...]:
+    findings: list[ClaimFinding] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if _allowed(line):
+            continue
+        for rule in RULES:
+            if rule.pattern.search(line):
+                findings.append(
+                    ClaimFinding(
+                        path=_display_path(path, root=root),
+                        line_no=line_no,
+                        code=rule.code,
+                        message=rule.message,
+                        line=line.strip(),
+                    )
+                )
+    return tuple(findings)
+
+
+def audit_paths_report(
+    paths: Sequence[str] = DEFAULT_PATHS,
+    *,
+    root: Path = REPO_ROOT,
+) -> ClaimAuditReport:
+    files = _iter_files(paths, root=root)
+    if not files:
+        raise ValueError("no Markdown/text files found to audit")
+    findings: list[ClaimFinding] = []
+    errors: list[ClaimAuditError] = []
+    for path in files:
+        try:
+            findings.extend(audit_file(path, root=root))
+        except (OSError, ValueError) as exc:
+            errors.append(
+                ClaimAuditError(
+                    path=_display_path(path, root=root),
+                    message=str(exc),
+                )
+            )
+    return ClaimAuditReport(
+        scanned_files=tuple(_display_path(path, root=root) for path in files),
+        findings=tuple(findings),
+        errors=tuple(errors),
+    )
+
+
+def audit_paths(paths: Sequence[str] = DEFAULT_PATHS, *, root: Path = REPO_ROOT) -> tuple[ClaimFinding, ...]:
+    report = audit_paths_report(paths, root=root)
+    if report.errors:
+        first = report.errors[0]
+        raise ValueError(f"could not audit {first.path}: {first.message}")
+    return report.findings
+
+
+def render_findings(findings: Iterable[ClaimFinding]) -> str:
+    lines = []
+    for finding in findings:
+        lines.append(
+            f"{finding.path}:{finding.line_no}: {finding.code}: "
+            f"{finding.message} [{finding.line}]"
+        )
+    return "\n".join(lines)
+
+
+def render_errors(errors: Iterable[ClaimAuditError]) -> str:
+    lines = []
+    for error in errors:
+        lines.append(f"{error.path}: ERROR: {error.message}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_PATHS),
+        help="Repo-relative files or directories to audit.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = audit_paths_report(args.paths, root=REPO_ROOT)
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if report.errors:
+        if report.findings:
+            print(render_findings(report.findings))
+        print(render_errors(report.errors), file=sys.stderr)
+        return 2
+    findings = report.findings
+    if findings:
+        print(render_findings(findings))
+        return 1
+    print(
+        "OK: no unsupported Content Ops marketing claims found "
+        f"({len(report.scanned_files)} files scanned)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_content_ops_marketing_claims.py
+++ b/tests/test_audit_content_ops_marketing_claims.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "audit_content_ops_marketing_claims.py"
+)
+
+
+def load_auditor():
+    spec = importlib.util.spec_from_file_location(
+        "audit_content_ops_marketing_claims",
+        SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(root: Path, relative: str, text: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_happy_path_allows_defensible_support_ticket_copy(tmp_path):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "# Ticket Deflection\n"
+        "Atlas groups repeated issue language from support-ticket exports, "
+        "ranks FAQ opportunities by ticket volume and failure-risk signals, "
+        "and drafts review-ready answers.\n",
+    )
+
+    findings = auditor.audit_paths(
+        ["docs/products/ticket-deflection.md"],
+        root=tmp_path,
+    )
+
+    assert findings == ()
+
+
+def test_audit_surfaces_unsupported_claim_families(tmp_path):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Connect Zendesk and automatically publish answers to your help center.\n"
+        "Native Shopify integration publishes directly to your docs site.\n"
+        "Self-serve hosted uploads handle 50,000 tickets and reduce ticket "
+        "volume by 30%.\n"
+        "Semantic clustering ranks by cost for every ticket export.\n",
+    )
+
+    findings = auditor.audit_paths(
+        ["docs/products"],
+        root=tmp_path,
+    )
+
+    assert {
+        (finding.code, finding.line_no, finding.message)
+        for finding in findings
+    } == {
+        (
+            "AUTO_PUBLISH",
+            1,
+            "Do not claim automatic help-center publishing.",
+        ),
+        (
+            "LIVE_HELPDESK_INTEGRATION",
+            1,
+            "Do not claim live help-desk integrations until built.",
+        ),
+        (
+            "AUTO_PUBLISH",
+            2,
+            "Do not claim automatic help-center publishing.",
+        ),
+        (
+            "LIVE_HELPDESK_INTEGRATION",
+            2,
+            "Do not claim live help-desk integrations until built.",
+        ),
+        (
+            "GUARANTEED_DEFLECTION",
+            3,
+            "Do not claim guaranteed ticket-volume outcomes.",
+        ),
+        (
+            "UNBOUNDED_HOSTED_UPLOADS",
+            3,
+            "Do not claim unbounded or 50k hosted synchronous uploads.",
+        ),
+        (
+            "COST_RANKING",
+            4,
+            "Do not claim cost ranking without imported cost/handle-time data.",
+        ),
+        (
+            "SEMANTIC_CLUSTERING",
+            4,
+            "Use intent/repeated-issue grouping unless semantic clustering lands.",
+        ),
+    }
+    assert all(finding.path == Path("docs/products/ticket-deflection.md") for finding in findings)
+
+
+def test_audit_catches_named_platform_and_publish_targets(tmp_path):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Connects to HubSpot Service Hub.\n"
+        "Native Shopify integration.\n"
+        "Front integration included.\n"
+        "Connect to Jira Service Management.\n"
+        "Publishes directly to your knowledge base.\n",
+    )
+
+    findings = auditor.audit_paths(
+        ["docs/products/ticket-deflection.md"],
+        root=tmp_path,
+    )
+
+    assert [finding.code for finding in findings] == [
+        "LIVE_HELPDESK_INTEGRATION",
+        "LIVE_HELPDESK_INTEGRATION",
+        "LIVE_HELPDESK_INTEGRATION",
+        "LIVE_HELPDESK_INTEGRATION",
+        "AUTO_PUBLISH",
+    ]
+
+
+def test_audit_catches_percent_ticket_reduction_phrase(tmp_path):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Reduce tickets by 30%.\n"
+        "Cut support tickets by 50%.\n"
+        "Deflect ticket volume by 20%.\n",
+    )
+
+    findings = auditor.audit_paths(
+        ["docs/products/ticket-deflection.md"],
+        root=tmp_path,
+    )
+
+    assert [finding.code for finding in findings] == [
+        "GUARANTEED_DEFLECTION",
+        "GUARANTEED_DEFLECTION",
+        "GUARANTEED_DEFLECTION",
+    ]
+
+
+def test_allow_marker_requires_reason_and_skips_documented_antipattern(tmp_path):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Do not say auto-publish. <!-- claim-audit: allow quoted anti-pattern -->\n"
+        "Do not say connect Zendesk. <!-- claim-audit: allow -->\n",
+    )
+
+    findings = auditor.audit_paths(
+        ["docs/products/ticket-deflection.md"],
+        root=tmp_path,
+    )
+
+    assert [finding.code for finding in findings] == ["LIVE_HELPDESK_INTEGRATION"]
+
+
+def test_audit_rejects_unsafe_paths(tmp_path):
+    auditor = load_auditor()
+
+    with pytest.raises(ValueError, match="absolute paths are not allowed"):
+        auditor.audit_paths([str(tmp_path / "docs")], root=tmp_path)
+
+    with pytest.raises(ValueError, match="path traversal is not allowed"):
+        auditor.audit_paths(["../outside.md"], root=tmp_path)
+
+    outside = tmp_path.parent / "outside-marketing-doc.md"
+    outside.write_text("Safe copy.\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "escape.md").symlink_to(outside)
+    with pytest.raises(ValueError, match="path escapes repository root"):
+        auditor.audit_paths(["docs/escape.md"], root=tmp_path)
+
+
+def test_audit_rejects_empty_scan_scope(tmp_path):
+    auditor = load_auditor()
+    (tmp_path / "docs" / "products").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="no Markdown/text files found"):
+        auditor.audit_paths(["docs/products"], root=tmp_path)
+
+
+def test_main_returns_failure_for_unsafe_claims(tmp_path, monkeypatch, capsys):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Unlimited tickets with semantic clustering.\n",
+    )
+    monkeypatch.setattr(auditor, "REPO_ROOT", tmp_path)
+
+    code = auditor.main(["docs/products"])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "UNBOUNDED_HOSTED_UPLOADS" in captured.out
+    assert "SEMANTIC_CLUSTERING" in captured.out
+
+
+def test_main_returns_zero_for_clean_copy(tmp_path, monkeypatch, capsys):
+    auditor = load_auditor()
+    _write(
+        tmp_path,
+        "docs/products/ticket-deflection.md",
+        "Atlas groups repeated issue language and drafts review-ready answers.\n",
+    )
+    monkeypatch.setattr(auditor, "REPO_ROOT", tmp_path)
+
+    code = auditor.main(["docs/products"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "1 files scanned" in captured.out
+
+
+def test_main_returns_error_for_bad_path(tmp_path, monkeypatch, capsys):
+    auditor = load_auditor()
+    monkeypatch.setattr(auditor, "REPO_ROOT", tmp_path)
+
+    code = auditor.main(["docs/products/missing.md"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "path does not exist" in captured.err


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Marketing-Claim-Audit.md
Slice phase: Workflow/process

Add a deterministic Content Ops marketing-claim audit for Support Ticket Deflection copy so unsafe claims around live integrations, auto-publish, guaranteed outcomes, semantic clustering, cost ranking, and unbounded hosted uploads are caught before PR review. Review follow-up makes the audit fail loud on empty/unreadable scans and expands coverage for the named platform/doc-site targets.

## Intentional
- No existing product copy is changed in this slice.
- The audit is phrase-based, not a semantic classifier; denial/example copy can use an explicit allow comment.
- The script is not wired into global local PR review yet; teams can run it manually first.

## Deferred
- Updating or landing the in-progress ticket-deflection GTM doc remains with the product-copy session that created it.
- CI/local-review integration for this audit is a later workflow slice.
- Adding a richer claim policy file is deferred until the first rule churn appears.

## Verification
- pytest tests/test_audit_content_ops_marketing_claims.py -q: 10 passed.
- python -m py_compile scripts/audit_content_ops_marketing_claims.py tests/test_audit_content_ops_marketing_claims.py: passed.
- python scripts/audit_content_ops_marketing_claims.py docs/products/llm_gateway_mvp_plan.md: passed, 1 file scanned.
- bash scripts/local_pr_review.sh --allow-dirty: passed.

## Diff size
3 files, +613 / -0
