### PR TITLE
Add support-ticket CSV mode to live generation smoke

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -380,6 +380,35 @@ python scripts/smoke_content_ops_live_generation.py \
   --json
 ```
 
+To run the same live smoke with support-ticket-derived inputs, add
+`--support-ticket-csv`. When no path is supplied, the script uses the packaged
+`extracted_content_pipeline/examples/support_ticket_sources.csv`, packages the
+rows through the Atlas support-ticket input provider, and then runs the normal
+landing-page or blog-post executor path:
+
+The CSV must be support-ticket-shaped: include fields such as ticket id,
+subject, description/message text, pain category/intent, or `source_type`.
+Non-ticket CSVs fail before execution so the smoke does not run with unexpanded
+provider defaults.
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --account-id acct_123 \
+  --support-ticket-csv \
+  --env-file /path/to/Atlas/.env \
+  --json
+```
+
+For low-cost live testing, point the env file at Haiku before running the smoke:
+
+```bash
+ATLAS_LLM__OPENROUTER_REASONING_MODEL=anthropic/claude-haiku-4-5
+```
+
+The blog-post variant also accepts `--support-ticket-csv`; its default seeded
+blueprint uses the same `content_ops_support_ticket_faq` topic type that the
+support-ticket provider emits.
+
 Minimal `blog-blueprint.json`:
 
 ```json

--- a/plans/PR-Support-Ticket-Provider-Live-Smoke-Source.md
+++ b/plans/PR-Support-Ticket-Provider-Live-Smoke-Source.md
@@ -1,0 +1,110 @@
+# PR: Support Ticket Provider Live Smoke Source
+
+## Why this slice exists
+
+The support-ticket provider lane has deterministic execute coverage for FAQ and
+landing/blog generation. The remaining operator gap is practical live testing:
+the existing live Content Ops smoke script can hit the DB-backed landing/blog
+services, but it only uses hand-built default inputs. We need a thin real-path
+smoke option that feeds the packaged support-ticket CSV through the Atlas
+support-ticket provider before executing landing-page or blog-post generation.
+
+This slice is over the normal 400 LOC target because live export inspection
+found a data-truthfulness issue in the first version: the support-ticket blog
+blueprint inherited generic benchmark counts that were not present in the CSV.
+Fixing that at the source requires CSV-derived blueprint facts plus regression
+coverage in the same PR that introduced the live smoke path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add a live smoke CLI option for support-ticket CSV source rows.
+2. Package those rows through the Atlas support-ticket input provider before
+   calling the existing Content Ops executor.
+3. Keep blog blueprint seeding aligned with provider-produced support-ticket
+   filters when the smoke runs `--output blog_post`.
+4. Derive the default support-ticket blog blueprint counts and clusters from
+   the uploaded CSV rows so the live smoke cannot invent evidence.
+5. Fail clearly when `--support-ticket-csv` points at a non-ticket-shaped CSV
+   instead of running with an unexpanded provider noop.
+6. Document the live smoke command and the Haiku OpenRouter model override for
+   lower-cost testing.
+
+### Files touched
+
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `extracted_content_pipeline/README.md`
+- `plans/PR-Support-Ticket-Provider-Live-Smoke-Source.md`
+
+## Mechanism
+
+`--support-ticket-csv` loads CSV rows as request `source_material`. Once a
+tenant scope exists, the script calls `build_content_ops_input_provider()` and
+merges the provider package into the execute payload using the extracted
+input-provider merge helper. This mirrors the hosted control-surface path while
+still using the script's direct executor call.
+
+For blog smoke runs, the default seeded blueprint switches to
+`content_ops_support_ticket_faq` when `--support-ticket-csv` is present, so the
+provider-produced filter and seeded row agree.
+
+The support-ticket blog blueprint derives source row count, question-like row
+count, and top pain/category clusters from the CSV rows. This prevents the
+smoke harness from reusing generic benchmark numbers that are not present in
+the uploaded ticket source.
+
+If the Atlas support-ticket provider classifies the CSV request as a noop, the
+script raises before execution. That keeps operator mistakes visible and avoids
+a confusing run that has raw `source_material` but none of the provider's FAQ
+Report defaults.
+
+## Intentional
+
+- No production route changes. This only improves the operator smoke harness.
+- No live test is added to CI; tests use fake services and the existing executor.
+- No FAQ generator changes. FAQ output remains owned by the FAQ session.
+- No file-ingestion import path changes. The source is an already-loaded CSV,
+  matching the support-ticket provider contract.
+
+## Deferred
+
+- Uploaded file import -> provider -> landing/blog generation remains blocked
+  on the file-ingestion/import lookup lane.
+- Full live validation beyond the packaged CSV can follow after this
+  support-ticket source mode lands.
+- Parked hardening: none. `HARDENING.md` was scanned; existing FAQ scale and
+  file-ingestion concurrency entries are outside this live smoke source slice.
+
+## Verification
+
+- Focused smoke-script tests for `tests/test_smoke_content_ops_live_generation.py`
+  - 14 passed.
+- Py compile for the smoke script and test file - passed.
+- Git whitespace check - passed.
+- Local PR review wrapper - passed.
+- Manual landing-page live smoke with the packaged support-ticket CSV and
+  Haiku OpenRouter model - passed; saved landing-page draft
+  `06e680c5-7ab4-4bff-8c94-24bd2cd1c969`.
+- Manual blog-post live smoke with the packaged support-ticket CSV and Haiku
+  OpenRouter model - passed; seeded blueprint
+  `4bfe5289-8aaf-42a0-9baf-800f5f2b23b2` and saved blog draft
+  `5a4b5ec9-ffcb-470b-955f-49e1e3302aaf`.
+- Follow-up blog-post live smoke after CSV-derived blueprint fix - passed;
+  seeded blueprint `8d4abd7b-4609-4f23-9664-812659e6c2fe` and saved blog draft
+  `57b5d81c-987a-4e38-a808-37c8a4ccfee8`. Export confirmed the draft carries
+  `source_row_count=4`, `question_like_ticket_count=2`, the two real CSV
+  clusters, and no old `186` / `78` / `42%` benchmark numbers.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~105 |
+| Script | ~270 |
+| Tests | ~170 |
+| Docs | ~30 |
+| **Total** | **~575** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import csv
 import json
 from pathlib import Path
 import re
@@ -54,6 +55,11 @@ DEFAULT_BLOG_TOPIC = (
     "Support ticket FAQ gaps: what 90 days of repeat tickets reveal"
 )
 DEFAULT_BLOG_TOPIC_TYPE = "content_ops_live_smoke"
+DEFAULT_SUPPORT_TICKET_CSV = (
+    ROOT / "extracted_content_pipeline" / "examples" / "support_ticket_sources.csv"
+)
+SUPPORT_TICKET_BLOG_TOPIC = "Support-ticket questions customers keep asking"
+SUPPORT_TICKET_BLOG_TOPIC_TYPE = "content_ops_support_ticket_faq"
 
 AsyncCallable = Callable[[], Awaitable[None]]
 ServicesFactory = Callable[[], Any]
@@ -111,6 +117,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional JSON object merged over the default inputs.",
     )
     parser.add_argument(
+        "--support-ticket-csv",
+        nargs="?",
+        const=DEFAULT_SUPPORT_TICKET_CSV,
+        type=Path,
+        help=(
+            "Load support-ticket source rows from CSV and package them through "
+            "the Atlas support-ticket input provider before execution. When "
+            "no path is provided, uses the packaged support_ticket_sources.csv. "
+            "CSV rows must include support-ticket-shaped fields such as "
+            "ticket id, subject, description/message, or source_type."
+        ),
+    )
+    parser.add_argument(
         "--blog-blueprint-json",
         type=Path,
         help=(
@@ -159,6 +178,14 @@ def _load_json_object(path: Path) -> dict[str, Any]:
     return parsed
 
 
+def _load_csv_rows(path: Path) -> list[dict[str, str]]:
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    except OSError as exc:
+        raise SystemExit(f"Unable to read --support-ticket-csv: {exc}") from exc
+
+
 def _parse_override(raw: str) -> tuple[str, Any]:
     if "=" not in raw:
         raise SystemExit("--input overrides must use key=value")
@@ -180,7 +207,9 @@ def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
     if int(args.quality_repair_attempts) < 0:
         raise SystemExit("--quality-repair-attempts must be >= 0")
     output = str(args.output or "landing_page").strip() or "landing_page"
-    if output == "landing_page":
+    if _uses_support_ticket_csv(args):
+        inputs = {"source_material": _load_csv_rows(Path(args.support_ticket_csv))}
+    elif output == "landing_page":
         inputs = dict(DEFAULT_LANDING_PAGE_INPUTS)
     elif output == "blog_post":
         inputs = {
@@ -204,6 +233,58 @@ def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
         "require_quality_gates": not bool(args.no_quality_gates),
         "inputs": inputs,
     }
+
+
+def _uses_support_ticket_csv(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "support_ticket_csv", None))
+
+
+def _support_ticket_rows_from_args(args: argparse.Namespace) -> list[dict[str, str]]:
+    if not _uses_support_ticket_csv(args):
+        return []
+    return _load_csv_rows(Path(args.support_ticket_csv))
+
+
+async def _payload_with_support_ticket_provider(
+    payload: Mapping[str, Any],
+    *,
+    scope: Any,
+) -> dict[str, Any]:
+    from atlas_brain._content_ops_input_provider import (  # noqa: PLC0415
+        build_content_ops_input_provider,
+    )
+    from extracted_content_pipeline.content_ops_input_provider import (  # noqa: PLC0415
+        merge_content_ops_input_package,
+    )
+
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=scope,
+        request=payload,
+    )
+    if hasattr(package, "__await__"):
+        package = await package
+    if _provider_package_is_noop(package):
+        raise ValueError(
+            "--support-ticket-csv did not contain support-ticket-shaped rows; "
+            "include ticket id, subject, and description/message fields."
+        )
+    return merge_content_ops_input_package(payload, package)
+
+
+def _provider_package_is_noop(package: Any) -> bool:
+    metadata = getattr(package, "metadata", None)
+    inputs = getattr(package, "inputs", None)
+    outputs = getattr(package, "outputs", None)
+    if isinstance(package, Mapping):
+        metadata = package.get("metadata")
+        inputs = package.get("inputs")
+        outputs = package.get("outputs")
+    return (
+        not inputs
+        and not outputs
+        and isinstance(metadata, Mapping)
+        and metadata.get("mode") == "noop"
+    )
 
 
 def _resolve_runtime_dependencies() -> tuple[AsyncCallable, AsyncCallable, ServicesFactory, Executor, Any]:
@@ -358,10 +439,165 @@ def _default_blog_blueprint_payload() -> dict[str, Any]:
     }
 
 
+def _support_ticket_blog_blueprint_payload(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    source_rows = [dict(row) for row in rows if isinstance(row, Mapping)]
+    row_count = len(source_rows)
+    question_like_count = sum(1 for row in source_rows if "?" in _ticket_row_text(row))
+    top_clusters = _top_ticket_clusters(source_rows)
+    cluster_summary = _cluster_summary(top_clusters)
+    draft_faq_entries = min(12, max(1, row_count))
+    return {
+        "topic": SUPPORT_TICKET_BLOG_TOPIC,
+        "data_context": {
+            "review_period": "last 90 days",
+            "source_row_count": row_count,
+            "question_like_ticket_count": question_like_count,
+            "top_clusters": top_clusters,
+            "_known_vendors": [],
+            "report_date": "2026-05-23",
+            "total_reviews_analyzed": row_count,
+            "deep_enriched_count": row_count,
+            "category": "support tickets",
+            "topic": SUPPORT_TICKET_BLOG_TOPIC,
+            "source_period": "Last 90 days of support tickets",
+            "source": "support_ticket_provider",
+        },
+        "sections": [
+            {
+                "id": "repeat-ticket-patterns",
+                "heading": "What do repeat support tickets reveal?",
+                "goal": (
+                    "Explain what the uploaded support-ticket rows show about "
+                    "customer questions and missing customer-facing answers."
+                ),
+                "key_stats": {
+                    "support_ticket_rows": row_count,
+                    "question_like_rows": question_like_count,
+                    "cluster_count": len(top_clusters),
+                },
+                "chart_ids": [],
+                "data_summary": (
+                    f"The uploaded CSV contains {row_count} support-ticket "
+                    f"rows. {question_like_count} rows include direct customer "
+                    f"questions. Top observed clusters: {cluster_summary}."
+                ),
+            },
+            {
+                "id": "faq-gap-priorities",
+                "heading": "Which FAQ gaps should a small team fix first?",
+                "goal": (
+                    "Rank the observed ticket clusters by volume and explain "
+                    "why the highest-volume issues should become FAQ entries."
+                ),
+                "key_stats": _cluster_key_stats(top_clusters),
+                "chart_ids": [],
+                "data_summary": (
+                    "Prioritize FAQ work by observed ticket volume. In this "
+                    f"CSV, the highest-volume clusters are: {cluster_summary}. "
+                    "Those clusters should be reviewed before lower-volume or "
+                    "one-off questions."
+                ),
+            },
+            {
+                "id": "publishable-answer-process",
+                "heading": "How should old tickets become customer-ready answers?",
+                "goal": (
+                    "Show the operational path from CSV upload to clustered "
+                    "questions, customer wording, draft answers, and review."
+                ),
+                "key_stats": {
+                    "source_window_days": 90,
+                    "source_rows": row_count,
+                    "draft_faq_entries": draft_faq_entries,
+                    "review_steps": 3,
+                },
+                "chart_ids": [],
+                "data_summary": (
+                    f"The uploaded ticket CSV can produce up to {draft_faq_entries} "
+                    "first-pass FAQ entries from observed customer wording. "
+                    "Each answer should preserve customer language, summarize "
+                    "the support team's resolution, and stay in review until "
+                    "the team approves it."
+                ),
+            },
+        ],
+        "available_charts": [],
+        "related_posts": [],
+        "grounded_vendors": [
+            "Support Tickets",
+            "Support Ticket FAQ",
+            "Support Ticket FAQ Gaps",
+            "FAQ Report",
+            "Help Center",
+        ],
+        "required_vendors": [],
+    }
+
+
+def _ticket_row_text(row: Mapping[str, Any]) -> str:
+    return " ".join(
+        str(row.get(key) or "").strip()
+        for key in (
+            "Description",
+            "description",
+            "Message",
+            "message",
+            "Text",
+            "text",
+            "Subject",
+            "subject",
+            "Title",
+            "title",
+        )
+        if str(row.get(key) or "").strip()
+    )
+
+
+def _ticket_cluster_label(row: Mapping[str, Any]) -> str:
+    for key in ("Pain Category", "pain_category", "Category", "category", "intent"):
+        value = str(row.get(key) or "").strip()
+        if value:
+            return value
+    return "uncategorized"
+
+
+def _top_ticket_clusters(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        label = _ticket_cluster_label(row)
+        counts[label] = counts.get(label, 0) + 1
+    return [
+        {"label": label, "count": count}
+        for label, count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0].lower()),
+        )[:5]
+    ]
+
+
+def _cluster_summary(clusters: Sequence[Mapping[str, Any]]) -> str:
+    if not clusters:
+        return "no categorized ticket clusters"
+    return ", ".join(
+        f"{cluster.get('label')} ({int(cluster.get('count') or 0)})"
+        for cluster in clusters
+    )
+
+
+def _cluster_key_stats(clusters: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    stats: dict[str, int] = {}
+    for index, cluster in enumerate(clusters[:5], start=1):
+        stats[f"cluster_{index}_count"] = int(cluster.get("count") or 0)
+    return stats or {"cluster_count": 0}
+
+
 def _load_single_blog_blueprint_from_file(
     path: Path,
     *,
     target_mode: str,
+    topic_type: str = DEFAULT_BLOG_TOPIC_TYPE,
 ) -> tuple[Any, list[dict[str, Any]]]:
     from extracted_content_pipeline.blog_blueprint_ingest import (  # noqa: PLC0415
         load_blog_blueprints_from_file,
@@ -371,7 +607,7 @@ def _load_single_blog_blueprint_from_file(
         loaded = load_blog_blueprints_from_file(
             path,
             target_mode=target_mode,
-            topic_type=DEFAULT_BLOG_TOPIC_TYPE,
+            topic_type=topic_type,
         )
     except OSError as exc:
         raise ValueError(f"unable to read --blog-blueprint-json: {exc}") from exc
@@ -415,7 +651,10 @@ def _align_blog_payload_to_seed(
             inputs["filters"] = filters
         filters["slug"] = slug
     seeded_topic = str(seeded_blog_blueprint.get("topic") or "").strip()
-    if seeded_topic and inputs.get("topic") == DEFAULT_BLOG_TOPIC:
+    if seeded_topic and inputs.get("topic") in {
+        DEFAULT_BLOG_TOPIC,
+        SUPPORT_TICKET_BLOG_TOPIC,
+    }:
         inputs["topic"] = seeded_topic
 
 
@@ -430,7 +669,18 @@ async def _seed_default_blog_blueprint(
     from extracted_content_pipeline.blog_ports import BlogBlueprint  # noqa: PLC0415
 
     account_slug = _account_slug(args.account_id)
-    slug = f"content-ops-blog-live-smoke-{account_slug}"
+    support_ticket_mode = _uses_support_ticket_csv(args)
+    topic_type = (
+        SUPPORT_TICKET_BLOG_TOPIC_TYPE
+        if support_ticket_mode
+        else DEFAULT_BLOG_TOPIC_TYPE
+    )
+    slug_prefix = (
+        "content-ops-support-ticket-live-smoke"
+        if support_ticket_mode
+        else "content-ops-blog-live-smoke"
+    )
+    slug = f"{slug_prefix}-{account_slug}"
     target_mode = str(args.target_mode or "vendor_retention").strip() or "vendor_retention"
     custom_path = getattr(args, "blog_blueprint_json", None)
     custom_warnings: list[dict[str, Any]] = []
@@ -439,15 +689,26 @@ async def _seed_default_blog_blueprint(
         blueprint, custom_warnings = _load_single_blog_blueprint_from_file(
             Path(custom_path),
             target_mode=target_mode,
+            topic_type=topic_type,
         )
         custom_source = str(custom_path)
     else:
         blueprint = BlogBlueprint(
             target_mode=target_mode,
-            topic_type=DEFAULT_BLOG_TOPIC_TYPE,
+            topic_type=topic_type,
             slug=slug,
-            suggested_title="Support Tickets: FAQ Gaps From 90 Days of Tickets",
-            payload=_default_blog_blueprint_payload(),
+            suggested_title=(
+                SUPPORT_TICKET_BLOG_TOPIC
+                if support_ticket_mode
+                else "Support Tickets: FAQ Gaps From 90 Days of Tickets"
+            ),
+            payload=(
+                _support_ticket_blog_blueprint_payload(
+                    _support_ticket_rows_from_args(args)
+                )
+                if support_ticket_mode
+                else _default_blog_blueprint_payload()
+            ),
         )
     saved_ids = await PostgresBlogBlueprintRepository(
         pool=get_db_pool()
@@ -514,6 +775,11 @@ async def run_content_ops_live_generation_smoke(
                 account_id=str(args.account_id or "").strip(),
                 user_id=str(args.user_id or "").strip(),
             )
+            if _uses_support_ticket_csv(args):
+                payload = await _payload_with_support_ticket_provider(
+                    payload,
+                    scope=scope,
+                )
             if output == "blog_post":
                 seeder = blog_blueprint_seed_fn or _seed_default_blog_blueprint
                 seeded_blog_blueprint = await seeder(args, scope)

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -86,6 +86,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "target_mode": "vendor_retention",
         "env_file": [],
         "input_json": None,
+        "support_ticket_csv": None,
         "blog_blueprint_json": None,
         "input": [],
         "quality_repair_attempts": 1,
@@ -95,6 +96,37 @@ def _args(**overrides: Any) -> argparse.Namespace:
     }
     values.update(overrides)
     return argparse.Namespace(**values)
+
+
+def _support_ticket_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "support_tickets.csv"
+    path.write_text(
+        "\n".join([
+            "Ticket ID,Subject,Description,Pain Category",
+            (
+                "ticket-login-1,Login email change,"
+                "How do I change my login email?,account"
+            ),
+            (
+                "ticket-export-1,Campaign export,"
+                "How do we export campaign attribution data before renewal?,reporting"
+            ),
+        ]),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _non_ticket_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "accounts.csv"
+    path.write_text(
+        "\n".join([
+            "Company,Website,Notes",
+            "Acme,https://example.com,Prospect account",
+        ]),
+        encoding="utf-8",
+    )
+    return path
 
 
 @pytest.mark.asyncio
@@ -131,6 +163,76 @@ async def test_live_generation_smoke_executes_landing_page_through_real_executor
     assert call["campaign"].context["faq_questions"] == ["How long does it take?"]
     assert call["quality_repair_attempts"] == 1
     assert call["quality_gates_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_packages_support_ticket_csv_for_landing_page(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(support_ticket_csv=_support_ticket_csv(tmp_path)),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["payload"]["inputs"]["target_keyword"] == "support ticket FAQ report"
+    assert result["payload"]["inputs"]["source_period"] == (
+        "Last 90 days of support tickets"
+    )
+    assert result["payload"]["inputs"]["faq_questions"] == [
+        "How do I change my login email?",
+        "How do we export campaign attribution data before renewal?",
+    ]
+    assert len(service.calls) == 1
+
+    call = service.calls[0]
+    assert call["campaign"].name == "FAQ Report"
+    assert call["campaign"].persona == (
+        "Small teams answering repeat support questions"
+    )
+    assert call["campaign"].context["cta_label"] == (
+        "Upload Ticket CSV -- Free Analysis"
+    )
+    assert call["campaign"].context["faq_questions"] == [
+        "How do I change my login email?",
+        "How do we export campaign attribution data before renewal?",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_rejects_non_ticket_csv(tmp_path: Path) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(support_ticket_csv=_non_ticket_csv(tmp_path)),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["execution"] is None
+    assert result["errors"] == [
+        "ValueError: --support-ticket-csv did not contain "
+        "support-ticket-shaped rows; include ticket id, subject, and "
+        "description/message fields."
+    ]
+    assert service.calls == []
+    assert lifecycle.initialized is True
+    assert lifecycle.closed is True
 
 
 @pytest.mark.asyncio
@@ -186,6 +288,55 @@ async def test_live_generation_smoke_seeds_and_executes_blog_post_through_real_e
     }
     assert call["topic"] == "Support ticket FAQ gaps"
     assert call["quality_gates_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_packages_support_ticket_csv_for_blog_post(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _BlogPostService()
+    seeded: list[dict[str, Any]] = []
+
+    async def _seed_blog_blueprint(args: argparse.Namespace, scope: TenantScope) -> dict[str, Any]:
+        seeded.append({"args": args, "scope": scope})
+        return {
+            "saved_ids": ["bp-support-ticket-smoke-1"],
+            "slug": "content-ops-support-ticket-live-smoke-acct-live-smoke",
+            "target_mode": args.target_mode,
+            "topic_type": "content_ops_support_ticket_faq",
+            "topic": "Support-ticket questions customers keep asking",
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="blog_post",
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(blog_post=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        blog_blueprint_seed_fn=_seed_blog_blueprint,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["payload"]["inputs"]["filters"] == {
+        "topic_type": "content_ops_support_ticket_faq",
+        "slug": "content-ops-support-ticket-live-smoke-acct-live-smoke",
+    }
+    assert len(seeded) == 1
+    assert len(service.calls) == 1
+
+    call = service.calls[0]
+    assert call["filters"] == {
+        "topic_type": "content_ops_support_ticket_faq",
+        "slug": "content-ops-support-ticket-live-smoke-acct-live-smoke",
+    }
+    assert call["topic"] == "Support-ticket questions customers keep asking"
 
 
 def test_blog_blueprint_json_loader_accepts_one_custom_blueprint(tmp_path: Path) -> None:
@@ -250,6 +401,76 @@ def test_blog_payload_alignment_uses_seeded_topic_type_and_title() -> None:
         "slug": "faq-gaps-for-onboarding-tickets",
     }
     assert payload["inputs"]["topic"] == "FAQ gaps for onboarding tickets"
+
+
+def test_blog_payload_alignment_replaces_support_ticket_provider_default_topic() -> None:
+    payload = {
+        "outputs": ["blog_post"],
+        "inputs": {
+            "topic": smoke.SUPPORT_TICKET_BLOG_TOPIC,
+            "filters": {"topic_type": smoke.SUPPORT_TICKET_BLOG_TOPIC_TYPE},
+        },
+    }
+
+    smoke._align_blog_payload_to_seed(
+        payload,
+        {
+            "topic_type": "custom_support_ticket_topic",
+            "slug": "custom-support-ticket-blueprint",
+            "topic": "Custom support-ticket article",
+        },
+    )
+
+    assert payload["inputs"]["filters"] == {
+        "topic_type": "custom_support_ticket_topic",
+        "slug": "custom-support-ticket-blueprint",
+    }
+    assert payload["inputs"]["topic"] == "Custom support-ticket article"
+
+
+def test_blog_payload_alignment_preserves_custom_operator_topic() -> None:
+    payload = {
+        "outputs": ["blog_post"],
+        "inputs": {
+            "topic": "Operator supplied smoke topic",
+            "filters": {"topic_type": smoke.SUPPORT_TICKET_BLOG_TOPIC_TYPE},
+        },
+    }
+
+    smoke._align_blog_payload_to_seed(
+        payload,
+        {
+            "topic_type": "custom_support_ticket_topic",
+            "slug": "custom-support-ticket-blueprint",
+            "topic": "Custom support-ticket article",
+        },
+    )
+
+    assert payload["inputs"]["topic"] == "Operator supplied smoke topic"
+
+
+def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -> None:
+    rows = smoke._load_csv_rows(_support_ticket_csv(tmp_path))
+
+    payload = smoke._support_ticket_blog_blueprint_payload(rows)
+
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "186" not in serialized
+    assert "78" not in serialized
+    assert "42%" not in serialized
+    assert payload["data_context"]["source_row_count"] == 2
+    assert payload["data_context"]["question_like_ticket_count"] == 2
+    assert payload["data_context"]["top_clusters"] == [
+        {"label": "account", "count": 1},
+        {"label": "reporting", "count": 1},
+    ]
+    first_section = payload["sections"][0]
+    assert first_section["key_stats"] == {
+        "support_ticket_rows": 2,
+        "question_like_rows": 2,
+        "cluster_count": 2,
+    }
+    assert "2 support-ticket rows" in first_section["data_summary"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Live-Smoke-Source.md
Slice phase: Functional validation

This gives the live Content Ops smoke script a support-ticket CSV mode. The script loads ticket rows, packages them through the Atlas support-ticket input provider, derives support-ticket blog blueprint facts from the actual CSV rows, then executes the existing DB/LLM-backed landing-page or blog-post path.

## Intentional
- Operator smoke harness only; no production route, FAQ generator, or file-ingestion changes.
- Uses the Atlas support-ticket input provider and extracted merge helper instead of duplicating provider defaults.
- Blog smoke seeding switches to the provider-emitted support-ticket topic type when --support-ticket-csv is used.
- The support-ticket blog blueprint derives row counts, question counts, and clusters from the CSV so the smoke cannot invent benchmark evidence.
- Seeded/custom blog blueprint titles replace smoke defaults, including the support-ticket provider default topic, while explicit operator topic overrides stay intact.
- Non-ticket-shaped CSV input now fails before execution instead of running with provider noop defaults.

## Deferred
- Uploaded file import -> provider -> landing/blog generation remains blocked on the file-ingestion/import lookup lane.
- Full live validation beyond the packaged CSV can follow after this support-ticket source mode lands.

## Parked hardening
- None. HARDENING.md was scanned; existing FAQ scale and file-ingestion concurrency entries are outside this support-ticket live smoke source slice.

## Verification
- Focused smoke-script tests for tests/test_smoke_content_ops_live_generation.py: 14 passed.
- Py compile for the smoke script and test file: passed.
- Git whitespace check: passed.
- Local PR review wrapper: passed.
- Manual landing-page live smoke with packaged support-ticket CSV + Haiku OpenRouter model: passed; saved draft 06e680c5-7ab4-4bff-8c94-24bd2cd1c969.
- Manual blog-post live smoke with packaged support-ticket CSV + Haiku OpenRouter model: passed; seeded blueprint 4bfe5289-8aaf-42a0-9baf-800f5f2b23b2 and saved draft 5a4b5ec9-ffcb-470b-955f-49e1e3302aaf.
- Follow-up blog-post live smoke after CSV-derived blueprint fix: passed; seeded blueprint 8d4abd7b-4609-4f23-9664-812659e6c2fe and saved draft 57b5d81c-987a-4e38-a808-37c8a4ccfee8. Export confirmed source_row_count=4, question_like_ticket_count=2, the two real CSV clusters, and no old 186 / 78 / 42% benchmark numbers.

## Diff size
4 files, +633 / -7