### PR TITLE
PR-Content-Ops-FAQ-Search-Projection-V1

### DIFF
--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -277,6 +277,9 @@
       "target": "extracted_content_pipeline/ticket_faq_postgres.py"
     },
     {
+      "target": "extracted_content_pipeline/ticket_faq_search.py"
+    },
+    {
       "target": "extracted_content_pipeline/ingestion_diagnostics.py"
     },
     {

--- a/extracted_content_pipeline/ticket_faq_search.py
+++ b/extracted_content_pipeline/ticket_faq_search.py
@@ -1,0 +1,227 @@
+"""Search projection helpers for generated ticket FAQ Markdown drafts."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+import re
+from typing import Any
+
+from .campaign_ports import JsonDict
+from .ticket_faq_ports import TicketFAQDraft
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class TicketFAQSearchDocument:
+    """Compact searchable projection for one generated FAQ item."""
+
+    account_id: str
+    corpus_id: str
+    faq_id: str
+    target_id: str
+    target_mode: str
+    status: str
+    rank: int
+    topic: str
+    question: str
+    answer_summary: str
+    source_ids: tuple[str, ...] = field(default_factory=tuple)
+    ticket_count: int = 0
+    search_text: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "account_id": self.account_id,
+            "corpus_id": self.corpus_id,
+            "faq_id": self.faq_id,
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "status": self.status,
+            "rank": self.rank,
+            "topic": self.topic,
+            "question": self.question,
+            "answer_summary": self.answer_summary,
+            "source_ids": list(self.source_ids),
+            "ticket_count": self.ticket_count,
+        }
+
+
+@dataclass(frozen=True)
+class TicketFAQSearchResult:
+    """A matched FAQ search document plus deterministic score."""
+
+    document: TicketFAQSearchDocument
+    score: int
+
+    def as_dict(self) -> JsonDict:
+        row = self.document.as_dict()
+        row["score"] = self.score
+        row.pop("search_text", None)
+        return row
+
+
+@dataclass(frozen=True)
+class TicketFAQSearchResponse:
+    """API-shaped FAQ search response envelope."""
+
+    query: str
+    results: tuple[TicketFAQSearchResult, ...]
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "query": self.query,
+            "results": [result.as_dict() for result in self.results],
+            "count": len(self.results),
+        }
+
+
+def build_ticket_faq_search_documents(
+    draft: TicketFAQDraft,
+    *,
+    account_id: str | None = None,
+    corpus_id: str | None = None,
+) -> tuple[TicketFAQSearchDocument, ...]:
+    """Project a generated FAQ draft into one searchable row per FAQ item."""
+
+    resolved_account_id = _clean(account_id) or _metadata_account_id(draft.metadata)
+    resolved_corpus_id = _clean(corpus_id) or _metadata_corpus_id(draft.metadata) or draft.target_id
+    documents: list[TicketFAQSearchDocument] = []
+    for index, item in enumerate(draft.items, start=1):
+        if not isinstance(item, Mapping):
+            continue
+        topic = _clean(item.get("topic"))
+        question = _clean(item.get("question"))
+        answer_summary = _answer_summary(item)
+        search_text = _search_text(item, topic=topic, question=question, answer_summary=answer_summary)
+        if not question and not search_text:
+            continue
+        documents.append(
+            TicketFAQSearchDocument(
+                account_id=resolved_account_id,
+                corpus_id=resolved_corpus_id,
+                faq_id=draft.id,
+                target_id=draft.target_id,
+                target_mode=draft.target_mode,
+                status=draft.status,
+                rank=_int_value(item.get("rank"), default=index),
+                topic=topic,
+                question=question,
+                answer_summary=answer_summary,
+                source_ids=_source_ids(item.get("source_ids")),
+                ticket_count=_int_value(item.get("ticket_count"), default=0),
+                search_text=search_text,
+            )
+        )
+    return tuple(documents)
+
+
+def search_ticket_faq_documents(
+    documents: Iterable[TicketFAQSearchDocument],
+    *,
+    query: str,
+    account_id: str,
+    corpus_id: str | None = None,
+    status: str | None = "approved",
+    limit: int = 10,
+) -> TicketFAQSearchResponse:
+    """Search projected FAQ rows with tenant/corpus/status isolation."""
+
+    normalized_query = _clean(query)
+    normalized_account_id = _clean(account_id)
+    query_tokens = _tokens(normalized_query)
+    if not normalized_account_id or not query_tokens or limit <= 0:
+        return TicketFAQSearchResponse(query=normalized_query, results=())
+    matches: list[TicketFAQSearchResult] = []
+    for document in documents:
+        if document.account_id != normalized_account_id:
+            continue
+        if corpus_id is not None and document.corpus_id != corpus_id:
+            continue
+        if status is not None and document.status != status:
+            continue
+        score = _score_document(document, query_tokens)
+        if score <= 0:
+            continue
+        matches.append(TicketFAQSearchResult(document=document, score=score))
+    matches.sort(key=lambda result: (-result.score, result.document.rank, result.document.question))
+    return TicketFAQSearchResponse(
+        query=normalized_query,
+        results=tuple(matches[:limit]),
+    )
+
+
+def _score_document(document: TicketFAQSearchDocument, query_tokens: Sequence[str]) -> int:
+    question_tokens = set(_tokens(document.question))
+    topic_tokens = set(_tokens(document.topic))
+    text_counts = Counter(_tokens(document.search_text))
+    score = 0
+    for token in query_tokens:
+        if token in question_tokens:
+            score += 4
+        if token in topic_tokens:
+            score += 2
+        score += min(text_counts.get(token, 0), 3)
+    return score
+
+
+def _search_text(item: Mapping[str, Any], *, topic: str, question: str, answer_summary: str) -> str:
+    parts: list[str] = [topic, question, answer_summary]
+    for key in ("answer", "when_to_contact_support"):
+        parts.append(_clean(item.get(key)))
+    steps = item.get("steps")
+    if isinstance(steps, Sequence) and not isinstance(steps, (str, bytes)):
+        parts.extend(_clean(step) for step in steps)
+    return " ".join(part for part in parts if part)
+
+
+def _answer_summary(item: Mapping[str, Any]) -> str:
+    for key in ("summary", "answer"):
+        value = _clean(item.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _source_ids(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(dict.fromkeys(_clean(item) for item in value if _clean(item)))
+
+
+def _metadata_account_id(metadata: Mapping[str, Any]) -> str:
+    scope = metadata.get("scope")
+    if isinstance(scope, Mapping):
+        return _clean(scope.get("account_id"))
+    return _clean(metadata.get("account_id"))
+
+
+def _metadata_corpus_id(metadata: Mapping[str, Any]) -> str:
+    return _clean(metadata.get("corpus_id") or metadata.get("source_file_id"))
+
+
+def _tokens(value: str) -> tuple[str, ...]:
+    return tuple(_TOKEN_RE.findall(value.lower()))
+
+
+def _int_value(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "TicketFAQSearchDocument",
+    "TicketFAQSearchResponse",
+    "TicketFAQSearchResult",
+    "build_ticket_faq_search_documents",
+    "search_ticket_faq_documents",
+]

--- a/plans/PR-Content-Ops-FAQ-Search-Projection-V1.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Projection-V1.md
@@ -1,0 +1,112 @@
+# PR-Content-Ops-FAQ-Search-Projection-V1
+
+## Why this slice exists
+
+FAQ generation and ingestion scale tests prove batch creation, but demo retrieval
+has a different failure mode: concurrent users should search compact generated
+FAQ documents, scoped by tenant and corpus, instead of querying raw uploaded
+ticket rows or full Markdown blobs.
+
+This slice creates the thinnest end-to-end retrieval contract:
+`TicketFAQDraft` -> search projection documents -> deterministic query envelope.
+It answers the current architecture question by establishing a separate search
+projection seam before a hosted route or database index exists.
+
+Review follow-up tightened two contract boundaries: `search_text` stays internal
+to the projection and blank tenant searches fail closed.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a small FAQ search projection helper over generated `TicketFAQDraft`
+   items.
+2. Add deterministic in-memory search that returns the future route envelope:
+   `{query, results, count}`.
+3. Preserve tenant/corpus isolation in the projection and search filters.
+4. Register the new owned module in the extracted package manifest.
+5. Add focused tests for projection fields, query ranking, envelope shape, and
+   tenant/corpus isolation.
+6. Keep internal index text out of serialized document/result payloads and
+   reject blank tenant searches.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Projection-V1.md`
+- `extracted_content_pipeline/ticket_faq_search.py`
+- `extracted_content_pipeline/manifest.json`
+- `tests/test_extracted_ticket_faq_search.py`
+
+## Mechanism
+
+`ticket_faq_search.py` will build one compact `TicketFAQSearchDocument` per FAQ
+item. Each document carries the scoped identifiers needed by the eventual route:
+`account_id`, `corpus_id`, `faq_id`, `target_mode`, `status`, item rank, topic,
+question, answer summary, source ids, ticket count, and normalized `search_text`.
+`search_text` is used for scoring only and is intentionally excluded from the
+serialized document/result payload.
+
+`search_ticket_faq_documents(...)` will filter by `account_id`, optional
+`corpus_id`, and optional `status`, score deterministic token matches over the
+compact search text, and return:
+
+```python
+{
+    "query": query,
+    "results": [result.as_dict(), ...],
+    "count": len(results),
+}
+```
+
+This is not the final storage layer. It locks the API-shaped result contract and
+the isolation/ranking semantics so the next slice can swap the backing store to
+Postgres without changing the consumer envelope.
+
+## Intentional
+
+- No hosted FastAPI route lands in this slice. The route should sit on top of
+  the projection contract after the data shape is proven.
+- No Postgres migration or full-text index lands here. This PR defines the
+  projection boundary and deterministic behavior first; database indexing is the
+  next natural slice.
+- No embeddings/vector search are added. Exact/token scoring is enough for the
+  first production-safe demo seam and is easier to reason about under tests.
+
+## Deferred
+
+- `PR-Content-Ops-FAQ-Search-Postgres-Projection`: write projected FAQ item rows
+  to a dedicated table with tenant/corpus/status indexes and Postgres search
+  indexes.
+- `PR-Content-Ops-FAQ-Deflection-Search-Route`: expose the hosted route that
+  returns `{query, results, count}` for the demo client.
+- `PR-Content-Ops-FAQ-Search-Concurrency-Smoke`: seed multiple corpora and run
+  concurrent filtered searches with latency and isolation assertions.
+- Result highlighting/snippets and synonym expansion remain deferred until the
+  core retrieval seam exists.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_search.py -q` - 6 passed after review fixes.
+- `python -m py_compile extracted_content_pipeline/ticket_faq_search.py tests/test_extracted_ticket_faq_search.py` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/local_pr_review.sh --allow-dirty` - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 111 |
+| Search projection module | 227 |
+| Manifest entry | 3 |
+| Tests | 190 |
+| **Total** | **531** |
+
+The estimate is slightly above the 400 LOC target because this is a complete
+vertical proof: projection, search envelope, manifest registration, and
+isolation/ranking tests. If implementation runs larger than expected, route and
+database work stay deferred rather than expanding this PR further.

--- a/tests/test_extracted_ticket_faq_search.py
+++ b/tests/test_extracted_ticket_faq_search.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+from extracted_content_pipeline.ticket_faq_search import (
+    build_ticket_faq_search_documents,
+    search_ticket_faq_documents,
+)
+
+
+def _draft(
+    *,
+    faq_id: str = "faq-1",
+    account_id: str = "acct-1",
+    corpus_id: str = "corpus-1",
+    status: str = "approved",
+    target_id: str = "support-account-1",
+    items: list[dict[str, object]] | None = None,
+) -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=faq_id,
+        target_id=target_id,
+        target_mode="support_account",
+        title="Support FAQ",
+        markdown="# Support FAQ",
+        status=status,
+        source_count=3,
+        ticket_source_count=3,
+        metadata={
+            "scope": {"account_id": account_id},
+            "corpus_id": corpus_id,
+        },
+        items=items or [
+            {
+                "topic": "password reset",
+                "question": "How do I reset my password?",
+                "summary": "Customers cannot find the password reset email.",
+                "steps": [
+                    "Open the login page.",
+                    "Request a new password reset email.",
+                ],
+                "when_to_contact_support": "Contact support if the reset email never arrives.",
+                "source_ids": ["ticket-1", "ticket-2", "ticket-2"],
+                "ticket_count": 2,
+            },
+            {
+                "topic": "billing invoice",
+                "question": "Where can I download an invoice?",
+                "answer": "Open billing settings and download the invoice PDF.",
+                "source_ids": ["ticket-3"],
+                "ticket_count": 1,
+            },
+        ],
+    )
+
+
+def test_build_ticket_faq_search_documents_projects_item_fields() -> None:
+    documents = build_ticket_faq_search_documents(_draft())
+
+    assert len(documents) == 2
+    first = documents[0]
+    assert first.account_id == "acct-1"
+    assert first.corpus_id == "corpus-1"
+    assert first.faq_id == "faq-1"
+    assert first.rank == 1
+    assert first.topic == "password reset"
+    assert first.question == "How do I reset my password?"
+    assert first.answer_summary == "Customers cannot find the password reset email."
+    assert first.source_ids == ("ticket-1", "ticket-2")
+    assert first.ticket_count == 2
+    assert "reset email" in first.search_text
+    assert "search_text" not in first.as_dict()
+
+
+def test_search_ticket_faq_documents_returns_route_shaped_envelope() -> None:
+    documents = build_ticket_faq_search_documents(_draft())
+
+    response = search_ticket_faq_documents(
+        documents,
+        query="password reset email",
+        account_id="acct-1",
+        corpus_id="corpus-1",
+    )
+
+    assert response.as_dict() == {
+        "query": "password reset email",
+        "count": 1,
+        "results": [{
+            "account_id": "acct-1",
+            "corpus_id": "corpus-1",
+            "faq_id": "faq-1",
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "status": "approved",
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer_summary": "Customers cannot find the password reset email.",
+            "source_ids": ["ticket-1", "ticket-2"],
+            "ticket_count": 2,
+            "score": 21,
+        }],
+    }
+
+
+def test_search_ticket_faq_documents_filters_tenant_corpus_and_status() -> None:
+    documents = (
+        *build_ticket_faq_search_documents(_draft(faq_id="faq-1", account_id="acct-1", corpus_id="corpus-1")),
+        *build_ticket_faq_search_documents(_draft(faq_id="faq-2", account_id="acct-2", corpus_id="corpus-1")),
+        *build_ticket_faq_search_documents(_draft(faq_id="faq-3", account_id="acct-1", corpus_id="corpus-2")),
+        *build_ticket_faq_search_documents(_draft(faq_id="faq-4", account_id="acct-1", corpus_id="corpus-1", status="draft")),
+    )
+
+    response = search_ticket_faq_documents(
+        documents,
+        query="reset",
+        account_id="acct-1",
+        corpus_id="corpus-1",
+        status="approved",
+    )
+
+    result_ids = [row["faq_id"] for row in response.as_dict()["results"]]
+    assert result_ids == ["faq-1"]
+
+
+def test_search_ticket_faq_documents_fails_closed_for_blank_tenant() -> None:
+    documents = build_ticket_faq_search_documents(
+        _draft(faq_id="empty-tenant-faq", account_id="", corpus_id="corpus-1")
+    )
+
+    response = search_ticket_faq_documents(
+        documents,
+        query="reset",
+        account_id="",
+        corpus_id="corpus-1",
+    )
+
+    assert response.as_dict() == {"query": "reset", "results": [], "count": 0}
+
+
+def test_search_ticket_faq_documents_ranks_by_score_then_rank() -> None:
+    documents = build_ticket_faq_search_documents(
+        _draft(
+            items=[
+                {
+                    "topic": "account access",
+                    "question": "How do I access the account?",
+                    "summary": "Customers ask about account access.",
+                    "source_ids": ["ticket-1"],
+                    "ticket_count": 1,
+                },
+                {
+                    "topic": "password reset",
+                    "question": "How do I reset account password access?",
+                    "summary": "Password reset access access.",
+                    "source_ids": ["ticket-2"],
+                    "ticket_count": 1,
+                },
+            ]
+        )
+    )
+
+    response = search_ticket_faq_documents(
+        documents,
+        query="password access",
+        account_id="acct-1",
+        corpus_id="corpus-1",
+    )
+
+    rows = response.as_dict()["results"]
+    assert [row["question"] for row in rows] == [
+        "How do I reset account password access?",
+        "How do I access the account?",
+    ]
+    assert rows[0]["score"] > rows[1]["score"]
+
+
+def test_search_ticket_faq_documents_handles_blank_query_and_limit() -> None:
+    documents = build_ticket_faq_search_documents(_draft())
+
+    blank = search_ticket_faq_documents(
+        documents,
+        query="   ",
+        account_id="acct-1",
+    )
+    limited = search_ticket_faq_documents(
+        documents,
+        query="password",
+        account_id="acct-1",
+        limit=0,
+    )
+
+    assert blank.as_dict() == {"query": "", "results": [], "count": 0}
+    assert limited.as_dict() == {"query": "password", "results": [], "count": 0}


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Projection-V1.md
Slice phase: Vertical slice

FAQ generation and ingestion scale tests prove batch creation, but demo retrieval has a different failure mode. This PR adds the thin projection/search seam: generated `TicketFAQDraft` items become compact searchable documents, and deterministic in-memory search returns the future route-shaped `{query, results, count}` envelope with tenant/corpus/status isolation. Review follow-up keeps internal `search_text` out of serialized payloads and makes blank tenant searches fail closed.

## Intentional
- No hosted FastAPI route lands in this slice.
- No Postgres migration, full-text index, or embeddings land here.
- The in-memory search locks the projection and envelope contract before persistent indexed retrieval.
- `target_id` and `target_mode` remain in the consumed contract for traceability back to the generated FAQ artifact and its source mode.

## Deferred
- `PR-Content-Ops-FAQ-Search-Postgres-Projection`: dedicated table plus tenant/corpus/status/search indexes.
- `PR-Content-Ops-FAQ-Deflection-Search-Route`: hosted route returning `{query, results, count}`.
- `PR-Content-Ops-FAQ-Search-Concurrency-Smoke`: concurrent filtered retrieval with latency/isolation assertions.
- Result highlighting/snippets and synonym expansion.
- Pagination totals / separate `returned` count remain deferred until the hosted route has a pagination contract.

## Verification
- `pytest tests/test_extracted_ticket_faq_search.py -q` - 6 passed.
- `python -m py_compile extracted_content_pipeline/ticket_faq_search.py tests/test_extracted_ticket_faq_search.py` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed after commit and in pre-push.

## Diff size
4 files, +535 / -0
