### PR TITLE
Add draft id export filters for smoke validation

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -351,7 +351,16 @@ The command fails if `landing_page` is not configured, which usually means the
 DB pool did not initialize or the pipeline LLM/OpenRouter credentials are not
 available. Set `OPENROUTER_API_KEY` or
 `ATLAS_B2B_CHURN_OPENROUTER_API_KEY` for the pipeline-routed Claude provider.
-On success it prints the saved `landing_pages` draft id.
+On success it prints the saved `landing_pages` draft id. Export that exact row
+for inspection with:
+
+```bash
+python scripts/export_extracted_content_assets.py \
+  --asset landing_page \
+  --account-id acct_123 \
+  --id <landing-page-id> \
+  --output landing-page-draft.json
+```
 
 To prove the live blog-post path too, run the same smoke with
 `--output blog_post`. The command upserts one account-scoped
@@ -367,9 +376,19 @@ python scripts/smoke_content_ops_live_generation.py \
 ```
 
 On success it prints the saved `blog_posts` draft id and the seeded blueprint
-id. Re-running the command refreshes the same smoke blueprint for that account.
-To seed a specific operator blueprint instead of the default smoke row, pass a
-JSON file that normalizes to one blog blueprint:
+id. Export that exact row for inspection with:
+
+```bash
+python scripts/export_extracted_content_assets.py \
+  --asset blog_post \
+  --account-id acct_123 \
+  --id <blog-post-id> \
+  --output blog-post-draft.json
+```
+
+Re-running the command refreshes the same smoke blueprint for that account. To
+seed a specific operator blueprint instead of the default smoke row, pass a JSON
+file that normalizes to one blog blueprint:
 
 ```bash
 python scripts/smoke_content_ops_live_generation.py \
@@ -1287,8 +1306,8 @@ Several small utility shims provide product-owned local behavior by default so t
 - `sales_brief_export.py`: read-only sales brief export for host review flows
 - `ticket_faq_export.py`: read-only ticket FAQ Markdown export for host review
   flows
-- `scripts/export_extracted_content_assets.py`: host-facing report, landing
-  page, sales brief, and FAQ Markdown export CLI
+- `scripts/export_extracted_content_assets.py`: host-facing report, blog post,
+  landing page, sales brief, and FAQ Markdown export CLI
 - `scripts/review_extracted_content_assets.py`: host-facing report, landing
   page, sales brief, and FAQ Markdown status-update CLI
 - `campaign_postgres_seller_targets.py`: seller target CRUD/list helpers for

--- a/extracted_content_pipeline/blog_ports.py
+++ b/extracted_content_pipeline/blog_ports.py
@@ -82,6 +82,7 @@ class BlogPostRepository(Protocol):
         scope: TenantScope,
         status: str | None = None,
         topic_type: str | None = None,
+        ids: Sequence[str] | None = None,
         limit: int | None = None,
     ) -> Sequence[BlogPostDraft]:
         """Return drafts filtered by tenant scope and optional facets."""

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import csv
 from dataclasses import dataclass
 from io import StringIO
@@ -77,12 +77,14 @@ async def export_blog_post_drafts(
     scope: TenantScope | Mapping[str, Any] | None = None,
     status: str | None = "draft",
     topic_type: str | None = None,
+    ids: Sequence[str] | None = None,
     limit: int = 20,
 ) -> BlogPostDraftExportResult:
     """Return generated blog-post drafts for host review/export workflows."""
 
     tenant = _tenant_scope(scope)
     normalized_limit = _normalize_limit(limit)
+    normalized_ids = _normalize_ids(ids)
     filters: dict[str, Any] = {}
     if status:
         filters["status"] = status
@@ -90,10 +92,13 @@ async def export_blog_post_drafts(
         filters["account_id"] = tenant.account_id
     if topic_type:
         filters["topic_type"] = topic_type
+    if normalized_ids:
+        filters["ids"] = list(normalized_ids)
     drafts = await repository.list_drafts(
         scope=tenant,
         status=status,
         topic_type=topic_type,
+        ids=normalized_ids or None,
         limit=normalized_limit,
     )
     return BlogPostDraftExportResult(
@@ -454,6 +459,12 @@ def _normalize_limit(value: Any) -> int:
     if limit < 0:
         raise ValueError("limit must be non-negative")
     return limit
+
+
+def _normalize_ids(value: Sequence[str] | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
 
 
 def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:

--- a/extracted_content_pipeline/blog_post_postgres.py
+++ b/extracted_content_pipeline/blog_post_postgres.py
@@ -265,6 +265,7 @@ class PostgresBlogPostRepository:
         scope: TenantScope,
         status: str | None = None,
         topic_type: str | None = None,
+        ids: Sequence[str] | None = None,
         limit: int | None = None,
     ) -> Sequence[BlogPostDraft]:
         clauses: list[str] = ["account_id = $1"]
@@ -275,6 +276,10 @@ class PostgresBlogPostRepository:
         if topic_type is not None:
             params.append(topic_type)
             clauses.append(f"topic_type = ${len(params)}")
+        normalized_ids = [str(item).strip() for item in ids or () if str(item).strip()]
+        if normalized_ids:
+            params.append(normalized_ids)
+            clauses.append(f"id = ANY(${len(params)}::uuid[])")
         sql = (
             "SELECT id, slug, title, description, topic_type, tags, content, "
             "charts, data_context, llm_model, status, "

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import csv
 from dataclasses import dataclass
 from io import StringIO
@@ -96,12 +96,14 @@ async def export_landing_page_drafts(
     status: str | None = "draft",
     campaign_name: str | None = None,
     slug: str | None = None,
+    ids: Sequence[str] | None = None,
     limit: int = 20,
 ) -> LandingPageDraftExportResult:
     """Return generated landing page drafts for host review/export workflows."""
 
     tenant = _tenant_scope(scope)
     normalized_limit = _normalize_limit(limit)
+    normalized_ids = _normalize_ids(ids)
     filters: dict[str, Any] = {}
     if status:
         filters["status"] = status
@@ -111,11 +113,14 @@ async def export_landing_page_drafts(
         filters["campaign_name"] = campaign_name
     if slug:
         filters["slug"] = slug
+    if normalized_ids:
+        filters["ids"] = list(normalized_ids)
     drafts = await repository.list_drafts(
         scope=tenant,
         status=status,
         campaign_name=campaign_name,
         slug=slug,
+        ids=normalized_ids or None,
         limit=normalized_limit,
     )
     return LandingPageDraftExportResult(
@@ -247,6 +252,12 @@ def _normalize_limit(value: Any) -> int:
     if limit < 0:
         raise ValueError("limit must be non-negative")
     return limit
+
+
+def _normalize_ids(value: Sequence[str] | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
 
 
 def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:

--- a/extracted_content_pipeline/landing_page_ports.py
+++ b/extracted_content_pipeline/landing_page_ports.py
@@ -197,6 +197,7 @@ class LandingPageRepository(Protocol):
         status: str | None = None,
         campaign_name: str | None = None,
         slug: str | None = None,
+        ids: Sequence[str] | None = None,
         limit: int | None = None,
     ) -> Sequence[LandingPageDraft]:
         """Return drafts filtered by tenant scope and optional facets."""

--- a/extracted_content_pipeline/landing_page_postgres.py
+++ b/extracted_content_pipeline/landing_page_postgres.py
@@ -214,6 +214,7 @@ class PostgresLandingPageRepository:
         status: str | None = None,
         campaign_name: str | None = None,
         slug: str | None = None,
+        ids: Sequence[str] | None = None,
         limit: int | None = None,
     ) -> Sequence[LandingPageDraft]:
         clauses: list[str] = ["account_id = $1"]
@@ -227,6 +228,10 @@ class PostgresLandingPageRepository:
         if slug is not None:
             params.append(slug)
             clauses.append(f"slug = ${len(params)}")
+        normalized_ids = [str(item).strip() for item in ids or () if str(item).strip()]
+        if normalized_ids:
+            params.append(normalized_ids)
+            clauses.append(f"id = ANY(${len(params)}::uuid[])")
         sql = (
             "SELECT id, campaign_name, persona, value_prop, title, slug, "
             "hero, sections, cta, meta, reference_ids, metadata, status "

--- a/plans/PR-Support-Ticket-Smoke-Draft-Export-Ids.md
+++ b/plans/PR-Support-Ticket-Smoke-Draft-Export-Ids.md
@@ -1,0 +1,79 @@
+# PR: Support Ticket Smoke Draft Export Ids
+
+## Why this slice exists
+
+The support-ticket provider live smoke now saves real landing-page and blog-post
+drafts, but inspecting the exact generated draft still requires broad export
+filters or manual DB lookup. That slows validation of the actual generated
+content and makes it easier to inspect the wrong row when multiple smoke runs
+share an account.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add exact draft-id filtering to landing-page and blog-post draft export
+   helpers.
+2. Add `--id` to `scripts/export_extracted_content_assets.py` for those assets.
+3. Document the smoke follow-up command that exports the saved draft by id.
+4. Add focused tests for helper forwarding and CLI SQL binding.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Smoke-Draft-Export-Ids.md`
+- `extracted_content_pipeline/README.md`
+- `extracted_content_pipeline/blog_ports.py`
+- `extracted_content_pipeline/blog_post_export.py`
+- `extracted_content_pipeline/blog_post_postgres.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/landing_page_ports.py`
+- `extracted_content_pipeline/landing_page_postgres.py`
+- `scripts/export_extracted_content_assets.py`
+- `tests/test_extracted_blog_post_export.py`
+- `tests/test_extracted_content_asset_export_cli.py`
+- `tests/test_extracted_landing_page_export.py`
+
+## Mechanism
+
+- Thread optional `ids` through `export_landing_page_drafts` and
+  `export_blog_post_drafts`.
+- Add optional `ids` to the Postgres repository `list_drafts` methods and use
+  tenant-scoped `id = ANY(...)` filters.
+- Keep existing status, topic, campaign, slug, and limit filters intact.
+
+## Intentional
+
+- This only changes read-only export/inspection paths.
+- No production generation, FAQ generator, file-ingestion, or review-status
+  behavior changes.
+- Exact ids remain tenant-scoped through the existing repository `scope`.
+
+## Deferred
+
+- The live smoke script still writes the execution JSON separately; this slice
+  documents the export command rather than coupling export side effects into the
+  smoke runner.
+- Parked hardening: none. `HARDENING.md` was scanned; the current entries are
+  FAQ scale and file-ingestion concurrency work outside this support-ticket
+  provider validation slice.
+
+## Verification
+
+- Focused export tests:
+  `pytest tests/test_extracted_blog_post_export.py tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_export_cli.py -q`
+  - 38 passed.
+- Py compile for changed Python files - passed.
+- Git whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Export helpers and repository filters | ~45 |
+| CLI | ~15 |
+| Tests | ~45 |
+| Docs | ~15 |
+| **Total** | **~190** |

--- a/scripts/export_extracted_content_assets.py
+++ b/scripts/export_extracted_content_assets.py
@@ -65,6 +65,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--topic-type", default=None, help="Blog post topic_type filter.")
     parser.add_argument("--campaign-name", default=None, help="Landing page campaign_name filter.")
     parser.add_argument("--slug", default=None, help="Landing page slug filter.")
+    parser.add_argument(
+        "--id",
+        action="append",
+        default=[],
+        dest="ids",
+        help=(
+            "Exact draft id to export. May be repeated. Supported for "
+            "blog_post and landing_page."
+        ),
+    )
     parser.add_argument("--brief-type", default=None, help="Sales brief type filter.")
     parser.add_argument("--limit", type=int, default=20, help="Maximum rows to export.")
     parser.add_argument(
@@ -91,6 +101,8 @@ async def _main() -> int:
     args = _parse_args()
     if not args.database_url:
         raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if args.ids and args.asset not in {"blog_post", "landing_page"}:
+        raise SystemExit("--id is only supported for blog_post and landing_page exports")
     pool = await _create_pool(args.database_url)
     try:
         result = await _export_for_asset(args, pool)
@@ -121,6 +133,7 @@ async def _export_for_asset(args: argparse.Namespace, pool: Any):
             scope=scope,
             status=status,
             topic_type=args.topic_type,
+            ids=args.ids,
             limit=args.limit,
         )
     if args.asset == "report":
@@ -139,6 +152,7 @@ async def _export_for_asset(args: argparse.Namespace, pool: Any):
             status=status,
             campaign_name=args.campaign_name,
             slug=args.slug,
+            ids=args.ids,
             limit=args.limit,
         )
     if args.asset == "sales_brief":

--- a/tests/test_extracted_blog_post_export.py
+++ b/tests/test_extracted_blog_post_export.py
@@ -24,12 +24,14 @@ class _Repository:
         scope,
         status=None,
         topic_type=None,
+        ids=None,
         limit=None,
     ):
         self.list_calls.append({
             "scope": scope,
             "status": status,
             "topic_type": topic_type,
+            "ids": ids,
             "limit": limit,
         })
         return self.drafts
@@ -103,6 +105,8 @@ def _draft(**overrides) -> BlogPostDraft:
         charts=overrides.get("charts", draft.charts),
         data_context=overrides.get("data_context", draft.data_context),
         metadata=overrides.get("metadata", draft.metadata),
+        id=overrides.get("id", draft.id),
+        status=overrides.get("status", draft.status),
     )
 
 
@@ -115,6 +119,7 @@ async def test_export_blog_post_drafts_passes_filters_to_repository() -> None:
         scope={"account_id": "acct_1", "user_id": "user_1"},
         status="approved",
         topic_type="vendor_alternative",
+        ids=["blog-1", " ", "blog-2"],
         limit=7,
     )
 
@@ -124,11 +129,13 @@ async def test_export_blog_post_drafts_passes_filters_to_repository() -> None:
     assert call["scope"].user_id == "user_1"
     assert call["status"] == "approved"
     assert call["topic_type"] == "vendor_alternative"
+    assert call["ids"] == ("blog-1", "blog-2")
     assert call["limit"] == 7
     assert result.filters == {
         "status": "approved",
         "account_id": "acct_1",
         "topic_type": "vendor_alternative",
+        "ids": ["blog-1", "blog-2"],
     }
 
 

--- a/tests/test_extracted_content_asset_export_cli.py
+++ b/tests/test_extracted_content_asset_export_cli.py
@@ -55,6 +55,7 @@ def _report_row():
 
 def _blog_post_row():
     return {
+        "id": "11111111-1111-1111-1111-111111111111",
         "slug": "acme-pricing-pressure",
         "title": "Acme Pricing Pressure",
         "description": "Pricing pressure dominates.",
@@ -74,6 +75,7 @@ def _blog_post_row():
 
 def _landing_page_row():
     return {
+        "id": "22222222-2222-2222-2222-222222222222",
         "campaign_name": "acme-launch",
         "persona": "VP Engineering",
         "value_prop": "Catch pressure early",
@@ -186,6 +188,8 @@ async def test_asset_export_cli_outputs_blog_post_json(monkeypatch, capsys) -> N
             "acct_1",
             "--topic-type",
             "vendor_alternative",
+            "--id",
+            "11111111-1111-1111-1111-111111111111",
             "--limit",
             "4",
         ],
@@ -197,7 +201,14 @@ async def test_asset_export_cli_outputs_blog_post_json(monkeypatch, capsys) -> N
     query, args = pool.fetch_calls[0]
     assert exit_code == 0
     assert "FROM blog_posts" in query
-    assert args == ("acct_1", "draft", "vendor_alternative", 4)
+    assert "id = ANY($4::uuid[])" in query
+    assert args == (
+        "acct_1",
+        "draft",
+        "vendor_alternative",
+        ["11111111-1111-1111-1111-111111111111"],
+        4,
+    )
     assert output["rows"][0]["slug"] == "acme-pricing-pressure"
     assert output["rows"][0]["reasoning_wedge"] == "price_squeeze"
 
@@ -225,6 +236,8 @@ async def test_asset_export_cli_writes_landing_page_csv(monkeypatch, tmp_path) -
             "acme-launch",
             "--slug",
             "acme-launch",
+            "--id",
+            "22222222-2222-2222-2222-222222222222",
             "--format",
             "csv",
             "--output",
@@ -237,7 +250,15 @@ async def test_asset_export_cli_writes_landing_page_csv(monkeypatch, tmp_path) -
     assert exit_code == 0
     query, args = pool.fetch_calls[0]
     assert "FROM landing_pages" in query
-    assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+    assert "id = ANY($5::uuid[])" in query
+    assert args == (
+        "",
+        "draft",
+        "acme-launch",
+        "acme-launch",
+        ["22222222-2222-2222-2222-222222222222"],
+        20,
+    )
     assert "Acme landing page" in output_path.read_text(encoding="utf-8")
 
 
@@ -328,4 +349,25 @@ async def test_asset_export_cli_requires_database_url(monkeypatch) -> None:
     monkeypatch.setattr(cli.sys, "argv", ["export", "--asset", "report"])
 
     with pytest.raises(SystemExit, match="Missing --database-url"):
+        await cli._main()
+
+
+@pytest.mark.asyncio
+async def test_asset_export_cli_rejects_id_for_unsupported_asset(monkeypatch) -> None:
+    cli = _load_cli_module()
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "export",
+            "--database-url",
+            "postgres://example",
+            "--asset",
+            "report",
+            "--id",
+            "11111111-1111-1111-1111-111111111111",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--id is only supported"):
         await cli._main()

--- a/tests/test_extracted_landing_page_export.py
+++ b/tests/test_extracted_landing_page_export.py
@@ -41,6 +41,7 @@ class _Repository:
         status=None,
         campaign_name=None,
         slug=None,
+        ids=None,
         limit=None,
     ):
         self.list_calls.append({
@@ -48,6 +49,7 @@ class _Repository:
             "status": status,
             "campaign_name": campaign_name,
             "slug": slug,
+            "ids": ids,
             "limit": limit,
         })
         return self.drafts
@@ -355,6 +357,7 @@ async def test_export_landing_page_drafts_passes_filters_to_repository() -> None
         status="approved",
         campaign_name="acme-q3-launch",
         slug="acme-q3-launch",
+        ids=["lp-1", "", "lp-2"],
         limit=7,
     )
 
@@ -365,6 +368,7 @@ async def test_export_landing_page_drafts_passes_filters_to_repository() -> None
     assert call["status"] == "approved"
     assert call["campaign_name"] == "acme-q3-launch"
     assert call["slug"] == "acme-q3-launch"
+    assert call["ids"] == ("lp-1", "lp-2")
     assert call["limit"] == 7
     assert result.limit == 7
     assert result.filters == {
@@ -372,6 +376,7 @@ async def test_export_landing_page_drafts_passes_filters_to_repository() -> None
         "account_id": "acct_1",
         "campaign_name": "acme-q3-launch",
         "slug": "acme-q3-launch",
+        "ids": ["lp-1", "lp-2"],
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Smoke-Draft-Export-Ids.md
Slice phase: Functional validation
Ownership lane: content-ops/support-ticket-input-provider

This adds exact draft-id filtering to the generated asset export path for landing pages and blog posts. The support-ticket live smoke prints saved_ids; this gives operators a direct follow-up command to export the exact generated draft instead of guessing with broad latest-row filters.

## Intentional
- Read-only export/inspection path only.
- No production generation, FAQ generator, file-ingestion, or review-status changes.
- ID filters remain tenant-scoped through the existing repository scope.
- `--id` is accepted only for blog_post and landing_page exports; unsupported assets fail clearly.

## Deferred
- The live smoke runner still writes execution JSON separately. This slice documents the export command instead of adding export side effects to smoke execution.

## Parked hardening
- None. HARDENING.md was scanned; current entries are FAQ scale and file-ingestion concurrency work outside this support-ticket provider validation slice.

## Verification
- `pytest tests/test_extracted_blog_post_export.py tests/test_extracted_landing_page_export.py tests/test_extracted_content_asset_export_cli.py -q` - 38 passed.
- Py compile for changed Python files - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh` - passed.

## Diff size
12 files, +210 / -10