### PR TITLE
Add generated asset API draft id filters

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -272,6 +272,7 @@ def create_generated_asset_router(
         slug: str | None = Query(None),
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
+        ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
         asset_name = _asset_arg(asset)
@@ -288,6 +289,7 @@ def create_generated_asset_router(
             slug=slug,
             topic_type=topic_type,
             brief_type=brief_type,
+            ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
         return result.as_dict()
@@ -302,6 +304,7 @@ def create_generated_asset_router(
         slug: str | None = Query(None),
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
+        ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
     ) -> Any:
@@ -319,6 +322,7 @@ def create_generated_asset_router(
             slug=slug,
             topic_type=topic_type,
             brief_type=brief_type,
+            ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
         format_name = _clean(format).lower()
@@ -629,14 +633,21 @@ async def _export_for_asset(
     slug: str | None,
     topic_type: str | None,
     brief_type: str | None,
+    ids: Sequence[str] | None,
     limit: int,
 ) -> Any:
+    if ids and asset not in {"blog_post", "landing_page"}:
+        raise HTTPException(
+            status_code=400,
+            detail="id filters are only supported for blog_post and landing_page",
+        )
     if asset == "blog_post":
         return await export_blog_post_drafts(
             PostgresBlogPostRepository(pool),
             scope=scope,
             status=status,
             topic_type=topic_type,
+            ids=ids,
             limit=limit,
         )
     if asset == "report":
@@ -655,6 +666,7 @@ async def _export_for_asset(
             status=status,
             campaign_name=campaign_name,
             slug=slug,
+            ids=ids,
             limit=limit,
         )
     if asset == "sales_brief":

--- a/plans/PR-Generated-Asset-API-Draft-Id-Filters.md
+++ b/plans/PR-Generated-Asset-API-Draft-Id-Filters.md
@@ -1,0 +1,65 @@
+# PR: Generated Asset API Draft Id Filters
+
+## Why this slice exists
+
+The support-ticket live smoke prints exact saved draft ids. The export CLI can
+use those ids after the previous slice, but the hosted generated-assets API
+still only supports broad filters such as topic type, campaign name, and slug.
+The API review path should inspect the same exact generated row the CLI can.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add repeatable `id` query filters to generated-asset draft list and export
+   endpoints.
+2. Thread ids through the existing generated-assets API export helper for
+   `blog_post` and `landing_page`.
+3. Reject `id` filters for unsupported asset types with a clear 400 response.
+4. Add focused API tests proving query binding and unsupported-asset behavior.
+
+### Files touched
+
+- `plans/PR-Generated-Asset-API-Draft-Id-Filters.md`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+
+## Mechanism
+
+FastAPI receives `?id=<draft-id>` as a repeatable query alias and passes the
+normalized ids into `_export_for_asset`. Blog-post and landing-page exports use
+the repository id filters introduced by the prior CLI slice. Other assets fail
+fast because their export helpers do not accept exact-id filters yet.
+
+## Intentional
+
+- API parity only. No generation, review-status, file-ingestion, or FAQ changes.
+- Exact id filtering remains tenant-scoped by the existing repositories.
+- This is stacked on the draft-id export helper slice until that PR lands.
+
+## Deferred
+
+- Report, sales brief, and FAQ Markdown exact-id export can be added later if
+  those lanes need it.
+- Parked hardening: none. `HARDENING.md` was scanned; current entries are FAQ
+  scale and file-ingestion concurrency work outside this support-ticket provider
+  validation slice.
+
+## Verification
+
+- Generated asset API tests:
+  `pytest tests/test_extracted_content_asset_api.py -q`
+  - 59 passed.
+- Py compile for changed Python files - passed.
+- Git whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~55 |
+| API | ~20 |
+| Tests | ~35 |
+| **Total** | **~110** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -483,13 +483,14 @@ def test_generated_asset_router_lists_report_drafts_with_filters() -> None:
 
 def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     pool = _Pool(rows=[_blog_post_row()])
+    draft_id = "11111111-1111-1111-1111-111111111111"
 
     response = _client(
         pool,
         scope=TenantScope(account_id="acct_1"),
     ).get(
         "/content-assets/blog_post/drafts"
-        "?topic_type=vendor_alternative&limit=5"
+        f"?topic_type=vendor_alternative&id={draft_id}&limit=5"
     )
 
     assert response.status_code == 200
@@ -505,18 +506,20 @@ def test_generated_asset_router_lists_blog_post_drafts_with_filters() -> None:
     assert body["rows"][0]["geo_readiness"]["passed"] == 7
     query, args = pool.fetch_calls[0]
     assert "FROM blog_posts" in query
-    assert args == ("acct_1", "draft", "vendor_alternative", 5)
+    assert "id = ANY($4::uuid[])" in query
+    assert args == ("acct_1", "draft", "vendor_alternative", [draft_id], 5)
 
 
 def test_generated_asset_router_lists_landing_page_drafts_with_readiness() -> None:
     pool = _Pool(rows=[_landing_page_row()])
+    draft_id = "22222222-2222-2222-2222-222222222222"
 
     response = _client(
         pool,
         scope=TenantScope(account_id="acct_1"),
     ).get(
         "/content-assets/landing_page/drafts"
-        "?campaign_name=acme-launch&slug=acme-launch&limit=5"
+        f"?campaign_name=acme-launch&slug=acme-launch&id={draft_id}&limit=5"
     )
 
     assert response.status_code == 200
@@ -529,15 +532,17 @@ def test_generated_asset_router_lists_landing_page_drafts_with_readiness() -> No
     assert row["geo_readiness"]["checks"]["trust_signal_visibility"] is True
     query, args = pool.fetch_calls[0]
     assert "FROM landing_pages" in query
-    assert args == ("acct_1", "draft", "acme-launch", "acme-launch", 5)
+    assert "id = ANY($5::uuid[])" in query
+    assert args == ("acct_1", "draft", "acme-launch", "acme-launch", [draft_id], 5)
 
 
 def test_generated_asset_router_exports_landing_page_csv() -> None:
     pool = _Pool(rows=[_landing_page_row()])
+    draft_id = "33333333-3333-3333-3333-333333333333"
 
     response = _client(pool).get(
         "/content-assets/landing_page/drafts/export"
-        "?format=csv&campaign_name=acme-launch&slug=acme-launch"
+        f"?format=csv&campaign_name=acme-launch&slug=acme-launch&id={draft_id}"
     )
 
     assert response.status_code == 200
@@ -547,7 +552,22 @@ def test_generated_asset_router_exports_landing_page_csv() -> None:
     assert "Acme landing page" in response.text
     query, args = pool.fetch_calls[0]
     assert "FROM landing_pages" in query
-    assert args == ("", "draft", "acme-launch", "acme-launch", 20)
+    assert "id = ANY($5::uuid[])" in query
+    assert args == ("", "draft", "acme-launch", "acme-launch", [draft_id], 20)
+
+
+def test_generated_asset_router_rejects_id_filter_for_unsupported_asset() -> None:
+    pool = _Pool(rows=[_report_row()])
+
+    response = _client(pool).get(
+        "/content-assets/report/drafts?id=11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "id filters are only supported for blog_post and landing_page"
+    )
+    assert pool.fetch_calls == []
 
 
 def test_generated_asset_router_updates_landing_page_draft_with_readiness() -> None:


### PR DESCRIPTION
Plan: plans/PR-Generated-Asset-API-Draft-Id-Filters.md
Slice phase: Functional validation
Ownership lane: content-ops/support-ticket-input-provider

This adds API parity for the exact draft-id export filters introduced in #924. The generated-assets list and export routes can now inspect the exact landing-page or blog-post draft id printed by the support-ticket live smoke.

## Intentional
- API parity only; no generation, review-status, file-ingestion, or FAQ changes.
- Exact id filters remain tenant-scoped by the existing blog_post and landing_page repositories.
- Unsupported assets return a clear 400 instead of silently ignoring id filters.

## Deferred
- Report, sales brief, and FAQ Markdown exact-id filters can be added later if those lanes need them.

## Parked hardening
- None. HARDENING.md was scanned; current entries are FAQ scale and file-ingestion concurrency work outside this support-ticket provider validation slice.

## Verification
- `pytest tests/test_extracted_content_asset_api.py -q` - 59 passed.
- Py compile for changed Python files - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh` - passed.

## Diff size
3 files, +103 / -6