### PR TITLE
Add saved draft export to live smoke

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -344,6 +344,7 @@ and the same executor path used by `/content-ops/execute`:
 python scripts/smoke_content_ops_live_generation.py \
   --account-id acct_123 \
   --env-file /path/to/Atlas/.env \
+  --export-saved-draft landing-page-draft.json \
   --json
 ```
 
@@ -351,8 +352,9 @@ The command fails if `landing_page` is not configured, which usually means the
 DB pool did not initialize or the pipeline LLM/OpenRouter credentials are not
 available. Set `OPENROUTER_API_KEY` or
 `ATLAS_B2B_CHURN_OPENROUTER_API_KEY` for the pipeline-routed Claude provider.
-On success it prints the saved `landing_pages` draft id. Export that exact row
-for inspection with:
+On success it prints the saved `landing_pages` draft id and, when
+`--export-saved-draft` is supplied, writes that exact exported draft row for
+inspection. You can also export the row after the fact with:
 
 ```bash
 python scripts/export_extracted_content_assets.py \
@@ -372,11 +374,13 @@ python scripts/smoke_content_ops_live_generation.py \
   --output blog_post \
   --account-id acct_123 \
   --env-file /path/to/Atlas/.env \
+  --export-saved-draft blog-post-draft.json \
   --json
 ```
 
 On success it prints the saved `blog_posts` draft id and the seeded blueprint
-id. Export that exact row for inspection with:
+id. When `--export-saved-draft` is supplied, it writes that exact exported draft
+row for inspection. You can also export the row after the fact with:
 
 ```bash
 python scripts/export_extracted_content_assets.py \

--- a/plans/PR-Live-Smoke-Saved-Draft-Export.md
+++ b/plans/PR-Live-Smoke-Saved-Draft-Export.md
@@ -1,0 +1,71 @@
+# PR: Live Smoke Saved Draft Export
+
+## Why this slice exists
+
+The support-ticket live smoke now saves real landing-page and blog-post drafts,
+and the export paths can fetch exact draft ids. The operator still has to copy
+the saved id into a second command to inspect the generated artifact. For live
+validation, the smoke should optionally write that exact saved draft export in
+the same run.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add an optional saved-draft export flag to the live Content Ops smoke.
+2. Export the exact saved landing-page or blog-post draft ids before closing the
+   DB pool.
+3. Include the export payload in the smoke result and write it to disk when the
+   flag is supplied.
+4. Add focused tests for exact saved-id export and no-saved-id failure behavior.
+
+### Files touched
+
+- `plans/PR-Live-Smoke-Saved-Draft-Export.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `extracted_content_pipeline/README.md`
+
+## Mechanism
+
+The smoke extracts saved ids from the executed output step. When
+`--export-saved-draft` is present, it calls the same generated-asset export
+helpers used by the CLI/API with `status=None`, exact ids, and the current
+tenant scope. The export happens before the smoke closes the database so the
+host pool is still available.
+
+## Intentional
+
+- Optional operator artifact only; no hosted route, generation, FAQ, or
+  file-ingestion behavior changes.
+- Exact export remains tenant-scoped by the existing repositories.
+- The smoke fails loudly if export is requested but generation returns no saved
+  ids.
+
+## Deferred
+
+- No HTML rendering in this slice. JSON export is the thinnest artifact that
+  preserves readiness, metadata, and source-derived fields for review.
+- Parked hardening: none. `HARDENING.md` was scanned; current entries are FAQ
+  scale and file-ingestion concurrency work outside this support-ticket provider
+  validation slice.
+
+## Verification
+
+- Focused smoke tests:
+  `pytest tests/test_smoke_content_ops_live_generation.py -q`
+  - 22 passed.
+- Py compile for the smoke script and test file - passed.
+- Git whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Script | ~90 |
+| Tests | ~270 |
+| Docs | ~10 |
+| **Total** | **~440** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 import re
 import sys
-from typing import Any, Awaitable, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -65,6 +65,7 @@ AsyncCallable = Callable[[], Awaitable[None]]
 ServicesFactory = Callable[[], Any]
 Executor = Callable[..., Awaitable[dict[str, Any]]]
 BlogBlueprintSeeder = Callable[[argparse.Namespace, Any], Awaitable[Mapping[str, Any]]]
+DraftExporter = Callable[[str, Sequence[str], Any], Awaitable[Mapping[str, Any]]]
 
 
 def _load_dotenv_files(extra_env_files: list[Path] | None = None) -> None:
@@ -161,6 +162,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--output-result",
         type=Path,
         help="Write the smoke result JSON to this path.",
+    )
+    parser.add_argument(
+        "--export-saved-draft",
+        type=Path,
+        help=(
+            "Write a JSON export of the exact saved landing_page/blog_post "
+            "draft ids produced by this smoke run."
+        ),
     )
     parser.add_argument("--json", action="store_true", help="Print machine JSON.")
     return parser.parse_args(argv)
@@ -314,6 +323,67 @@ def _step_result(result: Mapping[str, Any], output: str) -> Mapping[str, Any] | 
         if isinstance(step, Mapping) and step.get("output") == output:
             return step
     return None
+
+
+def _saved_ids_for_output(
+    result: Mapping[str, Any] | None,
+    output: str,
+) -> tuple[str, ...]:
+    if not isinstance(result, Mapping):
+        return ()
+    step = _step_result(result, output)
+    step_payload = step.get("result") if isinstance(step, Mapping) else {}
+    if not isinstance(step_payload, Mapping):
+        return ()
+    raw_ids = step_payload.get("saved_ids") or ()
+    if isinstance(raw_ids, (str, bytes)) or not isinstance(raw_ids, Sequence):
+        return ()
+    return tuple(str(item).strip() for item in raw_ids if str(item).strip())
+
+
+async def _export_saved_drafts(
+    output: str,
+    saved_ids: Sequence[str],
+    scope: Any,
+) -> Mapping[str, Any]:
+    if output not in {"landing_page", "blog_post"}:
+        raise ValueError(f"saved draft export is unsupported for output: {output}")
+
+    from atlas_brain.storage.database import get_db_pool  # noqa: PLC0415
+    from extracted_content_pipeline.blog_post_export import (  # noqa: PLC0415
+        export_blog_post_drafts,
+    )
+    from extracted_content_pipeline.blog_post_postgres import (  # noqa: PLC0415
+        PostgresBlogPostRepository,
+    )
+    from extracted_content_pipeline.landing_page_export import (  # noqa: PLC0415
+        export_landing_page_drafts,
+    )
+    from extracted_content_pipeline.landing_page_postgres import (  # noqa: PLC0415
+        PostgresLandingPageRepository,
+    )
+
+    pool = get_db_pool()
+    if output == "landing_page":
+        return (
+            await export_landing_page_drafts(
+                PostgresLandingPageRepository(pool),
+                scope=scope,
+                status=None,
+                ids=saved_ids,
+                limit=len(saved_ids),
+            )
+        ).as_dict()
+    if output == "blog_post":
+        return (
+            await export_blog_post_drafts(
+                PostgresBlogPostRepository(pool),
+                scope=scope,
+                status=None,
+                ids=saved_ids,
+                limit=len(saved_ids),
+            )
+        ).as_dict()
 
 
 def _smoke_errors(
@@ -736,6 +806,7 @@ async def run_content_ops_live_generation_smoke(
     executor: Executor | None = None,
     tenant_scope_cls: Any = None,
     blog_blueprint_seed_fn: BlogBlueprintSeeder | None = None,
+    draft_export_fn: DraftExporter | None = None,
 ) -> tuple[int, dict[str, Any]]:
     _load_dotenv_files(list(args.env_file or []))
     if (
@@ -758,6 +829,7 @@ async def run_content_ops_live_generation_smoke(
     configured_outputs: tuple[str, ...] = ()
     execution_result: dict[str, Any] | None = None
     seeded_blog_blueprint: Mapping[str, Any] | None = None
+    saved_draft_export: Mapping[str, Any] | None = None
     errors: list[str] = []
     try:
         await init_database_fn()
@@ -792,6 +864,15 @@ async def run_content_ops_live_generation_smoke(
                     result=execution_result,
                 )
             )
+            if not errors and getattr(args, "export_saved_draft", None):
+                saved_ids = _saved_ids_for_output(execution_result, output)
+                if not saved_ids:
+                    errors.append(
+                        "--export-saved-draft requested, but generation returned no saved_ids"
+                    )
+                else:
+                    exporter = draft_export_fn or _export_saved_drafts
+                    saved_draft_export = await exporter(output, saved_ids, scope)
     except Exception as exc:
         errors.append(f"{type(exc).__name__}: {exc}")
     finally:
@@ -807,6 +888,9 @@ async def run_content_ops_live_generation_smoke(
         "seeded_blog_blueprint": dict(seeded_blog_blueprint or {}),
         "payload": payload,
         "execution": execution_result,
+        "saved_draft_export": (
+            dict(saved_draft_export) if isinstance(saved_draft_export, Mapping) else None
+        ),
     }
     return (0 if result["ok"] else 1), result
 
@@ -839,6 +923,11 @@ async def _amain(argv: list[str] | None = None) -> int:
     if args.output_result:
         args.output_result.write_text(
             json.dumps(result, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    if args.export_saved_draft and result.get("saved_draft_export") is not None:
+        args.export_saved_draft.write_text(
+            json.dumps(result["saved_draft_export"], indent=2, sort_keys=True),
             encoding="utf-8",
         )
     _print_result(result, as_json=bool(args.json))

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -92,6 +92,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "quality_repair_attempts": 1,
         "no_quality_gates": False,
         "output_result": None,
+        "export_saved_draft": None,
         "json": True,
     }
     values.update(overrides)
@@ -130,6 +131,42 @@ def _non_ticket_csv(tmp_path: Path) -> Path:
 
 
 @pytest.mark.asyncio
+async def test_live_generation_smoke_main_writes_saved_draft_export(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "saved-draft.json"
+
+    async def _run(args: argparse.Namespace):
+        assert args.export_saved_draft == output_path
+        return 0, {
+            "ok": True,
+            "errors": [],
+            "configured_outputs": ["landing_page"],
+            "saved_draft_export": {
+                "count": 1,
+                "rows": [{"id": "lp-live-smoke-1"}],
+            },
+        }
+
+    monkeypatch.setattr(smoke, "run_content_ops_live_generation_smoke", _run)
+
+    code = await smoke._amain([
+        "--account-id",
+        "acct-live-smoke",
+        "--export-saved-draft",
+        str(output_path),
+        "--json",
+    ])
+
+    assert code == 0
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "count": 1,
+        "rows": [{"id": "lp-live-smoke-1"}],
+    }
+
+
+@pytest.mark.asyncio
 async def test_live_generation_smoke_executes_landing_page_through_real_executor() -> None:
     lifecycle = _Lifecycle()
     service = _LandingPageService()
@@ -163,6 +200,128 @@ async def test_live_generation_smoke_executes_landing_page_through_real_executor
     assert call["campaign"].context["faq_questions"] == ["How long does it take?"]
     assert call["quality_repair_attempts"] == 1
     assert call["quality_gates_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_exports_exact_saved_landing_page_draft(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+    export_calls: list[dict[str, Any]] = []
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        export_calls.append({
+            "output": output,
+            "saved_ids": tuple(saved_ids),
+            "scope": scope,
+            "closed_before_export": lifecycle.closed,
+        })
+        return {
+            "count": 1,
+            "rows": [{"id": saved_ids[0], "title": "Generated landing page"}],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(export_saved_draft=tmp_path / "landing-page-draft.json"),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["saved_draft_export"] == {
+        "count": 1,
+        "rows": [{"id": "lp-live-smoke-1", "title": "Generated landing page"}],
+    }
+    assert export_calls == [{
+        "output": "landing_page",
+        "saved_ids": ("lp-live-smoke-1",),
+        "scope": TenantScope(
+            account_id="acct-live-smoke",
+            user_id="user-live-smoke",
+        ),
+        "closed_before_export": False,
+    }]
+    assert lifecycle.closed is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_fails_export_when_no_saved_ids(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+
+    class _NoSavedIdLandingPageService:
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "requested": 1,
+                "generated": 1,
+                "skipped": 0,
+                "saved_ids": [],
+            }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(export_saved_draft=tmp_path / "landing-page-draft.json"),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(
+            landing_page=_NoSavedIdLandingPageService()
+        ),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["saved_draft_export"] is None
+    assert result["errors"] == [
+        "landing_page generation did not return saved draft ids"
+    ]
+    assert lifecycle.closed is True
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_fails_export_when_saved_ids_are_unusable(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+
+    class _MalformedSavedIdLandingPageService:
+        async def generate(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "requested": 1,
+                "generated": 1,
+                "skipped": 0,
+                "saved_ids": "lp-live-smoke-1",
+            }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(export_saved_draft=tmp_path / "landing-page-draft.json"),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(
+            landing_page=_MalformedSavedIdLandingPageService()
+        ),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["saved_draft_export"] is None
+    assert result["errors"] == [
+        "--export-saved-draft requested, but generation returned no saved_ids"
+    ]
+    assert lifecycle.closed is True
 
 
 @pytest.mark.asyncio
@@ -339,6 +498,55 @@ async def test_live_generation_smoke_packages_support_ticket_csv_for_blog_post(
     assert call["topic"] == "Support-ticket questions customers keep asking"
 
 
+@pytest.mark.asyncio
+async def test_live_generation_smoke_exports_exact_saved_blog_post_draft(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _BlogPostService()
+    export_calls: list[dict[str, Any]] = []
+
+    async def _seed_blog_blueprint(args: argparse.Namespace, scope: TenantScope) -> dict[str, Any]:
+        return {
+            "saved_ids": ["bp-live-smoke-1"],
+            "slug": "content-ops-blog-live-smoke-acct-live-smoke",
+            "target_mode": args.target_mode,
+            "topic_type": "complaint_roundup",
+        }
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        export_calls.append({"output": output, "saved_ids": tuple(saved_ids)})
+        return {"count": 1, "rows": [{"id": saved_ids[0]}]}
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="blog_post",
+            export_saved_draft=tmp_path / "blog-post-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(blog_post=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        blog_blueprint_seed_fn=_seed_blog_blueprint,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 0
+    assert result["saved_draft_export"] == {
+        "count": 1,
+        "rows": [{"id": "blog-live-smoke-1"}],
+    }
+    assert export_calls == [{
+        "output": "blog_post",
+        "saved_ids": ("blog-live-smoke-1",),
+    }]
+
+
 def test_blog_blueprint_json_loader_accepts_one_custom_blueprint(tmp_path: Path) -> None:
     path = tmp_path / "blueprint.json"
     path.write_text(
@@ -447,6 +655,59 @@ def test_blog_payload_alignment_preserves_custom_operator_topic() -> None:
     )
 
     assert payload["inputs"]["topic"] == "Operator supplied smoke topic"
+
+
+def test_saved_ids_for_output_rejects_malformed_shapes() -> None:
+    assert smoke._saved_ids_for_output(None, "landing_page") == ()
+    assert smoke._saved_ids_for_output({"steps": []}, "landing_page") == ()
+    assert smoke._saved_ids_for_output(
+        {"steps": [{"output": "landing_page", "result": "bad"}]},
+        "landing_page",
+    ) == ()
+    assert smoke._saved_ids_for_output(
+        {"steps": [{"output": "landing_page", "result": {}}]},
+        "landing_page",
+    ) == ()
+    assert smoke._saved_ids_for_output(
+        {
+            "steps": [{
+                "output": "landing_page",
+                "result": {"saved_ids": "lp-live-smoke-1"},
+            }]
+        },
+        "landing_page",
+    ) == ()
+    assert smoke._saved_ids_for_output(
+        {
+            "steps": [{
+                "output": "landing_page",
+                "result": {"saved_ids": ["  "]},
+            }]
+        },
+        "landing_page",
+    ) == ()
+
+
+def test_saved_ids_for_output_strips_and_preserves_multiple_ids() -> None:
+    assert smoke._saved_ids_for_output(
+        {
+            "steps": [{
+                "output": "blog_post",
+                "result": {"saved_ids": [" blog-1 ", "blog-2"]},
+            }]
+        },
+        "blog_post",
+    ) == ("blog-1", "blog-2")
+
+
+@pytest.mark.asyncio
+async def test_export_saved_drafts_rejects_unsupported_output() -> None:
+    with pytest.raises(ValueError, match="unsupported for output"):
+        await smoke._export_saved_drafts(
+            "report",
+            ("report-1",),
+            TenantScope(account_id="acct-live-smoke"),
+        )
 
 
 def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why this slice exists

Live Content Ops smoke tests can prove generation returns saved draft ids, but they did not prove those ids can be loaded through the export/review path in the same run. That left the support-ticket provider validation one step short of an inspectable artifact.

## Scope

Ownership lane: content-ops/support-ticket-input-provider

Slice phase: Functional validation

- Add `--export-saved-draft <path>` to `scripts/smoke_content_ops_live_generation.py`.
- Export the exact saved landing-page or blog-post draft ids produced by the smoke run.
- Write the exported JSON artifact after successful generation.
- Document the flag in the extracted content pipeline README.
- Cover the new behavior with unit tests, including missing/malformed saved ids and unsupported output handling.

## Verification

- `pytest tests/test_smoke_content_ops_live_generation.py -q` -> 22 passed
- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py`
- `git diff --check`
- `bash scripts/local_pr_review.sh`

## Diff size

4 files changed, 429 insertions(+), 4 deletions(-)
