### PR TITLE
PR-Content-Ops-FAQ-Search-Postgres-Projection

### DIFF
--- a/atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql
+++ b/atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql
@@ -1,0 +1,44 @@
+-- Ticket FAQ search projection: one compact searchable row per generated FAQ
+-- item. The generated Markdown document remains the canonical artifact in
+-- ticket_faq_markdown; this table is a read-optimized projection for deflection
+-- search routes and concurrent demo traffic.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_search_documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    corpus_id TEXT NOT NULL DEFAULT '',
+    faq_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) ON DELETE CASCADE,
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'draft',
+    rank INTEGER NOT NULL DEFAULT 0,
+    topic TEXT NOT NULL DEFAULT '',
+    question TEXT NOT NULL DEFAULT '',
+    answer_summary TEXT NOT NULL DEFAULT '',
+    source_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ticket_count INTEGER NOT NULL DEFAULT 0,
+    search_text TEXT NOT NULL DEFAULT '',
+    search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector(
+            'english',
+            question || ' ' || topic || ' ' || answer_summary || ' ' || search_text
+        )
+    ) STORED,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ticket_faq_search_account_id CHECK (btrim(account_id) <> ''),
+    CONSTRAINT chk_ticket_faq_search_corpus_id CHECK (btrim(corpus_id) <> ''),
+    CONSTRAINT chk_ticket_faq_search_status CHECK (btrim(status) <> ''),
+    CONSTRAINT chk_ticket_faq_search_rank CHECK (rank > 0),
+    CONSTRAINT chk_ticket_faq_search_ticket_count CHECK (ticket_count >= 0),
+    UNIQUE (account_id, corpus_id, faq_id, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_scope
+    ON ticket_faq_search_documents (account_id, corpus_id, status, rank);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_faq
+    ON ticket_faq_search_documents (faq_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_vector
+    ON ticket_faq_search_documents USING GIN (search_vector);

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -85,6 +85,10 @@
       "target": "extracted_content_pipeline/storage/migrations/325_ticket_faq_markdown.sql"
     },
     {
+      "source": "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql",
+      "target": "extracted_content_pipeline/storage/migrations/327_ticket_faq_search_documents.sql"
+    },
+    {
       "source": "atlas_brain/storage/migrations/066_b2b_campaigns.sql",
       "target": "extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql"
     },

--- a/extracted_content_pipeline/storage/migrations/327_ticket_faq_search_documents.sql
+++ b/extracted_content_pipeline/storage/migrations/327_ticket_faq_search_documents.sql
@@ -1,0 +1,44 @@
+-- Ticket FAQ search projection: one compact searchable row per generated FAQ
+-- item. The generated Markdown document remains the canonical artifact in
+-- ticket_faq_markdown; this table is a read-optimized projection for deflection
+-- search routes and concurrent demo traffic.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_search_documents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    corpus_id TEXT NOT NULL DEFAULT '',
+    faq_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) ON DELETE CASCADE,
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'draft',
+    rank INTEGER NOT NULL DEFAULT 0,
+    topic TEXT NOT NULL DEFAULT '',
+    question TEXT NOT NULL DEFAULT '',
+    answer_summary TEXT NOT NULL DEFAULT '',
+    source_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ticket_count INTEGER NOT NULL DEFAULT 0,
+    search_text TEXT NOT NULL DEFAULT '',
+    search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector(
+            'english',
+            question || ' ' || topic || ' ' || answer_summary || ' ' || search_text
+        )
+    ) STORED,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ticket_faq_search_account_id CHECK (btrim(account_id) <> ''),
+    CONSTRAINT chk_ticket_faq_search_corpus_id CHECK (btrim(corpus_id) <> ''),
+    CONSTRAINT chk_ticket_faq_search_status CHECK (btrim(status) <> ''),
+    CONSTRAINT chk_ticket_faq_search_rank CHECK (rank > 0),
+    CONSTRAINT chk_ticket_faq_search_ticket_count CHECK (ticket_count >= 0),
+    UNIQUE (account_id, corpus_id, faq_id, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_scope
+    ON ticket_faq_search_documents (account_id, corpus_id, status, rank);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_faq
+    ON ticket_faq_search_documents (faq_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_search_vector
+    ON ticket_faq_search_documents USING GIN (search_vector);

--- a/extracted_content_pipeline/ticket_faq_search.py
+++ b/extracted_content_pipeline/ticket_faq_search.py
@@ -9,6 +9,11 @@ import re
 from typing import Any
 
 from .campaign_ports import JsonDict
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    row_to_dict,
+)
 from .ticket_faq_ports import TicketFAQDraft
 
 
@@ -77,6 +82,15 @@ class TicketFAQSearchResponse:
             "results": [result.as_dict() for result in self.results],
             "count": len(self.results),
         }
+
+
+@dataclass(frozen=True)
+class TicketFAQSearchProjectionKey:
+    """Replacement key for one FAQ search projection group."""
+
+    account_id: str
+    corpus_id: str
+    faq_id: str
 
 
 def build_ticket_faq_search_documents(
@@ -154,6 +168,77 @@ def search_ticket_faq_documents(
     )
 
 
+@dataclass(frozen=True)
+class PostgresTicketFAQSearchRepository:
+    """Postgres adapter for persisted FAQ search projection rows."""
+
+    pool: Any
+
+    async def replace_documents(
+        self,
+        documents: Sequence[TicketFAQSearchDocument],
+        *,
+        replace_keys: Sequence[TicketFAQSearchProjectionKey] = (),
+    ) -> int:
+        """Replace projected rows for each requested FAQ/corpus group."""
+
+        groups: dict[TicketFAQSearchProjectionKey, list[TicketFAQSearchDocument]] = {
+            _validate_projection_key(key): [] for key in replace_keys
+        }
+        for document in documents:
+            _validate_search_document(document)
+            key = TicketFAQSearchProjectionKey(
+                account_id=document.account_id,
+                corpus_id=document.corpus_id,
+                faq_id=document.faq_id,
+            )
+            groups.setdefault(key, []).append(document)
+        for key, group_documents in groups.items():
+            _validate_distinct_ranks(key, group_documents)
+        return await _replace_document_groups_atomic(self.pool, groups)
+
+    async def search(
+        self,
+        *,
+        query: str,
+        account_id: str,
+        corpus_id: str | None = None,
+        status: str | None = "approved",
+        limit: int = 10,
+    ) -> TicketFAQSearchResponse:
+        """Search persisted FAQ projection rows with tenant/corpus filters."""
+
+        normalized_query = _clean(query)
+        normalized_account_id = _clean(account_id)
+        if not normalized_account_id or not _tokens(normalized_query) or limit <= 0:
+            return TicketFAQSearchResponse(query=normalized_query, results=())
+        clauses: list[str] = ["account_id = $2", "search_vector @@ search_query.query"]
+        params: list[Any] = [normalized_query, normalized_account_id]
+        if corpus_id is not None:
+            params.append(corpus_id)
+            clauses.append(f"corpus_id = ${len(params)}")
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        params.append(int(limit))
+        sql = (
+            "WITH search_query AS ("
+            "SELECT websearch_to_tsquery('english', $1) AS query"
+            ") "
+            "SELECT account_id, corpus_id, faq_id, target_id, target_mode, "
+            "status, rank, topic, question, answer_summary, source_ids, "
+            "ticket_count, search_text, "
+            "(ts_rank_cd(search_vector, search_query.query) * 1000)::integer AS score "
+            "FROM ticket_faq_search_documents, search_query "
+            "WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY score DESC, rank ASC, question ASC "
+            f"LIMIT ${len(params)}"
+        )
+        rows = await self.pool.fetch(sql, *params)
+        results = tuple(_row_to_search_result(row_to_dict(row)) for row in rows)
+        return TicketFAQSearchResponse(query=normalized_query, results=results)
+
+
 def _score_document(document: TicketFAQSearchDocument, query_tokens: Sequence[str]) -> int:
     question_tokens = set(_tokens(document.question))
     topic_tokens = set(_tokens(document.topic))
@@ -166,6 +251,155 @@ def _score_document(document: TicketFAQSearchDocument, query_tokens: Sequence[st
             score += 2
         score += min(text_counts.get(token, 0), 3)
     return score
+
+
+def _row_to_search_document(row: Mapping[str, Any]) -> TicketFAQSearchDocument:
+    return TicketFAQSearchDocument(
+        account_id=_clean(row.get("account_id")),
+        corpus_id=_clean(row.get("corpus_id")),
+        faq_id=_clean(row.get("faq_id")),
+        target_id=_clean(row.get("target_id")),
+        target_mode=_clean(row.get("target_mode")),
+        status=_clean(row.get("status")),
+        rank=_int_value(row.get("rank"), default=0),
+        topic=_clean(row.get("topic")),
+        question=_clean(row.get("question")),
+        answer_summary=_clean(row.get("answer_summary")),
+        source_ids=_source_ids_jsonb(row.get("source_ids")),
+        ticket_count=_int_value(row.get("ticket_count"), default=0),
+        search_text=_clean(row.get("search_text")),
+    )
+
+
+async def _replace_document_groups_atomic(
+    db: Any,
+    groups: Mapping[TicketFAQSearchProjectionKey, Sequence[TicketFAQSearchDocument]],
+) -> int:
+    transaction = getattr(db, "transaction", None)
+    if callable(transaction):
+        async with transaction() as connection:
+            return await _replace_document_groups(connection or db, groups)
+    acquire = getattr(db, "acquire", None)
+    if callable(acquire):
+        async with acquire() as connection:
+            connection_transaction = getattr(connection, "transaction", None)
+            if callable(connection_transaction):
+                async with connection_transaction():
+                    return await _replace_document_groups(connection, groups)
+            return await _replace_document_groups(connection, groups)
+    return await _replace_document_groups(db, groups)
+
+
+async def _replace_document_groups(
+    db: Any,
+    groups: Mapping[TicketFAQSearchProjectionKey, Sequence[TicketFAQSearchDocument]],
+) -> int:
+    replaced = 0
+    for key, documents in groups.items():
+        await db.execute(
+            """
+            DELETE FROM ticket_faq_search_documents
+             WHERE account_id = $1
+               AND corpus_id = $2
+               AND faq_id = $3::uuid
+            """,
+            key.account_id,
+            key.corpus_id,
+            key.faq_id,
+        )
+        for document in documents:
+            await db.execute(
+                """
+                INSERT INTO ticket_faq_search_documents (
+                    account_id, corpus_id, faq_id, target_id, target_mode,
+                    status, rank, topic, question, answer_summary,
+                    source_ids, ticket_count, search_text
+                )
+                VALUES (
+                    $1, $2, $3::uuid, $4, $5,
+                    $6, $7, $8, $9, $10,
+                    $11::jsonb, $12, $13
+                )
+                ON CONFLICT (account_id, corpus_id, faq_id, rank)
+                DO UPDATE SET
+                    target_id = EXCLUDED.target_id,
+                    target_mode = EXCLUDED.target_mode,
+                    status = EXCLUDED.status,
+                    topic = EXCLUDED.topic,
+                    question = EXCLUDED.question,
+                    answer_summary = EXCLUDED.answer_summary,
+                    source_ids = EXCLUDED.source_ids,
+                    ticket_count = EXCLUDED.ticket_count,
+                    search_text = EXCLUDED.search_text,
+                    updated_at = NOW()
+                """,
+                document.account_id,
+                document.corpus_id,
+                document.faq_id,
+                document.target_id,
+                document.target_mode,
+                document.status,
+                document.rank,
+                document.topic,
+                document.question,
+                document.answer_summary,
+                json_dump_jsonb(list(document.source_ids)),
+                document.ticket_count,
+                document.search_text,
+            )
+            replaced += 1
+    return replaced
+
+
+def _validate_projection_key(
+    key: TicketFAQSearchProjectionKey,
+) -> TicketFAQSearchProjectionKey:
+    if not _clean(key.account_id):
+        raise ValueError("ticket FAQ search projection key requires account_id")
+    if not _clean(key.corpus_id):
+        raise ValueError("ticket FAQ search projection key requires corpus_id")
+    if not _clean(key.faq_id):
+        raise ValueError("ticket FAQ search projection key requires faq_id")
+    return key
+
+
+def _validate_search_document(document: TicketFAQSearchDocument) -> None:
+    _validate_projection_key(
+        TicketFAQSearchProjectionKey(
+            account_id=document.account_id,
+            corpus_id=document.corpus_id,
+            faq_id=document.faq_id,
+        )
+    )
+    if not _clean(document.status):
+        raise ValueError("ticket FAQ search document requires status")
+    if int(document.rank) <= 0:
+        raise ValueError("ticket FAQ search document requires rank > 0")
+    if int(document.ticket_count) < 0:
+        raise ValueError("ticket FAQ search document requires ticket_count >= 0")
+
+
+def _validate_distinct_ranks(
+    key: TicketFAQSearchProjectionKey,
+    documents: Sequence[TicketFAQSearchDocument],
+) -> None:
+    ranks: set[int] = set()
+    for document in documents:
+        rank = int(document.rank)
+        if rank in ranks:
+            raise ValueError(
+                "ticket FAQ search projection requires distinct ranks "
+                f"for account_id={key.account_id} corpus_id={key.corpus_id} "
+                f"faq_id={key.faq_id}"
+            )
+        ranks.add(rank)
+
+
+def _row_to_search_result(row: Mapping[str, Any]) -> TicketFAQSearchResult:
+    return TicketFAQSearchResult(
+        document=_row_to_search_document(row),
+        score=_int_value(row.get("score"), default=0),
+    )
 
 
 def _search_text(item: Mapping[str, Any], *, topic: str, question: str, answer_summary: str) -> str:
@@ -190,6 +424,13 @@ def _source_ids(value: Any) -> tuple[str, ...]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         return ()
     return tuple(dict.fromkeys(_clean(item) for item in value if _clean(item)))
+
+
+def _source_ids_jsonb(value: Any) -> tuple[str, ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(dict.fromkeys(_clean(item) for item in decoded if _clean(item)))
 
 
 def _metadata_account_id(metadata: Mapping[str, Any]) -> str:
@@ -219,7 +460,9 @@ def _clean(value: Any) -> str:
 
 
 __all__ = [
+    "PostgresTicketFAQSearchRepository",
     "TicketFAQSearchDocument",
+    "TicketFAQSearchProjectionKey",
     "TicketFAQSearchResponse",
     "TicketFAQSearchResult",
     "build_ticket_faq_search_documents",

--- a/plans/PR-Content-Ops-FAQ-Search-Postgres-Projection.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Postgres-Projection.md
@@ -1,0 +1,127 @@
+# PR-Content-Ops-FAQ-Search-Postgres-Projection
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-Projection-V1` defines the compact FAQ search
+document and `{query, results, count}` envelope, but it still searches an
+in-memory iterable. That proves the contract, not production retrieval. A live
+demo with concurrent users needs a separate persisted search layer so reads do
+not scan raw uploaded ticket rows or full generated Markdown blobs.
+
+This slice adds the database projection needed before the hosted
+`faq-deflection-search` route can be built.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a Postgres migration for `ticket_faq_search_documents`.
+2. Add tenant/corpus/status and full-text search indexes for read latency.
+3. Add a Postgres search repository that replaces projected rows for a FAQ draft
+   and searches the projection using the #923 response envelope.
+4. Preserve replace semantics when a regenerated FAQ has zero searchable rows.
+5. Make each projection delete/insert replacement atomic.
+6. Fail closed before projection writes when tenant/corpus/status invariants are
+   missing.
+7. Reject duplicate ranks per projection group before any database write.
+8. Register the migration in the extracted package manifest.
+9. Add focused tests for replace semantics, tenant/corpus/status SQL filters,
+   invalid projection writes, duplicate ranks, real Postgres isolation/FTS, and
+   row-to-envelope mapping.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Postgres-Projection.md`
+- `atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql`
+- `extracted_content_pipeline/storage/migrations/327_ticket_faq_search_documents.sql`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/ticket_faq_search.py`
+- `tests/test_extracted_ticket_faq_search_postgres.py`
+
+## Mechanism
+
+The migration creates one projected row per FAQ item:
+
+- `account_id`, `corpus_id`, `status` for isolation and filtering.
+- `faq_id`, `target_id`, `target_mode`, `rank` for traceability.
+- `topic`, `question`, `answer_summary`, `source_ids`, `ticket_count`, and
+  `search_text` for rendering and retrieval.
+- a generated `search_vector` with a GIN index for Postgres full-text search.
+- CHECK constraints for non-blank tenant/corpus/status plus positive rank and
+  non-negative ticket counts.
+
+`PostgresTicketFAQSearchRepository.replace_documents(...)` deletes existing
+projection rows for each `(account_id, corpus_id, faq_id)` group and inserts the
+new documents inside a transaction boundary. This replacement behavior prevents
+stale FAQ item rows after a draft is regenerated with different item counts, and
+rolls back to the prior projection if an insert fails after the delete.
+
+Callers can pass explicit `TicketFAQSearchProjectionKey` values through
+`replace_keys` so a regenerated FAQ with zero searchable rows still clears the
+prior projection rows for that FAQ/corpus.
+
+Before any delete/insert runs, `replace_documents(...)` validates the projection
+document invariants that the table also enforces. Invalid projection rows and
+duplicate ranks within a projection group raise `ValueError` without touching
+the pool, preventing silent overwrite under the `(account_id, corpus_id, faq_id,
+rank)` unique key.
+
+`search(...)` uses `websearch_to_tsquery('english', query)` and scopes every read
+by `account_id`, optional `corpus_id`, and optional `status`. It returns the same
+`TicketFAQSearchResponse.as_dict()` envelope introduced in #923.
+
+The integration test applies the parent FAQ and search projection migrations to
+the configured Postgres database, seeds tenant-isolated rows, verifies FTS hit
+and miss behavior through the repository, and uses a scoped trigger to force an
+insert failure after delete so rollback is checked against the real table.
+
+## Intentional
+
+- The hosted FastAPI route is still deferred. This PR is only the durable search
+  layer behind that future route.
+- The repository replaces projection rows for a FAQ instead of patching per item;
+  FAQ generation emits a complete item list, so replace semantics are simpler
+  and avoid stale rows.
+- No vector/embedding search is added. Deterministic Postgres full-text search is
+  sufficient for the first production retrieval seam and easier to harden.
+
+## Deferred
+
+- `PR-Content-Ops-FAQ-Deflection-Search-Route`: expose the hosted route that
+  calls this repository and returns `{query, results, count}`.
+- `PR-Content-Ops-FAQ-Search-Concurrency-Smoke`: seed multiple corpora and run
+  concurrent filtered searches with latency and isolation assertions.
+- Search snippets/highlighting and synonym expansion remain deferred until the
+  route exists.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_search_postgres.py tests/test_extracted_ticket_faq_search.py -q - 15 passed, 1 skipped without DB URL.
+- pytest tests/test_extracted_ticket_faq_search_postgres.py::test_ticket_faq_search_contract_against_postgres -q - 1 passed with EXTRACTED_DATABASE_URL constructed from local `.env.backup` ATLAS_DB_* fields.
+- python -m py_compile extracted_content_pipeline/ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline - passed.
+- bash scripts/local_pr_review.sh --allow-dirty - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 127 |
+| Migration source + synced target | 88 |
+| Search repository | 243 |
+| Tests | 470 |
+| Manifest mapping | 4 |
+| **Total** | **932** |
+
+This is above the 400 LOC target because the migration, durable repository, and
+tests are indivisible for a real persisted retrieval seam. The additional
+projection invariant checks and review-driven transactional replacement semantics
+keep tenant isolation and stale-row correctness enforced at the source rather
+than relying only on the future route. The hosted route and concurrency smoke
+stay deferred to keep this slice bounded.

--- a/tests/test_extracted_ticket_faq_search_postgres.py
+++ b/tests/test_extracted_ticket_faq_search_postgres.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from extracted_content_pipeline.ticket_faq_search import (
+    PostgresTicketFAQSearchRepository,
+    TicketFAQSearchDocument,
+    TicketFAQSearchProjectionKey,
+)
+
+
+class _Transaction:
+    def __init__(self, pool: _Pool) -> None:
+        self.pool = pool
+
+    async def __aenter__(self):
+        self.pool.transaction_enters += 1
+        return self.pool
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.pool.transaction_exits.append(exc_type)
+        return False
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.execute_calls: list[dict[str, object]] = []
+        self.fetch_calls: list[dict[str, object]] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.transaction_enters = 0
+        self.transaction_exits: list[type[BaseException] | None] = []
+        self.fail_on_insert = False
+
+    async def execute(self, query, *args):
+        if self.fail_on_insert and "INSERT INTO ticket_faq_search_documents" in str(query):
+            raise RuntimeError("insert failed")
+        self.execute_calls.append({"query": query, "args": args})
+        return "INSERT 0 1"
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    def transaction(self):
+        return _Transaction(self)
+
+
+def _document(
+    *,
+    faq_id: str = "11111111-1111-1111-1111-111111111111",
+    rank: int = 1,
+    account_id: str = "acct-1",
+    corpus_id: str = "corpus-1",
+    status: str = "approved",
+    question: str = "How do I reset my password?",
+) -> TicketFAQSearchDocument:
+    return TicketFAQSearchDocument(
+        account_id=account_id,
+        corpus_id=corpus_id,
+        faq_id=faq_id,
+        target_id="support-account-1",
+        target_mode="support_account",
+        status=status,
+        rank=rank,
+        topic="password reset",
+        question=question,
+        answer_summary="Customers cannot find the password reset email.",
+        source_ids=("ticket-1", "ticket-2"),
+        ticket_count=2,
+        search_text="password reset email login support",
+    )
+
+
+def _projection_key(
+    *,
+    account_id: str = "acct-1",
+    corpus_id: str = "corpus-1",
+    faq_id: str = "11111111-1111-1111-1111-111111111111",
+) -> TicketFAQSearchProjectionKey:
+    return TicketFAQSearchProjectionKey(
+        account_id=account_id,
+        corpus_id=corpus_id,
+        faq_id=faq_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_deletes_existing_projection_then_inserts() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    replaced = await repo.replace_documents([
+        _document(rank=1),
+        _document(rank=2, question="Where is my reset email?"),
+    ])
+
+    assert replaced == 2
+    assert pool.transaction_enters == 1
+    assert pool.transaction_exits == [None]
+    assert len(pool.execute_calls) == 3
+    delete_call = pool.execute_calls[0]
+    assert "DELETE FROM ticket_faq_search_documents" in str(delete_call["query"])
+    assert delete_call["args"] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+    insert_call = pool.execute_calls[1]
+    assert "INSERT INTO ticket_faq_search_documents" in str(insert_call["query"])
+    assert "ON CONFLICT (account_id, corpus_id, faq_id, rank)" in str(insert_call["query"])
+    assert insert_call["args"][:10] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+        "support-account-1",
+        "support_account",
+        "approved",
+        1,
+        "password reset",
+        "How do I reset my password?",
+        "Customers cannot find the password reset email.",
+    )
+    assert json.loads(insert_call["args"][10]) == ["ticket-1", "ticket-2"]
+    assert insert_call["args"][11:] == (2, "password reset email login support")
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_groups_delete_by_account_corpus_and_faq() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    await repo.replace_documents([
+        _document(faq_id="11111111-1111-1111-1111-111111111111"),
+        _document(faq_id="22222222-2222-2222-2222-222222222222"),
+        _document(faq_id="22222222-2222-2222-2222-222222222222", rank=2),
+    ])
+
+    delete_args = [
+        call["args"]
+        for call in pool.execute_calls
+        if "DELETE FROM ticket_faq_search_documents" in str(call["query"])
+    ]
+    assert delete_args == [
+        ("acct-1", "corpus-1", "11111111-1111-1111-1111-111111111111"),
+        ("acct-1", "corpus-1", "22222222-2222-2222-2222-222222222222"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_can_clear_existing_projection_for_empty_results() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    replaced = await repo.replace_documents(
+        [],
+        replace_keys=[
+            _projection_key()
+        ],
+    )
+
+    assert replaced == 0
+    assert pool.transaction_enters == 1
+    assert pool.transaction_exits == [None]
+    assert len(pool.execute_calls) == 1
+    delete_call = pool.execute_calls[0]
+    assert "DELETE FROM ticket_faq_search_documents" in str(delete_call["query"])
+    assert delete_call["args"] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_uses_transaction_for_delete_and_insert() -> None:
+    pool = _Pool()
+    pool.fail_on_insert = True
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        await repo.replace_documents([_document()])
+
+    assert pool.transaction_enters == 1
+    assert pool.transaction_exits == [RuntimeError]
+    assert len(pool.execute_calls) == 1
+    assert "DELETE FROM ticket_faq_search_documents" in str(pool.execute_calls[0]["query"])
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_rejects_duplicate_ranks_before_database_write() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    with pytest.raises(ValueError, match="requires distinct ranks"):
+        await repo.replace_documents([
+            _document(rank=1),
+            _document(rank=1, question="Where is my reset email?"),
+        ])
+
+    assert pool.execute_calls == []
+    assert pool.transaction_enters == 0
+
+
+@pytest.mark.asyncio
+async def test_replace_documents_rejects_blank_tenant_before_database_write() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    with pytest.raises(ValueError, match="requires account_id"):
+        await repo.replace_documents([_document(account_id="   ")])
+
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_search_filters_by_tenant_corpus_status_and_uses_full_text_query() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        {
+            "account_id": "acct-1",
+            "corpus_id": "corpus-1",
+            "faq_id": "11111111-1111-1111-1111-111111111111",
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "status": "approved",
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer_summary": "Use the reset email.",
+            "source_ids": json.dumps(["ticket-1"]),
+            "ticket_count": 1,
+            "search_text": "password reset email",
+            "score": 84,
+        }
+    ]
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    response = await repo.search(
+        query="reset email",
+        account_id="acct-1",
+        corpus_id="corpus-1",
+        status="approved",
+        limit=5,
+    )
+
+    sql = str(pool.fetch_calls[0]["query"])
+    assert "websearch_to_tsquery('english', $1)" in sql
+    assert "account_id = $2" in sql
+    assert "corpus_id = $3" in sql
+    assert "status = $4" in sql
+    assert "LIMIT $5" in sql
+    assert pool.fetch_calls[0]["args"] == (
+        "reset email",
+        "acct-1",
+        "corpus-1",
+        "approved",
+        5,
+    )
+    assert response.as_dict() == {
+        "query": "reset email",
+        "count": 1,
+        "results": [{
+            "account_id": "acct-1",
+            "corpus_id": "corpus-1",
+            "faq_id": "11111111-1111-1111-1111-111111111111",
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "status": "approved",
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer_summary": "Use the reset email.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 1,
+            "score": 84,
+        }],
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_allows_optional_corpus_and_status_filters() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    await repo.search(
+        query="invoice",
+        account_id="acct-1",
+        corpus_id=None,
+        status=None,
+        limit=10,
+    )
+
+    sql = str(pool.fetch_calls[0]["query"])
+    assert "account_id = $2" in sql
+    assert "corpus_id =" not in sql
+    assert "status =" not in sql
+    assert "LIMIT $3" in sql
+    assert pool.fetch_calls[0]["args"] == ("invoice", "acct-1", 10)
+
+
+@pytest.mark.asyncio
+async def test_search_short_circuits_blank_query_and_zero_limit() -> None:
+    pool = _Pool()
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    blank = await repo.search(query="   ", account_id="acct-1")
+    limited = await repo.search(query="password", account_id="acct-1", limit=0)
+    blank_tenant = await repo.search(query="password", account_id="   ")
+
+    assert blank.as_dict() == {"query": "", "results": [], "count": 0}
+    assert limited.as_dict() == {"query": "password", "results": [], "count": 0}
+    assert blank_tenant.as_dict() == {"query": "password", "results": [], "count": 0}
+    assert pool.fetch_calls == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ticket_faq_search_contract_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    faq_id_a = str(uuid4())
+    faq_id_b = str(uuid4())
+    faq_id_rollback = str(uuid4())
+    account_a = f"acct-a-{uuid4().hex}"
+    account_b = f"acct-b-{uuid4().hex}"
+    account_rollback = f"acct-rb-{uuid4().hex}"
+    corpus_id = f"corpus-{uuid4().hex}"
+    function_name = f"test_fail_ticket_faq_insert_{uuid4().hex}"
+    trigger_name = f"test_fail_ticket_faq_insert_{uuid4().hex}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    repo = PostgresTicketFAQSearchRepository(pool)
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql").read_text())
+        for faq_id, account_id in (
+            (faq_id_a, account_a),
+            (faq_id_b, account_b),
+            (faq_id_rollback, account_rollback),
+        ):
+            await _insert_parent_faq(pool, faq_id=faq_id, account_id=account_id)
+
+        await repo.replace_documents([
+            _document(
+                faq_id=faq_id_a,
+                account_id=account_a,
+                corpus_id=corpus_id,
+                question="How do I reset my password?",
+            ),
+            _document(
+                faq_id=faq_id_b,
+                account_id=account_b,
+                corpus_id=corpus_id,
+                question="How do I reset my password?",
+            ),
+        ])
+
+        account_a_hit = await repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_id,
+        )
+        account_b_hit = await repo.search(
+            query="password reset",
+            account_id=account_b,
+            corpus_id=corpus_id,
+        )
+        miss = await repo.search(
+            query="escrow shortage",
+            account_id=account_a,
+            corpus_id=corpus_id,
+        )
+
+        assert [row["account_id"] for row in account_a_hit.as_dict()["results"]] == [account_a]
+        assert [row["account_id"] for row in account_b_hit.as_dict()["results"]] == [account_b]
+        assert miss.as_dict()["results"] == []
+
+        await repo.replace_documents([
+            _document(
+                faq_id=faq_id_rollback,
+                account_id=account_rollback,
+                corpus_id=corpus_id,
+                question="How do I update my billing address?",
+            )
+        ])
+        await pool.execute(
+            f"""
+            CREATE OR REPLACE FUNCTION {function_name}()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.account_id = '{account_rollback}' THEN
+                    RAISE EXCEPTION 'forced ticket FAQ search projection insert failure';
+                END IF;
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await pool.execute(
+            f"""
+            CREATE TRIGGER {trigger_name}
+            BEFORE INSERT ON ticket_faq_search_documents
+            FOR EACH ROW
+            EXECUTE FUNCTION {function_name}()
+            """
+        )
+
+        with pytest.raises(Exception, match="forced ticket FAQ search projection insert failure"):
+            await repo.replace_documents([
+                _document(
+                    faq_id=faq_id_rollback,
+                    account_id=account_rollback,
+                    corpus_id=corpus_id,
+                    question="How do I change my billing address?",
+                )
+            ])
+
+        rollback_count = await pool.fetchval(
+            """
+            SELECT COUNT(*)
+              FROM ticket_faq_search_documents
+             WHERE account_id = $1
+               AND corpus_id = $2
+               AND faq_id = $3::uuid
+               AND question = $4
+            """,
+            account_rollback,
+            corpus_id,
+            faq_id_rollback,
+            "How do I update my billing address?",
+        )
+        assert rollback_count == 1
+    finally:
+        await pool.execute(f"DROP TRIGGER IF EXISTS {trigger_name} ON ticket_faq_search_documents")
+        await pool.execute(f"DROP FUNCTION IF EXISTS {function_name}()")
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = ANY($1::text[])",
+            [account_a, account_b, account_rollback],
+        )
+        await pool.close()
+
+
+async def _insert_parent_faq(pool, *, faq_id: str, account_id: str) -> None:
+    await pool.execute(
+        """
+        INSERT INTO ticket_faq_markdown (
+            id, account_id, target_id, target_mode, title, markdown,
+            items, source_count, ticket_source_count, output_checks,
+            warnings, metadata, status
+        )
+        VALUES (
+            $1::uuid, $2, 'support-account-1', 'support_account',
+            'Support FAQ', '# Support FAQ', '[]'::jsonb, 1, 1,
+            '{}'::jsonb, '[]'::jsonb, '{}'::jsonb, 'approved'
+        )
+        """,
+        faq_id,
+        account_id,
+    )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Postgres-Projection.md

Add the durable Postgres projection layer for FAQ search documents so the future hosted deflection route reads a compact, tenant-scoped search table instead of raw uploaded rows or full Markdown blobs. Review feedback is addressed with explicit empty-projection replacement keys, atomic delete/insert replacement, duplicate-rank validation, and real Postgres isolation/FTS/rollback coverage.

Slice phase: Vertical slice

## Intentional
- The hosted FastAPI route is deferred; this PR is the durable search layer behind it.
- Projection rows are replaced per FAQ/corpus to avoid stale item rows after regeneration, including explicit empty-result replacement.
- Postgres full-text search is used before adding any embedding/vector layer.

## Deferred
- PR-Content-Ops-FAQ-Deflection-Search-Route: expose the hosted route returning `{query, results, count}`.
- PR-Content-Ops-FAQ-Search-Concurrency-Smoke: seed multiple corpora and test concurrent filtered retrieval.
- Search snippets/highlighting and synonym expansion stay deferred until the route exists.

## Verification
- pytest tests/test_extracted_ticket_faq_search_postgres.py tests/test_extracted_ticket_faq_search.py -q - 15 passed, 1 skipped without DB URL.
- pytest tests/test_extracted_ticket_faq_search_postgres.py::test_ticket_faq_search_contract_against_postgres -q - 1 passed with EXTRACTED_DATABASE_URL constructed from local `.env.backup` ATLAS_DB_* fields.
- python -m py_compile extracted_content_pipeline/ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline - passed.
- bash scripts/local_pr_review.sh --allow-dirty - passed.

## Diff size
6 files, +932 / -0
