### PR TITLE
PR-Content-Ops-FAQ-Deflection-Search-Route

### DIFF
--- a/extracted_content_pipeline/api/faq_search.py
+++ b/extracted_content_pipeline/api/faq_search.py
@@ -1,0 +1,197 @@
+"""FastAPI router factory for ticket FAQ deflection search."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+import asyncio
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+try:
+    from fastapi import APIRouter, HTTPException, Query
+except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
+    APIRouter = None
+    HTTPException = None
+    Query = None
+    _FASTAPI_IMPORT_ERROR: ImportError | None = exc
+else:
+    _FASTAPI_IMPORT_ERROR = None
+
+from ..campaign_ports import TenantScope
+from ..ticket_faq_search import PostgresTicketFAQSearchRepository
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
+RepositoryFactory = Callable[[Any], PostgresTicketFAQSearchRepository]
+logger = logging.getLogger(__name__)
+
+
+def _require_fastapi() -> None:
+    if _FASTAPI_IMPORT_ERROR is None:
+        return
+    raise RuntimeError(
+        "FastAPI is required to create FAQ deflection search routes. "
+        "Install fastapi in the host application environment."
+    ) from _FASTAPI_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class FAQDeflectionSearchApiConfig:
+    """Host-owned defaults for the FAQ deflection search route."""
+
+    prefix: str = "/content-ops/faq-deflection-search"
+    tags: tuple[str, ...] = ("content-ops", "faq-search")
+    default_status: str | None = "approved"
+    default_limit: int = 5
+    max_limit: int = 10
+    max_query_chars: int = 300
+    search_timeout_seconds: float | None = 5.0
+
+    def __post_init__(self) -> None:
+        if self.default_limit <= 0:
+            raise ValueError("default_limit must be positive")
+        if self.max_limit <= 0:
+            raise ValueError("max_limit must be positive")
+        if self.default_limit > self.max_limit:
+            raise ValueError("default_limit must be less than or equal to max_limit")
+        if self.max_query_chars <= 0:
+            raise ValueError("max_query_chars must be positive")
+        if self.search_timeout_seconds is not None and self.search_timeout_seconds <= 0:
+            raise ValueError("search_timeout_seconds must be positive")
+
+
+def create_faq_deflection_search_router(
+    *,
+    pool_provider: PoolProvider,
+    scope_provider: ScopeProvider | None = None,
+    repository_factory: RepositoryFactory = PostgresTicketFAQSearchRepository,
+    config: FAQDeflectionSearchApiConfig | None = None,
+    dependencies: Sequence[Any] | None = None,
+) -> APIRouter:
+    """Create host-mounted FAQ deflection search routes."""
+
+    _require_fastapi()
+    resolved_config = config or FAQDeflectionSearchApiConfig()
+    router = APIRouter(
+        prefix=resolved_config.prefix,
+        tags=list(resolved_config.tags),
+        dependencies=list(dependencies or ()),
+    )
+
+    @router.get("")
+    async def search_faq_deflection(
+        q: str = Query(..., description="Customer question or search text."),
+        corpus_id: str | None = Query(None),
+        status: str | None = Query(None),
+        limit: int | None = Query(None, ge=1),
+    ) -> dict[str, Any]:
+        query = _search_query(q, resolved_config)
+        scoped_account_id = _required_account_id(await _resolve_scope(scope_provider))
+        pool = await _resolve_pool(pool_provider)
+        repository = repository_factory(pool)
+        try:
+            response = await _with_timeout(
+                repository.search(
+                    query=query,
+                    account_id=scoped_account_id,
+                    corpus_id=_optional_filter(corpus_id),
+                    status=_status_filter(status, resolved_config),
+                    limit=_api_limit(limit, resolved_config),
+                ),
+                resolved_config,
+            )
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail="FAQ search timed out") from exc
+        except Exception as exc:
+            logger.exception("FAQ deflection search failed")
+            raise HTTPException(status_code=503, detail="FAQ search unavailable") from exc
+        return response.as_dict()
+
+    return router
+
+
+async def _with_timeout(awaitable: Awaitable[Any], config: FAQDeflectionSearchApiConfig) -> Any:
+    if config.search_timeout_seconds is None:
+        return await awaitable
+    return await asyncio.wait_for(awaitable, timeout=config.search_timeout_seconds)
+
+
+async def _resolve_pool(pool_provider: PoolProvider) -> Any:
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    if getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    return pool
+
+
+async def _resolve_scope(scope_provider: ScopeProvider | None) -> TenantScope:
+    if scope_provider is None:
+        return TenantScope()
+    scope = await _maybe_await(scope_provider())
+    if scope is None:
+        return TenantScope()
+    if isinstance(scope, TenantScope):
+        return scope
+    if isinstance(scope, Mapping):
+        return TenantScope(
+            account_id=str(scope.get("account_id") or "") or None,
+            user_id=str(scope.get("user_id") or "") or None,
+        )
+    raise HTTPException(status_code=500, detail="Invalid tenant scope")
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+def _required_account_id(scope: TenantScope) -> str:
+    account_id = _clean(scope.account_id)
+    if not account_id:
+        raise HTTPException(status_code=400, detail="account_id is required")
+    return account_id
+
+
+def _search_query(value: str, config: FAQDeflectionSearchApiConfig) -> str:
+    query = _clean(value)
+    if not query:
+        raise HTTPException(status_code=400, detail="q is required")
+    if len(query) > config.max_query_chars:
+        raise HTTPException(
+            status_code=400,
+            detail=f"q must be {config.max_query_chars} characters or fewer",
+        )
+    return query
+
+
+def _api_limit(value: int | None, config: FAQDeflectionSearchApiConfig) -> int:
+    limit = config.default_limit if value is None else int(value)
+    if limit <= 0:
+        raise HTTPException(status_code=400, detail="limit must be positive")
+    return min(limit, config.max_limit)
+
+
+def _status_filter(value: str | None, config: FAQDeflectionSearchApiConfig) -> str | None:
+    if value is None:
+        return config.default_status
+    cleaned = _clean(value)
+    return cleaned or None
+
+
+def _optional_filter(value: str | None) -> str | None:
+    cleaned = _clean(value)
+    return cleaned or None
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "FAQDeflectionSearchApiConfig",
+    "create_faq_deflection_search_router",
+]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -350,6 +350,9 @@
       "target": "extracted_content_pipeline/api/generated_assets.py"
     },
     {
+      "target": "extracted_content_pipeline/api/faq_search.py"
+    },
+    {
       "target": "extracted_content_pipeline/api/reasoning_contexts.py"
     },
     {

--- a/plans/PR-Content-Ops-FAQ-Deflection-Search-Route.md
+++ b/plans/PR-Content-Ops-FAQ-Deflection-Search-Route.md
@@ -1,0 +1,102 @@
+# PR-Content-Ops-FAQ-Deflection-Search-Route
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-Postgres-Projection` adds a durable Postgres search
+projection, but the demo and downstream client still need a hosted API seam.
+The next thin end-to-end step is a FastAPI route that takes a user query,
+resolves the host tenant scope, reads the projection, and returns the documented
+`{query, results, count}` envelope.
+
+This slice is stacked on the Postgres projection PR while that PR is in review.
+After the projection lands, this branch should rebase onto `origin/main` before
+opening the GitHub PR.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a host-mountable FastAPI router for `/content-ops/faq-deflection-search`.
+2. Wire the route to `PostgresTicketFAQSearchRepository` through injected pool
+   and tenant-scope providers.
+3. Enforce the go-live request guards at the route boundary: required tenant,
+   non-blank capped query, bounded limit, optional corpus/status filters, and a
+   server-side search timeout.
+4. Return the projection repository's `{query, results, count}` envelope without
+   reshaping result rows.
+5. Register the new API module in the extracted package manifest.
+6. Add focused route tests for the envelope, SQL filter wiring, request guards,
+   limit capping, and unavailable database handling.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Deflection-Search-Route.md`
+- `extracted_content_pipeline/api/faq_search.py`
+- `extracted_content_pipeline/manifest.json`
+- `tests/test_extracted_ticket_faq_search_api.py`
+
+## Mechanism
+
+The new router factory follows the existing extracted API pattern:
+
+- `pool_provider` is host-injected and resolved per request.
+- `scope_provider` is host-injected and may return `TenantScope`, a mapping, or
+  `None`.
+- Auth remains host-owned through FastAPI `dependencies`; the package route only
+  enforces that a non-blank `account_id` reaches the repository.
+
+`GET /content-ops/faq-deflection-search` accepts:
+
+- `q`: required search text, stripped and capped by config.
+- `corpus_id`: optional corpus filter.
+- `status`: optional status filter; omitted uses the configured default
+  (`approved`), while an empty string searches all statuses.
+- `limit`: optional result cap clamped to the configured max.
+
+The route calls `PostgresTicketFAQSearchRepository.search(...)` under
+`asyncio.wait_for(...)` when a timeout is configured, then returns
+`TicketFAQSearchResponse.as_dict()` unchanged.
+
+## Intentional
+
+- No Atlas global app mount or deployed host URL is added here. This is the
+  package-level router factory; host wiring and bearer-token deployment remain
+  separate.
+- No client/demo code changes land here. The client should point at this route
+  only after the host mounts it.
+- No query highlighting, synonyms, or embedding search are added. The route is
+  deliberately thin over the deterministic Postgres projection.
+
+## Deferred
+
+- `PR-Content-Ops-FAQ-Deflection-Host-Mount`: mount this route in the Atlas host
+  app, set auth dependencies, and document the deployed URL/token handoff.
+- `PR-Content-Ops-FAQ-Search-Concurrency-Smoke`: run concurrent filtered
+  retrieval against seeded corpora and capture latency/isolation output.
+- Client-side abort timeout and query cap remain in the demo/client lane.
+
+## Verification
+
+- pytest tests/test_extracted_ticket_faq_search_api.py tests/test_extracted_ticket_faq_search_postgres.py tests/test_extracted_ticket_faq_search.py -q - 21 passed, 1 skipped without DB URL.
+- python -m py_compile extracted_content_pipeline/api/faq_search.py tests/test_extracted_ticket_faq_search_api.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 102 |
+| API router | 197 |
+| Manifest entry | 3 |
+| Route tests | 174 |
+| **Total** | **476** |
+
+This is above the 400 LOC target because the route, request guards, and tests
+are the smallest useful hosted seam. The host mount and concurrency smoke stay
+deferred.

--- a/tests/test_extracted_ticket_faq_search_api.py
+++ b/tests/test_extracted_ticket_faq_search_api.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from extracted_content_pipeline.api.faq_search import (
+    FAQDeflectionSearchApiConfig,
+    create_faq_deflection_search_router,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(
+        self,
+        rows=None,
+        *,
+        initialized: bool = True,
+    ) -> None:
+        self.rows = list(rows or [])
+        self.is_initialized = initialized
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        return self.rows
+
+
+def _row() -> dict[str, object]:
+    return {
+        "account_id": "acct-1",
+        "corpus_id": "corpus-1",
+        "faq_id": "11111111-1111-1111-1111-111111111111",
+        "target_id": "support-account-1",
+        "target_mode": "support_account",
+        "status": "approved",
+        "rank": 1,
+        "topic": "password reset",
+        "question": "How do I reset my password?",
+        "answer_summary": "Use the reset email.",
+        "source_ids": json.dumps(["ticket-1"]),
+        "ticket_count": 1,
+        "search_text": "password reset email",
+        "score": 84,
+    }
+
+
+def _client(
+    pool: _Pool,
+    *,
+    scope: TenantScope | dict[str, object] | None = None,
+    config: FAQDeflectionSearchApiConfig | None = None,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(
+        create_faq_deflection_search_router(
+            pool_provider=lambda: pool,
+            scope_provider=lambda: scope,
+            config=config,
+        )
+    )
+    return TestClient(app)
+
+
+def test_faq_deflection_search_route_returns_documented_envelope() -> None:
+    pool = _Pool(rows=[_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    ).get(
+        "/content-ops/faq-deflection-search"
+        "?q=reset%20email&corpus_id=corpus-1&limit=5"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "query": "reset email",
+        "count": 1,
+        "results": [{
+            "account_id": "acct-1",
+            "corpus_id": "corpus-1",
+            "faq_id": "11111111-1111-1111-1111-111111111111",
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "status": "approved",
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer_summary": "Use the reset email.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 1,
+            "score": 84,
+        }],
+    }
+    sql, args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_search_documents" in sql
+    assert "account_id = $2" in sql
+    assert "corpus_id = $3" in sql
+    assert "status = $4" in sql
+    assert "LIMIT $5" in sql
+    assert args == ("reset email", "acct-1", "corpus-1", "approved", 5)
+
+
+def test_faq_deflection_search_route_allows_all_statuses_and_caps_limit() -> None:
+    pool = _Pool(rows=[])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct-1"},
+        config=FAQDeflectionSearchApiConfig(max_limit=3, default_limit=2),
+    ).get("/content-ops/faq-deflection-search?q=invoice&status=&limit=99")
+
+    assert response.status_code == 200
+    sql, args = pool.fetch_calls[0]
+    assert "status =" not in sql
+    assert "LIMIT $3" in sql
+    assert args == ("invoice", "acct-1", 3)
+
+
+def test_faq_deflection_search_route_rejects_blank_query_before_database() -> None:
+    pool = _Pool(rows=[_row()])
+
+    response = _client(pool, scope={"account_id": "acct-1"}).get(
+        "/content-ops/faq-deflection-search?q=%20%20%20"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "q is required"
+    assert pool.fetch_calls == []
+
+
+def test_faq_deflection_search_route_rejects_overlong_query_before_database() -> None:
+    pool = _Pool(rows=[_row()])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct-1"},
+        config=FAQDeflectionSearchApiConfig(max_query_chars=5),
+    ).get("/content-ops/faq-deflection-search?q=too-long")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "q must be 5 characters or fewer"
+    assert pool.fetch_calls == []
+
+
+def test_faq_deflection_search_route_requires_tenant_scope_before_database() -> None:
+    pool = _Pool(rows=[_row()])
+
+    response = _client(pool, scope=None).get(
+        "/content-ops/faq-deflection-search?q=reset"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account_id is required"
+    assert pool.fetch_calls == []
+
+
+def test_faq_deflection_search_route_reports_unavailable_database() -> None:
+    pool = _Pool(rows=[_row()], initialized=False)
+
+    response = _client(pool, scope={"account_id": "acct-1"}).get(
+        "/content-ops/faq-deflection-search?q=reset"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database unavailable"
+    assert pool.fetch_calls == []


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Deflection-Search-Route.md

Add a host-mountable FAQ deflection search route over the durable Postgres projection so the demo/client can call a real `{query, results, count}` API seam instead of in-memory search.

Slice phase: Vertical slice

## Intentional
- No Atlas global app mount or deployed host URL is added here; this is the package-level router factory.
- No client/demo code changes land here.
- No query highlighting, synonyms, or embedding search are added; this stays thin over deterministic Postgres projection search.

## Deferred
- PR-Content-Ops-FAQ-Deflection-Host-Mount: mount this route in the Atlas host app, set auth dependencies, and document the deployed URL/token handoff.
- PR-Content-Ops-FAQ-Search-Concurrency-Smoke: run concurrent filtered retrieval against seeded corpora.
- Client-side abort timeout and query cap remain in the demo/client lane.

## Verification
- pytest tests/test_extracted_ticket_faq_search_api.py tests/test_extracted_ticket_faq_search_postgres.py tests/test_extracted_ticket_faq_search.py -q - 21 passed, 1 skipped without DB URL.
- python -m py_compile extracted_content_pipeline/api/faq_search.py tests/test_extracted_ticket_faq_search_api.py - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline - passed.
- bash scripts/local_pr_review.sh --allow-dirty - passed.

## Diff size
4 files, +476 / -0
