### PR TITLE
PR-Content-Ops-FAQ-Deflection-Host-Mount

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -164,6 +164,9 @@ try:
         create_generated_asset_router,
         create_public_landing_page_router,
     )
+    from extracted_content_pipeline.api.faq_search import (
+        create_faq_deflection_search_router,
+    )
     from .._content_ops_input_provider import build_content_ops_input_provider
     from .._content_ops_infrastructure import (
         build_content_ops_llm_client,
@@ -225,6 +228,12 @@ try:
         dependencies=[Depends(_capture_content_ops_auth_user)],
     )
     router.include_router(content_assets_router)
+    faq_search_router = create_faq_deflection_search_router(
+        pool_provider=get_db_pool,
+        scope_provider=build_content_ops_scope,
+        dependencies=[Depends(_capture_content_ops_auth_user)],
+    )
+    router.include_router(faq_search_router)
     public_landing_page_router = create_public_landing_page_router(
         pool_provider=get_db_pool,
     )

--- a/plans/PR-Content-Ops-FAQ-Deflection-Host-Mount.md
+++ b/plans/PR-Content-Ops-FAQ-Deflection-Host-Mount.md
@@ -1,0 +1,72 @@
+# PR-Content-Ops-FAQ-Deflection-Host-Mount
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Deflection-Search-Route` adds the extracted package router,
+but the Atlas host still has to mount it before another session can point a demo
+at a real deployed URL. The existing Content Ops routes already have the right
+auth, tenant-scope, and database-pool bridge; this slice wires the FAQ search
+route into that same host surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Import `create_faq_deflection_search_router` in the Atlas API aggregator's
+   existing Content Ops optional-import block.
+2. Mount `/content-ops/faq-deflection-search` with `get_db_pool`,
+   `build_content_ops_scope`, and the same `_capture_content_ops_auth_user`
+   dependency used by `/content-ops/*` and `/content-assets/*`.
+3. Add a host wiring test that asserts the route is mounted with the shared pool,
+   scope provider, and auth dependency.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Deflection-Host-Mount.md`
+- `atlas_brain/api/__init__.py`
+- `tests/test_atlas_content_ops_generated_assets_api.py`
+
+## Mechanism
+
+The host aggregator already wraps Content Ops routes in a defensive import block
+so production images without the extracted package keep booting. This slice adds
+one more router factory import and one `router.include_router(...)` call inside
+that block:
+
+- `pool_provider=get_db_pool`
+- `scope_provider=build_content_ops_scope`
+- `dependencies=[Depends(_capture_content_ops_auth_user)]`
+
+The dependency preserves the existing B2B growth-plan auth gate and captures the
+authenticated user into the ContextVar that `build_content_ops_scope` reads.
+
+## Intentional
+
+- No new standalone bearer-token system is introduced. The host route uses the
+  same bearer-authenticated B2B plan dependency as the rest of Content Ops.
+- No deployed host URL or environment variable is committed here. That handoff
+  depends on deployment after merge.
+- No client/demo code changes land here.
+
+## Deferred
+
+- Deployment handoff: after merge, report the deployed `/api/v1/content-ops/faq-deflection-search`
+  URL and the existing bearer-token expectation to the demo session.
+- `PR-Content-Ops-FAQ-Search-Concurrency-Smoke`: run concurrent filtered
+  retrieval against seeded corpora after the hosted endpoint exists.
+
+## Verification
+
+- pytest tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_ticket_faq_search_api.py -q - 10 passed, 1 warning.
+- python -m py_compile atlas_brain/api/__init__.py tests/test_atlas_content_ops_generated_assets_api.py - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 72 |
+| Host mount | 9 |
+| Host wiring test | 19 |
+| **Total** | **100** |

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -57,6 +57,25 @@ def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> 
     assert "_capture_content_ops_auth_user" in dependency_names
 
 
+def test_faq_deflection_search_route_uses_shared_content_ops_auth_scope_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/faq-deflection-search")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert closure["scope_provider"].__name__ == "build_content_ops_scope"
+    assert "_capture_content_ops_auth_user" in dependency_names
+
+
 def test_public_landing_page_route_uses_pool_without_content_ops_auth_dependency() -> None:
     api_pkg = _fresh_api_package()
     route = _route(api_pkg, "/content-assets/landing_page/public/{landing_page_id}")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Deflection-Host-Mount.md

Mount the FAQ deflection search router in the Atlas API aggregator so the hosted API exposes `/api/v1/content-ops/faq-deflection-search` with the same Content Ops auth, tenant scope, and database pool wiring as the existing routes.

Slice phase: Vertical slice

## Intentional
- No new standalone bearer-token system is introduced; this reuses the existing bearer-authenticated B2B plan dependency.
- No deployed host URL or environment variable is committed here.
- No client/demo code changes land here.

## Deferred
- Deployment handoff: after merge, report the deployed `/api/v1/content-ops/faq-deflection-search` URL and existing bearer-token expectation to the demo session.
- PR-Content-Ops-FAQ-Search-Concurrency-Smoke: run concurrent filtered retrieval against seeded corpora after the hosted endpoint exists.

## Verification
- pytest tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_ticket_faq_search_api.py -q - 10 passed, 1 warning.
- python -m py_compile atlas_brain/api/__init__.py tests/test_atlas_content_ops_generated_assets_api.py - passed.
- bash scripts/local_pr_review.sh --allow-dirty - passed.

## Diff size
3 files, +100 / -0
