### PR TITLE
Add landing support ticket source context

### DIFF
--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -41,6 +41,7 @@ from .landing_page_ports import (
     LandingPageSection,
     MarketingCampaign,
 )
+from .landing_page_input_contract import LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS
 from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     normalize_landing_page_quality_repair_attempts,
@@ -872,6 +873,9 @@ class LandingPageGenerationService:
         if campaign_payload is not None:
             context = normalize_campaign_reasoning_context(campaign_payload)
             metadata.update(campaign_reasoning_context_metadata(context))
+        source_context = _landing_page_source_context(campaign.context)
+        if source_context:
+            metadata["source_context"] = source_context
         return LandingPageDraft(
             campaign_name=campaign.name,
             persona=campaign.persona,
@@ -885,6 +889,14 @@ class LandingPageGenerationService:
             reference_ids=reference_ids,
             metadata=metadata,
         )
+
+
+def _landing_page_source_context(context: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: context[key]
+        for key in LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS
+        if key in context and context[key] not in (None, "", [], {})
+    }
 
 
 def _quality_repair_history_row(

--- a/extracted_content_pipeline/landing_page_input_contract.py
+++ b/extracted_content_pipeline/landing_page_input_contract.py
@@ -27,6 +27,16 @@ LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS: tuple[str, ...] = (
     "cta_url",
 )
 
+LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS: tuple[str, ...] = (
+    "source_row_count",
+    "included_ticket_row_count",
+    "skipped_ticket_row_count",
+    "truncated_ticket_row_count",
+    "question_like_ticket_count",
+    "top_ticket_clusters",
+    "customer_wording_examples",
+)
+
 LANDING_PAGE_EXISTING_CONTEXT_KEYS: tuple[str, ...] = (
     "industry",
     "pain_points",
@@ -40,6 +50,7 @@ LANDING_PAGE_EXISTING_CONTEXT_KEYS: tuple[str, ...] = (
 LANDING_PAGE_CONTEXT_INPUT_KEYS: frozenset[str] = frozenset((
     *LANDING_PAGE_EXISTING_CONTEXT_KEYS,
     *LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS,
+    *LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS,
 ))
 
 
@@ -137,5 +148,6 @@ __all__ = [
     "LANDING_PAGE_EXISTING_CONTEXT_KEYS",
     "LANDING_PAGE_INPUT_ASSET",
     "LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS",
+    "LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS",
     "landing_page_seo_geo_aeo_input_contracts",
 ]

--- a/extracted_content_pipeline/skills/digest/landing_page_generation.md
+++ b/extracted_content_pipeline/skills/digest/landing_page_generation.md
@@ -66,6 +66,7 @@ SEO/GEO/AEO input policy:
 - `objections`: address supplied objections directly in objection, FAQ, pricing, implementation, risk-reversal, or proof sections.
 - `faq_questions`: answer supplied questions with plain-language section titles or FAQ entries. Each answer must start with the direct answer before expanding.
 - `source_period`: use as freshness context when relevant, such as "based on the last 90 days of tickets"; do not imply live or ongoing analysis unless the campaign says so.
+- `source_row_count`, `included_ticket_row_count`, `skipped_ticket_row_count`, `truncated_ticket_row_count`, `question_like_ticket_count`, `top_ticket_clusters`, and `customer_wording_examples`: when supplied, use them as source evidence for the problem, solution, FAQ, and proof sections. Mention the top ticket clusters and preserve customer wording where natural. Do not invent counts, clusters, vendors, customers, or quotes outside the supplied fields.
 - `internal_links`: include only supplied links and only when they fit the page. Do not create fake URLs.
 - `cta_label` and `cta_url`: use these for `hero.cta_label`, `hero.cta_url`, and the page-level `cta` unless the campaign gives a stronger CTA pattern.
 

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -9,6 +9,7 @@ the existing FAQ, landing-page, and blog planners already understand.
 from __future__ import annotations
 
 import re
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from typing import Any
@@ -128,11 +129,19 @@ def build_support_ticket_input_package(
             "max_rows": max_rows,
             "truncated_row_count": len(raw_rows) - max_rows,
         })
+    skipped_row_count = len(raw_rows[:max_rows]) - len(normalized_rows)
     truncated_row_count = max(0, len(raw_rows) - max_rows)
-
-    source_period = f"Last {window_days} days of support tickets"
+    has_valid_date_window = _all_rows_have_dates(normalized_rows)
+    source_period = (
+        f"Last {window_days} days of support tickets"
+        if has_valid_date_window
+        else "Uploaded support tickets"
+    )
     faq_questions = _ticket_questions(normalized_rows)
     faq_source_types = _source_types(normalized_rows)
+    question_like_ticket_count = _question_like_ticket_count(normalized_rows)
+    top_ticket_clusters = _top_ticket_clusters(normalized_rows)
+    customer_wording_examples = _customer_wording_examples(normalized_rows)
     resolved_secondary_keywords = tuple(secondary_keywords or (
         "customer support FAQ",
         "reduce repeat support tickets",
@@ -165,11 +174,18 @@ def build_support_ticket_input_package(
         "objections": list(resolved_objections),
         "faq_questions": faq_questions,
         "source_period": source_period,
+        "source_row_count": len(raw_rows),
+        "included_ticket_row_count": len(normalized_rows),
+        "skipped_ticket_row_count": skipped_row_count,
+        "truncated_ticket_row_count": truncated_row_count,
+        "question_like_ticket_count": question_like_ticket_count,
+        "top_ticket_clusters": top_ticket_clusters,
+        "customer_wording_examples": customer_wording_examples,
         "internal_links": list(internal_links or (DEFAULT_FAQ_REPORT_CTA_URL,)),
         "cta_label": cta_label,
         "cta_url": cta_url,
     }
-    if _all_rows_have_dates(normalized_rows):
+    if has_valid_date_window:
         inputs["faq_window_days"] = window_days
 
     return ContentOpsInputPackage(
@@ -182,7 +198,7 @@ def build_support_ticket_input_package(
             "source": "support_ticket_input_package",
             "source_row_count": len(raw_rows),
             "included_row_count": len(normalized_rows),
-            "skipped_row_count": len(raw_rows) - len(normalized_rows),
+            "skipped_row_count": skipped_row_count,
             "truncated_row_count": truncated_row_count,
             "source_period": source_period,
         },
@@ -280,6 +296,92 @@ def _source_types(rows: Sequence[Mapping[str, Any]]) -> list[str]:
         if source_type and source_type not in source_types:
             source_types.append(source_type)
     return source_types or ["support_ticket"]
+
+
+def _question_like_ticket_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    return sum(
+        1
+        for row in rows
+        if _first_question(row.get("text")) or _question_like(row.get("source_title"))
+    )
+
+
+def _top_ticket_clusters(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    limit: int = 6,
+) -> list[dict[str, Any]]:
+    counts: Counter[str] = Counter()
+    labels: dict[str, str] = {}
+    uncategorized_count = 0
+    for row in rows:
+        label = _cluster_label(row)
+        if not label:
+            uncategorized_count += 1
+            continue
+        key = label.lower()
+        labels.setdefault(key, label)
+        counts[key] += 1
+    clusters = [
+        {"label": labels[key], "count": count}
+        for key, count in counts.most_common(max(1, limit))
+    ]
+    shown_count = sum(int(item["count"]) for item in clusters)
+    remaining_count = sum(counts.values()) - shown_count
+    if remaining_count > 0:
+        clusters.append({"label": "remaining", "count": remaining_count})
+    if uncategorized_count > 0:
+        clusters.append({"label": "uncategorized", "count": uncategorized_count})
+    return clusters
+
+
+def _cluster_label(row: Mapping[str, Any]) -> str:
+    pain_category = _clean(row.get("pain_category"))
+    if pain_category:
+        return pain_category
+    source_title = _clean(row.get("source_title"))
+    source_id = _clean(row.get("source_id"))
+    if source_title and source_title != source_id:
+        return source_title
+    return ""
+
+
+def _customer_wording_examples(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    limit: int = 6,
+    max_text_chars: int = 220,
+) -> list[dict[str, Any]]:
+    examples: list[dict[str, Any]] = []
+    for row in rows:
+        text = _compact(row.get("text"))
+        if not text:
+            continue
+        example = {
+            "source_id": _clean(row.get("source_id")),
+            "text": _clip_text(text, max_chars=max_text_chars),
+        }
+        source_title = _clean(row.get("source_title"))
+        source_id = _clean(row.get("source_id"))
+        if source_title and source_title != source_id:
+            example["source_title"] = source_title
+        pain_category = _clean(row.get("pain_category"))
+        if pain_category:
+            example["pain_category"] = pain_category
+        examples.append(example)
+        if len(examples) >= limit:
+            return examples
+    return examples
+
+
+def _clip_text(value: str, *, max_chars: int) -> str:
+    text = _compact(value)
+    if len(text) <= max_chars:
+        return text
+    trimmed = text[:max_chars].rstrip()
+    if " " in trimmed:
+        trimmed = trimmed.rsplit(" ", 1)[0]
+    return f"{trimmed}..."
 
 
 def _all_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:

--- a/plans/PR-Landing-Page-Support-Ticket-Source-Context.md
+++ b/plans/PR-Landing-Page-Support-Ticket-Source-Context.md
@@ -1,0 +1,99 @@
+# PR: Landing Page Support Ticket Source Context
+
+## Why this slice exists
+
+Live support-ticket validation proved the blog-post path keeps CSV-derived
+counts and clusters, but the landing-page path only used the general support
+ticket theme and lost most source specificity. Landing pages need the same
+source facts carried through the input contract so generated copy can use
+ticket clusters and customer wording without exposing unrelated request fields.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: functional validation
+
+1. Add explicit support-ticket source fact keys to the landing-page context
+   allowlist.
+2. Have the support-ticket input package populate row counts, question counts,
+   truncation counts, top ticket clusters, and customer wording examples.
+3. Preserve those support-ticket source fields in saved landing-page draft
+   metadata for review/export inspection.
+4. Update the landing-page prompt to use supplied support-ticket facts as
+   service evidence.
+5. Add focused tests for provider output, executor context threading, prompt
+   payload visibility, and saved draft metadata.
+
+### Files touched
+
+- `plans/PR-Landing-Page-Support-Ticket-Source-Context.md`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `extracted_content_pipeline/landing_page_input_contract.py`
+- `extracted_content_pipeline/landing_page_generation.py`
+- `extracted_content_pipeline/skills/digest/landing_page_generation.md`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `tests/test_extracted_support_ticket_input_provider.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_landing_page_generation.py`
+
+## Mechanism
+
+The support-ticket provider derives compact facts from normalized ticket rows
+and adds them to request inputs under explicit landing-page-safe keys. The
+executor already builds `MarketingCampaign.context` from the landing-page
+allowlist, so adding those keys there makes them visible to the prompt without
+reopening the prior broad input leak. The landing generator then copies only
+those allowlisted source keys into draft metadata for auditability.
+
+Cluster labels are built only from genuine category/title signals. Rows without
+a real label are counted as `uncategorized`, top-cluster overflow is counted as
+`remaining`, and truncated rows are reported separately from examined rows that
+were skipped for missing text. Source-period language only claims a date window
+when all included rows have parseable dates.
+
+## Intentional
+
+- No FAQ generator changes. FAQ output remains owned by the FAQ session.
+- No file-ingestion route changes. This slice starts from already-loaded
+  support-ticket rows, matching this lane.
+- No broad `source_material` leak into `MarketingCampaign.context`; only the
+  summarized source facts are allowed.
+- No nested `support_ticket_source_summary` context blob. Landing context keeps
+  an explicit flat schema so request overrides cannot smuggle unrelated nested
+  fields into the prompt or saved metadata.
+
+## Deferred
+
+- No live smoke rerun in this PR. The next slice should rerun the Haiku landing
+  and blog smoke with `--export-saved-draft` to compare artifacts after this
+  source-context fix lands.
+- Parked hardening: none. `HARDENING.md` was scanned; current entries are FAQ
+  scale and file-ingestion concurrency work outside this support-ticket
+  provider validation slice.
+
+## Verification
+
+- Focused source-context tests:
+  `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_ops_execution.py::test_marketing_campaign_context_does_not_leak_unrelated_inputs tests/test_extracted_landing_page_generation.py::test_generate_threads_seo_geo_aeo_context_into_system_prompt_payload tests/test_extracted_landing_page_generation.py::test_build_draft_preserves_support_ticket_source_context_metadata -q`
+  - 20 passed.
+- Relevant file suites:
+  `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation.py -q`
+  - 107 passed.
+- Expanded source-period and live-smoke suites:
+  `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_live_generation.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation.py -q`
+  - 147 passed.
+- Py compile for changed Python files - passed.
+- Git whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~100 |
+| Provider + contract + generation | ~90 |
+| Prompt | ~10 |
+| Tests | ~150 |
+| **Total** | **~420** |

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -1094,6 +1094,19 @@ async def test_marketing_campaign_context_does_not_leak_unrelated_inputs() -> No
                     "What happens after upload?",
                 ],
                 "cta_url": "/systems/ai-content-ops/intake",
+                "source_row_count": 4,
+                "included_ticket_row_count": 4,
+                "skipped_ticket_row_count": 0,
+                "truncated_ticket_row_count": 0,
+                "question_like_ticket_count": 2,
+                "top_ticket_clusters": [{"label": "reporting friction", "count": 2}],
+                "customer_wording_examples": [{
+                    "source_id": "ticket-1",
+                    "source_title": "Export dashboard",
+                    "pain_category": "reporting friction",
+                    "text": "How do we export campaign attribution data before renewal?",
+                }],
+                "support_ticket_source_summary": {"unsafe": "should not pass through"},
             },
         },
         services=ContentOpsExecutionServices(landing_page=landing),
@@ -1115,6 +1128,21 @@ async def test_marketing_campaign_context_does_not_leak_unrelated_inputs() -> No
         "What happens after upload?",
     ]
     assert context.get("cta_url") == "/systems/ai-content-ops/intake"
+    assert context.get("source_row_count") == 4
+    assert context.get("included_ticket_row_count") == 4
+    assert context.get("skipped_ticket_row_count") == 0
+    assert context.get("truncated_ticket_row_count") == 0
+    assert context.get("question_like_ticket_count") == 2
+    assert context.get("top_ticket_clusters") == [
+        {"label": "reporting friction", "count": 2}
+    ]
+    assert context.get("customer_wording_examples") == [{
+        "source_id": "ticket-1",
+        "source_title": "Export dashboard",
+        "pain_category": "reporting friction",
+        "text": "How do we export campaign attribution data before renewal?",
+    }]
+    assert "support_ticket_source_summary" not in context
 
     # Pre-fix leakers stay out.
     assert "target_account" not in context

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -344,7 +344,8 @@ async def test_support_ticket_provider_feeds_real_landing_page_generation() -> N
     assert call["metadata"]["asset_type"] == "landing_page"
     system_prompt, user_prompt = _message_texts(call)
     assert "support ticket FAQ report" in system_prompt
-    assert "Last 90 days of support tickets" in system_prompt
+    assert "Uploaded support tickets" in system_prompt
+    assert "Last 90 days of support tickets" not in system_prompt
     assert "How do I change my login email?" in system_prompt
     assert "How do we export campaign attribution data before renewal?" in system_prompt
     assert "Generate one landing page" in user_prompt

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -459,6 +459,18 @@ async def test_generate_threads_seo_geo_aeo_context_into_system_prompt_payload()
                 "objections": ["Will this publish automatically?"],
                 "faq_questions": ["What happens after upload?"],
                 "source_period": "Last 90 days of support tickets",
+                "source_row_count": 4,
+                "included_ticket_row_count": 4,
+                "skipped_ticket_row_count": 0,
+                "truncated_ticket_row_count": 0,
+                "question_like_ticket_count": 2,
+                "top_ticket_clusters": [{"label": "reporting friction", "count": 2}],
+                "customer_wording_examples": [{
+                    "source_id": "ticket-1",
+                    "source_title": "Reporting dashboard export",
+                    "pain_category": "reporting friction",
+                    "text": "We cannot export the reporting dashboard for analysts.",
+                }],
                 "internal_links": ["/systems/ai-content-ops/intake"],
                 "cta_label": "Upload Ticket CSV -- Free Analysis",
                 "cta_url": "/systems/ai-content-ops/intake",
@@ -471,8 +483,58 @@ async def test_generate_threads_seo_geo_aeo_context_into_system_prompt_payload()
     assert '"target_keyword":"support ticket FAQ"' in system_msg
     assert '"secondary_keywords":["reduce repeat support tickets"]' in system_msg
     assert '"primary_entity":"FAQ Report"' in system_msg
+    assert '"source_row_count":4' in system_msg
+    assert '"top_ticket_clusters":[{"label":"reporting friction","count":2}]' in system_msg
+    assert "We cannot export the reporting dashboard for analysts." in system_msg
     assert '"cta_url":"/systems/ai-content-ops/intake"' in system_msg
     assert "support ticket FAQ" not in user_msg
+
+
+def test_build_draft_preserves_support_ticket_source_context_metadata() -> None:
+    service, _lp, _llm, _skills, _rp = _service()
+    campaign = MarketingCampaign(
+        name="support-faq-report",
+        persona="10-50 person SaaS team",
+        value_prop="Turn repeat support tickets into customer-ready FAQs",
+        context={
+            "source_row_count": 4,
+            "included_ticket_row_count": 4,
+            "skipped_ticket_row_count": 0,
+            "truncated_ticket_row_count": 0,
+            "question_like_ticket_count": 2,
+            "top_ticket_clusters": [{"label": "reporting friction", "count": 2}],
+            "customer_wording_examples": [{
+                "source_id": "ticket-1",
+                "source_title": "Reporting dashboard export",
+                "pain_category": "reporting friction",
+                "text": "We cannot export the reporting dashboard for analysts.",
+            }],
+            "support_ticket_source_summary": {"unsafe": "should not be copied"},
+            "target_account": "should not be copied",
+        },
+    )
+
+    draft = service._build_draft(  # noqa: SLF001 - source metadata contract
+        parse_landing_page_response(_valid_response()) or {},
+        campaign=campaign,
+    )
+
+    assert draft.metadata["source_context"] == {
+        "source_row_count": 4,
+        "included_ticket_row_count": 4,
+        "skipped_ticket_row_count": 0,
+        "truncated_ticket_row_count": 0,
+        "question_like_ticket_count": 2,
+        "top_ticket_clusters": [{"label": "reporting friction", "count": 2}],
+        "customer_wording_examples": [{
+            "source_id": "ticket-1",
+            "source_title": "Reporting dashboard export",
+            "pain_category": "reporting friction",
+            "text": "We cannot export the reporting dashboard for analysts.",
+        }],
+    }
+    assert "target_account" not in draft.metadata["source_context"]
+    assert "support_ticket_source_summary" not in draft.metadata["source_context"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -52,6 +52,25 @@ def test_support_ticket_input_package_feeds_existing_content_ops_plan() -> None:
     assert request.inputs["cta_label"] == DEFAULT_FAQ_REPORT_CTA_LABEL
     assert request.inputs["topic"] == "Support-ticket questions customers keep asking"
     assert request.inputs["filters"] == {"topic_type": "content_ops_support_ticket_faq"}
+    assert request.inputs["source_row_count"] == 2
+    assert request.inputs["included_ticket_row_count"] == 2
+    assert request.inputs["skipped_ticket_row_count"] == 0
+    assert request.inputs["truncated_ticket_row_count"] == 0
+    assert request.inputs["question_like_ticket_count"] == 2
+    assert request.inputs["top_ticket_clusters"] == [
+        {"label": "profile updates", "count": 1},
+        {"label": "Export dashboard", "count": 1},
+    ]
+    assert request.inputs["customer_wording_examples"][0] == {
+        "source_id": "ticket-1",
+        "source_title": "How do I change my login email?",
+        "pain_category": "profile updates",
+        "text": (
+            "How do I change my login email? I cannot find where to update the "
+            "email on my account."
+        ),
+    }
+    assert "support_ticket_source_summary" not in request.inputs
     assert request.inputs["faq_questions"] == [
         "How do I change my login email?",
         "Where do I export the dashboard before renewal?",
@@ -125,6 +144,43 @@ def test_support_ticket_input_package_derives_faq_source_types_from_rows() -> No
     assert package.inputs["faq_source_types"] == ["ticket", "support_ticket"]
 
 
+def test_support_ticket_clusters_do_not_use_synthetic_ticket_ids() -> None:
+    package = build_support_ticket_input_package([
+        {"description": "How do I export data?"},
+        {"description": "Where is the billing page?"},
+        {"description": "Can I change my plan?"},
+    ])
+
+    assert package.inputs["top_ticket_clusters"] == [
+        {"label": "uncategorized", "count": 3}
+    ]
+    assert package.inputs["customer_wording_examples"][0] == {
+        "source_id": "ticket-1",
+        "text": "How do I export data?",
+    }
+
+
+def test_support_ticket_clusters_include_remaining_bucket() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": f"ticket-{index}",
+            "description": f"How do I fix issue {index}?",
+            "pain_category": f"category-{index}",
+        }
+        for index in range(1, 9)
+    ])
+
+    assert package.inputs["top_ticket_clusters"] == [
+        {"label": "category-1", "count": 1},
+        {"label": "category-2", "count": 1},
+        {"label": "category-3", "count": 1},
+        {"label": "category-4", "count": 1},
+        {"label": "category-5", "count": 1},
+        {"label": "category-6", "count": 1},
+        {"label": "remaining", "count": 2},
+    ]
+
+
 def test_support_ticket_input_package_omits_window_filter_without_row_dates() -> None:
     package = build_support_ticket_input_package([
         {
@@ -135,7 +191,7 @@ def test_support_ticket_input_package_omits_window_filter_without_row_dates() ->
     ])
 
     assert "faq_window_days" not in package.inputs
-    assert package.inputs["source_period"] == "Last 90 days of support tickets"
+    assert package.inputs["source_period"] == "Uploaded support tickets"
 
 
 def test_support_ticket_input_package_omits_window_filter_without_parseable_row_dates() -> None:
@@ -149,6 +205,7 @@ def test_support_ticket_input_package_omits_window_filter_without_parseable_row_
     ])
 
     assert "faq_window_days" not in package.inputs
+    assert package.inputs["source_period"] == "Uploaded support tickets"
 
 
 def test_support_ticket_input_package_omits_window_filter_for_mixed_date_rows() -> None:
@@ -262,8 +319,12 @@ def test_support_ticket_input_package_reports_skipped_and_truncated_rows() -> No
     ]
     assert package.metadata["source_row_count"] == 3
     assert package.metadata["included_row_count"] == 1
-    assert package.metadata["skipped_row_count"] == 2
+    assert package.metadata["skipped_row_count"] == 1
     assert package.metadata["truncated_row_count"] == 1
+    assert package.inputs["source_row_count"] == 3
+    assert package.inputs["included_ticket_row_count"] == 1
+    assert package.inputs["skipped_ticket_row_count"] == 1
+    assert package.inputs["truncated_ticket_row_count"] == 1
     assert package.warnings == (
         {
             "code": "ticket_row_missing_text",
@@ -293,10 +354,16 @@ def test_support_ticket_input_package_reconciles_truncated_valid_row_counts() ->
 
     assert package.metadata["source_row_count"] == 4
     assert package.metadata["included_row_count"] == 2
-    assert package.metadata["skipped_row_count"] == 2
+    assert package.metadata["skipped_row_count"] == 0
     assert package.metadata["truncated_row_count"] == 2
+    assert package.inputs["source_row_count"] == 4
+    assert package.inputs["included_ticket_row_count"] == 2
+    assert package.inputs["skipped_ticket_row_count"] == 0
+    assert package.inputs["truncated_ticket_row_count"] == 2
     assert (
-        package.metadata["included_row_count"] + package.metadata["skipped_row_count"]
+        package.metadata["included_row_count"]
+        + package.metadata["skipped_row_count"]
+        + package.metadata["truncated_row_count"]
         == package.metadata["source_row_count"]
     )
     assert package.warnings == (

--- a/tests/test_extracted_support_ticket_input_provider.py
+++ b/tests/test_extracted_support_ticket_input_provider.py
@@ -58,7 +58,8 @@ def test_support_ticket_input_provider_builds_package_from_direct_source_materia
     assert package.metadata["source_row_count"] == 1
     assert package.metadata["host_request_id"] == "req-1"
     assert request.outputs == ("landing_page",)
-    assert request.inputs["source_period"] == "Last 30 days of support tickets"
+    assert request.inputs["source_period"] == "Uploaded support tickets"
+    assert "faq_window_days" not in request.inputs
     assert request.inputs["faq_questions"] == ["How do I change my login email?"]
     assert preview.can_run is True
 

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -344,9 +344,8 @@ async def test_live_generation_smoke_packages_support_ticket_csv_for_landing_pag
     assert result["ok"] is True
     assert result["errors"] == []
     assert result["payload"]["inputs"]["target_keyword"] == "support ticket FAQ report"
-    assert result["payload"]["inputs"]["source_period"] == (
-        "Last 90 days of support tickets"
-    )
+    assert result["payload"]["inputs"]["source_period"] == "Uploaded support tickets"
+    assert "faq_window_days" not in result["payload"]["inputs"]
     assert result["payload"]["inputs"]["faq_questions"] == [
         "How do I change my login email?",
         "How do we export campaign attribution data before renewal?",


### PR DESCRIPTION
## Why this slice exists

Live support-ticket validation showed the blog-post path keeps CSV-derived source counts and clusters, while the landing-page path only picked up the broad support-ticket theme. This PR carries explicit support-ticket facts through the landing-page input contract so landing copy can use ticket clusters and customer wording without reopening the older broad input leak.

## Scope

Ownership lane: content-ops/support-ticket-input-provider

Slice phase: functional validation

- Add explicit support-ticket source fact keys to the landing-page context allowlist.
- Have the support-ticket input package populate row counts, examined/skipped/truncated counts, question counts, top ticket clusters, and customer wording examples.
- Preserve those allowlisted support-ticket fields in saved landing-page draft metadata for review/export inspection.
- Update the landing-page prompt to use supplied support-ticket facts as service evidence.
- Keep `support_ticket_source_summary` out of landing context so request overrides cannot smuggle arbitrary nested fields into the prompt or saved metadata.
- Add focused tests for provider output, executor context threading, prompt payload visibility, saved draft metadata, uncategorized clusters, remaining cluster bucket, truncation counts, and source-period wording.

## Review fixes

- Synthetic ticket ids no longer become cluster labels; unlabeled rows are counted as `uncategorized`.
- Top-cluster overflow is counted as `remaining` instead of silently disappearing.
- Truncated rows are separated from examined rows skipped for missing text.
- `source_period` only claims `Last N days` when all included rows have parseable dates; otherwise it says `Uploaded support tickets`.
- `customer_wording_examples` omits empty `pain_category` and synthetic `source_title` fields.
- Removed the nested `support_ticket_source_summary` landing context field.
- Updated the smoke/provider/live-harness expectations that previously asserted a date window without dated rows.

## Verification

- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_content_ops_execution.py::test_marketing_campaign_context_does_not_leak_unrelated_inputs tests/test_extracted_landing_page_generation.py::test_generate_threads_seo_geo_aeo_context_into_system_prompt_payload tests/test_extracted_landing_page_generation.py::test_build_draft_preserves_support_ticket_source_context_metadata -q` -> 20 passed
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_live_generation.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation.py -q` -> 147 passed
- `python -m py_compile ...` for changed Python files
- `git diff --check`
- `bash scripts/local_pr_review.sh`

## Diff size

11 files changed, 397 insertions(+), 13 deletions(-)
