### PR TITLE
PR-Content-Ops-FAQ-Search-Concurrency-Smoke

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Concurrency-Smoke.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Concurrency-Smoke.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-FAQ-Search-Concurrency-Smoke
+
+## Why this slice exists
+
+The FAQ generator has batch-scale coverage and the search route is now mounted,
+but retrieval under concurrent demo traffic is a separate read-path risk. A few
+users querying different uploaded ticket corpora at the same time can expose
+tenant/corpus filter mistakes, slow full-text retrieval, or connection-pool
+behavior that batch ingestion tests do not exercise.
+
+This slice adds an operator smoke that uses the real Postgres search projection
+and produces a machine-readable result artifact with latency and isolation
+signals.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: robust testing.
+
+1. Add a Postgres-backed FAQ search concurrency smoke script.
+2. Seed multiple accounts/corpora into `ticket_faq_markdown` and
+   `ticket_faq_search_documents`.
+3. Run concurrent filtered hit/miss searches through
+   `PostgresTicketFAQSearchRepository`.
+4. Emit JSON with request counts, p50/p95/max latency, error count, and isolation
+   failures.
+5. Add focused unit tests for the smoke's deterministic planning, latency, and
+   gate-summary helpers.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Concurrency-Smoke.md`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_concurrency.py`
+
+## Mechanism
+
+The script reads `--database-url`, `EXTRACTED_DATABASE_URL`, `DATABASE_URL`, or
+the Atlas DB settings fallback. It applies the existing FAQ Markdown and FAQ
+search migrations, seeds shared corpus IDs across multiple accounts for the run,
+then runs concurrent repository searches with:
+
+- hit queries that must return only the requested account/corpus;
+- miss queries that must return zero rows;
+- a semaphore-limited concurrency level so operators can vary pressure without
+  changing code.
+
+The JSON result includes `ok`, `latency`, `requests`, `errors`, `isolation`, and
+`seed` sections. Any search exception, wrong-tenant row, wrong-corpus row,
+expected hit with no rows, or unexpected miss result fails the smoke. Sharing
+corpus IDs across accounts makes a dropped `account_id` predicate observable as a
+wrong-tenant row instead of being masked by corpus filtering.
+
+## Intentional
+
+- This does not call the hosted HTTP route. The route is a thin wrapper over the
+  same repository; this slice targets the durable read pattern directly.
+- No latency threshold fails the run yet. The first smoke captures measured
+  latency so we can set a defensible threshold after seeing real numbers.
+- Seeded rows are deleted by default. `--keep-data` exists only for local
+  debugging.
+
+## Deferred
+
+- HTTP-route concurrency with auth tokens remains deferred until a deployed
+  backend URL/token is available.
+- Latency SLO thresholds are deferred until we have baseline output from this
+  smoke in the target environment.
+
+## Verification
+
+- pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q - 5 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py - passed.
+- python scripts/smoke_content_ops_faq_search_concurrency.py --account-count 3 --corpora-per-account 2 --documents-per-corpus 3 --iterations 24 --concurrency 6 --pool-size 4 --output-result tmp/faq_search_concurrency_smoke.json --json - passed with EXTRACTED_DATABASE_URL constructed from local `.env.backup` ATLAS_DB_* fields; 24 requests, 0 isolation failures, p50 1.010468 ms, p95 6.789891 ms, max 7.104989 ms.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Smoke script | 378 |
+| Tests | 144 |
+| **Total** | **610** |
+
+This is above the 400 LOC target because the script includes DB setup, seed
+cleanup, concurrency, result serialization, and focused tests in one usable
+operator slice.

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Smoke-test concurrent FAQ search retrieval against Postgres."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Any
+from uuid import uuid4
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.ticket_faq_search import (  # noqa: E402
+    PostgresTicketFAQSearchRepository,
+    TicketFAQSearchDocument,
+)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
+
+@dataclass(frozen=True)
+class SearchCase:
+    account_id: str
+    corpus_id: str
+    faq_id: str
+    query: str
+    expected_hit: bool
+
+
+def _default_database_url() -> str | None:
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return None
+    dsn = str(getattr(db_settings, "dsn", "") or "").strip()
+    return dsn or None
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    _load_dotenv_files()
+    parser = argparse.ArgumentParser(
+        description="Run concurrent FAQ search retrieval against Postgres."
+    )
+    parser.add_argument("--database-url", default=_default_database_url())
+    parser.add_argument("--account-count", type=int, default=3)
+    parser.add_argument("--corpora-per-account", type=int, default=2)
+    parser.add_argument("--documents-per-corpus", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=30)
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--pool-size", type=int, default=4)
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--keep-data", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    for name in (
+        "account_count",
+        "corpora_per_account",
+        "documents_per_corpus",
+        "iterations",
+        "concurrency",
+        "pool_size",
+    ):
+        if int(getattr(args, name)) < 1:
+            raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+
+
+async def _create_pool(database_url: str, *, pool_size: int):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the FAQ search concurrency smoke; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=pool_size)
+
+
+def _build_cases(
+    *,
+    run_id: str,
+    account_count: int,
+    corpora_per_account: int,
+) -> tuple[SearchCase, ...]:
+    cases: list[SearchCase] = []
+    for account_index in range(account_count):
+        account_id = f"faq-search-{run_id}-acct-{account_index}"
+        for corpus_index in range(corpora_per_account):
+            corpus_id = f"faq-search-{run_id}-corpus-{corpus_index}"
+            faq_id = str(uuid4())
+            cases.append(
+                SearchCase(
+                    account_id=account_id,
+                    corpus_id=corpus_id,
+                    faq_id=faq_id,
+                    query="password reset",
+                    expected_hit=True,
+                )
+            )
+            cases.append(
+                SearchCase(
+                    account_id=account_id,
+                    corpus_id=corpus_id,
+                    faq_id=faq_id,
+                    query="escrow shortage",
+                    expected_hit=False,
+                )
+            )
+    return tuple(cases)
+
+
+def _documents_for_case(case: SearchCase, *, documents_per_corpus: int) -> tuple[TicketFAQSearchDocument, ...]:
+    documents: list[TicketFAQSearchDocument] = []
+    for rank in range(1, documents_per_corpus + 1):
+        documents.append(
+            TicketFAQSearchDocument(
+                account_id=case.account_id,
+                corpus_id=case.corpus_id,
+                faq_id=case.faq_id,
+                target_id=f"support-{case.corpus_id}",
+                target_mode="support_account",
+                status="approved",
+                rank=rank,
+                topic="password reset",
+                question=f"How do I reset my password for corpus {case.corpus_id}?",
+                answer_summary="Use the password reset email and contact support if it expires.",
+                source_ids=(f"{case.corpus_id}-ticket-{rank}",),
+                ticket_count=rank,
+                search_text="password reset email login support account",
+            )
+        )
+    return tuple(documents)
+
+
+async def _apply_migrations(pool: Any) -> None:
+    for relative in (
+        "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql",
+        "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql",
+    ):
+        await pool.execute((ROOT / relative).read_text(encoding="utf-8"))
+
+
+async def _seed(pool: Any, repo: PostgresTicketFAQSearchRepository, cases: Sequence[SearchCase], *, documents_per_corpus: int) -> None:
+    seen_faq_ids: set[str] = set()
+    for case in cases:
+        if case.faq_id in seen_faq_ids:
+            continue
+        seen_faq_ids.add(case.faq_id)
+        await pool.execute(
+            """
+            INSERT INTO ticket_faq_markdown (
+                id, account_id, target_id, target_mode, title, markdown,
+                items, source_count, ticket_source_count, output_checks,
+                warnings, metadata, status
+            )
+            VALUES (
+                $1::uuid, $2, $3, 'support_account', 'FAQ Search Smoke',
+                '# FAQ Search Smoke', '[]'::jsonb, $4, $4,
+                '{}'::jsonb, '[]'::jsonb, '{}'::jsonb, 'approved'
+            )
+            """,
+            case.faq_id,
+            case.account_id,
+            f"support-{case.corpus_id}",
+            documents_per_corpus,
+        )
+        await repo.replace_documents(
+            _documents_for_case(case, documents_per_corpus=documents_per_corpus)
+        )
+
+
+async def _cleanup(pool: Any, cases: Sequence[SearchCase]) -> None:
+    account_ids = sorted({case.account_id for case in cases})
+    if account_ids:
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = ANY($1::text[])",
+            account_ids,
+        )
+
+
+async def _run_case(
+    repo: PostgresTicketFAQSearchRepository,
+    case: SearchCase,
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = await repo.search(
+        query=case.query,
+        account_id=case.account_id,
+        corpus_id=case.corpus_id,
+        status="approved",
+        limit=limit,
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    rows = response.as_dict()["results"]
+    failures: list[str] = []
+    if case.expected_hit and not rows:
+        failures.append("expected hit returned no rows")
+    if not case.expected_hit and rows:
+        failures.append("expected miss returned rows")
+    for row in rows:
+        if row.get("account_id") != case.account_id:
+            failures.append("wrong account_id returned")
+        if row.get("corpus_id") != case.corpus_id:
+            failures.append("wrong corpus_id returned")
+    return {
+        "account_id": case.account_id,
+        "corpus_id": case.corpus_id,
+        "query": case.query,
+        "expected_hit": case.expected_hit,
+        "result_count": len(rows),
+        "elapsed_ms": round(elapsed_ms, 6),
+        "failures": failures,
+    }
+
+
+async def _run_concurrent_searches(
+    repo: PostgresTicketFAQSearchRepository,
+    cases: Sequence[SearchCase],
+    *,
+    iterations: int,
+    concurrency: int,
+) -> list[dict[str, Any]]:
+    semaphore = asyncio.Semaphore(concurrency)
+    selected = [cases[index % len(cases)] for index in range(iterations)]
+
+    async def worker(case: SearchCase) -> dict[str, Any]:
+        async with semaphore:
+            try:
+                return await _run_case(repo, case, limit=5)
+            except Exception as exc:  # pragma: no cover - exercised by live smoke failures.
+                return {
+                    "account_id": case.account_id,
+                    "corpus_id": case.corpus_id,
+                    "query": case.query,
+                    "expected_hit": case.expected_hit,
+                    "result_count": 0,
+                    "elapsed_ms": 0.0,
+                    "failures": [f"{type(exc).__name__}: {exc}"],
+                }
+
+    return list(await asyncio.gather(*(worker(case) for case in selected)))
+
+
+def _latency_summary(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    values = sorted(float(row.get("elapsed_ms") or 0.0) for row in results)
+    if not values:
+        return {"count": 0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
+    p95_index = min(len(values) - 1, max(0, int(len(values) * 0.95) - 1))
+    return {
+        "count": len(values),
+        "p50_ms": round(float(statistics.median(values)), 6),
+        "p95_ms": round(values[p95_index], 6),
+        "max_ms": round(values[-1], 6),
+    }
+
+
+def _failure_summary(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    failures = [
+        {
+            "account_id": row.get("account_id"),
+            "corpus_id": row.get("corpus_id"),
+            "query": row.get("query"),
+            "failures": row.get("failures"),
+        }
+        for row in results
+        if row.get("failures")
+    ]
+    return {
+        "count": len(failures),
+        "items": failures[:20],
+        "truncated": len(failures) > 20,
+    }
+
+
+async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    _validate_args(args)
+    run_id = uuid4().hex[:10]
+    cases = _build_cases(
+        run_id=run_id,
+        account_count=int(args.account_count),
+        corpora_per_account=int(args.corpora_per_account),
+    )
+    pool = await _create_pool(str(args.database_url), pool_size=int(args.pool_size))
+    repo = PostgresTicketFAQSearchRepository(pool)
+    started = time.perf_counter()
+    results: list[dict[str, Any]] = []
+    try:
+        await _apply_migrations(pool)
+        await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
+        results = await _run_concurrent_searches(
+            repo,
+            cases,
+            iterations=int(args.iterations),
+            concurrency=int(args.concurrency),
+        )
+    finally:
+        if not bool(args.keep_data):
+            await _cleanup(pool, cases)
+        await pool.close()
+    failure = _failure_summary(results)
+    summary = {
+        "ok": failure["count"] == 0,
+        "run_id": run_id,
+        "requests": {
+            "total": len(results),
+            "iterations": int(args.iterations),
+            "concurrency": int(args.concurrency),
+        },
+        "seed": {
+            "accounts": int(args.account_count),
+            "corpora_per_account": int(args.corpora_per_account),
+            "documents_per_corpus": int(args.documents_per_corpus),
+            "search_cases": len(cases),
+        },
+        "latency": _latency_summary(results),
+        "isolation": failure,
+        "elapsed_seconds": round(time.perf_counter() - started, 6),
+    }
+    return (0 if summary["ok"] else 1), summary
+
+
+def _write_result(path: Path, summary: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _print_summary(summary: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    latency = summary["latency"]
+    print(
+        "FAQ search concurrency smoke: "
+        f"ok={summary['ok']} requests={summary['requests']['total']} "
+        f"p50_ms={latency['p50_ms']} p95_ms={latency['p95_ms']} "
+        f"max_ms={latency['max_ms']} failures={summary['isolation']['count']}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    code, summary = asyncio.run(run_smoke(args))
+    if args.output_result:
+        _write_result(Path(args.output_result), summary)
+    _print_summary(summary, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_concurrency.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_concurrency", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+sys.modules["smoke_content_ops_faq_search_concurrency"] = smoke
+SPEC.loader.exec_module(smoke)
+
+
+def test_build_cases_creates_hit_and_miss_for_each_corpus() -> None:
+    cases = smoke._build_cases(
+        run_id="abc123",
+        account_count=2,
+        corpora_per_account=3,
+    )
+
+    assert len(cases) == 12
+    assert sum(1 for case in cases if case.expected_hit) == 6
+    assert sum(1 for case in cases if not case.expected_hit) == 6
+    assert len({case.account_id for case in cases}) == 2
+    assert len({case.corpus_id for case in cases}) == 3
+    assert all(case.account_id.startswith("faq-search-abc123-acct-") for case in cases)
+    for corpus_id in {case.corpus_id for case in cases}:
+        assert len({case.account_id for case in cases if case.corpus_id == corpus_id}) == 2
+
+
+def test_documents_for_case_are_ranked_and_scoped() -> None:
+    case = smoke.SearchCase(
+        account_id="acct-1",
+        corpus_id="corpus-1",
+        faq_id="11111111-1111-1111-1111-111111111111",
+        query="password reset",
+        expected_hit=True,
+    )
+
+    documents = smoke._documents_for_case(case, documents_per_corpus=3)
+
+    assert [document.rank for document in documents] == [1, 2, 3]
+    assert {document.account_id for document in documents} == {"acct-1"}
+    assert {document.corpus_id for document in documents} == {"corpus-1"}
+    assert {document.status for document in documents} == {"approved"}
+    assert {document.target_mode for document in documents} == {"support_account"}
+    assert all("password reset" in document.search_text for document in documents)
+
+
+@pytest.mark.asyncio
+async def test_run_case_records_failures_for_leaked_rows_and_hit_miss_mismatches() -> None:
+    class _Response:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def as_dict(self):
+            return {"results": self.rows}
+
+    class _Repo:
+        def __init__(self, rows):
+            self.rows = rows
+
+        async def search(self, **_kwargs):
+            return _Response(self.rows)
+
+    hit_case = smoke.SearchCase(
+        account_id="acct-1",
+        corpus_id="shared-corpus",
+        faq_id="faq-1",
+        query="password reset",
+        expected_hit=True,
+    )
+    miss_case = smoke.SearchCase(
+        account_id="acct-1",
+        corpus_id="shared-corpus",
+        faq_id="faq-1",
+        query="escrow shortage",
+        expected_hit=False,
+    )
+
+    leaked = await smoke._run_case(
+        _Repo([{"account_id": "acct-2", "corpus_id": "other-corpus"}]),
+        hit_case,
+        limit=5,
+    )
+    empty_hit = await smoke._run_case(_Repo([]), hit_case, limit=5)
+    unexpected_miss = await smoke._run_case(
+        _Repo([{"account_id": "acct-1", "corpus_id": "shared-corpus"}]),
+        miss_case,
+        limit=5,
+    )
+
+    assert leaked["failures"] == [
+        "wrong account_id returned",
+        "wrong corpus_id returned",
+    ]
+    assert empty_hit["failures"] == ["expected hit returned no rows"]
+    assert unexpected_miss["failures"] == ["expected miss returned rows"]
+
+
+def test_latency_summary_reports_empty_and_percentiles() -> None:
+    assert smoke._latency_summary([]) == {
+        "count": 0,
+        "p50_ms": 0.0,
+        "p95_ms": 0.0,
+        "max_ms": 0.0,
+    }
+
+    summary = smoke._latency_summary([
+        {"elapsed_ms": 4.0},
+        {"elapsed_ms": 1.0},
+        {"elapsed_ms": 3.0},
+        {"elapsed_ms": 2.0},
+    ])
+
+    assert summary == {
+        "count": 4,
+        "p50_ms": 2.5,
+        "p95_ms": 3.0,
+        "max_ms": 4.0,
+    }
+
+
+def test_failure_summary_limits_output() -> None:
+    results = [
+        {
+            "account_id": f"acct-{index}",
+            "corpus_id": "corpus",
+            "query": "password",
+            "failures": ["wrong account_id returned"],
+        }
+        for index in range(25)
+    ]
+
+    summary = smoke._failure_summary(results)
+
+    assert summary["count"] == 25
+    assert len(summary["items"]) == 20
+    assert summary["truncated"] is True


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Concurrency-Smoke.md

Add a real-Postgres FAQ search concurrency smoke that seeds tenant/corpus-separated search projections, runs concurrent filtered hit/miss repository searches, and writes machine-readable latency/isolation output.

Slice phase: robust testing

## Intentional
- This exercises the durable repository read pattern directly, not the hosted HTTP route.
- No latency threshold fails the run yet; this captures the baseline needed to set one defensibly.
- Seeded rows are deleted by default; `--keep-data` is only for local debugging.

## Deferred
- HTTP-route concurrency with auth tokens waits for a deployed backend URL/token.
- Latency SLO thresholds wait for baseline output in the target environment.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q - 5 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py - passed.
- python scripts/smoke_content_ops_faq_search_concurrency.py --account-count 3 --corpora-per-account 2 --documents-per-corpus 3 --iterations 24 --concurrency 6 --pool-size 4 --output-result tmp/faq_search_concurrency_smoke.json --json - passed with EXTRACTED_DATABASE_URL constructed from local `.env.backup` ATLAS_DB_* fields; 24 requests, 0 isolation failures, p50 1.010468 ms, p95 6.789891 ms, max 7.104989 ms.
- bash scripts/local_pr_review.sh --allow-dirty - passed.

## Diff size
3 files, +610 / -0
