### PR TITLE
Validate support ticket source context live smoke

### DIFF
--- a/docs/extraction/validation/support_ticket_source_context_live_validation_2026-05-24.md
+++ b/docs/extraction/validation/support_ticket_source_context_live_validation_2026-05-24.md
@@ -1,0 +1,114 @@
+# Support-Ticket Source Context Live Validation - 2026-05-24
+
+## Scope
+
+This validation proves the support-ticket input provider can feed live
+landing-page and blog-post generation, persist drafts, and export the exact
+saved draft rows for inspection after PR #930.
+
+Ownership lane: `content-ops/support-ticket-input-provider`
+
+## Environment
+
+- Repo: `canfieldjuan/ATLAS`
+- Branch: `claude/support-ticket-source-context-live-validation`
+- Model override: `anthropic/claude-haiku-4-5`
+- Source CSV:
+  `extracted_content_pipeline/examples/support_ticket_sources.csv`
+- Account ids:
+  - Landing: `acct_support_ticket_source_context_20260524`
+  - Blog: `acct_support_ticket_source_context_20260524b`
+
+The Atlas `.env` and `.env.local` files supplied DB and OpenRouter credentials.
+The Haiku override env file was loaded last.
+
+## Commands
+
+Landing page:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --account-id acct_support_ticket_source_context_20260524 \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file /tmp/atlas-support-ticket-source-context-validation/haiku.env \
+  --export-saved-draft /tmp/atlas-support-ticket-source-context-validation/landing-page-draft.json \
+  --json
+```
+
+Blog post:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_source_context_20260524b \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file /tmp/atlas-support-ticket-source-context-validation/haiku.env \
+  --export-saved-draft /tmp/atlas-support-ticket-source-context-validation/blog-post-draft-neutral-period.json \
+  --json
+```
+
+## Landing Result
+
+- Smoke status: passed
+- Saved draft id: `d181fc92-1711-40dd-98e0-e79bcdb1c304`
+- Export row count: 1
+- Quality repair attempts: 1
+- Last repair result: passed
+
+The exported landing-page draft includes `metadata.source_context` with:
+
+- `source_row_count`: 4
+- `included_ticket_row_count`: 4
+- `skipped_ticket_row_count`: 0
+- `truncated_ticket_row_count`: 0
+- `question_like_ticket_count`: 2
+- `top_ticket_clusters`:
+  - `email and profile updates`: 2
+  - `reporting friction`: 2
+- Four `customer_wording_examples`, including login-email, account-email,
+  campaign-attribution, and reporting-dashboard wording.
+
+Visible/exported landing copy contains the real source terms:
+
+- `email and profile updates`
+- `reporting friction`
+- `login email`
+- `account email`
+- `campaign attribution`
+- `reporting dashboard`
+
+## Blog Result
+
+- Smoke status: passed
+- Seeded blueprint id: `a7f2421b-f2ff-40ae-82a4-d0b1435ea44f`
+- Saved draft id: `90cf80e1-baad-478a-8b25-98394c509279`
+- Export row count: 1
+- SEO/AEO readiness: ready
+- GEO readiness: ready
+
+The exported blog draft carries:
+
+- `data_context.source_row_count`: 4
+- `data_context.question_like_ticket_count`: 2
+- `data_context.top_clusters`:
+  - `email and profile updates`: 2
+  - `reporting friction`: 2
+- `data_context.source_period`: `Uploaded support tickets`
+- `data_context.review_period`: `uploaded tickets`
+
+Because the packaged CSV does not include parseable ticket dates, the final
+blog export does not claim `last 90 days`.
+
+## Notes
+
+The live validation exposed and fixed a smoke-helper truthfulness gap: the
+support-ticket blog blueprint used to claim a 90-day source window even when
+the CSV rows did not carry dates. The helper now uses `Last 90 days of support
+tickets` only when every included row has a parseable date. Undated CSVs use
+neutral uploaded-ticket wording.
+
+No FAQ generator or file-ingestion behavior was changed in this slice.

--- a/plans/PR-Support-Ticket-Source-Context-Live-Validation.md
+++ b/plans/PR-Support-Ticket-Source-Context-Live-Validation.md
@@ -1,0 +1,82 @@
+# PR: Support Ticket Source Context Live Validation
+
+## Why this slice exists
+
+PR #930 fixed landing-page support-ticket source context, but the live smoke
+needed one more end-to-end proof after merge. The first validation pass also
+showed the support-ticket blog smoke helper could still claim a 90-day source
+window when the CSV rows did not carry parseable dates. That is the same
+evidence-truthfulness issue fixed for landing inputs, so this slice fixes the
+smoke helper and records the live proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: functional validation
+
+1. Gate the support-ticket blog smoke blueprint's `review_period`,
+   `source_period`, and `source_window_days` on parseable ticket dates.
+2. Keep undated support-ticket CSV smoke runs on neutral `Uploaded support
+   tickets` wording.
+3. Add focused tests for undated and dated blog blueprint source-period
+   behavior.
+4. Document the Haiku live landing-page and blog-post smoke/export validation
+   after #930 merged.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Source-Context-Live-Validation.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `docs/extraction/validation/support_ticket_source_context_live_validation_2026-05-24.md`
+
+## Mechanism
+
+The smoke helper now inspects common ticket date columns before claiming a
+`Last 90 days` window. If every included row has a parseable date, the
+blueprint keeps the 90-day source-period language and includes
+`source_window_days=90`. Otherwise it uses neutral uploaded-ticket wording and
+omits the window stat.
+
+## Intentional
+
+- This changes only the live smoke helper and validation docs. Hosted FAQ,
+  file-ingestion, landing generation, and blog generation services are not
+  changed.
+- The live smoke still uses the packaged support-ticket CSV and Haiku override
+  for low-cost validation.
+
+## Deferred
+
+- Larger customer CSV validation remains a later robust-testing slice.
+- Parked hardening: none. `HARDENING.md` was scanned; current entries are FAQ
+  scale and file-ingestion concurrency work outside this support-ticket
+  provider validation slice.
+
+## Verification
+
+- Focused smoke tests:
+  `pytest tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_csv_counts tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_validate tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_packages_support_ticket_csv_for_landing_page -q`
+  - 3 passed.
+- Expanded support-ticket/source-context suites:
+  `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_live_generation.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation.py -q`
+  - 148 passed.
+- Py compile for changed Python files - passed.
+- Git whitespace check - passed.
+- Manual Haiku landing-page live smoke with `--support-ticket-csv` and
+  `--export-saved-draft` - passed; exported draft
+  `d181fc92-1711-40dd-98e0-e79bcdb1c304`.
+- Manual Haiku blog-post live smoke with `--support-ticket-csv` and
+  `--export-saved-draft` after the source-period fix - passed; exported draft
+  `90cf80e1-baad-478a-8b25-98394c509279`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Smoke helper | ~45 |
+| Tests | ~20 |
+| Validation doc | ~90 |
+| **Total** | **~230** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+from datetime import date, datetime
 import json
 from pathlib import Path
 import re
@@ -518,10 +519,17 @@ def _support_ticket_blog_blueprint_payload(
     top_clusters = _top_ticket_clusters(source_rows)
     cluster_summary = _cluster_summary(top_clusters)
     draft_faq_entries = min(12, max(1, row_count))
+    has_valid_date_window = _support_ticket_rows_have_dates(source_rows)
+    review_period = "last 90 days" if has_valid_date_window else "uploaded tickets"
+    source_period = (
+        "Last 90 days of support tickets"
+        if has_valid_date_window
+        else "Uploaded support tickets"
+    )
     return {
         "topic": SUPPORT_TICKET_BLOG_TOPIC,
         "data_context": {
-            "review_period": "last 90 days",
+            "review_period": review_period,
             "source_row_count": row_count,
             "question_like_ticket_count": question_like_count,
             "top_clusters": top_clusters,
@@ -531,7 +539,7 @@ def _support_ticket_blog_blueprint_payload(
             "deep_enriched_count": row_count,
             "category": "support tickets",
             "topic": SUPPORT_TICKET_BLOG_TOPIC,
-            "source_period": "Last 90 days of support tickets",
+            "source_period": source_period,
             "source": "support_ticket_provider",
         },
         "sections": [
@@ -578,10 +586,10 @@ def _support_ticket_blog_blueprint_payload(
                     "questions, customer wording, draft answers, and review."
                 ),
                 "key_stats": {
-                    "source_window_days": 90,
                     "source_rows": row_count,
                     "draft_faq_entries": draft_faq_entries,
                     "review_steps": 3,
+                    **({"source_window_days": 90} if has_valid_date_window else {}),
                 },
                 "chart_ids": [],
                 "data_summary": (
@@ -623,6 +631,38 @@ def _ticket_row_text(row: Mapping[str, Any]) -> str:
         )
         if str(row.get(key) or "").strip()
     )
+
+
+def _support_ticket_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
+    return bool(rows) and all(_ticket_row_date(row) is not None for row in rows)
+
+
+def _ticket_row_date(row: Mapping[str, Any]) -> date | None:
+    for key in (
+        "Created At",
+        "created_at",
+        "Submitted At",
+        "submitted_at",
+        "Date",
+        "date",
+    ):
+        value = row.get(key)
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        text = str(value or "").strip()
+        if not text:
+            continue
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+        except ValueError:
+            pass
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            continue
+    return None
 
 
 def _ticket_cluster_label(row: Mapping[str, Any]) -> str:

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -720,6 +720,8 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
     assert "42%" not in serialized
     assert payload["data_context"]["source_row_count"] == 2
     assert payload["data_context"]["question_like_ticket_count"] == 2
+    assert payload["data_context"]["review_period"] == "uploaded tickets"
+    assert payload["data_context"]["source_period"] == "Uploaded support tickets"
     assert payload["data_context"]["top_clusters"] == [
         {"label": "account", "count": 1},
         {"label": "reporting", "count": 1},
@@ -731,6 +733,23 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
         "cluster_count": 2,
     }
     assert "2 support-ticket rows" in first_section["data_summary"]
+    assert "source_window_days" not in payload["sections"][2]["key_stats"]
+
+
+def test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_validate() -> None:
+    payload = smoke._support_ticket_blog_blueprint_payload([
+        {
+            "Ticket ID": "ticket-1",
+            "Subject": "How do I change my login email?",
+            "Description": "I cannot find where to update the email on my account.",
+            "Pain Category": "account",
+            "Created At": "2026-05-01",
+        }
+    ])
+
+    assert payload["data_context"]["review_period"] == "last 90 days"
+    assert payload["data_context"]["source_period"] == "Last 90 days of support tickets"
+    assert payload["sections"][2]["key_stats"]["source_window_days"] == 90
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why this slice exists

PR #930 fixed landing-page support-ticket source context, but the merged path needed live proof with saved draft exports. During validation, the support-ticket blog smoke helper also still claimed a 90-day source window for an undated CSV fixture, so this PR fixes that smoke-helper truthfulness gap and records the live validation.

## Scope

Ownership lane: content-ops/support-ticket-input-provider

Slice phase: functional validation

- Gate the support-ticket blog smoke blueprint `review_period`, `source_period`, and `source_window_days` on parseable ticket dates.
- Use neutral `Uploaded support tickets` wording for undated support-ticket CSV smoke runs.
- Add focused tests for undated and dated blog blueprint source-period behavior.
- Document the Haiku live landing-page and blog-post smoke/export validation after #930 merged.

## Verification

- `pytest tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_csv_counts tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_validate tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_packages_support_ticket_csv_for_landing_page -q` -> 3 passed
- `pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_live_generation.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_ops_execution.py tests/test_extracted_landing_page_generation.py -q` -> 148 passed
- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py`
- `git diff --check`
- `bash scripts/local_pr_review.sh`
- Manual Haiku landing live smoke/export passed; saved draft `d181fc92-1711-40dd-98e0-e79bcdb1c304`
- Manual Haiku blog live smoke/export passed after source-period fix; saved draft `90cf80e1-baad-478a-8b25-98394c509279`

## Diff size

4 files changed, 258 insertions(+), 3 deletions(-)
