### PR TITLE
PR-Content-Ops-FAQ-Search-Latency-Gates

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Latency-Gates.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Latency-Gates.md
@@ -1,0 +1,88 @@
+# PR-Content-Ops-FAQ-Search-Latency-Gates
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Search-Concurrency-Smoke added a real-Postgres read
+concurrency smoke for FAQ deflection search and recorded baseline latency. The
+next survivability step is to let that same smoke fail when a caller supplies
+explicit latency budgets.
+
+This keeps production hardening grounded in the real route repository path:
+first prove tenant/corpus isolation and read concurrency, then make the smoke
+usable as a repeatable latency gate for larger environments.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: robust testing.
+
+1. Add optional p95 and single-request latency budget flags to the FAQ search
+   concurrency smoke.
+2. Include latency budget pass/fail details in the result JSON.
+3. Fail the smoke when isolation checks fail or an explicit latency budget is
+   exceeded.
+4. Fix the p95 calculation now that p95 can drive a gate.
+5. Add focused unit coverage for passing and failing latency budgets.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Latency-Gates.md`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_concurrency.py`
+
+## Mechanism
+
+The smoke accepts optional budget flags:
+
+- `--max-p95-ms`
+- `--max-single-request-ms`
+
+When absent, behavior remains baseline-only: the smoke records latency and fails
+only for search exceptions, unexpected result rows, or isolation failures. When a
+budget is present, `run_smoke` compares the computed latency summary against the
+provided threshold and adds a deterministic `latency_budget` object to the JSON
+summary. Any exceeded threshold sets `ok=false` and returns exit code `1`.
+
+The p95 calculation moves to nearest-rank percentile indexing so the value used
+for a budget gate is not biased low on small smoke runs.
+
+## Intentional
+
+- No default threshold is introduced. Different laptops, CI runners, and
+  deployed databases need different budgets.
+- No hosted route load test is added here. This keeps the slice on the existing
+  direct repository smoke while the deployed host URL/token remains outside this
+  repo.
+- No retry/backoff behavior is added. A latency gate should expose slow reads,
+  not mask them.
+
+## Deferred
+
+- HTTP-route concurrency with auth tokens remains deferred until the deployed
+  backend URL and bearer token are available.
+- Production SLO values remain environment-owned; this PR only adds the
+  mechanism to enforce a caller-provided budget.
+- Write-path replacement concurrency remains separate from this read-path smoke.
+- Setup-time JSON failure artifacts for unreachable DB hosts should be parked in
+  `HARDENING.md` after PR #902 releases that shared file; this slice keeps the
+  gate logic focused on completed search runs and avoids a cross-session
+  `HARDENING.md` collision.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q` passed with
+  7 tests.
+- Python compile check for the smoke script and focused test module passed.
+- Live DB smoke with latency budgets was not completed because the active shell
+  has no `EXTRACTED_DATABASE_URL` or `DATABASE_URL`, and `.env.backup` points at
+  a DB host that does not resolve in this worktree.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Smoke script | 57 |
+| Tests | 55 |
+| **Total** | **200** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -8,6 +8,7 @@ import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
 import json
+import math
 import os
 from pathlib import Path
 import statistics
@@ -71,6 +72,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--iterations", type=int, default=30)
     parser.add_argument("--concurrency", type=int, default=8)
     parser.add_argument("--pool-size", type=int, default=4)
+    parser.add_argument("--max-p95-ms", type=float)
+    parser.add_argument("--max-single-request-ms", type=float)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--keep-data", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -89,6 +92,10 @@ def _validate_args(args: argparse.Namespace) -> None:
         "pool_size",
     ):
         if int(getattr(args, name)) < 1:
+            raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+    for name in ("max_p95_ms", "max_single_request_ms"):
+        value = getattr(args, name)
+        if value is not None and float(value) <= 0:
             raise SystemExit(f"--{name.replace('_', '-')} must be positive")
 
 
@@ -273,12 +280,46 @@ def _latency_summary(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
     values = sorted(float(row.get("elapsed_ms") or 0.0) for row in results)
     if not values:
         return {"count": 0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
-    p95_index = min(len(values) - 1, max(0, int(len(values) * 0.95) - 1))
+    p95_index = min(len(values) - 1, max(0, math.ceil(len(values) * 0.95) - 1))
     return {
         "count": len(values),
         "p50_ms": round(float(statistics.median(values)), 6),
         "p95_ms": round(values[p95_index], 6),
         "max_ms": round(values[-1], 6),
+    }
+
+
+def _latency_budget_summary(
+    latency: dict[str, Any],
+    *,
+    max_p95_ms: float | None,
+    max_single_request_ms: float | None,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for metric, limit in (
+        ("p95_ms", max_p95_ms),
+        ("max_ms", max_single_request_ms),
+    ):
+        if limit is None:
+            continue
+        actual = float(latency[metric])
+        max_ms = round(float(limit), 6)
+        ok = actual <= max_ms
+        checks.append(
+            {
+                "metric": metric,
+                "actual_ms": actual,
+                "max_ms": max_ms,
+                "ok": ok,
+            }
+        )
+        if not ok:
+            failures.append(f"{metric} exceeded {max_ms} ms")
+    return {
+        "ok": not failures,
+        "checks": checks,
+        "failures": failures,
     }
 
 
@@ -326,8 +367,14 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             await _cleanup(pool, cases)
         await pool.close()
     failure = _failure_summary(results)
+    latency = _latency_summary(results)
+    latency_budget = _latency_budget_summary(
+        latency,
+        max_p95_ms=args.max_p95_ms,
+        max_single_request_ms=args.max_single_request_ms,
+    )
     summary = {
-        "ok": failure["count"] == 0,
+        "ok": failure["count"] == 0 and latency_budget["ok"],
         "run_id": run_id,
         "requests": {
             "total": len(results),
@@ -340,7 +387,8 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "documents_per_corpus": int(args.documents_per_corpus),
             "search_cases": len(cases),
         },
-        "latency": _latency_summary(results),
+        "latency": latency,
+        "latency_budget": latency_budget,
         "isolation": failure,
         "elapsed_seconds": round(time.perf_counter() - started, 6),
     }
@@ -361,7 +409,8 @@ def _print_summary(summary: dict[str, Any], *, as_json: bool) -> None:
         "FAQ search concurrency smoke: "
         f"ok={summary['ok']} requests={summary['requests']['total']} "
         f"p50_ms={latency['p50_ms']} p95_ms={latency['p95_ms']} "
-        f"max_ms={latency['max_ms']} failures={summary['isolation']['count']}"
+        f"max_ms={latency['max_ms']} failures={summary['isolation']['count']} "
+        f"latency_budget_failures={len(summary['latency_budget']['failures'])}"
     )
 
 

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -121,9 +122,61 @@ def test_latency_summary_reports_empty_and_percentiles() -> None:
     assert summary == {
         "count": 4,
         "p50_ms": 2.5,
-        "p95_ms": 3.0,
+        "p95_ms": 4.0,
         "max_ms": 4.0,
     }
+
+
+def test_latency_budget_summary_reports_passes_and_failures() -> None:
+    latency = {"p95_ms": 4.0, "max_ms": 5.0}
+
+    assert smoke._latency_budget_summary(
+        latency,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+    ) == {"ok": True, "checks": [], "failures": []}
+
+    passing = smoke._latency_budget_summary(
+        latency,
+        max_p95_ms=4.0,
+        max_single_request_ms=5.0,
+    )
+    failing = smoke._latency_budget_summary(
+        latency,
+        max_p95_ms=3.5,
+        max_single_request_ms=4.5,
+    )
+
+    assert passing == {
+        "ok": True,
+        "checks": [
+            {"metric": "p95_ms", "actual_ms": 4.0, "max_ms": 4.0, "ok": True},
+            {"metric": "max_ms", "actual_ms": 5.0, "max_ms": 5.0, "ok": True},
+        ],
+        "failures": [],
+    }
+    assert failing["ok"] is False
+    assert failing["failures"] == [
+        "p95_ms exceeded 3.5 ms",
+        "max_ms exceeded 4.5 ms",
+    ]
+
+
+def test_validate_args_rejects_nonpositive_latency_budgets() -> None:
+    args = SimpleNamespace(
+        database_url="postgresql://example",
+        account_count=1,
+        corpora_per_account=1,
+        documents_per_corpus=1,
+        iterations=1,
+        concurrency=1,
+        pool_size=1,
+        max_p95_ms=0,
+        max_single_request_ms=None,
+    )
+
+    with pytest.raises(SystemExit, match="--max-p95-ms must be positive"):
+        smoke._validate_args(args)
 
 
 def test_failure_summary_limits_output() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Latency-Gates.md

Add optional latency budgets to the real-Postgres FAQ search concurrency smoke so the existing baseline can become an explicit p95/max request gate when a caller supplies thresholds.

Slice phase: robust testing

## Intentional
- No default threshold is introduced; each environment owns its latency budget.
- This stays on the direct repository smoke rather than the hosted HTTP route.
- No retry/backoff behavior is added because the gate should expose slow reads.

## Deferred
- HTTP-route concurrency with auth tokens waits for a deployed backend URL/token.
- Production SLO values remain environment-owned; this PR only adds the enforcement mechanism.
- Setup-time JSON failure artifacts for unreachable DB hosts should be parked in `HARDENING.md` after PR #902 releases that shared file.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q` - 7 passed.
- Python compile check for the smoke script and focused test module - passed.
- `bash scripts/local_pr_review.sh --allow-dirty` - passed.
- Live DB smoke with latency budgets was not completed because the active shell has no `EXTRACTED_DATABASE_URL` or `DATABASE_URL`, and `.env.backup` points at a DB host that does not resolve in this worktree.

## Diff size
3 files, +195 / -5
