### PR TITLE
Add support ticket package smoke

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -372,6 +372,16 @@ def load_source_campaign_opportunities_from_file(
     )
 
 
+def load_source_rows_from_file(
+    path: str | Path,
+    *,
+    file_format: SourceDataFormat = "auto",
+) -> list[Any]:
+    """Load source rows from a CSV, JSON, or JSONL file without opportunity mapping."""
+
+    return _load_source_rows(Path(path), file_format=file_format)
+
+
 def source_rows_to_campaign_opportunities(
     rows: Sequence[Any],
     *,
@@ -886,6 +896,7 @@ def _compact_field_key(key: str) -> str:
 __all__ = [
     "SourceDataFormat",
     "load_source_campaign_opportunities_from_file",
+    "load_source_rows_from_file",
     "parse_default_fields",
     "parse_default_fields_with_booking_url_or_exit",
     "parse_default_fields_or_exit",

--- a/plans/PR-Support-Ticket-Provider-Package-Smoke.md
+++ b/plans/PR-Support-Ticket-Provider-Package-Smoke.md
@@ -1,0 +1,106 @@
+# PR-Support-Ticket-Provider-Package-Smoke
+
+## Why this slice exists
+
+The support-ticket input provider now feeds real ticket context into landing-page
+and blog generation, and the live smoke proves the LLM/persistence path can save
+drafts. The next cheapest validation point is before any DB write or model call:
+given an uploaded/exported ticket file, can we package the rows into the exact
+Content Ops inputs the generators consume?
+
+This slice adds that pre-LLM proof path. It stays in the support-ticket provider
+lane and does not add FAQ-owned generation, file-upload routing, persistence, or
+hosted background execution.
+
+This is slightly over the 400 LOC soft budget because the useful slice needs the
+CLI, CI enrollment, and representative fixture-style tests together. Shipping
+the CLI without tests, or tests without the CI enrollment, would not prove the
+pre-LLM package path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Functional validation
+
+1. Add a small public source-row file loader that exposes the existing CSV/JSON/JSONL loader without changing normalization rules.
+2. Add a support-ticket package smoke CLI that loads a file, builds the real support-ticket input package, and emits a JSON readiness summary.
+3. Include row counts, skipped/truncated counts, source period, window-filter status, FAQ question count, top clusters, customer wording examples, and warnings in the summary.
+4. Add focused tests for undated CSV rows, dated rows, skipped rows, truncation, remaining clusters, uncategorized rows, and CLI failure on empty packaged rows.
+5. After PR #919 merged, update its support-ticket landing execute assertion to
+   match the current neutral source-period rule for undated ticket exports.
+
+### Files touched
+
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `scripts/smoke_content_ops_support_ticket_package.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_smoke_content_ops_support_ticket_package.py`
+- `tests/test_support_ticket_provider_landing_blog_execute.py`
+- `plans/PR-Support-Ticket-Provider-Package-Smoke.md`
+
+## Mechanism
+
+The CLI uses the existing source-row file reader, then calls
+`build_support_ticket_input_package(...)`. It does not reimplement the package
+rules. The emitted JSON summary is a compact view of the package fields that
+matter before generation:
+
+```json
+{
+  "source_row_count": 10,
+  "included_ticket_row_count": 9,
+  "skipped_ticket_row_count": 1,
+  "truncated_ticket_row_count": 0,
+  "source_period": "Uploaded support tickets",
+  "has_window_filter": false,
+  "top_ticket_clusters": []
+}
+```
+
+`--require-included-rows` exits non-zero if the file loads but no usable customer
+wording survives packaging, so hosted or local operators can catch bad exports
+before spending model calls.
+
+## Intentional
+
+- No LLM, DB, or generation call in this slice. This is the cheap validation
+  layer before those paths.
+- No new file-upload route. The hosted ingestion session owns upload and storage
+  behavior; this slice validates the provider package after rows are available.
+- The summary exposes package outputs instead of raw file contents so it does not
+  become a second parser or policy surface.
+- The #919 test correction is included because rebasing this PR onto current
+  main exposed that the merged test still expected a dated 90-day source period
+  for an undated CSV fixture.
+
+## Deferred
+
+- Future PR: hosted upload/intake code can call this same package summary for
+  preflight diagnostics once that owning route is ready.
+- Future PR: scale validation can run this CLI against larger ticket exports and
+  record memory/runtime once the representative customer file is selected.
+- Parked hardening: none.
+
+## Verification
+
+- python -m py_compile for `extracted_content_pipeline/campaign_source_adapters.py`, `scripts/smoke_content_ops_support_ticket_package.py`, and `tests/test_smoke_content_ops_support_ticket_package.py` - passed.
+- pytest for `tests/test_smoke_content_ops_support_ticket_package.py` and `tests/test_extracted_support_ticket_input_package.py` - 22 passed.
+- package smoke against `extracted_content_pipeline/examples/support_ticket_sources.csv` with max rows 5 - passed; 4 included rows, 2 clusters, zero warnings.
+- pytest for `tests/test_smoke_content_ops_support_ticket_package.py`, `tests/test_extracted_support_ticket_input_package.py`, and `tests/test_support_ticket_provider_landing_blog_execute.py` - 24 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 1956 passed, 1 skipped.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Public loader export | ~10 |
+| Smoke CLI | ~110 |
+| Test enrollment | ~1 |
+| Tests | ~191 |
+| **Total** | **~445** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -52,6 +52,7 @@ pytest \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_extracted_support_ticket_input_package.py \
   tests/test_extracted_support_ticket_input_provider.py \
+  tests/test_smoke_content_ops_support_ticket_package.py \
   tests/test_extracted_content_control_surface_api.py \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \

--- a/scripts/smoke_content_ops_support_ticket_package.py
+++ b/scripts/smoke_content_ops_support_ticket_package.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Smoke-test support-ticket input packaging before DB or LLM work."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from extracted_content_pipeline.campaign_source_adapters import (
+    SourceDataFormat,
+    load_source_rows_from_file,
+)
+from extracted_content_pipeline.support_ticket_input_package import (
+    DEFAULT_SUPPORT_TICKET_OUTPUTS,
+    build_support_ticket_input_package,
+)
+
+
+def build_support_ticket_package_smoke_summary(
+    path: str | Path,
+    *,
+    file_format: SourceDataFormat = "auto",
+    outputs: tuple[str, ...] = DEFAULT_SUPPORT_TICKET_OUTPUTS,
+    window_days: int = 90,
+    max_rows: int = 1000,
+    require_included_rows: bool = False,
+) -> dict[str, Any]:
+    """Return a compact summary of the support-ticket package built from a file."""
+
+    rows = load_source_rows_from_file(path, file_format=file_format)
+    package = build_support_ticket_input_package(
+        rows,
+        outputs=outputs,
+        window_days=window_days,
+        max_rows=max_rows,
+    )
+    inputs = package.inputs
+    included_row_count = int(inputs.get("included_ticket_row_count") or 0)
+    if require_included_rows and included_row_count < 1:
+        raise ValueError("No usable support-ticket rows survived packaging.")
+    customer_wording_examples = list(inputs.get("customer_wording_examples") or [])
+    faq_questions = list(inputs.get("faq_questions") or [])
+    return {
+        "path": str(Path(path)),
+        "provider": package.provider,
+        "outputs": list(package.outputs),
+        "source_row_count": int(inputs.get("source_row_count") or 0),
+        "included_ticket_row_count": included_row_count,
+        "skipped_ticket_row_count": int(inputs.get("skipped_ticket_row_count") or 0),
+        "truncated_ticket_row_count": int(inputs.get("truncated_ticket_row_count") or 0),
+        "source_period": inputs.get("source_period"),
+        "has_window_filter": "faq_window_days" in inputs,
+        "faq_window_days": inputs.get("faq_window_days"),
+        "faq_question_count": len(faq_questions),
+        "faq_questions": faq_questions,
+        "question_like_ticket_count": int(inputs.get("question_like_ticket_count") or 0),
+        "top_ticket_clusters": list(inputs.get("top_ticket_clusters") or []),
+        "customer_wording_example_count": len(customer_wording_examples),
+        "customer_wording_examples": customer_wording_examples,
+        "warning_count": len(package.warnings),
+        "warnings": list(package.warnings),
+        "metadata": dict(package.metadata),
+    }
+
+
+def _parse_outputs(value: str) -> tuple[str, ...]:
+    outputs = tuple(item.strip() for item in value.split(",") if item.strip())
+    if not outputs:
+        raise argparse.ArgumentTypeError("--outputs must include at least one output")
+    return outputs
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", help="CSV, JSON, or JSONL support-ticket export")
+    parser.add_argument(
+        "--format",
+        choices=("auto", "csv", "json", "jsonl"),
+        default="auto",
+        help="Source file format. Defaults to extension-based auto detection.",
+    )
+    parser.add_argument(
+        "--outputs",
+        type=_parse_outputs,
+        default=DEFAULT_SUPPORT_TICKET_OUTPUTS,
+        help="Comma-separated Content Ops outputs to package for.",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=90,
+        help="Date-window label to use when every included row has a parseable date.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=1000,
+        help="Maximum source rows to include before reporting truncation.",
+    )
+    parser.add_argument(
+        "--require-included-rows",
+        action="store_true",
+        help="Exit non-zero if no usable ticket wording survives packaging.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the JSON summary.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = build_support_ticket_package_smoke_summary(
+            args.path,
+            file_format=args.format,
+            outputs=args.outputs,
+            window_days=args.window_days,
+            max_rows=args.max_rows,
+            require_included_rows=args.require_included_rows,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"support-ticket package smoke failed: {exc}", file=sys.stderr)
+        return 1
+    indent = 2 if args.pretty else None
+    print(json.dumps(summary, indent=indent, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "smoke_content_ops_support_ticket_package.py"
+)
+_SCRIPT_SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_support_ticket_package",
+    _SCRIPT_PATH,
+)
+assert _SCRIPT_SPEC is not None
+assert _SCRIPT_SPEC.loader is not None
+_SCRIPT_MODULE = importlib.util.module_from_spec(_SCRIPT_SPEC)
+_SCRIPT_SPEC.loader.exec_module(_SCRIPT_MODULE)
+
+build_support_ticket_package_smoke_summary = (
+    _SCRIPT_MODULE.build_support_ticket_package_smoke_summary
+)
+main = _SCRIPT_MODULE.main
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    headers: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in headers:
+                headers.append(key)
+    lines = [",".join(headers)]
+    for row in rows:
+        lines.append(",".join(_csv_cell(row.get(header, "")) for header in headers))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _csv_cell(value: str) -> str:
+    escaped = str(value).replace('"', '""')
+    return f'"{escaped}"'
+
+
+def test_support_ticket_package_smoke_summarizes_undated_csv_without_window_filter(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tickets.csv"
+    _write_csv(path, [
+        {
+            "ticket_id": "ticket-1",
+            "subject": "How do I change my login email?",
+            "description": "I cannot find where to update the email on my account.",
+            "pain_category": "profile updates",
+        },
+        {
+            "ticket_id": "ticket-2",
+            "subject": "Export dashboard",
+            "description": "Where do I export the dashboard before renewal?",
+        },
+        {"ticket_id": "ticket-3"},
+    ])
+
+    summary = build_support_ticket_package_smoke_summary(path)
+
+    assert summary["source_row_count"] == 3
+    assert summary["included_ticket_row_count"] == 2
+    assert summary["skipped_ticket_row_count"] == 1
+    assert summary["truncated_ticket_row_count"] == 0
+    assert summary["source_period"] == "Uploaded support tickets"
+    assert summary["has_window_filter"] is False
+    assert summary["faq_question_count"] == 2
+    assert summary["question_like_ticket_count"] == 2
+    assert summary["top_ticket_clusters"] == [
+        {"label": "profile updates", "count": 1},
+        {"label": "Export dashboard", "count": 1},
+    ]
+    assert summary["customer_wording_examples"][0] == {
+        "source_id": "ticket-1",
+        "source_title": "How do I change my login email?",
+        "pain_category": "profile updates",
+        "text": (
+            "How do I change my login email? I cannot find where to update the "
+            "email on my account."
+        ),
+    }
+    assert summary["warnings"] == [
+        {
+            "code": "ticket_row_missing_text",
+            "row_index": 3,
+            "message": "Skipped ticket row because it did not include customer wording.",
+        }
+    ]
+
+
+def test_support_ticket_package_smoke_keeps_date_window_for_dated_rows(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tickets.csv"
+    _write_csv(path, [
+        {
+            "ticket_id": "ticket-1",
+            "description": "How do I export reports?",
+            "created_at": "2026-05-01",
+        },
+        {
+            "ticket_id": "ticket-2",
+            "description": "Where do I update billing?",
+            "created_at": "2026-05-02T12:00:00Z",
+        },
+    ])
+
+    summary = build_support_ticket_package_smoke_summary(path, window_days=45)
+
+    assert summary["source_period"] == "Last 45 days of support tickets"
+    assert summary["has_window_filter"] is True
+    assert summary["faq_window_days"] == 45
+
+
+def test_support_ticket_package_smoke_reports_cluster_rollup_and_truncation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tickets.csv"
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "description": f"How do I fix issue {index}?",
+            "pain_category": f"category-{index}",
+        }
+        for index in range(1, 9)
+    ]
+    rows.append({"ticket_id": "ticket-9", "description": "Can I change my plan?"})
+    rows.append({"ticket_id": "ticket-10", "description": "Why was I charged?"})
+    _write_csv(path, rows)
+
+    summary = build_support_ticket_package_smoke_summary(path, max_rows=9)
+
+    assert summary["source_row_count"] == 10
+    assert summary["included_ticket_row_count"] == 9
+    assert summary["truncated_ticket_row_count"] == 1
+    assert summary["top_ticket_clusters"] == [
+        {"label": "category-1", "count": 1},
+        {"label": "category-2", "count": 1},
+        {"label": "category-3", "count": 1},
+        {"label": "category-4", "count": 1},
+        {"label": "category-5", "count": 1},
+        {"label": "category-6", "count": 1},
+        {"label": "remaining", "count": 2},
+        {"label": "uncategorized", "count": 1},
+    ]
+    assert summary["warning_count"] == 1
+    assert summary["warnings"][0]["code"] == "ticket_rows_truncated"
+
+
+def test_support_ticket_package_smoke_main_writes_json(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    path = tmp_path / "tickets.csv"
+    _write_csv(path, [
+        {
+            "ticket_id": "ticket-1",
+            "subject": "How do I export reports?",
+            "created_at": "2026-05-01",
+        }
+    ])
+
+    assert main([str(path), "--outputs", "landing_page", "--pretty"]) == 0
+
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    assert summary["outputs"] == ["landing_page"]
+    assert summary["included_ticket_row_count"] == 1
+    assert captured.err == ""
+
+
+def test_support_ticket_package_smoke_can_fail_when_no_rows_survive(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    path = tmp_path / "tickets.csv"
+    _write_csv(path, [{"ticket_id": "ticket-1"}])
+
+    assert main([str(path), "--require-included-rows"]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "No usable support-ticket rows survived packaging." in captured.err

--- a/tests/test_support_ticket_provider_landing_blog_execute.py
+++ b/tests/test_support_ticket_provider_landing_blog_execute.py
@@ -142,7 +142,7 @@ async def test_support_ticket_provider_feeds_landing_page_execute_context() -> N
         "Small teams looking for a practical way to turn repeat support "
         "questions into help-center answers."
     )
-    assert context["source_period"] == "Last 90 days of support tickets"
+    assert context["source_period"] == "Uploaded support tickets"
     assert context["cta_label"] == "Upload Ticket CSV -- Free Analysis"
     assert context["cta_url"] == "/systems/ai-content-ops/intake"
     assert context["faq_questions"] == [


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Package-Smoke.md
Slice phase: Functional validation

Adds a pre-LLM support-ticket package smoke path: load CSV/JSON/JSONL rows, build the real support-ticket input package, and emit a JSON summary of counts, source period, clusters, customer wording examples, and warnings before DB or model work. After #919 merged, this PR also corrects its landing execute assertion to match the current neutral source-period rule for undated ticket exports.

## Intentional
- No LLM, DB, generation call, or hosted upload route in this slice; this validates the package before those paths.
- Exposes the existing source-row file loader publicly instead of adding a second parser.
- Keeps the one-line extracted-suite enrollment because this test needs to run in CI.
- Includes the #919 test correction because rebasing this PR onto current main exposed that the merged test still expected a dated 90-day source period for an undated CSV fixture.

## Deferred
- Hosted upload/intake code can call this summary for preflight diagnostics in a future owner-route PR.
- Larger representative ticket exports can use this CLI for scale/runtime validation once selected.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/campaign_source_adapters.py scripts/smoke_content_ops_support_ticket_package.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_support_ticket_provider_landing_blog_execute.py` - passed
- `pytest -q tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py` - 22 passed
- `pytest -q tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_package.py tests/test_support_ticket_provider_landing_blog_execute.py` - 24 passed
- `python scripts/smoke_content_ops_support_ticket_package.py extracted_content_pipeline/examples/support_ticket_sources.csv --max-rows 5 --pretty` - passed; 4 included rows, 2 clusters, zero warnings
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
- `bash scripts/check_ascii_python.sh` - passed
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - 1956 passed, 1 skipped before the #919 rebase; current focused tests and local PR review passed after rebase
- `bash scripts/local_pr_review.sh` - passed after rebase onto #919/current main

## Diff size
6 files, +447 / -1
