### PR TITLE
Prove support ticket package scale cap

### DIFF
--- a/docs/extraction/validation/support_ticket_provider_package_scale_cap_2026-05-24.md
+++ b/docs/extraction/validation/support_ticket_provider_package_scale_cap_2026-05-24.md
@@ -1,0 +1,116 @@
+# Support-Ticket Provider Package Scale Cap Validation - 2026-05-24
+
+## Summary
+
+This validation proves the support-ticket input package keeps generation inputs
+bounded before any DB write or LLM call. A 1,000-row source file packages all
+rows. A 10,000-row source file keeps the original count visible, includes the
+first 1,000 rows in `source_material`, and reports the remaining 9,000 rows as
+truncated.
+
+Ownership lane: `content-ops/support-ticket-input-provider`
+
+## Source Artifacts
+
+The run used existing ignored local CFPB-derived support-ticket-shaped JSONL
+artifacts:
+
+- `/home/juan-canfield/Desktop/Atlas/tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl`
+- `/home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`
+
+These artifacts were previously used by the FAQ scale validation trail. They
+are not committed because they are large local validation inputs.
+
+## Command
+
+```bash
+/usr/bin/time -v python - <<'PY'
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from time import perf_counter
+
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
+
+paths = [
+    Path('/home/juan-canfield/Desktop/Atlas/tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl'),
+    Path('/home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl'),
+]
+results = []
+for path in paths:
+    rows = [
+        json.loads(line)
+        for line in path.read_text(encoding='utf-8').splitlines()
+        if line.strip()
+    ]
+    started = perf_counter()
+    package = build_support_ticket_input_package(rows)
+    elapsed = perf_counter() - started
+    inputs = package.inputs
+    results.append({
+        'path': str(path),
+        'loaded_rows': len(rows),
+        'source_row_count': inputs['source_row_count'],
+        'included_ticket_row_count': inputs['included_ticket_row_count'],
+        'skipped_ticket_row_count': inputs['skipped_ticket_row_count'],
+        'truncated_ticket_row_count': inputs['truncated_ticket_row_count'],
+        'source_material_count': len(inputs['source_material']),
+        'source_period': inputs['source_period'],
+        'has_window_filter': 'faq_window_days' in inputs,
+        'question_like_ticket_count': inputs['question_like_ticket_count'],
+        'top_ticket_clusters': inputs['top_ticket_clusters'][:3],
+        'customer_wording_example_count': len(inputs['customer_wording_examples']),
+        'warning_count': len(package.warnings),
+        'warnings': list(package.warnings),
+        'elapsed_seconds': round(elapsed, 4),
+    })
+print(json.dumps(results, indent=2, sort_keys=True))
+PY
+```
+
+## Results
+
+| Source rows | Included rows | Truncated rows | Skipped rows | Source period | Package time |
+|---:|---:|---:|---:|---|---:|
+| 1,000 | 1,000 | 0 | 0 | `Uploaded support tickets` | 0.3195s |
+| 10,000 | 1,000 | 9,000 | 0 | `Uploaded support tickets` | 0.3061s |
+
+The 10,000-row run emitted one package warning:
+
+```json
+{
+  "code": "ticket_rows_truncated",
+  "max_rows": 1000,
+  "message": "Used first 1000 ticket rows out of 10000.",
+  "row_count": 10000,
+  "truncated_row_count": 9000
+}
+```
+
+Both runs preserved representative package context:
+
+- `source_material_count`: `1,000`
+- `customer_wording_example_count`: `6`
+- top clusters included `Incorrect information on your report`, `Attempts to
+  collect debt not owed`, and `Problem with a credit reporting company's
+  investigation into an existing problem`
+
+Resource use for the combined 1,000-row and 10,000-row package validation:
+
+- elapsed wall time: `0:00.78`
+- maximum resident set size: `93,312 KB`
+- exit status: `0`
+
+## Interpretation
+
+The provider package is bounded before generation. Oversized source exports keep
+their original row count visible for diagnostics, but only 1,000 rows enter
+`source_material` by default. That protects landing-page and blog prompt inputs
+from accidentally consuming 10,000+ support tickets in one generation request.
+
+The customer-facing question remains product policy: hosted upload/intake should
+decide whether to show the truncation warning to users, lower the synchronous
+limit, or route larger files into a background job path.

--- a/plans/PR-Support-Ticket-Provider-Package-Scale-Cap.md
+++ b/plans/PR-Support-Ticket-Provider-Package-Scale-Cap.md
@@ -1,0 +1,89 @@
+# PR-Support-Ticket-Provider-Package-Scale-Cap
+
+## Why this slice exists
+
+The support-ticket provider can feed landing-page and blog generation, and the
+next production risk is row volume before model calls. The provider package has
+a `max_rows` cap, but we need a concrete regression test and validation record
+showing that larger support-ticket-shaped exports are counted honestly and
+truncated before they reach generation inputs.
+
+This slice is independent of the package-smoke CLI PR. It uses the existing
+`build_support_ticket_input_package(...)` path directly so it can ship without
+stacking on #934.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Robust testing
+
+1. Add regression coverage proving the package default accepts at most 1,000
+   rows into `source_material`.
+2. Assert oversized input reports original source count, included count,
+   skipped count, truncated count, and warning metadata consistently.
+3. Run direct package validation against the existing local CFPB-derived 1,000
+   and 10,000 row support-ticket-shaped artifacts.
+4. Record the validation command, counts, timing, and memory in the extraction
+   validation trail.
+
+### Files touched
+
+- `tests/test_extracted_support_ticket_input_package.py`
+- `docs/extraction/validation/support_ticket_provider_package_scale_cap_2026-05-24.md`
+- `plans/PR-Support-Ticket-Provider-Package-Scale-Cap.md`
+
+## Mechanism
+
+The package builder already accepts loaded rows and enforces `max_rows` before
+normalization. The new test builds 1,005 valid ticket rows without passing a
+custom limit, then verifies:
+
+- `source_row_count == 1005`
+- `included_ticket_row_count == 1000`
+- `truncated_ticket_row_count == 5`
+- `source_material` contains exactly 1,000 rows
+- the truncation warning carries the same count fields
+
+The validation run uses the local CFPB-derived JSONL files already used by the
+FAQ scale proofs, but only calls the package builder. No FAQ generation, DB, or
+LLM path is exercised here.
+
+## Intentional
+
+- No dependency on the package-smoke CLI PR, because #934 is still under review.
+- No checked-in source artifact. The 1,000/10,000 row files are existing ignored
+  local validation artifacts, and the committed doc records the command and
+  results.
+- No change to the default cap in this slice. This proves the current default
+  behavior before we decide whether hosted uploads need a lower user-facing
+  limit or a background job path.
+
+## Deferred
+
+- Future PR: when #934 lands, rerun the same real-file validation through the
+  package-smoke CLI and compare the summary output.
+- Future PR: hosted upload/intake can surface the truncation warning to users
+  instead of only keeping it in package warnings.
+- Parked hardening: none.
+
+## Verification
+
+- Direct package validation against local 1,000-row and 10,000-row CFPB-derived
+  support-ticket-shaped JSONL files - passed; 10,000 rows truncated to 1,000
+  included rows with 9,000 reported truncations.
+- python -m py_compile for `tests/test_extracted_support_ticket_input_package.py` - passed.
+- pytest for `tests/test_extracted_support_ticket_input_package.py` - 18 passed.
+- validate_extracted_content_pipeline.sh - passed.
+- forbid_atlas_reasoning_imports.py for `extracted_content_pipeline` - passed.
+- audit_extracted_standalone.py with fail-on-debt - passed.
+- check_ascii_python.sh - passed.
+- run_extracted_pipeline_checks.sh - 1952 passed, 1 skipped.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Validation doc | ~100 |
+| Test | ~35 |
+| **Total** | **~215** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -377,6 +377,36 @@ def test_support_ticket_input_package_reconciles_truncated_valid_row_counts() ->
     )
 
 
+def test_support_ticket_input_package_caps_default_generation_rows_at_1000() -> None:
+    package = build_support_ticket_input_package([
+        {
+            "ticket_id": f"ticket-{index}",
+            "description": f"How do I fix issue {index}?",
+            "pain_category": "setup friction",
+        }
+        for index in range(1, 1006)
+    ])
+
+    assert package.inputs["source_row_count"] == 1005
+    assert package.inputs["included_ticket_row_count"] == 1000
+    assert package.inputs["skipped_ticket_row_count"] == 0
+    assert package.inputs["truncated_ticket_row_count"] == 5
+    assert len(package.inputs["source_material"]) == 1000
+    assert package.metadata["source_row_count"] == 1005
+    assert package.metadata["included_row_count"] == 1000
+    assert package.metadata["skipped_row_count"] == 0
+    assert package.metadata["truncated_row_count"] == 5
+    assert package.warnings == (
+        {
+            "code": "ticket_rows_truncated",
+            "message": "Used first 1000 ticket rows out of 1005.",
+            "row_count": 1005,
+            "max_rows": 1000,
+            "truncated_row_count": 5,
+        },
+    )
+
+
 def test_support_ticket_input_package_reports_non_mapping_rows() -> None:
     package = build_support_ticket_input_package([
         "bare string",


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Package-Scale-Cap.md
Slice phase: Robust testing

Adds a direct package-level scale proof for the support-ticket provider: the default package path keeps generation inputs capped at 1,000 rows while preserving honest source counts and truncation warnings for larger exports.

## Intentional
- No dependency on the package-smoke CLI PR; this uses `build_support_ticket_input_package` directly so it is not stacked on #934.
- No DB, LLM, FAQ generation, or hosted upload path in this slice.
- No checked-in large source artifacts; the validation doc records commands and metrics from existing ignored local CFPB-derived JSONL files.

## Deferred
- Rerun the same real-file validation through the package-smoke CLI after #934 lands.
- Hosted upload/intake can surface truncation warnings to users in a future route/UI PR.

## Parked hardening
- None.

## Verification
- Direct package validation against local 1,000-row and 10,000-row CFPB-derived support-ticket-shaped JSONL files - passed; 10,000 rows truncated to 1,000 included rows with 9,000 reported truncations.
- `python -m py_compile tests/test_extracted_support_ticket_input_package.py` - passed
- `pytest -q tests/test_extracted_support_ticket_input_package.py` - 18 passed
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
- `bash scripts/check_ascii_python.sh` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - 1952 passed, 1 skipped
- `bash scripts/local_pr_review.sh` - passed

## Diff size
3 files, +235 / -0
