### PR TITLE
Validate support ticket package CLI at scale

### DIFF
--- a/docs/extraction/validation/support_ticket_package_cli_scale_validation_2026-05-24.md
+++ b/docs/extraction/validation/support_ticket_package_cli_scale_validation_2026-05-24.md
@@ -1,0 +1,89 @@
+# Support-Ticket Package CLI Scale Validation - 2026-05-24
+
+## Summary
+
+This validation reruns the support-ticket package scale proof through the
+operator-facing package-smoke CLI merged in #934. It confirms the CLI reports the
+same bounded package behavior as the direct package proof from #935:
+
+- 1,000 source rows package fully.
+- 10,000 source rows keep the honest total count visible, include 1,000 rows in
+  generation inputs, and report 9,000 truncated rows.
+
+Ownership lane: `content-ops/support-ticket-input-provider`
+
+## Source Artifacts
+
+The run used existing ignored local CFPB-derived support-ticket-shaped JSONL
+artifacts:
+
+- `/home/juan-canfield/Desktop/Atlas/tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl`
+- `/home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl`
+
+CLI JSON summaries were written under ignored local `tmp/`:
+
+- `tmp/support_ticket_package_cli_scale_20260524/cfpb_1000_package_summary.json`
+- `tmp/support_ticket_package_cli_scale_20260524/cfpb_10000_package_summary.json`
+
+The source and summary artifacts are not committed because they are local
+validation artifacts. The commands and observed metrics are recorded below.
+
+## Commands
+
+```bash
+mkdir -p tmp/support_ticket_package_cli_scale_20260524
+
+/usr/bin/time -v python scripts/smoke_content_ops_support_ticket_package.py \
+  /home/juan-canfield/Desktop/Atlas/tmp/content_ops_faq_1000/cfpb_1000_source_rows.jsonl \
+  --pretty \
+  --require-included-rows \
+  > tmp/support_ticket_package_cli_scale_20260524/cfpb_1000_package_summary.json
+
+/usr/bin/time -v python scripts/smoke_content_ops_support_ticket_package.py \
+  /home/juan-canfield/Desktop/Atlas/tmp/faq_scale_stress_20260523/cfpb_10000_source_rows.jsonl \
+  --pretty \
+  --require-included-rows \
+  > tmp/support_ticket_package_cli_scale_20260524/cfpb_10000_package_summary.json
+```
+
+## Results
+
+| Source file | Source rows | Included rows | Truncated rows | Skipped rows | Warnings | Wall time | Max RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `cfpb_1000_source_rows.jsonl` | 1,000 | 1,000 | 0 | 0 | 0 | 0:00.36 | 22,728 KB |
+| `cfpb_10000_source_rows.jsonl` | 10,000 | 1,000 | 9,000 | 0 | 1 | 0:00.48 | 87,972 KB |
+
+Both runs reported:
+
+- `source_period`: `Uploaded support tickets`
+- `has_window_filter`: `false`
+- `question_like_ticket_count`: `58`
+- `customer_wording_example_count`: `6`
+- top clusters:
+  - `Incorrect information on your report` (`258`)
+  - `Attempts to collect debt not owed` (`133`)
+  - `Problem with a credit reporting company's investigation into an existing problem` (`130`)
+
+The 10,000-row CLI summary emitted the expected truncation warning:
+
+```json
+{
+  "code": "ticket_rows_truncated",
+  "max_rows": 1000,
+  "message": "Used first 1000 ticket rows out of 10000.",
+  "row_count": 10000,
+  "truncated_row_count": 9000
+}
+```
+
+## Interpretation
+
+The shipped package-smoke CLI is suitable as a cheap pre-LLM validation step for
+large support-ticket exports. It catches and reports the same bounded package
+behavior as the direct package path: operators can see the original source row
+count and truncation warning before spending model calls, while generation
+inputs remain capped at 1,000 rows by default.
+
+This does not replace hosted upload policy. The hosted intake path still needs a
+product decision on whether to show truncation warnings to users, reject larger
+files, or move oversized work into a background job.

--- a/plans/PR-Support-Ticket-Package-CLI-Scale-Validation.md
+++ b/plans/PR-Support-Ticket-Package-CLI-Scale-Validation.md
@@ -1,0 +1,79 @@
+# PR-Support-Ticket-Package-CLI-Scale-Validation
+
+## Why this slice exists
+
+PR-Support-Ticket-Provider-Package-Scale-Cap proved the package cap with a
+direct inline Python call and explicitly deferred rerunning the same real-file
+validation through the package-smoke CLI once #934 landed. #934 is now merged,
+so this slice closes that deferred proof with the shipped operator-facing smoke
+command.
+
+This stays in the support-ticket provider lane. It does not change package
+logic, hosted upload behavior, FAQ generation, database code, or LLM routing.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Robust testing
+
+1. Run `scripts/smoke_content_ops_support_ticket_package.py` against the existing
+   local CFPB-derived 1,000-row and 10,000-row support-ticket-shaped artifacts.
+2. Verify the CLI summary matches the direct package proof: 1,000 rows package
+   fully, 10,000 rows retain honest total counts while truncating generation
+   inputs to 1,000 rows.
+3. Record commands, summary counts, truncation warning, timing, and memory in
+   the extraction validation trail.
+
+### Files touched
+
+- `docs/extraction/validation/support_ticket_package_cli_scale_validation_2026-05-24.md`
+- `plans/PR-Support-Ticket-Package-CLI-Scale-Validation.md`
+
+## Mechanism
+
+The validation uses the CLI merged in #934:
+
+```bash
+python scripts/smoke_content_ops_support_ticket_package.py <source.jsonl> \
+  --pretty \
+  --require-included-rows
+```
+
+`--require-included-rows` proves the file did not merely load; at least one
+usable support-ticket row survived packaging. The committed doc records the
+result summaries instead of committing large ignored JSONL source artifacts or
+generated summary files.
+
+## Intentional
+
+- No code changes. This is a robust-testing proof of the shipped CLI.
+- No checked-in 1,000/10,000 row source or output artifacts. They remain ignored
+  local validation inputs/outputs; the committed doc records the reproducible
+  command and observed result.
+- No hosted route assertion. Hosted upload/intake behavior remains a separate
+  owner lane.
+
+## Deferred
+
+- Future PR: hosted upload/intake can surface the package CLI's truncation
+  summary to users or operators.
+- Future PR: choose product policy for customer-visible handling of files above
+  the synchronous 1,000-row package cap.
+- Parked hardening: none.
+
+## Verification
+
+- CLI package smoke for the 1,000-row local CFPB-derived JSONL file - passed;
+  1,000 included rows, 0 truncated rows, 0 warnings.
+- CLI package smoke for the 10,000-row local CFPB-derived JSONL file - passed;
+  1,000 included rows, 9,000 truncated rows, 1 truncation warning.
+- git diff whitespace check - passed.
+- local PR review - passed after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Validation doc | ~105 |
+| **Total** | **~180** |


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Package-CLI-Scale-Validation.md
Slice phase: Robust testing

Closes the #935 deferred follow-up by rerunning the 1,000-row and 10,000-row support-ticket package scale proof through the #934 package-smoke CLI. The CLI reports the same bounded behavior as the direct package path: 1,000 rows package fully, while 10,000 rows report 10,000 source rows, 1,000 included rows, and 9,000 truncated rows.

## Intentional
- No code changes; this is a robust-testing proof of the shipped CLI.
- No checked-in large source or output artifacts; commands and metrics are recorded in the validation doc.
- No hosted route assertion; hosted upload/intake remains a separate owner lane.

## Deferred
- Hosted upload/intake can surface the package CLI truncation summary to users or operators later.
- Product policy for files above the synchronous 1,000-row package cap remains future work.

## Parked hardening
- None.

## Verification
- CLI package smoke for the 1,000-row local CFPB-derived JSONL file - passed; 1,000 included rows, 0 truncated rows, 0 warnings.
- CLI package smoke for the 10,000-row local CFPB-derived JSONL file - passed; 1,000 included rows, 9,000 truncated rows, 1 truncation warning.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh` - passed.

## Diff size
2 files, +168 / -0
