### PR TITLE
Surface input provider warnings in Content Ops API

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -581,7 +581,10 @@ def create_content_ops_control_surface_router(
             input_provider=input_provider,
             scope_provider=scope_provider,
         )
-        return preview_from_mapping(payload_mapping)
+        return _with_input_provider_diagnostics(
+            preview_from_mapping(payload_mapping),
+            payload_mapping,
+        )
 
     @router.post("/plan")
     async def plan_generation(
@@ -593,7 +596,10 @@ def create_content_ops_control_surface_router(
                 input_provider=input_provider,
                 scope_provider=scope_provider,
             )
-            return build_generation_plan_from_mapping(payload_mapping)
+            return _with_input_provider_diagnostics(
+                build_generation_plan_from_mapping(payload_mapping),
+                payload_mapping,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -807,6 +813,7 @@ def create_content_ops_control_surface_router(
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             result = _sanitize_execution_result(result)
+            result = _with_input_provider_diagnostics(result, payload_mapping)
             if result["status"] == "blocked":
                 raise HTTPException(status_code=400, detail=result)
             if result["status"] == "failed":
@@ -1027,6 +1034,26 @@ async def _payload_with_input_provider(
             status_code=503,
             detail="Content Ops input provider is unavailable.",
         ) from exc
+
+
+def _with_input_provider_diagnostics(
+    response: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    diagnostics = payload.get("input_provider")
+    if not isinstance(diagnostics, Mapping):
+        return dict(response)
+    out = dict(response)
+    out["input_provider"] = {
+        "provider": _clean(diagnostics.get("provider")),
+        "metadata": dict(diagnostics.get("metadata") or {}),
+        "warnings": [
+            dict(warning)
+            for warning in diagnostics.get("warnings") or ()
+            if isinstance(warning, Mapping)
+        ],
+    }
+    return out
 
 
 async def _structured_reasoning_contexts(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -103,6 +103,14 @@ _UPLOAD_FILE_FORMATS = ("auto", "json", "jsonl", "csv")
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
 _SAFE_EXECUTION_REASONS = {"plan_not_executable", "service_not_configured"}
+_INPUT_PROVIDER_RESPONSE_METADATA_KEYS = frozenset({
+    "source",
+    "source_period",
+    "source_row_count",
+    "included_row_count",
+    "skipped_row_count",
+    "truncated_row_count",
+})
 _SOURCE_MATERIAL_ROW_LIST_KEYS = {
     "sources",
     "opportunities",
@@ -1046,7 +1054,7 @@ def _with_input_provider_diagnostics(
     out = dict(response)
     out["input_provider"] = {
         "provider": _clean(diagnostics.get("provider")),
-        "metadata": dict(diagnostics.get("metadata") or {}),
+        "metadata": _input_provider_response_metadata(diagnostics.get("metadata")),
         "warnings": [
             dict(warning)
             for warning in diagnostics.get("warnings") or ()
@@ -1054,6 +1062,16 @@ def _with_input_provider_diagnostics(
         ],
     }
     return out
+
+
+def _input_provider_response_metadata(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        key: value[key]
+        for key in sorted(_INPUT_PROVIDER_RESPONSE_METADATA_KEYS)
+        if key in value
+    }
 
 
 async def _structured_reasoning_contexts(

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1051,17 +1051,32 @@ def _with_input_provider_diagnostics(
     diagnostics = payload.get("input_provider")
     if not isinstance(diagnostics, Mapping):
         return dict(response)
+    warnings = [
+        dict(warning)
+        for warning in diagnostics.get("warnings") or ()
+        if isinstance(warning, Mapping)
+    ]
+    if _is_noop_input_provider_diagnostics(diagnostics, warnings):
+        return dict(response)
     out = dict(response)
     out["input_provider"] = {
         "provider": _clean(diagnostics.get("provider")),
         "metadata": _input_provider_response_metadata(diagnostics.get("metadata")),
-        "warnings": [
-            dict(warning)
-            for warning in diagnostics.get("warnings") or ()
-            if isinstance(warning, Mapping)
-        ],
+        "warnings": warnings,
     }
     return out
+
+
+def _is_noop_input_provider_diagnostics(
+    diagnostics: Mapping[str, Any],
+    warnings: Sequence[Mapping[str, Any]],
+) -> bool:
+    metadata = diagnostics.get("metadata")
+    return (
+        not warnings
+        and isinstance(metadata, Mapping)
+        and _clean(metadata.get("mode")) == "noop"
+    )
 
 
 def _input_provider_response_metadata(value: Any) -> dict[str, Any]:

--- a/extracted_content_pipeline/content_ops_input_provider.py
+++ b/extracted_content_pipeline/content_ops_input_provider.py
@@ -90,6 +90,7 @@ def content_ops_payload_from_input_package(
         "outputs": [str(output) for output in normalized_package.outputs],
         "inputs": dict(normalized_package.inputs),
         "ingestion_profile": normalized_package.ingestion_profile,
+        "input_provider": _package_diagnostics(normalized_package),
     }
     for key, value in base.items():
         if value is None:
@@ -175,6 +176,14 @@ def _warning_sequence(value: Any) -> tuple[JsonDict, ...]:
             raise TypeError("content ops input package warnings must contain mappings")
         warnings.append({str(key): warning_value for key, warning_value in item.items()})
     return tuple(warnings)
+
+
+def _package_diagnostics(package: ContentOpsInputPackage) -> JsonDict:
+    return {
+        "provider": package.provider,
+        "metadata": dict(package.metadata),
+        "warnings": [dict(warning) for warning in package.warnings],
+    }
 
 
 def _string_tuple(value: Any) -> tuple[str, ...]:

--- a/plans/PR-Support-Ticket-Provider-Warning-Surface.md
+++ b/plans/PR-Support-Ticket-Provider-Warning-Surface.md
@@ -56,6 +56,9 @@ execute completes.
 
 - No warning text is folded into `inputs`; generators should not consume
   operational warnings as content context.
+- API responses only expose the provider name, warnings, and allowlisted
+  operational metadata fields. Host-injected metadata remains available inside
+  the package but is not echoed wholesale to callers.
 - No hosted upload UI changes. This only makes the diagnostic available to the
   API response layer.
 - No blocking behavior for truncation warnings. The existing package cap stays

--- a/plans/PR-Support-Ticket-Provider-Warning-Surface.md
+++ b/plans/PR-Support-Ticket-Provider-Warning-Surface.md
@@ -1,0 +1,100 @@
+# PR-Support-Ticket-Provider-Warning-Surface
+
+## Why this slice exists
+
+The support-ticket package now reports skipped and truncated rows, and the
+package-smoke CLI exposes those warnings. The normal Content Ops API path still
+drops `ContentOpsInputPackage.warnings` when it merges provider inputs into a
+request payload, so preview/plan/execute callers cannot see that an uploaded
+ticket export was truncated before generation.
+
+This slice surfaces provider diagnostics without changing generation behavior.
+It keeps the package warnings available to host/UI layers while preserving the
+existing request contract for generators.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Production hardening
+
+1. Preserve input-provider diagnostics when converting a
+   `ContentOpsInputPackage` into a request payload.
+2. Include provider diagnostics in preview, plan, and execute API responses when
+   an input provider is configured.
+3. Add focused tests proving provider warnings/metadata survive the package
+   merge and both preflight and execute routes.
+
+### Files touched
+
+- `extracted_content_pipeline/content_ops_input_provider.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_ops_input_provider.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `plans/PR-Support-Ticket-Provider-Warning-Surface.md`
+
+## Mechanism
+
+`content_ops_payload_from_input_package(...)` will attach an `input_provider`
+diagnostic object alongside the existing request keys:
+
+```json
+{
+  "input_provider": {
+    "provider": "support_ticket_upload",
+    "metadata": {},
+    "warnings": []
+  }
+}
+```
+
+`request_from_mapping(...)` already ignores unknown top-level keys, so generation
+services continue to receive the same normalized request. The API routes can
+copy this diagnostic object onto their response payloads after preview/plan or
+execute completes.
+
+## Intentional
+
+- No warning text is folded into `inputs`; generators should not consume
+  operational warnings as content context.
+- No hosted upload UI changes. This only makes the diagnostic available to the
+  API response layer.
+- No blocking behavior for truncation warnings. The existing package cap stays
+  non-fatal; product policy can decide later whether to reject, warn, or queue
+  oversized uploads.
+- Cross-layer caller hints flag the router factory and payload merge helper
+  because they are shared. This slice adds focused preview/plan/execute route
+  assertions and ran the full extracted suite; existing callers that ignore the
+  optional `input_provider` response field remain compatible.
+
+## Deferred
+
+- Future PR: hosted upload/intake UI can display `input_provider.warnings` to
+  users or operators.
+- Future PR: product policy can decide whether files above the synchronous
+  1,000-row package cap should be rejected or moved to a background job.
+- Parked hardening: none.
+
+## Verification
+
+- python -m py_compile for `extracted_content_pipeline/content_ops_input_provider.py`,
+  `extracted_content_pipeline/api/control_surfaces.py`, and focused tests -
+  passed.
+- pytest for `tests/test_extracted_content_ops_input_provider.py` plus focused
+  preview/plan/execute API tests - 8 passed.
+- validate_extracted_content_pipeline.sh - passed.
+- forbid_atlas_reasoning_imports.py for `extracted_content_pipeline` - passed.
+- audit_extracted_standalone.py with fail-on-debt - passed.
+- check_ascii_python.sh - passed.
+- sync_extracted.sh for `extracted_content_pipeline` - passed.
+- run_extracted_pipeline_checks.sh - 1959 passed, 1 skipped.
+- local PR review - passed; caller-hint warning reviewed and covered by focused
+  route tests plus the full extracted suite.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| Payload/API code | ~45 |
+| Tests | ~85 |
+| **Total** | **~210** |

--- a/plans/PR-Support-Ticket-Provider-Warning-Surface.md
+++ b/plans/PR-Support-Ticket-Provider-Warning-Surface.md
@@ -59,6 +59,8 @@ execute completes.
 - API responses only expose the provider name, warnings, and allowlisted
   operational metadata fields. Host-injected metadata remains available inside
   the package but is not echoed wholesale to callers.
+- No-op provider packages stay hidden so Atlas' globally mounted request-aware
+  provider does not add noisy diagnostics to unrelated Content Ops requests.
 - No hosted upload UI changes. This only makes the diagnostic available to the
   API response layer.
 - No blocking behavior for truncation warnings. The existing package cap stays
@@ -83,7 +85,7 @@ execute completes.
   `extracted_content_pipeline/api/control_surfaces.py`, and focused tests -
   passed.
 - pytest for `tests/test_extracted_content_ops_input_provider.py` plus focused
-  preview/plan/execute API tests - 8 passed.
+  preview/plan/execute API tests - passed.
 - validate_extracted_content_pipeline.sh - passed.
 - forbid_atlas_reasoning_imports.py for `extracted_content_pipeline` - passed.
 - audit_extracted_standalone.py with fail-on-debt - passed.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -704,6 +704,11 @@ async def test_preview_generation_route_applies_sync_input_provider():
                 "audience": "10-50 person SaaS teams",
                 "offer": "Provider offer",
             },
+            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            warnings=({
+                "code": "ticket_rows_truncated",
+                "message": "Used first 1000 ticket rows out of 10000.",
+            },),
         )
     )
     router = create_content_ops_control_surface_router(
@@ -722,6 +727,14 @@ async def test_preview_generation_route_applies_sync_input_provider():
     assert payload["can_run"] is True
     assert payload["outputs"] == ["landing_page"]
     assert payload["missing_inputs"] == []
+    assert payload["input_provider"] == {
+        "provider": "ticket_upload",
+        "metadata": {"source_row_count": 10000, "included_row_count": 1000},
+        "warnings": [{
+            "code": "ticket_rows_truncated",
+            "message": "Used first 1000 ticket rows out of 10000.",
+        }],
+    }
     assert provider.calls[0]["scope"].account_id == "acct-1"
     assert provider.calls[0]["request"]["inputs"]["offer"] == "Operator offer"
 
@@ -739,6 +752,11 @@ async def test_plan_generation_route_applies_async_input_provider():
                     "text": "How do I export my dashboard?",
                 }],
             },
+            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            warnings=({
+                "code": "ticket_rows_truncated",
+                "message": "Used first 1000 ticket rows out of 10000.",
+            },),
         )
     )
     router = create_content_ops_control_surface_router(
@@ -752,6 +770,14 @@ async def test_plan_generation_route_applies_async_input_provider():
     assert payload["can_execute"] is True
     assert payload["steps"][0]["output"] == "faq_markdown"
     assert payload["steps"][0]["runner"] == "TicketFAQMarkdownService.generate"
+    assert payload["input_provider"] == {
+        "provider": "ticket_upload",
+        "metadata": {"source_row_count": 10000, "included_row_count": 1000},
+        "warnings": [{
+            "code": "ticket_rows_truncated",
+            "message": "Used first 1000 ticket rows out of 10000.",
+        }],
+    }
     assert provider.calls[0]["scope"].account_id is None
 
 
@@ -1608,6 +1634,11 @@ async def test_execute_generation_route_applies_input_provider_before_generation
                 "offer": "Provider offer",
                 "filters": {"status": "provider"},
             },
+            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            warnings=({
+                "code": "ticket_rows_truncated",
+                "message": "Used first 1000 ticket rows out of 10000.",
+            },),
         )
     )
     router = create_content_ops_control_surface_router(
@@ -1631,6 +1662,14 @@ async def test_execute_generation_route_applies_input_provider_before_generation
     assert service.calls[0]["filters"] == {"status": "operator"}
     assert service.calls[0]["target_mode"] == "vendor_retention"
     assert service.calls[0]["limit"] == 1
+    assert payload["input_provider"] == {
+        "provider": "ticket_upload",
+        "metadata": {"source_row_count": 10000, "included_row_count": 1000},
+        "warnings": [{
+            "code": "ticket_rows_truncated",
+            "message": "Used first 1000 ticket rows out of 10000.",
+        }],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -697,6 +697,40 @@ async def test_plan_generation_route_returns_execution_plan():
 
 
 @pytest.mark.asyncio
+async def test_preview_generation_route_hides_noop_input_provider_diagnostics():
+    provider = _SyncInputProvider(
+        ContentOpsInputPackage(
+            provider="atlas_support_ticket_request",
+            inputs={},
+            outputs=(),
+            target_mode="",
+            ingestion_profile="",
+            metadata={
+                "source": "atlas_content_ops_input_provider",
+                "mode": "noop",
+            },
+        )
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        input_provider=provider,
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint({
+        "outputs": ["email_campaign"],
+        "inputs": {
+            "target_account": "Acme",
+            "offer": "Churn audit",
+        },
+    })
+
+    assert payload["can_run"] is True
+    assert payload["outputs"] == ["email_campaign"]
+    assert "input_provider" not in payload
+
+
+@pytest.mark.asyncio
 async def test_preview_generation_route_applies_sync_input_provider():
     provider = _SyncInputProvider(
         ContentOpsInputPackage(

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -645,6 +645,7 @@ async def test_preview_generation_route_returns_preflight_plan():
     assert payload["outputs"] == ["email_campaign"]
     assert payload["estimated_cost_usd"] == 0.36
     assert payload["missing_inputs"] == []
+    assert "input_provider" not in payload
 
 
 @pytest.mark.asyncio
@@ -692,6 +693,7 @@ async def test_plan_generation_route_returns_execution_plan():
     assert payload["steps"][0]["runner"] == "CampaignGenerationService.generate"
     assert payload["steps"][0]["status"] == "runnable"
     assert payload["preview"]["can_run"] is True
+    assert "input_provider" not in payload
 
 
 @pytest.mark.asyncio
@@ -704,7 +706,11 @@ async def test_preview_generation_route_applies_sync_input_provider():
                 "audience": "10-50 person SaaS teams",
                 "offer": "Provider offer",
             },
-            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            metadata={
+                "source_row_count": 10000,
+                "included_row_count": 1000,
+                "internal_request_id": "req-secret",
+            },
             warnings=({
                 "code": "ticket_rows_truncated",
                 "message": "Used first 1000 ticket rows out of 10000.",
@@ -752,7 +758,11 @@ async def test_plan_generation_route_applies_async_input_provider():
                     "text": "How do I export my dashboard?",
                 }],
             },
-            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            metadata={
+                "source_row_count": 10000,
+                "included_row_count": 1000,
+                "internal_request_id": "req-secret",
+            },
             warnings=({
                 "code": "ticket_rows_truncated",
                 "message": "Used first 1000 ticket rows out of 10000.",
@@ -1620,6 +1630,7 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["target_mode"] == "vendor_retention"
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
+    assert "input_provider" not in payload
 
 
 @pytest.mark.asyncio
@@ -1634,7 +1645,11 @@ async def test_execute_generation_route_applies_input_provider_before_generation
                 "offer": "Provider offer",
                 "filters": {"status": "provider"},
             },
-            metadata={"source_row_count": 10000, "included_row_count": 1000},
+            metadata={
+                "source_row_count": 10000,
+                "included_row_count": 1000,
+                "internal_request_id": "req-secret",
+            },
             warnings=({
                 "code": "ticket_rows_truncated",
                 "message": "Used first 1000 ticket rows out of 10000.",

--- a/tests/test_extracted_content_ops_input_provider.py
+++ b/tests/test_extracted_content_ops_input_provider.py
@@ -65,6 +65,11 @@ def test_input_package_builds_existing_content_ops_request_payload() -> None:
     assert request.inputs["source_material"] == _source_material()
     assert request.inputs["topic"] == "Support ticket FAQ gaps customers keep asking about"
     assert request.inputs["offer"] == "Turn repeat support tickets into customer-ready FAQ answers"
+    assert payload["input_provider"] == {
+        "provider": "support_ticket_csv",
+        "metadata": {"source": "upload"},
+        "warnings": [{"code": "sampled_rows", "message": "Using first 1,000 rows."}],
+    }
 
 
 def test_merge_input_package_keeps_explicit_request_inputs_authoritative() -> None:
@@ -97,6 +102,11 @@ def test_merge_input_package_keeps_explicit_request_inputs_authoritative() -> No
     assert payload["outputs"] == ["landing_page"]
     assert payload["target_mode"] == "custom_target"
     assert payload["ingestion_profile"] == "manual"
+    assert payload["input_provider"] == {
+        "provider": "ticket_import",
+        "metadata": {},
+        "warnings": [],
+    }
     assert request.inputs["source_material"] == _source_material()
     assert request.inputs["audience"] == "Provider audience"
     assert request.inputs["offer"] == "Operator offer"


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Warning-Surface.md
Slice phase: Production hardening

Preserves `ContentOpsInputPackage` diagnostics on merged payloads and copies them into preview, plan, and execute API responses. This makes support-ticket truncation warnings visible to host/UI callers without changing generation inputs or blocking behavior.

## Intentional
- Warnings are not folded into `inputs`; generators should not consume operational diagnostics as content context.
- No hosted upload UI changes and no blocking behavior for truncation warnings.
- Cross-layer caller hints flag shared router/payload helpers; focused preview/plan/execute route tests plus the full extracted suite cover the affected response path, and callers that ignore the optional `input_provider` field remain compatible.

## Deferred
- Hosted upload/intake UI can display `input_provider.warnings` to users or operators later.
- Product policy for files above the synchronous 1,000-row package cap remains future work.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/content_ops_input_provider.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_control_surface_api.py` - passed
- `pytest -q tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_applies_sync_input_provider tests/test_extracted_content_control_surface_api.py::test_plan_generation_route_applies_async_input_provider tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_applies_input_provider_before_generation` - 8 passed
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
- `bash scripts/check_ascii_python.sh` - passed
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - 1959 passed, 1 skipped
- `bash scripts/local_pr_review.sh` - passed; caller-hint warning reviewed and covered

## Diff size
5 files, +187 / -2
