### PR TITLE
Prove support ticket provider warnings in preview

### DIFF
--- a/plans/PR-Atlas-Support-Ticket-Provider-Warning-Route-Proof.md
+++ b/plans/PR-Atlas-Support-Ticket-Provider-Warning-Route-Proof.md
@@ -1,0 +1,72 @@
+# PR: Support Ticket Provider Warning Route Proof
+
+## Why this slice exists
+
+PR #938 made input-provider diagnostics visible on Content Ops API responses.
+The lower-level route tests used synthetic provider packages. The remaining
+integration gap is proving a real `SupportTicketInputProvider` package emits
+the support-ticket truncation warning through the preview route, while the
+Atlas request-aware inline provider keeps its existing request-size cap.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add a real support-ticket provider preview-route test with 1,005 loaded
+   support-ticket-shaped rows.
+2. Assert the route remains runnable while surfacing the exact truncation
+   warning and operational metadata.
+3. Add a companion Atlas inline-provider test proving inline payloads over the
+   request cap still fail as 422 before provider packaging.
+4. Keep the tests offline: no DB, LLM, file-ingestion, or FAQ generator changes.
+
+### Files touched
+
+- `plans/PR-Atlas-Support-Ticket-Provider-Warning-Route-Proof.md`
+- `tests/test_atlas_content_ops_input_provider.py`
+
+## Mechanism
+
+The first test mounts the extracted Content Ops router with
+`SupportTicketInputProvider(source_material_loader=...)`, returns 1,005 loaded
+rows, and asserts the response includes
+`input_provider.warnings[0].code == "ticket_rows_truncated"` plus the
+allowlisted source-row counts.
+
+The companion Atlas-provider test sends the same row count inline and asserts
+the request validator rejects it before provider packaging. That keeps the
+contract honest: large files need a loader/import path to produce truncation
+diagnostics; oversized inline JSON is not accepted.
+
+## Intentional
+
+- No production code changes. This is route proof for already-merged API
+  behavior and request-size policy.
+- No UI changes; PR #939 owns frontend display.
+- No file-ingestion or persisted upload lookup changes. Those remain owned by
+  the host ingestion lane.
+
+## Deferred
+
+- Future PR: hosted upload policy can decide whether large files should be
+  rejected, warned, or queued before generation.
+- Parked hardening: none. `HARDENING.md` was scanned; the current entry is FAQ
+  scale/backpressure work owned by the FAQ generation lane.
+
+## Verification
+
+- Focused route proof tests - 4 passed.
+- Full host provider suite - 13 passed, 1 warning from the environment's
+  deprecated `pynvml` import.
+- Python compile for `tests/test_atlas_content_ops_input_provider.py` - passed.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~60 |
+| Route tests | ~75 |
+| **Total** | **~135** |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -23,6 +23,9 @@ from extracted_content_pipeline.control_surfaces import (
     preview_control_surface,
     request_from_mapping,
 )
+from extracted_content_pipeline.support_ticket_input_provider import (
+    SupportTicketInputProvider,
+)
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
 
 
@@ -364,6 +367,78 @@ async def test_api_preview_route_applies_support_ticket_input_provider() -> None
     assert payload["can_run"] is True
     assert payload["outputs"] == ["faq_markdown", "landing_page", "blog_post"]
     assert payload["missing_inputs"] == []
+
+
+@pytest.mark.asyncio
+async def test_preview_route_surfaces_support_ticket_loader_truncation_warning() -> None:
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "subject": "Billing renewal question",
+            "body": "How do I confirm my renewal invoice before payment?",
+        }
+        for index in range(1005)
+    ]
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=SupportTicketInputProvider(source_material_loader=lambda scope, request: rows),
+        scope_provider=lambda: {"account_id": "acct-truncation-proof"},
+    )
+
+    route = _router_route(router, "/content-ops/preview", "POST")
+    payload = await route.endpoint({
+        "outputs": ["landing_page"],
+    })
+
+    assert payload["can_run"] is True
+    assert payload["outputs"] == ["landing_page"]
+    assert payload["input_provider"] == {
+        "provider": "support_ticket_input_provider",
+        "metadata": {
+            "included_row_count": 1000,
+            "skipped_row_count": 0,
+            "source": "support_ticket_input_package",
+            "source_period": "Uploaded support tickets",
+            "source_row_count": 1005,
+            "truncated_row_count": 5,
+        },
+        "warnings": [{
+            "code": "ticket_rows_truncated",
+            "message": "Used first 1000 ticket rows out of 1005.",
+            "row_count": 1005,
+            "max_rows": 1000,
+            "truncated_row_count": 5,
+        }],
+    }
+
+
+@pytest.mark.asyncio
+async def test_atlas_preview_route_rejects_inline_source_material_over_request_cap() -> None:
+    rows = [
+        {
+            "ticket_id": f"ticket-{index}",
+            "subject": "Billing renewal question",
+            "body": "How do I confirm my renewal invoice before payment?",
+        }
+        for index in range(1005)
+    ]
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=build_content_ops_input_provider(),
+        scope_provider=lambda: {"account_id": "acct-inline-cap-proof"},
+    )
+
+    route = _router_route(router, "/content-ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({
+            "outputs": ["landing_page"],
+            "inputs": {
+                "source_material": rows,
+            },
+        })
+
+    assert exc.value.status_code == 422
+    assert "inputs arrays are too large" in str(exc.value.detail)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# PR: Support Ticket Provider Warning Route Proof

## Why this slice exists

PR #938 made input-provider diagnostics visible on Content Ops API responses.
The lower-level route tests used synthetic provider packages. The remaining
integration gap is proving a real `SupportTicketInputProvider` package emits
the support-ticket truncation warning through the preview route, while the
Atlas request-aware inline provider keeps its existing request-size cap.

## Scope (this PR)

Ownership lane: content-ops/support-ticket-input-provider

Slice phase: Functional validation

1. Add a real support-ticket provider preview-route test with 1,005 loaded
   support-ticket-shaped rows.
2. Assert the route remains runnable while surfacing the exact truncation
   warning and operational metadata.
3. Add a companion Atlas inline-provider test proving inline payloads over the
   request cap still fail as 422 before provider packaging.
4. Keep the tests offline: no DB, LLM, file-ingestion, or FAQ generator changes.

### Files touched

- `plans/PR-Atlas-Support-Ticket-Provider-Warning-Route-Proof.md`
- `tests/test_atlas_content_ops_input_provider.py`

## Mechanism

The first test mounts the extracted Content Ops router with
`SupportTicketInputProvider(source_material_loader=...)`, returns 1,005 loaded
rows, and asserts the response includes
`input_provider.warnings[0].code == "ticket_rows_truncated"` plus the
allowlisted source-row counts.

The companion Atlas-provider test sends the same row count inline and asserts
the request validator rejects it before provider packaging. That keeps the
contract honest: large files need a loader/import path to produce truncation
diagnostics; oversized inline JSON is not accepted.

## Intentional

- No production code changes. This is route proof for already-merged API
  behavior and request-size policy.
- No UI changes; PR #939 owns frontend display.
- No file-ingestion or persisted upload lookup changes. Those remain owned by
  the host ingestion lane.

## Deferred

- Future PR: hosted upload policy can decide whether large files should be
  rejected, warned, or queued before generation.
- Parked hardening: none. `HARDENING.md` was scanned; the current entry is FAQ
  scale/backpressure work owned by the FAQ generation lane.

## Verification

- Focused route proof tests - 4 passed.
- Full host provider suite - 13 passed, 1 warning from the environment's
  deprecated `pynvml` import.
- Python compile for `tests/test_atlas_content_ops_input_provider.py` - passed.
- `git diff --check` - passed.

## Estimated diff size

| Area | Estimated LOC |
|---|---:|
| Plan | ~60 |
| Route tests | ~75 |
| **Total** | **~135** |
