### PR TITLE
Prove support-ticket provider landing/blog stress

### DIFF
--- a/plans/PR-Support-Ticket-Provider-Landing-Blog-Stress.md
+++ b/plans/PR-Support-Ticket-Provider-Landing-Blog-Stress.md
@@ -1,0 +1,79 @@
+# PR-Support-Ticket-Provider-Landing-Blog-Stress
+
+## Why this slice exists
+
+The support-ticket input provider now feeds FAQ Markdown, landing-page, and
+blog-post generation. The happy path and live smoke are covered, but the route
+handoff still needs robust testing for larger host-loaded ticket exports and
+parallel requests before we claim the path can survive real customer files.
+
+This slice stays in the support-ticket provider lane. It does not change FAQ
+generation, hosted upload persistence, or generated content quality.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Robust testing
+
+1. Add offline route-level stress coverage for loader-backed support-ticket
+   source material.
+2. Prove preview/plan/execute keep provider diagnostics accurate for large
+   loaded inputs.
+3. Prove landing-page and blog-post execute calls receive bounded provider-built
+   inputs under concurrent requests.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Provider-Landing-Blog-Stress.md`
+- `tests/test_support_ticket_provider_landing_blog_execute.py`
+
+## Mechanism
+
+The tests use `SupportTicketInputProvider(source_material_loader=...)` instead
+of inline `inputs.source_material`, because inline requests over 1,000 rows are
+already rejected before provider packaging. The loader returns reusable
+support-ticket-shaped rows at 1,000, 10,000, and 50,000 rows. The provider keeps
+only the first 1,000 rows, reports `ticket_rows_truncated` when applicable, and
+the route surfaces bounded diagnostics on preview, plan, and execute responses.
+
+Execute tests use deterministic fake landing-page and blog-post services so the
+stress probe does not call an LLM, database, or external provider.
+
+## Intentional
+
+- No live LLM stress: this tests route/provider/generation handoff, not model
+  throughput or vendor rate limits.
+- No hosted file-upload changes: persisted upload lookup and background-job
+  policy are separate ingestion/host concerns.
+- No FAQ generator changes: FAQ generation is owned by the parallel FAQ
+  session.
+
+## Deferred
+
+- Future PR: hosted upload/background execution policy for large customer files
+  once persisted support-ticket uploads are wired into the provider loader.
+- Future PR: generated content quality evaluation using real support-ticket
+  datasets after route survivability is proven.
+- Parked hardening: none. `HARDENING.md` was scanned; the current FAQ scale
+  entry is owned by the FAQ generation lane and is not required for this
+  support-ticket provider handoff stress slice.
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py -q`
+  - passed, 9 tests.
+- `python -m pytest tests/test_extracted_support_ticket_input_provider.py tests/test_atlas_content_ops_input_provider.py -q`
+  - passed, 24 tests, 1 existing environment warning from `torch`/`pynvml`.
+- `scripts/local_pr_review.sh --allow-dirty`
+  - passed.
+- `scripts/local_pr_review.sh`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Route stress tests | ~215 |
+| **Total** | **~290** |

--- a/tests/test_support_ticket_provider_landing_blog_execute.py
+++ b/tests/test_support_ticket_provider_landing_blog_execute.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import csv
 from pathlib import Path
 from typing import Any, Mapping
@@ -13,6 +14,9 @@ from extracted_content_pipeline.api.control_surfaces import (
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
+from extracted_content_pipeline.support_ticket_input_provider import (
+    SupportTicketInputProvider,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -85,6 +89,27 @@ def _support_ticket_csv_rows() -> list[dict[str, str]]:
         return list(csv.DictReader(handle))
 
 
+def _generated_support_ticket_rows(row_count: int) -> list[dict[str, str]]:
+    return [
+        {
+            "ticket_id": f"ticket-{index}",
+            "source_type": "support_ticket",
+            "subject": (
+                "How do I change my login email?"
+                if index % 2 == 0
+                else "How do I export renewal billing data?"
+            ),
+            "description": (
+                "Customer cannot find the account email setting before launch."
+                if index % 2 == 0
+                else "Customer needs renewal invoice data before finance review."
+            ),
+            "pain_category": "account" if index % 2 == 0 else "billing",
+        }
+        for index in range(row_count)
+    ]
+
+
 def _execute_router(*, service: Any, output: str) -> Any:
     services = (
         ContentOpsExecutionServices(landing_page=service)
@@ -100,6 +125,55 @@ def _execute_router(*, service: Any, output: str) -> Any:
             user_id="user-support-ticket-content",
         ),
     )
+
+
+def _loader_backed_router(
+    *,
+    rows: list[dict[str, str]],
+    services: ContentOpsExecutionServices | None = None,
+    execute_max_concurrency: int = 8,
+) -> Any:
+    return create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            execute_max_concurrency=execute_max_concurrency,
+        ),
+        execution_services_provider=(lambda: services) if services is not None else None,
+        input_provider=SupportTicketInputProvider(
+            source_material_loader=lambda scope, request: rows,
+        ),
+        scope_provider=lambda: TenantScope(
+            account_id="acct-support-ticket-stress",
+            user_id="user-support-ticket-stress",
+        ),
+    )
+
+
+def _assert_provider_counts(
+    payload: Mapping[str, Any],
+    *,
+    source_row_count: int,
+    included_row_count: int,
+) -> None:
+    diagnostics = payload["input_provider"]
+    assert diagnostics["provider"] == "support_ticket_input_provider"
+    assert diagnostics["metadata"]["source_row_count"] == source_row_count
+    assert diagnostics["metadata"]["included_row_count"] == included_row_count
+    assert diagnostics["metadata"]["truncated_row_count"] == max(
+        0,
+        source_row_count - included_row_count,
+    )
+    if source_row_count > included_row_count:
+        assert diagnostics["warnings"] == [
+            {
+                "code": "ticket_rows_truncated",
+                "message": f"Used first {included_row_count} ticket rows out of {source_row_count}.",
+                "row_count": source_row_count,
+                "max_rows": included_row_count,
+                "truncated_row_count": source_row_count - included_row_count,
+            }
+        ]
+    else:
+        assert diagnostics["warnings"] == []
 
 
 @pytest.mark.asyncio
@@ -194,3 +268,142 @@ async def test_support_ticket_provider_feeds_blog_post_execute_inputs() -> None:
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("row_count", [1_000, 10_000, 50_000])
+async def test_loader_backed_support_ticket_provider_surfaces_scale_diagnostics(
+    row_count: int,
+) -> None:
+    rows = _generated_support_ticket_rows(row_count)
+    router = _loader_backed_router(rows=rows)
+
+    preview = await _route(router, "/content-ops/preview", "POST").endpoint({
+        "outputs": ["landing_page"],
+    })
+    plan = await _route(router, "/content-ops/plan", "POST").endpoint({
+        "outputs": ["blog_post"],
+    })
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["landing_page"]
+    _assert_provider_counts(
+        preview,
+        source_row_count=row_count,
+        included_row_count=min(row_count, 1_000),
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["output"] == "blog_post"
+    _assert_provider_counts(
+        plan,
+        source_row_count=row_count,
+        included_row_count=min(row_count, 1_000),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output", ["landing_page", "blog_post"])
+async def test_loader_backed_support_ticket_provider_bounds_large_execute_inputs(
+    output: str,
+) -> None:
+    rows = _generated_support_ticket_rows(50_000)
+    service = (
+        _LandingPageCaptureService()
+        if output == "landing_page"
+        else _BlogPostCaptureService()
+    )
+    services = (
+        ContentOpsExecutionServices(landing_page=service)
+        if output == "landing_page"
+        else ContentOpsExecutionServices(blog_post=service)
+    )
+    router = _loader_backed_router(rows=rows, services=services)
+
+    payload = await _route(router, "/content-ops/execute", "POST").endpoint({
+        "outputs": [output],
+        "require_quality_gates": False,
+    })
+
+    assert payload["status"] == "completed"
+    _assert_provider_counts(
+        payload,
+        source_row_count=50_000,
+        included_row_count=1_000,
+    )
+    assert len(service.calls) == 1
+
+    if output == "landing_page":
+        context = service.calls[0]["campaign"].context
+        assert "source_material" not in context
+        assert context["source_row_count"] == 50_000
+        assert context["included_ticket_row_count"] == 1_000
+        assert context["truncated_ticket_row_count"] == 49_000
+        assert len(context["customer_wording_examples"]) <= 6
+        assert len(context["top_ticket_clusters"]) <= 6
+    else:
+        assert service.calls[0]["filters"] == {
+            "topic_type": "content_ops_support_ticket_faq",
+        }
+        assert service.calls[0]["kwargs"]["topic"] == (
+            "Support-ticket questions customers keep asking"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output", ["landing_page", "blog_post"])
+async def test_loader_backed_support_ticket_execute_is_stable_under_concurrency(
+    output: str,
+) -> None:
+    rows = _generated_support_ticket_rows(10_000)
+    service = (
+        _LandingPageCaptureService()
+        if output == "landing_page"
+        else _BlogPostCaptureService()
+    )
+    services = (
+        ContentOpsExecutionServices(landing_page=service)
+        if output == "landing_page"
+        else ContentOpsExecutionServices(blog_post=service)
+    )
+    router = _loader_backed_router(
+        rows=rows,
+        services=services,
+        execute_max_concurrency=25,
+    )
+    route = _route(router, "/content-ops/execute", "POST")
+
+    async def execute_request(index: int) -> dict[str, Any]:
+        await asyncio.sleep(0)
+        payload = {
+            "outputs": [output],
+            "limit": index + 1,
+            "require_quality_gates": False,
+        }
+        if output == "landing_page":
+            payload["inputs"] = {"cta_label": f"Request {index} CTA"}
+        return await route.endpoint(payload)
+
+    responses = await asyncio.gather(
+        *(execute_request(index) for index in range(25)),
+    )
+
+    assert len(responses) == 25
+    assert len(service.calls) == 25
+    for response in responses:
+        assert response["status"] == "completed"
+        _assert_provider_counts(
+            response,
+            source_row_count=10_000,
+            included_row_count=1_000,
+        )
+
+    if output == "landing_page":
+        labels = {
+            call["campaign"].context["cta_label"]
+            for call in service.calls
+        }
+        assert labels == {f"Request {index} CTA" for index in range(25)}
+    else:
+        limits = {call["limit"] for call in service.calls}
+        assert limits == set(range(1, 26))


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Landing-Blog-Stress.md
Slice phase: Robust testing

Adds offline route-level stress coverage for loader-backed support-ticket inputs feeding landing-page and blog-post generation. This proves preview/plan/execute keep diagnostics accurate for 1k/10k/50k loaded inputs and that execute remains stable across 25 concurrent requests without calling an LLM, DB, or external provider.

## Intentional
- Uses `SupportTicketInputProvider(source_material_loader=...)` instead of inline `inputs.source_material`, because inline requests over 1,000 rows are intentionally rejected before provider packaging.
- Uses deterministic fake landing-page and blog-post services; this tests provider/route/generation handoff, not live model throughput.
- Leaves FAQ generator, hosted upload persistence, and content-quality evaluation out of scope.

## Deferred
- Future PR: hosted upload/background execution policy for large customer files once persisted support-ticket uploads are wired into the provider loader.
- Future PR: generated content quality evaluation using real support-ticket datasets after route survivability is proven.

## Parked hardening
- None. `HARDENING.md` was scanned; the current FAQ scale item belongs to the FAQ generation lane and is not required for this support-ticket provider handoff stress slice.

## Verification
- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py -q`
- `python -m pytest tests/test_extracted_support_ticket_input_provider.py tests/test_atlas_content_ops_input_provider.py -q`
- `python -m py_compile tests/test_support_ticket_provider_landing_blog_execute.py`
- `bash scripts/local_pr_review.sh`

## Diff size
2 files, +292 / -0