### PR TITLE
Prove support-ticket provider overload gate

### DIFF
--- a/plans/PR-Support-Ticket-Provider-Overload-Gate.md
+++ b/plans/PR-Support-Ticket-Provider-Overload-Gate.md
@@ -1,0 +1,72 @@
+# PR-Support-Ticket-Provider-Overload-Gate
+
+## Why this slice exists
+
+PR #942 proved large loader-backed support-ticket inputs stay bounded through
+preview, plan, and execute, including 25 concurrent successful execute calls.
+The remaining survivability question in this lane is overload behavior: when
+execute is already at capacity, the route should reject before it invokes a
+host loader that may read or parse a large customer export.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Robust testing
+
+1. Add a support-ticket-provider execute overload test.
+2. Prove the second request gets the existing `429` capacity response.
+3. Prove the rejected request does not call the support-ticket source loader.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Provider-Overload-Gate.md`
+- `tests/test_support_ticket_provider_landing_blog_execute.py`
+
+## Mechanism
+
+The test mounts the real Content Ops execute route with
+`execute_max_concurrency=1`, a loader-backed `SupportTicketInputProvider`, and a
+blocking fake landing-page service. The first request enters the service and
+holds the only execute slot. The second request is issued while the slot is
+held and must fail with `content_ops_execute_at_capacity`.
+
+The loader records each call. The assertion that the loader has only one call
+after the rejected request proves overload rejection happens before large
+support-ticket material is loaded or packaged.
+
+## Intentional
+
+- No production code changes; the route already gates before provider loading.
+- Landing page is enough for this overload proof because the execute gate sits
+  before output dispatch and provider packaging.
+- No live LLM, DB, or hosted upload path is used.
+- Local review's cross-layer caller hints are generic `__init__` and
+  `generate` references from a test fake class; no production symbol or caller
+  is changed.
+
+## Deferred
+
+- Future PR: hosted upload/background execution policy for large customer files
+  once persisted support-ticket uploads are wired into the provider loader.
+- Future PR: hosted HTTP-level load testing after the deployed auth/upload path
+  exists.
+- Parked hardening: none. `HARDENING.md` was scanned; the current FAQ scale
+  entry remains owned by the FAQ generation lane.
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py -q`
+  - passed, 10 tests.
+- `scripts/local_pr_review.sh --allow-dirty`
+  - passed.
+- `scripts/local_pr_review.sh`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| Route overload test | ~65 |
+| **Total** | **~130** |

--- a/tests/test_support_ticket_provider_landing_blog_execute.py
+++ b/tests/test_support_ticket_provider_landing_blog_execute.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 import pytest
 
 from atlas_brain._content_ops_input_provider import build_content_ops_input_provider
+import extracted_content_pipeline.api.control_surfaces as api_module
 from extracted_content_pipeline.api.control_surfaces import (
     ContentOpsControlSurfaceApiConfig,
     create_content_ops_control_surface_router,
@@ -38,6 +39,33 @@ class _LandingPageCaptureService:
             "campaign": campaign,
             "kwargs": dict(kwargs),
         })
+        return {
+            "generated": 1,
+            "saved_ids": ["landing-support-ticket-1"],
+            "campaign_name": getattr(campaign, "name", ""),
+        }
+
+
+class _BlockingLandingPageCaptureService(_LandingPageCaptureService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        campaign: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append({
+            "scope": scope,
+            "campaign": campaign,
+            "kwargs": dict(kwargs),
+        })
+        self.started.set()
+        await self.release.wait()
         return {
             "generated": 1,
             "saved_ids": ["landing-support-ticket-1"],
@@ -407,3 +435,57 @@ async def test_loader_backed_support_ticket_execute_is_stable_under_concurrency(
     else:
         limits = {call["limit"] for call in service.calls}
         assert limits == set(range(1, 26))
+
+
+@pytest.mark.asyncio
+async def test_loader_backed_support_ticket_execute_rejects_overload_before_loading_source() -> None:
+    rows = _generated_support_ticket_rows(50_000)
+    loader_calls: list[dict[str, Any]] = []
+
+    def loader(scope: TenantScope, request: Mapping[str, Any]) -> list[dict[str, str]]:
+        loader_calls.append({"scope": scope, "request": dict(request)})
+        return rows
+
+    service = _BlockingLandingPageCaptureService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(execute_max_concurrency=1),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            landing_page=service,
+        ),
+        input_provider=SupportTicketInputProvider(source_material_loader=loader),
+        scope_provider=lambda: TenantScope(
+            account_id="acct-support-ticket-overload",
+            user_id="user-support-ticket-overload",
+        ),
+    )
+    route = _route(router, "/content-ops/execute", "POST")
+    request = {
+        "outputs": ["landing_page"],
+        "require_quality_gates": False,
+    }
+
+    first = asyncio.create_task(route.endpoint(request))
+    try:
+        await asyncio.wait_for(service.started.wait(), timeout=1)
+        assert len(loader_calls) == 1
+
+        with pytest.raises(api_module.HTTPException) as exc:
+            await route.endpoint(request)
+
+        assert exc.value.status_code == 429
+        assert exc.value.detail == {
+            "reason": "content_ops_execute_at_capacity",
+            "max_concurrency": 1,
+        }
+        assert len(loader_calls) == 1
+        assert len(service.calls) == 1
+    finally:
+        service.release.set()
+
+    first_payload = await first
+    assert first_payload["status"] == "completed"
+
+    second_payload = await route.endpoint(request)
+    assert second_payload["status"] == "completed"
+    assert len(loader_calls) == 2
+    assert len(service.calls) == 2


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Provider-Overload-Gate.md
Slice phase: Robust testing

Adds a support-ticket-provider overload test proving execute capacity rejection happens before a large loader-backed support-ticket source is loaded or packaged. This follows #942 by testing the failure/overload path, not another all-success concurrency path.

## Intentional
- Test-only slice; the route already gates execute before support-ticket provider loading.
- Landing-page execute is enough because the capacity gate sits before provider packaging and output dispatch.
- No live LLM, DB, or hosted upload path is used.
- Local review caller hints are generic `__init__` and `generate` references from a test fake class; no production symbol or caller is changed.

## Deferred
- Future PR: hosted upload/background execution policy for large customer files once persisted support-ticket uploads are wired into the provider loader.
- Future PR: hosted HTTP-level load testing after the deployed auth/upload path exists.

## Parked hardening
- None. `HARDENING.md` was scanned; the current FAQ scale item remains owned by the FAQ generation lane.

## Verification
- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py -q`
- `python -m py_compile tests/test_support_ticket_provider_landing_blog_execute.py`
- `bash scripts/local_pr_review.sh`

## Diff size
2 files, +154 / -0