### PR TITLE
Index FAQ search rows on review

### DIFF
--- a/extracted_content_pipeline/ticket_faq_postgres.py
+++ b/extracted_content_pipeline/ticket_faq_postgres.py
@@ -9,10 +9,21 @@ from .campaign_ports import JsonDict, TenantScope
 from .storage._jsonb_helpers import (
     decode_jsonb_field,
     json_dump_jsonb,
-    parse_command_tag,
     row_to_dict,
 )
 from .ticket_faq_ports import TicketFAQDraft
+from .ticket_faq_search import (
+    PostgresTicketFAQSearchRepository,
+    build_ticket_faq_search_documents,
+    build_ticket_faq_search_projection_key,
+)
+
+
+_TICKET_FAQ_COLUMNS = (
+    "id, target_id, target_mode, title, markdown, items, "
+    "source_count, ticket_source_count, output_checks, warnings, "
+    "metadata, status"
+)
 
 
 def _draft_metadata(draft: TicketFAQDraft, scope: TenantScope) -> JsonDict:
@@ -117,9 +128,7 @@ class PostgresTicketFAQRepository:
             params.append(target_mode)
             clauses.append(f"target_mode = ${len(params)}")
         sql = (
-            "SELECT id, target_id, target_mode, title, markdown, items, "
-            "source_count, ticket_source_count, output_checks, warnings, "
-            "metadata, status "
+            f"SELECT {_TICKET_FAQ_COLUMNS} "
             "FROM ticket_faq_markdown WHERE " + " AND ".join(clauses) + " "
             "ORDER BY created_at DESC"
         )
@@ -136,19 +145,27 @@ class PostgresTicketFAQRepository:
         *,
         scope: TenantScope,
     ) -> bool:
-        result = await self.pool.execute(
-            """
-            UPDATE ticket_faq_markdown
-               SET status = $2,
-                   updated_at = NOW()
-             WHERE id = $1
-               AND account_id = $3
-            """,
-            faq_id,
-            status,
-            scope.account_id or "",
-        )
-        return parse_command_tag(result)
+        async def _update(db: Any) -> bool:
+            rows = await db.fetch(
+                f"""
+                UPDATE ticket_faq_markdown
+                   SET status = $2,
+                       updated_at = NOW()
+                 WHERE id = $1
+                   AND account_id = $3
+                RETURNING {_TICKET_FAQ_COLUMNS}
+                """,
+                faq_id,
+                status,
+                scope.account_id or "",
+            )
+            drafts = tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+            if not drafts:
+                return False
+            await self._replace_search_projection(drafts, scope=scope, db=db)
+            return True
+
+        return await _with_write_connection(self.pool, _update)
 
     async def update_statuses(
         self,
@@ -160,20 +177,74 @@ class PostgresTicketFAQRepository:
         ids = [str(item).strip() for item in faq_ids if str(item).strip()]
         if not ids:
             return ()
-        rows = await self.pool.fetch(
-            """
-            UPDATE ticket_faq_markdown
-               SET status = $2,
-                   updated_at = NOW()
-             WHERE id = ANY($1::uuid[])
-               AND account_id = $3
-            RETURNING id
-            """,
-            ids,
-            status,
-            scope.account_id or "",
+        async def _update(db: Any) -> Sequence[str]:
+            rows = await db.fetch(
+                f"""
+                UPDATE ticket_faq_markdown
+                   SET status = $2,
+                       updated_at = NOW()
+                 WHERE id = ANY($1::uuid[])
+                   AND account_id = $3
+                RETURNING {_TICKET_FAQ_COLUMNS}
+                """,
+                ids,
+                status,
+                scope.account_id or "",
+            )
+            drafts = tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+            if not drafts:
+                return ()
+            await self._replace_search_projection(drafts, scope=scope, db=db)
+            return tuple(draft.id for draft in drafts)
+
+        return await _with_write_connection(self.pool, _update)
+
+    async def _replace_search_projection(
+        self,
+        drafts: Sequence[TicketFAQDraft],
+        *,
+        scope: TenantScope,
+        db: Any | None = None,
+    ) -> None:
+        documents = []
+        replace_keys = []
+        for draft in drafts:
+            key = build_ticket_faq_search_projection_key(
+                draft,
+                account_id=scope.account_id,
+            )
+            if not key.account_id or not key.corpus_id or not key.faq_id:
+                continue
+            replace_keys.append(key)
+            documents.extend(
+                build_ticket_faq_search_documents(
+                    draft,
+                    account_id=key.account_id,
+                    corpus_id=key.corpus_id,
+                )
+            )
+        if not replace_keys:
+            return
+        await PostgresTicketFAQSearchRepository(db or self.pool).replace_documents(
+            tuple(documents),
+            replace_keys=tuple(replace_keys),
         )
-        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+async def _with_write_connection(db: Any, callback: Any) -> Any:
+    transaction = getattr(db, "transaction", None)
+    if callable(transaction):
+        async with transaction():
+            return await callback(db)
+    acquire = getattr(db, "acquire", None)
+    if callable(acquire):
+        async with acquire() as connection:
+            connection_transaction = getattr(connection, "transaction", None)
+            if callable(connection_transaction):
+                async with connection_transaction():
+                    return await callback(connection)
+            return await callback(connection)
+    return await callback(db)
 
 
 __all__ = [

--- a/extracted_content_pipeline/ticket_faq_search.py
+++ b/extracted_content_pipeline/ticket_faq_search.py
@@ -133,6 +133,23 @@ def build_ticket_faq_search_documents(
     return tuple(documents)
 
 
+def build_ticket_faq_search_projection_key(
+    draft: TicketFAQDraft,
+    *,
+    account_id: str | None = None,
+    corpus_id: str | None = None,
+) -> TicketFAQSearchProjectionKey:
+    """Build the replacement key for a generated FAQ draft projection."""
+
+    resolved_account_id = _clean(account_id) or _metadata_account_id(draft.metadata)
+    resolved_corpus_id = _clean(corpus_id) or _metadata_corpus_id(draft.metadata) or draft.target_id
+    return TicketFAQSearchProjectionKey(
+        account_id=resolved_account_id,
+        corpus_id=resolved_corpus_id,
+        faq_id=draft.id,
+    )
+
+
 def search_ticket_faq_documents(
     documents: Iterable[TicketFAQSearchDocument],
     *,
@@ -466,5 +483,6 @@ __all__ = [
     "TicketFAQSearchResponse",
     "TicketFAQSearchResult",
     "build_ticket_faq_search_documents",
+    "build_ticket_faq_search_projection_key",
     "search_ticket_faq_documents",
 ]

--- a/plans/PR-Content-Ops-FAQ-Search-Review-Index.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Review-Index.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-FAQ-Search-Review-Index
+
+## Why this slice exists
+The FAQ search route is mounted and contract-checked, but normal generated FAQ
+drafts still only persist to `ticket_faq_markdown`. This slice wires review
+actions to `ticket_faq_search_documents` so approved FAQ drafts feed the route.
+The slice is over the usual 400 LOC budget because review validation exposed the
+same write path in CLI fakes, lifecycle smoke fakes, and the real Postgres
+composition. Keeping those fixes with the projection change prevents the PR from
+shipping a route that works in one harness but fails in another.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a shared projection-key helper so empty FAQ items can clear stale rows.
+2. Update single and batch FAQ status updates to replace search projections.
+3. Keep non-FAQ asset review behavior unchanged.
+4. Add focused tests proving FAQ review writes/deletes search projection rows.
+5. Keep legacy/no-scope review updates from rolling back when they cannot build a
+   search projection key.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Review-Index.md`
+- `extracted_content_pipeline/ticket_faq_search.py`
+- `extracted_content_pipeline/ticket_faq_postgres.py`
+- `tests/test_extracted_ticket_faq_search.py`
+- `tests/test_extracted_ticket_faq_postgres.py`
+- `tests/test_extracted_ticket_faq_search_postgres.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_extracted_content_asset_review_cli.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+
+## Mechanism
+`PostgresTicketFAQRepository.update_status(...)` and `update_statuses(...)`
+switch to `UPDATE ... RETURNING` the same columns used by `list_drafts`.
+Returned drafts are projected through `build_ticket_faq_search_documents(...)`
+and written through `PostgresTicketFAQSearchRepository.replace_documents(...)`.
+Every updated draft also supplies a `TicketFAQSearchProjectionKey`. If a draft
+has no searchable FAQ items, the replace still deletes stale rows for that
+`account_id` / `corpus_id` / `faq_id` group.
+If a legacy/no-scope review update cannot supply `account_id`, `corpus_id`, or
+`faq_id`, the status update still commits and skips search projection instead of
+raising inside the review path.
+
+## Intentional
+- Search projection indexing stays in the FAQ repository, not the FastAPI route.
+- Statuses other than `approved` are projected with their actual status. The
+  search API defaults to `approved`, so rejected/draft rows stop appearing
+  without requiring a special delete path.
+- No-scope review updates keep the prior status-update behavior. They do not
+  create search rows because the hosted route is tenant-scoped and the projection
+  key is intentionally fail-closed.
+
+## Deferred
+- Backfilling already-approved FAQ drafts remains an ops/backfill slice.
+
+## Verification
+- `pytest tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_content_asset_api.py::test_generated_asset_router_reviews_ticket_faq_with_host_defined_status -q` passed with 16 tests.
+- `pytest tests/test_extracted_content_asset_api.py -q` passed with 59 tests.
+- `pytest tests/test_extracted_content_asset_review_cli.py::test_asset_review_cli_updates_ticket_faq_status tests/test_smoke_content_ops_faq_lifecycle.py::test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports tests/test_smoke_content_ops_faq_lifecycle.py::test_faq_lifecycle_smoke_persists_1000_row_json_bundle -q` passed with 3 tests.
+- `pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py -q` passed with 26 tests and 2 skips when no database URL is configured.
+- Full extracted pipeline check via `scripts/run_extracted_pipeline_checks.sh` passed with 2004 tests, 1 skip, and 1 third-party warning.
+- Python compile check for changed FAQ/search modules and focused tests passed.
+- Package guardrails and `bash scripts/local_pr_review.sh --allow-dirty origin/main` passed.
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Search helper | 18 |
+| FAQ repository | 131 |
+| Tests | 387 |
+| **Total** | **612** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1370,7 +1370,11 @@ def test_generated_asset_router_reviews_report_with_host_defined_status() -> Non
 
 
 def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
-    pool = _Pool()
+    row = _ticket_faq_row()
+    row["id"] = "11111111-1111-1111-1111-111111111111"
+    row["status"] = "approved"
+    row["metadata"] = {"corpus_id": "corpus-1"}
+    pool = _Pool(rows=[row])
 
     response = _client(
         pool,
@@ -1389,9 +1393,22 @@ def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() ->
         "status": "approved",
         "updated": True,
     }
-    query, args = pool.execute_calls[0]
+    query, args = pool.fetch_calls[0]
     assert "UPDATE ticket_faq_markdown" in query
     assert args == ("11111111-1111-1111-1111-111111111111", "approved", "acct_1")
+    delete_query, delete_args = pool.execute_calls[0]
+    assert "DELETE FROM ticket_faq_search_documents" in delete_query
+    assert delete_args == ("acct_1", "corpus-1", "11111111-1111-1111-1111-111111111111")
+    insert_query, insert_args = pool.execute_calls[1]
+    assert "INSERT INTO ticket_faq_search_documents" in insert_query
+    assert insert_args[:6] == (
+        "acct_1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+        "acct_1",
+        "support_account",
+        "approved",
+    )
 
 
 def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:

--- a/tests/test_extracted_content_asset_review_cli.py
+++ b/tests/test_extracted_content_asset_review_cli.py
@@ -27,7 +27,34 @@ class _Pool:
     def __init__(self, result: str = "UPDATE 1") -> None:
         self.result = result
         self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
         self.closed = False
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        if "UPDATE ticket_faq_markdown" not in str(query):
+            return []
+        if self.result == "UPDATE 0":
+            return []
+        return [{
+            "id": args[0],
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "title": "Support FAQ",
+            "markdown": "# Support FAQ",
+            "items": json.dumps([{
+                "question": "How do I reset login?",
+                "answer": "Use the reset link.",
+                "source_ids": ["ticket-1"],
+                "ticket_count": 1,
+            }]),
+            "source_count": 1,
+            "ticket_source_count": 1,
+            "output_checks": "{}",
+            "warnings": "[]",
+            "metadata": json.dumps({"corpus_id": "support-account-1"}),
+            "status": args[1],
+        }]
 
     async def execute(self, query, *args):
         self.execute_calls.append((str(query), args))
@@ -234,10 +261,11 @@ async def test_asset_review_cli_updates_ticket_faq_status(monkeypatch, capsys) -
     exit_code = await cli._main()
 
     output = json.loads(capsys.readouterr().out)
-    query, args = pool.execute_calls[0]
+    query, args = pool.fetch_calls[0]
     assert exit_code == 0
     assert "UPDATE ticket_faq_markdown" in query
     assert args == ("faq-uuid-1", "approved", "acct_1")
+    assert "INSERT INTO ticket_faq_search_documents" in pool.execute_calls[1][0]
     assert output == {
         "account_id": "acct_1",
         "asset": "faq_markdown",

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -31,6 +31,46 @@ class _Pool:
         return self.execute_result
 
 
+class _AsyncContext:
+    def __init__(self, value=None, enter=None) -> None:
+        self.value = value
+        self.enter = enter
+
+    async def __aenter__(self):
+        if self.enter is not None:
+            self.enter()
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _Connection(_Pool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.transaction_entries = 0
+
+    def transaction(self):
+        return _AsyncContext(enter=lambda: setattr(
+            self,
+            "transaction_entries",
+            self.transaction_entries + 1,
+        ))
+
+
+class _AcquirePool(_Pool):
+    def __init__(self, connection: _Connection) -> None:
+        super().__init__()
+        self.connection = connection
+        self.acquire_entries = 0
+
+    def acquire(self):
+        return _AsyncContext(
+            self.connection,
+            enter=lambda: setattr(self, "acquire_entries", self.acquire_entries + 1),
+        )
+
+
 def _draft() -> TicketFAQDraft:
     return TicketFAQDraft(
         target_id="ticket-1",
@@ -44,6 +84,30 @@ def _draft() -> TicketFAQDraft:
         warnings=({"code": "missing_source_text", "row_index": 2},),
         metadata={"source_types": ["ticket"]},
     )
+
+
+def _draft_row(*, draft_id: str = "11111111-1111-1111-1111-111111111111") -> dict:
+    return {
+        "id": draft_id,
+        "target_id": "ticket-1",
+        "target_mode": "vendor_retention",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ",
+        "items": json.dumps([{
+            "rank": 1,
+            "topic": "Login access",
+            "question": "How do I reset login?",
+            "answer": "Use the reset link.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 2,
+        }]),
+        "source_count": 3,
+        "ticket_source_count": 2,
+        "output_checks": json.dumps({"condensed": True}),
+        "warnings": json.dumps([]),
+        "metadata": json.dumps({"corpus_id": "corpus-1"}),
+        "status": "approved",
+    }
 
 
 @pytest.mark.asyncio
@@ -114,7 +178,7 @@ async def test_list_drafts_filters_by_status_target_mode_and_limit() -> None:
 @pytest.mark.asyncio
 async def test_update_status_returns_false_on_miss() -> None:
     pool = _Pool()
-    pool.execute_result = "UPDATE 0"
+    pool.fetch_rows = []
     repo = PostgresTicketFAQRepository(pool)
 
     updated = await repo.update_status(
@@ -124,22 +188,137 @@ async def test_update_status_returns_false_on_miss() -> None:
     )
 
     assert updated is False
-    assert "UPDATE ticket_faq_markdown" in pool.execute_calls[0]["query"]
-    assert pool.execute_calls[0]["args"] == ("faq-uuid-1", "approved", "acct-1")
+    assert "UPDATE ticket_faq_markdown" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == ("faq-uuid-1", "approved", "acct-1")
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_status_replaces_search_projection() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row()]
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is True
+    assert "RETURNING id, target_id" in pool.fetch_calls[0]["query"]
+    assert "DELETE FROM ticket_faq_search_documents" in pool.execute_calls[0]["query"]
+    assert pool.execute_calls[0]["args"] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+    assert "INSERT INTO ticket_faq_search_documents" in pool.execute_calls[1]["query"]
+    assert pool.execute_calls[1]["args"][:10] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+        "ticket-1",
+        "vendor_retention",
+        "approved",
+        1,
+        "Login access",
+        "How do I reset login?",
+        "Use the reset link.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_status_indexes_projection_on_acquired_transaction() -> None:
+    connection = _Connection()
+    connection.fetch_rows = [_draft_row()]
+    pool = _AcquirePool(connection)
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is True
+    assert pool.acquire_entries == 1
+    assert connection.transaction_entries == 2
+    assert pool.fetch_calls == []
+    assert "UPDATE ticket_faq_markdown" in connection.fetch_calls[0]["query"]
+    assert "INSERT INTO ticket_faq_search_documents" in connection.execute_calls[1]["query"]
+
+
+@pytest.mark.asyncio
+async def test_update_status_clears_stale_projection_for_empty_items() -> None:
+    pool = _Pool()
+    row = _draft_row()
+    row["items"] = json.dumps([])
+    pool.fetch_rows = [row]
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "11111111-1111-1111-1111-111111111111",
+        "rejected",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is True
+    assert len(pool.execute_calls) == 1
+    assert "DELETE FROM ticket_faq_search_documents" in pool.execute_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_update_status_without_projection_scope_keeps_review_update() -> None:
+    pool = _Pool()
+    row = _draft_row()
+    row["metadata"] = json.dumps({})
+    pool.fetch_rows = [row]
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_status(
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        scope=TenantScope(),
+    )
+
+    assert updated is True
+    assert pool.execute_calls == []
 
 
 @pytest.mark.asyncio
 async def test_update_statuses_returns_matched_ids() -> None:
     pool = _Pool()
-    pool.fetch_rows = [{"id": "faq-uuid-1"}]
+    pool.fetch_rows = [_draft_row(draft_id="22222222-2222-2222-2222-222222222222")]
     repo = PostgresTicketFAQRepository(pool)
 
     updated = await repo.update_statuses(
-        ["faq-uuid-1", ""],
+        ["22222222-2222-2222-2222-222222222222", ""],
         "approved",
         scope=TenantScope(account_id="acct-1"),
     )
 
-    assert updated == ("faq-uuid-1",)
+    assert updated == ("22222222-2222-2222-2222-222222222222",)
     assert "id = ANY($1::uuid[])" in pool.fetch_calls[0]["query"]
-    assert pool.fetch_calls[0]["args"] == (["faq-uuid-1"], "approved", "acct-1")
+    assert pool.fetch_calls[0]["args"] == (
+        ["22222222-2222-2222-2222-222222222222"],
+        "approved",
+        "acct-1",
+    )
+    assert "INSERT INTO ticket_faq_search_documents" in pool.execute_calls[1]["query"]
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_skips_projection_when_no_rows_match() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresTicketFAQRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["22222222-2222-2222-2222-222222222222"],
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ()
+    assert pool.execute_calls == []

--- a/tests/test_extracted_ticket_faq_search.py
+++ b/tests/test_extracted_ticket_faq_search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
 from extracted_content_pipeline.ticket_faq_search import (
     build_ticket_faq_search_documents,
+    build_ticket_faq_search_projection_key,
     search_ticket_faq_documents,
 )
 
@@ -69,6 +70,23 @@ def test_build_ticket_faq_search_documents_projects_item_fields() -> None:
     assert first.ticket_count == 2
     assert "reset email" in first.search_text
     assert "search_text" not in first.as_dict()
+
+
+def test_build_ticket_faq_search_projection_key_uses_same_scope_defaults() -> None:
+    key = build_ticket_faq_search_projection_key(_draft())
+
+    assert key.account_id == "acct-1"
+    assert key.corpus_id == "corpus-1"
+    assert key.faq_id == "faq-1"
+
+
+def test_build_ticket_faq_search_projection_key_falls_back_to_target_id() -> None:
+    draft = _draft(corpus_id="", target_id="support-account-1", items=[])
+
+    key = build_ticket_faq_search_projection_key(draft, account_id="acct-override")
+
+    assert key.account_id == "acct-override"
+    assert key.corpus_id == "support-account-1"
 
 
 def test_search_ticket_faq_documents_returns_route_shaped_envelope() -> None:

--- a/tests/test_extracted_ticket_faq_search_postgres.py
+++ b/tests/test_extracted_ticket_faq_search_postgres.py
@@ -12,6 +12,8 @@ from extracted_content_pipeline.ticket_faq_search import (
     TicketFAQSearchDocument,
     TicketFAQSearchProjectionKey,
 )
+from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
+from extracted_content_pipeline.campaign_ports import TenantScope
 
 
 class _Transaction:
@@ -451,6 +453,86 @@ async def test_ticket_faq_search_contract_against_postgres() -> None:
         await pool.close()
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ticket_faq_review_status_indexes_search_projection_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    faq_id = str(uuid4())
+    account_a = f"acct-a-{uuid4().hex}"
+    account_b = f"acct-b-{uuid4().hex}"
+    corpus_id = f"corpus-{uuid4().hex}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    faq_repo = PostgresTicketFAQRepository(pool)
+    search_repo = PostgresTicketFAQSearchRepository(pool)
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql").read_text())
+        await _insert_reviewable_faq(
+            pool,
+            faq_id=faq_id,
+            account_id=account_a,
+            corpus_id=corpus_id,
+        )
+
+        approved = await faq_repo.update_status(
+            faq_id,
+            "approved",
+            scope=TenantScope(account_id=account_a),
+        )
+        account_a_hit = await search_repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_id,
+        )
+        account_b_miss = await search_repo.search(
+            query="password reset",
+            account_id=account_b,
+            corpus_id=corpus_id,
+        )
+        account_b_update = await faq_repo.update_status(
+            faq_id,
+            "approved",
+            scope=TenantScope(account_id=account_b),
+        )
+        rejected = await faq_repo.update_status(
+            faq_id,
+            "rejected",
+            scope=TenantScope(account_id=account_a),
+        )
+        approved_after_reject = await search_repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_id,
+        )
+        rejected_after_reject = await search_repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_id,
+            status="rejected",
+        )
+
+        assert approved is True
+        assert account_a_hit.as_dict()["count"] == 1
+        assert account_b_miss.as_dict()["count"] == 0
+        assert account_b_update is False
+        assert rejected is True
+        assert approved_after_reject.as_dict()["count"] == 0
+        assert rejected_after_reject.as_dict()["count"] == 1
+        assert rejected_after_reject.as_dict()["results"][0]["status"] == "rejected"
+    finally:
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = ANY($1::text[])",
+            [account_a, account_b],
+        )
+        await pool.close()
+
+
 async def _insert_parent_faq(pool, *, faq_id: str, account_id: str) -> None:
     await pool.execute(
         """
@@ -467,4 +549,38 @@ async def _insert_parent_faq(pool, *, faq_id: str, account_id: str) -> None:
         """,
         faq_id,
         account_id,
+    )
+
+
+async def _insert_reviewable_faq(
+    pool,
+    *,
+    faq_id: str,
+    account_id: str,
+    corpus_id: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO ticket_faq_markdown (
+            id, account_id, target_id, target_mode, title, markdown,
+            items, source_count, ticket_source_count, output_checks,
+            warnings, metadata, status
+        )
+        VALUES (
+            $1::uuid, $2, 'support-account-1', 'support_account',
+            'Support FAQ', '# Support FAQ', $3::jsonb, 1, 1,
+            '{}'::jsonb, '[]'::jsonb, $4::jsonb, 'draft'
+        )
+        """,
+        faq_id,
+        account_id,
+        json.dumps([{
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer": "Use the reset link.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 1,
+        }]),
+        json.dumps({"corpus_id": corpus_id}),
     )

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -63,6 +63,15 @@ class _Pool:
 
     async def fetch(self, query, *args):
         self.fetch_calls.append({"query": str(query), "args": args})
+        if "UPDATE ticket_faq_markdown" in str(query):
+            if not self.update_hits:
+                return []
+            updated_rows = []
+            for row in self.rows:
+                if row["id"] == args[0] and row["account_id"] == args[2]:
+                    row["status"] = args[1]
+                    updated_rows.append(dict(row))
+            return updated_rows
         account_id = args[0] if args else ""
         status = args[1] if "status = $2" in str(query) and len(args) > 1 else None
         target_mode_index = 2 if "target_mode = $3" in str(query) else None


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Review-Index.md

Ownership lane: content-ops/faq-search
Slice phase: Vertical slice.

Wire FAQ draft review actions to `ticket_faq_search_documents` so approved generated FAQ drafts feed the hosted search route from the repository source of truth. Review follow-up also pins the fake-pool callers and one real-Postgres composition test for tenant isolation/status projection.

## Intentional
- Search projection indexing stays in the FAQ repository, not the FastAPI route.
- Statuses other than `approved` are projected with their actual status, so the approved-default search route stops returning them without a special delete path.
- No-scope review updates keep the prior status-update behavior and skip search projection because the hosted route is tenant-scoped.

## Deferred
- Backfilling already-approved FAQ drafts remains an ops/backfill slice.

## Verification
- `pytest tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_content_asset_api.py::test_generated_asset_router_reviews_ticket_faq_with_host_defined_status -q` - 16 passed.
- `pytest tests/test_extracted_content_asset_api.py -q` - 59 passed.
- `pytest tests/test_extracted_content_asset_review_cli.py::test_asset_review_cli_updates_ticket_faq_status tests/test_smoke_content_ops_faq_lifecycle.py::test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports tests/test_smoke_content_ops_faq_lifecycle.py::test_faq_lifecycle_smoke_persists_1000_row_json_bundle -q` - 3 passed.
- `pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py -q` - 26 passed, 2 skipped without database URL.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2004 passed, 1 skipped, 1 third-party warning.
- Python compile check for changed FAQ/search modules and focused tests passed.
- `bash scripts/local_pr_review.sh --allow-dirty origin/main` passed locally; `--allow-dirty` was only for unrelated pre-existing untracked files in this checkout.

## Diff size
9 files, +572 / -40
