### PR TITLE
Backfill FAQ search projection rows

### DIFF
--- a/extracted_content_pipeline/ticket_faq_postgres.py
+++ b/extracted_content_pipeline/ticket_faq_postgres.py
@@ -68,6 +68,36 @@ def _row_to_draft(row: Mapping[str, Any]) -> TicketFAQDraft:
 
 
 @dataclass(frozen=True)
+class TicketFAQSearchBackfillResult:
+    """Summary for a ticket FAQ search projection backfill run."""
+
+    apply: bool
+    status: str
+    account_id: str | None
+    limit: int | None
+    scanned: int
+    eligible_rows: int
+    skipped_missing_key: int
+    projected_documents: int
+    applied_rows: int
+    applied_documents: int
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "apply": self.apply,
+            "status": self.status,
+            "account_id": self.account_id,
+            "limit": self.limit,
+            "scanned": self.scanned,
+            "eligible_rows": self.eligible_rows,
+            "skipped_missing_key": self.skipped_missing_key,
+            "projected_documents": self.projected_documents,
+            "applied_rows": self.applied_rows,
+            "applied_documents": self.applied_documents,
+        }
+
+
+@dataclass(frozen=True)
 class PostgresTicketFAQRepository:
     """Async Postgres adapter for generated ticket FAQ Markdown."""
 
@@ -231,6 +261,84 @@ class PostgresTicketFAQRepository:
         )
 
 
+async def backfill_ticket_faq_search_documents(
+    pool: Any,
+    *,
+    status: str = "approved",
+    account_id: str | None = None,
+    limit: int | None = None,
+    apply: bool = False,
+) -> TicketFAQSearchBackfillResult:
+    """Backfill persisted FAQ drafts into the search projection table."""
+
+    normalized_status = str(status or "").strip()
+    if not normalized_status:
+        raise ValueError("ticket FAQ search backfill requires status")
+
+    normalized_account_id = str(account_id or "").strip() or None
+    normalized_limit = None if limit is None else max(0, int(limit))
+    clauses = ["status = $1"]
+    params: list[Any] = [normalized_status]
+    if normalized_account_id is not None:
+        params.append(normalized_account_id)
+        clauses.append(f"account_id = ${len(params)}")
+    sql = (
+        f"SELECT account_id, {_TICKET_FAQ_COLUMNS} "
+        "FROM ticket_faq_markdown WHERE " + " AND ".join(clauses) + " "
+        "ORDER BY updated_at DESC, created_at DESC"
+    )
+    if normalized_limit is not None:
+        params.append(normalized_limit)
+        sql += f" LIMIT ${len(params)}"
+
+    rows = await pool.fetch(sql, *params)
+    search_repo = PostgresTicketFAQSearchRepository(pool)
+    scanned = 0
+    eligible_rows = 0
+    skipped_missing_key = 0
+    projected_documents = 0
+    applied_rows = 0
+    applied_documents = 0
+
+    for row in rows:
+        scanned += 1
+        row_dict = row_to_dict(row)
+        draft = _row_to_draft(row_dict)
+        key = build_ticket_faq_search_projection_key(
+            draft,
+            account_id=str(row_dict.get("account_id") or "").strip(),
+        )
+        if not key.account_id or not key.corpus_id or not key.faq_id:
+            skipped_missing_key += 1
+            continue
+        documents = build_ticket_faq_search_documents(
+            draft,
+            account_id=key.account_id,
+            corpus_id=key.corpus_id,
+        )
+        eligible_rows += 1
+        projected_documents += len(documents)
+        if apply:
+            applied_documents += await search_repo.replace_documents(
+                documents,
+                replace_keys=(key,),
+            )
+            applied_rows += 1
+
+    return TicketFAQSearchBackfillResult(
+        apply=apply,
+        status=normalized_status,
+        account_id=normalized_account_id,
+        limit=normalized_limit,
+        scanned=scanned,
+        eligible_rows=eligible_rows,
+        skipped_missing_key=skipped_missing_key,
+        projected_documents=projected_documents,
+        applied_rows=applied_rows,
+        applied_documents=applied_documents,
+    )
+
+
 async def _with_write_connection(db: Any, callback: Any) -> Any:
     transaction = getattr(db, "transaction", None)
     if callable(transaction):
@@ -249,4 +357,6 @@ async def _with_write_connection(db: Any, callback: Any) -> Any:
 
 __all__ = [
     "PostgresTicketFAQRepository",
+    "TicketFAQSearchBackfillResult",
+    "backfill_ticket_faq_search_documents",
 ]

--- a/plans/PR-Content-Ops-FAQ-Search-Backfill.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Backfill.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-FAQ-Search-Backfill
+
+## Why this slice exists
+PR-Content-Ops-FAQ-Search-Review-Index wires new FAQ review actions into
+`ticket_faq_search_documents`, but already-approved FAQ drafts remain outside the
+search projection until someone re-reviews them. This slice adds the thin ops path
+needed to backfill approved historical drafts through the same projection helpers.
+The slice is over the usual 400 LOC budget because the backfill is a Postgres
+composition and now carries the lane-default real-Postgres integration coverage:
+multi-tenant projection is tested in the same PR as the write path.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a dry-run-first backfill function for approved ticket FAQ drafts.
+2. Reuse the review-index projection helpers and search repository write path.
+3. Add a small CLI wrapper for operators to run the backfill with `--apply`.
+4. Test dry-run counts, applied writes, account filtering, and skipped incomplete
+   projection keys.
+5. Pin multi-tenant per-row account projection with fake-pool and real-Postgres
+   coverage.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Backfill.md`
+- `extracted_content_pipeline/ticket_faq_postgres.py`
+- `scripts/backfill_ticket_faq_search_documents.py`
+- `tests/test_extracted_ticket_faq_postgres.py`
+- `tests/test_extracted_ticket_faq_search_postgres.py`
+
+## Mechanism
+`backfill_ticket_faq_search_documents(...)` scans `ticket_faq_markdown` rows by
+status, optional account, and optional limit. Each row is converted into the same
+`TicketFAQDraft` shape used by review indexing. The backfill resolves the
+projection key with the row's persisted `account_id`, builds documents with
+`build_ticket_faq_search_documents(...)`, and calls
+`PostgresTicketFAQSearchRepository.replace_documents(...)` only when `apply=True`.
+
+Dry-run mode returns counts without writing. Rows missing a complete projection
+key are skipped and counted instead of causing a partial backfill crash.
+The real-Postgres integration test inserts two accounts with a unique status,
+runs dry-run and apply, and verifies each account can only search its own
+projected rows.
+
+## Intentional
+- The default CLI mode is dry-run. Operators must pass `--apply` to mutate
+  `ticket_faq_search_documents`.
+- The backfill lives beside the FAQ Postgres adapter so it can reuse the
+  canonical row-to-draft conversion and projection path.
+- Existing approved drafts with empty FAQ items still clear stale projection rows
+  when their account/corpus/FAQ key is complete.
+- The integration test uses a unique non-default status to avoid scanning or
+  rewriting unrelated approved rows in a shared developer database.
+
+## Deferred
+- Scheduled or automatic backfill is deferred; this PR only adds the explicit ops
+  command.
+- Retry/report persistence for per-row projection failures is deferred until a
+  real legacy-data failure appears during an applied run.
+
+## Verification
+- `pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py -q` passed with 33 tests and 3 skips because no database URL is configured in this checkout.
+- Python compile check for the changed backfill module, CLI, and focused tests passed.
+- `python scripts/backfill_ticket_faq_search_documents.py --help` passed.
+- Package guardrails passed: validate extracted content pipeline, forbid Atlas reasoning imports, standalone audit, ASCII Python.
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Backfill function | 110 |
+| CLI | 60 |
+| Tests | 256 |
+| **Total** | **502** |

--- a/scripts/backfill_ticket_faq_search_documents.py
+++ b/scripts/backfill_ticket_faq_search_documents.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Backfill approved ticket FAQ drafts into the search projection table.
+
+Usage:
+  python scripts/backfill_ticket_faq_search_documents.py
+  python scripts/backfill_ticket_faq_search_documents.py --apply
+  python scripts/backfill_ticket_faq_search_documents.py --account-id acct-1 --limit 100 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.storage.database import close_database, get_db_pool, init_database
+from extracted_content_pipeline.ticket_faq_postgres import backfill_ticket_faq_search_documents
+
+
+async def _main(
+    *,
+    apply: bool,
+    status: str,
+    account_id: str | None,
+    limit: int | None,
+) -> None:
+    await init_database()
+    pool = get_db_pool()
+    try:
+        result = await backfill_ticket_faq_search_documents(
+            pool,
+            apply=apply,
+            status=status,
+            account_id=account_id,
+            limit=limit,
+        )
+    finally:
+        await close_database()
+
+    print(json.dumps(result.as_dict(), ensure_ascii=True, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="Write search projection rows.")
+    parser.add_argument("--status", default="approved", help="FAQ draft status to backfill.")
+    parser.add_argument("--account-id", default=None, help="Restrict backfill to one account.")
+    parser.add_argument("--limit", type=int, default=None, help="Maximum FAQ drafts to scan.")
+    args = parser.parse_args()
+    asyncio.run(
+        _main(
+            apply=args.apply,
+            status=args.status,
+            account_id=args.account_id,
+            limit=args.limit,
+        )
+    )

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -6,7 +6,10 @@ import pytest
 
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
-from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
+from extracted_content_pipeline.ticket_faq_postgres import (
+    PostgresTicketFAQRepository,
+    backfill_ticket_faq_search_documents,
+)
 
 
 class _Pool:
@@ -86,9 +89,15 @@ def _draft() -> TicketFAQDraft:
     )
 
 
-def _draft_row(*, draft_id: str = "11111111-1111-1111-1111-111111111111") -> dict:
+def _draft_row(
+    *,
+    draft_id: str = "11111111-1111-1111-1111-111111111111",
+    account_id: str = "acct-1",
+    status: str = "approved",
+) -> dict:
     return {
         "id": draft_id,
+        "account_id": account_id,
         "target_id": "ticket-1",
         "target_mode": "vendor_retention",
         "title": "Support FAQ",
@@ -106,7 +115,7 @@ def _draft_row(*, draft_id: str = "11111111-1111-1111-1111-111111111111") -> dic
         "output_checks": json.dumps({"condensed": True}),
         "warnings": json.dumps([]),
         "metadata": json.dumps({"corpus_id": "corpus-1"}),
-        "status": "approved",
+        "status": status,
     }
 
 
@@ -321,4 +330,156 @@ async def test_update_statuses_skips_projection_when_no_rows_match() -> None:
     )
 
     assert updated == ()
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_dry_run_reports_without_writing() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row()]
+
+    result = await backfill_ticket_faq_search_documents(pool)
+
+    assert result.as_dict() == {
+        "account_id": None,
+        "applied_documents": 0,
+        "applied_rows": 0,
+        "apply": False,
+        "eligible_rows": 1,
+        "limit": None,
+        "projected_documents": 1,
+        "scanned": 1,
+        "skipped_missing_key": 0,
+        "status": "approved",
+    }
+    assert "FROM ticket_faq_markdown" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == ("approved",)
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_applies_projection() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row()]
+
+    result = await backfill_ticket_faq_search_documents(pool, apply=True)
+
+    assert result.applied_rows == 1
+    assert result.applied_documents == 1
+    assert "DELETE FROM ticket_faq_search_documents" in pool.execute_calls[0]["query"]
+    assert pool.execute_calls[0]["args"] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+    assert "INSERT INTO ticket_faq_search_documents" in pool.execute_calls[1]["query"]
+    assert pool.execute_calls[1]["args"][:6] == (
+        "acct-1",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+        "ticket-1",
+        "vendor_retention",
+        "approved",
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_uses_each_rows_account_id() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        _draft_row(
+            draft_id="11111111-1111-1111-1111-111111111111",
+            account_id="acct-a",
+        ),
+        _draft_row(
+            draft_id="22222222-2222-2222-2222-222222222222",
+            account_id="acct-b",
+        ),
+    ]
+
+    result = await backfill_ticket_faq_search_documents(pool, apply=True)
+
+    assert result.scanned == 2
+    assert result.applied_rows == 2
+    assert pool.execute_calls[0]["args"][:3] == (
+        "acct-a",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+    assert pool.execute_calls[1]["args"][:3] == (
+        "acct-a",
+        "corpus-1",
+        "11111111-1111-1111-1111-111111111111",
+    )
+    assert pool.execute_calls[2]["args"][:3] == (
+        "acct-b",
+        "corpus-1",
+        "22222222-2222-2222-2222-222222222222",
+    )
+    assert pool.execute_calls[3]["args"][:3] == (
+        "acct-b",
+        "corpus-1",
+        "22222222-2222-2222-2222-222222222222",
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_clears_empty_items() -> None:
+    pool = _Pool()
+    row = _draft_row()
+    row["items"] = json.dumps([])
+    pool.fetch_rows = [row]
+
+    result = await backfill_ticket_faq_search_documents(pool, apply=True)
+
+    assert result.eligible_rows == 1
+    assert result.projected_documents == 0
+    assert result.applied_rows == 1
+    assert result.applied_documents == 0
+    assert len(pool.execute_calls) == 1
+    assert "DELETE FROM ticket_faq_search_documents" in pool.execute_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_rejects_blank_status() -> None:
+    pool = _Pool()
+
+    with pytest.raises(ValueError, match="requires status"):
+        await backfill_ticket_faq_search_documents(pool, status="  ")
+
+    assert pool.fetch_calls == []
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_filters_account_and_limit() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row(account_id="acct-2", status="rejected")]
+
+    result = await backfill_ticket_faq_search_documents(
+        pool,
+        status="rejected",
+        account_id="acct-2",
+        limit=5,
+    )
+
+    assert result.status == "rejected"
+    assert result.account_id == "acct-2"
+    assert result.limit == 5
+    assert "account_id = $2" in pool.fetch_calls[0]["query"]
+    assert "LIMIT $3" in pool.fetch_calls[0]["query"]
+    assert pool.fetch_calls[0]["args"] == ("rejected", "acct-2", 5)
+
+
+@pytest.mark.asyncio
+async def test_backfill_ticket_faq_search_documents_skips_incomplete_projection_key() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row(account_id="")]
+
+    result = await backfill_ticket_faq_search_documents(pool, apply=True)
+
+    assert result.scanned == 1
+    assert result.eligible_rows == 0
+    assert result.skipped_missing_key == 1
+    assert result.applied_rows == 0
     assert pool.execute_calls == []

--- a/tests/test_extracted_ticket_faq_search_postgres.py
+++ b/tests/test_extracted_ticket_faq_search_postgres.py
@@ -12,7 +12,10 @@ from extracted_content_pipeline.ticket_faq_search import (
     TicketFAQSearchDocument,
     TicketFAQSearchProjectionKey,
 )
-from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
+from extracted_content_pipeline.ticket_faq_postgres import (
+    PostgresTicketFAQRepository,
+    backfill_ticket_faq_search_documents,
+)
 from extracted_content_pipeline.campaign_ports import TenantScope
 
 
@@ -533,6 +536,88 @@ async def test_ticket_faq_review_status_indexes_search_projection_against_postgr
         await pool.close()
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ticket_faq_search_backfill_projects_each_account_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    run_id = uuid4().hex
+    status = f"approved_backfill_{run_id}"
+    account_a = f"acct-a-{run_id}"
+    account_b = f"acct-b-{run_id}"
+    corpus_a = f"corpus-a-{run_id}"
+    corpus_b = f"corpus-b-{run_id}"
+    faq_a = str(uuid4())
+    faq_b = str(uuid4())
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    search_repo = PostgresTicketFAQSearchRepository(pool)
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/327_ticket_faq_search_documents.sql").read_text())
+        await _insert_reviewable_faq(
+            pool,
+            faq_id=faq_a,
+            account_id=account_a,
+            corpus_id=corpus_a,
+            status=status,
+        )
+        await _insert_reviewable_faq(
+            pool,
+            faq_id=faq_b,
+            account_id=account_b,
+            corpus_id=corpus_b,
+            status=status,
+        )
+
+        dry_run = await backfill_ticket_faq_search_documents(pool, status=status)
+        dry_run_count = await pool.fetchval(
+            "SELECT COUNT(*) FROM ticket_faq_search_documents WHERE status = $1",
+            status,
+        )
+        applied = await backfill_ticket_faq_search_documents(pool, status=status, apply=True)
+        account_a_hit = await search_repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_a,
+            status=status,
+        )
+        account_a_cross_miss = await search_repo.search(
+            query="password reset",
+            account_id=account_a,
+            corpus_id=corpus_b,
+            status=status,
+        )
+        account_b_hit = await search_repo.search(
+            query="password reset",
+            account_id=account_b,
+            corpus_id=corpus_b,
+            status=status,
+        )
+
+        assert dry_run.scanned == 2
+        assert dry_run.applied_rows == 0
+        assert dry_run_count == 0
+        assert applied.scanned == 2
+        assert applied.applied_rows == 2
+        assert applied.applied_documents == 2
+        assert account_a_hit.as_dict()["count"] == 1
+        assert account_a_cross_miss.as_dict()["count"] == 0
+        assert account_b_hit.as_dict()["count"] == 1
+        assert account_a_hit.as_dict()["results"][0]["account_id"] == account_a
+        assert account_b_hit.as_dict()["results"][0]["account_id"] == account_b
+    finally:
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = ANY($1::text[])",
+            [account_a, account_b],
+        )
+        await pool.close()
+
+
 async def _insert_parent_faq(pool, *, faq_id: str, account_id: str) -> None:
     await pool.execute(
         """
@@ -558,6 +643,7 @@ async def _insert_reviewable_faq(
     faq_id: str,
     account_id: str,
     corpus_id: str,
+    status: str = "draft",
 ) -> None:
     await pool.execute(
         """
@@ -569,7 +655,7 @@ async def _insert_reviewable_faq(
         VALUES (
             $1::uuid, $2, 'support-account-1', 'support_account',
             'Support FAQ', '# Support FAQ', $3::jsonb, 1, 1,
-            '{}'::jsonb, '[]'::jsonb, $4::jsonb, 'draft'
+            '{}'::jsonb, '[]'::jsonb, $4::jsonb, $5
         )
         """,
         faq_id,
@@ -583,4 +669,5 @@ async def _insert_reviewable_faq(
             "ticket_count": 1,
         }]),
         json.dumps({"corpus_id": corpus_id}),
+        status,
     )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Backfill.md

Ownership lane: content-ops/faq-search
Slice phase: Vertical slice.

Add a dry-run-first ops path for historical ticket FAQ drafts so rows that were reviewed before PR #944 can be projected into `ticket_faq_search_documents` without re-reviewing them. Review follow-up adds the lane-default real-Postgres integration coverage for the backfill composition.

## Intentional
- Default CLI mode is dry-run; operators must pass `--apply` to mutate `ticket_faq_search_documents`.
- The backfill lives beside the FAQ Postgres adapter so it reuses the canonical row-to-draft conversion and projection path.
- Existing drafts with empty FAQ items still clear stale projection rows when their account/corpus/FAQ key is complete.
- The integration test uses a unique non-default status so it does not scan or rewrite unrelated approved rows in a shared developer database.

## Deferred
- Scheduled or automatic backfill is deferred; this PR only adds the explicit ops command.
- Retry/report persistence for per-row projection failures is deferred until a real legacy-data failure appears during an applied run.

## Verification
- `pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search.py tests/test_extracted_ticket_faq_search_postgres.py -q` - 33 passed, 3 skipped because no database URL is configured in this checkout.
- Python compile check for the changed backfill module, CLI, and focused tests passed.
- `python scripts/backfill_ticket_faq_search_documents.py --help` passed.
- Package guardrails passed: validate extracted content pipeline, forbid Atlas reasoning imports, standalone audit, ASCII Python.
- `bash scripts/local_pr_review.sh --allow-dirty origin/main` passed locally; `--allow-dirty` was only for unrelated pre-existing untracked files in this checkout.

## Diff size
5 files, +502 / -5
