### PR TITLE
Align support-ticket blog smoke context with package

### DIFF
--- a/plans/PR-Support-Ticket-Blog-Blueprint-Package-Context.md
+++ b/plans/PR-Support-Ticket-Blog-Blueprint-Package-Context.md
@@ -1,0 +1,82 @@
+# PR-Support-Ticket-Blog-Blueprint-Package-Context
+
+## Why this slice exists
+
+The support-ticket input package is now the source of truth for the uploaded
+ticket rows that feed Content Ops generation. The live-generation smoke helper
+still builds the support-ticket blog blueprint by re-parsing raw CSV rows with
+local helper functions for counts, date-window wording, and clusters.
+
+That duplication can drift from the ingestion layer. For functional validation,
+the support-ticket CSV should become one package, then both the execute payload
+and the seeded blog blueprint should read from that package's normalized inputs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Change the live-generation smoke helper's support-ticket blog blueprint
+   payload to derive source context from `build_support_ticket_input_package`.
+2. Remove the duplicated raw-row parsing helpers that only existed for the
+   support-ticket blog smoke blueprint.
+3. Update smoke-helper tests so package-derived source counts, clusters, date
+   window wording, and FAQ-entry estimates are covered.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Blog-Blueprint-Package-Context.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+
+## Mechanism
+
+`_support_ticket_blog_blueprint_payload` will call
+`build_support_ticket_input_package(rows)` and read the normalized package
+inputs:
+
+- `source_row_count`
+- `included_ticket_row_count`
+- `question_like_ticket_count`
+- `top_ticket_clusters`
+- `source_period`
+- `faq_questions`
+
+The seeded blog blueprint's `data_context` and section stats then reflect the
+same normalized ticket set that the support-ticket provider sends to execution.
+
+## Intentional
+
+- No FAQ generator behavior changes.
+- No DB, LLM, or hosted route changes.
+- No scale/backpressure work; the root `HARDENING.md` FAQSCALE-1 item belongs
+  to the FAQ scale session and remains parked.
+- This only removes duplicate validation-helper parsing; the package remains
+  the ingestion-layer source of truth.
+
+## Deferred
+
+- Future PR: run another live DB/LLM validation if we need a fresh saved-draft
+  artifact after this helper alignment.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py -q`
+  - passed, 24 tests.
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_support_ticket_input_package.py tests/test_support_ticket_provider_landing_blog_execute.py -q`
+  - passed, 52 tests.
+- `python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_provider.py -q`
+  - passed, 16 tests.
+- Python compile check for `scripts/smoke_content_ops_live_generation.py`
+  passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~85 |
+| Smoke helper | ~120 |
+| Tests | ~35 |
+| **Total** | **~240** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
-from datetime import date, datetime
 import json
 from pathlib import Path
 import re
@@ -513,30 +512,34 @@ def _default_blog_blueprint_payload() -> dict[str, Any]:
 def _support_ticket_blog_blueprint_payload(
     rows: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
-    source_rows = [dict(row) for row in rows if isinstance(row, Mapping)]
-    row_count = len(source_rows)
-    question_like_count = sum(1 for row in source_rows if "?" in _ticket_row_text(row))
-    top_clusters = _top_ticket_clusters(source_rows)
-    cluster_summary = _cluster_summary(top_clusters)
-    draft_faq_entries = min(12, max(1, row_count))
-    has_valid_date_window = _support_ticket_rows_have_dates(source_rows)
-    review_period = "last 90 days" if has_valid_date_window else "uploaded tickets"
-    source_period = (
-        "Last 90 days of support tickets"
-        if has_valid_date_window
-        else "Uploaded support tickets"
+    from extracted_content_pipeline.support_ticket_input_package import (  # noqa: PLC0415
+        build_support_ticket_input_package,
     )
+
+    package = build_support_ticket_input_package(rows)
+    inputs = dict(package.inputs)
+    source_row_count = int(inputs.get("source_row_count") or 0)
+    included_row_count = int(inputs.get("included_ticket_row_count") or 0)
+    question_like_count = int(inputs.get("question_like_ticket_count") or 0)
+    top_clusters = list(inputs.get("top_ticket_clusters") or [])
+    cluster_summary = _cluster_summary(top_clusters)
+    faq_questions = list(inputs.get("faq_questions") or [])
+    draft_faq_entries = min(12, max(1, len(faq_questions) or included_row_count))
+    source_period = str(inputs.get("source_period") or "Uploaded support tickets")
+    has_valid_date_window = bool(inputs.get("faq_window_days"))
+    review_period = "last 90 days" if has_valid_date_window else "uploaded tickets"
     return {
         "topic": SUPPORT_TICKET_BLOG_TOPIC,
         "data_context": {
             "review_period": review_period,
-            "source_row_count": row_count,
+            "source_row_count": source_row_count,
+            "included_ticket_row_count": included_row_count,
             "question_like_ticket_count": question_like_count,
             "top_clusters": top_clusters,
             "_known_vendors": [],
             "report_date": "2026-05-23",
-            "total_reviews_analyzed": row_count,
-            "deep_enriched_count": row_count,
+            "total_reviews_analyzed": included_row_count,
+            "deep_enriched_count": included_row_count,
             "category": "support tickets",
             "topic": SUPPORT_TICKET_BLOG_TOPIC,
             "source_period": source_period,
@@ -551,15 +554,17 @@ def _support_ticket_blog_blueprint_payload(
                     "customer questions and missing customer-facing answers."
                 ),
                 "key_stats": {
-                    "support_ticket_rows": row_count,
+                    "support_ticket_rows": source_row_count,
+                    "included_ticket_rows": included_row_count,
                     "question_like_rows": question_like_count,
                     "cluster_count": len(top_clusters),
                 },
                 "chart_ids": [],
                 "data_summary": (
-                    f"The uploaded CSV contains {row_count} support-ticket "
-                    f"rows. {question_like_count} rows include direct customer "
-                    f"questions. Top observed clusters: {cluster_summary}."
+                    f"The uploaded CSV contains {source_row_count} support-ticket "
+                    f"rows; {included_row_count} rows were included for generation. "
+                    f"{question_like_count} rows include direct customer questions. "
+                    f"Top observed clusters: {cluster_summary}."
                 ),
             },
             {
@@ -586,7 +591,8 @@ def _support_ticket_blog_blueprint_payload(
                     "questions, customer wording, draft answers, and review."
                 ),
                 "key_stats": {
-                    "source_rows": row_count,
+                    "source_rows": source_row_count,
+                    "included_rows": included_row_count,
                     "draft_faq_entries": draft_faq_entries,
                     "review_steps": 3,
                     **({"source_window_days": 90} if has_valid_date_window else {}),
@@ -612,79 +618,6 @@ def _support_ticket_blog_blueprint_payload(
         ],
         "required_vendors": [],
     }
-
-
-def _ticket_row_text(row: Mapping[str, Any]) -> str:
-    return " ".join(
-        str(row.get(key) or "").strip()
-        for key in (
-            "Description",
-            "description",
-            "Message",
-            "message",
-            "Text",
-            "text",
-            "Subject",
-            "subject",
-            "Title",
-            "title",
-        )
-        if str(row.get(key) or "").strip()
-    )
-
-
-def _support_ticket_rows_have_dates(rows: Sequence[Mapping[str, Any]]) -> bool:
-    return bool(rows) and all(_ticket_row_date(row) is not None for row in rows)
-
-
-def _ticket_row_date(row: Mapping[str, Any]) -> date | None:
-    for key in (
-        "Created At",
-        "created_at",
-        "Submitted At",
-        "submitted_at",
-        "Date",
-        "date",
-    ):
-        value = row.get(key)
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, date):
-            return value
-        text = str(value or "").strip()
-        if not text:
-            continue
-        try:
-            return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
-        except ValueError:
-            pass
-        try:
-            return date.fromisoformat(text[:10])
-        except ValueError:
-            continue
-    return None
-
-
-def _ticket_cluster_label(row: Mapping[str, Any]) -> str:
-    for key in ("Pain Category", "pain_category", "Category", "category", "intent"):
-        value = str(row.get(key) or "").strip()
-        if value:
-            return value
-    return "uncategorized"
-
-
-def _top_ticket_clusters(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    counts: dict[str, int] = {}
-    for row in rows:
-        label = _ticket_cluster_label(row)
-        counts[label] = counts.get(label, 0) + 1
-    return [
-        {"label": label, "count": count}
-        for label, count in sorted(
-            counts.items(),
-            key=lambda item: (-item[1], item[0].lower()),
-        )[:5]
-    ]
 
 
 def _cluster_summary(clusters: Sequence[Mapping[str, Any]]) -> str:

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -722,6 +722,9 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
     assert payload["data_context"]["question_like_ticket_count"] == 2
     assert payload["data_context"]["review_period"] == "uploaded tickets"
     assert payload["data_context"]["source_period"] == "Uploaded support tickets"
+    assert payload["data_context"]["included_ticket_row_count"] == 2
+    assert payload["data_context"]["total_reviews_analyzed"] == 2
+    assert payload["data_context"]["deep_enriched_count"] == 2
     assert payload["data_context"]["top_clusters"] == [
         {"label": "account", "count": 1},
         {"label": "reporting", "count": 1},
@@ -729,11 +732,45 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
     first_section = payload["sections"][0]
     assert first_section["key_stats"] == {
         "support_ticket_rows": 2,
+        "included_ticket_rows": 2,
         "question_like_rows": 2,
         "cluster_count": 2,
     }
     assert "2 support-ticket rows" in first_section["data_summary"]
+    assert "2 rows were included for generation" in first_section["data_summary"]
     assert "source_window_days" not in payload["sections"][2]["key_stats"]
+
+
+def test_support_ticket_blog_blueprint_payload_uses_package_included_counts() -> None:
+    payload = smoke._support_ticket_blog_blueprint_payload([
+        {
+            "Ticket ID": "ticket-1",
+            "Subject": "How do I change my login email?",
+            "Description": "I cannot find where to update the email on my account.",
+            "Pain Category": "account",
+        },
+        {
+            "Ticket ID": "ticket-empty",
+            "Subject": "",
+            "Description": "",
+            "Pain Category": "ignored",
+        },
+    ])
+
+    assert payload["data_context"]["source_row_count"] == 2
+    assert payload["data_context"]["included_ticket_row_count"] == 1
+    assert payload["data_context"]["total_reviews_analyzed"] == 1
+    assert payload["data_context"]["deep_enriched_count"] == 1
+    assert payload["data_context"]["top_clusters"] == [
+        {"label": "account", "count": 1},
+    ]
+    assert payload["sections"][0]["key_stats"] == {
+        "support_ticket_rows": 2,
+        "included_ticket_rows": 1,
+        "question_like_rows": 1,
+        "cluster_count": 1,
+    }
+    assert payload["sections"][2]["key_stats"]["included_rows"] == 1
 
 
 def test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_validate() -> None:


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Blog-Blueprint-Package-Context.md
Slice phase: Functional validation

The live-generation smoke helper was building the support-ticket blog blueprint by re-parsing raw CSV rows. This aligns it with the support-ticket input package so the execute payload and seeded blog blueprint read from the same normalized package context.

## Intentional
- No FAQ generator behavior changes.
- No DB, LLM, or hosted route changes.
- No scale/backpressure work; FAQSCALE-1 stays parked for the FAQ scale session.
- Removes duplicate validation-helper parsing and keeps the package as the ingestion source of truth.

## Deferred
- Future PR can run a fresh live DB/LLM validation if we need a saved-draft artifact after this helper alignment.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_smoke_content_ops_live_generation.py -q: 24 passed.
- python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_extracted_support_ticket_input_package.py tests/test_support_ticket_provider_landing_blog_execute.py -q: 52 passed.
- python -m pytest tests/test_smoke_content_ops_support_ticket_package.py tests/test_extracted_support_ticket_input_provider.py -q: 16 passed.
- Python compile check for scripts/smoke_content_ops_live_generation.py passed.
- scripts/local_pr_review.sh passed.

## Diff size
3 files, +145 / -93.