### PR TITLE
Validate support-ticket saved-draft export context

### DIFF
--- a/plans/PR-Support-Ticket-Export-Context-Validation.md
+++ b/plans/PR-Support-Ticket-Export-Context-Validation.md
@@ -1,0 +1,85 @@
+# Support Ticket Export Context Validation
+
+## Why this slice exists
+
+The support-ticket CSV live smoke can now generate landing-page and blog-post drafts
+from the shared support-ticket input package. The next validation gap is the saved
+draft export artifact: a run could pass because generation returned a saved id while
+the exported row lost the package-derived support-ticket context we need to inspect.
+
+This slice keeps the proof in the smoke harness, where operators already request
+`--support-ticket-csv` plus `--export-saved-draft`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add support-ticket export-context validation to the live generation smoke.
+2. Validate landing-page exports against `metadata.source_context`.
+3. Validate blog-post exports against `data_context`.
+4. Cover passing and failing export-context cases for both supported outputs.
+
+### Files touched
+
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `plans/PR-Support-Ticket-Export-Context-Validation.md`
+
+## Mechanism
+
+When the smoke runs in support-ticket CSV mode and `--export-saved-draft` is set,
+the script compares the exported saved draft row against the package-enriched
+payload inputs after generation. It checks durable context fields such as source
+row count, included ticket row count, question-like row count, and top ticket
+clusters. Landing-page export validation also checks skipped/truncated counts
+because `metadata.source_context` receives the provider source context directly.
+Blog export validation also checks source period because blog rows carry that
+value in `data_context`.
+
+Landing-page export rows are validated at `metadata.source_context`. Blog-post
+export rows are validated at `data_context`, where the blueprint context is already
+expected to survive.
+
+## Intentional
+
+- Validation only runs for support-ticket CSV mode plus saved-draft export.
+- The smoke remains read-only after generation; it does not mutate drafts to fix
+  missing context.
+- The helper validates the exported row shape instead of the in-memory generation
+  result because the exported artifact is what operators inspect.
+
+## Deferred
+
+- Parked hardening: none added by this slice.
+- Existing parked hardening `FAQSCALE-1` remains owned by
+  `content-ops/faq-generation-scale`; this slice does not touch FAQ generation or
+  hosted large-upload backpressure.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_validates_support_ticket_landing_export_context tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_support_ticket_landing_export_context_missing tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_validates_support_ticket_blog_export_context tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_support_ticket_blog_export_context_drifts -q`
+  - 4 passed.
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py -q`
+  - 28 passed.
+- `python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_support_ticket_provider_landing_blog_execute.py -q`
+  - 44 passed.
+- Py compile for `scripts/smoke_content_ops_live_generation.py`
+  - Passed.
+- Local PR review wrapper
+  - Passed.
+- Review comment fix: narrowed blog export expected context to the fields the
+  seeded support-ticket blog blueprint actually persists.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Smoke helper | ~90 |
+| Tests | ~205 |
+| **Total** | **~370** |
+
+Target under 400 LOC. This is a focused smoke/test change with no production
+route or schema changes.

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -386,6 +386,99 @@ async def _export_saved_drafts(
         ).as_dict()
 
 
+_LANDING_PAGE_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS = (
+    "source_row_count",
+    "included_ticket_row_count",
+    "skipped_ticket_row_count",
+    "truncated_ticket_row_count",
+    "question_like_ticket_count",
+)
+_BLOG_POST_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS = (
+    "source_row_count",
+    "included_ticket_row_count",
+    "question_like_ticket_count",
+)
+
+
+def _support_ticket_export_context_errors(
+    *,
+    output: str,
+    payload: Mapping[str, Any],
+    saved_draft_export: Mapping[str, Any] | None,
+) -> list[str]:
+    expected = _expected_support_ticket_export_context(output=output, payload=payload)
+    if not expected:
+        return []
+    rows = _export_rows(saved_draft_export)
+    if not rows:
+        return [f"exported {output} draft did not include rows"]
+    context = _exported_support_ticket_context(output=output, row=rows[0])
+    if not context:
+        return [f"exported {output} draft missing support-ticket source context"]
+    errors: list[str] = []
+    for key, expected_value in expected.items():
+        actual_value = context.get(key)
+        if actual_value != expected_value:
+            errors.append(
+                f"exported {output} draft support-ticket context mismatch for "
+                f"{key}: expected {expected_value!r}, got {actual_value!r}"
+            )
+    return errors
+
+
+def _expected_support_ticket_export_context(
+    *,
+    output: str,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    inputs = _as_mapping(payload.get("inputs"))
+    context_keys = (
+        _BLOG_POST_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS
+        if output == "blog_post"
+        else _LANDING_PAGE_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS
+    )
+    expected = {
+        key: inputs[key]
+        for key in context_keys
+        if key in inputs
+    }
+    clusters = inputs.get("top_ticket_clusters")
+    if clusters:
+        expected[
+            "top_clusters" if output == "blog_post" else "top_ticket_clusters"
+        ] = clusters
+    if output == "blog_post" and inputs.get("source_period"):
+        expected["source_period"] = inputs["source_period"]
+    return expected
+
+
+def _export_rows(
+    saved_draft_export: Mapping[str, Any] | None,
+) -> tuple[Mapping[str, Any], ...]:
+    export = _as_mapping(saved_draft_export)
+    rows = export.get("rows") or ()
+    if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence):
+        return ()
+    return tuple(row for row in rows if isinstance(row, Mapping))
+
+
+def _exported_support_ticket_context(
+    *,
+    output: str,
+    row: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if output == "landing_page":
+        metadata = _as_mapping(row.get("metadata"))
+        return _as_mapping(metadata.get("source_context"))
+    if output == "blog_post":
+        return _as_mapping(row.get("data_context"))
+    return {}
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
 def _smoke_errors(
     *,
     output: str,
@@ -846,6 +939,14 @@ async def run_content_ops_live_generation_smoke(
                 else:
                     exporter = draft_export_fn or _export_saved_drafts
                     saved_draft_export = await exporter(output, saved_ids, scope)
+                    if _uses_support_ticket_csv(args):
+                        errors.extend(
+                            _support_ticket_export_context_errors(
+                                output=output,
+                                payload=payload,
+                                saved_draft_export=saved_draft_export,
+                            )
+                        )
     except Exception as exc:
         errors.append(f"{type(exc).__name__}: {exc}")
     finally:

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -255,6 +255,93 @@ async def test_live_generation_smoke_exports_exact_saved_landing_page_draft(
 
 
 @pytest.mark.asyncio
+async def test_live_generation_smoke_validates_support_ticket_landing_export_context(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {
+            "count": 1,
+            "rows": [{
+                "id": saved_ids[0],
+                "metadata": {
+                    "source_context": {
+                        "source_row_count": 2,
+                        "included_ticket_row_count": 2,
+                        "skipped_ticket_row_count": 0,
+                        "truncated_ticket_row_count": 0,
+                        "question_like_ticket_count": 2,
+                        "top_ticket_clusters": [
+                            {"label": "account", "count": 1},
+                            {"label": "reporting", "count": 1},
+                        ],
+                    },
+                },
+            }],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "landing-page-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["saved_draft_export"]["rows"][0]["metadata"]["source_context"][
+        "source_row_count"
+    ] == 2
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_fails_when_support_ticket_landing_export_context_missing(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {"count": 1, "rows": [{"id": saved_ids[0], "metadata": {}}]}
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "landing-page-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["errors"] == [
+        "exported landing_page draft missing support-ticket source context"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_live_generation_smoke_fails_export_when_no_saved_ids(
     tmp_path: Path,
 ) -> None:
@@ -544,6 +631,123 @@ async def test_live_generation_smoke_exports_exact_saved_blog_post_draft(
         "output": "blog_post",
         "saved_ids": ("blog-live-smoke-1",),
     }]
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_validates_support_ticket_blog_export_context(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _BlogPostService()
+
+    async def _seed_blog_blueprint(args: argparse.Namespace, scope: TenantScope) -> dict[str, Any]:
+        return {
+            "saved_ids": ["bp-support-ticket-smoke-1"],
+            "slug": "content-ops-support-ticket-live-smoke-acct-live-smoke",
+            "target_mode": args.target_mode,
+            "topic_type": "content_ops_support_ticket_faq",
+            "topic": "Support-ticket questions customers keep asking",
+        }
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {
+            "count": 1,
+            "rows": [{
+                "id": saved_ids[0],
+                "data_context": {
+                    "source_row_count": 2,
+                    "included_ticket_row_count": 2,
+                    "question_like_ticket_count": 2,
+                    "source_period": "Uploaded support tickets",
+                    "top_clusters": [
+                        {"label": "account", "count": 1},
+                        {"label": "reporting", "count": 1},
+                    ],
+                },
+            }],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="blog_post",
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "blog-post-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(blog_post=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        blog_blueprint_seed_fn=_seed_blog_blueprint,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["saved_draft_export"]["rows"][0]["data_context"][
+        "source_period"
+    ] == "Uploaded support tickets"
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_fails_when_support_ticket_blog_export_context_drifts(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _BlogPostService()
+
+    async def _seed_blog_blueprint(args: argparse.Namespace, scope: TenantScope) -> dict[str, Any]:
+        return {
+            "saved_ids": ["bp-support-ticket-smoke-1"],
+            "slug": "content-ops-support-ticket-live-smoke-acct-live-smoke",
+            "target_mode": args.target_mode,
+            "topic_type": "content_ops_support_ticket_faq",
+            "topic": "Support-ticket questions customers keep asking",
+        }
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {
+            "count": 1,
+            "rows": [{
+                "id": saved_ids[0],
+                "data_context": {
+                    "source_row_count": 1,
+                    "included_ticket_row_count": 1,
+                    "question_like_ticket_count": 1,
+                },
+            }],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="blog_post",
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "blog-post-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(blog_post=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        blog_blueprint_seed_fn=_seed_blog_blueprint,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert (
+        "exported blog_post draft support-ticket context mismatch for "
+        "source_row_count: expected 2, got 1"
+    ) in result["errors"]
 
 
 def test_blog_blueprint_json_loader_accepts_one_custom_blueprint(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Export-Context-Validation.md
Slice phase: Functional validation

This adds a support-ticket CSV export validation to the live Content Ops smoke so a run with --export-saved-draft fails if the exported saved draft row lost the package-derived support-ticket context. Landing-page rows are checked at metadata.source_context; blog-post rows are checked at data_context.

## Intentional
- Validation only runs for support-ticket CSV mode plus saved-draft export.
- The smoke validates the exported artifact operators inspect, not only the in-memory generation result.
- No production routes, schema, DB wiring, or FAQ generator behavior changes in this slice.

## Deferred
- Existing FAQSCALE-1 remains parked under content-ops/faq-generation-scale and outside this lane.

## Parked hardening
- None added by this slice.

## Verification
- python -m pytest tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_validates_support_ticket_landing_export_context tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_support_ticket_landing_export_context_missing tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_validates_support_ticket_blog_export_context tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_support_ticket_blog_export_context_drifts -q
- python -m pytest tests/test_smoke_content_ops_live_generation.py -q
- python -m pytest tests/test_extracted_support_ticket_input_package.py tests/test_extracted_support_ticket_input_provider.py tests/test_smoke_content_ops_support_ticket_package.py tests/test_support_ticket_provider_landing_blog_execute.py -q
- python -m py_compile scripts/smoke_content_ops_live_generation.py
- bash scripts/local_pr_review.sh

## Diff size
3 files, +378 / -0