### PR TITLE
Write FAQ search route contract results

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Contract-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Contract-Result.md
@@ -1,0 +1,57 @@
+# PR-Content-Ops-FAQ-Search-Contract-Result
+
+## Why this slice exists
+The hosted FAQ search contract checker verifies the deployed route envelope, but
+it only prints a console summary. The demo and review handoff need a deterministic
+JSON artifact that records pass/fail, query metadata, and contract errors without
+including bearer tokens.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add `--output-result` to the hosted FAQ search route contract checker.
+2. Write a compact JSON artifact on success, contract failure, route failure, and
+   local preflight failure.
+3. Keep bearer tokens out of the artifact and console output.
+4. Add focused tests for success and failure artifacts.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Contract-Result.md`
+- `scripts/check_content_ops_faq_search_route_contract.py`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+
+## Mechanism
+The checker builds a result payload with `ok`, `phase`, route/query metadata,
+optional `count`, and any validation or request errors. `--output-result` writes
+that payload as deterministic JSON after the run. Missing local inputs use the
+same writer before returning exit code `2`; route and contract failures return
+exit code `1`; success returns `0`.
+
+## Intentional
+- This is not a new live HTTP smoke. It improves the existing deployed-route
+  checker so external runs can be archived.
+- The artifact does not include the bearer token or request headers.
+- Invalid argparse usage can still exit before writing a result, consistent with
+  the existing CLI behavior.
+
+## Deferred
+- Running this checker against a real deployed host remains environment-owned
+  until a backend URL and bearer token are provided.
+- Latency timing and HTTP status capture are deferred; this slice only records
+  contract outcome and validation details.
+
+## Verification
+- `pytest tests/test_check_content_ops_faq_search_route_contract.py -q` passed with 28 tests.
+- Python compile check for the route contract checker and focused tests passed.
+- Preflight CLI proof with blank `--token` exited `2` and wrote a JSON result with `ok=false`, `phase=preflight`, and no bearer token.
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 57 |
+| Checker | 146 |
+| Tests | 112 |
+| **Total** | **315** |

--- a/scripts/check_content_ops_faq_search_route_contract.py
+++ b/scripts/check_content_ops_faq_search_route_contract.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from pathlib import Path
 import sys
 import urllib.error
 import urllib.parse
@@ -42,6 +43,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--route", default=DEFAULT_ROUTE)
     parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
     parser.add_argument("--require-results", action="store_true")
+    parser.add_argument("--output-result", type=Path)
     return parser
 
 
@@ -138,39 +140,173 @@ def _validate_first_result(result: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+def _result_payload(
+    *,
+    ok: bool,
+    phase: str,
+    base_url: str,
+    route: str,
+    query: str,
+    corpus_id: str,
+    status: str,
+    limit: int,
+    require_results: bool,
+    count: Any = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "phase": phase,
+        "route": route,
+        "base_url": base_url,
+        "query": query,
+        "corpus_id": corpus_id,
+        "status": status,
+        "limit": limit,
+        "require_results": require_results,
+        "errors": list(errors or ()),
+    }
+    if type(count) is int:
+        payload["count"] = count
+    return payload
+
+
+def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     args = _build_parser().parse_args()
     base_url = _clean_url(args.base_url)
     token = str(args.token or "").strip()
     query = str(args.query or "").strip()
+    corpus_id = str(args.corpus_id or "").strip()
+    status = str(args.status or "").strip()
+    route = str(args.route or "").strip()
+    limit = int(args.limit)
     if not base_url:
         print("ATLAS_API_BASE_URL or --base-url is required.")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="preflight",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                errors=["ATLAS_API_BASE_URL or --base-url is required"],
+            ),
+        )
         return 2
     if not token:
         print("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required.")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="preflight",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                errors=["ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required"],
+            ),
+        )
         return 2
     if not query:
         print("ATLAS_FAQ_SEARCH_QUERY or --query is required.")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="preflight",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                errors=["ATLAS_FAQ_SEARCH_QUERY or --query is required"],
+            ),
+        )
         return 2
-    if args.limit <= 0:
+    if limit <= 0:
         print("--limit must be positive.")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="preflight",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                errors=["--limit must be positive"],
+            ),
+        )
         return 2
 
     url = _build_url(
         base_url=base_url,
-        route=args.route,
+        route=route,
         query=query,
-        corpus_id=args.corpus_id,
-        status=args.status,
-        limit=args.limit,
+        corpus_id=corpus_id,
+        status=status,
+        limit=limit,
     )
     try:
         data = _fetch_json(url, token=token, timeout=args.timeout)
     except RuntimeError as exc:
         print(f"FAQ search route check failed: {exc}")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="request",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                errors=[str(exc)],
+            ),
+        )
         return 1
 
     errors = _validate_envelope(data, require_results=args.require_results)
+    payload = _result_payload(
+        ok=not errors,
+        phase="contract",
+        base_url=base_url,
+        route=route,
+        query=query,
+        corpus_id=corpus_id,
+        status=status,
+        limit=limit,
+        require_results=bool(args.require_results),
+        count=data.get("count"),
+        errors=errors,
+    )
+    _write_result(args.output_result, payload)
     if errors:
         print("FAQ search route contract failed:")
         for error in errors:

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -1,5 +1,6 @@
 import importlib.util
 from io import BytesIO
+import json
 import sys
 import urllib.error
 from pathlib import Path
@@ -241,6 +242,117 @@ def test_main_checks_route_and_prints_summary(monkeypatch, capsys):
         )
     ]
     assert "FAQ search route contract passed" in capsys.readouterr().out
+
+
+def test_main_writes_success_result_without_token(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        _MODULE,
+        "_fetch_json",
+        lambda url, *, token, timeout: _valid_payload(),
+    )
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--query",
+        "mortgage payment dispute",
+        "--corpus-id",
+        "corpus-1",
+        "--require-results",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 0
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "base_url": "https://atlas.example.com",
+        "corpus_id": "corpus-1",
+        "count": 1,
+        "errors": [],
+        "limit": 5,
+        "ok": True,
+        "phase": "contract",
+        "query": "mortgage payment dispute",
+        "require_results": True,
+        "route": "/api/v1/content-ops/faq-deflection-search",
+        "status": "",
+    }
+    assert "secret-token" not in result_path.read_text(encoding="utf-8")
+
+
+def test_main_writes_contract_failure_result(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        _MODULE,
+        "_fetch_json",
+        lambda url, *, token, timeout: {"query": "reset", "results": [], "count": 1},
+    )
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 1
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is False
+    assert payload["phase"] == "contract"
+    assert payload["errors"] == ["count must match len(results)"]
+    assert "secret-token" not in result_path.read_text(encoding="utf-8")
+
+
+def test_main_writes_preflight_failure_result(monkeypatch, tmp_path, capsys):
+    monkeypatch.delenv("ATLAS_B2B_JWT", raising=False)
+    monkeypatch.delenv("ATLAS_TOKEN", raising=False)
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 2
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["errors"] == ["ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required"]
+    assert "token is required" in capsys.readouterr().out
+
+
+def test_main_writes_request_failure_result_without_token(monkeypatch, tmp_path):
+    def _fake_fetch_json(url, *, token, timeout):
+        raise RuntimeError("route returned HTTP 401: unauthorized")
+
+    monkeypatch.setattr(_MODULE, "_fetch_json", _fake_fetch_json)
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 1
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is False
+    assert payload["phase"] == "request"
+    assert payload["errors"] == ["route returned HTTP 401: unauthorized"]
+    assert "secret-token" not in result_path.read_text(encoding="utf-8")
 
 
 def test_main_does_not_print_token_on_http_failure(monkeypatch, capsys):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Contract-Result.md

Ownership lane: content-ops/faq-search
Slice phase: Vertical slice.

Add deterministic JSON result output to the hosted FAQ search route contract checker so demo/review runs can archive pass/fail, query metadata, and validation errors without exposing bearer tokens.

## Intentional
- This improves the existing deployed-route checker; it does not add a new live HTTP smoke.
- The artifact excludes bearer tokens and request headers.
- Invalid argparse usage can still exit before writing a result, consistent with the existing CLI behavior.

## Deferred
- Running this checker against a real deployed host remains environment-owned until a backend URL and bearer token are available.
- Latency timing and HTTP status capture are deferred; this slice only records contract outcome and validation details.

## Verification
- `pytest tests/test_check_content_ops_faq_search_route_contract.py -q` - 28 passed.
- Python compile check for the route contract checker and focused tests passed.
- Preflight CLI proof with blank `--token` exited `2` and wrote a JSON result with `ok=false`, `phase=preflight`, and no bearer token.
- `bash scripts/local_pr_review.sh --allow-dirty origin/main` passed locally; `--allow-dirty` was only for unrelated pre-existing untracked files in this checkout.

## Diff size
3 files, +310 / -5
