### PR TITLE
PR-Content-Ops-FAQ-Search-Detail

### DIFF
--- a/extracted_content_pipeline/api/faq_search.py
+++ b/extracted_content_pipeline/api/faq_search.py
@@ -7,6 +7,7 @@ import asyncio
 from dataclasses import dataclass
 import logging
 from typing import Any
+from uuid import UUID
 
 try:
     from fastapi import APIRouter, HTTPException, Query
@@ -19,12 +20,15 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import TenantScope
+from ..ticket_faq_ports import TicketFAQDraft
+from ..ticket_faq_postgres import PostgresTicketFAQRepository
 from ..ticket_faq_search import PostgresTicketFAQSearchRepository
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
-RepositoryFactory = Callable[[Any], PostgresTicketFAQSearchRepository]
+SearchRepositoryFactory = Callable[[Any], PostgresTicketFAQSearchRepository]
+FAQRepositoryFactory = Callable[[Any], PostgresTicketFAQRepository]
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +70,8 @@ def create_faq_deflection_search_router(
     *,
     pool_provider: PoolProvider,
     scope_provider: ScopeProvider | None = None,
-    repository_factory: RepositoryFactory = PostgresTicketFAQSearchRepository,
+    repository_factory: SearchRepositoryFactory = PostgresTicketFAQSearchRepository,
+    faq_repository_factory: FAQRepositoryFactory = PostgresTicketFAQRepository,
     config: FAQDeflectionSearchApiConfig | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -108,6 +113,33 @@ def create_faq_deflection_search_router(
             logger.exception("FAQ deflection search failed")
             raise HTTPException(status_code=503, detail="FAQ search unavailable") from exc
         return response.as_dict()
+
+    @router.get("/{faq_id}")
+    async def get_faq_deflection_detail(faq_id: str) -> dict[str, Any]:
+        normalized_faq_id = _required_uuid_path_id(faq_id, name="faq_id")
+        scope = await _resolve_scope(scope_provider)
+        scoped_account_id = _required_account_id(scope)
+        pool = await _resolve_pool(pool_provider)
+        repository = faq_repository_factory(pool)
+        try:
+            draft = await _with_timeout(
+                repository.get_draft(
+                    normalized_faq_id,
+                    scope=TenantScope(
+                        account_id=scoped_account_id,
+                        user_id=scope.user_id,
+                    ),
+                ),
+                resolved_config,
+            )
+        except TimeoutError as exc:
+            raise HTTPException(status_code=504, detail="FAQ detail timed out") from exc
+        except Exception as exc:
+            logger.exception("FAQ deflection detail failed")
+            raise HTTPException(status_code=503, detail="FAQ detail unavailable") from exc
+        if draft is None:
+            raise HTTPException(status_code=404, detail="FAQ not found")
+        return _faq_detail_payload(draft, account_id=scoped_account_id)
 
     return router
 
@@ -185,6 +217,29 @@ def _status_filter(value: str | None, config: FAQDeflectionSearchApiConfig) -> s
 def _optional_filter(value: str | None) -> str | None:
     cleaned = _clean(value)
     return cleaned or None
+
+
+def _required_path_id(value: str, *, name: str) -> str:
+    cleaned = _clean(value)
+    if not cleaned:
+        raise HTTPException(status_code=400, detail=f"{name} is required")
+    return cleaned
+
+
+def _required_uuid_path_id(value: str, *, name: str) -> str:
+    cleaned = _required_path_id(value, name=name)
+    try:
+        UUID(cleaned)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"{name} must be a valid UUID") from exc
+    return cleaned
+
+
+def _faq_detail_payload(draft: TicketFAQDraft, *, account_id: str) -> dict[str, Any]:
+    return {
+        "account_id": account_id,
+        **draft.as_dict(),
+    }
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/ticket_faq_ports.py
+++ b/extracted_content_pipeline/ticket_faq_ports.py
@@ -63,6 +63,14 @@ class TicketFAQRepository(Protocol):
     ) -> Sequence[TicketFAQDraft]:
         """Return drafts filtered by tenant scope and optional facets."""
 
+    async def get_draft(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+    ) -> TicketFAQDraft | None:
+        """Return one draft by id and tenant scope."""
+
     async def update_status(
         self,
         faq_id: str,

--- a/extracted_content_pipeline/ticket_faq_postgres.py
+++ b/extracted_content_pipeline/ticket_faq_postgres.py
@@ -168,6 +168,27 @@ class PostgresTicketFAQRepository:
         rows = await self.pool.fetch(sql, *params)
         return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
 
+    async def get_draft(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+    ) -> TicketFAQDraft | None:
+        rows = await self.pool.fetch(
+            f"""
+            SELECT {_TICKET_FAQ_COLUMNS}
+              FROM ticket_faq_markdown
+             WHERE id = $1
+               AND account_id = $2
+             LIMIT 1
+            """,
+            faq_id,
+            scope.account_id or "",
+        )
+        if not rows:
+            return None
+        return _row_to_draft(row_to_dict(rows[0]))
+
     async def update_status(
         self,
         faq_id: str,

--- a/plans/PR-Content-Ops-FAQ-Search-Detail.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Detail.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-FAQ-Search-Detail
+
+## Why this slice exists
+The FAQ deflection search route returns compact result rows with `faq_id`, which
+is enough to rank matches but not enough for the searchable demo to render the
+full generated FAQ artifact. The product direction is to keep search retrieval
+fast and compact, then hydrate the selected FAQ by id. This slice adds that
+thin, tenant-scoped detail path without changing generation or indexing.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Add a single-draft read method to the FAQ Markdown repository.
+2. Add a detail route under the existing FAQ deflection search router.
+3. Return the full generated FAQ body, items, checks, warnings, and metadata for
+   the requested `faq_id`.
+4. Preserve tenant fail-closed behavior: missing `account_id` is rejected and a
+   different tenant receives 404.
+5. Reject malformed FAQ ids as 400 before database access.
+6. Cover the new route with fake-pool tests and one real-Postgres route
+   composition test.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Detail.md`
+- `extracted_content_pipeline/api/faq_search.py`
+- `extracted_content_pipeline/ticket_faq_ports.py`
+- `extracted_content_pipeline/ticket_faq_postgres.py`
+- `tests/test_extracted_ticket_faq_postgres.py`
+- `tests/test_extracted_ticket_faq_search_api.py`
+
+## Mechanism
+`PostgresTicketFAQRepository.get_draft(...)` selects one row from
+`ticket_faq_markdown` by `id` and `account_id`, returning the existing
+`TicketFAQDraft` shape or `None`. `create_faq_deflection_search_router(...)`
+accepts a second repository factory for FAQ Markdown hydration and mounts
+`GET /content-ops/faq-deflection-search/{faq_id}`. The route validates `faq_id`
+as a UUID before database access, resolves the same host-provided tenant scope
+and database pool used by search, then returns `TicketFAQDraft.as_dict()` with
+an explicit `account_id` field for the API envelope. Misses return 404.
+
+## Intentional
+- Search results remain compact. The full Markdown artifact is fetched only
+  after a caller selects a `faq_id`.
+- This route uses the existing router factory and tenant resolver so host
+  mounting, bearer auth dependencies, and pool lifecycle stay in one place.
+- The detail route does not filter by status. Possession of the tenant-scoped
+  `faq_id` is enough for internal/demo hydration; review status still lives on
+  the returned draft.
+- The real-Postgres test skips when `EXTRACTED_DATABASE_URL` or `DATABASE_URL`
+  is absent, matching the lane's integration-test pattern.
+
+## Deferred
+- The hosted large-upload/backpressure item remains parked in `HARDENING.md`
+  as `FAQSCALE-1`; this read route does not exercise upload or generation load.
+- A deployed-host contract checker for the detail route is deferred until the
+  demo consumes this endpoint shape.
+- Returning a redacted/public detail envelope is deferred; this slice is for the
+  authenticated content-ops API mounted with host dependencies.
+
+## Verification
+- pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search_api.py -q passed with 28 tests and 1 skip because no database URL is configured in this checkout.
+- python -m compileall over the changed Python files passed.
+- Extracted package guardrail commands passed: validate_extracted_content_pipeline, forbid_atlas_reasoning_imports, audit_extracted_standalone --fail-on-debt, and check_ascii_python.
+- bash scripts/local_pr_review.sh passed from a temporary clean worktree at this commit because unrelated untracked files exist in the shared checkout.
+- python scripts/audit_pr_session_drift.py origin/main passed in the primary worktree and checked 0 open PRs.
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 68 |
+| Repository + port | 30 |
+| API route | 70 |
+| Tests | 180 |
+| **Total** | **348** |

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -185,6 +185,44 @@ async def test_list_drafts_filters_by_status_target_mode_and_limit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_draft_filters_by_id_and_scope() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_draft_row(draft_id="11111111-1111-1111-1111-111111111111")]
+    repo = PostgresTicketFAQRepository(pool)
+
+    draft = await repo.get_draft(
+        "11111111-1111-1111-1111-111111111111",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert draft is not None
+    assert draft.id == "11111111-1111-1111-1111-111111111111"
+    assert draft.metadata == {"corpus_id": "corpus-1"}
+    query = pool.fetch_calls[0]["query"]
+    assert "FROM ticket_faq_markdown" in query
+    assert "id = $1" in query
+    assert "account_id = $2" in query
+    assert pool.fetch_calls[0]["args"] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_draft_returns_none_on_miss() -> None:
+    pool = _Pool()
+    pool.fetch_rows = []
+    repo = PostgresTicketFAQRepository(pool)
+
+    draft = await repo.get_draft(
+        "11111111-1111-1111-1111-111111111111",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert draft is None
+
+
+@pytest.mark.asyncio
 async def test_update_status_returns_false_on_miss() -> None:
     pool = _Pool()
     pool.fetch_rows = []

--- a/tests/test_extracted_ticket_faq_search_api.py
+++ b/tests/test_extracted_ticket_faq_search_api.py
@@ -58,6 +58,30 @@ def _row() -> dict[str, object]:
     }
 
 
+def _faq_row() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "target_id": "support-account-1",
+        "target_mode": "support_account",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ\n\nUse the reset email.",
+        "items": json.dumps([{
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer": "Use the reset email.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 1,
+        }]),
+        "source_count": 1,
+        "ticket_source_count": 1,
+        "output_checks": json.dumps({"has_action_steps": True}),
+        "warnings": json.dumps([]),
+        "metadata": json.dumps({"corpus_id": "corpus-1"}),
+        "status": "approved",
+    }
+
+
 def _client(
     pool: _Pool,
     *,
@@ -181,8 +205,79 @@ def test_faq_deflection_search_route_reports_unavailable_database() -> None:
     assert pool.fetch_calls == []
 
 
+def test_faq_deflection_detail_route_returns_full_generated_faq() -> None:
+    pool = _Pool(rows=[_faq_row()])
+
+    response = _client(pool, scope={"account_id": "acct-1"}).get(
+        "/content-ops/faq-deflection-search/11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct-1",
+        "id": "11111111-1111-1111-1111-111111111111",
+        "target_id": "support-account-1",
+        "target_mode": "support_account",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ\n\nUse the reset email.",
+        "items": [{
+            "rank": 1,
+            "topic": "password reset",
+            "question": "How do I reset my password?",
+            "answer": "Use the reset email.",
+            "source_ids": ["ticket-1"],
+            "ticket_count": 1,
+        }],
+        "source_count": 1,
+        "ticket_source_count": 1,
+        "output_checks": {"has_action_steps": True},
+        "warnings": [],
+        "metadata": {"corpus_id": "corpus-1"},
+        "status": "approved",
+    }
+    sql, args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in sql
+    assert "account_id = $2" in sql
+    assert args == ("11111111-1111-1111-1111-111111111111", "acct-1")
+
+
+def test_faq_deflection_detail_route_requires_tenant_scope_before_database() -> None:
+    pool = _Pool(rows=[_faq_row()])
+
+    response = _client(pool, scope=None).get(
+        "/content-ops/faq-deflection-search/11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account_id is required"
+    assert pool.fetch_calls == []
+
+
+def test_faq_deflection_detail_route_rejects_malformed_faq_id_before_database() -> None:
+    pool = _Pool(rows=[_faq_row()])
+
+    response = _client(pool, scope={"account_id": "acct-1"}).get(
+        "/content-ops/faq-deflection-search/not-a-uuid"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "faq_id must be a valid UUID"
+    assert pool.fetch_calls == []
+
+
+def test_faq_deflection_detail_route_returns_404_on_scoped_miss() -> None:
+    pool = _Pool(rows=[])
+
+    response = _client(pool, scope={"account_id": "acct-2"}).get(
+        "/content-ops/faq-deflection-search/11111111-1111-1111-1111-111111111111"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "FAQ not found"
+
+
 @pytest.mark.integration
-def test_faq_deflection_search_route_queries_real_postgres_projection() -> None:
+def test_faq_deflection_search_route_queries_real_postgres_projection_and_detail() -> None:
     asyncpg = pytest.importorskip("asyncpg")
     database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
     if not database_url:
@@ -220,10 +315,16 @@ def test_faq_deflection_search_route_queries_real_postgres_projection() -> None:
                 "/content-ops/faq-deflection-search"
                 f"?q=password%20reset&corpus_id={corpus_id}&limit=5"
             )
+            detail_response = client.get(
+                f"/content-ops/faq-deflection-search/{faq_id}"
+            )
             scope_account["value"] = account_b
             cross_tenant_response = client.get(
                 "/content-ops/faq-deflection-search"
                 f"?q=password%20reset&corpus_id={corpus_id}&limit=5"
+            )
+            cross_tenant_detail_response = client.get(
+                f"/content-ops/faq-deflection-search/{faq_id}"
             )
 
         assert response.status_code == 200
@@ -254,6 +355,24 @@ def test_faq_deflection_search_route_queries_real_postgres_projection() -> None:
             "results": [],
             "count": 0,
         }
+        assert detail_response.status_code == 200
+        assert detail_response.json() == {
+            "account_id": account_a,
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "title": "Support FAQ",
+            "markdown": "# Support FAQ",
+            "items": [],
+            "source_count": 1,
+            "ticket_source_count": 1,
+            "output_checks": {},
+            "warnings": [],
+            "metadata": {"corpus_id": corpus_id},
+            "id": faq_id,
+            "status": "approved",
+        }
+        assert cross_tenant_detail_response.status_code == 404
+        assert cross_tenant_detail_response.json()["detail"] == "FAQ not found"
     finally:
         _run_async(
             _cleanup_faq_search_route_projection(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Detail.md

Ownership lane: content-ops/faq-search

Slice phase: Vertical slice

The FAQ deflection search route returns compact result rows with faq_id, but the searchable demo needs a tenant-scoped way to hydrate the selected full generated FAQ artifact. This adds the thin detail path without changing generation, indexing, or the compact search envelope.

## Intentional
- Search rows stay compact; full Markdown, items, checks, warnings, and metadata are fetched only after selecting a faq_id.
- The detail route reuses the existing FAQ search router pool, scope, timeout, and host dependency wiring.
- The detail route does not add a status filter; status remains part of the returned draft and tenant scope is the access boundary.

## Deferred
- Hosted large-upload/backpressure remains parked as FAQSCALE-1 in HARDENING.md because this slice is read-only hydration.
- A deployed-host detail-route contract checker waits until the demo consumes this endpoint shape.
- A redacted/public detail envelope is deferred; this route is for the authenticated content-ops API.

## Verification
- pytest tests/test_extracted_ticket_faq_postgres.py tests/test_extracted_ticket_faq_search_api.py -q passed: 28 passed, 1 skipped for no database URL in this checkout.
- python -m compileall over the changed Python files passed.
- Extracted package guardrails passed: validate_extracted_content_pipeline, forbid_atlas_reasoning_imports, audit_extracted_standalone --fail-on-debt, check_ascii_python.
- bash scripts/local_pr_review.sh passed from a temporary clean worktree at this commit.
- python scripts/audit_pr_session_drift.py origin/main passed and checked 0 open PRs.

## Diff size
6 files, +321 / -3