### PR TITLE
Add support-ticket generated content evaluator

### DIFF
--- a/plans/PR-Support-Ticket-Generated-Content-Quality-Eval.md
+++ b/plans/PR-Support-Ticket-Generated-Content-Quality-Eval.md
@@ -1,0 +1,117 @@
+# Support Ticket Generated Content Quality Eval
+
+## Why this slice exists
+
+PR #950 proves the support-ticket source context survives into saved-draft
+exports for landing pages and blog posts. That closes the artifact-truth gap,
+but it does not prove the generated copy actually uses the ticket facts well.
+
+The next validation gap is content quality on the generated artifact: when a
+live smoke writes an exported draft JSON, operators need a deterministic way to
+spot obvious drift such as missing support-ticket context, stale benchmark
+numbers, absent customer wording, or generated text that ignores the observed
+ticket clusters.
+
+This slice stays in the support-ticket provider lane and evaluates exported
+drafts after generation. It does not change generation prompts, FAQ generation,
+or hosted upload flow.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Add an offline support-ticket generated-content evaluator for saved-draft
+   export JSON files.
+2. Support both `landing_page` exports and `blog_post` exports.
+3. Check that the exported draft still has support-ticket context in the
+   expected location.
+4. Check generated text for concrete signs that it used the source facts:
+   source counts where present, top ticket clusters, customer questions or
+   wording examples, and support-ticket/FAQ framing.
+5. Flag stale generic benchmark numbers from prior smoke drift, including
+   `186`, `78`, and `42%`, when those values are not present in the source
+   context.
+6. Add focused tests with representative passing and failing landing/blog
+   export artifacts.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Generated-Content-Quality-Eval.md`
+- `scripts/evaluate_support_ticket_generated_content.py`
+- `tests/test_evaluate_support_ticket_generated_content.py`
+
+## Mechanism
+
+The evaluator will read a JSON export produced by
+`scripts/smoke_content_ops_live_generation.py --export-saved-draft`. The caller
+will pass `--output landing_page` or `--output blog_post`.
+
+For landing pages, the evaluator reads source context from
+`rows[0].metadata.source_context` and generated text from title, slug, hero,
+sections, CTA, and meta fields.
+
+For blog posts, the evaluator reads source context from `rows[0].data_context`
+and generated text from title, description, content, tags, and charts.
+
+The command returns machine-readable JSON with:
+
+- `ok`
+- `errors`
+- `warnings`
+- `checks`
+- `source_context_summary`
+
+Required failures should cover missing export rows, missing support-ticket
+context, stale benchmark numbers that are not source-backed, and generated text
+that does not mention any observed cluster/question/customer wording. Softer
+quality concerns can be warnings so this first version helps inspection without
+pretending to be a full editorial judge.
+
+## Intentional
+
+- No LLM judge. This is deterministic and cheap enough for local/live-smoke
+  validation.
+- No prompt changes. If the evaluator exposes quality problems, prompt or
+  generator fixes should be follow-up slices with concrete evidence.
+- No FAQ generator or FAQ article evaluation. FAQ output remains owned by the
+  parallel FAQ session.
+- No hosted route changes. This reads export JSON files produced by existing
+  smoke tooling.
+
+## Deferred
+
+- Future PR: wire this evaluator into the live smoke command as an optional
+  `--evaluate-generated-content` flag after the standalone evaluator is proven.
+- Future PR: use real exported CBFS/support-ticket artifacts as regression
+  fixtures if we can commit safe redacted samples.
+- Future PR: prompt/generator adjustments if the evaluator finds consistent
+  content drift in live Haiku outputs.
+- Parked hardening: none added by this slice. Existing `FAQSCALE-1` remains
+  owned by `content-ops/faq-generation-scale`.
+
+## Verification
+
+- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q`
+  - 9 passed.
+- Py compile for `scripts/evaluate_support_ticket_generated_content.py` and
+  `tests/test_evaluate_support_ticket_generated_content.py`
+  - Passed.
+- Local PR review wrapper
+  - Passed.
+- Review comment fix: stale benchmark numbers now match whole tokens, so
+  larger values like `2186` do not collide with stale `186`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~110 |
+| Evaluator script | ~415 |
+| Tests | ~225 |
+| **Total** | **~750** |
+
+This exceeds the 400 LOC soft target because the slice needs both asset shapes,
+CLI behavior, and failure coverage to be useful. The evaluator remains
+standalone and does not touch production routes or generation code.

--- a/scripts/evaluate_support_ticket_generated_content.py
+++ b/scripts/evaluate_support_ticket_generated_content.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Evaluate generated landing/blog drafts against support-ticket source context."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+JsonDict = dict[str, Any]
+
+_STALE_BENCHMARK_TOKENS = ("186", "78", "42%")
+_COUNT_CONTEXT_KEYS = (
+    "source_row_count",
+    "included_ticket_row_count",
+    "question_like_ticket_count",
+)
+_FRAMING_RE = re.compile(
+    r"\b(?:support[-\s]?tickets?|tickets?|faq|help[-\s]?center|answers?)\b",
+    re.IGNORECASE,
+)
+
+
+def evaluate_support_ticket_generated_content(
+    export: Mapping[str, Any],
+    *,
+    output: str,
+) -> JsonDict:
+    """Return deterministic quality checks for one exported generated draft."""
+
+    normalized_output = _normalize_output(output)
+    rows = _export_rows(export)
+    errors: list[str] = []
+    warnings: list[str] = []
+    checks: list[JsonDict] = []
+    if not rows:
+        return _result(
+            errors=["export did not include any rows"],
+            warnings=[],
+            checks=[_check("export_rows_present", False, "error")],
+            source_context={},
+        )
+
+    row = rows[0]
+    context = _source_context(row, output=normalized_output)
+    _record(
+        checks,
+        "support_ticket_context_present",
+        bool(context),
+        "error",
+        errors,
+        "export row is missing support-ticket source context",
+    )
+    if not context:
+        return _result(
+            errors=errors,
+            warnings=warnings,
+            checks=checks,
+            source_context={},
+        )
+
+    text = _generated_text(row, output=normalized_output)
+    text_lc = text.lower()
+    _record(
+        checks,
+        "generated_text_present",
+        bool(text_lc.strip()),
+        "error",
+        errors,
+        "export row did not contain generated text fields",
+    )
+    _record(
+        checks,
+        "support_ticket_framing_present",
+        bool(_FRAMING_RE.search(text)),
+        "error",
+        errors,
+        "generated text does not use support-ticket, FAQ, help-center, or answer framing",
+    )
+    _check_stale_benchmarks(
+        checks,
+        errors,
+        text=text,
+        source_context=context,
+    )
+    _check_count_visibility(
+        checks,
+        warnings,
+        text=text,
+        source_context=context,
+    )
+    _check_source_signal_visibility(
+        checks,
+        errors,
+        text_lc=text_lc,
+        source_context=context,
+    )
+    return _result(
+        errors=errors,
+        warnings=warnings,
+        checks=checks,
+        source_context=context,
+    )
+
+
+def _normalize_output(output: str) -> str:
+    value = str(output or "").strip()
+    if value not in {"landing_page", "blog_post"}:
+        raise ValueError("--output must be landing_page or blog_post")
+    return value
+
+
+def _export_rows(export: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    rows = export.get("rows") or ()
+    if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence):
+        return ()
+    return tuple(row for row in rows if isinstance(row, Mapping))
+
+
+def _source_context(row: Mapping[str, Any], *, output: str) -> Mapping[str, Any]:
+    if output == "landing_page":
+        metadata = _as_mapping(row.get("metadata"))
+        return _as_mapping(metadata.get("source_context"))
+    if output == "blog_post":
+        return _as_mapping(row.get("data_context"))
+    return {}
+
+
+def _generated_text(row: Mapping[str, Any], *, output: str) -> str:
+    if output == "landing_page":
+        return _join_text(
+            row.get("title"),
+            row.get("slug"),
+            row.get("hero"),
+            row.get("sections"),
+            row.get("cta"),
+            row.get("meta"),
+        )
+    if output == "blog_post":
+        return _join_text(
+            row.get("title"),
+            row.get("description"),
+            row.get("content"),
+            row.get("tags"),
+            row.get("charts"),
+        )
+    return ""
+
+
+def _check_stale_benchmarks(
+    checks: list[JsonDict],
+    errors: list[str],
+    *,
+    text: str,
+    source_context: Mapping[str, Any],
+) -> None:
+    context_text = json.dumps(source_context, sort_keys=True, default=str)
+    stale_hits = [
+        token
+        for token in _STALE_BENCHMARK_TOKENS
+        if _benchmark_token_present(text, token)
+        and not _benchmark_token_present(context_text, token)
+    ]
+    passed = not stale_hits
+    checks.append({
+        "name": "no_stale_benchmark_numbers",
+        "passed": passed,
+        "level": "error",
+        "details": stale_hits,
+    })
+    if stale_hits:
+        errors.append(
+            "generated text contains stale benchmark numbers not present in "
+            f"source context: {', '.join(stale_hits)}"
+        )
+
+
+def _benchmark_token_present(value: str, token: str) -> bool:
+    escaped = re.escape(token)
+    return bool(re.search(rf"(?<![A-Za-z0-9]){escaped}(?![A-Za-z0-9%])", value))
+
+
+def _check_count_visibility(
+    checks: list[JsonDict],
+    warnings: list[str],
+    *,
+    text: str,
+    source_context: Mapping[str, Any],
+) -> None:
+    expected_counts = [
+        int(source_context[key])
+        for key in _COUNT_CONTEXT_KEYS
+        if _positive_int(source_context.get(key)) is not None
+    ]
+    visible_counts = [
+        count for count in expected_counts if re.search(rf"\b{count}\b", text)
+    ]
+    passed = not expected_counts or bool(visible_counts)
+    checks.append({
+        "name": "source_count_visible",
+        "passed": passed,
+        "level": "warning",
+        "details": {
+            "expected_counts": expected_counts,
+            "visible_counts": visible_counts,
+        },
+    })
+    if not passed:
+        warnings.append(
+            "generated text does not visibly mention any support-ticket source counts"
+        )
+
+
+def _check_source_signal_visibility(
+    checks: list[JsonDict],
+    errors: list[str],
+    *,
+    text_lc: str,
+    source_context: Mapping[str, Any],
+) -> None:
+    signals = _source_signals(source_context)
+    matched = [signal for signal in signals if _signal_visible(signal, text_lc)]
+    passed = bool(matched)
+    checks.append({
+        "name": "source_signal_visible",
+        "passed": passed,
+        "level": "error",
+        "details": {
+            "expected_signal_count": len(signals),
+            "matched_signals": matched[:10],
+        },
+    })
+    if not signals:
+        errors.append(
+            "support-ticket source context did not include clusters, "
+            "questions, or wording"
+        )
+    elif not passed:
+        errors.append(
+            "generated text does not mention any observed ticket cluster, "
+            "customer question, or customer wording example"
+        )
+
+
+def _source_signals(source_context: Mapping[str, Any]) -> list[str]:
+    signals: list[str] = []
+    clusters = source_context.get("top_ticket_clusters") or source_context.get("top_clusters")
+    if isinstance(clusters, Sequence) and not isinstance(clusters, (str, bytes)):
+        for cluster in clusters:
+            if isinstance(cluster, Mapping):
+                label = str(cluster.get("label") or "").strip()
+                if label:
+                    signals.append(label)
+    for key in ("faq_questions", "customer_wording_examples"):
+        values = source_context.get(key) or ()
+        if isinstance(values, Sequence) and not isinstance(values, (str, bytes)):
+            signals.extend(str(item).strip() for item in values if str(item).strip())
+    return _dedupe(signals)
+
+
+def _signal_visible(signal: str, text_lc: str) -> bool:
+    normalized = signal.lower().strip()
+    if not normalized:
+        return False
+    if normalized in text_lc:
+        return True
+    words = [
+        word
+        for word in re.findall(r"[a-z0-9]+", normalized)
+        if len(word) >= 4
+    ]
+    if not words:
+        return False
+    return all(word in text_lc for word in words[:4])
+
+
+def _result(
+    *,
+    errors: list[str],
+    warnings: list[str],
+    checks: list[JsonDict],
+    source_context: Mapping[str, Any],
+) -> JsonDict:
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "checks": checks,
+        "source_context_summary": _source_context_summary(source_context),
+    }
+
+
+def _source_context_summary(source_context: Mapping[str, Any]) -> JsonDict:
+    clusters = source_context.get("top_ticket_clusters") or source_context.get("top_clusters")
+    return {
+        "source_row_count": source_context.get("source_row_count"),
+        "included_ticket_row_count": source_context.get("included_ticket_row_count"),
+        "question_like_ticket_count": source_context.get("question_like_ticket_count"),
+        "source_period": source_context.get("source_period"),
+        "cluster_count": (
+            len(clusters)
+            if isinstance(clusters, Sequence) and not isinstance(clusters, (str, bytes))
+            else 0
+        ),
+    }
+
+
+def _record(
+    checks: list[JsonDict],
+    name: str,
+    passed: bool,
+    level: str,
+    errors: list[str],
+    message: str,
+) -> None:
+    checks.append({"name": name, "passed": passed, "level": level})
+    if not passed:
+        errors.append(message)
+
+
+def _join_text(*values: Any) -> str:
+    parts: list[str] = []
+    for value in values:
+        parts.extend(_iter_text(value))
+    return "\n".join(parts)
+
+
+def _iter_text(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        parts: list[str] = []
+        for item in value.values():
+            parts.extend(_iter_text(item))
+        return parts
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        parts = []
+        for item in value:
+            parts.extend(_iter_text(item))
+        return parts
+    return [str(value)]
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        key = normalized.lower()
+        if normalized and key not in seen:
+            seen.add(key)
+            result.append(normalized)
+    return result
+
+
+def _load_export(path: Path) -> Mapping[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"unable to read export JSON: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"export path must contain JSON: {exc}") from exc
+    if not isinstance(parsed, Mapping):
+        raise ValueError("export JSON must be an object")
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Saved-draft export JSON path")
+    parser.add_argument(
+        "--output",
+        required=True,
+        choices=("landing_page", "blog_post"),
+        help="Generated asset type contained in the export.",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = evaluate_support_ticket_generated_content(
+            _load_export(args.path),
+            output=args.output,
+        )
+    except ValueError as exc:
+        result = {
+            "ok": False,
+            "errors": [str(exc)],
+            "warnings": [],
+            "checks": [],
+            "source_context_summary": {},
+        }
+    print(json.dumps(result, indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evaluate_support_ticket_generated_content.py
+++ b/tests/test_evaluate_support_ticket_generated_content.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/evaluate_support_ticket_generated_content.py"
+SPEC = importlib.util.spec_from_file_location(
+    "evaluate_support_ticket_generated_content",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+evaluator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(evaluator)
+
+
+def _landing_export(
+    *,
+    source_context: dict[str, Any] | None = None,
+    text_override: str | None = None,
+) -> dict[str, Any]:
+    context = source_context if source_context is not None else _source_context()
+    headline = text_override or (
+        "Turn 2 support-ticket rows about account and reporting questions "
+        "into FAQ answers customers can use."
+    )
+    return {
+        "count": 1,
+        "rows": [{
+            "id": "lp-live-smoke-1",
+            "title": "Support-ticket FAQ report",
+            "hero": {
+                "headline": headline,
+                "subheadline": (
+                    "Customers asked: How do I change my login email? "
+                    "The answer should be visible before they email support."
+                ),
+            },
+            "sections": [
+                {
+                    "heading": "Account questions keep coming back",
+                    "body": "Reporting export questions show the same help-center gap.",
+                }
+            ],
+            "cta": {"label": "Upload Ticket CSV -- Free Analysis"},
+            "meta": {"description": "Support ticket FAQ answers for small teams."},
+            "metadata": {"source_context": context},
+        }],
+    }
+
+
+def _blog_export(
+    *,
+    data_context: dict[str, Any] | None = None,
+    content_override: str | None = None,
+) -> dict[str, Any]:
+    context = data_context if data_context is not None else _blog_context()
+    content = content_override or (
+        "## What repeat support tickets reveal\n\n"
+        "The uploaded 2 ticket rows show account and reporting questions. "
+        "Those clusters should become FAQ answers before customers ask again."
+    )
+    return {
+        "count": 1,
+        "rows": [{
+            "id": "blog-live-smoke-1",
+            "title": "Support-ticket questions customers keep asking",
+            "description": "A support-ticket FAQ article for small teams.",
+            "content": content,
+            "tags": ["support tickets", "FAQ"],
+            "charts": [{"title": "Top support-ticket clusters"}],
+            "data_context": context,
+        }],
+    }
+
+
+def _source_context() -> dict[str, Any]:
+    return {
+        "source_row_count": 2,
+        "included_ticket_row_count": 2,
+        "skipped_ticket_row_count": 0,
+        "truncated_ticket_row_count": 0,
+        "question_like_ticket_count": 2,
+        "source_period": "Uploaded support tickets",
+        "top_ticket_clusters": [
+            {"label": "account", "count": 1},
+            {"label": "reporting", "count": 1},
+        ],
+        "faq_questions": [
+            "How do I change my login email?",
+            "How do we export campaign attribution data before renewal?",
+        ],
+        "customer_wording_examples": [
+            "I cannot find where to update the email on my account.",
+        ],
+    }
+
+
+def _blog_context() -> dict[str, Any]:
+    return {
+        "source_row_count": 2,
+        "included_ticket_row_count": 2,
+        "question_like_ticket_count": 2,
+        "source_period": "Uploaded support tickets",
+        "top_clusters": [
+            {"label": "account", "count": 1},
+            {"label": "reporting", "count": 1},
+        ],
+    }
+
+
+def test_landing_export_passes_when_generated_text_uses_ticket_context() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(),
+        output="landing_page",
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["source_context_summary"] == {
+        "source_row_count": 2,
+        "included_ticket_row_count": 2,
+        "question_like_ticket_count": 2,
+        "source_period": "Uploaded support tickets",
+        "cluster_count": 2,
+    }
+
+
+def test_blog_export_passes_with_blog_data_context_shape() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _blog_export(),
+        output="blog_post",
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert not result["warnings"]
+
+
+def test_landing_export_fails_when_source_context_missing() -> None:
+    export = _landing_export(source_context=None)
+    export["rows"][0]["metadata"] = {}
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    assert result["errors"] == [
+        "export row is missing support-ticket source context"
+    ]
+
+
+def test_landing_export_fails_on_stale_benchmark_numbers() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(
+            text_override=(
+                "Across 186 support tickets, 78 repeat questions created a "
+                "42% FAQ gap around account issues."
+            )
+        ),
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    assert (
+        "generated text contains stale benchmark numbers not present in "
+        "source context: 186, 78, 42%"
+    ) in result["errors"]
+
+
+def test_landing_export_does_not_match_stale_number_inside_larger_number() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(
+            text_override=(
+                "Across 2186 support-ticket records, account questions still "
+                "show where customers need FAQ answers."
+            )
+        ),
+        output="landing_page",
+    )
+
+    assert result["ok"] is True
+    assert not any("stale benchmark numbers" in error for error in result["errors"])
+
+
+def test_landing_export_context_larger_number_does_not_authorize_stale_number() -> None:
+    context = _source_context()
+    context["source_row_count"] = 2186
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(
+            source_context=context,
+            text_override=(
+                "Across 186 support tickets, account questions still show "
+                "where customers need FAQ answers."
+            ),
+        ),
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    assert (
+        "generated text contains stale benchmark numbers not present in "
+        "source context: 186"
+    ) in result["errors"]
+
+
+def test_blog_export_fails_when_no_source_signal_is_visible() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _blog_export(
+            content_override=(
+                "## Support ticket FAQ\n\n"
+                "This article discusses answers in general without naming "
+                "the observed ticket issues."
+            )
+        ),
+        output="blog_post",
+    )
+
+    assert result["ok"] is False
+    assert (
+        "generated text does not mention any observed ticket cluster, "
+        "customer question, or customer wording example"
+    ) in result["errors"]
+
+
+def test_cli_returns_nonzero_for_failing_export(tmp_path: Path, capsys: Any) -> None:
+    path = tmp_path / "landing-export.json"
+    export = _landing_export(text_override="Generic marketing copy.")
+    export["rows"][0]["title"] = "Generic marketing page"
+    export["rows"][0]["hero"]["subheadline"] = "A broad page about operations."
+    export["rows"][0]["sections"] = [{"heading": "Overview", "body": "General advice."}]
+    export["rows"][0]["cta"] = {"label": "Learn more"}
+    export["rows"][0]["meta"] = {"description": "General operations page."}
+    path.write_text(json.dumps(export), encoding="utf-8")
+
+    code = evaluator.main([str(path), "--output", "landing_page"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert any(
+        "support-ticket, FAQ, help-center, or answer framing" in error
+        for error in payload["errors"]
+    )
+
+
+def test_cli_returns_zero_for_passing_blog_export(tmp_path: Path, capsys: Any) -> None:
+    path = tmp_path / "blog-export.json"
+    path.write_text(json.dumps(_blog_export()), encoding="utf-8")
+
+    code = evaluator.main([str(path), "--output", "blog_post", "--pretty"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert code == 0
+    assert payload["ok"] is True


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Generated-Content-Quality-Eval.md
Slice phase: Functional validation

Adds a deterministic offline evaluator for saved-draft export JSON files so we can inspect whether generated landing-page/blog-post drafts actually use the support-ticket source facts that survived export.

## Intentional
- No LLM judge; this is deterministic local/live-smoke validation.
- No prompt, generator, route, hosted upload, or FAQ-generator changes.
- Reads existing saved-draft export artifacts after generation.

## Deferred
- Optional live-smoke integration via a future --evaluate-generated-content flag.
- Real redacted CBFS/support-ticket fixtures if we can commit safe samples.
- Prompt/generator changes if this evaluator exposes consistent live output drift.

## Parked hardening
- None added by this slice. Existing FAQSCALE-1 remains owned by content-ops/faq-generation-scale.

## Verification
- python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q
- python -m py_compile scripts/evaluate_support_ticket_generated_content.py tests/test_evaluate_support_ticket_generated_content.py
- bash scripts/local_pr_review.sh

## Diff size
3 files, +755 / -0