### PR TITLE
Harden FAQ search checker branch coverage

### DIFF
--- a/plans/PR-FAQ-Search-Checker-Branch-Coverage.md
+++ b/plans/PR-FAQ-Search-Checker-Branch-Coverage.md
@@ -1,0 +1,71 @@
+# FAQ Search Checker Branch Coverage
+
+## Why this slice exists
+
+The hosted FAQ search route checker is itself a detector. If its validation or
+request-error branches silently stop firing, the operator can get a false pass
+from the exact tool meant to catch a broken deployed route.
+
+Current main already covers the largest stale concerns: `count != len(results)`
+is pinned, and `_fetch_json` is tested through `urllib.request.urlopen` for
+HTTPError, URLError, malformed JSON, and non-object JSON. The remaining gap is
+smaller but real: most `main()` tests replace `_fetch_json`, so the CLI path does
+not prove transport failures through `main()`, and a few preflight/result-field
+branches are not pinned individually.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Functional validation
+
+1. Add negative tests for the remaining FAQ search checker preflight branches.
+2. Pin every first-result required-field branch, including missing `question`.
+3. Add `main()` tests that mock `urllib.request.urlopen`, not `_fetch_json`, for
+   success and request-failure paths.
+4. Keep production checker code unchanged unless a test exposes a real bug.
+
+### Files touched
+
+- `plans/PR-FAQ-Search-Checker-Branch-Coverage.md`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+
+## Mechanism
+
+The tests use the existing checker module and add branch-level negative cases:
+blank base URL, blank query, non-positive limit, missing required first-result
+fields, and `main()` transport behavior through `urllib.request.urlopen`.
+
+The transport tests keep the real `_fetch_json` in play while monkeypatching the
+standard-library `urlopen` call. That proves the CLI path exercises the same
+request/JSON/error handling an operator uses against a deployed route.
+
+## Intentional
+
+- Tests only unless a bug is discovered.
+- No live network call. The transport boundary is covered by monkeypatching
+  `urllib.request.urlopen`, not by replacing `_fetch_json`.
+- No route/API behavior changes. This hardens the checker around the existing
+  `{query, results, count}` contract.
+
+## Deferred
+
+- Future PR: generic checker-testing discipline docs or a mutation-testing
+  helper if this pattern recurs across more scripts.
+- Parked hardening: none added by this slice.
+
+## Verification
+
+- `python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q`
+  - 39 passed.
+- Py compile for `scripts/check_content_ops_faq_search_route_contract.py` and
+  `tests/test_check_content_ops_faq_search_route_contract.py`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| Tests | ~150 |
+| **Total** | **~220** |

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -118,6 +118,38 @@ def test_validate_envelope_requires_demo_fields_when_requested():
     ]
 
 
+@pytest.mark.parametrize("field", _MODULE.RESULT_FIELDS)
+def test_validate_envelope_requires_each_demo_field_when_requested(field):
+    result = dict(_valid_payload()["results"][0])
+    result.pop(field)
+    payload = {"query": "reset", "results": [result], "count": 1}
+
+    assert (
+        f"results[0].{field} is required"
+        in _MODULE._validate_envelope(payload, require_results=True)
+    )
+
+
+def test_main_requires_base_url(monkeypatch, capsys, tmp_path):
+    monkeypatch.delenv("ATLAS_API_BASE_URL", raising=False)
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "",
+        "--token",
+        "token-123",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 2
+    assert "ATLAS_API_BASE_URL or --base-url is required" in capsys.readouterr().out
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["phase"] == "preflight"
+    assert payload["errors"] == ["ATLAS_API_BASE_URL or --base-url is required"]
+
+
 def test_main_requires_token(monkeypatch, capsys):
     monkeypatch.delenv("ATLAS_B2B_JWT", raising=False)
     monkeypatch.delenv("ATLAS_TOKEN", raising=False)
@@ -125,6 +157,48 @@ def test_main_requires_token(monkeypatch, capsys):
 
     assert _MODULE.main() == 2
     assert "ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required" in capsys.readouterr().out
+
+
+def test_main_requires_query(monkeypatch, capsys, tmp_path):
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--query",
+        "",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 2
+    assert "ATLAS_FAQ_SEARCH_QUERY or --query is required" in capsys.readouterr().out
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["phase"] == "preflight"
+    assert payload["errors"] == ["ATLAS_FAQ_SEARCH_QUERY or --query is required"]
+
+
+def test_main_requires_positive_limit(monkeypatch, capsys, tmp_path):
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--limit",
+        "0",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 2
+    assert "--limit must be positive" in capsys.readouterr().out
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["phase"] == "preflight"
+    assert payload["errors"] == ["--limit must be positive"]
 
 
 def test_main_returns_failure_for_bad_contract(monkeypatch, capsys):
@@ -211,6 +285,68 @@ def test_fetch_json_reports_route_failures(monkeypatch, failure, expected):
 
     with pytest.raises(RuntimeError, match=expected):
         _MODULE._fetch_json("https://atlas.example.com/search", token="tok", timeout=3)
+
+
+def test_main_uses_urlopen_transport_for_success(monkeypatch, capsys):
+    calls = []
+
+    def _urlopen(request, *, timeout):
+        calls.append((request, timeout))
+        return _Response(json.dumps(_valid_payload()).encode("utf-8"))
+
+    monkeypatch.setattr(_MODULE.urllib.request, "urlopen", _urlopen)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--query",
+        "mortgage payment dispute",
+        "--require-results",
+    )
+
+    assert _MODULE.main() == 0
+    assert len(calls) == 1
+    assert calls[0][0].full_url == (
+        "https://atlas.example.com/api/v1/content-ops/faq-deflection-search"
+        "?q=mortgage+payment+dispute&limit=5"
+    )
+    assert calls[0][0].headers["Authorization"] == "Bearer token-123"
+    assert calls[0][1] == 10.0
+    assert "FAQ search route contract passed" in capsys.readouterr().out
+
+
+def test_main_uses_urlopen_transport_for_http_failure(monkeypatch, capsys, tmp_path):
+    def _urlopen(request, *, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "Server Error",
+            {},
+            BytesIO(b"<html>server error</html>"),
+        )
+
+    monkeypatch.setattr(_MODULE.urllib.request, "urlopen", _urlopen)
+    result_path = tmp_path / "faq-search-route-result.json"
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "secret-token",
+        "--output-result",
+        str(result_path),
+    )
+
+    assert _MODULE.main() == 1
+    output = capsys.readouterr().out
+    assert "route returned HTTP 500: <html>server error</html>" in output
+    assert "secret-token" not in output
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["phase"] == "request"
+    assert payload["errors"] == ["route returned HTTP 500: <html>server error</html>"]
+    assert "secret-token" not in result_path.read_text(encoding="utf-8")
 
 
 def test_main_checks_route_and_prints_summary(monkeypatch, capsys):


### PR DESCRIPTION
Plan: plans/PR-FAQ-Search-Checker-Branch-Coverage.md
Slice phase: Functional validation

Adds tests for the remaining FAQ search route checker detector branches. Current main already pins count mismatch and direct _fetch_json transport failures; this closes the remaining gap around main() transport coverage, preflight branches, and every required first-result field.

## Intentional
- Tests only; the existing checker behavior was sound.
- Transport coverage mocks urllib.request.urlopen, not _fetch_json.
- No route/API behavior changes.

## Deferred
- Generic checker-testing discipline docs or mutation helpers can follow if this pattern recurs across more scripts.

## Parked hardening
- None added by this slice.

## Verification
- python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q
- python -m py_compile scripts/check_content_ops_faq_search_route_contract.py tests/test_check_content_ops_faq_search_route_contract.py
- bash scripts/local_pr_review.sh

## Diff size
2 files, +207 / -0