### PR TITLE
PR-Content-Ops-FAQ-Search-Detail-Contract

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Detail-Contract.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Detail-Contract.md
@@ -1,0 +1,63 @@
+# PR-Content-Ops-FAQ-Search-Detail-Contract
+
+## Why this slice exists
+PR-Content-Ops-FAQ-Search-Detail added the tenant-scoped full FAQ hydration
+route, but the deployed smoke checker still validates only the compact search
+envelope. The demo handoff needs one command that can prove the hosted API can
+return search results and hydrate the selected generated FAQ by `faq_id`.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Vertical slice.
+
+1. Extend the hosted FAQ search contract checker with an optional detail
+   hydration check.
+2. Reuse the existing search route as the default detail route root:
+   `/api/v1/content-ops/faq-deflection-search/{faq_id}`.
+3. Validate the detail envelope shape without writing full Markdown into the
+   result artifact.
+4. Add fixture tests for URL construction, malformed search result ids, valid
+   detail payloads, and detail contract failures while preserving the checker
+   branch coverage merged in PR #954.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Detail-Contract.md`
+- `scripts/check_content_ops_faq_search_route_contract.py`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+
+## Mechanism
+The checker gains `--require-detail` and an optional `--detail-route` override.
+When detail is required, the search response must include a first result object
+with a string `faq_id`. The checker calls the detail URL with the same bearer
+token and timeout, validates the full FAQ artifact fields, and writes only
+compact proof fields (`detail_checked`, `detail_route`, `detail_faq_id`) into
+the JSON result. Markdown and item bodies stay out of the result file.
+
+## Intentional
+- Detail validation is opt-in so the existing lightweight search smoke remains
+  unchanged for environments that only need the compact route.
+- The result artifact does not duplicate Markdown content; it records proof that
+  the detail payload was fetched and validated.
+- The script does not seed data. `--require-results --require-detail` remains a
+  hosted-environment check that expects an already indexed approved FAQ.
+
+## Deferred
+- A public/redacted detail contract is deferred until a public detail surface
+  exists. This checker targets the authenticated content-ops API.
+- Latency thresholds for search plus detail are deferred; this slice verifies
+  contract shape, not performance budgets.
+
+## Verification
+- pytest tests/test_check_content_ops_faq_search_route_contract.py -q passed with 50 tests after rebasing over PR #954.
+- python -m compileall scripts/check_content_ops_faq_search_route_contract.py tests/test_check_content_ops_faq_search_route_contract.py passed.
+- Pending local run: bash scripts/local_pr_review.sh
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 60 |
+| Checker script | 120 |
+| Tests | 160 |
+| **Total** | **340** |

--- a/scripts/check_content_ops_faq_search_route_contract.py
+++ b/scripts/check_content_ops_faq_search_route_contract.py
@@ -25,6 +25,21 @@ RESULT_FIELDS = (
     "ticket_count",
     "score",
 )
+DETAIL_FIELDS = (
+    "account_id",
+    "id",
+    "target_id",
+    "target_mode",
+    "title",
+    "markdown",
+    "items",
+    "source_count",
+    "ticket_source_count",
+    "output_checks",
+    "warnings",
+    "metadata",
+    "status",
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -41,8 +56,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--status", default=os.environ.get("ATLAS_FAQ_SEARCH_STATUS", ""))
     parser.add_argument("--limit", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_LIMIT", "5"))
     parser.add_argument("--route", default=DEFAULT_ROUTE)
+    parser.add_argument("--detail-route", default=os.environ.get("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
     parser.add_argument("--require-results", action="store_true")
+    parser.add_argument("--require-detail", action="store_true")
     parser.add_argument("--output-result", type=Path)
     return parser
 
@@ -70,6 +87,21 @@ def _build_url(
     if status.strip():
         params["status"] = status.strip()
     return f"{_clean_url(base_url)}{path}?{urllib.parse.urlencode(params)}"
+
+
+def _build_detail_url(
+    *,
+    base_url: str,
+    route: str,
+    detail_route: str,
+    faq_id: str,
+) -> str:
+    route_template = detail_route.strip() or f"{route.rstrip('/')}/{{faq_id}}"
+    if "{faq_id}" in route_template:
+        path = route_template.replace("{faq_id}", urllib.parse.quote(faq_id, safe=""))
+    else:
+        path = f"{route_template.rstrip('/')}/{urllib.parse.quote(faq_id, safe='')}"
+    return f"{_clean_url(base_url)}/" + path.strip("/")
 
 
 def _fetch_json(url: str, *, token: str, timeout: float) -> dict[str, Any]:
@@ -140,6 +172,36 @@ def _validate_first_result(result: Mapping[str, Any]) -> list[str]:
     return errors
 
 
+def _first_result_faq_id(data: Mapping[str, Any]) -> str | None:
+    results = data.get("results")
+    if not isinstance(results, list) or not results or not isinstance(results[0], Mapping):
+        return None
+    faq_id = results[0].get("faq_id")
+    return faq_id if isinstance(faq_id, str) and faq_id.strip() else None
+
+
+def _validate_detail(data: Mapping[str, Any], *, faq_id: str) -> list[str]:
+    errors: list[str] = []
+    for field in DETAIL_FIELDS:
+        if field not in data:
+            errors.append(f"detail.{field} is required")
+    if data.get("id") != faq_id:
+        errors.append("detail.id must match results[0].faq_id")
+    for field in ("account_id", "id", "target_id", "target_mode", "title", "markdown", "status"):
+        if field in data and not isinstance(data[field], str):
+            errors.append(f"detail.{field} must be a string")
+    for field in ("source_count", "ticket_source_count"):
+        if field in data and type(data[field]) is not int:
+            errors.append(f"detail.{field} must be an integer")
+    for field in ("items", "warnings"):
+        if field in data and not isinstance(data[field], list):
+            errors.append(f"detail.{field} must be a list")
+    for field in ("output_checks", "metadata"):
+        if field in data and not isinstance(data[field], Mapping):
+            errors.append(f"detail.{field} must be an object")
+    return errors
+
+
 def _result_payload(
     *,
     ok: bool,
@@ -151,6 +213,10 @@ def _result_payload(
     status: str,
     limit: int,
     require_results: bool,
+    require_detail: bool,
+    detail_route: str,
+    detail_checked: bool = False,
+    detail_faq_id: str = "",
     count: Any = None,
     errors: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -164,8 +230,13 @@ def _result_payload(
         "status": status,
         "limit": limit,
         "require_results": require_results,
+        "require_detail": require_detail,
+        "detail_route": detail_route,
+        "detail_checked": detail_checked,
         "errors": list(errors or ()),
     }
+    if detail_faq_id:
+        payload["detail_faq_id"] = detail_faq_id
     if type(count) is int:
         payload["count"] = count
     return payload
@@ -189,6 +260,7 @@ def main() -> int:
     corpus_id = str(args.corpus_id or "").strip()
     status = str(args.status or "").strip()
     route = str(args.route or "").strip()
+    detail_route = str(args.detail_route or "").strip()
     limit = int(args.limit)
     if not base_url:
         print("ATLAS_API_BASE_URL or --base-url is required.")
@@ -204,6 +276,8 @@ def main() -> int:
                 status=status,
                 limit=limit,
                 require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
                 errors=["ATLAS_API_BASE_URL or --base-url is required"],
             ),
         )
@@ -222,6 +296,8 @@ def main() -> int:
                 status=status,
                 limit=limit,
                 require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
                 errors=["ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required"],
             ),
         )
@@ -240,6 +316,8 @@ def main() -> int:
                 status=status,
                 limit=limit,
                 require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
                 errors=["ATLAS_FAQ_SEARCH_QUERY or --query is required"],
             ),
         )
@@ -258,6 +336,8 @@ def main() -> int:
                 status=status,
                 limit=limit,
                 require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
                 errors=["--limit must be positive"],
             ),
         )
@@ -287,12 +367,35 @@ def main() -> int:
                 status=status,
                 limit=limit,
                 require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
                 errors=[str(exc)],
             ),
         )
         return 1
 
     errors = _validate_envelope(data, require_results=args.require_results)
+    detail_checked = False
+    detail_faq_id = ""
+    resolved_detail_route = detail_route or f"{route.rstrip('/')}/{{faq_id}}"
+    if args.require_detail and not errors:
+        detail_faq_id = _first_result_faq_id(data) or ""
+        if not detail_faq_id:
+            errors.append("results[0].faq_id is required for detail check")
+        else:
+            detail_url = _build_detail_url(
+                base_url=base_url,
+                route=route,
+                detail_route=detail_route,
+                faq_id=detail_faq_id,
+            )
+            try:
+                detail_data = _fetch_json(detail_url, token=token, timeout=args.timeout)
+                detail_checked = True
+            except RuntimeError as exc:
+                errors.append(str(exc))
+            else:
+                errors.extend(_validate_detail(detail_data, faq_id=detail_faq_id))
     payload = _result_payload(
         ok=not errors,
         phase="contract",
@@ -303,6 +406,10 @@ def main() -> int:
         status=status,
         limit=limit,
         require_results=bool(args.require_results),
+        require_detail=bool(args.require_detail),
+        detail_route=resolved_detail_route,
+        detail_checked=detail_checked,
+        detail_faq_id=detail_faq_id,
         count=data.get("count"),
         errors=errors,
     )
@@ -314,7 +421,8 @@ def main() -> int:
     else:
         print(
             "FAQ search route contract passed: "
-            f"query={data.get('query')!r}, count={data.get('count')}"
+            f"query={data.get('query')!r}, count={data.get('count')}, "
+            f"detail_checked={detail_checked}"
         )
     return 0 if not errors else 1
 

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -31,6 +31,7 @@ def _valid_payload():
         "query": "mortgage payment dispute",
         "results": [
             {
+                "faq_id": "11111111-1111-1111-1111-111111111111",
                 "question": "How do I dispute a mortgage payment error?",
                 "answer_summary": "Check the statement, gather records, then contact support.",
                 "topic": "Mortgage servicing issues",
@@ -40,6 +41,24 @@ def _valid_payload():
             }
         ],
         "count": 1,
+    }
+
+
+def _valid_detail_payload():
+    return {
+        "account_id": "acct-1",
+        "id": "11111111-1111-1111-1111-111111111111",
+        "target_id": "support-account-1",
+        "target_mode": "support_account",
+        "title": "Support FAQ",
+        "markdown": "# Support FAQ",
+        "items": [],
+        "source_count": 1,
+        "ticket_source_count": 1,
+        "output_checks": {},
+        "warnings": [],
+        "metadata": {"corpus_id": "corpus-1"},
+        "status": "approved",
     }
 
 
@@ -57,6 +76,31 @@ def test_build_url_encodes_query_and_optional_filters():
         "https://atlas.example.com/api/v1/content-ops/faq-deflection-search"
         "?q=mortgage+payment+dispute&limit=5&corpus_id=corpus+1&status=approved"
     )
+
+
+def test_build_detail_url_defaults_to_search_route_child():
+    url = _MODULE._build_detail_url(
+        base_url="https://atlas.example.com/",
+        route="/api/v1/content-ops/faq-deflection-search",
+        detail_route="",
+        faq_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    assert url == (
+        "https://atlas.example.com/api/v1/content-ops/faq-deflection-search/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+
+def test_build_detail_url_allows_template_override():
+    url = _MODULE._build_detail_url(
+        base_url="https://atlas.example.com",
+        route="/ignored",
+        detail_route="/api/v2/faqs/{faq_id}/full",
+        faq_id="id with space",
+    )
+
+    assert url == "https://atlas.example.com/api/v2/faqs/id%20with%20space/full"
 
 
 def test_validate_envelope_rejects_bool_count():
@@ -148,6 +192,33 @@ def test_main_requires_base_url(monkeypatch, capsys, tmp_path):
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert payload["phase"] == "preflight"
     assert payload["errors"] == ["ATLAS_API_BASE_URL or --base-url is required"]
+
+
+def test_validate_detail_accepts_full_generated_faq_payload():
+    assert _MODULE._validate_detail(
+        _valid_detail_payload(),
+        faq_id="11111111-1111-1111-1111-111111111111",
+    ) == []
+
+
+@pytest.mark.parametrize(
+    ("patch", "expected"),
+    [
+        ({"id": "22222222-2222-2222-2222-222222222222"}, "detail.id must match results[0].faq_id"),
+        ({"markdown": 1}, "detail.markdown must be a string"),
+        ({"items": {}}, "detail.items must be a list"),
+        ({"source_count": True}, "detail.source_count must be an integer"),
+        ({"output_checks": []}, "detail.output_checks must be an object"),
+    ],
+)
+def test_validate_detail_rejects_contract_drift(patch, expected):
+    payload = _valid_detail_payload()
+    payload.update(patch)
+
+    assert expected in _MODULE._validate_detail(
+        payload,
+        faq_id="11111111-1111-1111-1111-111111111111",
+    )
 
 
 def test_main_requires_token(monkeypatch, capsys):
@@ -380,6 +451,85 @@ def test_main_checks_route_and_prints_summary(monkeypatch, capsys):
     assert "FAQ search route contract passed" in capsys.readouterr().out
 
 
+def test_main_checks_detail_when_requested(monkeypatch, capsys):
+    calls = []
+
+    def _fake_fetch_json(url, *, token, timeout):
+        calls.append((url, token, timeout))
+        if url.endswith("/11111111-1111-1111-1111-111111111111"):
+            return _valid_detail_payload()
+        return _valid_payload()
+
+    monkeypatch.setattr(_MODULE, "_fetch_json", _fake_fetch_json)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--query",
+        "mortgage payment dispute",
+        "--require-results",
+        "--require-detail",
+    )
+
+    assert _MODULE.main() == 0
+    assert calls == [
+        (
+            "https://atlas.example.com/api/v1/content-ops/faq-deflection-search"
+            "?q=mortgage+payment+dispute&limit=5",
+            "token-123",
+            10.0,
+        ),
+        (
+            "https://atlas.example.com/api/v1/content-ops/faq-deflection-search/"
+            "11111111-1111-1111-1111-111111111111",
+            "token-123",
+            10.0,
+        ),
+    ]
+    assert "detail_checked=True" in capsys.readouterr().out
+
+
+def test_main_requires_faq_id_for_detail_check(monkeypatch, capsys):
+    payload = _valid_payload()
+    del payload["results"][0]["faq_id"]
+    monkeypatch.setattr(_MODULE, "_fetch_json", lambda url, *, token, timeout: payload)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-results",
+        "--require-detail",
+    )
+
+    assert _MODULE.main() == 1
+    assert "results[0].faq_id is required for detail check" in capsys.readouterr().out
+
+
+def test_main_reports_detail_contract_failure(monkeypatch, capsys):
+    def _fake_fetch_json(url, *, token, timeout):
+        if url.endswith("/11111111-1111-1111-1111-111111111111"):
+            return {**_valid_detail_payload(), "items": {}}
+        return _valid_payload()
+
+    monkeypatch.setattr(_MODULE, "_fetch_json", _fake_fetch_json)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-results",
+        "--require-detail",
+    )
+
+    assert _MODULE.main() == 1
+    assert "detail.items must be a list" in capsys.readouterr().out
+
+
 def test_main_writes_success_result_without_token(monkeypatch, tmp_path):
     monkeypatch.setattr(
         _MODULE,
@@ -408,11 +558,14 @@ def test_main_writes_success_result_without_token(monkeypatch, tmp_path):
         "base_url": "https://atlas.example.com",
         "corpus_id": "corpus-1",
         "count": 1,
+        "detail_checked": False,
+        "detail_route": "/api/v1/content-ops/faq-deflection-search/{faq_id}",
         "errors": [],
         "limit": 5,
         "ok": True,
         "phase": "contract",
         "query": "mortgage payment dispute",
+        "require_detail": False,
         "require_results": True,
         "route": "/api/v1/content-ops/faq-deflection-search",
         "status": "",
@@ -442,6 +595,7 @@ def test_main_writes_contract_failure_result(monkeypatch, tmp_path):
     assert payload["ok"] is False
     assert payload["phase"] == "contract"
     assert payload["errors"] == ["count must match len(results)"]
+    assert payload["detail_checked"] is False
     assert "secret-token" not in result_path.read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Detail-Contract.md

Ownership lane: content-ops/faq-search

Slice phase: Vertical slice

The hosted FAQ search checker only validated the compact `{ query, results, count }` route. This adds an opt-in `--require-detail` pass that follows `results[0].faq_id` to the tenant-scoped detail route and validates the full generated FAQ artifact shape without writing Markdown into the result JSON.

## Intentional
- Detail validation is opt-in so existing search-only smoke checks remain unchanged.
- Result JSON stays compact: it records detail proof metadata, not the full Markdown body.
- No data seeding is added; `--require-results --require-detail` expects an already indexed approved FAQ in the hosted environment.

## Deferred
- Public/redacted detail contract waits for a public detail surface.
- Latency thresholds for search plus detail are deferred; this slice validates contract shape only.

## Verification
- pytest tests/test_check_content_ops_faq_search_route_contract.py -q passed: 50 passed after rebasing over #954.
- python -m compileall scripts/check_content_ops_faq_search_route_contract.py tests/test_check_content_ops_faq_search_route_contract.py passed.
- python scripts/audit_pr_session_drift.py origin/main passed and checked 0 open PRs.
- bash scripts/local_pr_review.sh passed from a temporary clean worktree at this commit.

## Diff size
3 files, +326 / -1