### PR TITLE
Wire generated content evaluation into live smoke

### DIFF
--- a/plans/PR-Support-Ticket-Live-Smoke-Content-Eval.md
+++ b/plans/PR-Support-Ticket-Live-Smoke-Content-Eval.md
@@ -1,0 +1,93 @@
+# Support Ticket Live Smoke Content Eval
+
+## Why this slice exists
+
+PR #953 added a standalone deterministic evaluator for saved-draft exports. That
+lets operators check whether generated landing/blog copy actually uses the
+support-ticket facts that survived export, but it is still a separate manual
+step after the live smoke.
+
+The next product slice is to wire that evaluator into the live generation smoke
+as an optional flag, so one command can generate, export, validate source
+context, and fail on obvious generated-copy drift.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Product polish
+
+1. Add `--evaluate-generated-content` to the live Content Ops generation smoke.
+2. Require that flag to run with `--support-ticket-csv` and
+   `--export-saved-draft`, because the evaluator depends on support-ticket
+   export context.
+3. Run the deterministic evaluator against the in-memory saved-draft export
+   after source-context export validation passes.
+4. Add the evaluator result to the smoke result JSON.
+5. Fail the smoke when the evaluator returns errors.
+6. Add focused tests for passing evaluation, failing evaluation, and missing
+   required flags.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Live-Smoke-Content-Eval.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+
+## Mechanism
+
+The smoke keeps the generated-content evaluator optional. When
+`--evaluate-generated-content` is present, the smoke first ensures
+`--support-ticket-csv` and `--export-saved-draft` are also present. After
+generation returns saved draft ids and the existing export/context checks pass,
+the smoke calls `evaluate_support_ticket_generated_content(saved_draft_export,
+output=<landing_page|blog_post>)`.
+
+The evaluator payload is stored as `generated_content_evaluation` in the smoke
+result. Any evaluator errors are prefixed and appended to the smoke errors so
+CLI callers get a non-zero exit and a readable failure reason.
+
+## Intentional
+
+- No prompt or generator changes. This only wires the existing evaluator into
+  the operator smoke path.
+- No FAQ generator changes. FAQ-owned work remains separate.
+- The evaluator does not run unless explicitly requested.
+- The smoke reuses the in-memory export result; it does not reread the JSON file
+  it just wrote.
+- Local review caller hints are generic name collisions (`_parse_args`,
+  test-local `_evaluate`) across unrelated scripts/tests; this slice only
+  changes `scripts/smoke_content_ops_live_generation.py` behavior and covers it
+  with focused smoke tests.
+
+## Deferred
+
+- Future PR: run this flag in a recorded live Haiku validation and archive the
+  evaluator output.
+- Future PR: decide whether the flag should become default for support-ticket
+  live smokes after we see live output quality over several runs.
+- Parked hardening: none added by this slice.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_real_generated_content_evaluator_imports tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_evaluates_support_ticket_landing_export_content tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_generated_content_evaluation_fails tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_requires_export_for_generated_content_evaluation tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_requires_support_ticket_csv_for_content_evaluation -q`
+  - 5 passed.
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py -q`
+  - 33 passed.
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_evaluate_support_ticket_generated_content.py -q`
+  - 42 passed.
+- Py compile for `scripts/smoke_content_ops_live_generation.py`,
+  `tests/test_smoke_content_ops_live_generation.py`, and
+  `scripts/evaluate_support_ticket_generated_content.py`
+  - Passed.
+- Local PR review wrapper
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| Smoke script | ~90 |
+| Tests | ~220 |
+| **Total** | **~400** |

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -13,7 +13,10 @@ import sys
 from typing import Any, Awaitable, Callable, Mapping, Sequence
 
 
-ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[0]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
@@ -66,6 +69,7 @@ ServicesFactory = Callable[[], Any]
 Executor = Callable[..., Awaitable[dict[str, Any]]]
 BlogBlueprintSeeder = Callable[[argparse.Namespace, Any], Awaitable[Mapping[str, Any]]]
 DraftExporter = Callable[[str, Sequence[str], Any], Awaitable[Mapping[str, Any]]]
+GeneratedContentEvaluator = Callable[..., Mapping[str, Any]]
 
 
 def _load_dotenv_files(extra_env_files: list[Path] | None = None) -> None:
@@ -171,6 +175,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "draft ids produced by this smoke run."
         ),
     )
+    parser.add_argument(
+        "--evaluate-generated-content",
+        action="store_true",
+        help=(
+            "Run deterministic support-ticket generated-content evaluation "
+            "against the saved draft export. Requires --support-ticket-csv "
+            "and --export-saved-draft."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Print machine JSON.")
     return parser.parse_args(argv)
 
@@ -246,6 +259,27 @@ def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
 
 def _uses_support_ticket_csv(args: argparse.Namespace) -> bool:
     return bool(getattr(args, "support_ticket_csv", None))
+
+
+def _evaluates_generated_content(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "evaluate_generated_content", False))
+
+
+def _generated_content_evaluation_preflight_errors(
+    args: argparse.Namespace,
+) -> list[str]:
+    if not _evaluates_generated_content(args):
+        return []
+    errors: list[str] = []
+    if not _uses_support_ticket_csv(args):
+        errors.append(
+            "--evaluate-generated-content requires --support-ticket-csv"
+        )
+    if not getattr(args, "export_saved_draft", None):
+        errors.append(
+            "--evaluate-generated-content requires --export-saved-draft"
+        )
+    return errors
 
 
 def _support_ticket_rows_from_args(args: argparse.Namespace) -> list[dict[str, str]]:
@@ -477,6 +511,21 @@ def _exported_support_ticket_context(
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
+
+
+def _evaluate_generated_content_export(
+    saved_draft_export: Mapping[str, Any],
+    *,
+    output: str,
+) -> Mapping[str, Any]:
+    from evaluate_support_ticket_generated_content import (  # noqa: PLC0415
+        evaluate_support_ticket_generated_content,
+    )
+
+    return evaluate_support_ticket_generated_content(
+        saved_draft_export,
+        output=output,
+    )
 
 
 def _smoke_errors(
@@ -873,6 +922,7 @@ async def run_content_ops_live_generation_smoke(
     tenant_scope_cls: Any = None,
     blog_blueprint_seed_fn: BlogBlueprintSeeder | None = None,
     draft_export_fn: DraftExporter | None = None,
+    generated_content_evaluator: GeneratedContentEvaluator | None = None,
 ) -> tuple[int, dict[str, Any]]:
     _load_dotenv_files(list(args.env_file or []))
     if (
@@ -896,7 +946,19 @@ async def run_content_ops_live_generation_smoke(
     execution_result: dict[str, Any] | None = None
     seeded_blog_blueprint: Mapping[str, Any] | None = None
     saved_draft_export: Mapping[str, Any] | None = None
-    errors: list[str] = []
+    generated_content_evaluation: Mapping[str, Any] | None = None
+    errors: list[str] = _generated_content_evaluation_preflight_errors(args)
+    if errors:
+        return 1, {
+            "ok": False,
+            "errors": errors,
+            "configured_outputs": [],
+            "seeded_blog_blueprint": {},
+            "payload": payload,
+            "execution": None,
+            "saved_draft_export": None,
+            "generated_content_evaluation": None,
+        }
     try:
         await init_database_fn()
         services = services_factory()
@@ -947,6 +1009,25 @@ async def run_content_ops_live_generation_smoke(
                                 saved_draft_export=saved_draft_export,
                             )
                         )
+                    if _evaluates_generated_content(args) and not errors:
+                        evaluator = (
+                            generated_content_evaluator
+                            or _evaluate_generated_content_export
+                        )
+                        generated_content_evaluation = evaluator(
+                            saved_draft_export,
+                            output=output,
+                        )
+                        evaluation_errors = [
+                            str(item)
+                            for item in generated_content_evaluation.get("errors", ())
+                        ]
+                        if not generated_content_evaluation.get("ok") and not evaluation_errors:
+                            evaluation_errors = ["unknown generated-content failure"]
+                        errors.extend(
+                            f"generated content evaluation failed: {error}"
+                            for error in evaluation_errors
+                        )
     except Exception as exc:
         errors.append(f"{type(exc).__name__}: {exc}")
     finally:
@@ -964,6 +1045,11 @@ async def run_content_ops_live_generation_smoke(
         "execution": execution_result,
         "saved_draft_export": (
             dict(saved_draft_export) if isinstance(saved_draft_export, Mapping) else None
+        ),
+        "generated_content_evaluation": (
+            dict(generated_content_evaluation)
+            if isinstance(generated_content_evaluation, Mapping)
+            else None
         ),
     }
     return (0 if result["ok"] else 1), result

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -93,6 +93,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "no_quality_gates": False,
         "output_result": None,
         "export_saved_draft": None,
+        "evaluate_generated_content": False,
         "json": True,
     }
     values.update(overrides)
@@ -305,6 +306,232 @@ async def test_live_generation_smoke_validates_support_ticket_landing_export_con
     assert result["saved_draft_export"]["rows"][0]["metadata"]["source_context"][
         "source_row_count"
     ] == 2
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_evaluates_support_ticket_landing_export_content(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+    evaluations: list[dict[str, Any]] = []
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {
+            "count": 1,
+            "rows": [{
+                "id": saved_ids[0],
+                "title": "Support-ticket FAQ report",
+                "hero": {
+                    "headline": (
+                        "Turn 2 support-ticket rows about account questions "
+                        "into FAQ answers."
+                    )
+                },
+                "sections": [{"body": "Reporting questions need clearer answers."}],
+                "metadata": {
+                    "source_context": {
+                        "source_row_count": 2,
+                        "included_ticket_row_count": 2,
+                        "skipped_ticket_row_count": 0,
+                        "truncated_ticket_row_count": 0,
+                        "question_like_ticket_count": 2,
+                        "top_ticket_clusters": [
+                            {"label": "account", "count": 1},
+                            {"label": "reporting", "count": 1},
+                        ],
+                    },
+                },
+            }],
+        }
+
+    def _evaluate(export: dict[str, Any], *, output: str) -> dict[str, Any]:
+        evaluations.append({"export": export, "output": output})
+        return {"ok": True, "errors": [], "checks": [{"name": "ok"}]}
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "landing-page-draft.json",
+            evaluate_generated_content=True,
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+        generated_content_evaluator=_evaluate,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["generated_content_evaluation"] == {
+        "ok": True,
+        "errors": [],
+        "checks": [{"name": "ok"}],
+    }
+    assert evaluations == [{
+        "export": result["saved_draft_export"],
+        "output": "landing_page",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_fails_when_generated_content_evaluation_fails(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        return {
+            "count": 1,
+            "rows": [{
+                "id": saved_ids[0],
+                "metadata": {
+                    "source_context": {
+                        "source_row_count": 2,
+                        "included_ticket_row_count": 2,
+                        "skipped_ticket_row_count": 0,
+                        "truncated_ticket_row_count": 0,
+                        "question_like_ticket_count": 2,
+                        "top_ticket_clusters": [
+                            {"label": "account", "count": 1},
+                            {"label": "reporting", "count": 1},
+                        ],
+                    },
+                },
+            }],
+        }
+
+    def _evaluate(export: dict[str, Any], *, output: str) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "errors": ["generated text ignored account cluster"],
+            "checks": [],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            export_saved_draft=tmp_path / "landing-page-draft.json",
+            evaluate_generated_content=True,
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+        generated_content_evaluator=_evaluate,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["generated_content_evaluation"]["ok"] is False
+    assert result["errors"] == [
+        "generated content evaluation failed: generated text ignored account cluster"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_requires_export_for_generated_content_evaluation(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _LandingPageService()
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            support_ticket_csv=_support_ticket_csv(tmp_path),
+            evaluate_generated_content=True,
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(landing_page=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["execution"] is None
+    assert result["errors"] == [
+        "--evaluate-generated-content requires --export-saved-draft"
+    ]
+    assert lifecycle.initialized is False
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_requires_support_ticket_csv_for_content_evaluation(
+) -> None:
+    lifecycle = _Lifecycle()
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            export_saved_draft=Path("landing-page-draft.json"),
+            evaluate_generated_content=True,
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(
+            landing_page=_LandingPageService()
+        ),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 1
+    assert result["ok"] is False
+    assert result["execution"] is None
+    assert result["errors"] == [
+        "--evaluate-generated-content requires --support-ticket-csv"
+    ]
+    assert lifecycle.initialized is False
+
+
+def test_live_generation_smoke_real_generated_content_evaluator_imports() -> None:
+    result = smoke._evaluate_generated_content_export(
+        {
+            "count": 1,
+            "rows": [{
+                "id": "lp-live-smoke-1",
+                "title": "Support-ticket FAQ report",
+                "hero": {
+                    "headline": (
+                        "Turn 2 support-ticket rows about account questions "
+                        "into FAQ answers."
+                    )
+                },
+                "sections": [{"body": "Reporting questions need clearer answers."}],
+                "metadata": {
+                    "source_context": {
+                        "source_row_count": 2,
+                        "included_ticket_row_count": 2,
+                        "question_like_ticket_count": 2,
+                        "top_ticket_clusters": [
+                            {"label": "account", "count": 1},
+                            {"label": "reporting", "count": 1},
+                        ],
+                    },
+                },
+            }],
+        },
+        output="landing_page",
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Live-Smoke-Content-Eval.md
Slice phase: Product polish

Adds an opt-in --evaluate-generated-content flag to the live Content Ops generation smoke. When used with --support-ticket-csv and --export-saved-draft, the smoke evaluates the exported draft with the deterministic support-ticket generated-content evaluator and fails the smoke on generated-copy drift.

## Intentional
- Opt-in only; existing live smokes keep current behavior.
- Reuses the in-memory saved-draft export and existing deterministic evaluator.
- No prompt, generator, route, hosted upload, or FAQ-generator changes.
- Local review caller hints are generic name collisions across unrelated scripts/tests and are covered in the plan.

## Deferred
- Recorded live Haiku validation with evaluator output can follow.
- Decide later whether evaluation should become default for support-ticket live smokes.

## Parked hardening
- None added by this slice.

## Verification
- python -m pytest tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_real_generated_content_evaluator_imports tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_evaluates_support_ticket_landing_export_content tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_fails_when_generated_content_evaluation_fails tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_requires_export_for_generated_content_evaluation tests/test_smoke_content_ops_live_generation.py::test_live_generation_smoke_requires_support_ticket_csv_for_content_evaluation -q
- python -m pytest tests/test_smoke_content_ops_live_generation.py -q
- python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_evaluate_support_ticket_generated_content.py -q
- python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py scripts/evaluate_support_ticket_generated_content.py
- bash scripts/local_pr_review.sh

## Diff size
3 files, +408 / -2