### PR TITLE
Validate support-ticket live Haiku generated content eval

### DIFF
--- a/atlas_brain/skills/digest/blog_post_generation.md
+++ b/atlas_brain/skills/digest/blog_post_generation.md
@@ -97,12 +97,12 @@ Return valid JSON with exactly these keys:
 
 ## Content Rules
 
-1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, or review counts.
+1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, ROI ranges, future ticket-reduction ranges, time-savings ranges, or review counts. For support-ticket or uploaded-ticket topics, do not estimate future ticket reduction, hours saved, customer-satisfaction lift, or ROI math; keep benefits qualitative unless the exact numbers are present in the blueprint.
 2. **Chart placement**: Every `chart_id` listed in a section's `chart_ids` MUST appear exactly once in the content as `{{chart:chart-id}}` on its own line. Do not invent chart IDs that are not in `available_charts`.
-3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead.
+3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead. Start at least the first two H2 sections with a self-contained 40-120 word answer paragraph that includes the target keyword or clearest named subject.
 4. **Tone**: Authoritative but accessible. Data journalist style -- let the numbers tell the story. Avoid marketing fluff, superlatives, and filler.
 5. **Quotable phrases**: Where `quotable_phrases` are provided, weave 2-4 of them into the text as blockquotes (`> "quote" -- verified buyer`). Choose the most impactful ones.
-6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..."
+6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..." If `data_context.review_period` is "uploaded tickets" or `data_context.source_period` is "Uploaded support tickets", say "In the uploaded tickets..." and do not invent calendar dates, "last 90 days", or "between [month/year] and present" phrasing unless that exact window appears in `data_context`.
 7. **Length**: 1500-2200 words for the main content. Concise paragraphs (2-4 sentences each).
 8. **No CTA in content**: The frontend adds its own call-to-action section. End with a conclusion/verdict, not a sales pitch.
 9. **Formatting**: Use markdown headers (##), bold for key numbers, blockquotes for review excerpts, and bullet lists for comparisons. No HTML tags except tables.

--- a/docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md
+++ b/docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md
@@ -1,0 +1,137 @@
+# Support-Ticket Live Haiku Generated Content Eval - 2026-05-25
+
+## Scope
+
+This validation proves the live Content Ops smoke can run support-ticket-backed
+landing-page and blog-post generation with:
+
+- the support-ticket CSV input provider
+- saved-draft export
+- deterministic generated-content evaluation
+- OpenRouter routed to the Claude Haiku family for lower-cost testing
+
+Ownership lane: `content-ops/support-ticket-input-provider`
+
+## Environment
+
+- Repo: `canfieldjuan/ATLAS`
+- Branch: `claude/pr-support-ticket-live-haiku-eval`
+- Source CSV:
+  `extracted_content_pipeline/examples/support_ticket_sources.csv`
+- Env files:
+  - `/home/juan-canfield/Desktop/Atlas/.env`
+  - `/home/juan-canfield/Desktop/Atlas/.env.local`
+  - `tmp/support_ticket_live_haiku_eval_20260525/haiku.env`
+- Haiku override:
+  - `ATLAS_LLM_OPENROUTER_REASONING_MODEL=anthropic/claude-haiku-4-5`
+  - `ATLAS_LLM__OPENROUTER_REASONING_MODEL=anthropic/claude-haiku-4-5`
+
+The raw smoke outputs and saved-draft exports were written to ignored local
+`tmp/support_ticket_live_haiku_eval_20260525/`.
+
+## Commands
+
+Landing page:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --account-id acct_support_ticket_live_haiku_eval_20260525_landing \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_live_haiku_eval_20260525/landing-page-draft.json \
+  --output-result tmp/support_ticket_live_haiku_eval_20260525/landing-page-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+Blog post, after prompt/evaluator tightening:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_live_haiku_eval_20260525_blog_fixed4 \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_live_haiku_eval_20260525/blog-post-draft-fixed4.json \
+  --output-result tmp/support_ticket_live_haiku_eval_20260525/blog-post-result-fixed4.json \
+  --evaluate-generated-content \
+  --json
+```
+
+## Landing Result
+
+- Smoke status: passed
+- Saved draft id: `cad10d59-d62a-4c04-a111-7036cfd73e0b`
+- Generated: 1
+- Skipped: 0
+- SEO/AEO readiness: ready
+- GEO readiness: ready
+- Generated-content evaluation: passed
+- Evaluator errors: none
+
+The landing export carried source context for all 4 uploaded support-ticket
+rows and surfaced both observed clusters:
+
+- `email and profile updates` - 2 tickets
+- `reporting friction` - 2 tickets
+
+## Blog Result
+
+The blog path generated and saved drafts, but the generated-content evaluator
+correctly failed the latest run because the model invented unsupported future
+impact percentages.
+
+Latest run:
+
+- Smoke status: failed by generated-content evaluation
+- Saved draft id: `c0669850-b56a-48ac-9eff-7eb1a43582ea`
+- Generated: 1
+- Skipped: 0
+- SEO/AEO readiness: ready
+- GEO readiness in export: needs_review
+- Generated-content evaluation: failed
+- Evaluator error:
+  `generated text contains percentage claims not backed by support-ticket source counts: 30-50%, 30-50%, 30-50%`
+
+Earlier live blog runs exposed two additional issues that are now guarded:
+
+- Unsupported uploaded-ticket timeframe language such as
+  `Between May 2026 and the present`.
+- Unsupported future impact percentages such as `20-40%`, `70%`, and `75%`.
+
+## Code Changes From This Validation
+
+The validation exposed gaps that could have produced a false green. This slice
+closed those detection/source gaps:
+
+- Undated support-ticket blog blueprints no longer include `report_date`.
+- The blog-generation prompt now says uploaded-ticket inputs must use uploaded
+  ticket language and must not invent calendar windows.
+- The blog-generation prompt now tells the model not to invent predictive ROI,
+  future ticket-reduction, time-savings, or customer-satisfaction numbers.
+- The generated-content evaluator now fails unsupported calendar-window claims
+  for undated uploaded tickets.
+- The generated-content evaluator now fails unsupported percentage claims unless
+  the percentage is directly source-backed by the support-ticket counts.
+- The blog prompt now names the citable-section shape required by the GEO gate.
+
+## Interpretation
+
+The landing-page path is currently proven end to end with Haiku, saved-draft
+export, readiness, and generated-content evaluation.
+
+The blog-post path is not yet clean end to end. The smoke now catches the drift
+instead of passing it silently, but Haiku still tends to invent future impact
+percentages for support-ticket FAQ copy. That should be the next generator
+slice: use the evaluator failure as repair feedback or tighten the
+support-ticket blog prompt/input contract further until the saved draft passes
+both export readiness and generated-content evaluation.
+
+One additional integration gap was observed: the latest blog run saved a draft
+whose exported `geo_readiness.status` was `needs_review`. A follow-up should
+align blog save-time quality gating with the exported readiness checks, or make
+the live smoke fail on exported readiness when quality gates are enabled.

--- a/extracted_content_pipeline/skills/digest/blog_post_generation.md
+++ b/extracted_content_pipeline/skills/digest/blog_post_generation.md
@@ -97,12 +97,12 @@ Return valid JSON with exactly these keys:
 
 ## Content Rules
 
-1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, or review counts.
+1. **Data integrity**: ONLY cite numbers that appear in `key_stats` or `data_summary`. Never fabricate statistics, percentages, ROI ranges, future ticket-reduction ranges, time-savings ranges, or review counts. For support-ticket or uploaded-ticket topics, do not estimate future ticket reduction, hours saved, customer-satisfaction lift, or ROI math; keep benefits qualitative unless the exact numbers are present in the blueprint.
 2. **Chart placement**: Every `chart_id` listed in a section's `chart_ids` MUST appear exactly once in the content as `{{chart:chart-id}}` on its own line. Do not invent chart IDs that are not in `available_charts`.
-3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead.
+3. **Structure**: Follow the section order from the blueprint. Use the provided `heading` for each section as an H2 (`##`). Do not use vague H2 headings such as "Overview", "Introduction", "Conclusion", "Summary", "Final Thoughts", or "Key Takeaways"; use specific question or answer headings instead. Start at least the first two H2 sections with a self-contained 40-120 word answer paragraph that includes the target keyword or clearest named subject.
 4. **Tone**: Authoritative but accessible. Data journalist style -- let the numbers tell the story. Avoid marketing fluff, superlatives, and filler.
 5. **Quotable phrases**: Where `quotable_phrases` are provided, weave 2-4 of them into the text as blockquotes (`> "quote" -- verified buyer`). Choose the most impactful ones.
-6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..."
+6. **Timeframes**: Anchor all statistics with the time period from `data_context.review_period`. Example: "Between January 2025 and March 2026, we analyzed..." If `data_context.review_period` is "uploaded tickets" or `data_context.source_period` is "Uploaded support tickets", say "In the uploaded tickets..." and do not invent calendar dates, "last 90 days", or "between [month/year] and present" phrasing unless that exact window appears in `data_context`.
 7. **Length**: 1500-2200 words for the main content. Concise paragraphs (2-4 sentences each).
 8. **No CTA in content**: The frontend adds its own call-to-action section. End with a conclusion/verdict, not a sales pitch.
 9. **Formatting**: Use markdown headers (##), bold for key numbers, blockquotes for review excerpts, and bullet lists for comparisons. No HTML tags except tables.

--- a/plans/PR-Support-Ticket-Live-Haiku-Generated-Content-Eval.md
+++ b/plans/PR-Support-Ticket-Live-Haiku-Generated-Content-Eval.md
@@ -1,0 +1,128 @@
+# Support Ticket Live Haiku Generated Content Eval
+
+## Why this slice exists
+
+PR #956 wired the deterministic generated-content evaluator into the live
+Content Ops smoke, but the new flag has only been proven with focused tests.
+The next validation step is a recorded live Haiku run that generates real
+support-ticket-backed landing-page and blog-post drafts, exports the saved
+drafts, and runs the evaluator in the same smoke command.
+
+This keeps us in the support-ticket provider lane and proves the current
+end-to-end generation path before changing the generated-copy contract.
+
+This slice is slightly over the normal diff budget because the live validation
+found two false-green classes in the same path: unsupported uploaded-ticket
+timeframes and unsupported future-impact percentages. Keeping the validation
+report, evaluator guards, and focused regressions together makes the recorded
+outcome reproducible.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+
+Slice phase: Functional validation
+
+1. Run live landing-page generation with the packaged support-ticket CSV,
+   saved-draft export, and generated-content evaluation enabled.
+2. Run live blog-post generation with the same support-ticket CSV,
+   saved-draft export, and generated-content evaluation enabled.
+3. Force OpenRouter to the Claude Haiku family for this validation run.
+4. Close the unsupported temporal and percentage-claim gaps exposed by the live
+   blog output.
+5. Archive the observed ids, evaluator results, and any follow-up findings in a
+   validation document.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Live-Haiku-Generated-Content-Eval.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `scripts/evaluate_support_ticket_generated_content.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `tests/test_evaluate_support_ticket_generated_content.py`
+- `atlas_brain/skills/digest/blog_post_generation.md`
+- `extracted_content_pipeline/skills/digest/blog_post_generation.md`
+- `docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md`
+
+## Mechanism
+
+The smoke command loads the Atlas DB/OpenRouter env files plus a temporary
+Haiku override env file. Each run uses `--support-ticket-csv` so the provider
+packages the example ticket rows, `--export-saved-draft` so the exact saved row
+can be inspected, and `--evaluate-generated-content` so the new evaluator runs
+against the in-memory export before the command exits.
+
+The validation doc records the command shape and summarized results. Large or
+environment-specific JSON exports stay in ignored local `tmp/`.
+
+The live blog runs exposed truthfulness gaps: an undated CSV generated copy that
+said "Between May 2026 and the present" even though the source period was only
+`Uploaded support tickets`, plus unsupported future-impact percentages such as
+`20-40%`, `70%`, `75%`, and `30-50%`. The fix removes `report_date` from
+undated support-ticket blog blueprint context, updates the blog-generation
+prompt to forbid invented calendar windows and predictive ROI math for
+uploaded-ticket inputs, and adds deterministic evaluator checks for unsupported
+calendar-window and percentage language.
+
+The same prompt update also names the citable-section shape required by the
+blog GEO readiness gate, after one Haiku run generated usable uploaded-ticket
+language but missed `geo_citable_section_structure_missing`.
+
+## Intentional
+
+- The prompt change is limited to uploaded-ticket truthfulness and the existing
+  GEO citable-section gate shape. It does not change blog SEO fields or FAQ
+  ownership.
+- No FAQ generator changes. FAQ generation remains owned by the parallel FAQ
+  session.
+- No Sonnet spend for this validation; the temporary env override points the
+  OpenRouter reasoning route at Haiku.
+
+## Deferred
+
+- Future PR: use generated-content evaluator failures as blog repair feedback,
+  or otherwise tighten support-ticket blog generation until the live Haiku blog
+  path passes without unsupported future-impact percentages.
+- Future PR: align blog save-time quality gating with exported
+  `geo_readiness`, or make the live smoke fail on exported readiness when
+  quality gates are enabled. The latest failed blog smoke still saved a draft
+  whose exported `geo_readiness.status` was `needs_review`.
+- Parked hardening: none added by this slice.
+
+## Verification
+
+- Live landing-page smoke command recorded in
+  `docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md`
+  - Passed; saved draft `cad10d59-d62a-4c04-a111-7036cfd73e0b`; SEO/AEO ready; GEO ready; generated-content evaluation passed.
+- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_csv_counts tests/test_smoke_content_ops_live_generation.py::test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_validate -q`
+  - 14 passed.
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_evaluate_support_ticket_generated_content.py -q`
+  - 51 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .`
+  - OK, 114 matching tests enrolled.
+- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q`
+  - 18 passed.
+- Py compile for the changed Python scripts and tests
+  - Passed.
+- Generated-content evaluator against the live landing-page export
+  - Passed.
+- Generated-content evaluator against the earlier live blog export
+  - Failed as expected after the new percentage guard, catching unsupported `20-40%`.
+- Live blog-post smoke command recorded in
+  `docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md`
+  - Failed by generated-content evaluation as expected, catching unsupported `30-50%` claims. This proves the smoke no longer gives a false green for unsupported impact percentages.
+- `bash scripts/local_pr_review.sh --allow-dirty`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan and validation report | ~220 |
+| Evaluator guardrails and tests | ~370 |
+| Smoke/prompt alignment | ~80 |
+| **Total** | **~670** |
+
+Over budget by design: the validation report plus focused evaluator regressions
+are the bulk of the diff, and splitting them would separate the live failure
+evidence from the guardrails that now catch it.

--- a/scripts/evaluate_support_ticket_generated_content.py
+++ b/scripts/evaluate_support_ticket_generated_content.py
@@ -14,6 +14,7 @@ from typing import Any
 
 JsonDict = dict[str, Any]
 
+# From earlier stale smoke benchmark drift; still allowed when source-backed.
 _STALE_BENCHMARK_TOKENS = ("186", "78", "42%")
 _COUNT_CONTEXT_KEYS = (
     "source_row_count",
@@ -23,6 +24,20 @@ _COUNT_CONTEXT_KEYS = (
 _FRAMING_RE = re.compile(
     r"\b(?:support[-\s]?tickets?|tickets?|faq|help[-\s]?center|answers?)\b",
     re.IGNORECASE,
+)
+_UNSUPPORTED_UPLOADED_TICKET_TIMEFRAME_RE = re.compile(
+    r"\b(?:"
+    r"between\s+(?:january|february|march|april|may|june|july|august|"
+    r"september|october|november|december)\s+\d{4}\s+and|"
+    r"(?:over|in|during)\s+the\s+(?:last|past)\s+\d+\s+days|"
+    r"(?:last|past)\s+\d+\s+days|"
+    r"last\s+90\s+days"
+    r")\b",
+    re.IGNORECASE,
+)
+_PERCENT_CLAIM_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?P<first>\d+(?:\.\d+)?)"
+    r"(?:\s*[-\u2013\u2014]\s*(?P<second>\d+(?:\.\d+)?))?\s*%"
 )
 
 
@@ -91,6 +106,18 @@ def evaluate_support_ticket_generated_content(
     _check_count_visibility(
         checks,
         warnings,
+        text=text,
+        source_context=context,
+    )
+    _check_uploaded_ticket_timeframe_truthfulness(
+        checks,
+        errors,
+        text=text,
+        source_context=context,
+    )
+    _check_unsupported_percentage_claims(
+        checks,
+        errors,
         text=text,
         source_context=context,
     )
@@ -214,6 +241,120 @@ def _check_count_visibility(
         warnings.append(
             "generated text does not visibly mention any support-ticket source counts"
         )
+
+
+def _check_uploaded_ticket_timeframe_truthfulness(
+    checks: list[JsonDict],
+    errors: list[str],
+    *,
+    text: str,
+    source_context: Mapping[str, Any],
+) -> None:
+    source_period = str(source_context.get("source_period") or "").strip().lower()
+    review_period = str(source_context.get("review_period") or "").strip().lower()
+    if source_period != "uploaded support tickets" and review_period != "uploaded tickets":
+        checks.append({
+            "name": "uploaded_ticket_timeframe_truthful",
+            "passed": True,
+            "level": "error",
+            "details": {"applicable": False},
+        })
+        return
+    unsupported_hits = _dedupe(
+        [
+            match.group(0).strip()
+            for match in _UNSUPPORTED_UPLOADED_TICKET_TIMEFRAME_RE.finditer(text)
+        ]
+    )
+    passed = not unsupported_hits
+    checks.append({
+        "name": "uploaded_ticket_timeframe_truthful",
+        "passed": passed,
+        "level": "error",
+        "details": {"unsupported_timeframes": unsupported_hits},
+    })
+    if unsupported_hits:
+        errors.append(
+            "generated text claims a calendar or rolling time window for an "
+            "undated uploaded-ticket source: " + ", ".join(unsupported_hits)
+        )
+
+
+def _check_unsupported_percentage_claims(
+    checks: list[JsonDict],
+    errors: list[str],
+    *,
+    text: str,
+    source_context: Mapping[str, Any],
+) -> None:
+    claims = _percentage_claims(text)
+    if not claims:
+        checks.append({
+            "name": "percentage_claims_source_backed",
+            "passed": True,
+            "level": "error",
+            "details": {"claims": [], "unsupported": []},
+        })
+        return
+    allowed = _source_backed_percentages(source_context)
+    unsupported = [
+        claim["text"]
+        for claim in claims
+        if not all(value in allowed for value in claim["values"])
+    ]
+    checks.append({
+        "name": "percentage_claims_source_backed",
+        "passed": not unsupported,
+        "level": "error",
+        "details": {
+            "claims": [claim["text"] for claim in claims],
+            "source_backed_percentages": sorted(allowed),
+            "unsupported": unsupported,
+        },
+    })
+    if unsupported:
+        errors.append(
+            "generated text contains percentage claims not backed by support-ticket "
+            "source counts: " + ", ".join(unsupported)
+        )
+
+
+def _percentage_claims(text: str) -> list[JsonDict]:
+    claims: list[JsonDict] = []
+    for match in _PERCENT_CLAIM_RE.finditer(text):
+        values = [_whole_percent(match.group("first"))]
+        if match.group("second") is not None:
+            values.append(_whole_percent(match.group("second")))
+        claims.append({"text": match.group(0).strip(), "values": values})
+    return claims
+
+
+def _source_backed_percentages(source_context: Mapping[str, Any]) -> set[int]:
+    counts = [
+        count
+        for count in (
+            _positive_int(source_context.get(key))
+            for key in _COUNT_CONTEXT_KEYS
+        )
+        if count is not None
+    ]
+    clusters = source_context.get("top_ticket_clusters") or source_context.get("top_clusters")
+    if isinstance(clusters, Sequence) and not isinstance(clusters, (str, bytes)):
+        for cluster in clusters:
+            if isinstance(cluster, Mapping):
+                count = _positive_int(cluster.get("count"))
+                if count is not None:
+                    counts.append(count)
+    backed: set[int] = set()
+    for numerator in counts:
+        for denominator in counts:
+            if denominator:
+                backed.add(_whole_percent((numerator / denominator) * 100))
+    return backed
+
+
+def _whole_percent(value: str | float) -> int:
+    return int(round(float(value)))
 
 
 def _check_source_signal_visibility(

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -670,23 +670,25 @@ def _support_ticket_blog_blueprint_payload(
     source_period = str(inputs.get("source_period") or "Uploaded support tickets")
     has_valid_date_window = bool(inputs.get("faq_window_days"))
     review_period = "last 90 days" if has_valid_date_window else "uploaded tickets"
+    data_context = {
+        "review_period": review_period,
+        "source_row_count": source_row_count,
+        "included_ticket_row_count": included_row_count,
+        "question_like_ticket_count": question_like_count,
+        "top_clusters": top_clusters,
+        "_known_vendors": [],
+        "total_reviews_analyzed": included_row_count,
+        "deep_enriched_count": included_row_count,
+        "category": "support tickets",
+        "topic": SUPPORT_TICKET_BLOG_TOPIC,
+        "source_period": source_period,
+        "source": "support_ticket_provider",
+    }
+    if has_valid_date_window:
+        data_context["report_date"] = "2026-05-23"
     return {
         "topic": SUPPORT_TICKET_BLOG_TOPIC,
-        "data_context": {
-            "review_period": review_period,
-            "source_row_count": source_row_count,
-            "included_ticket_row_count": included_row_count,
-            "question_like_ticket_count": question_like_count,
-            "top_clusters": top_clusters,
-            "_known_vendors": [],
-            "report_date": "2026-05-23",
-            "total_reviews_analyzed": included_row_count,
-            "deep_enriched_count": included_row_count,
-            "category": "support tickets",
-            "topic": SUPPORT_TICKET_BLOG_TOPIC,
-            "source_period": source_period,
-            "source": "support_ticket_provider",
-        },
+        "data_context": data_context,
         "sections": [
             {
                 "id": "repeat-ticket-patterns",

--- a/tests/test_evaluate_support_ticket_generated_content.py
+++ b/tests/test_evaluate_support_ticket_generated_content.py
@@ -140,6 +140,204 @@ def test_blog_export_passes_with_blog_data_context_shape() -> None:
     assert not result["warnings"]
 
 
+def test_blog_export_fails_unsupported_uploaded_ticket_timeframe() -> None:
+    export = _blog_export(
+        content_override=(
+            "Between May 2026 and the present, we analyzed 2 support tickets. "
+            "The account and reporting clusters show what customers keep asking."
+        )
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is False
+    assert any(
+        "undated uploaded-ticket source" in error
+        for error in result["errors"]
+    )
+    timeframe_check = next(
+        check for check in result["checks"]
+        if check["name"] == "uploaded_ticket_timeframe_truthful"
+    )
+    assert timeframe_check["passed"] is False
+    assert timeframe_check["details"] == {
+        "unsupported_timeframes": ["Between May 2026 and"]
+    }
+
+
+def test_landing_export_fails_unsupported_uploaded_ticket_timeframe() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(
+            text_override=(
+                "Between May 2026 and today, the uploaded 2 support tickets "
+                "show account and reporting questions."
+            )
+        ),
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    assert any(
+        "undated uploaded-ticket source" in error
+        for error in result["errors"]
+    )
+    timeframe_check = next(
+        check for check in result["checks"]
+        if check["name"] == "uploaded_ticket_timeframe_truthful"
+    )
+    assert timeframe_check["passed"] is False
+    assert timeframe_check["details"] == {
+        "unsupported_timeframes": ["Between May 2026 and"]
+    }
+
+
+def test_blog_export_allows_timeframe_when_source_period_supplies_it() -> None:
+    context = _blog_context()
+    context["source_period"] = "Last 90 days of support tickets"
+    context["review_period"] = "last 90 days"
+    export = _blog_export(
+        data_context=context,
+        content_override=(
+            "In the last 90 days, the 2 support tickets show account and "
+            "reporting questions customers keep asking."
+        ),
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is True
+    timeframe_check = next(
+        check for check in result["checks"]
+        if check["name"] == "uploaded_ticket_timeframe_truthful"
+    )
+    assert timeframe_check["passed"] is True
+    assert timeframe_check["details"] == {"applicable": False}
+
+
+def test_blog_export_fails_unsupported_percentage_claims() -> None:
+    export = _blog_export(
+        content_override=(
+            "The uploaded 2 support tickets show account and reporting clusters. "
+            "These FAQ answers can reduce support volume by 20-40%."
+        )
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is False
+    assert any(
+        "percentage claims not backed" in error
+        for error in result["errors"]
+    )
+    percent_check = next(
+        check for check in result["checks"]
+        if check["name"] == "percentage_claims_source_backed"
+    )
+    assert percent_check["passed"] is False
+    assert percent_check["details"]["unsupported"] == ["20-40%"]
+
+
+def test_blog_export_fails_unsupported_em_dash_percentage_claims() -> None:
+    claim = "20\u201440%"
+    export = _blog_export(
+        content_override=(
+            "The uploaded 2 support tickets show account and reporting clusters. "
+            f"These FAQ answers can reduce support volume by {claim}."
+        )
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is False
+    percent_check = next(
+        check for check in result["checks"]
+        if check["name"] == "percentage_claims_source_backed"
+    )
+    assert percent_check["passed"] is False
+    assert percent_check["details"]["unsupported"] == [claim]
+
+
+def test_landing_export_fails_unsupported_percentage_claims() -> None:
+    result = evaluator.evaluate_support_ticket_generated_content(
+        _landing_export(
+            text_override=(
+                "The uploaded 2 support tickets show account and reporting "
+                "questions, and the FAQ can cut repeat tickets by 30-50%."
+            )
+        ),
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    percent_check = next(
+        check for check in result["checks"]
+        if check["name"] == "percentage_claims_source_backed"
+    )
+    assert percent_check["passed"] is False
+    assert percent_check["details"]["unsupported"] == ["30-50%"]
+
+
+def test_blog_export_allows_percentage_claim_derived_from_source_counts() -> None:
+    export = _blog_export(
+        content_override=(
+            "The uploaded 2 support tickets show account and reporting clusters. "
+            "That means 50% of included tickets mention account issues."
+        )
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is True
+    percent_check = next(
+        check for check in result["checks"]
+        if check["name"] == "percentage_claims_source_backed"
+    )
+    assert percent_check["details"]["unsupported"] == []
+
+
+def test_blog_export_allows_whole_percent_rounding_from_source_counts() -> None:
+    context = _blog_context()
+    context["source_row_count"] = 3
+    context["included_ticket_row_count"] = 3
+    context["question_like_ticket_count"] = 3
+    context["top_clusters"] = [{"label": "account", "count": 1}]
+    export = _blog_export(
+        data_context=context,
+        content_override=(
+            "The uploaded 3 support tickets show account questions. "
+            "That means 33% of included tickets mention account issues."
+        ),
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is True
+    percent_check = next(
+        check for check in result["checks"]
+        if check["name"] == "percentage_claims_source_backed"
+    )
+    assert percent_check["details"]["source_backed_percentages"] == [33, 100, 300]
+    assert percent_check["details"]["unsupported"] == []
+
+
 def test_landing_export_fails_when_source_context_missing() -> None:
     export = _landing_export(source_context=None)
     export["rows"][0]["metadata"] = {}
@@ -153,6 +351,29 @@ def test_landing_export_fails_when_source_context_missing() -> None:
     assert result["errors"] == [
         "export row is missing support-ticket source context"
     ]
+
+
+def test_landing_export_fails_when_generated_text_is_blank() -> None:
+    export = _landing_export()
+    row = export["rows"][0]
+    row["title"] = ""
+    row["hero"] = {"headline": " ", "subheadline": "\n"}
+    row["sections"] = []
+    row["cta"] = {"label": ""}
+    row["meta"] = {"description": ""}
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="landing_page",
+    )
+
+    assert result["ok"] is False
+    assert "export row did not contain generated text fields" in result["errors"]
+    text_check = next(
+        check for check in result["checks"]
+        if check["name"] == "generated_text_present"
+    )
+    assert text_check["passed"] is False
 
 
 def test_landing_export_fails_on_stale_benchmark_numbers() -> None:

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -1153,6 +1153,7 @@ def test_support_ticket_blog_blueprint_payload_uses_csv_counts(tmp_path: Path) -
     assert payload["data_context"]["question_like_ticket_count"] == 2
     assert payload["data_context"]["review_period"] == "uploaded tickets"
     assert payload["data_context"]["source_period"] == "Uploaded support tickets"
+    assert "report_date" not in payload["data_context"]
     assert payload["data_context"]["included_ticket_row_count"] == 2
     assert payload["data_context"]["total_reviews_analyzed"] == 2
     assert payload["data_context"]["deep_enriched_count"] == 2
@@ -1217,6 +1218,7 @@ def test_support_ticket_blog_blueprint_payload_uses_date_window_when_dates_valid
 
     assert payload["data_context"]["review_period"] == "last 90 days"
     assert payload["data_context"]["source_period"] == "Last 90 days of support tickets"
+    assert payload["data_context"]["report_date"] == "2026-05-23"
     assert payload["sections"][2]["key_stats"]["source_window_days"] == 90
 
 


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Live-Haiku-Generated-Content-Eval.md
Slice phase: Functional validation

This records live Haiku support-ticket generation with saved-draft export and generated-content evaluation. Landing is proven clean end to end; blog is now correctly failing the smoke when Haiku invents unsupported future-impact percentages instead of producing a false green.

## Intentional
- Prompt changes are limited to uploaded-ticket truthfulness and the existing GEO citable-section gate shape.
- No FAQ generator changes; FAQ-owned work stays in the parallel session.
- Haiku was used for live validation to avoid Sonnet spend.
- Diff is over the normal budget because the validation evidence, evaluator guardrails, and regressions need to ship together.

## Deferred
- Future PR: use generated-content evaluator failures as blog repair feedback, or tighten support-ticket blog generation until the live Haiku blog path passes without unsupported future-impact percentages.
- Future PR: align blog save-time quality gating with exported geo_readiness, or make the live smoke fail on exported readiness when quality gates are enabled.

## Parked hardening
- None.

## Verification
- Live landing smoke passed; details in docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md.
- Live blog smoke failed by generated-content evaluation as expected; details in docs/extraction/validation/support_ticket_live_haiku_generated_content_eval_2026-05-25.md.
- python -m pytest tests/test_smoke_content_ops_live_generation.py tests/test_evaluate_support_ticket_generated_content.py -q
- python scripts/audit_extracted_pipeline_ci_enrollment.py .
- python -m py_compile scripts/evaluate_support_ticket_generated_content.py scripts/smoke_content_ops_live_generation.py tests/test_evaluate_support_ticket_generated_content.py tests/test_smoke_content_ops_live_generation.py
- bash scripts/local_pr_review.sh

## Diff size
8 files, +499 / -21