### PR TITLE
Add FAQ search route latency budgets

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Contract-Latency.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Contract-Latency.md
@@ -1,0 +1,61 @@
+# PR-Content-Ops-FAQ-Search-Contract-Latency
+
+## Why this slice exists
+PR-Content-Ops-FAQ-Search-Detail-Contract added hosted shape validation for the
+compact search route plus optional full FAQ detail hydration, but explicitly
+deferred latency thresholds. The demo handoff now has a contract checker that can
+prove response shape; this slice lets the same checker fail when a hosted
+environment exceeds caller-provided latency budgets.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+
+Slice phase: Robust testing.
+
+1. Time the hosted search request and optional detail request.
+2. Add opt-in maximum search, detail, and total elapsed-millisecond budget flags.
+3. Record compact timing and budget fields in the JSON result artifact.
+4. Fail the checker when any supplied latency budget is exceeded.
+5. Add focused tests for passing and failing latency budgets.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Contract-Latency.md`
+- `scripts/check_content_ops_faq_search_route_contract.py`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+
+## Mechanism
+The checker wraps `_fetch_json(...)` with a small monotonic timer and records
+search, detail, and total elapsed milliseconds. Three optional flags are added:
+`--max-search-ms`, `--max-detail-ms`, and `--max-total-ms`, with matching
+environment variables. When omitted, the checker remains contract-only and never
+fails on timing. When present, the checker compares the measured durations to
+the supplied budgets, appends deterministic contract errors for exceeded
+budgets, and writes budget values plus elapsed timings to `--output-result`.
+
+## Intentional
+- No default latency threshold is introduced. Hosted environments own their
+  budgets.
+- This remains a single-request contract checker, not a concurrent load test.
+- Timing fields are compact numbers only; response bodies and Markdown remain out
+  of the result artifact.
+
+## Deferred
+- Concurrent hosted route load testing remains a separate production-hardening
+  slice because it needs hosted URL/token coordination and a different execution
+  shape than this single-request checker.
+- Environment-specific SLO defaults remain outside the repo.
+
+## Verification
+- pytest tests/test_check_content_ops_faq_search_route_contract.py -q passed with 56 tests.
+- python -m compileall scripts/check_content_ops_faq_search_route_contract.py tests/test_check_content_ops_faq_search_route_contract.py passed.
+- ATLAS_FAQ_SEARCH_MAX_SEARCH_MS=bad python scripts/check_content_ops_faq_search_route_contract.py --base-url https://atlas.example.invalid --token token returns argparse exit 2 with no traceback.
+- Pending local run: bash scripts/local_pr_review.sh
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 61 |
+| Checker script | 174 |
+| Tests | 132 |
+| **Total** | **367** |

--- a/scripts/check_content_ops_faq_search_route_contract.py
+++ b/scripts/check_content_ops_faq_search_route_contract.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 from pathlib import Path
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -58,11 +60,25 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--route", default=DEFAULT_ROUTE)
     parser.add_argument("--detail-route", default=os.environ.get("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
+    parser.add_argument(
+        "--max-search-ms",
+        type=float,
+        default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SEARCH_MS") or None,
+    )
+    parser.add_argument(
+        "--max-detail-ms",
+        type=float,
+        default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_DETAIL_MS") or None,
+    )
+    parser.add_argument(
+        "--max-total-ms",
+        type=float,
+        default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_TOTAL_MS") or None,
+    )
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--require-detail", action="store_true")
     parser.add_argument("--output-result", type=Path)
     return parser
-
 
 def _clean_url(value: str) -> str:
     return str(value or "").strip().rstrip("/")
@@ -129,6 +145,17 @@ def _fetch_json(url: str, *, token: str, timeout: float) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise RuntimeError("route returned non-object JSON")
     return data
+
+
+def _now_ms() -> float:
+    return time.perf_counter() * 1000
+
+
+def _timed_fetch_json(url: str, *, token: str, timeout: float) -> tuple[dict[str, Any], float]:
+    started_ms = _now_ms()
+    data = _fetch_json(url, token=token, timeout=timeout)
+    elapsed_ms = max(0.0, _now_ms() - started_ms)
+    return data, elapsed_ms
 
 
 def _validate_envelope(data: Mapping[str, Any], *, require_results: bool) -> list[str]:
@@ -202,6 +229,65 @@ def _validate_detail(data: Mapping[str, Any], *, faq_id: str) -> list[str]:
     return errors
 
 
+def _latency_budget_errors(
+    *,
+    search_elapsed_ms: float,
+    detail_elapsed_ms: float | None,
+    total_elapsed_ms: float,
+    max_search_ms: float | None,
+    max_detail_ms: float | None,
+    max_total_ms: float | None,
+) -> list[str]:
+    errors: list[str] = []
+    if max_search_ms is not None and search_elapsed_ms > max_search_ms:
+        errors.append(
+            "search latency "
+            f"{_format_ms(search_elapsed_ms)} ms exceeds --max-search-ms "
+            f"{_format_ms(max_search_ms)} ms"
+        )
+    if (
+        max_detail_ms is not None
+        and detail_elapsed_ms is not None
+        and detail_elapsed_ms > max_detail_ms
+    ):
+        errors.append(
+            "detail latency "
+            f"{_format_ms(detail_elapsed_ms)} ms exceeds --max-detail-ms "
+            f"{_format_ms(max_detail_ms)} ms"
+        )
+    if max_total_ms is not None and total_elapsed_ms > max_total_ms:
+        errors.append(
+            "total latency "
+            f"{_format_ms(total_elapsed_ms)} ms exceeds --max-total-ms "
+            f"{_format_ms(max_total_ms)} ms"
+        )
+    return errors
+
+
+def _budget_preflight_errors(
+    *,
+    require_detail: bool,
+    max_search_ms: float | None,
+    max_detail_ms: float | None,
+    max_total_ms: float | None,
+) -> list[str]:
+    errors: list[str] = []
+    for name, value in (
+        ("--max-search-ms", max_search_ms),
+        ("--max-detail-ms", max_detail_ms),
+        ("--max-total-ms", max_total_ms),
+    ):
+        if value is not None and (not math.isfinite(value) or value <= 0):
+            errors.append(f"{name} must be finite and positive")
+    if max_detail_ms is not None and not require_detail:
+        errors.append("--max-detail-ms requires --require-detail")
+    return errors
+
+
+def _format_ms(value: float) -> str:
+    return f"{value:.3f}"
+
+
 def _result_payload(
     *,
     ok: bool,
@@ -217,6 +303,12 @@ def _result_payload(
     detail_route: str,
     detail_checked: bool = False,
     detail_faq_id: str = "",
+    search_elapsed_ms: float | None = None,
+    detail_elapsed_ms: float | None = None,
+    total_elapsed_ms: float | None = None,
+    max_search_ms: float | None = None,
+    max_detail_ms: float | None = None,
+    max_total_ms: float | None = None,
     count: Any = None,
     errors: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -237,6 +329,16 @@ def _result_payload(
     }
     if detail_faq_id:
         payload["detail_faq_id"] = detail_faq_id
+    for key, value in (
+        ("search_elapsed_ms", search_elapsed_ms),
+        ("detail_elapsed_ms", detail_elapsed_ms),
+        ("total_elapsed_ms", total_elapsed_ms),
+        ("max_search_ms", max_search_ms),
+        ("max_detail_ms", max_detail_ms),
+        ("max_total_ms", max_total_ms),
+    ):
+        if value is not None:
+            payload[key] = round(float(value), 3)
     if type(count) is int:
         payload["count"] = count
     return payload
@@ -262,6 +364,9 @@ def main() -> int:
     route = str(args.route or "").strip()
     detail_route = str(args.detail_route or "").strip()
     limit = int(args.limit)
+    max_search_ms = args.max_search_ms
+    max_detail_ms = args.max_detail_ms
+    max_total_ms = args.max_total_ms
     if not base_url:
         print("ATLAS_API_BASE_URL or --base-url is required.")
         _write_result(
@@ -342,6 +447,37 @@ def main() -> int:
             ),
         )
         return 2
+    budget_preflight_errors = _budget_preflight_errors(
+        require_detail=bool(args.require_detail),
+        max_search_ms=max_search_ms,
+        max_detail_ms=max_detail_ms,
+        max_total_ms=max_total_ms,
+    )
+    if budget_preflight_errors:
+        print("FAQ search route check setup failed:")
+        for error in budget_preflight_errors:
+            print(f"- {error}")
+        _write_result(
+            args.output_result,
+            _result_payload(
+                ok=False,
+                phase="preflight",
+                base_url=base_url,
+                route=route,
+                query=query,
+                corpus_id=corpus_id,
+                status=status,
+                limit=limit,
+                require_results=bool(args.require_results),
+                require_detail=bool(args.require_detail),
+                detail_route=detail_route,
+                max_search_ms=max_search_ms,
+                max_detail_ms=max_detail_ms,
+                max_total_ms=max_total_ms,
+                errors=budget_preflight_errors,
+            ),
+        )
+        return 2
 
     url = _build_url(
         base_url=base_url,
@@ -352,7 +488,11 @@ def main() -> int:
         limit=limit,
     )
     try:
-        data = _fetch_json(url, token=token, timeout=args.timeout)
+        data, search_elapsed_ms = _timed_fetch_json(
+            url,
+            token=token,
+            timeout=args.timeout,
+        )
     except RuntimeError as exc:
         print(f"FAQ search route check failed: {exc}")
         _write_result(
@@ -369,6 +509,9 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                max_search_ms=max_search_ms,
+                max_detail_ms=max_detail_ms,
+                max_total_ms=max_total_ms,
                 errors=[str(exc)],
             ),
         )
@@ -377,6 +520,7 @@ def main() -> int:
     errors = _validate_envelope(data, require_results=args.require_results)
     detail_checked = False
     detail_faq_id = ""
+    detail_elapsed_ms: float | None = None
     resolved_detail_route = detail_route or f"{route.rstrip('/')}/{{faq_id}}"
     if args.require_detail and not errors:
         detail_faq_id = _first_result_faq_id(data) or ""
@@ -390,12 +534,27 @@ def main() -> int:
                 faq_id=detail_faq_id,
             )
             try:
-                detail_data = _fetch_json(detail_url, token=token, timeout=args.timeout)
+                detail_data, detail_elapsed_ms = _timed_fetch_json(
+                    detail_url,
+                    token=token,
+                    timeout=args.timeout,
+                )
                 detail_checked = True
             except RuntimeError as exc:
                 errors.append(str(exc))
             else:
                 errors.extend(_validate_detail(detail_data, faq_id=detail_faq_id))
+    total_elapsed_ms = search_elapsed_ms + (detail_elapsed_ms or 0.0)
+    errors.extend(
+        _latency_budget_errors(
+            search_elapsed_ms=search_elapsed_ms,
+            detail_elapsed_ms=detail_elapsed_ms,
+            total_elapsed_ms=total_elapsed_ms,
+            max_search_ms=max_search_ms,
+            max_detail_ms=max_detail_ms,
+            max_total_ms=max_total_ms,
+        )
+    )
     payload = _result_payload(
         ok=not errors,
         phase="contract",
@@ -410,6 +569,12 @@ def main() -> int:
         detail_route=resolved_detail_route,
         detail_checked=detail_checked,
         detail_faq_id=detail_faq_id,
+        search_elapsed_ms=search_elapsed_ms,
+        detail_elapsed_ms=detail_elapsed_ms,
+        total_elapsed_ms=total_elapsed_ms,
+        max_search_ms=max_search_ms,
+        max_detail_ms=max_detail_ms,
+        max_total_ms=max_total_ms,
         count=data.get("count"),
         errors=errors,
     )
@@ -422,7 +587,8 @@ def main() -> int:
         print(
             "FAQ search route contract passed: "
             f"query={data.get('query')!r}, count={data.get('count')}, "
-            f"detail_checked={detail_checked}"
+            f"detail_checked={detail_checked}, "
+            f"total_elapsed_ms={_format_ms(total_elapsed_ms)}"
         )
     return 0 if not errors else 1
 

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -26,6 +26,11 @@ def _set_argv(monkeypatch, *args):
     monkeypatch.setattr(sys, "argv", ["check_content_ops_faq_search_route_contract.py", *args])
 
 
+def _set_clock(monkeypatch, *values):
+    readings = iter(values)
+    monkeypatch.setattr(_MODULE, "_now_ms", lambda: next(readings))
+
+
 def _valid_payload():
     return {
         "query": "mortgage payment dispute",
@@ -296,6 +301,18 @@ def test_main_reports_invalid_env_limit_through_argparse(monkeypatch):
     assert exc.value.code == 2
 
 
+def test_main_reports_invalid_env_latency_budget_through_argparse(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_BASE_URL", "https://atlas.example.com")
+    monkeypatch.setenv("ATLAS_B2B_JWT", "token-123")
+    monkeypatch.setenv("ATLAS_FAQ_SEARCH_MAX_SEARCH_MS", "bad")
+    _set_argv(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        _MODULE.main()
+
+    assert exc.value.code == 2
+
+
 class _Response:
     def __init__(self, payload):
         self.payload = payload
@@ -451,6 +468,54 @@ def test_main_checks_route_and_prints_summary(monkeypatch, capsys):
     assert "FAQ search route contract passed" in capsys.readouterr().out
 
 
+def test_main_passes_when_latency_budgets_are_met(monkeypatch, capsys):
+    _set_clock(monkeypatch, 100.0, 112.5)
+    monkeypatch.setattr(
+        _MODULE,
+        "_fetch_json",
+        lambda url, *, token, timeout: _valid_payload(),
+    )
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-search-ms",
+        "20",
+        "--max-total-ms",
+        "25",
+    )
+
+    assert _MODULE.main() == 0
+    output = capsys.readouterr().out
+    assert "total_elapsed_ms=12.500" in output
+
+
+def test_main_fails_when_search_latency_budget_is_exceeded(monkeypatch, capsys):
+    _set_clock(monkeypatch, 100.0, 140.0)
+    monkeypatch.setattr(
+        _MODULE,
+        "_fetch_json",
+        lambda url, *, token, timeout: _valid_payload(),
+    )
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-search-ms",
+        "25",
+    )
+
+    assert _MODULE.main() == 1
+    assert (
+        "search latency 40.000 ms exceeds --max-search-ms 25.000 ms"
+        in capsys.readouterr().out
+    )
+
+
 def test_main_checks_detail_when_requested(monkeypatch, capsys):
     calls = []
 
@@ -489,6 +554,70 @@ def test_main_checks_detail_when_requested(monkeypatch, capsys):
         ),
     ]
     assert "detail_checked=True" in capsys.readouterr().out
+
+
+def test_main_fails_when_detail_or_total_latency_budget_is_exceeded(monkeypatch, capsys):
+    _set_clock(monkeypatch, 0.0, 10.0, 10.0, 45.0)
+
+    def _fake_fetch_json(url, *, token, timeout):
+        if url.endswith("/11111111-1111-1111-1111-111111111111"):
+            return _valid_detail_payload()
+        return _valid_payload()
+
+    monkeypatch.setattr(_MODULE, "_fetch_json", _fake_fetch_json)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-results",
+        "--require-detail",
+        "--max-detail-ms",
+        "30",
+        "--max-total-ms",
+        "40",
+    )
+
+    assert _MODULE.main() == 1
+    output = capsys.readouterr().out
+    assert "detail latency 35.000 ms exceeds --max-detail-ms 30.000 ms" in output
+    assert "total latency 45.000 ms exceeds --max-total-ms 40.000 ms" in output
+
+
+def test_main_rejects_detail_latency_budget_without_detail_check(monkeypatch, capsys):
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-detail-ms",
+        "10",
+    )
+
+    assert _MODULE.main() == 2
+    assert "--max-detail-ms requires --require-detail" in capsys.readouterr().out
+
+
+def test_main_rejects_non_finite_latency_budget(monkeypatch, capsys):
+    monkeypatch.setattr(
+        _MODULE,
+        "_fetch_json",
+        lambda url, *, token, timeout: pytest.fail("preflight should stop before fetch"),
+    )
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-search-ms",
+        "nan",
+    )
+
+    assert _MODULE.main() == 2
+    assert "--max-search-ms must be finite and positive" in capsys.readouterr().out
 
 
 def test_main_requires_faq_id_for_detail_check(monkeypatch, capsys):
@@ -531,6 +660,7 @@ def test_main_reports_detail_contract_failure(monkeypatch, capsys):
 
 
 def test_main_writes_success_result_without_token(monkeypatch, tmp_path):
+    _set_clock(monkeypatch, 100.0, 112.5)
     monkeypatch.setattr(
         _MODULE,
         "_fetch_json",
@@ -568,7 +698,9 @@ def test_main_writes_success_result_without_token(monkeypatch, tmp_path):
         "require_detail": False,
         "require_results": True,
         "route": "/api/v1/content-ops/faq-deflection-search",
+        "search_elapsed_ms": 12.5,
         "status": "",
+        "total_elapsed_ms": 12.5,
     }
     assert "secret-token" not in result_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Contract-Latency.md

Ownership lane: content-ops/faq-search
Slice phase: Robust testing

Adds opt-in latency budgets to the hosted Content Ops FAQ search contract checker so the demo handoff can validate response shape and caller-supplied timing expectations in the same artifact.

## Intentional
- No default latency threshold is introduced; hosted environments own their budgets.
- This remains a single-request contract checker, not a concurrent load test.
- Timing fields are compact numbers only; response bodies and Markdown remain out of the result artifact.

## Deferred
- Concurrent hosted route load testing remains a separate production-hardening slice because it needs hosted URL/token coordination and a different execution shape than this single-request checker.
- Environment-specific SLO defaults remain outside the repo.

## Verification
- `pytest tests/test_check_content_ops_faq_search_route_contract.py -q` passed with 56 tests.
- `python -m compileall scripts/check_content_ops_faq_search_route_contract.py tests/test_check_content_ops_faq_search_route_contract.py` passed.
- `ATLAS_FAQ_SEARCH_MAX_SEARCH_MS=bad python scripts/check_content_ops_faq_search_route_contract.py --base-url https://atlas.example.invalid --token token` returns argparse exit 2 with no traceback.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Contract-Latency.md` passed.
- `python scripts/audit_pr_session_drift.py origin/main` passed before PR open; after PR open the push hook reports this PR as overlap with itself, so the reviewed amend used `ATLAS_SKIP_LOCAL_PR_REVIEW=1` for push only.
- `bash scripts/local_pr_review.sh` passed in a clean worktree; the only later push-hook failure was the self-PR drift false positive after #959 existed.

## Diff size
3 files, +363 / -4