### PR TITLE
Add hosted FAQ search concurrency smoke

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Hosted-Concurrency.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Hosted-Concurrency.md
@@ -1,0 +1,86 @@
+# PR-Content-Ops-FAQ-Search-Hosted-Concurrency
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Search-Contract-Latency added single-request timing budgets
+to the hosted FAQ search contract checker. That still does not exercise the
+read-path failure Claude called out: several demo users querying the hosted
+route at the same time can fail differently than one well-formed request.
+
+This slice adds the thinnest hosted concurrency smoke for the existing
+`/api/v1/content-ops/faq-deflection-search` route. It does not seed data or
+change the route; it gives operators a repeatable way to pressure the deployed
+read envelope with a real URL and token.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Robust testing.
+
+1. Add a hosted FAQ search route concurrency smoke script.
+2. Reuse the existing route URL builder, fetcher, and envelope validator.
+3. Run a caller-specified number of concurrent search requests.
+4. Emit compact JSON with request totals, error rate, p50/p95/max latency, and
+   budget failures.
+5. Add focused unit tests for argument validation, latency/error summaries, and
+   mixed success/failure concurrent execution.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Hosted-Concurrency.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The new smoke reads the same base URL, token, query, corpus/status filters,
+limit, route, and timeout inputs used by
+`check_content_ops_faq_search_route_contract.py`. It uses a
+`ThreadPoolExecutor` to issue blocking hosted HTTP reads concurrently, validates
+each response with the existing search envelope validator, and records each
+request as a compact result row.
+
+The summary fails when any request raises, any response violates the envelope,
+the observed error rate exceeds `--max-error-rate`, or optional p95/max latency
+budgets are exceeded. By default the error-rate budget is zero; latency budgets
+remain opt-in because hosted environments own their own thresholds.
+
+## Intentional
+
+- No data seeding lands here. Hosted route concurrency needs a deployed route
+  and token; test data preparation remains an operator responsibility.
+- No detail-route hydration lands here. This smoke focuses on concurrent compact
+  search reads.
+- No default latency SLO lands here. Operators pass environment-specific p95/max
+  budgets when they have a baseline.
+
+## Deferred
+
+- A hosted seeded end-to-end load test that creates isolated corpora, searches
+  them over HTTP, and cleans them up remains a later production-hardening slice.
+- Multi-query mixes are deferred until we have representative demo queries from
+  the deployed data set.
+
+## Verification
+
+- pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q passed with 7 tests.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . passed with 115 matching tests enrolled.
+- python scripts/smoke_content_ops_faq_search_route_concurrency.py --base-url '' --token token-123 --output-result tmp/faq_search_hosted_concurrency_preflight.json --json returned exit 2 and wrote the preflight JSON artifact.
+- Pending local run: bash scripts/local_pr_review.sh
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 86 |
+| CI runner | 1 |
+| Smoke script | 254 |
+| Tests | 182 |
+| **Total** | **523** |
+
+This is over the 400 LOC target because the slice needs an operator script,
+result artifact, validation, budget accounting, and tests to be usable end to
+end. Route/data seeding stays deferred rather than expanding the PR further.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -28,6 +28,7 @@ pytest \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \
+  tests/test_smoke_content_ops_faq_search_route_concurrency.py \
   tests/test_check_content_ops_faq_search_route_contract.py \
   tests/test_evaluate_support_ticket_generated_content.py \
   tests/test_smoke_content_ops_faq_scale_run.py \

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Smoke-test concurrent hosted FAQ search route reads."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_content_ops_faq_search_route_contract as contract  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run concurrent hosted FAQ search route reads."
+    )
+    parser.add_argument("--base-url", default=os.environ.get("ATLAS_API_BASE_URL", ""))
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("ATLAS_B2B_JWT") or os.environ.get("ATLAS_TOKEN", ""),
+    )
+    parser.add_argument(
+        "--query",
+        default=os.environ.get("ATLAS_FAQ_SEARCH_QUERY", contract.DEFAULT_QUERY),
+    )
+    parser.add_argument("--corpus-id", default=os.environ.get("ATLAS_FAQ_SEARCH_CORPUS_ID", ""))
+    parser.add_argument("--status", default=os.environ.get("ATLAS_FAQ_SEARCH_STATUS", ""))
+    parser.add_argument("--limit", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_LIMIT", "5"))
+    parser.add_argument("--route", default=contract.DEFAULT_ROUTE)
+    parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
+    parser.add_argument("--requests", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_REQUESTS", "12"))
+    parser.add_argument("--concurrency", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_CONCURRENCY", "4"))
+    parser.add_argument("--max-error-rate", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_ERROR_RATE", "0"))
+    parser.add_argument("--max-p95-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_P95_MS") or None)
+    parser.add_argument("--max-single-request-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SINGLE_REQUEST_MS") or None)
+    parser.add_argument("--require-results", action="store_true")
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def _validate_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    if not contract._clean_url(args.base_url):
+        errors.append("ATLAS_API_BASE_URL or --base-url is required")
+    if not str(args.token or "").strip():
+        errors.append("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required")
+    if not str(args.query or "").strip():
+        errors.append("ATLAS_FAQ_SEARCH_QUERY or --query is required")
+    for name in ("limit", "requests", "concurrency"):
+        if int(getattr(args, name)) <= 0:
+            errors.append(f"--{name.replace('_', '-')} must be positive")
+    for name in ("timeout", "max_error_rate", "max_p95_ms", "max_single_request_ms"):
+        value = getattr(args, name)
+        if value is not None and not math.isfinite(float(value)):
+            errors.append(f"--{name.replace('_', '-')} must be finite")
+    if float(args.timeout) <= 0:
+        errors.append("--timeout must be positive")
+    if not 0 <= float(args.max_error_rate) <= 1:
+        errors.append("--max-error-rate must be between 0 and 1")
+    for name in ("max_p95_ms", "max_single_request_ms"):
+        value = getattr(args, name)
+        if value is not None and float(value) <= 0:
+            errors.append(f"--{name.replace('_', '-')} must be positive")
+    return errors
+
+
+def _run_one(index: int, args: argparse.Namespace) -> dict[str, Any]:
+    url = contract._build_url(
+        base_url=str(args.base_url),
+        route=str(args.route),
+        query=str(args.query),
+        corpus_id=str(args.corpus_id),
+        status=str(args.status),
+        limit=int(args.limit),
+    )
+    started = time.perf_counter()
+    errors: list[str] = []
+    count: int | None = None
+    try:
+        payload = contract._fetch_json(url, token=str(args.token).strip(), timeout=float(args.timeout))
+        errors.extend(contract._validate_envelope(payload, require_results=bool(args.require_results)))
+        if type(payload.get("count")) is int:
+            count = int(payload["count"])
+    except Exception as exc:  # pragma: no cover - covered through monkeypatched failures.
+        errors.append(f"{type(exc).__name__}: {exc}")
+    elapsed_ms = max(0.0, (time.perf_counter() - started) * 1000)
+    return {
+        "index": index,
+        "ok": not errors,
+        "count": count,
+        "elapsed_ms": round(elapsed_ms, 6),
+        "errors": errors,
+    }
+
+
+def _run_concurrent(args: argparse.Namespace) -> list[dict[str, Any]]:
+    workers = min(int(args.concurrency), int(args.requests))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(_run_one, index, args) for index in range(int(args.requests))]
+        results = [future.result() for future in concurrent.futures.as_completed(futures)]
+    return sorted(results, key=lambda row: int(row["index"]))
+
+
+def _latency_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    values = sorted(float(row.get("elapsed_ms") or 0.0) for row in results)
+    if not values:
+        return {"count": 0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
+    p95_index = min(len(values) - 1, max(0, math.ceil(len(values) * 0.95) - 1))
+    return {
+        "count": len(values),
+        "p50_ms": round(float(statistics.median(values)), 6),
+        "p95_ms": round(values[p95_index], 6),
+        "max_ms": round(values[-1], 6),
+    }
+
+
+def _error_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    failures = [
+        {
+            "index": row.get("index"),
+            "errors": row.get("errors"),
+        }
+        for row in results
+        if row.get("errors")
+    ]
+    total = len(results)
+    return {
+        "count": len(failures),
+        "rate": round((len(failures) / total) if total else 0.0, 6),
+        "items": failures[:20],
+        "truncated": len(failures) > 20,
+    }
+
+
+def _budget_summary(
+    *,
+    latency: Mapping[str, Any],
+    errors: Mapping[str, Any],
+    max_error_rate: float,
+    max_p95_ms: float | None,
+    max_single_request_ms: float | None,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for metric, actual, limit in (
+        ("error_rate", float(errors["rate"]), float(max_error_rate)),
+        ("p95_ms", float(latency["p95_ms"]), max_p95_ms),
+        ("max_ms", float(latency["max_ms"]), max_single_request_ms),
+    ):
+        if limit is None:
+            continue
+        limit_value = round(float(limit), 6)
+        ok = actual <= limit_value
+        checks.append({"metric": metric, "actual": actual, "max": limit_value, "ok": ok})
+        if not ok:
+            failures.append(f"{metric} exceeded {limit_value}")
+    return {"ok": not failures, "checks": checks, "failures": failures}
+
+
+def _summary_payload(
+    *,
+    args: argparse.Namespace,
+    results: Sequence[Mapping[str, Any]],
+    elapsed_seconds: float,
+    preflight_errors: Sequence[str] = (),
+) -> dict[str, Any]:
+    errors = _error_summary(results)
+    latency = _latency_summary(results)
+    budgets = _budget_summary(
+        latency=latency,
+        errors=errors,
+        max_error_rate=float(args.max_error_rate),
+        max_p95_ms=args.max_p95_ms,
+        max_single_request_ms=args.max_single_request_ms,
+    )
+    return {
+        "ok": not preflight_errors and budgets["ok"],
+        "phase": "preflight" if preflight_errors else "complete",
+        "route": str(args.route),
+        "base_url": contract._clean_url(str(args.base_url)),
+        "query": str(args.query),
+        "corpus_id": str(args.corpus_id or ""),
+        "status": str(args.status or ""),
+        "limit": int(args.limit),
+        "require_results": bool(args.require_results),
+        "requests": {
+            "total": len(results),
+            "configured": int(args.requests),
+            "concurrency": int(args.concurrency),
+        },
+        "latency": latency,
+        "errors": errors,
+        "budgets": budgets,
+        "preflight_errors": list(preflight_errors),
+        "elapsed_seconds": round(elapsed_seconds, 6),
+    }
+
+
+def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    latency = summary["latency"]
+    print(
+        "FAQ search hosted concurrency smoke: "
+        f"ok={summary['ok']} requests={summary['requests']['total']} "
+        f"errors={summary['errors']['count']} p95_ms={latency['p95_ms']} "
+        f"max_ms={latency['max_ms']} budget_failures={len(summary['budgets']['failures'])}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    started = time.perf_counter()
+    preflight_errors = _validate_args(args)
+    results: list[dict[str, Any]] = []
+    if not preflight_errors:
+        results = _run_concurrent(args)
+    summary = _summary_payload(
+        args=args,
+        results=results,
+        elapsed_seconds=time.perf_counter() - started,
+        preflight_errors=preflight_errors,
+    )
+    _write_result(args.output_result, summary)
+    _print_summary(summary, as_json=bool(args.json))
+    if preflight_errors:
+        return 2
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_route_concurrency", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+def _args(**overrides):
+    values = {
+        "base_url": "https://atlas.example.com",
+        "token": "token-123",
+        "query": "mortgage dispute",
+        "corpus_id": "",
+        "status": "",
+        "limit": 5,
+        "route": "/api/v1/content-ops/faq-deflection-search",
+        "timeout": 10.0,
+        "requests": 4,
+        "concurrency": 2,
+        "max_error_rate": 0.0,
+        "max_p95_ms": None,
+        "max_single_request_ms": None,
+        "require_results": True,
+        "output_result": None,
+        "json": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _valid_payload():
+    return {
+        "query": "mortgage dispute",
+        "results": [
+            {
+                "question": "How do I dispute a mortgage payment error?",
+                "answer_summary": "Gather records and contact support.",
+                "topic": "Mortgage servicing issues",
+                "source_ids": ["CFPB-1"],
+                "ticket_count": 4,
+                "score": 10,
+            }
+        ],
+        "count": 1,
+    }
+
+
+def test_validate_args_reports_preflight_errors():
+    errors = smoke._validate_args(
+        _args(base_url="", token="", requests=0, concurrency=0, max_error_rate=1.5)
+    )
+
+    assert errors == [
+        "ATLAS_API_BASE_URL or --base-url is required",
+        "ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required",
+        "--requests must be positive",
+        "--concurrency must be positive",
+        "--max-error-rate must be between 0 and 1",
+    ]
+
+
+def test_latency_and_error_summaries_are_compact():
+    results = [
+        {"index": 0, "elapsed_ms": 5.0, "errors": []},
+        {"index": 1, "elapsed_ms": 2.0, "errors": ["bad envelope"]},
+        {"index": 2, "elapsed_ms": 4.0, "errors": []},
+        {"index": 3, "elapsed_ms": 3.0, "errors": []},
+    ]
+
+    assert smoke._latency_summary(results) == {
+        "count": 4,
+        "p50_ms": 3.5,
+        "p95_ms": 5.0,
+        "max_ms": 5.0,
+    }
+    assert smoke._error_summary(results) == {
+        "count": 1,
+        "rate": 0.25,
+        "items": [{"index": 1, "errors": ["bad envelope"]}],
+        "truncated": False,
+    }
+
+
+def test_budget_summary_reports_error_and_latency_failures():
+    summary = smoke._budget_summary(
+        latency={"p95_ms": 50.0, "max_ms": 75.0},
+        errors={"rate": 0.25},
+        max_error_rate=0.0,
+        max_p95_ms=40.0,
+        max_single_request_ms=100.0,
+    )
+
+    assert summary == {
+        "ok": False,
+        "checks": [
+            {"metric": "error_rate", "actual": 0.25, "max": 0.0, "ok": False},
+            {"metric": "p95_ms", "actual": 50.0, "max": 40.0, "ok": False},
+            {"metric": "max_ms", "actual": 75.0, "max": 100.0, "ok": True},
+        ],
+        "failures": [
+            "error_rate exceeded 0.0",
+            "p95_ms exceeded 40.0",
+        ],
+    }
+
+
+def test_run_one_validates_contract_and_records_count(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.012]).__next__)
+    monkeypatch.setattr(smoke.contract, "_fetch_json", lambda *_args, **_kwargs: _valid_payload())
+
+    result = smoke._run_one(3, _args())
+
+    assert result == {
+        "index": 3,
+        "ok": True,
+        "count": 1,
+        "elapsed_ms": 12.0,
+        "errors": [],
+    }
+
+
+def test_run_one_captures_fetch_and_contract_errors(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001, 2.0, 2.002]).__next__)
+    calls = iter([
+        RuntimeError("network failed"),
+        {"query": "mortgage dispute", "results": [], "count": 0},
+    ])
+
+    def _fake_fetch(*_args, **_kwargs):
+        value = next(calls)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(smoke.contract, "_fetch_json", _fake_fetch)
+
+    failed_fetch = smoke._run_one(0, _args(require_results=False))
+    bad_contract = smoke._run_one(1, _args(require_results=True))
+
+    assert failed_fetch["ok"] is False
+    assert failed_fetch["errors"] == ["RuntimeError: network failed"]
+    assert bad_contract["ok"] is False
+    assert bad_contract["errors"] == ["results must include at least one item"]
+
+
+def test_run_concurrent_sorts_results(monkeypatch):
+    def _fake_run_one(index, _args):
+        return {"index": index, "ok": True, "count": 1, "elapsed_ms": float(3 - index), "errors": []}
+
+    monkeypatch.setattr(smoke, "_run_one", _fake_run_one)
+
+    assert [row["index"] for row in smoke._run_concurrent(_args(requests=3, concurrency=3))] == [0, 1, 2]
+
+
+def test_main_writes_preflight_result(tmp_path, capsys):
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    code = smoke.main([
+        "--base-url",
+        "",
+        "--token",
+        "token-123",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["preflight_errors"] == ["ATLAS_API_BASE_URL or --base-url is required"]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Hosted-Concurrency.md

Ownership lane: content-ops/faq-search
Slice phase: Robust testing

Adds the thinnest hosted FAQ search route concurrency smoke so operators can pressure the deployed compact search route with a real URL/token and capture request counts, error rate, latency percentiles, and budget failures.

## Intentional
- No data seeding lands here; hosted route concurrency needs a deployed route and token, and test data preparation remains an operator responsibility.
- No detail-route hydration lands here; this smoke focuses on concurrent compact search reads.
- No default latency SLO lands here; operators pass environment-specific p95/max budgets when they have a baseline.

## Deferred
- Hosted seeded end-to-end load testing with isolated corpora and cleanup remains a later production-hardening slice.
- Multi-query mixes are deferred until representative demo queries are available.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q` passed with 7 tests.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py` passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` passed with 115 matching tests enrolled.
- `python scripts/smoke_content_ops_faq_search_route_concurrency.py --base-url '' --token token-123 --output-result tmp/faq_search_hosted_concurrency_preflight.json --json` returned exit 2 and wrote the preflight JSON artifact.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Hosted-Concurrency.md` passed.
- `bash scripts/local_pr_review.sh` passed.

## Diff size
4 files, +523 / -0