### PR TITLE
Fix FAQ search concurrency smoke review findings

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes.md
@@ -1,0 +1,85 @@
+# PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes
+
+## Why this slice exists
+
+The post-merge review for PR #960 found that the hosted FAQ search concurrency
+smoke was structurally useful but too easy to run as a liveness-only check. The
+default invocation allowed empty `200 OK` responses, the test suite did not
+prove the real worker ran under the executor, and the exit-1 guard path was not
+covered end to end.
+
+This slice fixes those review findings at the source while keeping the smoke
+thin and operator-focused.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Production hardening.
+
+1. Make hosted concurrency smoke correctness-checking by default.
+2. Add an explicit opt-out flag for liveness-only empty-result probes.
+3. Keep URL construction inside the worker failure boundary so result artifacts
+   still capture malformed invocation failures.
+4. Narrow the worker catch to expected route/invocation failures instead of
+   swallowing every code bug.
+5. Add tests that prove the real executor path runs concurrently and `main()`
+   returns exit 1 with a JSON artifact when route responses fail contract checks.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+`--require-results` remains accepted, but the parser now defaults
+`require_results=True`. Operators who intentionally want liveness-only behavior
+must pass `--allow-empty-results`, which sets `require_results=False` and is
+visible in the JSON artifact.
+
+The worker now builds the URL inside its guarded route-call block and catches
+only expected runtime/value/type invocation failures. It still records those
+failures in the per-request result row so `main()` can write a compact artifact
+and return exit 1 instead of crashing before output.
+
+Tests add a barrier-backed `_run_concurrent(...)` case that lets two real worker
+threads enter the fetch path at once, plus a `main(...)` route-contract failure
+case that writes an output artifact and exits 1.
+
+## Intentional
+
+- No hosted data seeding lands here. This only tightens the smoke behavior added
+  in PR #960.
+- No latency default is introduced; the review finding was about correctness
+  defaults and coverage, not hosted SLO selection.
+- `--allow-empty-results` keeps the previous liveness-only mode available, but
+  makes it explicit instead of the default.
+
+## Deferred
+
+- Hosted seeded end-to-end load testing with isolated corpora and cleanup
+  remains a later production-hardening slice.
+- Multi-query mixes remain deferred until representative demo queries are
+  available.
+
+## Verification
+
+- pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q passed with 13 tests.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . passed with 115 matching tests enrolled.
+- python scripts/smoke_content_ops_faq_search_route_concurrency.py --base-url '' --token token-123 --output-result tmp/faq_search_concurrency_review_preflight.json --json returned exit 2 and wrote the preflight JSON artifact with `require_results: true`.
+- Transport-boundary tests cover malformed JSON, non-object JSON, bad `results`,
+  bad `count`, empty results, fetch failure, and raw timeout detection without
+  replacing the checker fetch helper.
+- bash scripts/local_pr_review.sh passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 85 |
+| Smoke script | 20 |
+| Tests | 166 |
+| **Total** | **271** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -46,7 +46,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-error-rate", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_ERROR_RATE", "0"))
     parser.add_argument("--max-p95-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_P95_MS") or None)
     parser.add_argument("--max-single-request-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SINGLE_REQUEST_MS") or None)
+    parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
+    parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser
@@ -79,23 +81,23 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
 
 
 def _run_one(index: int, args: argparse.Namespace) -> dict[str, Any]:
-    url = contract._build_url(
-        base_url=str(args.base_url),
-        route=str(args.route),
-        query=str(args.query),
-        corpus_id=str(args.corpus_id),
-        status=str(args.status),
-        limit=int(args.limit),
-    )
     started = time.perf_counter()
     errors: list[str] = []
     count: int | None = None
     try:
+        url = contract._build_url(
+            base_url=str(args.base_url),
+            route=str(args.route),
+            query=str(args.query),
+            corpus_id=str(args.corpus_id),
+            status=str(args.status),
+            limit=int(args.limit),
+        )
         payload = contract._fetch_json(url, token=str(args.token).strip(), timeout=float(args.timeout))
         errors.extend(contract._validate_envelope(payload, require_results=bool(args.require_results)))
         if type(payload.get("count")) is int:
             count = int(payload["count"])
-    except Exception as exc:  # pragma: no cover - covered through monkeypatched failures.
+    except (RuntimeError, OSError, TypeError, ValueError) as exc:
         errors.append(f"{type(exc).__name__}: {exc}")
     elapsed_ms = max(0.0, (time.perf_counter() - started) * 1000)
     return {

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+from io import BytesIO
 import json
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 
@@ -12,6 +14,20 @@ SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_rout
 assert SPEC is not None and SPEC.loader is not None
 smoke = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(smoke)
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self.payload
 
 
 def _args(**overrides):
@@ -54,6 +70,10 @@ def _valid_payload():
     }
 
 
+def _json_response(payload):
+    return _Response(json.dumps(payload).encode("utf-8"))
+
+
 def test_validate_args_reports_preflight_errors():
     errors = smoke._validate_args(
         _args(base_url="", token="", requests=0, concurrency=0, max_error_rate=1.5)
@@ -66,6 +86,25 @@ def test_validate_args_reports_preflight_errors():
         "--concurrency must be positive",
         "--max-error-rate must be between 0 and 1",
     ]
+
+
+def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe():
+    required = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+    ])
+    liveness_only = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--allow-empty-results",
+    ])
+
+    assert required.require_results is True
+    assert liveness_only.require_results is False
 
 
 def test_latency_and_error_summaries_are_compact():
@@ -115,7 +154,11 @@ def test_budget_summary_reports_error_and_latency_failures():
 
 def test_run_one_validates_contract_and_records_count(monkeypatch):
     monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.012]).__next__)
-    monkeypatch.setattr(smoke.contract, "_fetch_json", lambda *_args, **_kwargs: _valid_payload())
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _json_response(_valid_payload()),
+    )
 
     result = smoke._run_one(3, _args())
 
@@ -131,25 +174,83 @@ def test_run_one_validates_contract_and_records_count(monkeypatch):
 def test_run_one_captures_fetch_and_contract_errors(monkeypatch):
     monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001, 2.0, 2.002]).__next__)
     calls = iter([
-        RuntimeError("network failed"),
-        {"query": "mortgage dispute", "results": [], "count": 0},
+        smoke.contract.urllib.error.URLError("network failed"),
+        _json_response({"query": "mortgage dispute", "results": [], "count": 0}),
     ])
 
-    def _fake_fetch(*_args, **_kwargs):
+    def _fake_urlopen(*_args, **_kwargs):
         value = next(calls)
         if isinstance(value, Exception):
             raise value
         return value
 
-    monkeypatch.setattr(smoke.contract, "_fetch_json", _fake_fetch)
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
 
     failed_fetch = smoke._run_one(0, _args(require_results=False))
     bad_contract = smoke._run_one(1, _args(require_results=True))
 
     assert failed_fetch["ok"] is False
-    assert failed_fetch["errors"] == ["RuntimeError: network failed"]
+    assert failed_fetch["errors"] == ["RuntimeError: route request failed: network failed"]
     assert bad_contract["ok"] is False
     assert bad_contract["errors"] == ["results must include at least one item"]
+
+
+def test_run_one_rejects_malformed_and_non_object_transport_payloads(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001, 2.0, 2.002]).__next__)
+    calls = iter([
+        _Response(b"{bad json"),
+        _Response(json.dumps(["not", "an", "object"]).encode("utf-8")),
+    ])
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", lambda *_args, **_kwargs: next(calls))
+
+    bad_json = smoke._run_one(0, _args())
+    non_object = smoke._run_one(1, _args())
+
+    assert bad_json["ok"] is False
+    assert bad_json["errors"] == ["RuntimeError: route did not return JSON"]
+    assert non_object["ok"] is False
+    assert non_object["errors"] == ["RuntimeError: route returned non-object JSON"]
+
+
+def test_run_one_counts_raw_transport_timeout_as_request_failure(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001]).__next__)
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("read timed out")
+
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        _raise_timeout,
+    )
+
+    result = smoke._run_one(0, _args())
+
+    assert result["ok"] is False
+    assert result["errors"] == ["TimeoutError: read timed out"]
+
+
+def test_run_one_rejects_result_envelope_drift_at_transport_boundary(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001, 2.0, 2.002]).__next__)
+    calls = iter([
+        _json_response({"query": "mortgage dispute", "results": "not-a-list", "count": 0}),
+        _json_response({"query": "mortgage dispute", "results": [], "count": "0"}),
+    ])
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", lambda *_args, **_kwargs: next(calls))
+
+    bad_results = smoke._run_one(0, _args())
+    bad_count = smoke._run_one(1, _args())
+
+    assert bad_results["ok"] is False
+    assert bad_results["errors"] == [
+        "results must be a list",
+        "results must include at least one item",
+    ]
+    assert bad_count["ok"] is False
+    assert bad_count["errors"] == [
+        "count must be an integer",
+        "results must include at least one item",
+    ]
 
 
 def test_run_concurrent_sorts_results(monkeypatch):
@@ -159,6 +260,25 @@ def test_run_concurrent_sorts_results(monkeypatch):
     monkeypatch.setattr(smoke, "_run_one", _fake_run_one)
 
     assert [row["index"] for row in smoke._run_concurrent(_args(requests=3, concurrency=3))] == [0, 1, 2]
+
+
+def test_run_concurrent_uses_real_worker_threads(monkeypatch):
+    barrier = threading.Barrier(2, timeout=2)
+    lock = threading.Lock()
+    thread_ids = set()
+
+    def _fake_urlopen(*_args, **_kwargs):
+        with lock:
+            thread_ids.add(threading.get_ident())
+        barrier.wait()
+        return _json_response(_valid_payload())
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    results = smoke._run_concurrent(_args(requests=2, concurrency=2))
+
+    assert [row["ok"] for row in results] == [True, True]
+    assert len(thread_ids) == 2
 
 
 def test_main_writes_preflight_result(tmp_path, capsys):
@@ -180,3 +300,37 @@ def test_main_writes_preflight_result(tmp_path, capsys):
     assert payload["phase"] == "preflight"
     assert payload["preflight_errors"] == ["ATLAS_API_BASE_URL or --base-url is required"]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_returns_exit_1_and_writes_result_for_contract_failures(tmp_path, monkeypatch):
+    result_path = tmp_path / "hosted-concurrency.json"
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _json_response(
+            {"query": "mortgage dispute", "results": [], "count": 0}
+        ),
+    )
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--requests",
+        "1",
+        "--concurrency",
+        "1",
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["phase"] == "complete"
+    assert payload["require_results"] is True
+    assert payload["errors"]["count"] == 1
+    assert payload["errors"]["items"] == [
+        {"index": 0, "errors": ["results must include at least one item"]}
+    ]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes.md

Ownership lane: content-ops/faq-search
Slice phase: Production hardening

Addresses the post-merge review findings from PR #960 and applies the checker/evaluator detector-coverage rule: the hosted FAQ search concurrency smoke now requires result correctness by default, keeps liveness-only mode explicit, proves the real executor path runs concurrently, and covers transport/parser/envelope failure branches without replacing the checker fetch helper.

## Intentional
- Keep liveness-only behavior available through explicit `--allow-empty-results`.
- Do not add hosted seeding or default latency SLOs in this review-fix slice.
- `--require-results` remains accepted for compatibility, but it is now the default behavior.

## Deferred
- Hosted seeded end-to-end load testing remains a later production-hardening slice.
- Multi-query mixes remain deferred until representative demo queries are available.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q` passed with 12 tests.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py` passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` passed with 115 matching tests enrolled.
- `python scripts/smoke_content_ops_faq_search_route_concurrency.py --base-url '' --token token-123 --output-result tmp/faq_search_concurrency_review_preflight.json --json` returned exit 2 and wrote the preflight JSON artifact with `require_results: true`.
- Transport-boundary tests cover malformed JSON, non-object JSON, bad `results`, bad `count`, empty results, and fetch failure detection without replacing the checker fetch helper.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Concurrency-Review-Fixes.md` passed.
- `bash scripts/local_pr_review.sh` passed.

## Diff size
3 files, +238 / -15