### PR TITLE
PR-Content-Ops-FAQ-Search-Concurrency-Cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md
@@ -1,0 +1,67 @@
+# PR-Content-Ops-FAQ-Search-Concurrency-Cases
+
+## Why this slice exists
+The hosted FAQ search concurrency smoke now fails closed and exercises real
+transport/parser/envelope failures, but it still models only one repeated query.
+The next demo-read risk is concurrent users searching different ticket corpora
+or statuses at the same time. Operators need that mixed-query pressure without
+editing Python or waiting for the larger hosted seeded load-test slice.
+
+This slice adds a small case-file input to the hosted concurrency smoke. The
+diff approaches 400 LOC because each new case-file detector branch is pinned
+with a focused negative fixture per the checker/auditor rule.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+
+1. Add `--case-file` JSON support to the hosted FAQ search concurrency smoke.
+2. Validate case-file shape fail-closed before issuing requests.
+3. Round-robin configured requests across the loaded cases.
+4. Include case metadata in each result row and in the summary artifact.
+5. Add focused negative fixtures for malformed case files and bad field types.
+
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+The new `--case-file` flag accepts a JSON list of objects. Each object supports:
+`query` (required non-empty string), optional `corpus_id`, optional `status`,
+optional positive integer `limit`, and optional boolean `require_results`.
+Omitted optional fields inherit the global CLI defaults.
+
+When no case file is supplied, behavior remains the existing single-case smoke.
+When a file is supplied, the smoke validates the whole file during preflight and
+round-robins `--requests` across the case list. Each request result records the
+case index and filters used, so failures can be traced back to a specific query
+or corpus filter.
+
+## Intentional
+- No hosted data seeding lands here. This is a case-mix runner only.
+- No new auth/account override is added; tenant scoping remains token-derived by
+  the hosted route.
+- Case-file validation is strict and fails before requests. A malformed operator
+  input should not produce a partial smoke.
+
+## Deferred
+- Hosted seeded end-to-end load testing with isolated corpora and cleanup
+  remains a later production-hardening slice.
+- Per-case expected source IDs or result IDs remain deferred until we have a
+  seeded hosted fixture shape.
+
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 30 passed in 0.07s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | +67 / -0 |
+| Smoke script | +127 / -10 |
+| Tests | +187 / -3 |
+| **Total** | **394** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -23,6 +23,26 @@ if str(SCRIPT_DIR) not in sys.path:
 import check_content_ops_faq_search_route_contract as contract  # noqa: E402
 
 
+def _case_snapshot(case: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "query": str(case["query"]),
+        "corpus_id": str(case.get("corpus_id") or ""),
+        "status": str(case.get("status") or ""),
+        "limit": int(case["limit"]),
+        "require_results": bool(case["require_results"]),
+    }
+
+
+def _default_case(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "query": str(args.query),
+        "corpus_id": str(args.corpus_id or ""),
+        "status": str(args.status or ""),
+        "limit": int(args.limit),
+        "require_results": bool(args.require_results),
+    }
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run concurrent hosted FAQ search route reads."
@@ -49,6 +69,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
+    parser.add_argument("--case-file", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser
@@ -60,7 +81,7 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("ATLAS_API_BASE_URL or --base-url is required")
     if not str(args.token or "").strip():
         errors.append("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required")
-    if not str(args.query or "").strip():
+    if args.case_file is None and not str(args.query or "").strip():
         errors.append("ATLAS_FAQ_SEARCH_QUERY or --query is required")
     for name in ("limit", "requests", "concurrency"):
         if int(getattr(args, name)) <= 0:
@@ -80,21 +101,87 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     return errors
 
 
-def _run_one(index: int, args: argparse.Namespace) -> dict[str, Any]:
+def _load_cases(args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[str]]:
+    if args.case_file is None:
+        return [_default_case(args)], []
+
+    try:
+        raw = json.loads(args.case_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [], [f"--case-file could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [], [f"--case-file must contain JSON: {exc.msg}"]
+
+    if not isinstance(raw, list) or not raw:
+        return [], ["--case-file must contain a non-empty JSON list"]
+
+    cases: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            errors.append(f"case[{index}] must be an object")
+            continue
+
+        query = item.get("query")
+        if not isinstance(query, str) or not query.strip():
+            errors.append(f"case[{index}].query must be a non-empty string")
+
+        corpus_id = item.get("corpus_id", args.corpus_id or "")
+        if not isinstance(corpus_id, str):
+            errors.append(f"case[{index}].corpus_id must be a string")
+
+        status = item.get("status", args.status or "")
+        if not isinstance(status, str):
+            errors.append(f"case[{index}].status must be a string")
+
+        limit = item.get("limit", int(args.limit))
+        if type(limit) is not int or limit <= 0:
+            errors.append(f"case[{index}].limit must be a positive integer")
+
+        require_results = item.get("require_results", bool(args.require_results))
+        if type(require_results) is not bool:
+            errors.append(f"case[{index}].require_results must be a boolean")
+
+        if errors and any(error.startswith(f"case[{index}].") for error in errors):
+            continue
+
+        cases.append(
+            {
+                "query": query.strip(),
+                "corpus_id": corpus_id.strip(),
+                "status": status.strip(),
+                "limit": limit,
+                "require_results": require_results,
+            }
+        )
+    return cases, errors
+
+
+def _run_one(
+    index: int,
+    args: argparse.Namespace,
+    case: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     started = time.perf_counter()
     errors: list[str] = []
     count: int | None = None
+    active_case = _default_case(args) if case is None else case
     try:
         url = contract._build_url(
             base_url=str(args.base_url),
             route=str(args.route),
-            query=str(args.query),
-            corpus_id=str(args.corpus_id),
-            status=str(args.status),
-            limit=int(args.limit),
+            query=str(active_case["query"]),
+            corpus_id=str(active_case.get("corpus_id") or ""),
+            status=str(active_case.get("status") or ""),
+            limit=int(active_case["limit"]),
         )
         payload = contract._fetch_json(url, token=str(args.token).strip(), timeout=float(args.timeout))
-        errors.extend(contract._validate_envelope(payload, require_results=bool(args.require_results)))
+        errors.extend(
+            contract._validate_envelope(
+                payload,
+                require_results=bool(active_case["require_results"]),
+            )
+        )
         if type(payload.get("count")) is int:
             count = int(payload["count"])
     except (RuntimeError, OSError, TypeError, ValueError) as exc:
@@ -106,13 +193,30 @@ def _run_one(index: int, args: argparse.Namespace) -> dict[str, Any]:
         "count": count,
         "elapsed_ms": round(elapsed_ms, 6),
         "errors": errors,
+        "case_index": int(active_case.get("case_index", 0)),
+        "case": _case_snapshot(active_case),
     }
 
 
-def _run_concurrent(args: argparse.Namespace) -> list[dict[str, Any]]:
+def _run_concurrent(
+    args: argparse.Namespace,
+    cases: Sequence[Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    active_cases = list(cases) if cases is not None else [_default_case(args)]
     workers = min(int(args.concurrency), int(args.requests))
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = [executor.submit(_run_one, index, args) for index in range(int(args.requests))]
+        futures = [
+            executor.submit(
+                _run_one,
+                index,
+                args,
+                {
+                    **dict(active_cases[index % len(active_cases)]),
+                    "case_index": index % len(active_cases),
+                },
+            )
+            for index in range(int(args.requests))
+        ]
         results = [future.result() for future in concurrent.futures.as_completed(futures)]
     return sorted(results, key=lambda row: int(row["index"]))
 
@@ -134,6 +238,8 @@ def _error_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     failures = [
         {
             "index": row.get("index"),
+            **({"case_index": row.get("case_index")} if "case_index" in row else {}),
+            **({"case": row.get("case")} if "case" in row else {}),
             "errors": row.get("errors"),
         }
         for row in results
@@ -176,10 +282,12 @@ def _budget_summary(
 def _summary_payload(
     *,
     args: argparse.Namespace,
+    cases: Sequence[Mapping[str, Any]] | None = None,
     results: Sequence[Mapping[str, Any]],
     elapsed_seconds: float,
     preflight_errors: Sequence[str] = (),
 ) -> dict[str, Any]:
+    active_cases = list(cases) if cases is not None else [_default_case(args)]
     errors = _error_summary(results)
     latency = _latency_summary(results)
     budgets = _budget_summary(
@@ -199,6 +307,12 @@ def _summary_payload(
         "status": str(args.status or ""),
         "limit": int(args.limit),
         "require_results": bool(args.require_results),
+        "cases": {
+            "total": len(active_cases),
+            "case_file": str(args.case_file or ""),
+            "items": [_case_snapshot(case) for case in active_cases[:20]],
+            "truncated": len(active_cases) > 20,
+        },
         "requests": {
             "total": len(results),
             "configured": int(args.requests),
@@ -236,11 +350,14 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     started = time.perf_counter()
     preflight_errors = _validate_args(args)
+    cases, case_errors = _load_cases(args)
+    preflight_errors.extend(case_errors)
     results: list[dict[str, Any]] = []
     if not preflight_errors:
-        results = _run_concurrent(args)
+        results = _run_concurrent(args, cases)
     summary = _summary_payload(
         args=args,
+        cases=cases,
         results=results,
         elapsed_seconds=time.perf_counter() - started,
         preflight_errors=preflight_errors,

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
-from io import BytesIO
 import json
 from pathlib import Path
 import threading
 from types import SimpleNamespace
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,6 +47,7 @@ def _args(**overrides):
         "max_p95_ms": None,
         "max_single_request_ms": None,
         "require_results": True,
+        "case_file": None,
         "output_result": None,
         "json": False,
     }
@@ -72,6 +74,15 @@ def _valid_payload():
 
 def _json_response(payload):
     return _Response(json.dumps(payload).encode("utf-8"))
+
+
+def _write_case_file(tmp_path, payload):
+    path = tmp_path / "cases.json"
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
 
 
 def test_validate_args_reports_preflight_errors():
@@ -105,6 +116,94 @@ def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe()
 
     assert required.require_results is True
     assert liveness_only.require_results is False
+
+
+def test_load_cases_defaults_to_cli_case():
+    cases, errors = smoke._load_cases(
+        _args(query="credit report", corpus_id="corp-1", status="published", limit=7)
+    )
+
+    assert errors == []
+    assert cases == [
+        {
+            "query": "credit report",
+            "corpus_id": "corp-1",
+            "status": "published",
+            "limit": 7,
+            "require_results": True,
+        }
+    ]
+
+
+def test_load_cases_inherits_optional_cli_defaults(tmp_path):
+    case_file = _write_case_file(
+        tmp_path,
+        [
+            {"query": "credit report", "require_results": False},
+            {
+                "query": "mortgage issue",
+                "corpus_id": "corp-b",
+                "status": "draft",
+                "limit": 2,
+            },
+        ],
+    )
+
+    cases, errors = smoke._load_cases(
+        _args(case_file=case_file, corpus_id="corp-a", status="published", limit=9)
+    )
+
+    assert errors == []
+    assert cases == [
+        {
+            "query": "credit report",
+            "corpus_id": "corp-a",
+            "status": "published",
+            "limit": 9,
+            "require_results": False,
+        },
+        {
+            "query": "mortgage issue",
+            "corpus_id": "corp-b",
+            "status": "draft",
+            "limit": 2,
+            "require_results": True,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ("{bad json", "--case-file must contain JSON: Expecting property name enclosed in double quotes"),
+        ({}, "--case-file must contain a non-empty JSON list"),
+        ([], "--case-file must contain a non-empty JSON list"),
+        ([[]], "case[0] must be an object"),
+        ([{}], "case[0].query must be a non-empty string"),
+        ([{"query": ""}], "case[0].query must be a non-empty string"),
+        ([{"query": "x", "corpus_id": 1}], "case[0].corpus_id must be a string"),
+        ([{"query": "x", "status": 1}], "case[0].status must be a string"),
+        ([{"query": "x", "limit": "5"}], "case[0].limit must be a positive integer"),
+        ([{"query": "x", "limit": True}], "case[0].limit must be a positive integer"),
+        ([{"query": "x", "limit": 0}], "case[0].limit must be a positive integer"),
+        ([{"query": "x", "require_results": "yes"}], "case[0].require_results must be a boolean"),
+    ],
+)
+def test_load_cases_rejects_bad_case_file_shapes(tmp_path, payload, expected_error):
+    case_file = _write_case_file(tmp_path, payload)
+
+    cases, errors = smoke._load_cases(_args(case_file=case_file))
+
+    assert cases == []
+    assert expected_error in errors
+
+
+def test_load_cases_reports_unreadable_case_file():
+    cases, errors = smoke._load_cases(_args(case_file=Path("/tmp/atlas-missing-case-file.json")))
+
+    assert cases == []
+    assert errors
+    assert errors[0].startswith("--case-file could not be read:")
 
 
 def test_latency_and_error_summaries_are_compact():
@@ -168,6 +267,14 @@ def test_run_one_validates_contract_and_records_count(monkeypatch):
         "count": 1,
         "elapsed_ms": 12.0,
         "errors": [],
+        "case_index": 0,
+        "case": {
+            "query": "mortgage dispute",
+            "corpus_id": "",
+            "status": "",
+            "limit": 5,
+            "require_results": True,
+        },
     }
 
 
@@ -254,7 +361,7 @@ def test_run_one_rejects_result_envelope_drift_at_transport_boundary(monkeypatch
 
 
 def test_run_concurrent_sorts_results(monkeypatch):
-    def _fake_run_one(index, _args):
+    def _fake_run_one(index, _args, _case):
         return {"index": index, "ok": True, "count": 1, "elapsed_ms": float(3 - index), "errors": []}
 
     monkeypatch.setattr(smoke, "_run_one", _fake_run_one)
@@ -281,6 +388,46 @@ def test_run_concurrent_uses_real_worker_threads(monkeypatch):
     assert len(thread_ids) == 2
 
 
+def test_run_concurrent_round_robins_case_file_requests(monkeypatch, tmp_path):
+    case_file = _write_case_file(
+        tmp_path,
+        [
+            {"query": "credit report", "corpus_id": "corp-a", "limit": 2},
+            {
+                "query": "mortgage dispute",
+                "status": "published",
+                "limit": 3,
+                "require_results": False,
+            },
+        ],
+    )
+    args = _args(case_file=case_file, requests=3, concurrency=2)
+    cases, errors = smoke._load_cases(args)
+    urls = []
+    lock = threading.Lock()
+
+    def _fake_urlopen(request, **_kwargs):
+        with lock:
+            urls.append(request.full_url)
+        return _json_response(_valid_payload())
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    results = smoke._run_concurrent(args, cases)
+
+    parsed = [
+        smoke.contract.urllib.parse.parse_qs(smoke.contract.urllib.parse.urlsplit(url).query)
+        for url in sorted(urls)
+    ]
+    assert [row["case_index"] for row in results] == [0, 1, 0]
+    assert results[1]["case"]["require_results"] is False
+    assert parsed == [
+        {"corpus_id": ["corp-a"], "limit": ["2"], "q": ["credit report"]},
+        {"corpus_id": ["corp-a"], "limit": ["2"], "q": ["credit report"]},
+        {"limit": ["3"], "q": ["mortgage dispute"], "status": ["published"]},
+    ]
+
+
 def test_main_writes_preflight_result(tmp_path, capsys):
     result_path = tmp_path / "hosted-concurrency.json"
 
@@ -299,6 +446,32 @@ def test_main_writes_preflight_result(tmp_path, capsys):
     assert payload["ok"] is False
     assert payload["phase"] == "preflight"
     assert payload["preflight_errors"] == ["ATLAS_API_BASE_URL or --base-url is required"]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_writes_case_file_preflight_result(tmp_path, capsys):
+    case_file = _write_case_file(tmp_path, [{"query": "x", "limit": "5"}])
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--case-file",
+        str(case_file),
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["cases"]["case_file"] == str(case_file)
+    assert payload["cases"]["total"] == 0
+    assert payload["preflight_errors"] == ["case[0].limit must be a positive integer"]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 
 
@@ -332,5 +505,16 @@ def test_main_returns_exit_1_and_writes_result_for_contract_failures(tmp_path, m
     assert payload["require_results"] is True
     assert payload["errors"]["count"] == 1
     assert payload["errors"]["items"] == [
-        {"index": 0, "errors": ["results must include at least one item"]}
+        {
+            "index": 0,
+            "case_index": 0,
+            "case": {
+                "query": "mortgage payment dispute",
+                "corpus_id": "",
+                "status": "",
+                "limit": 5,
+                "require_results": True,
+            },
+            "errors": ["results must include at least one item"],
+        }
     ]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md

Slice phase: Production hardening.

Add case-file support to the hosted FAQ search concurrency smoke so operators can run mixed query/corpus/status reads in one concurrency pass instead of repeating a single query shape. This is the next read-path hardening step after the smoke started failing closed by default.

## Intentional
- No hosted data seeding lands here; this is a case-mix runner only.
- No new auth/account override is added; tenant scoping remains token-derived by the hosted route.
- Case-file validation is strict and fails before requests so malformed operator input cannot create a partial smoke.

## Deferred
- Hosted seeded end-to-end load testing with isolated corpora and cleanup.
- Per-case expected source IDs or result IDs once seeded hosted fixtures exist.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 30 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Concurrency-Cases.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
3 files, +381 / -13