### PR TITLE
PR-Content-Ops-FAQ-Search-Seeded-Route-Cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Seeded-Route-Cases.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Seeded-Route-Cases.md
@@ -1,0 +1,49 @@
+# PR-Content-Ops-FAQ-Search-Seeded-Route-Cases
+
+## Why this slice exists
+The hosted FAQ search concurrency smoke can now run mixed query/corpus cases,
+but it only validates the generic response envelope. It cannot prove that seeded
+corpora return expected rows or that miss cases stay empty.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Add expected count and first-result fields to hosted route case validation.
+2. Add account override plus hosted case-file output to the seeded DB smoke.
+3. Require kept seed data when writing a hosted route case file.
+4. Add negative fixtures for every new checker branch.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Seeded-Route-Cases.md`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+## Mechanism
+The seeded DB smoke can write a hosted route `--case-file` JSON artifact. Hit
+cases include seeded corpus, expected count, and expected first result
+account/corpus/FAQ IDs. Miss cases set `require_results=false` and
+`expected_count=0`.
+The hosted route smoke keeps existing no-case-file behavior. When expectations
+are present, each request validates actual count and first-result fields after
+the envelope check; mismatches become request errors in the JSON summary.
+## Intentional
+- The DB smoke does not launch hosted HTTP; operators pass the emitted case file
+  to the hosted smoke with the correct base URL and token.
+- Route case output requires `--keep-data`; cleanup remains explicit so seeded
+  rows are not removed before the hosted route reads them.
+- Account override is limited to one seeded account because one token maps to
+  one tenant.
+## Deferred
+- One-command seed, hosted HTTP load, and cleanup orchestration.
+- Hosted detail-route expectation checks.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 52 passed in 0.13s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py; git diff --check - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 49 |
+| Seeded DB smoke | 68 |
+| Hosted route smoke | 79 |
+| Tests | 203 |
+| **Total** | **399** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -67,6 +67,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--database-url", default=_default_database_url())
     parser.add_argument("--account-count", type=int, default=3)
+    parser.add_argument("--account-id", default="")
     parser.add_argument("--corpora-per-account", type=int, default=2)
     parser.add_argument("--documents-per-corpus", type=int, default=3)
     parser.add_argument("--iterations", type=int, default=30)
@@ -75,6 +76,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-p95-ms", type=float)
     parser.add_argument("--max-single-request-ms", type=float)
     parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--route-case-file-output", type=Path)
     parser.add_argument("--keep-data", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -97,6 +99,10 @@ def _validate_args(args: argparse.Namespace) -> None:
         value = getattr(args, name)
         if value is not None and float(value) <= 0:
             raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+    if str(args.account_id or "").strip() and int(args.account_count) != 1:
+        raise SystemExit("--account-id requires --account-count 1")
+    if args.route_case_file_output and not bool(args.keep_data):
+        raise SystemExit("--route-case-file-output requires --keep-data")
 
 
 async def _create_pool(database_url: str, *, pool_size: int):
@@ -114,16 +120,17 @@ def _build_cases(
     run_id: str,
     account_count: int,
     corpora_per_account: int,
+    account_id: str = "",
 ) -> tuple[SearchCase, ...]:
     cases: list[SearchCase] = []
     for account_index in range(account_count):
-        account_id = f"faq-search-{run_id}-acct-{account_index}"
+        resolved_account_id = account_id.strip() or f"faq-search-{run_id}-acct-{account_index}"
         for corpus_index in range(corpora_per_account):
             corpus_id = f"faq-search-{run_id}-corpus-{corpus_index}"
             faq_id = str(uuid4())
             cases.append(
                 SearchCase(
-                    account_id=account_id,
+                    account_id=resolved_account_id,
                     corpus_id=corpus_id,
                     faq_id=faq_id,
                     query="password reset",
@@ -132,7 +139,7 @@ def _build_cases(
             )
             cases.append(
                 SearchCase(
-                    account_id=account_id,
+                    account_id=resolved_account_id,
                     corpus_id=corpus_id,
                     faq_id=faq_id,
                     query="escrow shortage",
@@ -140,6 +147,55 @@ def _build_cases(
                 )
             )
     return tuple(cases)
+
+
+def _route_case_payload(
+    cases: Sequence[SearchCase],
+    *,
+    documents_per_corpus: int,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    expected_hit_count = min(documents_per_corpus, limit)
+    payload: list[dict[str, Any]] = []
+    for case in cases:
+        row = {
+            "query": case.query,
+            "corpus_id": case.corpus_id,
+            "status": "approved",
+            "limit": limit,
+            "require_results": case.expected_hit,
+            "expected_count": expected_hit_count if case.expected_hit else 0,
+        }
+        if case.expected_hit:
+            row.update(
+                {
+                    "expected_first_account_id": case.account_id,
+                    "expected_first_corpus_id": case.corpus_id,
+                    "expected_first_faq_id": case.faq_id,
+                }
+            )
+        payload.append(row)
+    return payload
+
+
+def _write_route_case_file(
+    path: Path | None,
+    cases: Sequence[SearchCase],
+    *,
+    documents_per_corpus: int,
+) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            _route_case_payload(cases, documents_per_corpus=documents_per_corpus),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _documents_for_case(case: SearchCase, *, documents_per_corpus: int) -> tuple[TicketFAQSearchDocument, ...]:
@@ -387,6 +443,7 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         run_id=run_id,
         account_count=int(args.account_count),
         corpora_per_account=int(args.corpora_per_account),
+        account_id=str(args.account_id or ""),
     )
     started = time.perf_counter()
     try:
@@ -414,6 +471,11 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     try:
         await _apply_migrations(pool)
         await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
+        _write_route_case_file(
+            args.route_case_file_output,
+            cases,
+            documents_per_corpus=int(args.documents_per_corpus),
+        )
         results = await _run_concurrent_searches(
             repo,
             cases,

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -24,13 +24,22 @@ import check_content_ops_faq_search_route_contract as contract  # noqa: E402
 
 
 def _case_snapshot(case: Mapping[str, Any]) -> dict[str, Any]:
-    return {
+    snapshot = {
         "query": str(case["query"]),
         "corpus_id": str(case.get("corpus_id") or ""),
         "status": str(case.get("status") or ""),
         "limit": int(case["limit"]),
         "require_results": bool(case["require_results"]),
     }
+    for key in (
+        "expected_count",
+        "expected_first_account_id",
+        "expected_first_corpus_id",
+        "expected_first_faq_id",
+    ):
+        if key in case:
+            snapshot[key] = case[key]
+    return snapshot
 
 
 def _default_case(args: argparse.Namespace) -> dict[str, Any]:
@@ -142,19 +151,68 @@ def _load_cases(args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[st
         if type(require_results) is not bool:
             errors.append(f"case[{index}].require_results must be a boolean")
 
+        expected_count = item.get("expected_count")
+        if "expected_count" in item and (type(expected_count) is not int or expected_count < 0):
+            errors.append(f"case[{index}].expected_count must be a non-negative integer")
+
+        expected_first: dict[str, str] = {}
+        for key in (
+            "expected_first_account_id",
+            "expected_first_corpus_id",
+            "expected_first_faq_id",
+        ):
+            if key not in item:
+                continue
+            value = item.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"case[{index}].{key} must be a non-empty string")
+            else:
+                expected_first[key] = value.strip()
+
         if errors and any(error.startswith(f"case[{index}].") for error in errors):
             continue
 
-        cases.append(
-            {
-                "query": query.strip(),
-                "corpus_id": corpus_id.strip(),
-                "status": status.strip(),
-                "limit": limit,
-                "require_results": require_results,
-            }
-        )
+        case = {
+            "query": query.strip(),
+            "corpus_id": corpus_id.strip(),
+            "status": status.strip(),
+            "limit": limit,
+            "require_results": require_results,
+        }
+        if "expected_count" in item:
+            case["expected_count"] = expected_count
+        case.update(expected_first)
+        cases.append(case)
     return cases, errors
+
+
+def _expected_case_errors(payload: Mapping[str, Any], case: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    count = payload.get("count")
+    if "expected_count" in case and count != case["expected_count"]:
+        errors.append(f"expected count {case['expected_count']} but got {count}")
+
+    first_expectations = {
+        "expected_first_account_id": "account_id",
+        "expected_first_corpus_id": "corpus_id",
+        "expected_first_faq_id": "faq_id",
+    }
+    expected_keys = [key for key in first_expectations if key in case]
+    if not expected_keys:
+        return errors
+
+    results = payload.get("results")
+    first = results[0] if isinstance(results, list) and results else None
+    if not isinstance(first, Mapping):
+        errors.append("expected first result but none was returned")
+        return errors
+    for expected_key in expected_keys:
+        field = first_expectations[expected_key]
+        expected = case[expected_key]
+        actual = first.get(field)
+        if actual != expected:
+            errors.append(f"expected first {field} {expected!r} but got {actual!r}")
+    return errors
 
 
 def _run_one(
@@ -182,6 +240,7 @@ def _run_one(
                 require_results=bool(active_case["require_results"]),
             )
         )
+        errors.extend(_expected_case_errors(payload, active_case))
         if type(payload.get("count")) is int:
             count = int(payload["count"])
     except (RuntimeError, OSError, TypeError, ValueError) as exc:

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -18,6 +18,16 @@ sys.modules["smoke_content_ops_faq_search_concurrency"] = smoke
 SPEC.loader.exec_module(smoke)
 
 
+def _case(*, query: str = "password reset", expected_hit: bool = True):
+    return smoke.SearchCase(
+        account_id="acct-1",
+        corpus_id="corpus-1",
+        faq_id="11111111-1111-1111-1111-111111111111",
+        query=query,
+        expected_hit=expected_hit,
+    )
+
+
 def test_build_cases_creates_hit_and_miss_for_each_corpus() -> None:
     cases = smoke._build_cases(
         run_id="abc123",
@@ -35,16 +45,20 @@ def test_build_cases_creates_hit_and_miss_for_each_corpus() -> None:
         assert len({case.account_id for case in cases if case.corpus_id == corpus_id}) == 2
 
 
-def test_documents_for_case_are_ranked_and_scoped() -> None:
-    case = smoke.SearchCase(
-        account_id="acct-1",
-        corpus_id="corpus-1",
-        faq_id="11111111-1111-1111-1111-111111111111",
-        query="password reset",
-        expected_hit=True,
+def test_build_cases_accepts_single_account_override() -> None:
+    cases = smoke._build_cases(
+        run_id="abc123",
+        account_count=1,
+        corpora_per_account=2,
+        account_id="hosted-token-account",
     )
 
-    documents = smoke._documents_for_case(case, documents_per_corpus=3)
+    assert {case.account_id for case in cases} == {"hosted-token-account"}
+    assert len(cases) == 4
+
+
+def test_documents_for_case_are_ranked_and_scoped() -> None:
+    documents = smoke._documents_for_case(_case(), documents_per_corpus=3)
 
     assert [document.rank for document in documents] == [1, 2, 3]
     assert {document.account_id for document in documents} == {"acct-1"}
@@ -52,6 +66,36 @@ def test_documents_for_case_are_ranked_and_scoped() -> None:
     assert {document.status for document in documents} == {"approved"}
     assert {document.target_mode for document in documents} == {"support_account"}
     assert all("password reset" in document.search_text for document in documents)
+
+
+def test_route_case_payload_carries_seeded_hit_and_miss_expectations() -> None:
+    payload = smoke._route_case_payload(
+        [_case(), _case(query="escrow shortage", expected_hit=False)],
+        documents_per_corpus=7,
+        limit=5,
+    )
+
+    assert payload[0]["expected_count"] == 5
+    assert payload[0]["expected_first_account_id"] == "acct-1"
+    assert payload[0]["expected_first_corpus_id"] == "corpus-1"
+    assert payload[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload[1] == {
+        "query": "escrow shortage",
+        "corpus_id": "corpus-1",
+        "status": "approved",
+        "limit": 5,
+        "require_results": False,
+        "expected_count": 0,
+    }
+
+
+def test_write_route_case_file_writes_deterministic_json(tmp_path) -> None:
+    path = tmp_path / "route-cases.json"
+    smoke._write_route_case_file(path, [_case()], documents_per_corpus=1)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload[0]["expected_count"] == 1
+    assert payload[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
 
 
 @pytest.mark.asyncio
@@ -177,6 +221,46 @@ def test_validate_args_rejects_nonpositive_latency_budgets() -> None:
     )
 
     with pytest.raises(SystemExit, match="--max-p95-ms must be positive"):
+        smoke._validate_args(args)
+
+
+def test_validate_args_rejects_route_case_output_without_kept_data() -> None:
+    args = SimpleNamespace(
+        database_url="postgresql://example",
+        account_count=1,
+        account_id="acct-1",
+        corpora_per_account=1,
+        documents_per_corpus=1,
+        iterations=1,
+        concurrency=1,
+        pool_size=1,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        route_case_file_output=Path("cases.json"),
+        keep_data=False,
+    )
+
+    with pytest.raises(SystemExit, match="--route-case-file-output requires --keep-data"):
+        smoke._validate_args(args)
+
+
+def test_validate_args_rejects_account_override_for_multiple_accounts() -> None:
+    args = SimpleNamespace(
+        database_url="postgresql://example",
+        account_count=2,
+        account_id="acct-1",
+        corpora_per_account=1,
+        documents_per_corpus=1,
+        iterations=1,
+        concurrency=1,
+        pool_size=1,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        route_case_file_output=None,
+        keep_data=True,
+    )
+
+    with pytest.raises(SystemExit, match="--account-id requires --account-count 1"):
         smoke._validate_args(args)
 
 

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -60,6 +60,9 @@ def _valid_payload():
         "query": "mortgage dispute",
         "results": [
             {
+                "account_id": "acct-1",
+                "corpus_id": "corpus-1",
+                "faq_id": "11111111-1111-1111-1111-111111111111",
                 "question": "How do I dispute a mortgage payment error?",
                 "answer_summary": "Gather records and contact support.",
                 "topic": "Mortgage servicing issues",
@@ -187,6 +190,21 @@ def test_load_cases_inherits_optional_cli_defaults(tmp_path):
         ([{"query": "x", "limit": True}], "case[0].limit must be a positive integer"),
         ([{"query": "x", "limit": 0}], "case[0].limit must be a positive integer"),
         ([{"query": "x", "require_results": "yes"}], "case[0].require_results must be a boolean"),
+        ([{"query": "x", "expected_count": "1"}], "case[0].expected_count must be a non-negative integer"),
+        ([{"query": "x", "expected_count": True}], "case[0].expected_count must be a non-negative integer"),
+        ([{"query": "x", "expected_count": -1}], "case[0].expected_count must be a non-negative integer"),
+        (
+            [{"query": "x", "expected_first_account_id": ""}],
+            "case[0].expected_first_account_id must be a non-empty string",
+        ),
+        (
+            [{"query": "x", "expected_first_corpus_id": 1}],
+            "case[0].expected_first_corpus_id must be a non-empty string",
+        ),
+        (
+            [{"query": "x", "expected_first_faq_id": []}],
+            "case[0].expected_first_faq_id must be a non-empty string",
+        ),
     ],
 )
 def test_load_cases_rejects_bad_case_file_shapes(tmp_path, payload, expected_error):
@@ -204,6 +222,27 @@ def test_load_cases_reports_unreadable_case_file():
     assert cases == []
     assert errors
     assert errors[0].startswith("--case-file could not be read:")
+
+
+def test_load_cases_accepts_seeded_expectations(tmp_path):
+    case_file = _write_case_file(
+        tmp_path,
+        [{
+            "query": "reset password",
+            "expected_count": 1,
+            "expected_first_account_id": "acct-1",
+            "expected_first_corpus_id": "corpus-1",
+            "expected_first_faq_id": "11111111-1111-1111-1111-111111111111",
+        }],
+    )
+
+    cases, errors = smoke._load_cases(_args(case_file=case_file))
+
+    assert errors == []
+    assert cases[0]["expected_count"] == 1
+    assert cases[0]["expected_first_account_id"] == "acct-1"
+    assert cases[0]["expected_first_corpus_id"] == "corpus-1"
+    assert cases[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
 
 
 def test_latency_and_error_summaries_are_compact():
@@ -358,6 +397,70 @@ def test_run_one_rejects_result_envelope_drift_at_transport_boundary(monkeypatch
         "count must be an integer",
         "results must include at least one item",
     ]
+
+
+def test_run_one_rejects_seeded_expectation_drift(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001]).__next__)
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _json_response(_valid_payload()),
+    )
+
+    result = smoke._run_one(
+        0,
+        _args(),
+        {
+            "query": "mortgage dispute",
+            "corpus_id": "corpus-1",
+            "status": "",
+            "limit": 5,
+            "require_results": True,
+            "expected_count": 2,
+            "expected_first_account_id": "acct-2",
+            "expected_first_corpus_id": "corpus-2",
+            "expected_first_faq_id": "22222222-2222-2222-2222-222222222222",
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["errors"] == [
+        "expected count 2 but got 1",
+        "expected first account_id 'acct-2' but got 'acct-1'",
+        "expected first corpus_id 'corpus-2' but got 'corpus-1'",
+        (
+            "expected first faq_id '22222222-2222-2222-2222-222222222222' "
+            "but got '11111111-1111-1111-1111-111111111111'"
+        ),
+    ]
+
+
+def test_run_one_rejects_missing_expected_first_result(monkeypatch):
+    monkeypatch.setattr(smoke.time, "perf_counter", iter([1.0, 1.001]).__next__)
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _json_response(
+            {"query": "mortgage dispute", "results": [], "count": 0}
+        ),
+    )
+
+    result = smoke._run_one(
+        0,
+        _args(require_results=False),
+        {
+            "query": "mortgage dispute",
+            "corpus_id": "corpus-1",
+            "status": "",
+            "limit": 5,
+            "require_results": False,
+            "expected_count": 0,
+            "expected_first_faq_id": "11111111-1111-1111-1111-111111111111",
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["errors"] == ["expected first result but none was returned"]
 
 
 def test_run_concurrent_sorts_results(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Seeded-Route-Cases.md

Slice phase: Production hardening.

Bridge seeded FAQ search data to hosted route concurrency checks by emitting expectation-bearing route case files and validating expected counts and first-result IDs. This lets us prove known seeded corpora through hosted reads without adding a larger one-command orchestration layer yet.

## Intentional
- The DB smoke does not launch hosted HTTP; operators pass the emitted case file to the hosted smoke with the correct base URL and token.
- Route case output requires --keep-data so emitted cases do not point at cleaned-up rows.
- Account override is limited to one seeded account because one token maps to one tenant.

## Deferred
- One-command seed, hosted HTTP load, and cleanup orchestration.
- Hosted detail-route expectation checks.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 52 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Seeded-Route-Cases.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
5 files, +378 / -21