### PR TITLE
PR-Content-Ops-FAQ-Search-Seeded-Route-E2E

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md
@@ -1,0 +1,57 @@
+# PR-Content-Ops-FAQ-Search-Seeded-Route-E2E
+
+## Why this slice exists
+The seeded DB smoke can now emit expectation-bearing hosted route cases, but an
+operator still has to run seed, hosted HTTP, and cleanup manually. That leaves
+the highest-risk path unproven as one repeatable command.
+
+This slice intentionally exceeds the 400 LOC target because the runner is a new
+checker/gate and ships with negative fixtures for its parser, preflight, phase,
+and cleanup failure branches.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Add a thin seeded-hosted FAQ search e2e runner.
+2. Reuse the existing seeded DB smoke and hosted route concurrency smoke.
+3. Always clean up seeded FAQ drafts by emitted FAQ IDs unless explicitly kept.
+4. Write one compact JSON result for seed, route, cleanup, and artifacts.
+5. Add focused negative fixtures for the new detector branches.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+The new runner creates a temporary artifact directory, invokes the DB smoke with
+`--keep-data --route-case-file-output`, invokes the hosted route smoke with that
+case file, then reads seeded FAQ IDs from the case file and deletes those drafts.
+The route token's tenant must be supplied as `--account-id`, so seeded rows match
+the hosted auth scope.
+
+Each phase is summarized separately. Seed or route failures still attempt cleanup
+when a case file exists. Cleanup failure makes the run fail closed unless
+`--keep-data` is set.
+## Intentional
+- No new database seeding implementation is added; the existing DB smoke remains
+  the producer.
+- No token decoding is attempted. The operator supplies the account ID that
+  matches the bearer token.
+- Cleanup deletes only emitted FAQ IDs, not all drafts for an account.
+## Deferred
+- Hosted detail-route expectation checks.
+- CI enrollment for this live e2e runner.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_extracted_pipeline_route_ci_contract.py tests/test_audit_extracted_pipeline_ci_enrollment.py -q - 27 passed in 0.18s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . - Passed; 116 matching tests enrolled.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 57 |
+| CI runner enrollment | 1 |
+| Runner | 325 |
+| Tests | 308 |
+| **Total** | **691** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \
   tests/test_smoke_content_ops_faq_search_route_concurrency.py \
+  tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py \
   tests/test_check_content_ops_faq_search_route_contract.py \
   tests/test_evaluate_support_ticket_generated_content.py \
   tests/test_smoke_content_ops_faq_scale_run.py \

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Seed FAQ search rows, hit the hosted route, then clean up."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SEED_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_concurrency.py"
+ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - host dependency
+    load_dotenv = None
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+def _default_database_url() -> str:
+    raw = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if raw:
+        return raw
+    try:
+        from atlas_brain.storage.config import db_settings
+    except Exception:
+        return ""
+    return str(getattr(db_settings, "dsn", "") or "").strip()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    _load_dotenv_files()
+    parser = argparse.ArgumentParser(
+        description="Run seeded DB plus hosted FAQ search route smoke."
+    )
+    parser.add_argument("--database-url", default=_default_database_url())
+    parser.add_argument("--base-url", default=os.getenv("ATLAS_API_BASE_URL", ""))
+    parser.add_argument(
+        "--token",
+        default=os.getenv("ATLAS_B2B_JWT") or os.getenv("ATLAS_TOKEN", ""),
+    )
+    parser.add_argument("--account-id", default=os.getenv("ATLAS_FAQ_SEARCH_ACCOUNT_ID", ""))
+    parser.add_argument("--corpora-per-account", type=int, default=2)
+    parser.add_argument("--documents-per-corpus", type=int, default=3)
+    parser.add_argument("--seed-iterations", type=int, default=12)
+    parser.add_argument("--route-requests", type=int, default=12)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--pool-size", type=int, default=2)
+    parser.add_argument("--route", default="/api/v1/content-ops/faq-deflection-search")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--max-error-rate", type=float, default=0.0)
+    parser.add_argument("--max-p95-ms", type=float)
+    parser.add_argument("--max-single-request-ms", type=float)
+    parser.add_argument("--artifact-dir", type=Path)
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--keep-data", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def _validate_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    for name, message in (
+        ("database_url", "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"),
+        ("base_url", "ATLAS_API_BASE_URL or --base-url is required"),
+        ("token", "ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required"),
+        ("account_id", "ATLAS_FAQ_SEARCH_ACCOUNT_ID or --account-id is required"),
+    ):
+        if not str(getattr(args, name) or "").strip():
+            errors.append(message)
+    for name in (
+        "corpora_per_account",
+        "documents_per_corpus",
+        "seed_iterations",
+        "route_requests",
+        "concurrency",
+        "pool_size",
+    ):
+        if int(getattr(args, name)) <= 0:
+            errors.append(f"--{name.replace('_', '-')} must be positive")
+    if float(args.timeout) <= 0:
+        errors.append("--timeout must be positive")
+    if not 0 <= float(args.max_error_rate) <= 1:
+        errors.append("--max-error-rate must be between 0 and 1")
+    for name in ("max_p95_ms", "max_single_request_ms"):
+        value = getattr(args, name)
+        if value is not None and float(value) <= 0:
+            errors.append(f"--{name.replace('_', '-')} must be positive")
+    return errors
+
+
+def _seed_command(args: argparse.Namespace, *, case_file: Path, seed_result: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(SEED_SCRIPT),
+        "--database-url",
+        str(args.database_url),
+        "--account-count",
+        "1",
+        "--account-id",
+        str(args.account_id),
+        "--corpora-per-account",
+        str(args.corpora_per_account),
+        "--documents-per-corpus",
+        str(args.documents_per_corpus),
+        "--iterations",
+        str(args.seed_iterations),
+        "--concurrency",
+        str(args.concurrency),
+        "--pool-size",
+        str(args.pool_size),
+        "--keep-data",
+        "--route-case-file-output",
+        str(case_file),
+        "--output-result",
+        str(seed_result),
+        "--json",
+    ]
+
+
+def _route_command(args: argparse.Namespace, *, case_file: Path, route_result: Path) -> list[str]:
+    command = [
+        sys.executable,
+        str(ROUTE_SCRIPT),
+        "--base-url",
+        str(args.base_url),
+        "--token",
+        str(args.token),
+        "--route",
+        str(args.route),
+        "--timeout",
+        str(args.timeout),
+        "--requests",
+        str(args.route_requests),
+        "--concurrency",
+        str(args.concurrency),
+        "--max-error-rate",
+        str(args.max_error_rate),
+        "--case-file",
+        str(case_file),
+        "--output-result",
+        str(route_result),
+        "--json",
+    ]
+    for arg_name, flag in (
+        ("max_p95_ms", "--max-p95-ms"),
+        ("max_single_request_ms", "--max-single-request-ms"),
+    ):
+        value = getattr(args, arg_name)
+        if value is not None:
+            command.extend([flag, str(value)])
+    return command
+
+
+def _run_command(command: Sequence[str]) -> dict[str, Any]:
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    return {
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-2000:],
+        "stderr_tail": completed.stderr[-2000:],
+    }
+
+
+def _faq_ids_from_case_file(path: Path) -> tuple[list[str], list[str]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [], [f"case file could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [], [f"case file must contain JSON: {exc.msg}"]
+    if not isinstance(data, list):
+        return [], ["case file must contain a JSON list"]
+
+    faq_ids: list[str] = []
+    errors: list[str] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, Mapping):
+            errors.append(f"case[{index}] must be an object")
+            continue
+        faq_id = item.get("expected_first_faq_id")
+        if faq_id is None:
+            continue
+        if not isinstance(faq_id, str) or not faq_id.strip():
+            errors.append(f"case[{index}].expected_first_faq_id must be a non-empty string")
+            continue
+        if faq_id.strip() not in faq_ids:
+            faq_ids.append(faq_id.strip())
+    return faq_ids, errors
+
+
+async def _cleanup_seeded_faqs(database_url: str, faq_ids: Sequence[str]) -> dict[str, Any]:
+    if not faq_ids:
+        return {"ok": True, "deleted_faq_ids": 0, "error": None}
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        return {"ok": False, "deleted_faq_ids": 0, "error": f"ImportError: {exc}"}
+
+    try:
+        pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+        try:
+            await pool.execute(
+                "DELETE FROM ticket_faq_markdown WHERE id = ANY($1::uuid[])",
+                list(faq_ids),
+            )
+        finally:
+            await pool.close()
+    except Exception as exc:
+        return {"ok": False, "deleted_faq_ids": 0, "error": f"{type(exc).__name__}: {exc}"}
+    return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+
+
+def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    print(
+        "FAQ search seeded route e2e: "
+        f"ok={summary['ok']} seed={summary['seed']['ok']} "
+        f"route={summary['route']['ok']} cleanup={summary['cleanup']['ok']}"
+    )
+
+
+def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed: float) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "phase": "preflight",
+        "artifacts": {},
+        "seed": {"ok": False, "returncode": None},
+        "route": {"ok": False, "returncode": None},
+        "cleanup": {"ok": False, "deleted_faq_ids": 0, "error": None},
+        "preflight_errors": list(errors),
+        "keep_data": bool(args.keep_data),
+        "elapsed_seconds": round(elapsed, 6),
+    }
+
+
+async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    started = time.perf_counter()
+    errors = _validate_args(args)
+    if errors:
+        return 2, _preflight_summary(args, errors, time.perf_counter() - started)
+
+    temp_context = (
+        tempfile.TemporaryDirectory(prefix="atlas-faq-search-e2e-")
+        if args.artifact_dir is None
+        else None
+    )
+    artifact_dir = Path(temp_context.name) if temp_context else Path(args.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    case_file = artifact_dir / "route-cases.json"
+    seed_result = artifact_dir / "seed-result.json"
+    route_result = artifact_dir / "route-result.json"
+
+    cleanup = {"ok": True, "deleted_faq_ids": 0, "error": None}
+    try:
+        seed = _run_command(_seed_command(args, case_file=case_file, seed_result=seed_result))
+        route = {"ok": False, "returncode": None, "stdout_tail": "", "stderr_tail": ""}
+        if seed["ok"]:
+            route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
+        faq_ids, case_errors = _faq_ids_from_case_file(case_file) if case_file.exists() else ([], [])
+        if case_errors:
+            cleanup = {
+                "ok": False,
+                "deleted_faq_ids": 0,
+                "error": "; ".join(case_errors),
+            }
+        elif not bool(args.keep_data):
+            cleanup = await _cleanup_seeded_faqs(str(args.database_url), faq_ids)
+        ok = bool(seed["ok"] and route["ok"] and cleanup["ok"])
+        summary = {
+            "ok": ok,
+            "phase": "complete",
+            "artifacts": {
+                "dir": str(artifact_dir),
+                "case_file": str(case_file),
+                "seed_result": str(seed_result),
+                "route_result": str(route_result),
+            },
+            "seed": seed,
+            "route": route,
+            "cleanup": cleanup,
+            "preflight_errors": [],
+            "keep_data": bool(args.keep_data),
+            "elapsed_seconds": round(time.perf_counter() - started, 6),
+        }
+        return (0 if ok else 1), summary
+    finally:
+        if temp_context is not None:
+            temp_context.cleanup()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    code, summary = asyncio.run(_run(args))
+    _write_result(args.output_result, summary)
+    _print_summary(summary, as_json=bool(args.json))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_seeded_route_e2e.py"
+SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_seeded_route_e2e", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+def _args(**overrides):
+    values = {
+        "database_url": "postgresql://example/atlas",
+        "base_url": "https://atlas.example.com",
+        "token": "token-123",
+        "account_id": "acct-1",
+        "corpora_per_account": 2,
+        "documents_per_corpus": 3,
+        "seed_iterations": 12,
+        "route_requests": 12,
+        "concurrency": 4,
+        "pool_size": 2,
+        "route": "/api/v1/content-ops/faq-deflection-search",
+        "timeout": 10.0,
+        "max_error_rate": 0.0,
+        "max_p95_ms": None,
+        "max_single_request_ms": None,
+        "artifact_dir": None,
+        "output_result": None,
+        "keep_data": False,
+        "json": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _write_cases(path: Path, payload) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_validate_args_reports_missing_required_fields_and_bad_numbers():
+    errors = smoke._validate_args(
+        _args(
+            database_url="",
+            base_url="",
+            token="",
+            account_id="",
+            route_requests=0,
+            timeout=0,
+            max_error_rate=2,
+            max_p95_ms=0,
+        )
+    )
+
+    assert errors == [
+        "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL",
+        "ATLAS_API_BASE_URL or --base-url is required",
+        "ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required",
+        "ATLAS_FAQ_SEARCH_ACCOUNT_ID or --account-id is required",
+        "--route-requests must be positive",
+        "--timeout must be positive",
+        "--max-error-rate must be between 0 and 1",
+        "--max-p95-ms must be positive",
+    ]
+
+
+def test_seed_command_keeps_data_and_writes_route_cases(tmp_path):
+    args = _args(account_id="hosted-acct", artifact_dir=tmp_path)
+    case_file = tmp_path / "cases.json"
+    seed_result = tmp_path / "seed.json"
+
+    command = smoke._seed_command(args, case_file=case_file, seed_result=seed_result)
+
+    assert str(smoke.SEED_SCRIPT) in command
+    assert "--keep-data" in command
+    assert command[command.index("--account-id") + 1] == "hosted-acct"
+    assert command[command.index("--route-case-file-output") + 1] == str(case_file)
+    assert command[command.index("--output-result") + 1] == str(seed_result)
+
+
+def test_route_command_uses_seeded_case_file_and_budgets(tmp_path):
+    args = _args(max_p95_ms=50, max_single_request_ms=80)
+    case_file = tmp_path / "cases.json"
+    route_result = tmp_path / "route.json"
+
+    command = smoke._route_command(args, case_file=case_file, route_result=route_result)
+
+    assert str(smoke.ROUTE_SCRIPT) in command
+    assert command[command.index("--case-file") + 1] == str(case_file)
+    assert command[command.index("--max-p95-ms") + 1] == "50"
+    assert command[command.index("--max-single-request-ms") + 1] == "80"
+
+
+def test_faq_ids_from_case_file_deduplicates_expected_ids(tmp_path):
+    case_file = tmp_path / "cases.json"
+    _write_cases(
+        case_file,
+        [
+            {"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"},
+            {"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"},
+            {"query": "miss case"},
+        ],
+    )
+
+    faq_ids, errors = smoke._faq_ids_from_case_file(case_file)
+
+    assert errors == []
+    assert faq_ids == ["11111111-1111-1111-1111-111111111111"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ("{bad json", "case file must contain JSON: Expecting property name enclosed in double quotes"),
+        ({}, "case file must contain a JSON list"),
+        ([[]], "case[0] must be an object"),
+        (
+            [{"expected_first_faq_id": ""}],
+            "case[0].expected_first_faq_id must be a non-empty string",
+        ),
+        (
+            [{"expected_first_faq_id": 1}],
+            "case[0].expected_first_faq_id must be a non-empty string",
+        ),
+    ],
+)
+def test_faq_ids_from_case_file_rejects_bad_shapes(tmp_path, payload, expected_error):
+    case_file = tmp_path / "cases.json"
+    if isinstance(payload, str):
+        case_file.write_text(payload, encoding="utf-8")
+    else:
+        _write_cases(case_file, payload)
+
+    faq_ids, errors = smoke._faq_ids_from_case_file(case_file)
+
+    assert faq_ids == []
+    assert expected_error in errors
+
+
+def test_faq_ids_from_case_file_reports_unreadable_file():
+    faq_ids, errors = smoke._faq_ids_from_case_file(Path("/tmp/atlas-missing-e2e-cases.json"))
+
+    assert faq_ids == []
+    assert errors
+    assert errors[0].startswith("case file could not be read:")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_seeded_faqs_noops_without_ids():
+    assert await smoke._cleanup_seeded_faqs("postgresql://example", []) == {
+        "ok": True,
+        "deleted_faq_ids": 0,
+        "error": None,
+    }
+
+
+def test_main_writes_preflight_result(tmp_path, capsys):
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["phase"] == "preflight"
+    assert payload["preflight_errors"] == [
+        "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
+    ]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
+    calls = []
+
+    def _fake_run_command(command):
+        calls.append(command)
+        if str(smoke.SEED_SCRIPT) in command:
+            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                case_file,
+                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+            )
+        return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+    async def _fake_cleanup(_database_url, faq_ids):
+        return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["cleanup"]["deleted_faq_ids"] == 1
+    assert len(calls) == 2
+
+
+def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
+    calls = []
+
+    def _fake_run_command(command):
+        calls.append(command)
+        if str(smoke.SEED_SCRIPT) in command:
+            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                case_file,
+                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+            )
+            return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+        return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad route"}
+
+    async def _fake_cleanup(_database_url, faq_ids):
+        return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+    ])
+
+    assert code == 1
+    assert len(calls) == 2
+
+
+def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
+    def _fake_run_command(command):
+        if str(smoke.SEED_SCRIPT) in command:
+            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                case_file,
+                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+            )
+        return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+    async def _fake_cleanup(_database_url, _faq_ids):
+        return {"ok": False, "deleted_faq_ids": 0, "error": "cleanup failed"}
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["cleanup"] == {
+        "ok": False,
+        "deleted_faq_ids": 0,
+        "error": "cleanup failed",
+    }


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md

Slice phase: Production hardening.

Add a seeded hosted FAQ search e2e smoke that runs the existing DB seed smoke, executes hosted route concurrency against emitted expected cases, and cleans up seeded FAQ drafts by emitted FAQ IDs. This is the full repeatable path after the prior seed-case bridge.

## Intentional
- Reuse existing seed and hosted route smokes instead of adding a parallel implementation.
- Require the operator to supply the token-scoped account ID rather than decoding bearer tokens.
- Delete only emitted FAQ IDs during cleanup.

## Deferred
- Hosted detail-route expectation checks.
- CI enrollment for this live e2e runner.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 15 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Seeded-Route-E2E.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
3 files, +687 / -0