### PR TITLE
PR-Content-Ops-FAQ-Search-Cleanup-Manifest

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md
@@ -1,0 +1,49 @@
+# PR-Content-Ops-FAQ-Search-Cleanup-Manifest
+
+## Why this slice exists
+#967 proved the one-command seeded hosted FAQ search path, but cleanup still
+inferred seeded FAQ IDs from hit-case route expectations. That is narrower than
+the seed data and can miss rows if a future seeded corpus lacks a hit case.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Have the DB seed smoke emit a cleanup manifest with every seeded FAQ ID.
+2. Write that manifest before DB inserts so partial seed failures still expose
+   cleanup IDs.
+3. Have the e2e runner clean from the manifest instead of route-case hits.
+4. Add negative fixtures for malformed cleanup manifests.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+The DB seed smoke accepts `--cleanup-manifest-output` and writes a compact JSON
+object with all generated account, corpus, and FAQ IDs immediately after cases
+are built. The e2e runner passes that path into the seed smoke and reads FAQ IDs
+from the manifest for teardown.
+
+Manifest parsing fails closed on missing JSON object shape, malformed `faq_ids`,
+or non-string IDs. Cleanup still deletes only explicit FAQ IDs and relies on the
+existing foreign-key cascade for search rows.
+## Intentional
+- No broad delete by account or corpus; cleanup remains ID-scoped.
+- No CI enrollment change; this updates already-enrolled smoke tests.
+## Deferred
+- Hosted detail-route expectation checks.
+- A live validation doc for running the seeded e2e against the hosted route.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 31 passed in 0.12s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 49 |
+| DB seed smoke | 23 |
+| E2E runner | 54 |
+| Tests | 136 |
+| **Total** | **262** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -77,6 +77,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-single-request-ms", type=float)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--route-case-file-output", type=Path)
+    parser.add_argument("--cleanup-manifest-output", type=Path)
     parser.add_argument("--keep-data", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -103,6 +104,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--account-id requires --account-count 1")
     if args.route_case_file_output and not bool(args.keep_data):
         raise SystemExit("--route-case-file-output requires --keep-data")
+    if args.cleanup_manifest_output and not bool(args.keep_data):
+        raise SystemExit("--cleanup-manifest-output requires --keep-data")
 
 
 async def _create_pool(database_url: str, *, pool_size: int):
@@ -194,6 +197,25 @@ def _write_route_case_file(
             sort_keys=True,
         )
         + "\n",
+        encoding="utf-8",
+    )
+
+
+def _cleanup_manifest_payload(cases: Sequence[SearchCase]) -> dict[str, Any]:
+    return {
+        "account_ids": sorted({case.account_id for case in cases}),
+        "corpus_ids": sorted({case.corpus_id for case in cases}),
+        "faq_ids": sorted({case.faq_id for case in cases}),
+        "search_cases": len(cases),
+    }
+
+
+def _write_cleanup_manifest(path: Path | None, cases: Sequence[SearchCase]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_cleanup_manifest_payload(cases), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
 
@@ -470,6 +492,7 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     results: list[dict[str, Any]] = []
     try:
         await _apply_migrations(pool)
+        _write_cleanup_manifest(args.cleanup_manifest_output, cases)
         await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
         _write_route_case_file(
             args.route_case_file_output,

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -104,7 +104,13 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     return errors
 
 
-def _seed_command(args: argparse.Namespace, *, case_file: Path, seed_result: Path) -> list[str]:
+def _seed_command(
+    args: argparse.Namespace,
+    *,
+    case_file: Path,
+    cleanup_manifest: Path,
+    seed_result: Path,
+) -> list[str]:
     return [
         sys.executable,
         str(SEED_SCRIPT),
@@ -127,6 +133,8 @@ def _seed_command(args: argparse.Namespace, *, case_file: Path, seed_result: Pat
         "--keep-data",
         "--route-case-file-output",
         str(case_file),
+        "--cleanup-manifest-output",
+        str(cleanup_manifest),
         "--output-result",
         str(seed_result),
         "--json",
@@ -177,27 +185,24 @@ def _run_command(command: Sequence[str]) -> dict[str, Any]:
     }
 
 
-def _faq_ids_from_case_file(path: Path) -> tuple[list[str], list[str]]:
+def _faq_ids_from_cleanup_manifest(path: Path) -> tuple[list[str], list[str]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
-        return [], [f"case file could not be read: {exc}"]
+        return [], [f"cleanup manifest could not be read: {exc}"]
     except json.JSONDecodeError as exc:
-        return [], [f"case file must contain JSON: {exc.msg}"]
-    if not isinstance(data, list):
-        return [], ["case file must contain a JSON list"]
+        return [], [f"cleanup manifest must contain JSON: {exc.msg}"]
+    if not isinstance(data, Mapping):
+        return [], ["cleanup manifest must contain a JSON object"]
 
     faq_ids: list[str] = []
     errors: list[str] = []
-    for index, item in enumerate(data):
-        if not isinstance(item, Mapping):
-            errors.append(f"case[{index}] must be an object")
-            continue
-        faq_id = item.get("expected_first_faq_id")
-        if faq_id is None:
-            continue
+    raw_faq_ids = data.get("faq_ids")
+    if not isinstance(raw_faq_ids, list):
+        return [], ["cleanup manifest faq_ids must be a list"]
+    for index, faq_id in enumerate(raw_faq_ids):
         if not isinstance(faq_id, str) or not faq_id.strip():
-            errors.append(f"case[{index}].expected_first_faq_id must be a non-empty string")
+            errors.append(f"cleanup manifest faq_ids[{index}] must be a non-empty string")
             continue
         if faq_id.strip() not in faq_ids:
             faq_ids.append(faq_id.strip())
@@ -272,21 +277,33 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     artifact_dir = Path(temp_context.name) if temp_context else Path(args.artifact_dir)
     artifact_dir.mkdir(parents=True, exist_ok=True)
     case_file = artifact_dir / "route-cases.json"
+    cleanup_manifest = artifact_dir / "cleanup-manifest.json"
     seed_result = artifact_dir / "seed-result.json"
     route_result = artifact_dir / "route-result.json"
 
     cleanup = {"ok": True, "deleted_faq_ids": 0, "error": None}
     try:
-        seed = _run_command(_seed_command(args, case_file=case_file, seed_result=seed_result))
+        seed = _run_command(
+            _seed_command(
+                args,
+                case_file=case_file,
+                cleanup_manifest=cleanup_manifest,
+                seed_result=seed_result,
+            )
+        )
         route = {"ok": False, "returncode": None, "stdout_tail": "", "stderr_tail": ""}
         if seed["ok"]:
             route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
-        faq_ids, case_errors = _faq_ids_from_case_file(case_file) if case_file.exists() else ([], [])
-        if case_errors:
+        faq_ids, manifest_errors = (
+            _faq_ids_from_cleanup_manifest(cleanup_manifest)
+            if cleanup_manifest.exists()
+            else ([], [])
+        )
+        if manifest_errors:
             cleanup = {
                 "ok": False,
                 "deleted_faq_ids": 0,
-                "error": "; ".join(case_errors),
+                "error": "; ".join(manifest_errors),
             }
         elif not bool(args.keep_data):
             cleanup = await _cleanup_seeded_faqs(str(args.database_url), faq_ids)
@@ -297,6 +314,7 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "artifacts": {
                 "dir": str(artifact_dir),
                 "case_file": str(case_file),
+                "cleanup_manifest": str(cleanup_manifest),
                 "seed_result": str(seed_result),
                 "route_result": str(route_result),
             },

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -98,6 +98,43 @@ def test_write_route_case_file_writes_deterministic_json(tmp_path) -> None:
     assert payload[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
 
 
+def test_cleanup_manifest_payload_carries_all_seeded_ids() -> None:
+    cases = [
+        _case(),
+        _case(query="escrow shortage", expected_hit=False),
+        smoke.SearchCase(
+            account_id="acct-1",
+            corpus_id="corpus-2",
+            faq_id="22222222-2222-2222-2222-222222222222",
+            query="password reset",
+            expected_hit=True,
+        ),
+    ]
+
+    assert smoke._cleanup_manifest_payload(cases) == {
+        "account_ids": ["acct-1"],
+        "corpus_ids": ["corpus-1", "corpus-2"],
+        "faq_ids": [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ],
+        "search_cases": 3,
+    }
+
+
+def test_write_cleanup_manifest_writes_deterministic_json(tmp_path) -> None:
+    path = tmp_path / "cleanup-manifest.json"
+
+    smoke._write_cleanup_manifest(path, [_case()])
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "account_ids": ["acct-1"],
+        "corpus_ids": ["corpus-1"],
+        "faq_ids": ["11111111-1111-1111-1111-111111111111"],
+        "search_cases": 1,
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_case_records_failures_for_leaked_rows_and_hit_miss_mismatches() -> None:
     class _Response:
@@ -237,6 +274,7 @@ def test_validate_args_rejects_route_case_output_without_kept_data() -> None:
         max_p95_ms=None,
         max_single_request_ms=None,
         route_case_file_output=Path("cases.json"),
+        cleanup_manifest_output=None,
         keep_data=False,
     )
 
@@ -257,10 +295,32 @@ def test_validate_args_rejects_account_override_for_multiple_accounts() -> None:
         max_p95_ms=None,
         max_single_request_ms=None,
         route_case_file_output=None,
+        cleanup_manifest_output=None,
         keep_data=True,
     )
 
     with pytest.raises(SystemExit, match="--account-id requires --account-count 1"):
+        smoke._validate_args(args)
+
+
+def test_validate_args_rejects_cleanup_manifest_without_kept_data() -> None:
+    args = SimpleNamespace(
+        database_url="postgresql://example",
+        account_count=1,
+        account_id="acct-1",
+        corpora_per_account=1,
+        documents_per_corpus=1,
+        iterations=1,
+        concurrency=1,
+        pool_size=1,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        route_case_file_output=None,
+        cleanup_manifest_output=Path("cleanup.json"),
+        keep_data=False,
+    )
+
+    with pytest.raises(SystemExit, match="--cleanup-manifest-output requires --keep-data"):
         smoke._validate_args(args)
 
 

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -75,14 +75,21 @@ def test_validate_args_reports_missing_required_fields_and_bad_numbers():
 def test_seed_command_keeps_data_and_writes_route_cases(tmp_path):
     args = _args(account_id="hosted-acct", artifact_dir=tmp_path)
     case_file = tmp_path / "cases.json"
+    cleanup_manifest = tmp_path / "cleanup.json"
     seed_result = tmp_path / "seed.json"
 
-    command = smoke._seed_command(args, case_file=case_file, seed_result=seed_result)
+    command = smoke._seed_command(
+        args,
+        case_file=case_file,
+        cleanup_manifest=cleanup_manifest,
+        seed_result=seed_result,
+    )
 
     assert str(smoke.SEED_SCRIPT) in command
     assert "--keep-data" in command
     assert command[command.index("--account-id") + 1] == "hosted-acct"
     assert command[command.index("--route-case-file-output") + 1] == str(case_file)
+    assert command[command.index("--cleanup-manifest-output") + 1] == str(cleanup_manifest)
     assert command[command.index("--output-result") + 1] == str(seed_result)
 
 
@@ -99,18 +106,19 @@ def test_route_command_uses_seeded_case_file_and_budgets(tmp_path):
     assert command[command.index("--max-single-request-ms") + 1] == "80"
 
 
-def test_faq_ids_from_case_file_deduplicates_expected_ids(tmp_path):
-    case_file = tmp_path / "cases.json"
+def test_faq_ids_from_cleanup_manifest_deduplicates_expected_ids(tmp_path):
+    manifest = tmp_path / "cleanup.json"
     _write_cases(
-        case_file,
-        [
-            {"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"},
-            {"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"},
-            {"query": "miss case"},
-        ],
+        manifest,
+        {
+            "faq_ids": [
+                "11111111-1111-1111-1111-111111111111",
+                "11111111-1111-1111-1111-111111111111",
+            ]
+        },
     )
 
-    faq_ids, errors = smoke._faq_ids_from_case_file(case_file)
+    faq_ids, errors = smoke._faq_ids_from_cleanup_manifest(manifest)
 
     assert errors == []
     assert faq_ids == ["11111111-1111-1111-1111-111111111111"]
@@ -119,38 +127,38 @@ def test_faq_ids_from_case_file_deduplicates_expected_ids(tmp_path):
 @pytest.mark.parametrize(
     ("payload", "expected_error"),
     [
-        ("{bad json", "case file must contain JSON: Expecting property name enclosed in double quotes"),
-        ({}, "case file must contain a JSON list"),
-        ([[]], "case[0] must be an object"),
+        ("{bad json", "cleanup manifest must contain JSON: Expecting property name enclosed in double quotes"),
+        ([], "cleanup manifest must contain a JSON object"),
+        ({}, "cleanup manifest faq_ids must be a list"),
         (
-            [{"expected_first_faq_id": ""}],
-            "case[0].expected_first_faq_id must be a non-empty string",
+            {"faq_ids": [""]},
+            "cleanup manifest faq_ids[0] must be a non-empty string",
         ),
         (
-            [{"expected_first_faq_id": 1}],
-            "case[0].expected_first_faq_id must be a non-empty string",
+            {"faq_ids": [1]},
+            "cleanup manifest faq_ids[0] must be a non-empty string",
         ),
     ],
 )
-def test_faq_ids_from_case_file_rejects_bad_shapes(tmp_path, payload, expected_error):
-    case_file = tmp_path / "cases.json"
+def test_faq_ids_from_cleanup_manifest_rejects_bad_shapes(tmp_path, payload, expected_error):
+    manifest = tmp_path / "cleanup.json"
     if isinstance(payload, str):
-        case_file.write_text(payload, encoding="utf-8")
+        manifest.write_text(payload, encoding="utf-8")
     else:
-        _write_cases(case_file, payload)
+        _write_cases(manifest, payload)
 
-    faq_ids, errors = smoke._faq_ids_from_case_file(case_file)
+    faq_ids, errors = smoke._faq_ids_from_cleanup_manifest(manifest)
 
     assert faq_ids == []
     assert expected_error in errors
 
 
-def test_faq_ids_from_case_file_reports_unreadable_file():
-    faq_ids, errors = smoke._faq_ids_from_case_file(Path("/tmp/atlas-missing-e2e-cases.json"))
+def test_faq_ids_from_cleanup_manifest_reports_unreadable_file():
+    faq_ids, errors = smoke._faq_ids_from_cleanup_manifest(Path("/tmp/atlas-missing-e2e-cleanup.json"))
 
     assert faq_ids == []
     assert errors
-    assert errors[0].startswith("case file could not be read:")
+    assert errors[0].startswith("cleanup manifest could not be read:")
 
 
 @pytest.mark.asyncio
@@ -194,10 +202,10 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     def _fake_run_command(command):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
-            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             _write_cases(
-                case_file,
-                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+                cleanup_manifest,
+                {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
             )
         return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
 
@@ -236,10 +244,10 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
     def _fake_run_command(command):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
-            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             _write_cases(
-                case_file,
-                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+                cleanup_manifest,
+                {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
             )
             return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
         return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad route"}
@@ -270,10 +278,10 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
 def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
     def _fake_run_command(command):
         if str(smoke.SEED_SCRIPT) in command:
-            case_file = Path(command[command.index("--route-case-file-output") + 1])
+            cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             _write_cases(
-                case_file,
-                [{"expected_first_faq_id": "11111111-1111-1111-1111-111111111111"}],
+                cleanup_manifest,
+                {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
             )
         return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md

Slice phase: Production hardening.

Add a cleanup manifest for seeded FAQ search smokes so hosted e2e teardown uses every generated FAQ ID instead of inferring cleanup IDs from hit-case route expectations. The manifest is written before seed inserts, so partial seed failures still expose cleanup IDs.

## Intentional
- Cleanup remains scoped to explicit FAQ IDs, not broad account or corpus deletes.
- No CI enrollment change; the touched smoke tests are already enrolled.

## Deferred
- Hosted detail-route expectation checks.
- Live validation doc for running seeded e2e against the hosted route.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 31 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Cleanup-Manifest.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
5 files, +210 / -52