### PR TITLE
Report seeded FAQ cleanup rowcounts

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md
@@ -1,0 +1,49 @@
+# PR-Content-Ops-FAQ-Search-Cleanup-Rowcount
+
+## Why this slice exists
+#969 added manifest-based cleanup for seeded FAQ search e2e runs. The review
+called out one remaining visibility gap: the cleanup result reports the number
+of FAQ IDs it attempted to delete, not the rowcount confirmed by Postgres.
+That can hide stale cleanup IDs or a delete that matched fewer rows than
+expected.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Parse the asyncpg `DELETE N` command tag returned by seeded FAQ cleanup.
+2. Report both requested FAQ IDs and actual deleted FAQ rows in cleanup output.
+3. Add focused fixtures for valid tags, malformed tags, and the async cleanup
+   integration point.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+`_cleanup_seeded_faqs` captures the string returned by `pool.execute(...)`.
+A small helper accepts only exact two-token `DELETE <integer>` tags and returns
+`None` for unknown or malformed shapes. The cleanup payload keeps
+`deleted_faq_ids` as the actual confirmed delete count when parsing succeeds,
+adds `requested_faq_ids` for the attempted ID count, and includes the raw
+`delete_status` tag for debugging.
+## Intentional
+- No change to cleanup scope; deletes still target explicit FAQ IDs only.
+- Malformed command tags do not fail the whole smoke because the delete already
+  completed. The raw tag is emitted so drift is visible in the JSON artifact.
+- No broad rowcount mismatch gate yet; this slice surfaces the actual count
+  without changing pass/fail semantics.
+## Deferred
+- A future hosted-data hygiene slice can decide whether `deleted_faq_ids` lower
+  than `requested_faq_ids` should fail the e2e run.
+- Hosted detail-route expectation checks remain deferred from #969.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 27 passed in 0.08s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 44 |
+| E2E runner | 67 |
+| Tests | 122 |
+| **Total** | **233** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -209,26 +209,65 @@ def _faq_ids_from_cleanup_manifest(path: Path) -> tuple[list[str], list[str]]:
     return faq_ids, errors
 
 
+def _deleted_row_count(delete_status: object) -> int | None:
+    if not isinstance(delete_status, str):
+        return None
+    parts = delete_status.strip().split()
+    if len(parts) != 2 or parts[0] != "DELETE":
+        return None
+    try:
+        row_count = int(parts[1])
+    except ValueError:
+        return None
+    return row_count if row_count >= 0 else None
+
+
 async def _cleanup_seeded_faqs(database_url: str, faq_ids: Sequence[str]) -> dict[str, Any]:
+    requested_faq_ids = len(faq_ids)
     if not faq_ids:
-        return {"ok": True, "deleted_faq_ids": 0, "error": None}
+        return {
+            "ok": True,
+            "requested_faq_ids": 0,
+            "deleted_faq_ids": 0,
+            "delete_status": None,
+            "error": None,
+        }
     try:
         import asyncpg  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - host dependency
-        return {"ok": False, "deleted_faq_ids": 0, "error": f"ImportError: {exc}"}
+        return {
+            "ok": False,
+            "requested_faq_ids": requested_faq_ids,
+            "deleted_faq_ids": 0,
+            "delete_status": None,
+            "error": f"ImportError: {exc}",
+        }
 
+    delete_status = None
     try:
         pool = await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
         try:
-            await pool.execute(
+            delete_status = await pool.execute(
                 "DELETE FROM ticket_faq_markdown WHERE id = ANY($1::uuid[])",
                 list(faq_ids),
             )
         finally:
             await pool.close()
     except Exception as exc:
-        return {"ok": False, "deleted_faq_ids": 0, "error": f"{type(exc).__name__}: {exc}"}
-    return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+        return {
+            "ok": False,
+            "requested_faq_ids": requested_faq_ids,
+            "deleted_faq_ids": 0,
+            "delete_status": delete_status,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "ok": True,
+        "requested_faq_ids": requested_faq_ids,
+        "deleted_faq_ids": _deleted_row_count(delete_status),
+        "delete_status": delete_status,
+        "error": None,
+    }
 
 
 def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
@@ -256,7 +295,13 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
         "artifacts": {},
         "seed": {"ok": False, "returncode": None},
         "route": {"ok": False, "returncode": None},
-        "cleanup": {"ok": False, "deleted_faq_ids": 0, "error": None},
+        "cleanup": {
+            "ok": False,
+            "requested_faq_ids": 0,
+            "deleted_faq_ids": 0,
+            "delete_status": None,
+            "error": None,
+        },
         "preflight_errors": list(errors),
         "keep_data": bool(args.keep_data),
         "elapsed_seconds": round(elapsed, 6),
@@ -281,7 +326,13 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     seed_result = artifact_dir / "seed-result.json"
     route_result = artifact_dir / "route-result.json"
 
-    cleanup = {"ok": True, "deleted_faq_ids": 0, "error": None}
+    cleanup = {
+        "ok": True,
+        "requested_faq_ids": 0,
+        "deleted_faq_ids": 0,
+        "delete_status": None,
+        "error": None,
+    }
     try:
         seed = _run_command(
             _seed_command(
@@ -302,7 +353,9 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         if manifest_errors:
             cleanup = {
                 "ok": False,
+                "requested_faq_ids": len(faq_ids),
                 "deleted_faq_ids": 0,
+                "delete_status": None,
                 "error": "; ".join(manifest_errors),
             }
         elif not bool(args.keep_data):

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -161,11 +162,106 @@ def test_faq_ids_from_cleanup_manifest_reports_unreadable_file():
     assert errors[0].startswith("cleanup manifest could not be read:")
 
 
+@pytest.mark.parametrize(("delete_status", "expected"), [("DELETE 2", 2), (" DELETE 0 ", 0)])
+def test_deleted_row_count_accepts_delete_tags(delete_status, expected):
+    assert smoke._deleted_row_count(delete_status) == expected
+
+
+@pytest.mark.parametrize(
+    "delete_status",
+    [
+        "UPDATE 2",
+        "DELETE",
+        "DELETE two",
+        "DELETE -1",
+        "DELETE 1 extra",
+        "",
+        ["DELETE", 1],
+        None,
+    ],
+)
+def test_deleted_row_count_rejects_malformed_tags(delete_status):
+    assert smoke._deleted_row_count(delete_status) is None
+
+
 @pytest.mark.asyncio
 async def test_cleanup_seeded_faqs_noops_without_ids():
     assert await smoke._cleanup_seeded_faqs("postgresql://example", []) == {
         "ok": True,
+        "requested_faq_ids": 0,
         "deleted_faq_ids": 0,
+        "delete_status": None,
+        "error": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cleanup_seeded_faqs_reports_actual_delete_rowcount(monkeypatch):
+    class FakePool:
+        def __init__(self):
+            self.closed = False
+            self.deleted_ids = None
+
+        async def execute(self, _query, faq_ids):
+            self.deleted_ids = faq_ids
+            return "DELETE 1"
+
+        async def close(self):
+            self.closed = True
+
+    fake_pool = FakePool()
+
+    async def _create_pool(**_kwargs):
+        return fake_pool
+
+    monkeypatch.setitem(sys.modules, "asyncpg", SimpleNamespace(create_pool=_create_pool))
+
+    payload = await smoke._cleanup_seeded_faqs(
+        "postgresql://example",
+        [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ],
+    )
+
+    assert payload == {
+        "ok": True,
+        "requested_faq_ids": 2,
+        "deleted_faq_ids": 1,
+        "delete_status": "DELETE 1",
+        "error": None,
+    }
+    assert fake_pool.deleted_ids == [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    ]
+    assert fake_pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_seeded_faqs_surfaces_malformed_delete_status(monkeypatch):
+    class FakePool:
+        async def execute(self, _query, _faq_ids):
+            return "UPDATE 1"
+
+        async def close(self):
+            return None
+
+    async def _create_pool(**_kwargs):
+        return FakePool()
+
+    monkeypatch.setitem(sys.modules, "asyncpg", SimpleNamespace(create_pool=_create_pool))
+
+    payload = await smoke._cleanup_seeded_faqs(
+        "postgresql://example",
+        ["11111111-1111-1111-1111-111111111111"],
+    )
+
+    assert payload == {
+        "ok": True,
+        "requested_faq_ids": 1,
+        "deleted_faq_ids": None,
+        "delete_status": "UPDATE 1",
         "error": None,
     }
 
@@ -210,7 +306,13 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
         return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
 
     async def _fake_cleanup(_database_url, faq_ids):
-        return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+        return {
+            "ok": True,
+            "requested_faq_ids": len(faq_ids),
+            "deleted_faq_ids": len(faq_ids),
+            "delete_status": f"DELETE {len(faq_ids)}",
+            "error": None,
+        }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
     monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
@@ -253,7 +355,13 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
         return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad route"}
 
     async def _fake_cleanup(_database_url, faq_ids):
-        return {"ok": True, "deleted_faq_ids": len(faq_ids), "error": None}
+        return {
+            "ok": True,
+            "requested_faq_ids": len(faq_ids),
+            "deleted_faq_ids": len(faq_ids),
+            "delete_status": f"DELETE {len(faq_ids)}",
+            "error": None,
+        }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
     monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
@@ -286,7 +394,13 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
         return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
 
     async def _fake_cleanup(_database_url, _faq_ids):
-        return {"ok": False, "deleted_faq_ids": 0, "error": "cleanup failed"}
+        return {
+            "ok": False,
+            "requested_faq_ids": 1,
+            "deleted_faq_ids": 0,
+            "delete_status": None,
+            "error": "cleanup failed",
+        }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
     monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
@@ -311,6 +425,8 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
     assert code == 1
     assert payload["cleanup"] == {
         "ok": False,
+        "requested_faq_ids": 1,
         "deleted_faq_ids": 0,
+        "delete_status": None,
         "error": "cleanup failed",
     }


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md

Slice phase: Production hardening.

Report the actual asyncpg DELETE rowcount from seeded FAQ search e2e cleanup instead of only reporting the number of FAQ IDs cleanup attempted to delete. The result artifact now includes requested_faq_ids, deleted_faq_ids, and the raw delete_status tag so stale cleanup IDs and command-tag drift are visible.

## Intentional
- Cleanup remains scoped to explicit FAQ IDs only.
- Malformed delete command tags surface in the result artifact without failing the smoke because the delete already completed.
- No broad rowcount mismatch gate yet; this slice adds visibility without changing pass/fail semantics.

## Deferred
- A future hosted-data hygiene slice can decide whether deleted_faq_ids lower than requested_faq_ids should fail the e2e run.
- Hosted detail-route expectation checks remain deferred from #969.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 27 passed in 0.08s.
- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Cleanup-Rowcount.md - Passed.
- bash scripts/local_pr_review.sh - Passed after rebasing onto current origin/main.

## Diff size
3 files, +228 / -10