### PR TITLE
Check seeded FAQ search detail route in e2e

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md
@@ -1,0 +1,52 @@
+# PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E
+
+## Why this slice exists
+#967 gave us a one-command seeded hosted FAQ search e2e, and #969/#971 made
+cleanup safer and more visible. The remaining deferred gap is that the e2e
+proves search results but does not prove a returned FAQ ID can be dereferenced
+through the hosted detail route into the full generated FAQ shape.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Add a detail-contract step to the seeded hosted FAQ search e2e runner.
+2. Reuse the existing `check_content_ops_faq_search_route_contract.py`
+   checker with `--require-results --require-detail`.
+3. Select the detail probe from the seeded hit cases already written for the
+   hosted search smoke.
+4. Keep teardown unchanged so seeded rows are still cleaned up after route or
+   detail failures.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+After the DB seed smoke writes the route case artifact, the e2e runner reads the
+first case with `require_results: true` and builds a call to the existing
+contract checker. The checker re-runs the hosted search for that case, follows
+`results[0].faq_id` through the detail route, and validates the full FAQ detail
+envelope. The e2e summary gains a `detail` section next to `seed`, `route`, and
+`cleanup`.
+## Intentional
+- No new detail-route validator is introduced; this composes the existing
+  contract checker so the hosted route shape stays single-sourced.
+- The detail check runs only after seed and route success to keep failures
+  attributable. Cleanup still runs regardless of route/detail outcome.
+- A `--skip-detail-check` escape hatch is included for local liveness/debug
+  runs, but the default e2e path exercises the real search-to-detail flow.
+## Deferred
+- Latency budgets for the detail contract checker remain a standalone checker
+  concern; this slice wires correctness into the seeded e2e.
+- Rowcount mismatch gating remains deferred from #971.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 42 passed in 0.09s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 47 |
+| E2E runner | 108 |
+| Tests | 180 |
+| **Total** | **340** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -19,6 +19,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 SEED_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_concurrency.py"
 ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
+CONTRACT_SCRIPT = ROOT / "scripts/check_content_ops_faq_search_route_contract.py"
 
 try:
     from dotenv import load_dotenv
@@ -66,9 +67,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-error-rate", type=float, default=0.0)
     parser.add_argument("--max-p95-ms", type=float)
     parser.add_argument("--max-single-request-ms", type=float)
+    parser.add_argument("--detail-route", default=os.getenv("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--keep-data", action="store_true")
+    parser.add_argument("--skip-detail-check", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -172,6 +175,78 @@ def _route_command(args: argparse.Namespace, *, case_file: Path, route_result: P
         value = getattr(args, arg_name)
         if value is not None:
             command.extend([flag, str(value)])
+    return command
+
+
+def _detail_case_from_route_cases(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return None, [f"route case file could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return None, [f"route case file must contain JSON: {exc.msg}"]
+    if not isinstance(data, list) or not data:
+        return None, ["route case file must contain a non-empty JSON list"]
+
+    for index, item in enumerate(data):
+        if not isinstance(item, Mapping):
+            return None, [f"route case[{index}] must be an object"]
+        require_results = item.get("require_results")
+        if "require_results" in item and type(require_results) is not bool:
+            return None, [f"route case[{index}].require_results must be a boolean"]
+        if require_results is not True:
+            continue
+        query = item.get("query")
+        if not isinstance(query, str) or not query.strip():
+            return None, [f"route case[{index}].query must be a non-empty string"]
+        corpus_id = item.get("corpus_id", "")
+        if not isinstance(corpus_id, str):
+            return None, [f"route case[{index}].corpus_id must be a string"]
+        status = item.get("status", "")
+        if not isinstance(status, str):
+            return None, [f"route case[{index}].status must be a string"]
+        limit = item.get("limit", 5)
+        if type(limit) is not int or limit <= 0:
+            return None, [f"route case[{index}].limit must be a positive integer"]
+        return {
+            "query": query.strip(),
+            "corpus_id": corpus_id.strip(),
+            "status": status.strip(),
+            "limit": limit,
+        }, []
+    return None, ["route case file must include a require_results case for detail check"]
+
+
+def _detail_command(
+    args: argparse.Namespace,
+    *,
+    detail_case: Mapping[str, Any],
+    detail_result: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(CONTRACT_SCRIPT),
+        "--base-url",
+        str(args.base_url),
+        "--token",
+        str(args.token),
+        "--route",
+        str(args.route),
+        "--query",
+        str(detail_case["query"]),
+        "--limit",
+        str(detail_case["limit"]),
+        "--require-results",
+        "--require-detail",
+        "--output-result",
+        str(detail_result),
+    ]
+    if str(detail_case.get("corpus_id") or "").strip():
+        command.extend(["--corpus-id", str(detail_case["corpus_id"])])
+    if str(detail_case.get("status") or "").strip():
+        command.extend(["--status", str(detail_case["status"])])
+    if str(args.detail_route or "").strip():
+        command.extend(["--detail-route", str(args.detail_route)])
     return command
 
 
@@ -284,7 +359,8 @@ def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
     print(
         "FAQ search seeded route e2e: "
         f"ok={summary['ok']} seed={summary['seed']['ok']} "
-        f"route={summary['route']['ok']} cleanup={summary['cleanup']['ok']}"
+        f"route={summary['route']['ok']} detail={summary['detail']['ok']} "
+        f"cleanup={summary['cleanup']['ok']}"
     )
 
 
@@ -295,6 +371,11 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
         "artifacts": {},
         "seed": {"ok": False, "returncode": None},
         "route": {"ok": False, "returncode": None},
+        "detail": {
+            "ok": bool(args.skip_detail_check),
+            "returncode": None,
+            "skipped": bool(args.skip_detail_check),
+        },
         "cleanup": {
             "ok": False,
             "requested_faq_ids": 0,
@@ -325,7 +406,13 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     cleanup_manifest = artifact_dir / "cleanup-manifest.json"
     seed_result = artifact_dir / "seed-result.json"
     route_result = artifact_dir / "route-result.json"
+    detail_result = artifact_dir / "detail-result.json"
 
+    detail = {
+        "ok": bool(args.skip_detail_check),
+        "returncode": None,
+        "skipped": bool(args.skip_detail_check),
+    }
     cleanup = {
         "ok": True,
         "requested_faq_ids": 0,
@@ -345,6 +432,21 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         route = {"ok": False, "returncode": None, "stdout_tail": "", "stderr_tail": ""}
         if seed["ok"]:
             route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
+        if bool(seed["ok"] and route["ok"]) and not bool(args.skip_detail_check):
+            detail_case, detail_errors = _detail_case_from_route_cases(case_file)
+            if detail_errors:
+                detail = {
+                    "ok": False,
+                    "returncode": None,
+                    "stdout_tail": "",
+                    "stderr_tail": "; ".join(detail_errors),
+                    "skipped": False,
+                }
+            elif detail_case is not None:
+                detail = _run_command(
+                    _detail_command(args, detail_case=detail_case, detail_result=detail_result)
+                )
+                detail["skipped"] = False
         faq_ids, manifest_errors = (
             _faq_ids_from_cleanup_manifest(cleanup_manifest)
             if cleanup_manifest.exists()
@@ -360,7 +462,7 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             }
         elif not bool(args.keep_data):
             cleanup = await _cleanup_seeded_faqs(str(args.database_url), faq_ids)
-        ok = bool(seed["ok"] and route["ok"] and cleanup["ok"])
+        ok = bool(seed["ok"] and route["ok"] and detail["ok"] and cleanup["ok"])
         summary = {
             "ok": ok,
             "phase": "complete",
@@ -370,9 +472,11 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 "cleanup_manifest": str(cleanup_manifest),
                 "seed_result": str(seed_result),
                 "route_result": str(route_result),
+                "detail_result": str(detail_result),
             },
             "seed": seed,
             "route": route,
+            "detail": detail,
             "cleanup": cleanup,
             "preflight_errors": [],
             "keep_data": bool(args.keep_data),

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -34,9 +34,11 @@ def _args(**overrides):
         "max_error_rate": 0.0,
         "max_p95_ms": None,
         "max_single_request_ms": None,
+        "detail_route": "",
         "artifact_dir": None,
         "output_result": None,
         "keep_data": False,
+        "skip_detail_check": False,
         "json": False,
     }
     values.update(overrides)
@@ -105,6 +107,96 @@ def test_route_command_uses_seeded_case_file_and_budgets(tmp_path):
     assert command[command.index("--case-file") + 1] == str(case_file)
     assert command[command.index("--max-p95-ms") + 1] == "50"
     assert command[command.index("--max-single-request-ms") + 1] == "80"
+
+
+def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
+    case_file = tmp_path / "route-cases.json"
+    _write_cases(
+        case_file,
+        [
+            {"query": "escrow shortage", "limit": 5, "require_results": False},
+            {
+                "query": "password reset",
+                "corpus_id": "corp-1",
+                "status": "approved",
+                "limit": 3,
+                "require_results": True,
+            },
+        ],
+    )
+
+    detail_case, errors = smoke._detail_case_from_route_cases(case_file)
+
+    assert errors == []
+    assert detail_case == {
+        "query": "password reset",
+        "corpus_id": "corp-1",
+        "status": "approved",
+        "limit": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ("{bad json", "route case file must contain JSON: Expecting property name enclosed in double quotes"),
+        ({}, "route case file must contain a non-empty JSON list"),
+        ([], "route case file must contain a non-empty JSON list"),
+        ([[]], "route case[0] must be an object"),
+        ([{"query": "reset", "limit": 5, "require_results": "yes"}], "route case[0].require_results must be a boolean"),
+        ([{"query": "escrow", "limit": 5, "require_results": False}], "route case file must include a require_results case for detail check"),
+        ([{"query": "", "limit": 5, "require_results": True}], "route case[0].query must be a non-empty string"),
+        ([{"query": "reset", "corpus_id": 1, "limit": 5, "require_results": True}], "route case[0].corpus_id must be a string"),
+        ([{"query": "reset", "status": 1, "limit": 5, "require_results": True}], "route case[0].status must be a string"),
+        ([{"query": "reset", "limit": "5", "require_results": True}], "route case[0].limit must be a positive integer"),
+        ([{"query": "reset", "limit": True, "require_results": True}], "route case[0].limit must be a positive integer"),
+    ],
+)
+def test_detail_case_from_route_cases_rejects_bad_shapes(tmp_path, payload, expected_error):
+    case_file = tmp_path / "route-cases.json"
+    if isinstance(payload, str):
+        case_file.write_text(payload, encoding="utf-8")
+    else:
+        _write_cases(case_file, payload)
+
+    detail_case, errors = smoke._detail_case_from_route_cases(case_file)
+
+    assert detail_case is None
+    assert expected_error in errors
+
+
+def test_detail_case_from_route_cases_reports_unreadable_file():
+    detail_case, errors = smoke._detail_case_from_route_cases(Path("/tmp/atlas-missing-route-cases.json"))
+
+    assert detail_case is None
+    assert errors
+    assert errors[0].startswith("route case file could not be read:")
+
+
+def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
+    args = _args(detail_route="/api/v2/faqs/{faq_id}/full")
+    detail_result = tmp_path / "detail.json"
+
+    command = smoke._detail_command(
+        args,
+        detail_case={
+            "query": "password reset",
+            "corpus_id": "corp-1",
+            "status": "approved",
+            "limit": 3,
+        },
+        detail_result=detail_result,
+    )
+
+    assert str(smoke.CONTRACT_SCRIPT) in command
+    assert command[command.index("--query") + 1] == "password reset"
+    assert command[command.index("--corpus-id") + 1] == "corp-1"
+    assert command[command.index("--status") + 1] == "approved"
+    assert command[command.index("--limit") + 1] == "3"
+    assert "--require-results" in command
+    assert "--require-detail" in command
+    assert command[command.index("--detail-route") + 1] == "/api/v2/faqs/{faq_id}/full"
+    assert command[command.index("--output-result") + 1] == str(detail_result)
 
 
 def test_faq_ids_from_cleanup_manifest_deduplicates_expected_ids(tmp_path):
@@ -299,6 +391,17 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+            route_cases = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                route_cases,
+                [{
+                    "query": "password reset",
+                    "corpus_id": "corp-1",
+                    "status": "approved",
+                    "limit": 5,
+                    "require_results": True,
+                }],
+            )
             _write_cases(
                 cleanup_manifest,
                 {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
@@ -336,8 +439,11 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 0
     assert payload["ok"] is True
+    assert payload["detail"]["ok"] is True
+    assert payload["artifacts"]["detail_result"].endswith("detail-result.json")
     assert payload["cleanup"]["deleted_faq_ids"] == 1
-    assert len(calls) == 2
+    assert len(calls) == 3
+    assert str(smoke.CONTRACT_SCRIPT) in calls[2]
 
 
 def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
@@ -347,6 +453,17 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+            route_cases = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                route_cases,
+                [{
+                    "query": "password reset",
+                    "corpus_id": "corp-1",
+                    "status": "approved",
+                    "limit": 5,
+                    "require_results": True,
+                }],
+            )
             _write_cases(
                 cleanup_manifest,
                 {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
@@ -381,12 +498,73 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
 
     assert code == 1
     assert len(calls) == 2
+    assert all(str(smoke.CONTRACT_SCRIPT) not in command for command in calls)
+
+
+def test_main_can_skip_detail_check_for_liveness_runs(tmp_path, monkeypatch):
+    calls = []
+
+    def _fake_run_command(command):
+        calls.append(command)
+        if str(smoke.SEED_SCRIPT) in command:
+            cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+            _write_cases(
+                cleanup_manifest,
+                {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
+            )
+        return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+    async def _fake_cleanup(_database_url, faq_ids):
+        return {
+            "ok": True,
+            "requested_faq_ids": len(faq_ids),
+            "deleted_faq_ids": len(faq_ids),
+            "delete_status": f"DELETE {len(faq_ids)}",
+            "error": None,
+        }
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
+        "--skip-detail-check",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["detail"] == {"ok": True, "returncode": None, "skipped": True}
+    assert len(calls) == 2
+    assert all(str(smoke.CONTRACT_SCRIPT) not in command for command in calls)
 
 
 def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
     def _fake_run_command(command):
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+            route_cases = Path(command[command.index("--route-case-file-output") + 1])
+            _write_cases(
+                route_cases,
+                [{
+                    "query": "password reset",
+                    "corpus_id": "corp-1",
+                    "status": "approved",
+                    "limit": 5,
+                    "require_results": True,
+                }],
+            )
             _write_cases(
                 cleanup_manifest,
                 {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md

Slice phase: Production hardening.

Add a detail-contract step to the seeded hosted FAQ search e2e runner so a seeded search hit is dereferenced through the hosted detail route and validated against the full generated FAQ envelope before cleanup.

## Intentional
- Reuses the existing FAQ search route contract checker instead of duplicating detail validation.
- Runs the detail check only after seed and hosted search success so failures remain attributable.
- Cleanup still runs after route or detail failures.
- Includes --skip-detail-check only as an explicit local liveness/debug escape hatch; the default e2e path checks detail.

## Deferred
- Detail latency budgets remain a standalone checker concern.
- Rowcount mismatch gating remains deferred from #971.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 42 passed in 0.09s.
- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Seeded-Detail-E2E.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
3 files, +337 / -3