### PR TITLE
Assert seeded FAQ detail fields

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md
@@ -1,0 +1,58 @@
+# PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations
+
+## Why this slice exists
+#972 proves that a seeded hosted search hit can be dereferenced through the FAQ
+detail route and that the detail route returns the full FAQ envelope. The review
+noted one remaining gap: the detail contract does not assert that the returned
+detail belongs to the seeded account/target beyond matching `faq_id`.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Add optional expected detail-field assertions to the existing FAQ search
+   route contract checker.
+2. Thread seeded account/target expectations from route cases into the seeded
+   hosted e2e detail checker call.
+3. Add negative fixtures for each new expectation branch.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md`
+- `scripts/check_content_ops_faq_search_route_contract.py`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+The contract checker gains optional CLI flags for expected detail account,
+target id, target mode, title, and status. When a flag is provided and
+`--require-detail` runs, `_validate_detail` compares the returned detail field
+against the expected value and reports a contract error on mismatch.
+
+The seeded e2e detail case already reads the hit case's account and corpus IDs.
+It now derives the seeded target id as `support-<corpus_id>` and passes the
+known seeded title/status/target mode into the checker. This keeps validation
+single-sourced in the checker while proving the detail row matches the seeded
+search hit.
+## Intentional
+- No new database read is added to the e2e runner; it validates through the
+  hosted route only.
+- Expected detail checks are opt-in for the generic checker so existing manual
+  contract probes keep their current behavior.
+- The seeded title/target-mode constants mirror the existing seed smoke rows;
+  broader seed customization is deferred until the seed smoke needs it.
+## Deferred
+- A separate slice can make the seeded smoke emit richer route-case metadata if
+  the seeded FAQ shape becomes configurable.
+- The #972 observation about a distinct "not run" detail state is left parked;
+  it is presentation polish, not required for seeded detail correctness.
+## Verification
+- pytest tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 108 passed in 0.18s.
+- python -m py_compile scripts/check_content_ops_faq_search_route_contract.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 51 |
+| Contract checker | 52 |
+| E2E runner | 18 |
+| Tests | 107 |
+| **Total** | **235** |

--- a/scripts/check_content_ops_faq_search_route_contract.py
+++ b/scripts/check_content_ops_faq_search_route_contract.py
@@ -59,6 +59,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_LIMIT", "5"))
     parser.add_argument("--route", default=DEFAULT_ROUTE)
     parser.add_argument("--detail-route", default=os.environ.get("ATLAS_FAQ_DETAIL_ROUTE", ""))
+    parser.add_argument("--expected-detail-account-id", default="")
+    parser.add_argument("--expected-detail-target-id", default="")
+    parser.add_argument("--expected-detail-target-mode", default="")
+    parser.add_argument("--expected-detail-title", default="")
+    parser.add_argument("--expected-detail-status", default="")
     parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
     parser.add_argument(
         "--max-search-ms",
@@ -207,7 +212,23 @@ def _first_result_faq_id(data: Mapping[str, Any]) -> str | None:
     return faq_id if isinstance(faq_id, str) and faq_id.strip() else None
 
 
-def _validate_detail(data: Mapping[str, Any], *, faq_id: str) -> list[str]:
+def _expected_detail_values(args: argparse.Namespace) -> dict[str, str]:
+    values = {
+        "account_id": str(getattr(args, "expected_detail_account_id", "") or "").strip(),
+        "target_id": str(getattr(args, "expected_detail_target_id", "") or "").strip(),
+        "target_mode": str(getattr(args, "expected_detail_target_mode", "") or "").strip(),
+        "title": str(getattr(args, "expected_detail_title", "") or "").strip(),
+        "status": str(getattr(args, "expected_detail_status", "") or "").strip(),
+    }
+    return {key: value for key, value in values.items() if value}
+
+
+def _validate_detail(
+    data: Mapping[str, Any],
+    *,
+    faq_id: str,
+    expected: Mapping[str, str] | None = None,
+) -> list[str]:
     errors: list[str] = []
     for field in DETAIL_FIELDS:
         if field not in data:
@@ -226,6 +247,12 @@ def _validate_detail(data: Mapping[str, Any], *, faq_id: str) -> list[str]:
     for field in ("output_checks", "metadata"):
         if field in data and not isinstance(data[field], Mapping):
             errors.append(f"detail.{field} must be an object")
+    for field, expected_value in (expected or {}).items():
+        actual = data.get(field)
+        if actual != expected_value:
+            errors.append(
+                f"detail.{field} expected {expected_value!r} but got {actual!r}"
+            )
     return errors
 
 
@@ -267,6 +294,7 @@ def _latency_budget_errors(
 def _budget_preflight_errors(
     *,
     require_detail: bool,
+    expected_detail: Mapping[str, str],
     max_search_ms: float | None,
     max_detail_ms: float | None,
     max_total_ms: float | None,
@@ -281,6 +309,8 @@ def _budget_preflight_errors(
             errors.append(f"{name} must be finite and positive")
     if max_detail_ms is not None and not require_detail:
         errors.append("--max-detail-ms requires --require-detail")
+    if expected_detail and not require_detail:
+        errors.append("expected detail checks require --require-detail")
     return errors
 
 
@@ -301,6 +331,7 @@ def _result_payload(
     require_results: bool,
     require_detail: bool,
     detail_route: str,
+    expected_detail: Mapping[str, str] | None = None,
     detail_checked: bool = False,
     detail_faq_id: str = "",
     search_elapsed_ms: float | None = None,
@@ -327,6 +358,8 @@ def _result_payload(
         "detail_checked": detail_checked,
         "errors": list(errors or ()),
     }
+    if expected_detail:
+        payload["expected_detail"] = dict(expected_detail)
     if detail_faq_id:
         payload["detail_faq_id"] = detail_faq_id
     for key, value in (
@@ -367,6 +400,7 @@ def main() -> int:
     max_search_ms = args.max_search_ms
     max_detail_ms = args.max_detail_ms
     max_total_ms = args.max_total_ms
+    expected_detail = _expected_detail_values(args)
     if not base_url:
         print("ATLAS_API_BASE_URL or --base-url is required.")
         _write_result(
@@ -383,6 +417,7 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 errors=["ATLAS_API_BASE_URL or --base-url is required"],
             ),
         )
@@ -403,6 +438,7 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 errors=["ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required"],
             ),
         )
@@ -423,6 +459,7 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 errors=["ATLAS_FAQ_SEARCH_QUERY or --query is required"],
             ),
         )
@@ -443,12 +480,14 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 errors=["--limit must be positive"],
             ),
         )
         return 2
     budget_preflight_errors = _budget_preflight_errors(
         require_detail=bool(args.require_detail),
+        expected_detail=expected_detail,
         max_search_ms=max_search_ms,
         max_detail_ms=max_detail_ms,
         max_total_ms=max_total_ms,
@@ -471,6 +510,7 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 max_search_ms=max_search_ms,
                 max_detail_ms=max_detail_ms,
                 max_total_ms=max_total_ms,
@@ -509,6 +549,7 @@ def main() -> int:
                 require_results=bool(args.require_results),
                 require_detail=bool(args.require_detail),
                 detail_route=detail_route,
+                expected_detail=expected_detail,
                 max_search_ms=max_search_ms,
                 max_detail_ms=max_detail_ms,
                 max_total_ms=max_total_ms,
@@ -543,7 +584,13 @@ def main() -> int:
             except RuntimeError as exc:
                 errors.append(str(exc))
             else:
-                errors.extend(_validate_detail(detail_data, faq_id=detail_faq_id))
+                errors.extend(
+                    _validate_detail(
+                        detail_data,
+                        faq_id=detail_faq_id,
+                        expected=expected_detail,
+                    )
+                )
     total_elapsed_ms = search_elapsed_ms + (detail_elapsed_ms or 0.0)
     errors.extend(
         _latency_budget_errors(
@@ -567,6 +614,7 @@ def main() -> int:
         require_results=bool(args.require_results),
         require_detail=bool(args.require_detail),
         detail_route=resolved_detail_route,
+        expected_detail=expected_detail,
         detail_checked=detail_checked,
         detail_faq_id=detail_faq_id,
         search_elapsed_ms=search_elapsed_ms,

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -199,6 +199,9 @@ def _detail_case_from_route_cases(path: Path) -> tuple[dict[str, Any] | None, li
         query = item.get("query")
         if not isinstance(query, str) or not query.strip():
             return None, [f"route case[{index}].query must be a non-empty string"]
+        account_id = item.get("expected_first_account_id")
+        if not isinstance(account_id, str) or not account_id.strip():
+            return None, [f"route case[{index}].expected_first_account_id must be a non-empty string"]
         corpus_id = item.get("corpus_id", "")
         if not isinstance(corpus_id, str):
             return None, [f"route case[{index}].corpus_id must be a string"]
@@ -213,6 +216,11 @@ def _detail_case_from_route_cases(path: Path) -> tuple[dict[str, Any] | None, li
             "corpus_id": corpus_id.strip(),
             "status": status.strip(),
             "limit": limit,
+            "expected_detail_account_id": account_id.strip(),
+            "expected_detail_target_id": f"support-{corpus_id.strip()}",
+            "expected_detail_target_mode": "support_account",
+            "expected_detail_title": "FAQ Search Smoke",
+            "expected_detail_status": "approved",
         }, []
     return None, ["route case file must include a require_results case for detail check"]
 
@@ -247,6 +255,16 @@ def _detail_command(
         command.extend(["--status", str(detail_case["status"])])
     if str(args.detail_route or "").strip():
         command.extend(["--detail-route", str(args.detail_route)])
+    for key, flag in (
+        ("expected_detail_account_id", "--expected-detail-account-id"),
+        ("expected_detail_target_id", "--expected-detail-target-id"),
+        ("expected_detail_target_mode", "--expected-detail-target-mode"),
+        ("expected_detail_title", "--expected-detail-title"),
+        ("expected_detail_status", "--expected-detail-status"),
+    ):
+        value = str(detail_case.get(key) or "").strip()
+        if value:
+            command.extend([flag, value])
     return command
 
 

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -206,6 +206,20 @@ def test_validate_detail_accepts_full_generated_faq_payload():
     ) == []
 
 
+def test_validate_detail_accepts_expected_seed_fields():
+    assert _MODULE._validate_detail(
+        _valid_detail_payload(),
+        faq_id="11111111-1111-1111-1111-111111111111",
+        expected={
+            "account_id": "acct-1",
+            "target_id": "support-account-1",
+            "target_mode": "support_account",
+            "title": "Support FAQ",
+            "status": "approved",
+        },
+    ) == []
+
+
 @pytest.mark.parametrize(
     ("patch", "expected"),
     [
@@ -223,6 +237,30 @@ def test_validate_detail_rejects_contract_drift(patch, expected):
     assert expected in _MODULE._validate_detail(
         payload,
         faq_id="11111111-1111-1111-1111-111111111111",
+    )
+
+
+@pytest.mark.parametrize(
+    ("expected", "message"),
+    [
+        ({"account_id": "acct-2"}, "detail.account_id expected 'acct-2' but got 'acct-1'"),
+        (
+            {"target_id": "support-account-2"},
+            "detail.target_id expected 'support-account-2' but got 'support-account-1'",
+        ),
+        (
+            {"target_mode": "org"},
+            "detail.target_mode expected 'org' but got 'support_account'",
+        ),
+        ({"title": "Seed FAQ"}, "detail.title expected 'Seed FAQ' but got 'Support FAQ'"),
+        ({"status": "draft"}, "detail.status expected 'draft' but got 'approved'"),
+    ],
+)
+def test_validate_detail_rejects_expected_seed_field_mismatches(expected, message):
+    assert message in _MODULE._validate_detail(
+        _valid_detail_payload(),
+        faq_id="11111111-1111-1111-1111-111111111111",
+        expected=expected,
     )
 
 
@@ -600,6 +638,21 @@ def test_main_rejects_detail_latency_budget_without_detail_check(monkeypatch, ca
     assert "--max-detail-ms requires --require-detail" in capsys.readouterr().out
 
 
+def test_main_rejects_expected_detail_without_detail_check(monkeypatch, capsys):
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--expected-detail-account-id",
+        "acct-1",
+    )
+
+    assert _MODULE.main() == 2
+    assert "expected detail checks require --require-detail" in capsys.readouterr().out
+
+
 def test_main_rejects_non_finite_latency_budget(monkeypatch, capsys):
     monkeypatch.setattr(
         _MODULE,
@@ -657,6 +710,29 @@ def test_main_reports_detail_contract_failure(monkeypatch, capsys):
 
     assert _MODULE.main() == 1
     assert "detail.items must be a list" in capsys.readouterr().out
+
+
+def test_main_reports_expected_detail_mismatch(monkeypatch, capsys):
+    def _fake_fetch_json(url, *, token, timeout):
+        if url.endswith("/11111111-1111-1111-1111-111111111111"):
+            return _valid_detail_payload()
+        return _valid_payload()
+
+    monkeypatch.setattr(_MODULE, "_fetch_json", _fake_fetch_json)
+    _set_argv(
+        monkeypatch,
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-results",
+        "--require-detail",
+        "--expected-detail-account-id",
+        "acct-2",
+    )
+
+    assert _MODULE.main() == 1
+    assert "detail.account_id expected 'acct-2' but got 'acct-1'" in capsys.readouterr().out
 
 
 def test_main_writes_success_result_without_token(monkeypatch, tmp_path):

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -121,6 +121,7 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
                 "status": "approved",
                 "limit": 3,
                 "require_results": True,
+                "expected_first_account_id": "acct-1",
             },
         ],
     )
@@ -133,6 +134,11 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
         "corpus_id": "corp-1",
         "status": "approved",
         "limit": 3,
+        "expected_detail_account_id": "acct-1",
+        "expected_detail_target_id": "support-corp-1",
+        "expected_detail_target_mode": "support_account",
+        "expected_detail_title": "FAQ Search Smoke",
+        "expected_detail_status": "approved",
     }
 
 
@@ -145,11 +151,13 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
         ([[]], "route case[0] must be an object"),
         ([{"query": "reset", "limit": 5, "require_results": "yes"}], "route case[0].require_results must be a boolean"),
         ([{"query": "escrow", "limit": 5, "require_results": False}], "route case file must include a require_results case for detail check"),
-        ([{"query": "", "limit": 5, "require_results": True}], "route case[0].query must be a non-empty string"),
-        ([{"query": "reset", "corpus_id": 1, "limit": 5, "require_results": True}], "route case[0].corpus_id must be a string"),
-        ([{"query": "reset", "status": 1, "limit": 5, "require_results": True}], "route case[0].status must be a string"),
-        ([{"query": "reset", "limit": "5", "require_results": True}], "route case[0].limit must be a positive integer"),
-        ([{"query": "reset", "limit": True, "require_results": True}], "route case[0].limit must be a positive integer"),
+        ([{"query": "", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].query must be a non-empty string"),
+        ([{"query": "reset", "limit": 5, "require_results": True}], "route case[0].expected_first_account_id must be a non-empty string"),
+        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": ""}], "route case[0].expected_first_account_id must be a non-empty string"),
+        ([{"query": "reset", "corpus_id": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].corpus_id must be a string"),
+        ([{"query": "reset", "status": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].status must be a string"),
+        ([{"query": "reset", "limit": "5", "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
+        ([{"query": "reset", "limit": True, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
     ],
 )
 def test_detail_case_from_route_cases_rejects_bad_shapes(tmp_path, payload, expected_error):
@@ -184,6 +192,11 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
             "corpus_id": "corp-1",
             "status": "approved",
             "limit": 3,
+            "expected_detail_account_id": "acct-1",
+            "expected_detail_target_id": "support-corp-1",
+            "expected_detail_target_mode": "support_account",
+            "expected_detail_title": "FAQ Search Smoke",
+            "expected_detail_status": "approved",
         },
         detail_result=detail_result,
     )
@@ -196,6 +209,11 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
     assert "--require-results" in command
     assert "--require-detail" in command
     assert command[command.index("--detail-route") + 1] == "/api/v2/faqs/{faq_id}/full"
+    assert command[command.index("--expected-detail-account-id") + 1] == "acct-1"
+    assert command[command.index("--expected-detail-target-id") + 1] == "support-corp-1"
+    assert command[command.index("--expected-detail-target-mode") + 1] == "support_account"
+    assert command[command.index("--expected-detail-title") + 1] == "FAQ Search Smoke"
+    assert command[command.index("--expected-detail-status") + 1] == "approved"
     assert command[command.index("--output-result") + 1] == str(detail_result)
 
 
@@ -400,6 +418,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
                     "status": "approved",
                     "limit": 5,
                     "require_results": True,
+                    "expected_first_account_id": "acct-1",
                 }],
             )
             _write_cases(
@@ -462,6 +481,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
                     "status": "approved",
                     "limit": 5,
                     "require_results": True,
+                    "expected_first_account_id": "acct-1",
                 }],
             )
             _write_cases(
@@ -563,6 +583,7 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
                     "status": "approved",
                     "limit": 5,
                     "require_results": True,
+                    "expected_first_account_id": "acct-1",
                 }],
             )
             _write_cases(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md

Slice phase: Production hardening.

Add opt-in expected detail-field assertions to the FAQ search route contract checker, then have the seeded hosted FAQ search e2e pass seeded account and target expectations into the detail check. This closes the gap where #972 proved detail reachability and shape, but not that the detail row matched the seeded hit beyond faq_id.

## Intentional
- Expected detail checks are opt-in for the generic checker so manual probes keep existing behavior.
- The seeded e2e validates through the hosted route only; no direct DB read is added.
- Seeded title, status, and target mode mirror the existing seed smoke row constants.

## Deferred
- Richer route-case metadata can follow if seeded FAQ rows become configurable.
- The #972 distinct detail-not-run state remains presentation polish, not required for seeded detail correctness.

## Verification
- pytest tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 108 passed in 0.18s.
- python -m py_compile scripts/check_content_ops_faq_search_route_contract.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Detail-Seed-Expectations.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
5 files, +228 / -7