### PR TITLE
Emit FAQ detail expectations in route cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md
@@ -1,0 +1,55 @@
+# PR-Content-Ops-FAQ-Search-Detail-Case-Metadata
+
+## Why this slice exists
+#974 added seeded detail-field assertions, but the review noted that the seed
+smoke and e2e runner now duplicate the seeded FAQ title, target mode, status,
+and target-id format. That creates drift risk if the seed row changes without
+the e2e expectation builder changing with it.
+## Scope (this PR)
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+1. Have the DB seed smoke emit expected detail fields in the route-case file it
+   already writes for hosted e2e runs.
+2. Keep the seed row values and route-case metadata sourced from the same
+   constants/functions inside the seed smoke.
+3. Have the seeded e2e consume those expected detail fields instead of
+   reconstructing seed literals.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+## Mechanism
+The seed smoke defines the seeded FAQ detail constants once and uses them for
+both the `ticket_faq_markdown` insert and the hit-case metadata emitted to the
+route case artifact. Hit cases now include expected detail account, target,
+target mode, title, and status fields.
+
+The seeded e2e detail-case parser validates those fields on the selected hit
+case and forwards them to the existing route contract checker. It no longer
+derives target id, title, mode, or status on its own.
+## Intentional
+- No new module is introduced; the duplicated values live in one producing
+  script and are serialized into the existing artifact boundary.
+- Miss cases still omit detail expectations because they are never dereferenced.
+- The e2e parser fails closed on missing/malformed expected detail fields for
+  hit cases.
+## Deferred
+- If more scripts need the seeded FAQ constants later, a tiny shared helper
+  module can be introduced in that future slice.
+- The #972 distinct detail-not-run state remains presentation polish.
+## Verification
+- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 62 passed in 0.14s.
+- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md - Passed.
+- bash scripts/local_pr_review.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 48 |
+| Seed smoke | 27 |
+| E2E runner | 17 |
+| Tests | 27 |
+| **Total** | **126** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -27,6 +27,11 @@ from extracted_content_pipeline.ticket_faq_search import (  # noqa: E402
     TicketFAQSearchDocument,
 )
 
+SEEDED_FAQ_TARGET_MODE = "support_account"
+SEEDED_FAQ_TITLE = "FAQ Search Smoke"
+SEEDED_FAQ_MARKDOWN = "# FAQ Search Smoke"
+SEEDED_FAQ_STATUS = "approved"
+
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - host dependency
@@ -152,6 +157,10 @@ def _build_cases(
     return tuple(cases)
 
 
+def _seeded_faq_target_id(case: SearchCase) -> str:
+    return f"support-{case.corpus_id}"
+
+
 def _route_case_payload(
     cases: Sequence[SearchCase],
     *,
@@ -164,7 +173,7 @@ def _route_case_payload(
         row = {
             "query": case.query,
             "corpus_id": case.corpus_id,
-            "status": "approved",
+            "status": SEEDED_FAQ_STATUS,
             "limit": limit,
             "require_results": case.expected_hit,
             "expected_count": expected_hit_count if case.expected_hit else 0,
@@ -175,6 +184,11 @@ def _route_case_payload(
                     "expected_first_account_id": case.account_id,
                     "expected_first_corpus_id": case.corpus_id,
                     "expected_first_faq_id": case.faq_id,
+                    "expected_detail_account_id": case.account_id,
+                    "expected_detail_target_id": _seeded_faq_target_id(case),
+                    "expected_detail_target_mode": SEEDED_FAQ_TARGET_MODE,
+                    "expected_detail_title": SEEDED_FAQ_TITLE,
+                    "expected_detail_status": SEEDED_FAQ_STATUS,
                 }
             )
         payload.append(row)
@@ -265,15 +279,18 @@ async def _seed(pool: Any, repo: PostgresTicketFAQSearchRepository, cases: Seque
                 warnings, metadata, status
             )
             VALUES (
-                $1::uuid, $2, $3, 'support_account', 'FAQ Search Smoke',
-                '# FAQ Search Smoke', '[]'::jsonb, $4, $4,
-                '{}'::jsonb, '[]'::jsonb, '{}'::jsonb, 'approved'
+                $1::uuid, $2, $3, $4, $5, $6, '[]'::jsonb, $7, $7,
+                '{}'::jsonb, '[]'::jsonb, '{}'::jsonb, $8
             )
             """,
             case.faq_id,
             case.account_id,
-            f"support-{case.corpus_id}",
+            _seeded_faq_target_id(case),
+            SEEDED_FAQ_TARGET_MODE,
+            SEEDED_FAQ_TITLE,
+            SEEDED_FAQ_MARKDOWN,
             documents_per_corpus,
+            SEEDED_FAQ_STATUS,
         )
         await repo.replace_documents(
             _documents_for_case(case, documents_per_corpus=documents_per_corpus)

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -211,16 +211,25 @@ def _detail_case_from_route_cases(path: Path) -> tuple[dict[str, Any] | None, li
         limit = item.get("limit", 5)
         if type(limit) is not int or limit <= 0:
             return None, [f"route case[{index}].limit must be a positive integer"]
+        expected_detail: dict[str, str] = {}
+        for key in (
+            "expected_detail_account_id",
+            "expected_detail_target_id",
+            "expected_detail_target_mode",
+            "expected_detail_title",
+            "expected_detail_status",
+        ):
+            value = item.get(key)
+            if not isinstance(value, str) or not value.strip():
+                return None, [f"route case[{index}].{key} must be a non-empty string"]
+            expected_detail[key] = value.strip()
         return {
             "query": query.strip(),
             "corpus_id": corpus_id.strip(),
             "status": status.strip(),
             "limit": limit,
             "expected_detail_account_id": account_id.strip(),
-            "expected_detail_target_id": f"support-{corpus_id.strip()}",
-            "expected_detail_target_mode": "support_account",
-            "expected_detail_title": "FAQ Search Smoke",
-            "expected_detail_status": "approved",
+            **expected_detail,
         }, []
     return None, ["route case file must include a require_results case for detail check"]
 

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -79,6 +79,11 @@ def test_route_case_payload_carries_seeded_hit_and_miss_expectations() -> None:
     assert payload[0]["expected_first_account_id"] == "acct-1"
     assert payload[0]["expected_first_corpus_id"] == "corpus-1"
     assert payload[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload[0]["expected_detail_account_id"] == "acct-1"
+    assert payload[0]["expected_detail_target_id"] == "support-corpus-1"
+    assert payload[0]["expected_detail_target_mode"] == "support_account"
+    assert payload[0]["expected_detail_title"] == "FAQ Search Smoke"
+    assert payload[0]["expected_detail_status"] == "approved"
     assert payload[1] == {
         "query": "escrow shortage",
         "corpus_id": "corpus-1",

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -122,6 +122,11 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
                 "limit": 3,
                 "require_results": True,
                 "expected_first_account_id": "acct-1",
+                "expected_detail_account_id": "acct-1",
+                "expected_detail_target_id": "support-corp-1",
+                "expected_detail_target_mode": "support_account",
+                "expected_detail_title": "FAQ Search Smoke",
+                "expected_detail_status": "approved",
             },
         ],
     )
@@ -158,6 +163,8 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
         ([{"query": "reset", "status": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].status must be a string"),
         ([{"query": "reset", "limit": "5", "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
         ([{"query": "reset", "limit": True, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
+        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": ""}], "route case[0].expected_detail_account_id must be a non-empty string"),
+        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": "acct-1", "expected_detail_target_id": 1}], "route case[0].expected_detail_target_id must be a non-empty string"),
     ],
 )
 def test_detail_case_from_route_cases_rejects_bad_shapes(tmp_path, payload, expected_error):
@@ -419,6 +426,11 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
                     "limit": 5,
                     "require_results": True,
                     "expected_first_account_id": "acct-1",
+                    "expected_detail_account_id": "acct-1",
+                    "expected_detail_target_id": "support-corp-1",
+                    "expected_detail_target_mode": "support_account",
+                    "expected_detail_title": "FAQ Search Smoke",
+                    "expected_detail_status": "approved",
                 }],
             )
             _write_cases(
@@ -482,6 +494,11 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
                     "limit": 5,
                     "require_results": True,
                     "expected_first_account_id": "acct-1",
+                    "expected_detail_account_id": "acct-1",
+                    "expected_detail_target_id": "support-corp-1",
+                    "expected_detail_target_mode": "support_account",
+                    "expected_detail_title": "FAQ Search Smoke",
+                    "expected_detail_status": "approved",
                 }],
             )
             _write_cases(
@@ -584,6 +601,11 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
                     "limit": 5,
                     "require_results": True,
                     "expected_first_account_id": "acct-1",
+                    "expected_detail_account_id": "acct-1",
+                    "expected_detail_target_id": "support-corp-1",
+                    "expected_detail_target_mode": "support_account",
+                    "expected_detail_title": "FAQ Search Smoke",
+                    "expected_detail_status": "approved",
                 }],
             )
             _write_cases(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md

Slice phase: Production hardening.

Move seeded FAQ detail expectations into the seed-emitted route-case artifact so the hosted e2e consumes producer-owned metadata instead of reconstructing seeded title, status, target mode, and target-id format independently.

## Intentional
- No new module is introduced; the duplicated values live in one producing script and are serialized through the existing artifact boundary.
- Miss cases still omit detail expectations because they are never dereferenced.
- The e2e parser fails closed on missing or malformed expected detail fields for hit cases.

## Deferred
- A shared helper module can follow if more scripts need the seeded FAQ constants later.
- The #972 distinct detail-not-run state remains presentation polish.

## Verification
- pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 62 passed in 0.14s.
- python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Detail-Case-Metadata.md - Passed.
- bash scripts/local_pr_review.sh - Passed.

## Diff size
5 files, +117 / -9