### PR TITLE
Content Ops FAQ execute admission limit

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -200,6 +200,7 @@ def _compose_describe_response(
     configured_outputs: frozenset[str],
     execution_configured: bool,
     execute_max_concurrency: int,
+    faq_execute_max_source_material_rows: int,
     reasoning_status: Mapping[str, Any],
 ) -> dict[str, Any]:
     # Re-project the cached static template into a fresh dict tree so
@@ -229,6 +230,7 @@ def _compose_describe_response(
                 "max_source_material_rows": static["execute_limits"][
                     "max_source_material_rows"
                 ],
+                "faq_max_source_material_rows": faq_execute_max_source_material_rows,
                 "large_upload_strategy": static["execute_limits"][
                     "large_upload_strategy"
                 ],
@@ -292,6 +294,7 @@ class ContentOpsControlSurfaceApiConfig:
     structured_reasoning_drop_falsified: bool = False
     ingestion_opportunity_table: str = "campaign_opportunities"
     execute_max_concurrency: int = 8
+    faq_execute_max_source_material_rows: int = _MAX_INGESTION_ROWS
     ingestion_import_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
@@ -332,6 +335,13 @@ class ContentOpsControlSurfaceApiConfig:
             raise ValueError("structured_reasoning_max_continuations must be non-negative")
         if self.execute_max_concurrency <= 0:
             raise ValueError("execute_max_concurrency must be positive")
+        if self.faq_execute_max_source_material_rows <= 0:
+            raise ValueError("faq_execute_max_source_material_rows must be positive")
+        if self.faq_execute_max_source_material_rows > _MAX_INGESTION_ROWS:
+            raise ValueError(
+                "faq_execute_max_source_material_rows cannot exceed "
+                f"{_MAX_INGESTION_ROWS}"
+            )
         if self.ingestion_import_max_concurrency <= 0:
             raise ValueError("ingestion_import_max_concurrency must be positive")
         if not isinstance(
@@ -577,6 +587,9 @@ def create_content_ops_control_surface_router(
             configured_outputs=configured_outputs,
             execution_configured=execution_services is not None,
             execute_max_concurrency=execute_gate.max_concurrency,
+            faq_execute_max_source_material_rows=(
+                resolved_config.faq_execute_max_source_material_rows
+            ),
             reasoning_status=reasoning_status,
         )
 
@@ -778,6 +791,10 @@ def create_content_ops_control_surface_router(
                 payload_mapping,
                 input_provider=input_provider,
                 scope=scope,
+            )
+            _enforce_faq_execute_source_material_limit(
+                payload_mapping,
+                max_rows=resolved_config.faq_execute_max_source_material_rows,
             )
             # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
             # per-request reasoning provider and derive a reasoning-aware
@@ -1087,6 +1104,48 @@ def _input_provider_response_metadata(value: Any) -> dict[str, Any]:
         for key in sorted(_INPUT_PROVIDER_RESPONSE_METADATA_KEYS)
         if key in value
     }
+
+
+def _enforce_faq_execute_source_material_limit(
+    payload: Mapping[str, Any],
+    *,
+    max_rows: int,
+) -> None:
+    try:
+        request = request_from_mapping(payload)
+        outputs = resolve_outputs(request)
+    except ValueError:
+        return
+    if "faq_markdown" not in outputs:
+        return
+    inputs = payload.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return
+    row_count = _source_material_row_count(inputs.get("source_material"))
+    if row_count <= max_rows:
+        return
+    raise HTTPException(
+        status_code=413,
+        detail={
+            "reason": "faq_source_material_too_large_for_sync_execute",
+            "max_source_material_rows": max_rows,
+            "source_material_rows": row_count,
+            "large_upload_strategy": "background_or_offline",
+        },
+    )
+
+
+def _source_material_row_count(source_material: Any) -> int:
+    if isinstance(source_material, (list, tuple)):
+        return len(source_material)
+    if not isinstance(source_material, Mapping):
+        return 0
+    total = 0
+    for key in _SOURCE_MATERIAL_ROW_LIST_KEYS:
+        rows = source_material.get(key)
+        if isinstance(rows, (list, tuple)):
+            total += len(rows)
+    return total
 
 
 async def _structured_reasoning_contexts(

--- a/plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md
+++ b/plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md
@@ -1,0 +1,64 @@
+# PR-Content-Ops-FAQ-Execute-Admission-Limit
+
+## Why this slice exists
+`HARDENING.md` records `FAQSCALE-1`: 50,000-row deterministic FAQ generation
+works offline, but hosted synchronous execution must not accept unbounded large
+uploads. The execute route already has generic request-shape caps, but the FAQ
+sync row limit is implicit and static. This slice makes the FAQ admission rule
+an explicit host config and exposes the configured value through the existing
+control-surface metadata.
+## Scope (this PR)
+Ownership lane: content-ops/faq-generation-scale
+Slice phase: Production hardening.
+1. Add a host-configured maximum source-material row count for synchronous FAQ
+   Markdown execution.
+2. Enforce that limit only when the execute request resolves to `faq_markdown`.
+3. Surface the configured FAQ sync limit in the existing execute metadata.
+4. Add focused tests for under-limit pass, over-limit fail-closed behavior,
+   non-FAQ requests, invalid config, and metadata exposure.
+### Files touched
+- `plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+## Mechanism
+`ContentOpsControlSurfaceApiConfig` gains
+`faq_execute_max_source_material_rows`, defaulting to the existing inline
+source-material limit. The `/execute` route calls a small admission helper after
+input-provider merge and before reasoning/service execution. The helper resolves
+the requested outputs, counts top-level and known bundled `source_material`
+rows, and raises an HTTP 413 with the configured max when a synchronous
+`faq_markdown` request exceeds the cap.
+
+`GET /content-ops/control-surfaces` continues to expose the generic
+`max_source_material_rows` value for compatibility and adds the explicit
+`faq_max_source_material_rows` value for operators and clients.
+## Intentional
+- The generic Pydantic request-shape cap stays in place. This PR adds a
+  product-specific admission rule rather than loosening broad request safety.
+- The FAQ guard runs after input-provider merge so hosted uploaded-ticket
+  packages are admitted or rejected based on the actual request handed to the
+  generator.
+- The guard is FAQ-specific. Other outputs are still governed by the existing
+  generic shape limits, but not by this configurable FAQ cap.
+## Deferred
+- Background jobs, durable queues, retryable job status, and cross-process
+  backpressure remain the larger follow-up for `FAQSCALE-1`.
+- Raising the hosted synchronous FAQ cap above the current inline safety limit
+  remains deferred until the background/offline execution path is ready.
+## Verification
+- pytest tests/test_extracted_content_control_surface_api.py -q - 105 passed in 2.90s.
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py - Passed.
+- git diff --check - Passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md - Passed after plan verification formatting was corrected.
+- bash scripts/local_pr_review.sh - Passed.
+- bash scripts/validate_extracted_content_pipeline.sh - Passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - Passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - Passed.
+- bash scripts/check_ascii_python.sh - Passed.
+## Estimated diff size
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 57 |
+| Control-surface API | 55 |
+| Tests | 185 |
+| **Total** | **297** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.skipif(
 _DEFAULT_EXECUTION_LIMITS = {
     "max_concurrency": 8,
     "max_source_material_rows": 1000,
+    "faq_max_source_material_rows": 1000,
     "large_upload_strategy": "background_or_offline",
 }
 
@@ -360,6 +361,23 @@ async def test_describe_control_surfaces_reports_configured_execute_concurrency(
     assert payload["execution"]["limits"] == {
         **_DEFAULT_EXECUTION_LIMITS,
         "max_concurrency": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_describe_control_surfaces_reports_configured_faq_execute_row_limit():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            faq_execute_max_source_material_rows=250
+        )
+    )
+
+    route = _route(router, "/content-ops/control-surfaces", "GET")
+    payload = await route.endpoint()
+
+    assert payload["execution"]["limits"] == {
+        **_DEFAULT_EXECUTION_LIMITS,
+        "faq_max_source_material_rows": 250,
     }
 
 
@@ -1821,6 +1839,160 @@ async def test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_
 
 
 @pytest.mark.asyncio
+async def test_execute_generation_route_accepts_faq_source_material_at_configured_limit():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=service
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_material": {
+                    "support_tickets": [
+                        {
+                            "source_type": "ticket",
+                            "text": f"Ticket row {index}",
+                        }
+                        for index in range(2)
+                    ],
+                },
+            },
+        }
+    )
+
+    assert payload["status"] == "completed"
+    assert len(service.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_rejects_faq_source_material_over_configured_limit():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=service
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_markdown"],
+                "inputs": {
+                    "source_material": {
+                        "support_tickets": [
+                            {
+                                "source_type": "ticket",
+                                "text": f"Ticket row {index}",
+                            }
+                            for index in range(3)
+                        ],
+                    },
+                },
+            }
+        )
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == {
+        "reason": "faq_source_material_too_large_for_sync_execute",
+        "max_source_material_rows": 2,
+        "source_material_rows": 3,
+        "large_upload_strategy": "background_or_offline",
+    }
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_checks_input_provider_faq_rows_after_merge():
+    service = _CampaignService()
+    provider = _SyncInputProvider(
+        ContentOpsInputPackage(
+            provider="ticket_upload",
+            outputs=("faq_markdown",),
+            inputs={
+                "source_material": {
+                    "support_tickets": [
+                        {
+                            "source_type": "ticket",
+                            "text": f"Ticket row {index}",
+                        }
+                        for index in range(3)
+                    ],
+                },
+            },
+        )
+    )
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=service
+        ),
+        input_provider=provider,
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint({})
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail["source_material_rows"] == 3
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_does_not_apply_faq_row_limit_to_non_faq_outputs():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            signal_extraction=service
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["signal_extraction"],
+            "inputs": {
+                "source_material": [
+                    {
+                        "source_type": "ticket",
+                        "text": f"Ticket row {index}",
+                    }
+                    for index in range(3)
+                ],
+            },
+        }
+    )
+
+    assert payload["status"] == "completed"
+    assert len(service.calls[0]["kwargs"]["source_material"]) == 3
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_rejects_source_material_over_1000_as_422():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
@@ -2863,6 +3035,19 @@ def test_content_ops_config_stores_output_pack_names_immutably():
 def test_content_ops_config_rejects_invalid_execute_concurrency():
     with pytest.raises(ValueError, match="execute_max_concurrency must be positive"):
         ContentOpsControlSurfaceApiConfig(execute_max_concurrency=0)
+
+
+def test_content_ops_config_rejects_invalid_faq_execute_row_limit():
+    with pytest.raises(
+        ValueError,
+        match="faq_execute_max_source_material_rows must be positive",
+    ):
+        ContentOpsControlSurfaceApiConfig(faq_execute_max_source_material_rows=0)
+    with pytest.raises(
+        ValueError,
+        match="faq_execute_max_source_material_rows cannot exceed 1000",
+    ):
+        ContentOpsControlSurfaceApiConfig(faq_execute_max_source_material_rows=1001)
 
 
 def test_content_ops_config_rejects_invalid_ingestion_import_concurrency():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md

Slice phase: Production hardening.

Make the hosted synchronous FAQ Markdown source-material row limit explicit and host-configured. The execute route now rejects over-limit FAQ requests after input-provider merge and before generation, and the control-surface metadata exposes the configured FAQ sync limit.

## Intentional
- The generic Pydantic request-shape caps stay in place; this slice adds a FAQ-specific admission rule instead of loosening broad request safety.
- The configurable FAQ sync limit cannot exceed the existing inline source-material limit until background/offline execution exists.
- The guard is FAQ-specific: other outputs are still governed by existing generic shape limits, not this FAQ cap.

## Deferred
- Background jobs, durable queues, retryable job status, and cross-process backpressure remain the larger FAQSCALE-1 follow-up.
- Raising the hosted synchronous FAQ cap above the current inline safety limit remains deferred until the background/offline execution path is ready.

## Verification
- pytest tests/test_extracted_content_control_surface_api.py -q - 105 passed in 2.90s.
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py - Passed.
- git diff --check - Passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Execute-Admission-Limit.md - Passed.
- bash scripts/local_pr_review.sh - Passed.
- bash scripts/validate_extracted_content_pipeline.sh - Passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - Passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - Passed.
- bash scripts/check_ascii_python.sh - Passed.

## Diff size
3 files, +308 / -0