### PR TITLE
Atlas local PR body preflight

### DIFF
--- a/plans/PR-Atlas-Local-PR-Body-Preflight.md
+++ b/plans/PR-Atlas-Local-PR-Body-Preflight.md
@@ -1,0 +1,86 @@
+# PR-Atlas-Local-PR-Body-Preflight
+
+## Why this slice exists
+
+Reviewer feedback flagged a repeated workflow miss: code quality is staying
+high, but first pushes keep failing metadata/CI contracts after the PR is
+already open. Recent misses include PR-body `Slice phase` omissions and extracted
+test enrollment drift. The scanners catch the problems, but the builder path
+needs to run the same checks before the first PR push.
+
+This slice makes the existing local PR review bundle enforce the two recurring
+metadata gates directly: current PR body phase validation and extracted pipeline
+test enrollment.
+
+## Scope (this PR)
+
+Ownership lane: atlas-workflow
+
+Slice phase: Workflow/process.
+
+1. Let the drift audit validate a local PR body file before a GitHub PR exists.
+2. Require current PR body validation from `scripts/local_pr_review.sh`, using
+   either the open PR body or a supplied local body file.
+3. Run the extracted pipeline CI-enrollment scanner from the local review bundle.
+4. Add focused negative/positive fixtures for the new pre-open PR body path.
+
+### Files touched
+
+- `plans/PR-Atlas-Local-PR-Body-Preflight.md`
+- `scripts/audit_pr_session_drift.py`
+- `scripts/local_pr_review.sh`
+- `tests/test_audit_pr_session_drift.py`
+
+## Mechanism
+
+`audit_pr_session_drift.py` gets two options:
+
+```bash
+--current-pr-body-file <path>
+--require-current-pr-body
+```
+
+When a branch adds a plan doc with a `Slice phase`, `--require-current-pr-body`
+fails unless either the open PR body is checked through GitHub metadata or a
+local body file is supplied. The same slice-phase parser validates both paths,
+so the pre-open body check and GitHub body check cannot diverge.
+
+`local_pr_review.sh` passes `--require-current-pr-body` to the drift audit and
+accepts `--current-pr-body-file` / `--pr-body-file` for the pre-open path. The
+installed pre-push hook can use `ATLAS_CURRENT_PR_BODY_FILE=...` for the same
+body file because hook invocations cannot receive ad hoc CLI flags. The wrapper
+also runs `scripts/audit_extracted_pipeline_ci_enrollment.py` when present.
+
+## Intentional
+
+- This does not generate PR bodies. It enforces that the body exists and matches
+  the plan phase before the builder treats local review as green.
+- The current GitHub PR body remains authoritative after a PR exists. The local
+  body file is for the pre-open review path.
+- The enrollment scanner runs unconditionally when available. It is already a
+  repo-wide audit and is fast enough for the local mechanical bundle.
+
+## Deferred
+
+- Future PR: consider a body-render helper if builders still hand-write PR
+  descriptions incorrectly after this gate.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m pytest tests/test_audit_pr_session_drift.py -q` - 26 passed.
+- `python -m py_compile scripts/audit_pr_session_drift.py` - passed.
+- `bash scripts/local_pr_review.sh --help` - passed.
+- `git diff --check` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file <temp body>` - passed.
+- `ATLAS_CURRENT_PR_BODY_FILE=<temp body> bash scripts/local_pr_review.sh` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Drift audit body-file gate | ~97 |
+| Local review wiring | ~35 |
+| Tests | ~85 |
+| Plan doc | ~85 |
+| **Total** | **~302** |

--- a/scripts/audit_pr_session_drift.py
+++ b/scripts/audit_pr_session_drift.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any, Iterable, Sequence
 
@@ -78,10 +79,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="skip GitHub open-PR overlap checks",
     )
+    parser.add_argument(
+        "--current-pr-body-file",
+        help="validate this local PR body file as the current PR body",
+    )
+    parser.add_argument(
+        "--require-current-pr-body",
+        action="store_true",
+        help="fail when a branch plan has a Slice phase but no current PR body was checked",
+    )
     args = parser.parse_args(argv)
 
     try:
-        report = build_report(args.base_ref, skip_github=args.skip_github)
+        report = build_report(
+            args.base_ref,
+            skip_github=args.skip_github,
+            current_pr_body_file=args.current_pr_body_file,
+            require_current_pr_body=args.require_current_pr_body,
+        )
     except AuditError as exc:
         print(f"DRIFT audit error: {exc}", file=sys.stderr)
         return 2
@@ -99,7 +114,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
+def build_report(
+    base_ref: str,
+    *,
+    skip_github: bool = False,
+    current_pr_body_file: str | None = None,
+    require_current_pr_body: bool = False,
+) -> DriftReport:
     ensure_git_ref(base_ref)
     base = git_stdout(["merge-base", "HEAD", base_ref])
     branch_files = changed_files([base, "HEAD"], triple_dot=True)
@@ -116,8 +137,19 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
     open_pr_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
     open_pr_lane_overlaps: list[tuple[OpenPullRequest, frozenset[str]]] = []
     current_pr_phase_errors: list[str] = []
+    current_pr_body_checked = False
     github_status = "skipped (--skip-github)"
     github_warnings: list[str] = []
+
+    if current_pr_body_file:
+        current_pr_body_checked = True
+        current_pr_phase_errors.extend(
+            current_pr_body_errors(
+                read_text_file(current_pr_body_file),
+                branch_slice_phases=branch_slice_phases,
+                source="current PR body",
+            )
+        )
 
     if not skip_github and os.environ.get("ATLAS_SKIP_PR_SESSION_DRIFT_GITHUB") != "1":
         github_status, prs, loaded_github_warnings = load_open_pull_requests(base_ref)
@@ -127,19 +159,15 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
         for pr in prs:
             is_current_pr = pr.head_ref == current_branch or (pr.head_oid and pr.head_oid == current_oid)
             if is_current_pr:
+                current_pr_body_checked = True
                 current_pr_phase_errors.extend(pr.slice_phase_errors)
-                if branch_slice_phases and not pr.slice_phases:
-                    current_pr_phase_errors.append("current PR body: missing Slice phase")
-                elif (
-                    branch_slice_phases
-                    and pr.slice_phases
-                    and branch_slice_phases.isdisjoint(pr.slice_phases)
-                ):
-                    current_pr_phase_errors.append(
-                        "current PR body Slice phase "
-                        f"{format_values(pr.slice_phases)} does not match branch plan phase(s) "
-                        f"{format_values(branch_slice_phases)}"
+                current_pr_phase_errors.extend(
+                    compare_current_pr_body_slice_phases(
+                        pr.slice_phases,
+                        branch_slice_phases=branch_slice_phases,
+                        source="current PR body",
                     )
+                )
                 continue
             overlap = frozenset(branch_files & pr.files)
             if overlap:
@@ -147,6 +175,12 @@ def build_report(base_ref: str, *, skip_github: bool = False) -> DriftReport:
             lane_overlap = frozenset(branch_ownership_lanes & pr.ownership_lanes)
             if lane_overlap:
                 open_pr_lane_overlaps.append((pr, lane_overlap))
+
+    if require_current_pr_body and branch_slice_phases and not current_pr_body_checked:
+        current_pr_phase_errors.append(
+            "current PR body: not checked; pass --current-pr-body-file before "
+            "opening the PR, or run after the GitHub PR exists"
+        )
 
     return DriftReport(
         branch_files=frozenset(branch_files),
@@ -267,6 +301,36 @@ def extract_slice_phases(text: str, *, source: str) -> tuple[frozenset[str], tup
     return frozenset(phases), tuple(errors)
 
 
+def current_pr_body_errors(
+    text: str,
+    *,
+    branch_slice_phases: frozenset[str],
+    source: str,
+) -> tuple[str, ...]:
+    phases, phase_errors = extract_slice_phases(text, source=source)
+    return tuple(phase_errors) + compare_current_pr_body_slice_phases(
+        phases,
+        branch_slice_phases=branch_slice_phases,
+        source=source,
+    )
+
+
+def compare_current_pr_body_slice_phases(
+    phases: frozenset[str],
+    *,
+    branch_slice_phases: frozenset[str],
+    source: str,
+) -> tuple[str, ...]:
+    if branch_slice_phases and not phases:
+        return (f"{source}: missing Slice phase",)
+    if branch_slice_phases and phases and branch_slice_phases.isdisjoint(phases):
+        return (
+            f"{source} Slice phase {format_values(phases)} "
+            f"does not match branch plan phase(s) {format_values(branch_slice_phases)}",
+        )
+    return ()
+
+
 def normalize_slice_phase(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip().rstrip(".").lower())
 
@@ -322,6 +386,13 @@ def load_open_pull_requests(base_ref: str) -> tuple[str, tuple[OpenPullRequest, 
             warnings.append(error)
 
     return f"checked {len(prs)} open PR(s)", tuple(prs), tuple(warnings)
+
+
+def read_text_file(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AuditError(f"could not read current PR body file {path!r}: {exc}") from exc
 
 
 def load_open_pull_request_files(number: int, row: dict[str, Any]) -> tuple[OpenPullRequest, tuple[str, ...]]:

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -8,6 +8,7 @@ cd "$(git rev-parse --show-toplevel)"
 base_ref="origin/main"
 base_ref_set=0
 allow_dirty=0
+current_pr_body_file="${ATLAS_CURRENT_PR_BODY_FILE:-}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -15,13 +16,26 @@ while [ "$#" -gt 0 ]; do
             allow_dirty=1
             shift
             ;;
+        --current-pr-body-file|--pr-body-file)
+            if [ "$#" -lt 2 ]; then
+                echo "local_pr_review.sh: $1 requires a path" >&2
+                exit 2
+            fi
+            current_pr_body_file="$2"
+            shift 2
+            ;;
         --help|-h)
             cat <<'EOF'
-Usage: bash scripts/local_pr_review.sh [--allow-dirty] [base-ref]
+Usage: bash scripts/local_pr_review.sh [--allow-dirty] [--current-pr-body-file PATH] [base-ref]
 
 Run the local mechanical review bundle before opening or updating a PR.
 By default, the worktree must be clean so committed-diff checks cannot
 silently ignore uncommitted edits.
+
+When running before the GitHub PR exists, pass --current-pr-body-file
+with the PR description you plan to use. The drift audit validates that
+body's Slice phase against the branch plan. Installed pre-push hooks can
+use ATLAS_CURRENT_PR_BODY_FILE=PATH for the same check.
 EOF
             exit 0
             ;;
@@ -81,8 +95,21 @@ git diff --name-status "$base"...HEAD || true
 
 run_check "Pre-push audit wrapper" bash scripts/pre_push_audit.sh
 
+if [ -f scripts/audit_extracted_pipeline_ci_enrollment.py ]; then
+    run_check "Extracted pipeline CI enrollment" \
+        python scripts/audit_extracted_pipeline_ci_enrollment.py
+else
+    echo
+    echo "==> Extracted pipeline CI enrollment"
+    echo "    SKIP (scripts/audit_extracted_pipeline_ci_enrollment.py not found)"
+fi
+
 if [ -f scripts/audit_pr_session_drift.py ]; then
-    run_check "Cross-session PR drift" python scripts/audit_pr_session_drift.py "$base_ref"
+    drift_args=(scripts/audit_pr_session_drift.py "$base_ref" --require-current-pr-body)
+    if [ -n "$current_pr_body_file" ]; then
+        drift_args+=(--current-pr-body-file "$current_pr_body_file")
+    fi
+    run_check "Cross-session PR drift" python "${drift_args[@]}"
 else
     echo
     echo "==> Cross-session PR drift"

--- a/tests/test_audit_pr_session_drift.py
+++ b/tests/test_audit_pr_session_drift.py
@@ -207,6 +207,91 @@ def test_cli_fails_when_current_pr_body_slice_phase_mismatches_plan(tmp_path: Pa
     assert "does not match branch plan phase(s) workflow/process" in result.stdout
 
 
+def test_cli_fails_when_required_pr_body_was_not_checked_before_pr_exists(
+    tmp_path: Path,
+) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+
+    result = _run(
+        repo,
+        [
+            "python",
+            "scripts/audit_pr_session_drift.py",
+            "--skip-github",
+            "--require-current-pr-body",
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "current PR body slice phase contract failed" in result.stdout
+    assert "current PR body: not checked" in result.stdout
+    assert "--current-pr-body-file" in result.stdout
+
+
+def test_cli_accepts_current_pr_body_file_before_pr_exists(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    body = repo / "pr-body.md"
+    body.write_text(
+        "Plan: plans/PR-Current.md\n\nSlice phase: Workflow/process\n",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        repo,
+        [
+            "python",
+            "scripts/audit_pr_session_drift.py",
+            "--skip-github",
+            "--require-current-pr-body",
+            "--current-pr-body-file",
+            str(body),
+        ],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: no blocking drift detected" in result.stdout
+
+
+def test_cli_rejects_current_pr_body_file_missing_slice_phase(tmp_path: Path) -> None:
+    repo = _write_fixture_repo(tmp_path, branch="claude/current")
+    _commit(
+        repo,
+        "plans/PR-Current.md",
+        "# PR-Current\n\n## Scope (this PR)\n\n"
+        "Ownership lane: atlas-workflow\n\nSlice phase: Workflow/process\n",
+    )
+    body = repo / "pr-body.md"
+    body.write_text("Plan: plans/PR-Current.md\n", encoding="utf-8")
+
+    result = _run(
+        repo,
+        [
+            "python",
+            "scripts/audit_pr_session_drift.py",
+            "--skip-github",
+            "--require-current-pr-body",
+            "--current-pr-body-file",
+            str(body),
+        ],
+    )
+
+    assert result.returncode == 1
+    assert "current PR body slice phase contract failed" in result.stdout
+    assert "current PR body: missing Slice phase" in result.stdout
+
+
 def test_cli_accepts_current_pr_body_matching_plan_slice_phase(tmp_path: Path) -> None:
     repo = _write_fixture_repo(tmp_path, branch="claude/current")
     path = "plans/PR-Current.md"


### PR DESCRIPTION
Plan: plans/PR-Atlas-Local-PR-Body-Preflight.md
Slice phase: Workflow/process

This hardens the local PR review path so recurring metadata misses are caught before first push/open. The local review bundle now validates either the open PR body or a supplied local body file, and it runs the extracted pipeline CI-enrollment scanner locally.

## Intentional
- This does not generate PR bodies. It enforces that the body exists and matches the plan phase before the builder treats local review as green.
- The current GitHub PR body remains authoritative after a PR exists. The local body file is for the pre-open review path.
- The enrollment scanner runs unconditionally when available. It is already a repo-wide audit and is fast enough for the local mechanical bundle.

## Deferred
- Future PR: consider a body-render helper if builders still hand-write PR descriptions incorrectly after this gate.
- Parked hardening: none.

## Verification
- `python -m pytest tests/test_audit_pr_session_drift.py -q` - 26 passed.
- `python -m py_compile scripts/audit_pr_session_drift.py` - passed.
- `bash scripts/local_pr_review.sh --help` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <temp body>` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=<temp body> bash scripts/local_pr_review.sh` - passed.

## Diff size
4 files, +284 / -15
