### PR TITLE
FAQ answer step grounding

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-26
-
-### FAQ action steps are intent-template based, not resolution-evidence gated
-- File/location: `extracted_content_pipeline/ticket_faq_markdown.py` (`_ACTION_RULES`, `_article_steps`).
-- Description: The deterministic FAQ generator emits action steps from intent templates. The steps are grounded to the detected topic and source IDs, but they are not gated on explicit support-resolution evidence from the uploaded rows.
-- Why it matters: This is acceptable for draft/review FAQ output, but publish-ready support answers should not imply verified product-specific resolution steps unless the upload includes resolution evidence or the output labels the steps as draft guidance.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/faq-generator
-- Found during: PR-FAQ-Generator-Output-Proof.
-
 ## 2026-05-23
 
 ### FAQSCALE-1 - Large synchronous FAQ generation needs hosted limits / backpressure / background execution

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -73,10 +73,6 @@ _MORTGAGE_INTENT_TERMS = (
     "reverse mortgage",
     "mortgage servicer",
 )
-_MORTGAGE_ACTION_STEPS = (
-    "Gather the mortgage statement, payment history, escrow record, payoff quote, or loss-mitigation notice tied to the issue.",
-    "Send the servicer a written request or dispute with the dates, amounts, account number, and copies of the records you want reviewed.",
-)
 _FAILURE_RISK_RULES = (
     ("blocked_access", ("cannot", "can't", "can not", "unable", "locked", "blocked", "denied")),
     ("failed_workflow", ("failed", "fails", "not working", "does not work", "keeps timing out", "timed out", "missing")),
@@ -205,6 +201,14 @@ _SOURCE_WEIGHT_KEYS = (
     # aggregate fields so round-tripped FAQ output does not mask search_count.
     "frequency",
 )
+_RESOLUTION_TEXT_KEYS = (
+    "resolution_text",
+    "resolved_text",
+    "resolution_summary",
+    "support_resolution",
+    "agent_resolution",
+    "answer_text",
+)
 _VOCABULARY_GAP_RULES = (
     ("export", "download", "download report", "report download"),
     ("dashboard", "analytics", "reporting", "reports"),
@@ -214,47 +218,6 @@ _VOCABULARY_GAP_RULES = (
     ("connect", "connection", "integration", "sync"),
     ("cancel", "cancellation", "renewal"),
 )
-_ACTION_RULES = (
-    (("credit report", "credit file", "credit bureau", "credit bureaus", "credit reporting", "incorrect information"), (
-        "Get your latest credit reports and mark the account, date, balance, or status that looks wrong.",
-        "File a dispute with the credit bureau and the company that supplied the information, then keep the confirmation numbers and copies of your records.",
-    )),
-    (("debt not owed", "not owe", "do not owe", "collect debt", "debt collection", "collector", "debt collector", "collection letter", "collection agency", "debt validation", "validation letter", "medical debt", "settled the debt"), (
-        "Ask the collector in writing to identify the original creditor, the amount, the account, and why they say you owe it.",
-        "Compare the notice with your payment, settlement, insurance, or provider records before you pay or share more information.",
-    )),
-    (_MORTGAGE_INTENT_TERMS, _MORTGAGE_ACTION_STEPS),
-    (("opening an account", "open an account", "opened an account", "early warning services", "identity theft"), (
-        "Gather the application, account-opening notice, denial reason, identity-theft report, or bank message tied to the issue.",
-        "Ask the bank or card issuer in writing to explain the account decision, fraud record, bonus term, or access restriction and keep copies of the response.",
-    )),
-    (("getting a credit card", "applied for a credit card", "credit card application", "activate card"), (
-        "Gather the card application, offer, denial notice, account terms, or activation message tied to the issue.",
-        "Ask the issuer to explain the decision, promotion, account status, or card record in writing before you reapply or activate anything.",
-    )),
-    (("communication and contact issues", "call at all hours", "calling at all hours", "various numbers", "telephone calls", "harass", "harassed", "harassment"), (
-        "Save the call log, message, notice, or contact record that shows when and how the company contacted you.",
-        "Ask the company in writing to explain the contact reason and update any communication preferences or dispute notes tied to the account.",
-    )),
-    (("export", "dashboard", "attribution", "analytics report", "download report", "report export"), (
-        "Open the reporting or analytics area and choose the date range you need.",
-        "Look for an Export or Download option, then ask an admin to check your role and plan access if it is missing.",
-    )),
-    (("handoff", "follow-up", "workflow", "automation", "manual"), (
-        "Find the workflow or automation rule that should handle this step.",
-        "Check the last failed handoff, note which step stopped, and send that detail to support if it still needs manual cleanup.",
-    )),
-    (("billing", "invoice", "payment", "receipt", "charge", "fee", "fees", "interest", "loan", "lease", "statement", "dispute"), (
-        "Open the bill, statement, payment history, or dispute record connected to the issue.",
-        "Compare the charge, fee, payment, or balance against your receipt, contract, or written confirmation.",
-    )),
-    (("login", "email", "profile", "password", "account"), (
-        "Open your profile, account settings, or login settings and find the email, password, or account field you need to change.",
-        "Save the change, then check the old and new inboxes for a confirmation message.",
-    )),
-)
-
-
 @dataclass(frozen=True)
 class TicketFAQMarkdownResult:
     """FAQ Markdown plus metadata useful for CLI summaries and tests."""
@@ -495,6 +458,7 @@ def build_ticket_faq_markdown(
                 "zero_results": _first_present(evidence, opportunity, key="zero_results"),
                 "zero_result": _first_present(evidence, opportunity, key="zero_result"),
                 "source_weight": _source_weight(evidence, opportunity),
+                "resolution_text": _resolution_text(evidence, opportunity),
             })
 
     sorted_groups = sorted(groups.items(), key=_group_sort_key)
@@ -650,7 +614,16 @@ def _item(
         source_count=len(source_ids),
         question_source=question_source,
     )
-    steps = _article_steps(topic, action_context, support_contact=support_contact)
+    resolution_texts = _resolution_texts(rows)
+    answer_evidence_status = (
+        "resolution_evidence" if resolution_texts else "draft_needs_review"
+    )
+    steps = _article_steps(
+        topic,
+        action_context,
+        support_contact=support_contact,
+        resolution_texts=resolution_texts,
+    )
     escalation = _escalation_guidance(topic, action_context, support_contact=support_contact)
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     opportunity = _opportunity_score(topic, rows)
@@ -665,9 +638,11 @@ def _item(
         "failure_risk_signals": opportunity["failure_risk_signals"],
         "opportunity_score": opportunity["opportunity_score"],
         "answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s).",
-        "action_items": _action_items(topic, action_context),
+        "action_items": steps,
         "summary": summary,
         "steps": steps,
+        "answer_evidence_status": answer_evidence_status,
+        "resolution_source_count": _resolution_source_count(rows),
         "when_to_contact_support": escalation,
         "evidence_quotes": evidence_quotes,
         "term_mappings": term_mappings,
@@ -765,6 +740,38 @@ def source_row_weight(*rows: Mapping[str, Any]) -> int:
 
 def _source_weight(*rows: Mapping[str, Any]) -> int:
     return source_row_weight(*rows)
+
+
+def _resolution_text(*rows: Mapping[str, Any]) -> str:
+    for row in rows:
+        for key in _RESOLUTION_TEXT_KEYS:
+            text = _compact(_field_value(row, key))
+            if text:
+                return text
+    return ""
+
+
+def _resolution_texts(rows: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    values = (
+        _compact(row.get("resolution_text"))
+        for row in rows
+        if _compact(row.get("resolution_text"))
+    )
+    return tuple(dict.fromkeys(values))
+
+
+def _resolution_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    return len(_distinct_source_keys([
+        row for row in rows if _compact(row.get("resolution_text"))
+    ]))
+
+
+def _resolution_excerpt(value: Any, *, limit: int = 180) -> str:
+    sentence = _first_sentence(_compact(value))
+    text = sentence or _compact(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit].rstrip()}..."
 
 
 def _term_mappings(
@@ -1316,11 +1323,49 @@ def _summary(
     )
 
 
-def _article_steps(topic: str, evidence_text: str, *, support_contact: str | None) -> tuple[str, ...]:
-    steps = _action_items(topic, evidence_text)
+def _article_steps(
+    _topic: str,
+    _evidence_text: str,
+    *,
+    support_contact: str | None,
+    resolution_texts: Sequence[str] = (),
+) -> tuple[str, ...]:
+    if resolution_texts:
+        return _resolution_article_steps(resolution_texts, support_contact=support_contact)
+    return _draft_review_steps(support_contact)
+
+
+def _resolution_article_steps(
+    resolution_texts: Sequence[str],
+    *,
+    support_contact: str | None,
+) -> tuple[str, ...]:
+    excerpts = tuple(
+        dict.fromkeys(
+            excerpt
+            for text in resolution_texts
+            if (excerpt := _resolution_excerpt(text))
+        )
+    )
+    steps = tuple(
+        f"Use the uploaded resolution evidence: {excerpt}"
+        for excerpt in excerpts[:2]
+    )
+    if len(steps) >= 2:
+        return (*steps, _support_step(support_contact))
+    if len(steps) == 1:
+        return (
+            steps[0],
+            "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+            _support_step(support_contact),
+        )
+    return _draft_review_steps(support_contact)
+
+
+def _draft_review_steps(support_contact: str | None) -> tuple[str, ...]:
     return (
-        steps[0],
-        steps[1],
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
         _support_step(support_contact),
     )
 
@@ -1539,19 +1584,6 @@ def _vocabulary_gap_rule_metadata(rules: Sequence[Sequence[str]]) -> dict[str, A
     if not cleaned:
         return {}
     return {"vocabulary_gap_rules": [list(rule) for rule in cleaned]}
-
-
-def _action_items(topic: str, evidence_text: str) -> tuple[str, ...]:
-    if topic == "mortgage servicing issues":
-        return _MORTGAGE_ACTION_STEPS
-    text = f"{topic} {evidence_text}".lower()
-    for terms, steps in _ACTION_RULES:
-        if any(term in text for term in terms):
-            return steps
-    return (
-        "Review the account, page, or workflow named in the ticket.",
-        "Write down what you tried and the exact message or behavior you saw.",
-    )
 
 
 def _output_checks(

--- a/plans/PR-FAQ-Answer-Step-Grounding.md
+++ b/plans/PR-FAQ-Answer-Step-Grounding.md
@@ -1,0 +1,119 @@
+# PR-FAQ-Answer-Step-Grounding
+
+## Why this slice exists
+
+The FAQ generator is deterministic and grounded in source-ticket language, but
+its "What to do next" steps are currently chosen from intent templates even
+when the upload contains no resolved-answer evidence. That is acceptable for a
+review draft only if the artifact says so clearly. Without that contract, the
+FAQ wedge can imply verified support instructions from tickets that only
+describe problems.
+
+This slice is production hardening for the FAQ lane: concrete generated steps
+should be grounded in uploaded resolution evidence. When that evidence is
+absent, the artifact should degrade to draft/review guidance instead of
+presenting template steps as verified answers.
+
+Slice size: **medium**. This changes the generated FAQ output contract and its
+focused tests, but it stays inside the FAQ renderer and does not touch hosted
+routes, persistence, DB migrations, or landing/blog generation.
+
+The final diff is expected to exceed the usual 400 LOC target after review
+because the same slice now includes the stale CFPB smoke consumer assertion, the
+negative disposition-key fixture, and the render-cap/source-count regression
+fixtures needed to close the hardening item honestly.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+
+Slice phase: Production hardening.
+
+1. Preserve resolution-style fields from source rows when grouping FAQ evidence.
+2. Use resolution evidence to build concrete FAQ action steps when present.
+3. Render explicit draft/review guidance when resolution evidence is absent.
+4. Expose compact per-item metadata so callers can tell which mode was used.
+5. Remove the now-closed FAQ action-step hardening entry.
+6. Update the CFPB FAQ smoke consumer to the new no-resolution draft contract.
+7. Add focused regression tests for grounded, no-resolution, disposition-key,
+   render-cap, and source-count behavior.
+
+### Files touched
+
+- `plans/PR-FAQ-Answer-Step-Grounding.md`
+- `HARDENING.md`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_smoke_content_ops_cfpb_faq_markdown.py`
+
+## Mechanism
+
+The FAQ grouping path will carry a normalized `resolution_text` field from
+explicit resolution-text fields on evidence/opportunity rows. `_item(...)` will classify each FAQ item into one of
+two modes:
+
+```python
+if resolution_texts:
+    answer_evidence_status = "resolution_evidence"
+    steps = _resolution_article_steps(resolution_texts, support_contact=...)
+else:
+    answer_evidence_status = "draft_needs_review"
+    steps = _draft_review_steps(support_contact=...)
+```
+
+The Markdown still keeps the same "What to do next" section so downstream
+renderers do not need a shape change, but no-resolution output will explicitly
+say it is draft guidance that must be reviewed against the team's policy or
+runbook before publishing.
+
+Resolution grounding uses all rows in a grouped FAQ item, not only the
+displayed evidence rows, so `max_evidence_per_item` cannot hide resolution
+evidence. `resolution_source_count` counts distinct resolution-backed source
+IDs instead of deduplicated macro text.
+
+## Intentional
+
+- No LLM call, summarizer, or policy inference is introduced. Resolution
+  evidence is copied/excerpted from uploaded structured fields.
+- Existing topic, scoring, vocabulary-gap, and source-id behavior stays
+  unchanged.
+- The no-resolution path still has actionable review steps so existing
+  `has_action_items` output checks remain meaningful, but those steps are about
+  authoring/reviewing the answer rather than instructing an end user to perform
+  unsupported product-specific actions.
+- Bare upload columns like `resolution`, `answer`, and `solution` are not
+  treated as resolution evidence because they commonly contain disposition or
+  survey values, not verified support-answer text.
+
+## Deferred
+
+- Rich resolution parsing from long chat transcripts is deferred; this slice
+  only uses structured resolution-style fields already present on rows.
+- Hosted UI display for `answer_evidence_status` is deferred until the frontend
+  consumes FAQ item metadata.
+- The older FAQ scale/backpressure item remains parked; this slice only closes
+  the answer-step grounding item.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py -q` - 145 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2421 passed, 5 skipped, 1 warning.
+- `python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Answer-Step-Grounding.md` - passed.
+- `git diff --check` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/local_pr_review.sh` - pending clean-branch run after commit.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 119 |
+| Hardening closeout | 11 |
+| FAQ renderer | 160 |
+| FAQ tests | 175 |
+| CFPB smoke consumer | 2 |
+| **Total** | **467** |

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -143,10 +143,12 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "Customers are asking about reporting friction across 2 ticket sources."
     )
     assert result.items[0]["steps"] == (
-        "Open the reporting or analytics area and choose the date range you need.",
-        "Look for an Export or Download option, then ask an admin to check your role and plan access if it is missing.",
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
         "If it still does not work, contact support at 1-800-555-0100 and include the cited ticket details.",
     )
+    assert result.items[0]["answer_evidence_status"] == "draft_needs_review"
+    assert result.items[0]["resolution_source_count"] == 0
     assert result.items[0]["failure_risk_score"] == 1
     assert result.items[0]["failure_risk_signals"] == ("blocked_access",)
     assert result.items[0]["opportunity_score"] == 4
@@ -175,6 +177,129 @@ def test_build_ticket_faq_markdown_does_not_invent_support_contact() -> None:
 
     assert "contact support at" not in result.markdown.lower()
     assert "If it still does not work, contact support and include the cited ticket details." in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export issue",
+            "evidence": [{
+                "text": "How do I export the attribution dashboard before renewal?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Open Analytics, choose the attribution dashboard, and select "
+                    "Export CSV. Ask an admin to enable Report Downloads if the "
+                    "button is hidden."
+                ),
+            }],
+        }],
+        support_contact="support@example.com",
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Use the uploaded resolution evidence: Open Analytics, choose the "
+        "attribution dashboard, and select Export CSV"
+    )
+    assert item["steps"][1] == (
+        "Confirm the answer matches the customer's account, plan, policy, or "
+        "support record before publishing it."
+    )
+    assert "Draft the customer-facing steps" not in result.markdown
+    assert "support@example.com" in result.markdown
+
+
+def test_build_ticket_faq_markdown_ignores_disposition_resolution_aliases() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export issue",
+            "resolution": "Closed",
+            "answer": "Yes",
+            "solution": "Escalated",
+            "evidence": [{
+                "text": "The reporting dashboard export is missing for my analyst role.",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_source_count"] == 0
+    assert item["steps"][0].startswith("Review the cited ticket evidence")
+    assert "Use the uploaded resolution evidence: Closed" not in result.markdown
+
+
+def test_build_ticket_faq_markdown_uses_resolution_evidence_beyond_display_rows() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Export issue",
+                "evidence": [{
+                    "text": "How do I export the attribution dashboard?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Export issue",
+                "evidence": [{
+                    "text": "The dashboard export is missing for analysts.",
+                    "source_id": "ticket-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Enable Report Downloads for the analyst role.",
+                }],
+            },
+        ],
+        max_evidence_per_item=1,
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_source_count"] == 1
+    assert item["steps"][0] == (
+        "Use the uploaded resolution evidence: Enable Report Downloads for the analyst role"
+    )
+
+
+def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Login reset",
+                "evidence": [{
+                    "text": "I cannot reset my password.",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Send the reset email from Account Settings.",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Login reset",
+                "evidence": [{
+                    "text": "How do I reset my password?",
+                    "source_id": "ticket-2",
+                    "source_type": "support_ticket",
+                    "resolution_text": "Send the reset email from Account Settings.",
+                }],
+            },
+        ]
+    )
+
+    item = result.items[0]
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_source_count"] == 2
+    assert len([step for step in item["steps"] if step.startswith("Use the uploaded")]) == 1
 
 
 def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
@@ -773,7 +898,8 @@ def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -
         "condensed": True,
         "has_action_items": True,
     }
-    assert "Open the bill, statement, payment history, or dispute record" in result.markdown
+    assert "Review the cited ticket evidence and confirm the policy-approved answer" in result.markdown
+    assert result.items[0]["answer_evidence_status"] == "draft_needs_review"
     assert "contact support at https://example.com/support" in result.markdown
 
 
@@ -1275,12 +1401,13 @@ def test_build_ticket_faq_markdown_handles_1000_cfpb_style_rows_without_archive(
     assert all(item["question_source"] != "topic_fallback" for item in result.items)
     assert all("XX/XX/2019" not in question for question in questions)
     assert all("allowed ''" not in question for question in questions)
-    assert opening["steps"][0].startswith("Gather the application")
+    assert opening["steps"][0].startswith("Review the cited ticket evidence")
+    assert opening["answer_evidence_status"] == "draft_needs_review"
     assert "Export or Download" not in " ".join(opening["steps"])
     assert "export is missing" not in opening["when_to_contact_support"]
 
 
-def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_account_topics() -> None:
+def test_build_ticket_faq_markdown_uses_financial_contact_guidance_for_cfpb_account_topics() -> None:
     result = build_ticket_faq_markdown(
         [
             {
@@ -1307,7 +1434,8 @@ def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_account_topics(
     )
 
     assert result.items[0]["topic"] == "opening an account"
-    assert result.items[0]["steps"][0].startswith("Gather the application")
+    assert result.items[0]["steps"][0].startswith("Review the cited ticket evidence")
+    assert result.items[0]["answer_evidence_status"] == "draft_needs_review"
     assert "Export or Download" not in result.markdown
     assert "export is missing" not in result.markdown
 
@@ -1373,7 +1501,7 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
     )
     assert any("the field is locked" in paragraph for paragraph in rendered.paragraphs)
     assert any(
-        "Open the reporting or analytics area and choose the date range you need."
+        "Draft the customer-facing steps from a verified help article"
         in item
         for item in rendered.list_items
     )
@@ -1824,7 +1952,7 @@ def test_build_ticket_faq_markdown_accepts_ticket_source_type_alias() -> None:
     assert "I need help with billing." in result.markdown
 
 
-def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_shaped_rows() -> None:
+def test_build_ticket_faq_markdown_uses_financial_support_guidance_for_cfpb_shaped_rows() -> None:
     result = build_ticket_faq_markdown(
         [
             {
@@ -1860,14 +1988,14 @@ def test_build_ticket_faq_markdown_uses_financial_steps_for_cfpb_shaped_rows() -
     )
 
     markdown = result.markdown
-    assert "Open the bill, statement, payment history, or dispute record connected to the issue." in markdown
-    assert "Compare the charge, fee, payment, or balance against your receipt, contract, or written confirmation." in markdown
+    assert "Review the cited ticket evidence and confirm the policy-approved answer" in markdown
+    assert "Draft the customer-facing steps from a verified help article" in markdown
     assert "charge, fee, payment, balance, or dispute still looks wrong" in markdown
     assert "Open your profile, account settings, or login settings" not in markdown
     assert "https://www.consumerfinance.gov/complaint/" in markdown
 
 
-def test_build_ticket_faq_markdown_uses_debt_collection_steps_before_account_steps() -> None:
+def test_build_ticket_faq_markdown_uses_debt_collection_guidance_before_account_guidance() -> None:
     result = build_ticket_faq_markdown(
         [{
             "source_type": "complaint",
@@ -1883,13 +2011,13 @@ def test_build_ticket_faq_markdown_uses_debt_collection_steps_before_account_ste
 
     markdown = result.markdown
     assert result.items[0]["topic"] == "debt collection disputes"
-    assert "Ask the collector in writing to identify the original creditor" in markdown
-    assert "Compare the notice with your payment, settlement, insurance, or provider records" in markdown
+    assert "collector will not validate the debt" in markdown
+    assert "Draft the customer-facing steps from a verified help article" in markdown
     assert "Open your profile, account settings, or login settings" not in markdown
     assert "Open the reporting or analytics area" not in markdown
 
 
-def test_build_ticket_faq_markdown_uses_credit_report_steps_before_reporting_steps() -> None:
+def test_build_ticket_faq_markdown_uses_credit_report_guidance_before_reporting_guidance() -> None:
     result = build_ticket_faq_markdown(
         [{
             "source_type": "complaint",
@@ -1905,8 +2033,8 @@ def test_build_ticket_faq_markdown_uses_credit_report_steps_before_reporting_ste
 
     markdown = result.markdown
     assert result.items[0]["topic"] == "credit report disputes"
-    assert "Get your latest credit reports and mark the account" in markdown
-    assert "File a dispute with the credit bureau and the company that supplied the information" in markdown
+    assert "incorrect after you dispute it" in markdown
+    assert "Draft the customer-facing steps from a verified help article" in markdown
     assert "Open the reporting or analytics area" not in markdown
 
 
@@ -1957,7 +2085,7 @@ def test_build_ticket_faq_markdown_does_not_classify_generic_investigation_as_cr
 
     assert result.items[0]["topic"] == "reporting friction"
     assert result.items[0]["question"] == "How do I export the investigation dashboard report?"
-    assert "Open the reporting or analytics area" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "credit bureau" not in result.markdown
 
 
@@ -1978,7 +2106,7 @@ def test_build_ticket_faq_markdown_does_not_treat_cfpb_report_as_saas_reporting(
     assert result.items[0]["topic"] == "opening an account"
     assert result.items[0]["question_source"] == "customer_wording"
     assert "Open the reporting or analytics area" not in result.markdown
-    assert "Gather the application, account-opening notice" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
 
 
 def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_credit_report_rows(tmp_path: Path) -> None:
@@ -2006,7 +2134,7 @@ def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_credit_report_r
         "condensed": True,
         "has_action_items": True,
     }
-    assert "Get your latest credit reports and mark the account" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "Open the reporting or analytics area" not in result.markdown
 
 
@@ -2030,7 +2158,7 @@ def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_debt_collection
 
     assert result.items[0]["topic"] == "debt collection disputes"
     assert result.output_checks["uses_user_vocabulary"] is True
-    assert "Ask the collector in writing to identify the original creditor" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "Open your profile, account settings, or login settings" not in result.markdown
 
 
@@ -2062,7 +2190,7 @@ def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_mortgage_rows(t
         "condensed": True,
         "has_action_items": True,
     }
-    assert "Gather the mortgage statement, payment history, escrow record" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "Open the bill, statement, payment history, or dispute record" not in result.markdown
 
 
@@ -2089,7 +2217,7 @@ def test_build_ticket_faq_markdown_does_not_treat_generic_loan_modification_as_m
     assert result.items[0]["topic"] == "billing and payments"
     assert "mortgage servicer" not in result.markdown
     assert "Gather the mortgage statement" not in result.markdown
-    assert "Open the bill, statement, payment history, or dispute record" in result.markdown
+    assert "Draft the customer-facing steps from a verified help article" in result.markdown
 
 
 def test_build_ticket_faq_markdown_rejects_complaint_process_boilerplate_question() -> None:
@@ -2230,7 +2358,8 @@ def test_build_ticket_faq_markdown_separates_contact_complaints_from_billing_dis
     ]
     assert result.items[0]["source_ids"] == ("cfpb:3442136",)
     assert result.items[1]["source_ids"] == ("cfpb:3584679",)
-    assert "Save the call log" in result.items[1]["steps"][0]
+    assert "Review the cited ticket evidence" in result.items[1]["steps"][0]
+    assert result.items[1]["answer_evidence_status"] == "draft_needs_review"
     assert "keeps contacting you" in result.items[1]["when_to_contact_support"]
 
 

--- a/tests/test_smoke_content_ops_cfpb_faq_markdown.py
+++ b/tests/test_smoke_content_ops_cfpb_faq_markdown.py
@@ -107,7 +107,7 @@ def test_cfpb_faq_smoke_builds_grounded_markdown(monkeypatch, tmp_path: Path) ->
     assert payload["source_profile"]["missing_narrative_count"] == 2
     markdown = (tmp_path / "cfpb_faq.md").read_text(encoding="utf-8")
     assert "What should I do if I was charged overdraft fees" in markdown
-    assert "Open the bill, statement, payment history, or dispute record" in markdown
+    assert "Review the cited ticket evidence and confirm the policy-approved answer" in markdown
 
 
 def test_cfpb_faq_smoke_fails_when_fetch_returns_too_few_rows(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Answer-Step-Grounding.md
Slice phase: Production hardening

Hardens the FAQ generator so concrete action steps are grounded in uploaded resolution evidence. When source rows only describe the problem, the FAQ artifact now renders explicit draft/review steps instead of intent-template end-user instructions, while preserving topic, scoring, source, support, and vocabulary-gap behavior.

## Intentional
- Keep FAQ generation deterministic and extractive; no LLM, policy inference, or detector expansion.
- Keep no-resolution output actionable for the operator by telling them what to verify before publishing.
- Remove the old template action-rule table so unsupported instructions are not left reachable through JSON metadata.
- Do not treat bare upload columns like resolution, answer, or solution as resolution evidence because they can be disposition or survey values.

## Deferred
- Rich resolution parsing from long chat transcripts is deferred; this slice only uses structured resolution-style fields already present on rows.
- Hosted UI display for answer_evidence_status is deferred until the frontend consumes FAQ item metadata.
- The older FAQ scale/backpressure item remains parked; this slice only closes the answer-step grounding item.

## Verification
- python -m pytest tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py -q — 145 passed
- bash scripts/run_extracted_pipeline_checks.sh — 2421 passed, 5 skipped, 1 warning
- python -m py_compile extracted_content_pipeline/ticket_faq_markdown.py tests/test_extracted_ticket_faq_markdown.py tests/test_smoke_content_ops_cfpb_faq_markdown.py — passed
- python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Answer-Step-Grounding.md — passed
- git diff --check — passed
- bash scripts/validate_extracted_content_pipeline.sh — passed
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed
- bash scripts/check_ascii_python.sh — passed
- bash scripts/local_pr_review.sh — passed

## Diff size
5 files, +368 / -99