### PR TITLE
Validate support-ticket descriptive blog live generation

### DIFF
--- a/ATLAS-HARDENING.md
+++ b/ATLAS-HARDENING.md
@@ -27,6 +27,16 @@ parked and note in the plan's Deferred.
 
 ## Parked Items
 
+## 2026-05-26
+
+### Support-ticket descriptive blog output is long and repetitive on tiny uploads
+- File/location: `atlas_brain/skills/digest/blog_post_generation.md` and `extracted_content_pipeline/skills/digest/blog_post_generation.md`, support-ticket descriptive draft path.
+- Description: The live Haiku validation saved a truth-safe support-ticket blog from a 4-row upload, but the article repeated similar sections and used 10k+ output tokens.
+- Why it matters: The current output is acceptable for truthfulness validation, but small support-ticket uploads need tighter length/section guidance so review drafts are cheaper, easier to edit, and less repetitive.
+- Effort: S
+- Category: polish
+- Found during: PR-Support-Ticket-Descriptive-Blog-Live-Validation.
+
 ## 2026-05-22
 
 ### Some posts DECLARE excluded sources (Capterra/Trustpilot) in their methodology/corpus list

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-26
-
-### Support-ticket descriptive blog output is long and repetitive on tiny uploads
-- File/location: `atlas_brain/skills/digest/blog_post_generation.md` and `extracted_content_pipeline/skills/digest/blog_post_generation.md`, support-ticket descriptive draft path.
-- Description: The live Haiku validation saved a truth-safe support-ticket blog from a 4-row upload, but the article repeated similar sections and used 10k+ output tokens.
-- Why it matters: The current output is acceptable for truthfulness validation, but small support-ticket uploads need tighter length/section guidance so review drafts are cheaper, easier to edit, and less repetitive.
-- Effort: S
-- Category: polish
-- Owner/session: content-ops/support-ticket-provider-descriptive-blog-live-validation
-- Found during: PR-Support-Ticket-Descriptive-Blog-Live-Validation.
-
 ## 2026-05-23
 
 ### FAQSCALE-1 - Large synchronous FAQ generation needs hosted limits / backpressure / background execution

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-26
+
+### Support-ticket descriptive blog output is long and repetitive on tiny uploads
+- File/location: `atlas_brain/skills/digest/blog_post_generation.md` and `extracted_content_pipeline/skills/digest/blog_post_generation.md`, support-ticket descriptive draft path.
+- Description: The live Haiku validation saved a truth-safe support-ticket blog from a 4-row upload, but the article repeated similar sections and used 10k+ output tokens.
+- Why it matters: The current output is acceptable for truthfulness validation, but small support-ticket uploads need tighter length/section guidance so review drafts are cheaper, easier to edit, and less repetitive.
+- Effort: S
+- Category: polish
+- Owner/session: content-ops/support-ticket-provider-descriptive-blog-live-validation
+- Found during: PR-Support-Ticket-Descriptive-Blog-Live-Validation.
+
 ## 2026-05-23
 
 ### FAQSCALE-1 - Large synchronous FAQ generation needs hosted limits / backpressure / background execution

--- a/docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md
+++ b/docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md
@@ -113,7 +113,7 @@ cluster explanations and used more than 10k output tokens. This is not a
 truthfulness blocker for this validation, but it should be tightened before the
 product experience is polished.
 
-Parked in `HARDENING.md`:
+Parked in `ATLAS-HARDENING.md`:
 
 - `Support-ticket descriptive blog output is long and repetitive on tiny uploads`
 
@@ -124,4 +124,3 @@ Parked in `HARDENING.md`:
 - Explicit generated-content evaluator rerun - passed.
 - Manual copy audit for unsupported outcomes, unsupported timeframes/cadence,
   and concrete answer steps without resolution evidence - passed.
-

--- a/docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md
+++ b/docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md
@@ -1,0 +1,127 @@
+# Support-Ticket Descriptive Blog Live Validation - 2026-05-26
+
+## Scope
+
+This validation reran the live Content Ops support-ticket blog-post path after
+PR #983 changed the no-outcome/no-resolution blog contract from promissory to
+descriptive.
+
+The goal was to prove the real route can now save a grounded support-ticket
+blog draft from uploaded-ticket context instead of failing closed or saving
+unsupported benefit claims.
+
+Environment:
+
+- Repo: `/home/juan-canfield/Desktop/Atlas-support-ticket-provider`
+- Env files:
+  - `/home/juan-canfield/Desktop/Atlas/.env`
+  - `/home/juan-canfield/Desktop/Atlas/.env.local`
+  - `tmp/support_ticket_live_haiku_eval_20260525/haiku.env`
+- Artifact directory:
+  - `tmp/support_ticket_descriptive_blog_live_validation_20260526`
+- Model override:
+  - Claude Haiku family through OpenRouter
+
+Source input:
+
+- `extracted_content_pipeline/examples/support_ticket_sources.csv`
+- 4 uploaded support-ticket rows
+- 2 direct customer questions
+- 2 ticket clusters:
+  - `email and profile updates` - 2 tickets
+  - `reporting friction` - 2 tickets
+- No dated window
+- No measured outcomes
+- No verified resolution evidence
+
+## Command
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_descriptive_blog_live_validation_20260526_blog \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-draft.json \
+  --output-result tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+Explicit evaluator rerun:
+
+```bash
+python scripts/evaluate_support_ticket_generated_content.py \
+  --output blog_post \
+  tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-draft.json \
+  --pretty
+```
+
+## Result
+
+Live Haiku blog generation passed and saved one draft.
+
+- Saved draft id: `3e9de393-2eb6-4afd-b2a0-62d77a11dd87`
+- Draft title:
+  `Support-Ticket Questions Customers Keep Asking: What Your Uploaded Tickets Reveal`
+- SEO/AEO readiness: ready
+- GEO readiness: ready
+- Generated-content evaluation: passed
+- Source count visibility: passed with visible counts `4`, `4`, and `2`
+- Matched source signals:
+  - `email and profile updates`
+  - `reporting friction`
+  - `How do I change my login email?`
+  - `How do we export campaign attribution data before renewal?`
+
+Generation usage:
+
+- Input tokens: 23,153
+- Output tokens: 10,315
+- Cache write tokens: 18,684
+- Cached tokens: 4,460
+- Billable input tokens: 9
+
+## Manual Audit
+
+The saved draft is source-truthful for the support-ticket evidence contract:
+
+- It uses the uploaded-ticket source period and does not invent a calendar
+  window or recurring cadence.
+- It cites the real uploaded counts: 4 rows, 2 clusters, and 2 tickets per
+  cluster.
+- It preserves customer wording from the source rows.
+- It does not make percentage, ROI, churn, retention, ticket-volume, capacity,
+  or time-savings claims.
+- It keeps verified-resolution content as a review-needed placeholder:
+  `Draft answer - support team should add the verified resolution before publishing.`
+- It does not include concrete UI paths or exact product steps when
+  `support_ticket_resolution_evidence_present` is false.
+
+The draft does contain operational review advice such as verifying feature
+availability, UI accuracy, permissions, completeness, and clarity before
+publishing. That is acceptable because it is guidance for the support team to
+verify answers, not a claim that the uploaded tickets contain verified product
+resolution steps.
+
+## Parked Polish
+
+The output is safe but long and repetitive for a 4-row upload. It repeats some
+cluster explanations and used more than 10k output tokens. This is not a
+truthfulness blocker for this validation, but it should be tightened before the
+product experience is polished.
+
+Parked in `HARDENING.md`:
+
+- `Support-ticket descriptive blog output is long and repetitive on tiny uploads`
+
+## Verification
+
+- Live Haiku blog-post smoke with support-ticket CSV and generated-content
+  evaluation - passed.
+- Explicit generated-content evaluator rerun - passed.
+- Manual copy audit for unsupported outcomes, unsupported timeframes/cadence,
+  and concrete answer steps without resolution evidence - passed.
+

--- a/plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md
+++ b/plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md
@@ -1,0 +1,110 @@
+# PR: Support-Ticket Descriptive Blog Live Validation
+
+## Why this slice exists
+
+PR #983 changed the support-ticket blog contract so no-outcome/no-resolution
+ticket uploads can produce a descriptive article instead of either saving
+unsupported claims or failing closed. Unit and service tests proved the new
+contract deterministically, but the live route still needs to prove the real
+Haiku generation path can produce and save a grounded support-ticket blog draft
+from the packaged CSV.
+
+This slice is the live validation follow-up named in #983. It exercises the
+host DB pool, support-ticket input provider, packaged skills, pipeline-routed
+LLM, save path, export path, and generated-content evaluator together.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider-descriptive-blog-live-validation
+Slice phase: Functional validation
+
+1. Run a live Claude Haiku blog-post smoke with the packaged support-ticket CSV.
+2. Export the saved draft if one is produced.
+3. Run the deterministic support-ticket generated-content evaluation against
+   the saved export.
+4. Manually inspect the saved draft or blocked candidate for the contract
+   classes this lane protects:
+   - unsupported support-volume, churn, retention, time-savings, or speed claims
+   - unsupported date-window or cadence claims
+   - concrete answer steps without resolution evidence
+   - copied guardrail language instead of reader-facing descriptive prose
+5. Record commands, artifact paths, result, and follow-up in a validation doc.
+6. If live output exposes a data-truthfulness blocker, fix it in this PR. If it
+   exposes only non-blocking product polish, park it in the appropriate
+   hardening file.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md` | Plan doc for this live validation slice. |
+| `docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md` | Live Haiku validation record. |
+| `HARDENING.md` | Park non-blocking product polish found during live validation. |
+
+## Mechanism
+
+Use the existing live smoke harness with the Haiku override:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_descriptive_blog_live_validation_20260526_blog \
+  --support-ticket-csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-draft.json \
+  --output-result tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+The saved JSON artifacts stay under `tmp/`; the committed validation doc records
+their paths and summarizes the result. The slice succeeds if the live path
+either saves a draft that passes the generated-content evaluator or blocks a
+misleading candidate before save.
+
+## Intentional
+
+- This is validation, not another prompt or evaluator redesign unless live
+  output proves a truthfulness blocker.
+- The run uses Haiku because it is the cheaper and stricter stress case for
+  this lane.
+- This does not add FAQ Article output or customer-language keyword promotion;
+  that future product slice was logged in #983.
+
+## Deferred
+
+- Parked hardening: `Support-ticket descriptive blog output is long and
+  repetitive on tiny uploads`.
+- Broader support-ticket acceptance testing across many real customer CSV
+  shapes remains a later robust-testing slice.
+- Customer-language keyword promotion and standalone FAQ Article output remain
+  a future product slice owned outside this validation PR.
+
+## Verification
+
+Planned:
+
+- Live Haiku blog-post smoke with support-ticket CSV and generated-content
+  evaluation - passed; saved draft id
+  `3e9de393-2eb6-4afd-b2a0-62d77a11dd87`.
+- Manual copy audit of the saved draft - passed for source-truthfulness;
+  parked long/repetitive article shape as polish.
+- `python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-draft.json --pretty`
+  - passed.
+- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q`
+  - `42 passed`.
+- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py tests/test_extracted_blog_generation.py tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_content_ops_live_execute_harness.py -q`
+  - `118 passed`.
+- `bash scripts/local_pr_review.sh --current-pr-body-file <PR body file>`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~115 |
+| Validation doc | ~150 |
+| Hardening note | ~10 |
+| **Total** | **~275** |

--- a/plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md
+++ b/plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md
@@ -39,7 +39,7 @@ Slice phase: Functional validation
 |---|---|
 | `plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md` | Plan doc for this live validation slice. |
 | `docs/extraction/validation/support_ticket_descriptive_blog_live_validation_2026-05-26.md` | Live Haiku validation record. |
-| `HARDENING.md` | Park non-blocking product polish found during live validation. |
+| `ATLAS-HARDENING.md` | Park non-blocking blog polish found during live validation. |
 
 ## Mechanism
 


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Descriptive-Blog-Live-Validation.md
Slice phase: Functional validation

This PR records the live Haiku follow-up after #983: the real support-ticket blog path now saves a descriptive, source-truthful draft from the packaged CSV, the generated-content evaluator passes, and the only issue found is parked as polish because the small-upload draft is long and repetitive.

## Intentional
- This is validation, not another prompt/evaluator redesign; the live output passed the truthfulness contract.
- Haiku remains the model for this proof because it is the cheaper and stricter stress case.
- FAQ Article output and customer-language keyword promotion stay deferred as a future product slice.

## Deferred
- Broader support-ticket acceptance testing across many real customer CSV shapes remains a later robust-testing slice.
- Customer-language keyword promotion and standalone FAQ Article output remain a future product slice.

## Parked hardening
- `Support-ticket descriptive blog output is long and repetitive on tiny uploads` in `ATLAS-HARDENING.md`.

## Verification
- Live Haiku blog-post smoke with support-ticket CSV and generated-content evaluation -> passed; saved draft `3e9de393-2eb6-4afd-b2a0-62d77a11dd87`.
- Manual copy audit -> passed for source truthfulness.
- `python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_descriptive_blog_live_validation_20260526/blog-post-draft.json --pretty` -> passed.
- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q` -> 42 passed.
- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py tests/test_extracted_blog_generation.py tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_content_ops_live_execute_harness.py -q` -> 118 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-support-ticket-descriptive-blog-live-body.md` -> passed.

## Diff size
3 files, +246 / -0.