### PR TITLE
FAQ search cleanup rowcount gate

### DIFF
--- a/plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md
+++ b/plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md
@@ -1,0 +1,83 @@
+# PR-FAQ-Search-Cleanup-Rowcount-Gate
+
+## Why this slice exists
+
+#971 made the seeded hosted FAQ search e2e report both requested cleanup IDs and
+the actual Postgres delete rowcount, but deliberately left rowcount mismatch as
+visibility-only. Now that the seeded search-to-detail e2e is the live
+correctness path for the FAQ search route, cleanup must fail closed when it
+cannot prove every seeded FAQ row was deleted.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening.
+
+1. Make seeded FAQ cleanup fail when the asyncpg `DELETE N` tag is malformed.
+2. Make seeded FAQ cleanup fail when `N` differs from the requested unique FAQ
+   ID count.
+3. Keep the cleanup result compact and explicit: requested count, deleted count,
+   raw delete status, and a diagnostic error.
+4. Add focused negative fixtures for malformed status and rowcount mismatch.
+
+### Files touched
+
+- `plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+
+## Mechanism
+
+`_cleanup_seeded_faqs(...)` already executes an ID-scoped delete and parses the
+asyncpg command tag through `_deleted_row_count(...)`. This slice makes that
+parsed count load-bearing:
+
+```python
+row_count = _deleted_row_count(delete_status)
+ok = row_count == requested_faq_ids
+```
+
+Malformed tags produce `deleted_faq_ids: None` and `ok: False`. Mismatched tags
+produce `ok: False` with the actual parsed count. The top-level e2e already
+includes `cleanup["ok"]` in its final status, so no separate orchestration
+change is needed.
+
+## Intentional
+
+- No broader delete scope is added; cleanup still deletes only FAQ IDs emitted
+  by the seed smoke cleanup manifest.
+- No live hosted route behavior changes; this is an operator/test runner
+  hardening slice.
+- No retry loop is added. A mismatch means the e2e cannot prove cleanup
+  completed, so the result should fail and preserve the diagnostic.
+- Local review's cross-layer caller hints were noisy test-local `FakePool`
+  matches; `_cleanup_seeded_faqs(...)` is only called by this runner and its
+  focused tests.
+
+## Deferred
+
+- Parked hardening: none.
+- Cleanup retry/backoff remains deferred until a real transient-delete failure
+  is observed; this slice only makes existing proof strict.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q`
+  - 47 passed.
+- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+  - passed.
+- `git diff --check` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md`
+  - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `ATLAS_CURRENT_PR_BODY_FILE=/tmp/atlas-faq-search-cleanup-rowcount-gate-pr-body.md bash scripts/local_pr_review.sh`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 83 |
+| Seeded E2E runner | 22 |
+| Tests | 41 |
+| **Total** | **146** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -363,10 +363,30 @@ async def _cleanup_seeded_faqs(database_url: str, faq_ids: Sequence[str]) -> dic
             "delete_status": delete_status,
             "error": f"{type(exc).__name__}: {exc}",
         }
+    deleted_faq_ids = _deleted_row_count(delete_status)
+    if deleted_faq_ids is None:
+        return {
+            "ok": False,
+            "requested_faq_ids": requested_faq_ids,
+            "deleted_faq_ids": None,
+            "delete_status": delete_status,
+            "error": f"cleanup delete status is not parseable: {delete_status!r}",
+        }
+    if deleted_faq_ids != requested_faq_ids:
+        return {
+            "ok": False,
+            "requested_faq_ids": requested_faq_ids,
+            "deleted_faq_ids": deleted_faq_ids,
+            "delete_status": delete_status,
+            "error": (
+                "cleanup deleted "
+                f"{deleted_faq_ids} FAQ rows but requested {requested_faq_ids}"
+            ),
+        }
     return {
         "ok": True,
         "requested_faq_ids": requested_faq_ids,
-        "deleted_faq_ids": _deleted_row_count(delete_status),
+        "deleted_faq_ids": deleted_faq_ids,
         "delete_status": delete_status,
         "error": None,
     }

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -321,7 +321,7 @@ async def test_cleanup_seeded_faqs_reports_actual_delete_rowcount(monkeypatch):
 
         async def execute(self, _query, faq_ids):
             self.deleted_ids = faq_ids
-            return "DELETE 1"
+            return "DELETE 2"
 
         async def close(self):
             self.closed = True
@@ -344,8 +344,8 @@ async def test_cleanup_seeded_faqs_reports_actual_delete_rowcount(monkeypatch):
     assert payload == {
         "ok": True,
         "requested_faq_ids": 2,
-        "deleted_faq_ids": 1,
-        "delete_status": "DELETE 1",
+        "deleted_faq_ids": 2,
+        "delete_status": "DELETE 2",
         "error": None,
     }
     assert fake_pool.deleted_ids == [
@@ -353,6 +353,37 @@ async def test_cleanup_seeded_faqs_reports_actual_delete_rowcount(monkeypatch):
         "22222222-2222-2222-2222-222222222222",
     ]
     assert fake_pool.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_seeded_faqs_fails_when_delete_rowcount_mismatches(monkeypatch):
+    class FakePool:
+        async def execute(self, _query, _faq_ids):
+            return "DELETE 1"
+
+        async def close(self):
+            return None
+
+    async def _create_pool(**_kwargs):
+        return FakePool()
+
+    monkeypatch.setitem(sys.modules, "asyncpg", SimpleNamespace(create_pool=_create_pool))
+
+    payload = await smoke._cleanup_seeded_faqs(
+        "postgresql://example",
+        [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ],
+    )
+
+    assert payload == {
+        "ok": False,
+        "requested_faq_ids": 2,
+        "deleted_faq_ids": 1,
+        "delete_status": "DELETE 1",
+        "error": "cleanup deleted 1 FAQ rows but requested 2",
+    }
 
 
 @pytest.mark.asyncio
@@ -375,11 +406,11 @@ async def test_cleanup_seeded_faqs_surfaces_malformed_delete_status(monkeypatch)
     )
 
     assert payload == {
-        "ok": True,
+        "ok": False,
         "requested_faq_ids": 1,
         "deleted_faq_ids": None,
         "delete_status": "UPDATE 1",
-        "error": None,
+        "error": "cleanup delete status is not parseable: 'UPDATE 1'",
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md
Slice phase: Production hardening

Makes the seeded hosted FAQ search e2e fail closed when cleanup cannot prove every seeded FAQ row was deleted. The runner already parsed the asyncpg DELETE rowcount; this turns malformed tags and rowcount mismatches from visibility-only diagnostics into the cleanup gate that drives the final e2e status.

## Intentional
- Cleanup still deletes only FAQ IDs emitted by the seed smoke cleanup manifest.
- No live hosted route behavior changes; this is operator/test runner hardening.
- No retry loop; mismatches preserve diagnostics and fail the run.
- Local review's cross-layer caller hints are noisy test-local FakePool matches; _cleanup_seeded_faqs(...) is only called by this runner and its focused tests.

## Deferred
- Cleanup retry/backoff remains deferred until a real transient-delete failure is observed.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 47 passed
- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py - passed
- git diff --check - passed
- python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Search-Cleanup-Rowcount-Gate.md - passed
- bash scripts/check_ascii_python.sh - passed
- ATLAS_CURRENT_PR_BODY_FILE=/tmp/atlas-faq-search-cleanup-rowcount-gate-pr-body.md bash scripts/local_pr_review.sh - passed

## Diff size
3 files, +140 / -6
