### PR TITLE
Document generated FAQ report contract

### DIFF
--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -1,0 +1,144 @@
+# Content Ops FAQ Report Contract
+
+This is the frontend/demo handoff for generated support-ticket FAQ reports.
+The canonical producer is
+`extracted_content_pipeline.ticket_faq_markdown.TicketFAQMarkdownResult.as_dict()`.
+
+Use this contract for Content Ops `faq_markdown` execute results, persisted FAQ
+detail hydration, and landing-page demos that render the full generated FAQ
+artifact.
+
+Do not use the compact search result row as the full report. Search returns a
+ranked match preview; detail hydration returns the generated report.
+
+## Generated Report
+
+```ts
+type TicketFAQMarkdownResult = {
+  generated: number;
+  markdown: string;
+  items: TicketFAQItem[];
+  source_count: number;
+  ticket_source_count: number;
+  output_checks: {
+    uses_user_vocabulary: boolean;
+    condensed: boolean;
+    has_action_items: boolean;
+  };
+  warnings: Array<Record<string, unknown>>;
+  saved_ids: string[];
+};
+```
+
+## FAQ Item
+
+```ts
+type TicketFAQItem = {
+  topic: string;
+  question: string;
+  question_source: "customer_wording" | "source_policy";
+  summary: string;
+
+  frequency: number;
+  weighted_frequency: number;
+  ticket_count: number;
+  opportunity_score: number;
+  failure_risk_score: number;
+  failure_risk_signals: string[];
+
+  answer: string;
+  steps: string[];
+  action_items: string[];
+  answer_evidence_status: "resolution_evidence" | "draft_needs_review";
+  resolution_source_count: number;
+  when_to_contact_support: string;
+
+  evidence_quotes: string[];
+  source_ids: string[];
+  source_labels: string[];
+  source_type_counts: Record<string, number>;
+  weighted_source_volume_by_type: Record<string, number>;
+
+  term_mappings: FAQTermMapping[];
+
+  evidence_count: number;
+  displayed_evidence_count: number;
+};
+
+type FAQTermMapping = {
+  customer_term: string;
+  documentation_term: string;
+  suggestion: string;
+  source_id_count: number;
+  zero_result_source_count: number;
+  failure_risk_score: number;
+  failure_risk_signals: string[];
+  opportunity_score: number;
+  first_source_id: string;
+};
+```
+
+## Persisted Detail
+
+The detail route returns the persisted draft wrapper. Its `items` and `markdown`
+fields are the same generated report artifact.
+
+```ts
+type TicketFAQDraft = {
+  account_id: string;
+  id: string;
+  status: string;
+  target_id: string;
+  target_mode: string;
+  title: string;
+  markdown: string;
+  items: TicketFAQItem[];
+  source_count: number;
+  ticket_source_count: number;
+  output_checks: Record<string, boolean>;
+  warnings: Array<Record<string, unknown>>;
+  metadata: Record<string, unknown>;
+};
+```
+
+## Compact Search Result
+
+Search is intentionally smaller. Use `faq_id` from a selected result to hydrate
+the full report detail.
+
+```ts
+type TicketFAQSearchResponse = {
+  query: string;
+  count: number;
+  results: Array<{
+    account_id: string;
+    corpus_id: string;
+    faq_id: string;
+    target_id: string;
+    target_mode: string;
+    status: string;
+    rank: number;
+    topic: string;
+    question: string;
+    answer_summary: string;
+    source_ids: string[];
+    ticket_count: number;
+    score: number;
+  }>;
+};
+```
+
+## Rendering Guidance
+
+- Use `items` for ranked cards or sections, and `markdown` for the full report.
+- Show `source_count`, `ticket_source_count`, and `output_checks` as proof badges.
+- Show `answer_evidence_status` near steps. `draft_needs_review` means the
+  system found repeated customer wording but no uploaded resolution evidence, so
+  the generated steps are review placeholders.
+- Show `term_mappings` as vocabulary-gap suggestions. These are grounded in the
+  supplied documentation terms/rules and customer wording.
+- Treat `source_ids` and `evidence_quotes` as proof links/footnotes, not primary
+  marketing copy.
+
+See [`content_ops_faq_report_example.json`](./content_ops_faq_report_example.json)
+for a current compact example.

--- a/docs/frontend/content_ops_faq_report_example.json
+++ b/docs/frontend/content_ops_faq_report_example.json
@@ -1,0 +1,122 @@
+{
+  "generated": 2,
+  "items": [
+    {
+      "action_items": [
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "answer": "Customers mention: \"How do I export attribution report?\" Evidence comes from 1 ticket source(s).",
+      "answer_evidence_status": "draft_needs_review",
+      "displayed_evidence_count": 1,
+      "evidence_count": 1,
+      "evidence_quotes": [
+        "`search-export-1`: \"How do I export attribution report?\""
+      ],
+      "failure_risk_score": 1,
+      "failure_risk_signals": [
+        "zero_result_search"
+      ],
+      "frequency": 20,
+      "opportunity_score": 40,
+      "question": "How do I export attribution report?",
+      "question_source": "customer_wording",
+      "resolution_source_count": 0,
+      "source_ids": [
+        "search-export-1"
+      ],
+      "source_labels": [
+        "`search-export-1`"
+      ],
+      "source_type_counts": {
+        "search_log": 1
+      },
+      "steps": [
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "summary": "A customer asked about reporting friction: \"How do I export attribution report?\". This FAQ should answer the request directly and tell the user exactly what to try next.",
+      "term_mappings": [
+        {
+          "customer_term": "export",
+          "documentation_term": "Download report",
+          "failure_risk_score": 1,
+          "failure_risk_signals": [
+            "zero_result_search"
+          ],
+          "first_source_id": "search-export-1",
+          "opportunity_score": 40,
+          "source_id_count": 1,
+          "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+          "zero_result_source_count": 1
+        }
+      ],
+      "ticket_count": 1,
+      "topic": "reporting friction",
+      "weighted_frequency": 20,
+      "weighted_source_volume_by_type": {
+        "search_log": 20
+      },
+      "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
+    },
+    {
+      "action_items": [
+        "Use the uploaded resolution evidence: Open account settings, choose Profile, update the email address, then confirm the verification email",
+        "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "answer": "Customers mention: \"How do I change my email?\" / \"I need to update the email on my account.\" Evidence comes from 2 ticket source(s).",
+      "answer_evidence_status": "resolution_evidence",
+      "displayed_evidence_count": 2,
+      "evidence_count": 2,
+      "evidence_quotes": [
+        "`ticket-email-1` - Email update: \"How do I change my email?\"",
+        "`ticket-email-2` - Email settings: \"I need to update the email on my account.\""
+      ],
+      "failure_risk_score": 0,
+      "failure_risk_signals": [],
+      "frequency": 2,
+      "opportunity_score": 2,
+      "question": "How do I change my email?",
+      "question_source": "customer_wording",
+      "resolution_source_count": 2,
+      "source_ids": [
+        "ticket-email-1",
+        "ticket-email-2"
+      ],
+      "source_labels": [
+        "`ticket-email-1` - Email update",
+        "`ticket-email-2` - Email settings"
+      ],
+      "source_type_counts": {
+        "support_ticket": 2
+      },
+      "steps": [
+        "Use the uploaded resolution evidence: Open account settings, choose Profile, update the email address, then confirm the verification email",
+        "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "summary": "Customers are asking about email and profile updates across 2 ticket sources. The clearest customer wording is \"How do I change my email?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+      "term_mappings": [],
+      "ticket_count": 2,
+      "topic": "email and profile updates",
+      "weighted_frequency": 2,
+      "weighted_source_volume_by_type": {
+        "support_ticket": 2
+      },
+      "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives."
+    }
+  ],
+  "markdown": "# Support Ticket FAQ Report\n\n_Source rows analyzed: 5. Ticket sources used: 5._\n\n## 1. How do I export attribution report?\n\nA customer asked about reporting friction: \"How do I export attribution report?\". This FAQ should answer the request directly and tell the user exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 1 source(s); 1 zero-result search source(s); mapping score 40.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `search-export-1`: \"How do I export attribution report?\"\n\n## 2. How do I change my email?\n\nCustomers are asking about email and profile updates across 2 ticket sources. The clearest customer wording is \"How do I change my email?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+  "output_checks": {
+    "condensed": true,
+    "has_action_items": true,
+    "uses_user_vocabulary": true
+  },
+  "saved_ids": [],
+  "source_count": 5,
+  "ticket_source_count": 5,
+  "warnings": []
+}

--- a/plans/PR-FAQ-Report-Contract-Example.md
+++ b/plans/PR-FAQ-Report-Contract-Example.md
@@ -1,0 +1,79 @@
+# PR-FAQ-Report-Contract-Example
+
+## Why this slice exists
+
+The FAQ generator and search/detail route now produce a stable full FAQ report
+shape, and a parallel landing-page session needs that shape for truthful demo
+wiring. Right now the contract is discoverable only by reading Python
+dataclasses, builder output, and tests. This slice adds a checked-in handoff doc
+and current JSON example generated from the canonical builder.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Product polish.
+
+1. Document the generated FAQ report result shape used by execute, persistence,
+   detail hydration, and landing-page rendering.
+2. Add a compact generated JSON example from the current deterministic FAQ
+   builder.
+3. Add a focused fixture test that keeps the checked-in example parseable and
+   aligned to the documented core keys.
+4. Keep the example scoped to frontend/demo consumption; no runtime behavior or
+   API schema changes.
+
+### Files touched
+
+- `plans/PR-FAQ-Report-Contract-Example.md`
+- `docs/frontend/content_ops_faq_report_contract.md`
+- `docs/frontend/content_ops_faq_report_example.json`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+## Mechanism
+
+The doc names the canonical producer (`TicketFAQMarkdownResult.as_dict()`), the
+persisted detail wrapper (`TicketFAQDraft.as_dict()`), and the compact search
+projection envelope. The JSON example is generated from representative
+support-ticket and search-log rows using `build_ticket_faq_markdown(...)`, then
+trimmed to the fields a frontend/demo needs to render proof cards and the full
+report preview. The focused test parses the JSON and asserts the documented core
+item fields, evidence status values, output checks, and doc-to-example link.
+
+## Intentional
+
+- No generated FAQ code changes; this is a handoff artifact for downstream UI
+  work.
+- The search route remains compact. Full report rendering should use the detail
+  route or execute result, not the search result row alone.
+- The example uses synthetic ticket/search IDs and an example support URL; it is
+  not customer data.
+
+## Deferred
+
+- Parked hardening: none.
+- A formal OpenAPI/schema export remains deferred until the hosted API schema is
+  generated from the FastAPI app.
+
+## Verification
+
+- JSON validation for `docs/frontend/content_ops_faq_report_example.json` -
+  passed.
+- Focused pytest for the contract doc fixture and CI enrollment audit - 11
+  passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed with
+  119 matching tests enrolled.
+- Plan/code consistency audit for this plan - passed.
+- `git diff --check` - passed.
+- Local PR review bundle - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 79 |
+| Contract doc | 144 |
+| JSON example | 122 |
+| CI runner enrollment | 1 |
+| Fixture test | 52 |
+| **Total** | **398** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -26,6 +26,7 @@ pytest \
   tests/test_extracted_campaign_generation_example.py \
   tests/test_extracted_campaign_customer_data.py \
   tests/test_extracted_campaign_source_adapters.py \
+  tests/test_content_ops_faq_report_contract_docs.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_smoke_content_ops_faq_output_proof.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = ROOT / "docs/frontend/content_ops_faq_report_contract.md"
+EXAMPLE_PATH = ROOT / "docs/frontend/content_ops_faq_report_example.json"
+
+
+def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
+    payload = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+    assert payload["generated"] == len(payload["items"])
+    assert isinstance(payload["markdown"], str) and payload["markdown"].startswith("# ")
+    assert payload["source_count"] >= payload["ticket_source_count"] >= 1
+    assert payload["output_checks"] == {
+        "condensed": True,
+        "has_action_items": True,
+        "uses_user_vocabulary": True,
+    }
+
+    required_item_keys = {
+        "answer_evidence_status",
+        "evidence_quotes",
+        "failure_risk_signals",
+        "opportunity_score",
+        "question",
+        "question_source",
+        "source_ids",
+        "steps",
+        "summary",
+        "term_mappings",
+        "topic",
+        "when_to_contact_support",
+    }
+    for item in payload["items"]:
+        assert required_item_keys <= set(item)
+        assert item["question_source"] in {"customer_wording", "source_policy"}
+        assert item["answer_evidence_status"] in {
+            "draft_needs_review",
+            "resolution_evidence",
+        }
+        assert item["steps"]
+        assert item["source_ids"]
+
+
+def test_content_ops_faq_report_contract_links_example() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "content_ops_faq_report_example.json" in doc
+    assert "account_id: string;" in doc
+    assert EXAMPLE_PATH.exists()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Report-Contract-Example.md
Slice phase: Product polish

Adds a frontend-facing generated FAQ report contract and compact current JSON example so landing-page/demo work can render the real report shape without reverse-engineering Python dataclasses.

## Intentional
- No generated FAQ runtime behavior changes.
- Search remains compact; full rendering uses execute results or detail hydration.
- Example data is synthetic and uses example IDs/support URL.

## Deferred
- Formal OpenAPI/schema export remains deferred until the hosted API schema is generated from FastAPI.

## Parked hardening
- None.

## Verification
- JSON validation for docs/frontend/content_ops_faq_report_example.json - passed
- Focused pytest for the contract doc fixture and CI enrollment audit - 11 passed
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed with 119 matching tests enrolled
- Plan/code consistency audit for this plan - passed
- git diff --check - passed
- Local PR review bundle - passed

## Diff size
5 files, +398 / -0
