### PR TITLE
Guard FAQ report contract against producer drift

### DIFF
--- a/plans/PR-FAQ-Report-Contract-Producer-Fidelity.md
+++ b/plans/PR-FAQ-Report-Contract-Producer-Fidelity.md
@@ -1,0 +1,70 @@
+# PR-FAQ-Report-Contract-Producer-Fidelity
+
+## Why this slice exists
+
+PR #988 documented the frontend-facing generated FAQ report shape and shipped a
+compact JSON example for landing-page/demo work. Review accepted the contract
+as accurate, but flagged that the doc test only proved the example matched a
+hardcoded test mirror, not the actual FAQ producer.
+
+This slice closes that drift gap while the contract is new. If
+`build_ticket_faq_markdown` adds, removes, or renames an item field, the
+frontend contract example should fail until the doc/example updates in the same
+change.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Functional validation
+
+1. Derive the expected generated FAQ item key set from
+   `build_ticket_faq_markdown`.
+2. Assert the checked-in frontend JSON example uses the same item field surface
+   as the producer.
+3. Keep the existing semantic checks for output checks, source IDs, question
+   source, and answer evidence status.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-FAQ-Report-Contract-Producer-Fidelity.md` | Plan contract for this validation slice. |
+| `tests/test_content_ops_faq_report_contract_docs.py` | Tie the example item field surface to the real FAQ producer. |
+
+## Mechanism
+
+The contract-doc test builds a small deterministic FAQ result with
+`build_ticket_faq_markdown`, reads the first generated item, and compares its
+keys to every item in `docs/frontend/content_ops_faq_report_example.json`.
+
+The synthetic example values remain checked in for frontend use; only the field
+surface is producer-derived so future producer drift fails closed.
+
+## Intentional
+
+- No generated FAQ runtime behavior changes.
+- No documentation text or JSON example value changes unless the producer field
+  surface is already different.
+- This does not generate the frontend example dynamically; the static artifact
+  remains easy for other sessions to consume.
+
+## Deferred
+
+- Formal OpenAPI/schema export remains deferred until the hosted API schema is
+  generated from FastAPI.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q - 2 passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Report-Contract-Producer-Fidelity.md - passed.
+- git diff --check - passed.
+- Local PR review bundle - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 70 |
+| Test update | 38 |
+| **Total** | **~108** |

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -1,15 +1,52 @@
 import json
 from pathlib import Path
 
+from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+
 
 ROOT = Path(__file__).resolve().parents[1]
 DOC_PATH = ROOT / "docs/frontend/content_ops_faq_report_contract.md"
 EXAMPLE_PATH = ROOT / "docs/frontend/content_ops_faq_report_example.json"
 
 
+def _producer_report_shape() -> tuple[set[str], set[str]]:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "search-export-1",
+                "source_type": "search_log",
+                "text": "How do I export attribution report?",
+                "zero_results": "true",
+                "source_weight": "20",
+            },
+            {
+                "source_id": "ticket-email-1",
+                "source_type": "support_ticket",
+                "source_title": "Email update",
+                "text": "How do I change my email?",
+                "resolution_text": (
+                    "Open account settings, choose Profile, update the email "
+                    "address, then confirm the verification email"
+                ),
+            },
+        ],
+        title="Support Ticket FAQ Report",
+        max_items=2,
+        max_evidence_per_item=2,
+        support_contact="https://example.com/support",
+        documentation_terms=("Download report",),
+        vocabulary_gap_rules=(("export", "download report"),),
+    )
+
+    assert result.items
+    return set(result.as_dict()), set(result.items[0])
+
+
 def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
     payload = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+    producer_payload_keys, producer_item_keys = _producer_report_shape()
 
+    assert set(payload) == producer_payload_keys
     assert payload["generated"] == len(payload["items"])
     assert isinstance(payload["markdown"], str) and payload["markdown"].startswith("# ")
     assert payload["source_count"] >= payload["ticket_source_count"] >= 1
@@ -34,6 +71,7 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
         "when_to_contact_support",
     }
     for item in payload["items"]:
+        assert set(item) == producer_item_keys
         assert required_item_keys <= set(item)
         assert item["question_source"] in {"customer_wording", "source_policy"}
         assert item["answer_evidence_status"] in {


### PR DESCRIPTION
Plan: plans/PR-FAQ-Report-Contract-Producer-Fidelity.md
Slice phase: Functional validation

Adds a producer-fidelity guard for the generated FAQ report contract so the frontend JSON example fails when the real FAQ producer's report field surface changes.

## Intentional
- No generated FAQ runtime behavior changes.
- No documentation text or JSON example value changes unless the producer field surface is already different.
- Static frontend example remains checked in for other sessions to consume.

## Deferred
- Formal OpenAPI/schema export remains deferred until the hosted API schema is generated from FastAPI.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q - 2 passed.
- python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Report-Contract-Producer-Fidelity.md - passed.
- git diff --check - passed.
- Local PR review bundle - passed.

## Diff size
2 files, +108 / -0