### PR TITLE
Use SaaS-shaped FAQ search smoke cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md
+++ b/plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases
+
+## Why this slice exists
+
+The hosted FAQ search smoke currently seeds a generic hit query (`password
+reset`) and a consumer-finance miss query (`escrow shortage`). That is useful
+for route mechanics, but it is a poor default for the support-ticket FAQ product
+lane: a future operator or demo runner can see non-SaaS search language in the
+seeded cases and mistake it for product-facing demo data.
+
+This slice keeps the smoke deterministic while making the seeded hit and miss
+queries B2B SaaS-shaped. It does not build the public on-domain demo corpus;
+that larger sample-source decision remains parked until we are ready.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Functional validation
+
+1. Replace the seeded FAQ search hit query with a B2B SaaS reporting/export
+   support-ticket query.
+2. Replace the seeded miss query with an unrelated but still SaaS-shaped admin
+   query.
+3. Update seeded FAQ document topic, question, answer summary, and search text
+   to match the reporting/export hit.
+4. Update focused smoke tests to assert the new SaaS-shaped cases.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md` | Plan contract for this validation slice. |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | Seed SaaS-shaped hit/miss search cases and matching FAQ document text. |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | Update direct seeded-search smoke assertions. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Update seeded route/detail case assertions. |
+
+## Mechanism
+
+The seed smoke still writes one approved FAQ draft per corpus and projects
+`TicketFAQSearchDocument` rows through the existing repository. Only the fixed
+seed text changes:
+
+- Hit query: `export attribution report`
+- Miss query: `saml domain verification`
+
+The miss remains a SaaS admin query but is absent from the projected
+`search_text`, so the existing require-results and allow-empty route cases still
+exercise both branches.
+
+## Intentional
+
+- No search scoring, API, repository, schema, or route behavior changes.
+- No public demo corpus is added in this slice.
+- CFPB scale and durability validations remain documented separately; this
+  slice only changes the small hosted search smoke seed vocabulary.
+
+## Deferred
+
+- A future demo-corpus slice should create a larger labeled synthetic B2B SaaS
+  support-ticket corpus and guard it against CFPB/consumer-finance leakage.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 63 passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md - passed.
+- git diff --check - passed.
+- Local PR review bundle - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 77 |
+| Smoke seed text | 14 |
+| Tests | 59 |
+| **Total** | **~150** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -31,6 +31,8 @@ SEEDED_FAQ_TARGET_MODE = "support_account"
 SEEDED_FAQ_TITLE = "FAQ Search Smoke"
 SEEDED_FAQ_MARKDOWN = "# FAQ Search Smoke"
 SEEDED_FAQ_STATUS = "approved"
+SEEDED_HIT_QUERY = "export attribution report"
+SEEDED_MISS_QUERY = "saml domain verification"
 
 try:
     from dotenv import load_dotenv
@@ -141,7 +143,7 @@ def _build_cases(
                     account_id=resolved_account_id,
                     corpus_id=corpus_id,
                     faq_id=faq_id,
-                    query="password reset",
+                    query=SEEDED_HIT_QUERY,
                     expected_hit=True,
                 )
             )
@@ -150,7 +152,7 @@ def _build_cases(
                     account_id=resolved_account_id,
                     corpus_id=corpus_id,
                     faq_id=faq_id,
-                    query="escrow shortage",
+                    query=SEEDED_MISS_QUERY,
                     expected_hit=False,
                 )
             )
@@ -246,12 +248,12 @@ def _documents_for_case(case: SearchCase, *, documents_per_corpus: int) -> tuple
                 target_mode="support_account",
                 status="approved",
                 rank=rank,
-                topic="password reset",
-                question=f"How do I reset my password for corpus {case.corpus_id}?",
-                answer_summary="Use the password reset email and contact support if it expires.",
+                topic="reporting export",
+                question=f"How do I export attribution reports for corpus {case.corpus_id}?",
+                answer_summary="Use the reporting export workflow and contact support if the CSV is missing.",
                 source_ids=(f"{case.corpus_id}-ticket-{rank}",),
                 ticket_count=rank,
-                search_text="password reset email login support account",
+                search_text="export attribution report dashboard csv support account",
             )
         )
     return tuple(documents)

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -18,7 +18,7 @@ sys.modules["smoke_content_ops_faq_search_concurrency"] = smoke
 SPEC.loader.exec_module(smoke)
 
 
-def _case(*, query: str = "password reset", expected_hit: bool = True):
+def _case(*, query: str = "export attribution report", expected_hit: bool = True):
     return smoke.SearchCase(
         account_id="acct-1",
         corpus_id="corpus-1",
@@ -41,6 +41,11 @@ def test_build_cases_creates_hit_and_miss_for_each_corpus() -> None:
     assert len({case.account_id for case in cases}) == 2
     assert len({case.corpus_id for case in cases}) == 3
     assert all(case.account_id.startswith("faq-search-abc123-acct-") for case in cases)
+    assert {case.query for case in cases} == {
+        "export attribution report",
+        "saml domain verification",
+    }
+    assert not any("escrow" in case.query for case in cases)
     for corpus_id in {case.corpus_id for case in cases}:
         assert len({case.account_id for case in cases if case.corpus_id == corpus_id}) == 2
 
@@ -65,12 +70,12 @@ def test_documents_for_case_are_ranked_and_scoped() -> None:
     assert {document.corpus_id for document in documents} == {"corpus-1"}
     assert {document.status for document in documents} == {"approved"}
     assert {document.target_mode for document in documents} == {"support_account"}
-    assert all("password reset" in document.search_text for document in documents)
+    assert all("export attribution report" in document.search_text for document in documents)
 
 
 def test_route_case_payload_carries_seeded_hit_and_miss_expectations() -> None:
     payload = smoke._route_case_payload(
-        [_case(), _case(query="escrow shortage", expected_hit=False)],
+        [_case(), _case(query="saml domain verification", expected_hit=False)],
         documents_per_corpus=7,
         limit=5,
     )
@@ -85,7 +90,7 @@ def test_route_case_payload_carries_seeded_hit_and_miss_expectations() -> None:
     assert payload[0]["expected_detail_title"] == "FAQ Search Smoke"
     assert payload[0]["expected_detail_status"] == "approved"
     assert payload[1] == {
-        "query": "escrow shortage",
+        "query": "saml domain verification",
         "corpus_id": "corpus-1",
         "status": "approved",
         "limit": 5,
@@ -106,12 +111,12 @@ def test_write_route_case_file_writes_deterministic_json(tmp_path) -> None:
 def test_cleanup_manifest_payload_carries_all_seeded_ids() -> None:
     cases = [
         _case(),
-        _case(query="escrow shortage", expected_hit=False),
+        _case(query="saml domain verification", expected_hit=False),
         smoke.SearchCase(
             account_id="acct-1",
             corpus_id="corpus-2",
             faq_id="22222222-2222-2222-2222-222222222222",
-            query="password reset",
+            query="export attribution report",
             expected_hit=True,
         ),
     ]
@@ -160,14 +165,14 @@ async def test_run_case_records_failures_for_leaked_rows_and_hit_miss_mismatches
         account_id="acct-1",
         corpus_id="shared-corpus",
         faq_id="faq-1",
-        query="password reset",
+        query="export attribution report",
         expected_hit=True,
     )
     miss_case = smoke.SearchCase(
         account_id="acct-1",
         corpus_id="shared-corpus",
         faq_id="faq-1",
-        query="escrow shortage",
+        query="saml domain verification",
         expected_hit=False,
     )
 
@@ -381,7 +386,7 @@ def test_failure_summary_limits_output() -> None:
         {
             "account_id": f"acct-{index}",
             "corpus_id": "corpus",
-            "query": "password",
+            "query": "export",
             "failures": ["wrong account_id returned"],
         }
         for index in range(25)

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -114,9 +114,9 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
     _write_cases(
         case_file,
         [
-            {"query": "escrow shortage", "limit": 5, "require_results": False},
+            {"query": "saml domain verification", "limit": 5, "require_results": False},
             {
-                "query": "password reset",
+                "query": "export attribution report",
                 "corpus_id": "corp-1",
                 "status": "approved",
                 "limit": 3,
@@ -135,7 +135,7 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
 
     assert errors == []
     assert detail_case == {
-        "query": "password reset",
+        "query": "export attribution report",
         "corpus_id": "corp-1",
         "status": "approved",
         "limit": 3,
@@ -154,17 +154,17 @@ def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):
         ({}, "route case file must contain a non-empty JSON list"),
         ([], "route case file must contain a non-empty JSON list"),
         ([[]], "route case[0] must be an object"),
-        ([{"query": "reset", "limit": 5, "require_results": "yes"}], "route case[0].require_results must be a boolean"),
-        ([{"query": "escrow", "limit": 5, "require_results": False}], "route case file must include a require_results case for detail check"),
+        ([{"query": "export", "limit": 5, "require_results": "yes"}], "route case[0].require_results must be a boolean"),
+        ([{"query": "workspace ownership", "limit": 5, "require_results": False}], "route case file must include a require_results case for detail check"),
         ([{"query": "", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].query must be a non-empty string"),
-        ([{"query": "reset", "limit": 5, "require_results": True}], "route case[0].expected_first_account_id must be a non-empty string"),
-        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": ""}], "route case[0].expected_first_account_id must be a non-empty string"),
-        ([{"query": "reset", "corpus_id": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].corpus_id must be a string"),
-        ([{"query": "reset", "status": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].status must be a string"),
-        ([{"query": "reset", "limit": "5", "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
-        ([{"query": "reset", "limit": True, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
-        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": ""}], "route case[0].expected_detail_account_id must be a non-empty string"),
-        ([{"query": "reset", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": "acct-1", "expected_detail_target_id": 1}], "route case[0].expected_detail_target_id must be a non-empty string"),
+        ([{"query": "export", "limit": 5, "require_results": True}], "route case[0].expected_first_account_id must be a non-empty string"),
+        ([{"query": "export", "limit": 5, "require_results": True, "expected_first_account_id": ""}], "route case[0].expected_first_account_id must be a non-empty string"),
+        ([{"query": "export", "corpus_id": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].corpus_id must be a string"),
+        ([{"query": "export", "status": 1, "limit": 5, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].status must be a string"),
+        ([{"query": "export", "limit": "5", "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
+        ([{"query": "export", "limit": True, "require_results": True, "expected_first_account_id": "acct-1"}], "route case[0].limit must be a positive integer"),
+        ([{"query": "export", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": ""}], "route case[0].expected_detail_account_id must be a non-empty string"),
+        ([{"query": "export", "limit": 5, "require_results": True, "expected_first_account_id": "acct-1", "expected_detail_account_id": "acct-1", "expected_detail_target_id": 1}], "route case[0].expected_detail_target_id must be a non-empty string"),
     ],
 )
 def test_detail_case_from_route_cases_rejects_bad_shapes(tmp_path, payload, expected_error):
@@ -195,7 +195,7 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
     command = smoke._detail_command(
         args,
         detail_case={
-            "query": "password reset",
+            "query": "export attribution report",
             "corpus_id": "corp-1",
             "status": "approved",
             "limit": 3,
@@ -209,7 +209,7 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
     )
 
     assert str(smoke.CONTRACT_SCRIPT) in command
-    assert command[command.index("--query") + 1] == "password reset"
+    assert command[command.index("--query") + 1] == "export attribution report"
     assert command[command.index("--corpus-id") + 1] == "corp-1"
     assert command[command.index("--status") + 1] == "approved"
     assert command[command.index("--limit") + 1] == "3"
@@ -451,7 +451,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
             _write_cases(
                 route_cases,
                 [{
-                    "query": "password reset",
+                    "query": "export attribution report",
                     "corpus_id": "corp-1",
                     "status": "approved",
                     "limit": 5,
@@ -519,7 +519,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
             _write_cases(
                 route_cases,
                 [{
-                    "query": "password reset",
+                    "query": "export attribution report",
                     "corpus_id": "corp-1",
                     "status": "approved",
                     "limit": 5,
@@ -626,7 +626,7 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
             _write_cases(
                 route_cases,
                 [{
-                    "query": "password reset",
+                    "query": "export attribution report",
                     "corpus_id": "corp-1",
                     "status": "approved",
                     "limit": 5,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md
Slice phase: Functional validation

Updates the seeded FAQ search smoke so its hit and miss cases use B2B SaaS support-ticket language instead of generic password-reset and consumer-finance terms.

## Intentional
- No search scoring, API, repository, schema, or route behavior changes.
- No public demo corpus is added in this slice.
- CFPB scale and durability validations remain documented separately.

## Deferred
- A future demo-corpus slice should create a larger labeled synthetic B2B SaaS support-ticket corpus and guard it against CFPB/consumer-finance leakage.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q - 63 passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-SaaS-Smoke-Cases.md - passed.
- git diff --check - passed.
- Local PR review bundle - passed.

## Diff size
4 files, +117 / -33