### PR TITLE
Validate large support-ticket blog context

### DIFF
--- a/plans/PR-Support-Ticket-Blog-Large-Context-Acceptance.md
+++ b/plans/PR-Support-Ticket-Blog-Large-Context-Acceptance.md
@@ -1,0 +1,81 @@
+# PR: Support-Ticket Blog Large Context Acceptance
+
+## Why this slice exists
+
+PR #991 pinned the compact-policy selector directly, but the production path is
+route provider -> blog dispatcher -> blog generation service -> quality gate.
+We still need a deterministic acceptance proof that a larger support-ticket
+upload carries large row counts through the blog execute handoff and that the
+blog generation service keeps the default 1500-word floor for that context.
+
+This is the next robust-testing slice after the small-upload live validation:
+prove the large-upload branch remains large all the way to the quality gate,
+without spending another live LLM call.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider-blog-polish
+Slice phase: Robust testing
+
+1. Extend the loader-backed blog execute stress test so the captured blog
+   service call asserts large support-ticket row counts in the blog data context.
+2. Add a deterministic blog-generation service test proving a large
+   no-outcome/no-resolution support-ticket context still blocks short content
+   with the default 1500-word floor.
+3. Keep runtime code unchanged unless those acceptance tests expose a real
+   wiring defect.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Support-Ticket-Blog-Large-Context-Acceptance.md` | Plan doc for the large support-ticket blog context acceptance slice. |
+| `tests/test_support_ticket_provider_landing_blog_execute.py` | Assert large loader-backed blog execute calls pass bounded large row counts into the blog data context. |
+| `tests/test_extracted_blog_generation.py` | Prove large support-ticket blog generation keeps the default 1500-word quality floor. |
+
+## Mechanism
+
+The route-level test reuses the existing 50,000-row loader-backed execute
+coverage. It already proves provider diagnostics are bounded; this slice adds
+assertions on the captured blog service kwargs so the large counts are shown to
+survive the handoff into the blog data context.
+
+The service-level test passes a large trusted support-ticket data context into
+BlogPostGenerationService.generate and feeds a deterministic 1,000-ish word
+draft. If the small-upload compact policy accidentally applies, the draft would
+not produce the content-too-short blocker requiring 1500 words. The test asserts the default
+1500-word blocker, which proves the large branch reached the quality gate.
+
+## Intentional
+
+- No live Haiku run in this slice. The small-upload path already has live proof;
+  this slice tests large-upload wiring and quality-policy selection
+  deterministically.
+- No FAQ generator or standalone FAQ Article changes. FAQ output shape remains
+  owned by the parallel FAQ session.
+- No runtime code change is expected. If the tests fail, the fix will happen at
+  the source of the wiring/policy defect rather than by weakening assertions.
+
+## Deferred
+
+- Broader customer CSV acceptance testing across varied real exports remains a
+  later robust-testing slice.
+- Customer-language keyword promotion and standalone FAQ Article output remain
+  future product slices coordinated with the FAQ lane.
+- Parked hardening: none planned.
+
+## Verification
+
+- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_blog_generation.py -q`
+  - `76 passed`
+- Local PR review with PR body
+  - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Route acceptance assertions | ~15 |
+| Blog-generation acceptance test | ~65 |
+| **Total** | **~155** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -165,6 +165,22 @@ def _valid_support_ticket_content(extra: str = "") -> str:
     return body
 
 
+def _large_support_ticket_descriptive_content(word_count: int = 1_000) -> str:
+    sentence = (
+        "Customers asked support about account email changes, billing exports, "
+        "and report access in the uploaded ticket rows. "
+    )
+    words = sentence.split()
+    repeated = (words * ((word_count // len(words)) + 1))[:word_count]
+    midpoint = max(1, len(repeated) // 2)
+    return (
+        "## What do the uploaded support tickets show?\n\n"
+        + " ".join(repeated[:midpoint])
+        + "\n\n## Which repeated questions need clearer answers?\n\n"
+        + " ".join(repeated[midpoint:])
+    )
+
+
 def _valid_blog_json(**overrides):
     payload = {
         "title": "HubSpot Pricing Pressure Is Changing Buyer Shortlists",
@@ -780,6 +796,47 @@ async def test_generate_saves_descriptive_support_ticket_blog_without_outcome_or
     draft = blog_posts.saved[0]["drafts"][0]
     assert not draft.data_context.get("support_ticket_resolution_evidence_present")
     assert not draft.data_context.get("has_measured_outcomes")
+
+
+@pytest.mark.asyncio
+async def test_generate_large_support_ticket_context_keeps_default_word_floor() -> None:
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        rows=[_support_ticket_blueprint()],
+        responses=[
+            _valid_support_ticket_blog_json(
+                content=_large_support_ticket_descriptive_content(),
+            )
+        ],
+        config=BlogPostGenerationConfig(
+            parse_retry_attempts=0,
+            quality_repair_attempts=0,
+        ),
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+        data_context={
+            "source": "support_ticket_provider",
+            "source_row_count": 250,
+            "included_ticket_row_count": 75,
+            "question_like_ticket_count": 75,
+            "has_measured_outcomes": False,
+            "support_ticket_resolution_evidence_present": False,
+            "support_ticket_resolution_evidence_count": 0,
+        },
+    )
+
+    assert result.generated == 0
+    assert result.skipped == 1
+    assert result.errors[0]["reason"] == "quality_blocked"
+    assert any(
+        blocker.startswith("content_too_short:")
+        and blocker.endswith("_words_need_1500")
+        for blocker in result.errors[0]["blockers"]
+    )
+    assert blog_posts.saved == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_support_ticket_provider_landing_blog_execute.py
+++ b/tests/test_support_ticket_provider_landing_blog_execute.py
@@ -445,6 +445,18 @@ async def test_loader_backed_support_ticket_provider_bounds_large_execute_inputs
         assert service.calls[0]["kwargs"]["topic"] == (
             "Support-ticket questions customers keep asking"
         )
+        data_context = service.calls[0]["kwargs"]["data_context"]
+        assert data_context["source"] == "support_ticket_provider"
+        assert data_context["source_row_count"] == 50_000
+        assert data_context["included_ticket_row_count"] == 1_000
+        assert data_context["question_like_ticket_count"] == 1_000
+        assert data_context["has_dated_window"] is False
+        assert data_context["support_ticket_resolution_evidence_present"] is False
+        assert data_context["support_ticket_resolution_evidence_count"] == 0
+        assert data_context["has_measured_outcomes"] is False
+        assert data_context["measured_outcome_count"] == 0
+        assert len(data_context["customer_wording_examples"]) <= 6
+        assert len(data_context["top_ticket_clusters"]) <= 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Blog-Large-Context-Acceptance.md
Slice phase: Robust testing

This slice proves the large support-ticket branch stays large through the real route/provider/blog handoff and into the blog quality gate. PR #991 pinned the selector directly; this PR pins the production path around it without adding another live LLM run.

## Intentional
- No live Haiku run; this is deterministic route and service acceptance coverage.
- No FAQ generator or standalone FAQ Article changes.
- No runtime code change; the current source behavior is being pinned.

## Deferred
- Broader customer CSV acceptance testing across varied real exports remains a later robust-testing slice.
- Customer-language keyword promotion and standalone FAQ Article output remain future product slices coordinated with the FAQ lane.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_support_ticket_provider_landing_blog_execute.py tests/test_extracted_blog_generation.py -q`
  - `76 passed`
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-support-ticket-blog-large-context-acceptance-body.md`
  - passed

## Diff size
3 files, about +155 / -0.
