### PR TITLE
Trace Content Ops LLM usage

### DIFF
--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -17,12 +18,19 @@ class LLMUnavailableError(RuntimeError):
 
 
 LLMResolver = Callable[..., Any]
+LLMTraceCallable = Callable[..., None]
 
 
 def _default_resolver(**kwargs: Any) -> Any:
     from .pipelines.llm import get_pipeline_llm
 
     return get_pipeline_llm(**kwargs)
+
+
+def _default_trace_llm_call(*args: Any, **kwargs: Any) -> None:
+    from .pipelines.llm import trace_llm_call
+
+    trace_llm_call(*args, **kwargs)
 
 
 def _to_bool(value: Any, default: bool) -> bool:
@@ -103,6 +111,7 @@ class PipelineLLMClient:
     auto_activate_ollama: bool = True
     openrouter_model: str | None = None
     resolver: LLMResolver = _default_resolver
+    tracer: LLMTraceCallable | None = _default_trace_llm_call
 
     async def complete(
         self,
@@ -122,15 +131,88 @@ class PipelineLLMClient:
         if llm is None:
             raise LLMUnavailableError("No LLM route configured for campaign generation")
 
-        result = self._call_llm(
-            llm,
-            list(messages),
-            max_tokens=max_tokens,
-            temperature=temperature,
+        started = time.monotonic()
+        try:
+            result = self._call_llm(
+                llm,
+                list(messages),
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            if inspect.isawaitable(result):
+                result = await result
+            response = _to_response(result, llm=llm)
+        except Exception as exc:
+            self._trace_call(
+                llm=llm,
+                response=None,
+                duration_ms=_duration_ms(started),
+                metadata=metadata,
+                status="failed",
+                error_message=str(exc)[:500],
+                error_type=type(exc).__name__,
+            )
+            raise
+        self._trace_call(
+            llm=llm,
+            response=response,
+            duration_ms=_duration_ms(started),
+            metadata=metadata,
         )
-        if inspect.isawaitable(result):
-            result = await result
-        return _to_response(result, llm=llm)
+        return response
+
+    def _trace_call(
+        self,
+        *,
+        llm: Any,
+        response: LLMResponse | None,
+        duration_ms: float,
+        metadata: Mapping[str, Any] | None,
+        status: str = "completed",
+        error_message: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
+        if self.tracer is None:
+            return
+        usage = dict(getattr(response, "usage", {}) or {}) if response else {}
+        trace_meta = _trace_meta_from_response(response)
+        cached_tokens, cache_write_tokens, billable_input_tokens = _trace_cache_metrics(
+            usage,
+            trace_meta,
+        )
+        trace_metadata = {
+            "product": "content_ops",
+            "workload": self.workload or "default",
+            "llm_adapter": "pipeline",
+        }
+        trace_metadata.update(dict(metadata or {}))
+        try:
+            self.tracer(
+                "content_ops.llm.complete",
+                input_tokens=_usage_int(usage.get("input_tokens")),
+                output_tokens=_usage_int(usage.get("output_tokens")),
+                cached_tokens=cached_tokens,
+                cache_write_tokens=cache_write_tokens,
+                billable_input_tokens=billable_input_tokens,
+                model=_trace_model_name(llm=llm, response=response),
+                provider=_provider_name(llm),
+                duration_ms=duration_ms,
+                status=status,
+                metadata=trace_metadata,
+                api_endpoint=_optional_trace_text(trace_meta.get("api_endpoint")),
+                provider_request_id=_optional_trace_text(
+                    trace_meta.get("provider_request_id"),
+                ),
+                ttft_ms=_optional_trace_float(trace_meta.get("ttft_ms")),
+                inference_time_ms=_optional_trace_float(
+                    trace_meta.get("inference_time_ms"),
+                ),
+                queue_time_ms=_optional_trace_float(trace_meta.get("queue_time_ms")),
+                error_message=error_message,
+                error_type=error_type,
+            )
+        except Exception:
+            return
 
     def _call_llm(
         self,
@@ -228,6 +310,73 @@ def _to_response(result: Any, *, llm: Any) -> LLMResponse:
         usage=dict(usage),
         raw=result,
     )
+
+
+def _duration_ms(started: float) -> float:
+    return max((time.monotonic() - started) * 1000, 0.0)
+
+
+def _usage_int(value: Any) -> int:
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _trace_cache_metrics(
+    usage: Mapping[str, Any],
+    trace_meta: Mapping[str, Any],
+) -> tuple[int, int, int | None]:
+    cached_tokens = _usage_int(
+        usage.get("cached_tokens")
+        or usage.get("cache_read_tokens")
+        or usage.get("cache_read_input_tokens")
+        or trace_meta.get("cached_tokens")
+        or trace_meta.get("cache_read_tokens")
+    )
+    cache_write_tokens = _usage_int(
+        usage.get("cache_write_tokens")
+        or usage.get("cache_creation_tokens")
+        or usage.get("cache_creation_input_tokens")
+        or trace_meta.get("cache_write_tokens")
+        or trace_meta.get("cache_creation_tokens")
+    )
+    raw_billable = usage.get("billable_input_tokens")
+    if raw_billable is None:
+        raw_billable = trace_meta.get("billable_input_tokens")
+    billable_input_tokens = _usage_int(raw_billable) if raw_billable is not None else None
+    return cached_tokens, cache_write_tokens, billable_input_tokens
+
+
+def _trace_meta_from_response(response: LLMResponse | None) -> Mapping[str, Any]:
+    raw = getattr(response, "raw", None) if response is not None else None
+    if isinstance(raw, Mapping) and isinstance(raw.get("_trace_meta"), Mapping):
+        return raw["_trace_meta"]
+    return {}
+
+
+def _optional_trace_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_trace_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _provider_name(llm: Any) -> str:
+    return str(getattr(llm, "name", "") or llm.__class__.__name__)
+
+
+def _trace_model_name(*, llm: Any, response: LLMResponse | None) -> str:
+    if response is not None and response.model:
+        return str(response.model)
+    return _model_name(llm) or ""
 
 
 def _model_name(llm: Any) -> str | None:

--- a/plans/PR-Content-Ops-LLM-Usage-Tracing.md
+++ b/plans/PR-Content-Ops-LLM-Usage-Tracing.md
@@ -1,0 +1,93 @@
+# PR: Content Ops LLM Usage Tracing
+
+## Why this slice exists
+
+The extracted LLM infrastructure already has the `llm_usage` tracing surface
+needed for cost dashboards, cache savings, drift reports, and budget gates. The
+Content Ops live generation path currently records provider usage only inside
+generated draft metadata, so operators can inspect one saved asset but cannot
+roll up spend by account, output type, source type, run, model, or repair loop.
+
+This is the first cost/caching integration slice. Before wiring budget gates or
+exact caching, Content Ops needs actual LLM usage rows for the calls it already
+makes through `PipelineLLMClient`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Trace `PipelineLLMClient.complete` calls through the existing LLM
+   infrastructure `trace_llm_call` bridge after successful provider calls.
+2. Trace failed provider calls with failure status, provider/model identity when
+   available, duration, and error type.
+3. Preserve caller metadata and add stable Content Ops attribution fields so
+   later cost dashboards can group usage without parsing draft metadata.
+4. Keep prompt/response bodies out of the trace in this first slice to avoid
+   persisting uploaded support-ticket text into cost logs.
+5. Add focused tests proving success and failure traces are emitted and that
+   tracing failures do not break generation.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-LLM-Usage-Tracing.md` | Plan doc for the first Content Ops cost-surfacing slice. |
+| `extracted_content_pipeline/campaign_llm_client.py` | Emit safe usage traces from the Content Ops LLM adapter. |
+| `tests/test_extracted_campaign_llm_client.py` | Cover success, failure, metadata, and trace-failure behavior. |
+
+## Mechanism
+
+`PipelineLLMClient.complete` already owns the direct provider call for the
+Content Ops generation services. This slice measures the call duration, converts
+the provider response to `LLMResponse`, normalizes usage fields, and calls the
+existing trace bridge with:
+
+- span name: `content_ops.llm.complete`
+- provider/model identity from the resolved LLM and response
+- input/output tokens plus cache-read/cache-write token counters when present
+- metadata merged from the generation service plus `product=content_ops`,
+  `workload`, and `llm_adapter=pipeline`
+
+No `input_data` or `output_data` is sent in this slice. That keeps customer CSV
+content out of the cost table while still making spend queryable.
+
+## Intentional
+
+- This does not wire exact caching yet. Cache policy needs an explicit
+  support-ticket privacy/no-store decision before generated response text is
+  stored.
+- This does not add a runtime budget gate yet. Budget decisions should be based
+  on actual traced usage first.
+- The trace hook is best-effort. A telemetry failure must not fail the user's
+  generation request.
+- No database migration is needed; the shared `llm_usage` table already exists.
+
+## Deferred
+
+- Future PR: expose Content Ops usage/cost rollups in the generated-asset or
+  control-surface API.
+- Future PR: add a `BudgetGate` integration once Content Ops usage rows are
+  present and queryable.
+- Future PR: add exact-cache wiring with a support-ticket privacy policy,
+  account scoping, and no-store behavior.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_campaign_llm_client.py -q — 15 passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline — completed with synced files refreshed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| LLM client tracing | ~165 |
+| Tests | ~120 |
+| **Total** | **~375** |

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -62,6 +62,40 @@ class _GenerateStringLLM:
         return "plain generated response"
 
 
+class _TraceLLM:
+    name = "openrouter"
+    model = "anthropic/claude-haiku-4-5"
+
+    def chat(self, messages, *, max_tokens, temperature):
+        return {
+            "response": "traced response",
+            "model": "anthropic/claude-haiku-4-5",
+            "usage": {
+                "input_tokens": "100",
+                "output_tokens": 25,
+                "total_tokens": 125,
+            },
+            "_trace_meta": {
+                "cache_read_tokens": 7,
+                "cache_creation_tokens": 5,
+                "billable_input_tokens": 93,
+                "api_endpoint": "https://openrouter.ai/api/v1/chat/completions",
+                "provider_request_id": "req_trace_123",
+                "ttft_ms": "12.5",
+                "inference_time_ms": 55,
+                "queue_time_ms": None,
+            },
+        }
+
+
+class _FailingChatLLM:
+    name = "openrouter"
+    model = "anthropic/claude-haiku-4-5"
+
+    def chat(self, messages, *, max_tokens, temperature):
+        raise RuntimeError("provider timeout")
+
+
 @pytest.mark.asyncio
 async def test_pipeline_llm_client_resolves_and_normalizes_chat_response():
     llm = _ChatLLM()
@@ -152,6 +186,101 @@ async def test_pipeline_llm_client_normalizes_string_generate_response():
     assert response.content == "plain generated response"
     assert response.model is None
     assert response.raw == "plain generated response"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_traces_successful_provider_usage_without_io_capture():
+    trace_calls = []
+    client = PipelineLLMClient(
+        workload="draft",
+        resolver=lambda **_: _TraceLLM(),
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+    )
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="customer ticket text")],
+        max_tokens=200,
+        temperature=0.2,
+        metadata={"asset_type": "blog_post", "request_id": "req_123"},
+    )
+
+    assert response.content == "traced response"
+    assert len(trace_calls) == 1
+    span_name, trace = trace_calls[0]
+    assert span_name == "content_ops.llm.complete"
+    assert trace["status"] == "completed"
+    assert trace["input_tokens"] == 100
+    assert trace["output_tokens"] == 25
+    assert trace["cached_tokens"] == 7
+    assert trace["cache_write_tokens"] == 5
+    assert trace["billable_input_tokens"] == 93
+    assert trace["model"] == "anthropic/claude-haiku-4-5"
+    assert trace["provider"] == "openrouter"
+    assert trace["provider_request_id"] == "req_trace_123"
+    assert trace["api_endpoint"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert trace["ttft_ms"] == 12.5
+    assert trace["inference_time_ms"] == 55
+    assert trace["queue_time_ms"] is None
+    assert trace["metadata"] == {
+        "product": "content_ops",
+        "workload": "draft",
+        "llm_adapter": "pipeline",
+        "asset_type": "blog_post",
+        "request_id": "req_123",
+    }
+    assert "input_data" not in trace
+    assert "output_data" not in trace
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_traces_failed_provider_calls_without_io_capture():
+    trace_calls = []
+    client = PipelineLLMClient(
+        resolver=lambda **_: _FailingChatLLM(),
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+    )
+
+    with pytest.raises(RuntimeError, match="provider timeout"):
+        await client.complete(
+            [LLMMessage(role="user", content="customer ticket text")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={"asset_type": "landing_page"},
+        )
+
+    assert len(trace_calls) == 1
+    span_name, trace = trace_calls[0]
+    assert span_name == "content_ops.llm.complete"
+    assert trace["status"] == "failed"
+    assert trace["input_tokens"] == 0
+    assert trace["output_tokens"] == 0
+    assert trace["model"] == "anthropic/claude-haiku-4-5"
+    assert trace["provider"] == "openrouter"
+    assert trace["error_type"] == "RuntimeError"
+    assert trace["error_message"] == "provider timeout"
+    assert trace["metadata"]["product"] == "content_ops"
+    assert trace["metadata"]["asset_type"] == "landing_page"
+    assert "input_data" not in trace
+    assert "output_data" not in trace
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_does_not_fail_generation_when_tracing_fails():
+    def broken_tracer(span_name, **kwargs):
+        raise RuntimeError("trace table unavailable")
+
+    client = PipelineLLMClient(
+        resolver=lambda **_: _TraceLLM(),
+        tracer=broken_tracer,
+    )
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="Write the email")],
+        max_tokens=200,
+        temperature=0.2,
+    )
+
+    assert response.content == "traced response"
 
 
 def test_llm_client_config_from_mapping_parses_provider_routing_fields():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-LLM-Usage-Tracing.md
Slice phase: Production hardening

Content Ops already records generation usage inside individual asset metadata, but the live provider calls do not emit shared llm_usage rows. This slice traces the existing PipelineLLMClient path so spend, model, provider, cache counters, failures, and Content Ops attribution are available before we wire cost dashboards, budget gates, or exact cache policy.

## Intentional
- Exact caching is deferred until uploaded support-ticket privacy/no-store policy is explicit.
- Prompt and response bodies are not captured in llm_usage in this slice.
- Tracing is best-effort so telemetry failures do not break generation.
- No database migration is needed because llm_usage already exists.

## Deferred
- Future PR: expose Content Ops usage and cost rollups in generated-asset or control-surface APIs.
- Future PR: wire BudgetGate once traced usage rows are present.
- Future PR: add exact-cache wiring with account scoping and no-store behavior.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_campaign_llm_client.py -q — 15 passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline — completed with synced files refreshed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.

## Diff size
3 files, +379 / -8.