### PR TITLE
Add generated SaaS FAQ demo artifact

### DIFF
--- a/extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md
+++ b/extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md
@@ -1,0 +1,143 @@
+# Synthetic B2B SaaS Support FAQ Demo
+
+_Source rows analyzed: 36. Ticket sources used: 36._
+
+## 1. How do I export attribution reports before our board meeting?
+
+Customers are asking about reporting friction across 8 ticket sources. The clearest customer wording is "How do I export attribution reports before our board meeting?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.
+
+**Sources:**
+
+- `saas-demo-001` - Attribution export blocked: "How do I export attribution reports before our board meeting?"
+- `saas-demo-002` - CSV export missing fields: "Why is the campaign CSV export missing source and owner columns?"
+- `saas-demo-003` - Export scheduled report: "Can I schedule a weekly attribution report export for finance?"
+
+## 2. Where can I see failed webhook delivery attempts?
+
+Customers are asking about integration setup across 7 ticket sources. The clearest customer wording is "Where can I see failed webhook delivery attempts?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the issue still affects the workflow after you try the steps above.
+
+**Sources:**
+
+- `saas-demo-017` - Webhook retries: "Where can I see failed webhook delivery attempts?"
+- `saas-demo-018` - API rate limits: "How do we know when the API rate limit has been reached?"
+- `saas-demo-019` - Webhook secret rotation: "Can we rotate webhook signing secrets without downtime?"
+
+## 3. Which CSV columns are required for account imports?
+
+Customers are asking about data import across 4 ticket sources. The clearest customer wording is "Which CSV columns are required for account imports?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.
+
+**Sources:**
+
+- `saas-demo-025` - CSV import columns: "Which CSV columns are required for account imports?"
+- `saas-demo-026` - Import validation errors: "How do I fix import errors for missing owner email values?"
+- `saas-demo-027` - Historical data import: "Can we import historical opportunities from last quarter?"
+
+## 4. How do I send workflow alerts to a different Slack channel?
+
+Customers are asking about manual follow-up across 5 ticket sources. The clearest customer wording is "How do I send workflow alerts to a different Slack channel?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the issue still affects the workflow after you try the steps above.
+
+**Sources:**
+
+- `saas-demo-024` - Slack notification routing: "How do I send workflow alerts to a different Slack channel?"
+- `saas-demo-029` - Follow-up automation: "How do I automate demo follow-up after a meeting is completed?"
+- `saas-demo-030` - Workflow enrollment: "Why did a prospect not enter the renewal workflow?"
+
+## 5. Where can I download invoices for the annual subscription?
+
+Customers are asking about billing and payments across 4 ticket sources. The clearest customer wording is "Where can I download invoices for the annual subscription?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the charge, fee, payment, balance, or dispute still looks wrong after you compare it with your records.
+
+**Sources:**
+
+- `saas-demo-033` - Invoice download: "Where can I download invoices for the annual subscription?"
+- `saas-demo-034` - Plan limit warning: "Why did we get a plan limit warning after adding seats?"
+- `saas-demo-035` - Upgrade timing: "Can we upgrade before renewal and keep the same billing date?"
+
+## 6. How do I let managers edit workflows without full admin access?
+
+Customers are asking about permissions and seats across 4 ticket sources. The clearest customer wording is "How do I let managers edit workflows without full admin access?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the issue still affects the workflow after you try the steps above.
+
+**Sources:**
+
+- `saas-demo-013` - Role permissions: "How do I let managers edit workflows without full admin access?"
+- `saas-demo-014` - Seat transfer: "Can I transfer a paid seat from a departed employee?"
+- `saas-demo-015` - Viewer role limits: "Why can viewers open a report but not save filters?"
+
+## 7. How do I configure SAML single sign-on for our workspace?
+
+Customers are asking about sso setup across 4 ticket sources. The clearest customer wording is "How do I configure SAML single sign-on for our workspace?", so this FAQ should answer that request directly and tell users exactly what to try next.
+
+**What to do next:**
+
+1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.
+2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.
+3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.
+
+**When to contact support:**
+
+Contact support at https://example.com/support if the issue still affects the workflow after you try the steps above.
+
+**Sources:**
+
+- `saas-demo-009` - SAML setup: "How do I configure SAML single sign-on for our workspace?"
+- `saas-demo-010` - Domain verification: "Why is domain verification failing during SSO setup?"
+- `saas-demo-011` - SCIM provisioning: "Can SCIM create users before they sign in with SSO?"

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Artifact
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Corpus added a labeled synthetic B2B SaaS support
+ticket corpus and proved the real FAQ generator can process it, but the repo
+still lacks a checked-in generated FAQ report that another session can inspect
+or hand to a landing-page demo without rerunning the generator.
+
+This slice closes that handoff gap with a static Markdown artifact generated
+from the synthetic corpus through the existing FAQ producer. It stays small
+because the corpus already exists and the generated output is deterministic.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Functional validation
+
+1. Add a checked-in Markdown FAQ report generated from the synthetic B2B SaaS
+   support-ticket corpus.
+2. Extend the corpus test to regenerate the Markdown through the real producer
+   and compare it to the checked artifact.
+3. Keep runtime APIs, generator behavior, search projection, and frontend code
+   unchanged.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md` | Plan contract for this artifact handoff slice. |
+| `extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md` | Static generated FAQ report from the synthetic B2B SaaS corpus. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Regeneration guard proving the static artifact matches the real producer output. |
+
+## Mechanism
+
+The Markdown artifact is generated with the existing CLI-compatible producer
+settings used by the prior corpus proof:
+
+```bash
+python scripts/build_extracted_ticket_faq_markdown.py \
+  extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --title "Synthetic B2B SaaS Support FAQ Demo" \
+  --max-items 12 \
+  --max-evidence-per-item 3 \
+  --support-contact https://example.com/support \
+  --require-output-checks \
+  --output extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md
+```
+
+The test reads the CSV, normalizes it with `source_rows_to_campaign_opportunities`,
+runs `build_ticket_faq_markdown`, and asserts the committed Markdown file is an
+exact match. The existing leakage guard still scans generated Markdown for the
+consumer-finance terms that should not appear in this SaaS demo lane.
+
+## Intentional
+
+- The artifact is synthetic and labeled in the title; this is not represented
+  as design-partner or anonymized customer data.
+- The generated answer steps remain draft-review placeholders because the
+  synthetic corpus has no resolution evidence. That is data-truthful for the
+  current FAQ generator contract.
+- No result JSON is checked in; the Markdown is the artifact needed by the
+  landing-page/demo handoff, and the test already covers producer fidelity.
+
+## Deferred
+
+- Future PR: seed this corpus and generated FAQ into the hosted FAQ search demo
+  route once the demo session is ready to consume it.
+- Future PR: replace or supplement the synthetic artifact with an anonymized
+  real SaaS export when one exists.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 3 passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md - passed.
+- git diff --check - passed.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md` | 143 |
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md` | 87 |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | 37 |
+| **Total** | **267** |

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -9,6 +9,7 @@ from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_mark
 
 ROOT = Path(__file__).resolve().parents[1]
 DEMO_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv"
+DEMO_FAQ_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md"
 
 EXPECTED_LABEL = "synthetic_b2b_saas_demo"
 MIN_ROWS = 36
@@ -44,6 +45,22 @@ def _haystack(rows: list[dict[str, str]]) -> str:
     return "\n".join(" ".join(row.values()) for row in rows).lower()
 
 
+def _generated_demo_faq():
+    rows = _rows()
+    normalized = source_rows_to_campaign_opportunities(
+        rows,
+        target_mode="support_account",
+    )
+    result = build_ticket_faq_markdown(
+        normalized.opportunities,
+        title="Synthetic B2B SaaS Support FAQ Demo",
+        max_items=12,
+        max_evidence_per_item=3,
+        support_contact="https://example.com/support",
+    )
+    return rows, normalized, result
+
+
 def test_saas_demo_corpus_is_labeled_and_domain_clean() -> None:
     rows = _rows()
 
@@ -63,22 +80,10 @@ def test_saas_demo_corpus_is_labeled_and_domain_clean() -> None:
 
 
 def test_saas_demo_corpus_generates_valid_faq_output() -> None:
-    rows = _rows()
-    normalized = source_rows_to_campaign_opportunities(
-        rows,
-        target_mode="support_account",
-    )
+    rows, normalized, result = _generated_demo_faq()
 
     assert normalized.warnings == ()
     assert len(normalized.opportunities) == len(rows)
-
-    result = build_ticket_faq_markdown(
-        normalized.opportunities,
-        title="Synthetic B2B SaaS Support FAQ Demo",
-        max_items=12,
-        max_evidence_per_item=3,
-        support_contact="https://example.com/support",
-    )
 
     assert result.source_count == len(rows)
     assert result.ticket_source_count == len(rows)
@@ -101,3 +106,9 @@ def test_saas_demo_corpus_generates_valid_faq_output() -> None:
         if term in markdown
     ]
     assert leaked_terms == []
+
+
+def test_saas_demo_faq_artifact_matches_real_generator() -> None:
+    _rows, _normalized, result = _generated_demo_faq()
+
+    assert DEMO_FAQ_PATH.read_text(encoding="utf-8") == result.markdown


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md
Slice phase: Functional validation

PR-Content-Ops-FAQ-SaaS-Demo-Corpus added a labeled synthetic SaaS support-ticket corpus; this slice adds the checked generated FAQ Markdown artifact from that corpus and proves it still matches the real producer output.

## Intentional
- The artifact is synthetic and labeled in the title; it is not represented as design-partner or anonymized customer data.
- Draft-review answer steps remain placeholders because the corpus has no resolution evidence.
- No result JSON is checked in; the Markdown is the handoff artifact and the test covers producer fidelity.

## Deferred
- Future PR: seed this corpus and generated FAQ into the hosted FAQ search demo route once the demo session is ready to consume it.
- Future PR: replace or supplement the synthetic artifact with an anonymized real SaaS export when one exists.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 3 passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Artifact.md - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> - passed.

## Diff size
3 files, +254 / -13
