### PR TITLE
Surface Content Ops LLM usage summary

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -213,6 +213,7 @@ try:
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
         input_provider=build_content_ops_input_provider(),
         opportunity_import_pool_provider=get_db_pool,
+        usage_pool_provider=get_db_pool,
         ingestion_import_admission_provider=lambda: (
             build_content_ops_import_admission_gate(
                 max_concurrency=content_ops_config.ingestion_import_max_concurrency

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -4,7 +4,7 @@ API routers for Atlas Brain.
 
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from .alerts import router as alerts_router
 from .comms import router as comms_router
@@ -201,6 +201,13 @@ try:
         set_current_auth_user(user)
         return user
 
+    async def _require_content_ops_usage_operator(
+        user: AuthUser = Depends(_capture_content_ops_auth_user),
+    ) -> AuthUser:
+        if bool(getattr(user, "is_platform_admin", False)):
+            return user
+        raise HTTPException(status_code=403, detail="Platform admin access required")
+
     content_ops_config = ContentOpsControlSurfaceApiConfig()
     content_ops_router = create_content_ops_control_surface_router(
         config=content_ops_config,
@@ -214,6 +221,7 @@ try:
         input_provider=build_content_ops_input_provider(),
         opportunity_import_pool_provider=get_db_pool,
         usage_pool_provider=get_db_pool,
+        usage_dependencies=[Depends(_require_content_ops_usage_operator)],
         ingestion_import_admission_provider=lambda: (
             build_content_ops_import_admission_gate(
                 max_concurrency=content_ops_config.ingestion_import_max_concurrency

--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -25,6 +25,7 @@ class AuthUser:
     product: str = "consumer"  # consumer | b2b_retention | b2b_challenger
     trial_ends_at: Optional[datetime] = field(default=None, repr=False)
     is_admin: bool = False
+    is_platform_admin: bool = False
 
 
 def _synthetic_admin() -> AuthUser:
@@ -37,6 +38,7 @@ def _synthetic_admin() -> AuthUser:
         role="owner",
         product="consumer",
         is_admin=True,
+        is_platform_admin=True,
     )
 
 
@@ -119,6 +121,7 @@ async def require_auth(request: Request) -> AuthUser:
         product=row["product"] or "consumer",
         trial_ends_at=trial_ends,
         is_admin=_effective_is_admin(row["role"], row["is_admin"]),
+        is_platform_admin=bool(row["is_admin"]),
     )
 
 
@@ -180,6 +183,7 @@ async def optional_auth(request: Request) -> Optional[AuthUser]:
         product=row["product"] or "consumer",
         trial_ends_at=row["trial_ends_at"],
         is_admin=_effective_is_admin(row["role"], row["is_admin"]),
+        is_platform_admin=bool(row["is_admin"]),
     )
 
 
@@ -361,6 +365,7 @@ async def require_api_key(request: Request) -> AuthUser:
         product=account_row["product"] or "consumer",
         trial_ends_at=trial_ends,
         is_admin=False,
+        is_platform_admin=False,
     )
 
     client_ip = request.client.host if request.client else None

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -14,7 +14,7 @@ from types import MappingProxyType
 from typing import Any
 
 try:
-    from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
+    from fastapi import APIRouter, Body, File, Form, HTTPException, Query, UploadFile
     from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
     APIRouter = None
@@ -22,6 +22,7 @@ except ImportError as exc:  # pragma: no cover - exercised in dependency-light C
     HTTPException = None
     File = None
     Form = None
+    Query = None
     UploadFile = None
     BaseModel = None
     ConfigDict = None
@@ -38,6 +39,7 @@ from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
 )
+from ..content_ops_usage_summary import summarize_content_ops_llm_usage
 from ..content_ops_input_provider import (
     ContentOpsInputProvider,
     merge_content_ops_input_package,
@@ -541,6 +543,7 @@ def create_content_ops_control_surface_router(
     llm_provider: LLMProvider | None = None,
     input_provider: InputProvider | None = None,
     opportunity_import_pool_provider: PoolProvider | None = None,
+    usage_pool_provider: PoolProvider | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -591,6 +594,22 @@ def create_content_ops_control_surface_router(
                 resolved_config.faq_execute_max_source_material_rows
             ),
             reasoning_status=reasoning_status,
+        )
+
+    @router.get("/usage/summary")
+    async def usage_summary(
+        days: int = Query(default=7, ge=1, le=90),
+        asset_type: str | None = Query(default=None, max_length=80),
+        run_id: str | None = Query(default=None, max_length=200),
+        request_id: str | None = Query(default=None, max_length=200),
+    ) -> dict[str, Any]:
+        pool = await _resolve_usage_pool(usage_pool_provider)
+        return await summarize_content_ops_llm_usage(
+            pool,
+            days=days,
+            asset_type=asset_type,
+            run_id=run_id,
+            request_id=request_id,
         )
 
     @router.post("/preview")
@@ -1428,6 +1447,31 @@ async def _resolve_import_pool(provider: PoolProvider | None) -> Any:
         raise HTTPException(
             status_code=503,
             detail="Content Ops ingestion import database is unavailable.",
+        )
+    return pool
+
+
+async def _resolve_usage_pool(pool_provider: PoolProvider | None) -> Any:
+    if pool_provider is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops usage database is unavailable.",
+        )
+    try:
+        pool = await _resolve_provider(pool_provider)
+    except Exception as exc:
+        logger.warning(
+            "Content Ops usage pool provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops usage database is unavailable.",
+        ) from exc
+    if pool is None or getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops usage database is unavailable.",
         )
     return pool
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -544,6 +544,7 @@ def create_content_ops_control_surface_router(
     input_provider: InputProvider | None = None,
     opportunity_import_pool_provider: PoolProvider | None = None,
     usage_pool_provider: PoolProvider | None = None,
+    usage_dependencies: Sequence[Any] | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -596,7 +597,7 @@ def create_content_ops_control_surface_router(
             reasoning_status=reasoning_status,
         )
 
-    @router.get("/usage/summary")
+    @router.get("/usage/summary", dependencies=list(usage_dependencies or ()))
     async def usage_summary(
         days: int = Query(default=7, ge=1, le=90),
         asset_type: str | None = Query(default=None, max_length=80),

--- a/extracted_content_pipeline/content_ops_usage_summary.py
+++ b/extracted_content_pipeline/content_ops_usage_summary.py
@@ -1,0 +1,209 @@
+"""Read-side usage rollups for AI Content Ops LLM calls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+
+_CONTENT_OPS_SPAN_NAME = "content_ops.llm.complete"
+
+
+async def summarize_content_ops_llm_usage(
+    pool: Any,
+    *,
+    days: int = 7,
+    asset_type: str | None = None,
+    run_id: str | None = None,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a recent Content Ops cost/token summary from ``llm_usage``."""
+
+    resolved_days = _bounded_days(days)
+    filters = _UsageFilters(
+        days=resolved_days,
+        asset_type=_clean_filter(asset_type),
+        run_id=_clean_filter(run_id),
+        request_id=_clean_filter(request_id),
+    )
+    where_sql, args = _usage_where_clause(filters)
+    summary = await pool.fetchrow(
+        f"""
+        SELECT
+            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS total_cost_usd,
+            COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+            COALESCE(SUM(billable_input_tokens), 0)::BIGINT AS billable_input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens,
+            COALESCE(SUM(total_tokens), 0)::BIGINT AS total_tokens,
+            COALESCE(SUM(cached_tokens), 0)::BIGINT AS cached_tokens,
+            COALESCE(SUM(cache_write_tokens), 0)::BIGINT AS cache_write_tokens,
+            COUNT(*)::BIGINT AS total_calls,
+            COUNT(*) FILTER (WHERE status != 'completed')::BIGINT AS failed_calls,
+            COUNT(*) FILTER (WHERE cached_tokens > 0)::BIGINT AS cache_hit_calls,
+            COALESCE(AVG(duration_ms) FILTER (WHERE duration_ms > 0), 0) AS avg_duration_ms,
+            MAX(created_at) AS latest_call_at
+        FROM llm_usage
+        WHERE {where_sql}
+        """,
+        *args,
+    )
+    by_model = await pool.fetch(
+        f"""
+        SELECT
+            COALESCE(NULLIF(BTRIM(model_provider), ''), 'unknown') AS provider,
+            COALESCE(NULLIF(BTRIM(model_name), ''), 'unknown') AS model,
+            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS cost_usd,
+            COUNT(*)::BIGINT AS calls,
+            COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
+        FROM llm_usage
+        WHERE {where_sql}
+        GROUP BY provider, model
+        ORDER BY cost_usd DESC, calls DESC
+        LIMIT 20
+        """,
+        *args,
+    )
+    by_asset_type = await pool.fetch(
+        f"""
+        SELECT
+            COALESCE(NULLIF(BTRIM(metadata ->> 'asset_type'), ''), 'unknown') AS asset_type,
+            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS cost_usd,
+            COUNT(*)::BIGINT AS calls,
+            COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
+        FROM llm_usage
+        WHERE {where_sql}
+        GROUP BY asset_type
+        ORDER BY cost_usd DESC, calls DESC
+        LIMIT 20
+        """,
+        *args,
+    )
+    return {
+        "period_days": resolved_days,
+        "filters": filters.as_dict(),
+        "summary": _summary_payload(summary),
+        "by_model": [_breakdown_payload(row, label_keys=("provider", "model")) for row in by_model],
+        "by_asset_type": [
+            _breakdown_payload(row, label_keys=("asset_type",)) for row in by_asset_type
+        ],
+    }
+
+
+class _UsageFilters:
+    def __init__(
+        self,
+        *,
+        days: int,
+        asset_type: str | None,
+        run_id: str | None,
+        request_id: str | None,
+    ) -> None:
+        self.days = days
+        self.asset_type = asset_type
+        self.run_id = run_id
+        self.request_id = request_id
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "asset_type": self.asset_type,
+            "run_id": self.run_id,
+            "request_id": self.request_id,
+        }
+
+
+def _usage_where_clause(filters: _UsageFilters) -> tuple[str, list[Any]]:
+    args: list[Any] = [filters.days]
+    clauses = [
+        "created_at >= NOW() - ($1::INT * INTERVAL '1 day')",
+        (
+            f"(span_name = '{_CONTENT_OPS_SPAN_NAME}' "
+            "OR metadata ->> 'product' = 'content_ops')"
+        ),
+    ]
+    if filters.asset_type:
+        args.append(filters.asset_type)
+        clauses.append(f"metadata ->> 'asset_type' = ${len(args)}")
+    if filters.run_id:
+        args.append(filters.run_id)
+        clauses.append(f"(run_id = ${len(args)} OR metadata ->> 'run_id' = ${len(args)})")
+    if filters.request_id:
+        args.append(filters.request_id)
+        clauses.append(f"metadata ->> 'request_id' = ${len(args)}")
+    return "\n          AND ".join(clauses), args
+
+
+def _summary_payload(row: Mapping[str, Any] | None) -> dict[str, Any]:
+    row = row or {}
+    return {
+        "total_cost_usd": _float_value(row.get("total_cost_usd")),
+        "total_calls": _int_value(row.get("total_calls")),
+        "failed_calls": _int_value(row.get("failed_calls")),
+        "input_tokens": _int_value(row.get("input_tokens")),
+        "billable_input_tokens": _int_value(row.get("billable_input_tokens")),
+        "output_tokens": _int_value(row.get("output_tokens")),
+        "total_tokens": _int_value(row.get("total_tokens")),
+        "cached_tokens": _int_value(row.get("cached_tokens")),
+        "cache_write_tokens": _int_value(row.get("cache_write_tokens")),
+        "cache_hit_calls": _int_value(row.get("cache_hit_calls")),
+        "avg_duration_ms": round(_float_value(row.get("avg_duration_ms")), 1),
+        "latest_call_at": _iso_or_none(row.get("latest_call_at")),
+    }
+
+
+def _breakdown_payload(
+    row: Mapping[str, Any],
+    *,
+    label_keys: tuple[str, ...],
+) -> dict[str, Any]:
+    payload = {key: str(row.get(key) or "unknown") for key in label_keys}
+    payload.update({
+        "cost_usd": _float_value(row.get("cost_usd")),
+        "calls": _int_value(row.get("calls")),
+        "input_tokens": _int_value(row.get("input_tokens")),
+        "output_tokens": _int_value(row.get("output_tokens")),
+    })
+    return payload
+
+
+def _bounded_days(value: int) -> int:
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return 7
+    return min(max(days, 1), 90)
+
+
+def _clean_filter(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return text[:200]
+
+
+def _int_value(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float_value(value: Any) -> float:
+    if isinstance(value, Decimal):
+        return round(float(value), 6)
+    try:
+        return round(float(value or 0), 6)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _iso_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    text = str(value).strip()
+    return text or None
+

--- a/extracted_content_pipeline/content_ops_usage_summary.py
+++ b/extracted_content_pipeline/content_ops_usage_summary.py
@@ -30,7 +30,7 @@ async def summarize_content_ops_llm_usage(
     summary = await pool.fetchrow(
         f"""
         SELECT
-            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS total_cost_usd,
+            COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
             COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
             COALESCE(SUM(billable_input_tokens), 0)::BIGINT AS billable_input_tokens,
             COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens,
@@ -52,7 +52,7 @@ async def summarize_content_ops_llm_usage(
         SELECT
             COALESCE(NULLIF(BTRIM(model_provider), ''), 'unknown') AS provider,
             COALESCE(NULLIF(BTRIM(model_name), ''), 'unknown') AS model,
-            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS cost_usd,
+            COALESCE(SUM(cost_usd), 0) AS cost_usd,
             COUNT(*)::BIGINT AS calls,
             COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
             COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
@@ -68,7 +68,7 @@ async def summarize_content_ops_llm_usage(
         f"""
         SELECT
             COALESCE(NULLIF(BTRIM(metadata ->> 'asset_type'), ''), 'unknown') AS asset_type,
-            COALESCE(SUM(cost_usd), 0)::NUMERIC(12, 6) AS cost_usd,
+            COALESCE(SUM(cost_usd), 0) AS cost_usd,
             COUNT(*)::BIGINT AS calls,
             COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
             COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
@@ -206,4 +206,3 @@ def _iso_or_none(value: Any) -> str | None:
         return str(isoformat())
     text = str(value).strip()
     return text or None
-

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -305,6 +305,9 @@
       "target": "extracted_content_pipeline/content_ops_execution.py"
     },
     {
+      "target": "extracted_content_pipeline/content_ops_usage_summary.py"
+    },
+    {
       "target": "extracted_content_pipeline/control_surfaces.py"
     },
     {

--- a/plans/PR-Content-Ops-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Usage-Summary.md
@@ -18,24 +18,29 @@ Slice phase: Production hardening
 1. Add a Content Ops usage summary helper that aggregates llm_usage rows
    attributed to `content_ops`.
 2. Add an optional `/content-ops/usage/summary` route behind a host-provided
-   usage pool provider.
+   usage pool provider and route-specific operator dependency.
 3. Support narrow operator filters for recent days, asset type, run id, and
    request id.
 4. Return total cost/tokens/cache/failure counts plus provider/model and
    asset-type breakdowns.
-5. Add focused tests for provider configuration, filters, and response shape.
+5. Add focused tests for provider configuration, filters, response shape,
+   operator-only hosted wiring, and real Postgres rollup composition.
 
 ### Files touched
 
 | File | Change |
 |---|---|
 | `plans/PR-Content-Ops-Usage-Summary.md` | Plan doc for the first Content Ops cost read path. |
-| `atlas_brain/api/__init__.py` | Wire the hosted Content Ops usage route to the Atlas DB pool. |
+| `atlas_brain/api/__init__.py` | Wire the hosted Content Ops usage route to the Atlas DB pool and platform-admin-only gate. |
+| `atlas_brain/auth/dependencies.py` | Preserve the raw platform admin flag separately from account owner/admin access. |
 | `extracted_content_pipeline/content_ops_usage_summary.py` | Query and serialize Content Ops llm_usage rollups. |
-| `extracted_content_pipeline/api/control_surfaces.py` | Expose the optional usage summary route. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Expose the optional usage summary route with per-route dependencies. |
 | `extracted_content_pipeline/manifest.json` | Register the new usage-summary helper as an owned extracted-package file. |
+| `scripts/run_extracted_pipeline_checks.sh` | Enroll the new extracted usage-summary test in the CI runner. |
 | `tests/test_extracted_content_control_surface_api.py` | Cover route provider behavior and usage-summary filters/output. |
 | `tests/test_atlas_content_ops_generated_assets_api.py` | Cover hosted Atlas wiring for the usage route. |
+| `tests/test_auth_dependencies.py` | Pin the platform-admin flag as distinct from account admin access. |
+| `tests/test_extracted_content_ops_usage_summary.py` | Cover the usage summary SQL contract against real Postgres when configured. |
 
 ## Mechanism
 
@@ -51,7 +56,15 @@ the route returns 503 instead of pretending usage is available.
 
 Atlas wires the route to its shared DB pool in `atlas_brain/api/__init__.py` so
 the hosted `/api/v1/content-ops/usage/summary` path is usable immediately after
-merge.
+merge. The Atlas mount also supplies a route-specific platform-admin dependency
+for usage summary only. That keeps global spend aggregation as an operator view
+without changing the tenant-gated `/preview`, `/plan`, `/execute`, ingestion,
+or catalog routes.
+
+`AuthUser.is_admin` remains the existing effective account-admin flag because
+other Atlas admin surfaces use owner/admin as account admin access. This slice
+adds `AuthUser.is_platform_admin` from the raw `saas_users.is_admin` value and
+uses that stricter field for the global Content Ops usage route.
 
 ## Intentional
 
@@ -60,6 +73,10 @@ merge.
 - This does not add new schema. It reads the existing llm_usage fields written
   by the shared tracer.
 - This does not capture or expose prompt/response bodies.
+- This keeps the usage rollup global and operator-only rather than adding a
+  tenant account filter, because `llm_usage` does not currently have a first-
+  class account column. Tenant-scoped spend cards need account metadata
+  propagation first.
 
 ## Deferred
 
@@ -69,32 +86,36 @@ merge.
   policy and account scoping.
 - Future PR: add execution/run identifiers to Content Ops `/execute` if we need
   first-class run-level grouping beyond caller metadata.
+- Future PR: add tenant-scoped Content Ops usage once trace metadata reliably
+  carries account scope for every call.
 - Parked hardening: none planned.
 
 ## Verification
 
-- python -m pytest tests/test_extracted_content_control_surface_api.py -q — 107 passed.
-- python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q — 5 passed.
-- python -m compileall -q atlas_brain/api/__init__.py extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py — passed.
+- python -m pytest tests/test_auth_dependencies.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_content_ops_usage_summary.py -q — 123 passed, 1 skipped.
+- python -m compileall -q atlas_brain/api/__init__.py atlas_brain/auth/dependencies.py extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed after enrolling `tests/test_extracted_content_ops_usage_summary.py` in the extracted pipeline runner.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~105 |
-| Atlas host wiring | ~15 |
+| Plan doc | ~120 |
+| Atlas host wiring | ~35 |
+| Auth platform-admin flag | ~20 |
 | Usage summary helper | ~210 |
 | API route | ~60 |
-| Tests | ~140 |
+| Tests | ~335 |
+| CI runner enrollment | ~5 |
 | Manifest | ~5 |
-| **Total** | **~535** |
+| **Total** | **~790** |
 
 This exceeds the 400 LOC soft cap because the first read path needs a query
-helper, a route seam, manifest inventory, and response-shape tests in the same
-slice. UI, budget gating, and cache wiring stay deferred rather than expanding
-this PR further.
+helper, a route seam, hosted wiring, manifest inventory, response-shape tests,
+operator-gate coverage, and a real Postgres aggregation contract test in the
+same slice. UI, budget gating, tenant-scoped usage, and cache wiring stay
+deferred rather than expanding this PR further.

--- a/plans/PR-Content-Ops-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Usage-Summary.md
@@ -30,10 +30,12 @@ Slice phase: Production hardening
 | File | Change |
 |---|---|
 | `plans/PR-Content-Ops-Usage-Summary.md` | Plan doc for the first Content Ops cost read path. |
+| `atlas_brain/api/__init__.py` | Wire the hosted Content Ops usage route to the Atlas DB pool. |
 | `extracted_content_pipeline/content_ops_usage_summary.py` | Query and serialize Content Ops llm_usage rollups. |
 | `extracted_content_pipeline/api/control_surfaces.py` | Expose the optional usage summary route. |
 | `extracted_content_pipeline/manifest.json` | Register the new usage-summary helper as an owned extracted-package file. |
 | `tests/test_extracted_content_control_surface_api.py` | Cover route provider behavior and usage-summary filters/output. |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | Cover hosted Atlas wiring for the usage route. |
 
 ## Mechanism
 
@@ -46,6 +48,10 @@ llm_usage run_id column when present.
 The route is opt-in via `usage_pool_provider`, matching the existing host-owned
 provider pattern in the control-surface API. If the host does not wire a pool,
 the route returns 503 instead of pretending usage is available.
+
+Atlas wires the route to its shared DB pool in `atlas_brain/api/__init__.py` so
+the hosted `/api/v1/content-ops/usage/summary` path is usable immediately after
+merge.
 
 ## Intentional
 
@@ -68,7 +74,8 @@ the route returns 503 instead of pretending usage is available.
 ## Verification
 
 - python -m pytest tests/test_extracted_content_control_surface_api.py -q — 107 passed.
-- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py — passed.
+- python -m pytest tests/test_atlas_content_ops_generated_assets_api.py -q — 5 passed.
+- python -m compileall -q atlas_brain/api/__init__.py extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
@@ -79,12 +86,13 @@ the route returns 503 instead of pretending usage is available.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~95 |
+| Plan doc | ~105 |
+| Atlas host wiring | ~15 |
 | Usage summary helper | ~210 |
 | API route | ~60 |
-| Tests | ~120 |
+| Tests | ~140 |
 | Manifest | ~5 |
-| **Total** | **~490** |
+| **Total** | **~535** |
 
 This exceeds the 400 LOC soft cap because the first read path needs a query
 helper, a route seam, manifest inventory, and response-shape tests in the same

--- a/plans/PR-Content-Ops-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Usage-Summary.md
@@ -1,0 +1,92 @@
+# PR: Content Ops Usage Summary
+
+## Why this slice exists
+
+PR-Content-Ops-LLM-Usage-Tracing made Content Ops provider calls write shared
+llm_usage rows. The next production hardening step is a small read path that
+lets operators see recent Content Ops spend before we wire budget gates or exact
+caching.
+
+This keeps the cost/caching lane source-first: trace actual calls, then surface
+actual spend, then make budget/cache decisions from that data.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a Content Ops usage summary helper that aggregates llm_usage rows
+   attributed to `content_ops`.
+2. Add an optional `/content-ops/usage/summary` route behind a host-provided
+   usage pool provider.
+3. Support narrow operator filters for recent days, asset type, run id, and
+   request id.
+4. Return total cost/tokens/cache/failure counts plus provider/model and
+   asset-type breakdowns.
+5. Add focused tests for provider configuration, filters, and response shape.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Usage-Summary.md` | Plan doc for the first Content Ops cost read path. |
+| `extracted_content_pipeline/content_ops_usage_summary.py` | Query and serialize Content Ops llm_usage rollups. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Expose the optional usage summary route. |
+| `extracted_content_pipeline/manifest.json` | Register the new usage-summary helper as an owned extracted-package file. |
+| `tests/test_extracted_content_control_surface_api.py` | Cover route provider behavior and usage-summary filters/output. |
+
+## Mechanism
+
+The helper builds a fixed SQL filter around rows where
+`span_name = 'content_ops.llm.complete'` or `metadata ->> 'product' =
+'content_ops'`. Optional filters add exact matches against `asset_type`,
+`request_id`, and `run_id` metadata, with `run_id` also checking the promoted
+llm_usage run_id column when present.
+
+The route is opt-in via `usage_pool_provider`, matching the existing host-owned
+provider pattern in the control-surface API. If the host does not wire a pool,
+the route returns 503 instead of pretending usage is available.
+
+## Intentional
+
+- This is read-only. It does not introduce budget gating or cache behavior.
+- This does not add UI yet; the route gives the UI a stable backend contract.
+- This does not add new schema. It reads the existing llm_usage fields written
+  by the shared tracer.
+- This does not capture or expose prompt/response bodies.
+
+## Deferred
+
+- Future PR: add UI/control-surface cards that call this route.
+- Future PR: wire `BudgetGate` once usage summary is queryable in the product.
+- Future PR: add exact-cache integration with explicit support-ticket privacy
+  policy and account scoping.
+- Future PR: add execution/run identifiers to Content Ops `/execute` if we need
+  first-class run-level grouping beyond caller metadata.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_control_surface_api.py -q — 107 passed.
+- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Usage summary helper | ~210 |
+| API route | ~60 |
+| Tests | ~120 |
+| Manifest | ~5 |
+| **Total** | **~490** |
+
+This exceeds the 400 LOC soft cap because the first read path needs a query
+helper, a route seam, manifest inventory, and response-shape tests in the same
+slice. UI, budget gating, and cache wiring stay deferred rather than expanding
+this PR further.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -69,6 +69,7 @@ pytest \
   tests/test_extracted_support_ticket_input_provider.py \
   tests/test_smoke_content_ops_support_ticket_package.py \
   tests/test_extracted_content_control_surface_api.py \
+  tests/test_extracted_content_ops_usage_summary.py \
   tests/test_extracted_content_ops_execution.py \
   tests/test_extracted_content_ops_execution_smoke.py \
   tests/test_atlas_content_ops_infrastructure.py \

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -12,6 +12,8 @@ import sys
 
 import pytest
 
+from atlas_brain.auth.dependencies import AuthUser
+
 pytest.importorskip("asyncpg")
 
 
@@ -96,6 +98,45 @@ def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
 
     assert closure["usage_pool_provider"].__name__ == "get_db_pool"
     assert "_capture_content_ops_auth_user" in dependency_names
+    assert "_require_content_ops_usage_operator" in dependency_names
+
+
+@pytest.mark.asyncio
+async def test_content_ops_usage_summary_operator_gate_rejects_account_admin() -> None:
+    api_pkg = _fresh_api_package()
+    user = AuthUser(
+        user_id="user-1",
+        account_id="account-1",
+        plan="b2b_growth",
+        plan_status="active",
+        role="owner",
+        product="b2b_retention",
+        is_admin=True,
+        is_platform_admin=False,
+    )
+
+    with pytest.raises(api_pkg.HTTPException) as exc:
+        await api_pkg._require_content_ops_usage_operator(user=user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Platform admin access required"
+
+
+@pytest.mark.asyncio
+async def test_content_ops_usage_summary_operator_gate_allows_platform_admin() -> None:
+    api_pkg = _fresh_api_package()
+    user = AuthUser(
+        user_id="user-1",
+        account_id="account-1",
+        plan="b2b_growth",
+        plan_status="active",
+        role="member",
+        product="b2b_retention",
+        is_admin=True,
+        is_platform_admin=True,
+    )
+
+    assert await api_pkg._require_content_ops_usage_operator(user=user) is user
 
 
 def test_public_landing_page_route_uses_pool_without_content_ops_auth_dependency() -> None:

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -80,6 +80,24 @@ def test_faq_deflection_search_route_uses_shared_content_ops_auth_scope_and_pool
     assert "_capture_content_ops_auth_user" in dependency_names
 
 
+def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/usage/summary")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["usage_pool_provider"].__name__ == "get_db_pool"
+    assert "_capture_content_ops_auth_user" in dependency_names
+
+
 def test_public_landing_page_route_uses_pool_without_content_ops_auth_dependency() -> None:
     api_pkg = _fresh_api_package()
     route = _route(api_pkg, "/content-assets/landing_page/public/{landing_page_id}")

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -1,6 +1,7 @@
 import pytest
 
 from atlas_brain.auth.dependencies import (
+    AuthUser,
     B2B_PLAN_ORDER,
     PLAN_ORDER,
     _effective_is_admin,
@@ -23,6 +24,22 @@ def test_effective_is_admin_true_from_admin_role():
 
 def test_effective_is_admin_false_for_member_without_flag():
     assert _effective_is_admin("member", False) is False
+
+
+def test_auth_user_keeps_platform_admin_separate_from_account_admin():
+    user = AuthUser(
+        user_id="user-1",
+        account_id="account-1",
+        plan="b2b_growth",
+        plan_status="active",
+        role="owner",
+        product="b2b_retention",
+        is_admin=True,
+        is_platform_admin=False,
+    )
+
+    assert user.is_admin is True
+    assert user.is_platform_admin is False
 
 
 def test_require_plan_rejects_unknown_consumer_tier():

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+from datetime import datetime, timezone
+from decimal import Decimal
 
 import pytest
 
@@ -137,6 +139,54 @@ class _Pool:
     async def execute(self, query, *args):
         self.executed.append((str(query), args))
         return "EXECUTE"
+
+
+class _UsagePool:
+    is_initialized = True
+
+    def __init__(self):
+        self.fetchrow_calls = []
+        self.fetch_calls = []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((str(query), args))
+        return {
+            "total_cost_usd": Decimal("1.234567"),
+            "input_tokens": 1200,
+            "billable_input_tokens": 1100,
+            "output_tokens": 300,
+            "total_tokens": 1500,
+            "cached_tokens": 100,
+            "cache_write_tokens": 25,
+            "total_calls": 4,
+            "failed_calls": 1,
+            "cache_hit_calls": 2,
+            "avg_duration_ms": Decimal("234.56"),
+            "latest_call_at": datetime(2026, 5, 26, 17, 0, tzinfo=timezone.utc),
+        }
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        if "GROUP BY provider, model" in str(query):
+            return [
+                {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-haiku-4-5",
+                    "cost_usd": Decimal("1.000000"),
+                    "calls": 3,
+                    "input_tokens": 900,
+                    "output_tokens": 200,
+                }
+            ]
+        return [
+            {
+                "asset_type": "blog_post",
+                "cost_usd": Decimal("0.750000"),
+                "calls": 2,
+                "input_tokens": 600,
+                "output_tokens": 150,
+            }
+        ]
 
 
 class _Transaction:
@@ -309,6 +359,83 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
         "max_source_text_chars": 10000,
         "max_sample_limit": 25,
     }
+
+
+@pytest.mark.asyncio
+async def test_usage_summary_route_requires_configured_pool_provider():
+    router = create_content_ops_control_surface_router()
+
+    route = _route(router, "/content-ops/usage/summary", "GET")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint()
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Content Ops usage database is unavailable."
+
+
+@pytest.mark.asyncio
+async def test_usage_summary_route_returns_content_ops_llm_rollup_with_filters():
+    pool = _UsagePool()
+    router = create_content_ops_control_surface_router(
+        usage_pool_provider=lambda: pool,
+    )
+
+    route = _route(router, "/content-ops/usage/summary", "GET")
+    payload = await route.endpoint(
+        days=14,
+        asset_type="blog_post",
+        run_id="run-123",
+        request_id="req-456",
+    )
+
+    assert payload["period_days"] == 14
+    assert payload["filters"] == {
+        "asset_type": "blog_post",
+        "run_id": "run-123",
+        "request_id": "req-456",
+    }
+    assert payload["summary"] == {
+        "total_cost_usd": 1.234567,
+        "total_calls": 4,
+        "failed_calls": 1,
+        "input_tokens": 1200,
+        "billable_input_tokens": 1100,
+        "output_tokens": 300,
+        "total_tokens": 1500,
+        "cached_tokens": 100,
+        "cache_write_tokens": 25,
+        "cache_hit_calls": 2,
+        "avg_duration_ms": 234.6,
+        "latest_call_at": "2026-05-26T17:00:00+00:00",
+    }
+    assert payload["by_model"] == [
+        {
+            "provider": "openrouter",
+            "model": "anthropic/claude-haiku-4-5",
+            "cost_usd": 1.0,
+            "calls": 3,
+            "input_tokens": 900,
+            "output_tokens": 200,
+        }
+    ]
+    assert payload["by_asset_type"] == [
+        {
+            "asset_type": "blog_post",
+            "cost_usd": 0.75,
+            "calls": 2,
+            "input_tokens": 600,
+            "output_tokens": 150,
+        }
+    ]
+    summary_query, summary_args = pool.fetchrow_calls[0]
+    assert "span_name = 'content_ops.llm.complete'" in summary_query
+    assert "metadata ->> 'product' = 'content_ops'" in summary_query
+    assert "metadata ->> 'asset_type' = $2" in summary_query
+    assert "(run_id = $3 OR metadata ->> 'run_id' = $3)" in summary_query
+    assert "metadata ->> 'request_id' = $4" in summary_query
+    assert summary_args == (14, "blog_post", "run-123", "req-456")
+    assert len(pool.fetch_calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_ops_usage_summary.py
+++ b/tests/test_extracted_content_ops_usage_summary.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from extracted_content_pipeline.content_ops_usage_summary import (
+    summarize_content_ops_llm_usage,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_content_ops_usage_summary_contract_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    request_id = f"usage-summary-{uuid4().hex}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/127_llm_usage.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/252_llm_usage_cache_breakdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/253_llm_usage_vendor_and_run_id.sql").read_text())
+        await pool.executemany(
+            """
+            INSERT INTO llm_usage (
+                span_name, operation_type, model_name, model_provider,
+                input_tokens, output_tokens, total_tokens, billable_input_tokens,
+                cached_tokens, cache_write_tokens, cost_usd, duration_ms, status,
+                metadata, run_id
+            )
+            VALUES (
+                $1, 'llm_call', $2, $3,
+                $4, $5, $6, $7,
+                $8, $9, $10, $11, $12,
+                $13::jsonb, $14
+            )
+            """,
+            [
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    100,
+                    40,
+                    140,
+                    90,
+                    10,
+                    5,
+                    Decimal("0.100000"),
+                    120,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "asset_type": "blog_post",
+                        "request_id": request_id,
+                    }),
+                    "run-a",
+                ),
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    30,
+                    10,
+                    40,
+                    30,
+                    0,
+                    0,
+                    Decimal("0.050000"),
+                    80,
+                    "failed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "asset_type": "blog_post",
+                        "request_id": request_id,
+                    }),
+                    "run-a",
+                ),
+                (
+                    "other.span",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    999,
+                    999,
+                    1998,
+                    999,
+                    0,
+                    0,
+                    Decimal("9.990000"),
+                    10,
+                    "completed",
+                    json.dumps({
+                        "product": "other",
+                        "asset_type": "blog_post",
+                        "request_id": request_id,
+                    }),
+                    "run-a",
+                ),
+            ],
+        )
+
+        payload = await summarize_content_ops_llm_usage(
+            pool,
+            days=1,
+            asset_type="blog_post",
+            run_id="run-a",
+            request_id=request_id,
+        )
+
+        assert payload["summary"]["total_cost_usd"] == 0.15
+        assert payload["summary"]["total_calls"] == 2
+        assert payload["summary"]["failed_calls"] == 1
+        assert payload["summary"]["input_tokens"] == 130
+        assert payload["summary"]["output_tokens"] == 50
+        assert payload["summary"]["total_tokens"] == 180
+        assert payload["summary"]["billable_input_tokens"] == 120
+        assert payload["summary"]["cached_tokens"] == 10
+        assert payload["summary"]["cache_write_tokens"] == 5
+        assert payload["summary"]["cache_hit_calls"] == 1
+        assert payload["by_model"] == [
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-haiku-4-5",
+                "cost_usd": 0.15,
+                "calls": 2,
+                "input_tokens": 130,
+                "output_tokens": 50,
+            }
+        ]
+        assert payload["by_asset_type"] == [
+            {
+                "asset_type": "blog_post",
+                "cost_usd": 0.15,
+                "calls": 2,
+                "input_tokens": 130,
+                "output_tokens": 50,
+            }
+        ]
+    finally:
+        await pool.execute(
+            "DELETE FROM llm_usage WHERE metadata ->> 'request_id' = $1",
+            request_id,
+        )
+        await pool.close()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Usage-Summary.md
Slice phase: Production hardening

Surface a read-only Content Ops LLM usage summary from `llm_usage`, wired through the hosted Content Ops API as an operator-only global spend view. This closes the first cost-surfacing path before budget gates, UI cards, or cache controls are added.

## Intentional
- Keep usage aggregation global but gate it to platform admins only until tenant-scoped usage metadata is first-class.
- Keep this read-only; budget gates and cache behavior are deferred.
- Do not add UI or prompt/response body exposure in this slice.
- Reuse the existing `llm_usage` schema and Content Ops trace metadata.
- Remove restrictive `NUMERIC(12, 6)` sum casts while keeping response serialization rounded.

## Deferred
- Future PR: add UI/control-surface cards that call this route.
- Future PR: wire `BudgetGate` once usage summary is queryable.
- Future PR: add exact-cache integration with explicit support-ticket privacy policy and account scoping.
- Future PR: add execution/run identifiers to Content Ops `/execute` if first-class run grouping is needed.
- Future PR: add tenant-scoped Content Ops usage once trace metadata reliably carries account scope for every call.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_auth_dependencies.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_content_ops_usage_summary.py -q` — 123 passed, 1 skipped.
- `python -m compileall -q atlas_brain/api/__init__.py atlas_brain/auth/dependencies.py extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <body>` — passed after enrolling `tests/test_extracted_content_ops_usage_summary.py` in the extracted pipeline runner.

## Diff size
11 files, ~752 LOC actual. Over the 400 LOC soft cap because this first read path includes the query helper, route seam, hosted wiring, manifest inventory, response tests, operator-gate coverage, CI enrollment, and a real Postgres aggregation contract test.
