### PR TITLE
Seed SaaS FAQ demo into search projection

### DIFF
--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md
@@ -1,0 +1,106 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Corpus added a synthetic B2B SaaS support-ticket
+corpus, and PR-Content-Ops-FAQ-SaaS-Demo-Artifact added the generated Markdown
+FAQ artifact. The remaining demo handoff gap is search: the hosted FAQ search
+route can only return the SaaS demo FAQ after a host operator has a repeatable
+way to seed that generated FAQ into the existing ticket FAQ tables and search
+projection.
+
+This slice adds the thinnest write path for that handoff. It does not change the
+route or search repository; it uses the existing FAQ producer, FAQ repository,
+approval/status transition, and search repository projection path.
+
+The diff is over the 400 LOC soft target because the vertical slice needs the
+operator script, fake-boundary orchestration tests, and plan together to prove
+the real flow without adding runtime API code. Splitting the script from its
+tests would leave an unproven DB-write handoff.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Vertical slice
+
+1. Add a CLI script that generates the SaaS FAQ from the checked CSV, saves it as
+   a ticket FAQ draft, approves it, and verifies the projected search result.
+2. Return a compact JSON summary with the seeded FAQ id, corpus id, generated
+   item count, projected document count, and verification search result.
+3. Add focused tests in the already-enrolled SaaS demo corpus test file proving
+   the generated draft projects into searchable documents and the seeder
+   orchestrates save -> approve/project -> search.
+4. Keep hosted route code, repository code, migrations, and frontend code
+   unchanged.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md` | Plan contract for this vertical demo seeding slice. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Operator CLI for seeding the generated SaaS FAQ into DB-backed FAQ search. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Existing enrolled test file extended with seeder/search-projection coverage. |
+
+## Mechanism
+
+The script reads `support_ticket_saas_demo_sources.csv`, normalizes it with
+`source_rows_to_campaign_opportunities`, and calls `build_ticket_faq_markdown`
+with the same deterministic parameters as the checked Markdown artifact.
+
+It then creates a `TicketFAQDraft` with `metadata.corpus_id`, persists it through
+`PostgresTicketFAQRepository.save_drafts`, and calls `update_status(...,
+"approved")`. The existing repository status transition is the integration point
+that replaces search projection rows via `build_ticket_faq_search_documents`.
+After that, the script calls `PostgresTicketFAQSearchRepository.search` with a
+known SaaS query and fails closed if no result comes back for the requested
+account/corpus/status.
+
+The tests avoid a live DB by faking the repository boundary, while still using
+the real generator and search projection/search code. A live DB run remains an
+operator command:
+
+```bash
+python scripts/seed_content_ops_faq_saas_demo.py \
+  --database-url "$EXTRACTED_DATABASE_URL" \
+  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --json
+```
+
+## Intentional
+
+- No hosted route change. This slice seeds data the existing route can read.
+- No migration runner is embedded in the seeder; operators should run the
+  existing extracted pipeline migrations before seeding.
+- No cleanup command lands here. The script returns the seeded FAQ id so cleanup
+  can use the existing FAQ/search tables or a later cleanup helper.
+
+## Deferred
+
+- Future PR: route-level live validation against a deployed host after seeding
+  the SaaS demo corpus in the target environment.
+- Future PR: optional cleanup helper for demo FAQ ids if operators need repeated
+  reseeding in shared environments.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 7 passed.
+- python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py - passed.
+- python scripts/seed_content_ops_faq_saas_demo.py --database-url '' --account-id '' --corpus-id '' --target-id '' --status '' --query '' --limit 0 - returned exit 1 with the expected fail-closed validation errors.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
+- git diff --check - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- Live DB seed not run: this checkout does not expose `EXTRACTED_DATABASE_URL` or `DATABASE_URL`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md` | 106 |
+| `scripts/seed_content_ops_faq_saas_demo.py` | 288 |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | 163 |
+| **Total** | **557** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Seed the synthetic B2B SaaS FAQ demo into ticket FAQ search."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    source_rows_to_campaign_opportunities,
+)
+from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    build_ticket_faq_markdown,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft  # noqa: E402
+from extracted_content_pipeline.ticket_faq_postgres import (  # noqa: E402
+    PostgresTicketFAQRepository,
+)
+from extracted_content_pipeline.ticket_faq_search import (  # noqa: E402
+    PostgresTicketFAQSearchRepository,
+    build_ticket_faq_search_documents,
+)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional host dependency
+    load_dotenv = None
+
+
+DEMO_SOURCE_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv"
+DEMO_TITLE = "Synthetic B2B SaaS Support FAQ Demo"
+DEMO_DATASET_LABEL = "synthetic_b2b_saas_demo"
+DEFAULT_CORPUS_ID = "synthetic-b2b-saas-demo"
+DEFAULT_TARGET_ID = "support-synthetic-b2b-saas-demo"
+DEFAULT_TARGET_MODE = "support_account"
+DEFAULT_STATUS = "approved"
+DEFAULT_SUPPORT_CONTACT = "https://example.com/support"
+DEFAULT_QUERY = "export attribution reports"
+
+
+def _load_dotenv_files() -> None:
+    if load_dotenv is not None:
+        load_dotenv(ROOT / ".env")
+        load_dotenv(ROOT / ".env.local", override=True)
+
+
+def _env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return ""
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    _load_dotenv_files()
+    parser = argparse.ArgumentParser(
+        description="Seed the synthetic B2B SaaS FAQ demo into FAQ search."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=_env("EXTRACTED_DATABASE_URL", "DATABASE_URL"),
+    )
+    parser.add_argument(
+        "--account-id",
+        default=_env("ATLAS_FAQ_SEARCH_ACCOUNT_ID", "ATLAS_ACCOUNT_ID"),
+    )
+    parser.add_argument("--user-id", default="")
+    parser.add_argument("--corpus-id", default=DEFAULT_CORPUS_ID)
+    parser.add_argument("--target-id", default=DEFAULT_TARGET_ID)
+    parser.add_argument("--status", default=DEFAULT_STATUS)
+    parser.add_argument("--query", default=DEFAULT_QUERY)
+    parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    if not str(args.database_url or "").strip():
+        errors.append("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if not str(args.account_id or "").strip():
+        errors.append("ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required")
+    if not str(args.corpus_id or "").strip():
+        errors.append("--corpus-id is required")
+    if not str(args.target_id or "").strip():
+        errors.append("--target-id is required")
+    if not str(args.status or "").strip():
+        errors.append("--status is required")
+    if not str(args.query or "").strip():
+        errors.append("--query is required")
+    if int(args.limit) < 1:
+        errors.append("--limit must be positive")
+    return errors
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError("asyncpg is required to seed the SaaS FAQ demo") from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _demo_rows(path: Path = DEMO_SOURCE_PATH) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def build_saas_demo_faq_draft(
+    *,
+    corpus_id: str = DEFAULT_CORPUS_ID,
+    target_id: str = DEFAULT_TARGET_ID,
+) -> TicketFAQDraft:
+    rows = _demo_rows()
+    normalized = source_rows_to_campaign_opportunities(
+        rows,
+        target_mode=DEFAULT_TARGET_MODE,
+    )
+    result = build_ticket_faq_markdown(
+        normalized.opportunities,
+        title=DEMO_TITLE,
+        max_items=12,
+        max_evidence_per_item=3,
+        support_contact=DEFAULT_SUPPORT_CONTACT,
+    )
+    failed_checks = [
+        name for name, passed in sorted(result.output_checks.items())
+        if passed is not True
+    ]
+    if normalized.warnings:
+        raise ValueError("SaaS demo source rows produced normalization warnings")
+    if failed_checks:
+        raise ValueError(f"SaaS demo FAQ output checks failed: {', '.join(failed_checks)}")
+    return TicketFAQDraft(
+        target_id=target_id,
+        target_mode=DEFAULT_TARGET_MODE,
+        title=DEMO_TITLE,
+        markdown=result.markdown,
+        items=result.items,
+        source_count=result.source_count,
+        ticket_source_count=result.ticket_source_count,
+        output_checks=result.output_checks,
+        warnings=result.warnings,
+        metadata={
+            "corpus_id": corpus_id,
+            "dataset_label": DEMO_DATASET_LABEL,
+            "demo_source_path": str(DEMO_SOURCE_PATH.relative_to(ROOT)),
+            "synthetic": True,
+        },
+    )
+
+
+async def seed_saas_demo_faq(
+    pool: Any,
+    *,
+    account_id: str,
+    user_id: str = "",
+    corpus_id: str = DEFAULT_CORPUS_ID,
+    target_id: str = DEFAULT_TARGET_ID,
+    status: str = DEFAULT_STATUS,
+    query: str = DEFAULT_QUERY,
+    limit: int = 5,
+) -> dict[str, Any]:
+    scope = TenantScope(account_id=account_id, user_id=user_id)
+    draft = build_saas_demo_faq_draft(corpus_id=corpus_id, target_id=target_id)
+    faq_repo = PostgresTicketFAQRepository(pool)
+    search_repo = PostgresTicketFAQSearchRepository(pool)
+    saved_ids = tuple(await faq_repo.save_drafts([draft], scope=scope))
+    faq_id = saved_ids[0] if saved_ids else ""
+    errors: list[str] = []
+    if not faq_id:
+        errors.append("FAQ repository did not return a saved FAQ id")
+    updated = False
+    if faq_id:
+        updated = bool(await faq_repo.update_status(faq_id, status, scope=scope))
+        if not updated:
+            errors.append("FAQ repository did not approve the saved FAQ id")
+    # Projection persistence happens inside update_status(...). This projection is
+    # only a diagnostic parity count for the summary payload.
+    projected_draft = replace(draft, id=faq_id, status=status)
+    projected_documents = build_ticket_faq_search_documents(
+        projected_draft,
+        account_id=account_id,
+        corpus_id=corpus_id,
+    )
+    response = await search_repo.search(
+        query=query,
+        account_id=account_id,
+        corpus_id=corpus_id,
+        status=status,
+        limit=limit,
+    )
+    search_payload = response.as_dict()
+    search_results = search_payload.get("results") or []
+    matched_seeded_faq = any(
+        isinstance(row, dict) and row.get("faq_id") == faq_id
+        for row in search_results
+    )
+    if not matched_seeded_faq:
+        errors.append("Seeded SaaS FAQ id was not present in verification search results")
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "account_id": account_id,
+        "corpus_id": corpus_id,
+        "faq_id": faq_id,
+        "status": status,
+        "source_count": draft.source_count,
+        "ticket_source_count": draft.ticket_source_count,
+        "generated_items": len(draft.items),
+        "projected_documents": len(projected_documents),
+        "search": {
+            "query": search_payload.get("query"),
+            "count": search_payload.get("count"),
+            "matched_seeded_faq": matched_seeded_faq,
+            "first_result": (
+                search_results[0]
+                if search_results
+                else None
+            ),
+        },
+    }
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    pool = await _create_pool(str(args.database_url))
+    try:
+        return await seed_saas_demo_faq(
+            pool,
+            account_id=str(args.account_id),
+            user_id=str(args.user_id or ""),
+            corpus_id=str(args.corpus_id),
+            target_id=str(args.target_id),
+            status=str(args.status),
+            query=str(args.query),
+            limit=int(args.limit),
+        )
+    finally:
+        await pool.close()
+
+
+def _write_result(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _print_result(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(
+        "SaaS FAQ demo seed: "
+        f"ok={payload['ok']} faq_id={payload['faq_id']} "
+        f"corpus_id={payload['corpus_id']} search_count={payload['search']['count']} "
+        f"errors={len(payload['errors'])}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    errors = _validate_args(args)
+    if errors:
+        raise SystemExit("; ".join(errors))
+    payload = asyncio.run(_run(args))
+    _write_result(args.output_result, payload)
+    _print_result(payload, as_json=bool(args.json))
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -1,15 +1,35 @@
 import csv
+from dataclasses import replace
+import importlib.util
 from pathlib import Path
+import sys
+from types import SimpleNamespace
 
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.campaign_source_adapters import (
     source_rows_to_campaign_opportunities,
 )
 from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+from extracted_content_pipeline.ticket_faq_search import (
+    build_ticket_faq_search_documents,
+    search_ticket_faq_documents,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEMO_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv"
 DEMO_FAQ_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md"
+SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
+SEED_SPEC = importlib.util.spec_from_file_location(
+    "seed_content_ops_faq_saas_demo",
+    SEED_SCRIPT,
+)
+assert SEED_SPEC is not None and SEED_SPEC.loader is not None
+seeder = importlib.util.module_from_spec(SEED_SPEC)
+sys.modules["seed_content_ops_faq_saas_demo"] = seeder
+SEED_SPEC.loader.exec_module(seeder)
 
 EXPECTED_LABEL = "synthetic_b2b_saas_demo"
 MIN_ROWS = 36
@@ -112,3 +132,146 @@ def test_saas_demo_faq_artifact_matches_real_generator() -> None:
     _rows, _normalized, result = _generated_demo_faq()
 
     assert DEMO_FAQ_PATH.read_text(encoding="utf-8") == result.markdown
+
+
+def test_saas_demo_faq_draft_projects_to_search_documents() -> None:
+    draft = seeder.build_saas_demo_faq_draft()
+    searchable = replace(draft, id="faq-demo-1", status="approved")
+
+    documents = build_ticket_faq_search_documents(
+        searchable,
+        account_id="acct-demo",
+        corpus_id="synthetic-b2b-saas-demo",
+    )
+    response = search_ticket_faq_documents(
+        documents,
+        query="export attribution reports",
+        account_id="acct-demo",
+        corpus_id="synthetic-b2b-saas-demo",
+        status="approved",
+    )
+
+    assert len(documents) == len(draft.items)
+    assert response.as_dict()["count"] >= 1
+    first = response.as_dict()["results"][0]
+    assert first["account_id"] == "acct-demo"
+    assert first["corpus_id"] == "synthetic-b2b-saas-demo"
+    assert "export" in first["question"].lower()
+
+
+def test_saas_demo_seed_args_fail_closed_for_missing_required_values() -> None:
+    errors = seeder._validate_args(
+        SimpleNamespace(
+            database_url="",
+            account_id="",
+            corpus_id="",
+            target_id="",
+            status="",
+            query="",
+            limit=0,
+        )
+    )
+
+    assert errors == [
+        "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL",
+        "ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required",
+        "--corpus-id is required",
+        "--target-id is required",
+        "--status is required",
+        "--query is required",
+        "--limit must be positive",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_saas_demo_seeder_saves_approves_projects_and_searches(monkeypatch) -> None:
+    class _Pool:
+        draft = None
+        scope = None
+        documents = ()
+
+    class _FAQRepo:
+        def __init__(self, pool):
+            self.pool = pool
+
+        async def save_drafts(self, drafts, *, scope: TenantScope):
+            self.pool.draft = drafts[0]
+            self.pool.scope = scope
+            return ("11111111-1111-1111-1111-111111111111",)
+
+        async def update_status(self, faq_id, status, *, scope: TenantScope):
+            assert faq_id == "11111111-1111-1111-1111-111111111111"
+            assert status == "approved"
+            assert scope.account_id == "acct-demo"
+            self.pool.documents = build_ticket_faq_search_documents(
+                replace(self.pool.draft, id=faq_id, status=status),
+                account_id=scope.account_id,
+                corpus_id=self.pool.draft.metadata["corpus_id"],
+            )
+            return True
+
+    class _SearchRepo:
+        def __init__(self, pool):
+            self.pool = pool
+
+        async def search(self, **kwargs):
+            return search_ticket_faq_documents(self.pool.documents, **kwargs)
+
+    monkeypatch.setattr(seeder, "PostgresTicketFAQRepository", _FAQRepo)
+    monkeypatch.setattr(seeder, "PostgresTicketFAQSearchRepository", _SearchRepo)
+
+    payload = await seeder.seed_saas_demo_faq(
+        _Pool(),
+        account_id="acct-demo",
+        corpus_id="synthetic-b2b-saas-demo",
+    )
+
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+    assert payload["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["source_count"] >= MIN_ROWS
+    assert payload["projected_documents"] == payload["generated_items"]
+    assert payload["search"]["count"] >= 1
+    assert payload["search"]["matched_seeded_faq"] is True
+    assert payload["search"]["first_result"]["faq_id"] == payload["faq_id"]
+
+
+@pytest.mark.asyncio
+async def test_saas_demo_seeder_rejects_search_results_for_different_faq(monkeypatch) -> None:
+    class _Response:
+        def as_dict(self):
+            return {
+                "query": "export attribution reports",
+                "count": 1,
+                "results": [{"faq_id": "different-faq-id"}],
+            }
+
+    class _FAQRepo:
+        def __init__(self, _pool):
+            pass
+
+        async def save_drafts(self, _drafts, *, scope: TenantScope):
+            assert scope.account_id == "acct-demo"
+            return ("11111111-1111-1111-1111-111111111111",)
+
+        async def update_status(self, _faq_id, _status, *, scope: TenantScope):
+            assert scope.account_id == "acct-demo"
+            return True
+
+    class _SearchRepo:
+        def __init__(self, _pool):
+            pass
+
+        async def search(self, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr(seeder, "PostgresTicketFAQRepository", _FAQRepo)
+    monkeypatch.setattr(seeder, "PostgresTicketFAQSearchRepository", _SearchRepo)
+
+    payload = await seeder.seed_saas_demo_faq(object(), account_id="acct-demo")
+
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "Seeded SaaS FAQ id was not present in verification search results"
+    ]
+    assert payload["search"]["matched_seeded_faq"] is False


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md
Slice phase: Vertical slice

Adds an operator script that generates the checked synthetic SaaS FAQ, saves it through the ticket FAQ repository, approves it to trigger the existing search projection, and verifies a scoped SaaS search result.

## Intentional
- No hosted route change; this seeds data the existing route can read.
- No migration runner is embedded; operators should run existing extracted migrations first.
- No cleanup command lands here; the result includes the seeded FAQ id for existing table cleanup or a future helper.

## Deferred
- Future PR: route-level live validation against a deployed host after seeding the SaaS demo corpus in the target environment.
- Future PR: optional cleanup helper for repeated reseeding in shared environments.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 7 passed.
- python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py - passed.
- CLI validation with empty required args returned exit 1 with expected fail-closed errors.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder.md - passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- Live DB seed not run: this checkout does not expose EXTRACTED_DATABASE_URL or DATABASE_URL.

## Diff size
3 files, +557 / -0
