### PR TITLE
Add SaaS FAQ demo seeder cleanup

### DIFF
--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Search-Seeder added a real seed path for the
+synthetic B2B SaaS FAQ demo, and the reviewer independently confirmed that
+deleting the seeded FAQ row cascades the projected search rows. The seeder still
+leaves cleanup as a manual SQL step, which is workable for one local proof but
+awkward and risky for repeated shared-environment demo seeding.
+
+This slice adds explicit cleanup by FAQ id and account id to the same operator
+script. It keeps the cleanup narrow: no broad account cleanup, no corpus-wide
+delete, and no route changes.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add `--cleanup-faq-id` support to `seed_content_ops_faq_saas_demo.py`.
+2. Delete only the requested FAQ id within the requested account id.
+3. Parse the asyncpg `DELETE N` command tag and fail closed when it is malformed
+   or when the rowcount is not exactly one.
+4. Add focused positive and negative cleanup tests in the existing enrolled SaaS
+   demo corpus test file.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md` | Plan contract for this cleanup hardening slice. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Adds explicit FAQ-id cleanup mode and result payload. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Adds cleanup success and failure coverage. |
+
+## Mechanism
+
+The CLI keeps seed mode as the default. When `--cleanup-faq-id <id>` is passed,
+`_run(...)` calls `cleanup_saas_demo_faq(...)` instead of the seed path.
+
+Cleanup executes:
+
+```sql
+DELETE FROM ticket_faq_markdown
+ WHERE id = $1::uuid
+   AND account_id = $2
+```
+
+Migration 327 already makes `ticket_faq_search_documents.faq_id` cascade from
+`ticket_faq_markdown.id`, so the source row delete is the correct cleanup
+integration point. The script parses the returned command tag, requires
+`DELETE 1`, and returns a compact JSON payload with the requested FAQ id,
+deleted row count, raw delete status, and error if any.
+
+## Intentional
+
+- Cleanup is by explicit FAQ id plus account id only. Broad demo-account cleanup
+  is deferred so this slice cannot delete unrelated FAQ rows.
+- No migration or live route validation is embedded in this script.
+- Search-document rowcount is not queried here; the database FK cascade is the
+  existing integration contract.
+
+## Deferred
+
+- Future PR: route-level live validation against a deployed host after seeding
+  and cleaning up the SaaS demo in the target environment.
+- Future PR: optional cleanup by manifest file if the demo flow starts seeding
+  multiple FAQ ids per run.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 12 passed.
+- python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py - passed.
+- python scripts/seed_content_ops_faq_saas_demo.py --database-url postgresql://example --account-id acct-demo --cleanup-faq-id '' --json - returned exit 1 with the expected cleanup validation error.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
+- git diff --check - passed.
+- Live DB cleanup not run: this checkout does not expose `EXTRACTED_DATABASE_URL` or `DATABASE_URL`.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md` | 87 |
+| `scripts/seed_content_ops_faq_saas_demo.py` | 66 |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | 96 |
+| **Total** | **249** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -84,6 +84,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--status", default=DEFAULT_STATUS)
     parser.add_argument("--query", default=DEFAULT_QUERY)
     parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument(
+        "--cleanup-faq-id",
+        default=None,
+        help="Delete one seeded FAQ id for this account instead of seeding.",
+    )
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -95,6 +100,10 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
     if not str(args.account_id or "").strip():
         errors.append("ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required")
+    if getattr(args, "cleanup_faq_id", None) is not None:
+        if not str(args.cleanup_faq_id or "").strip():
+            errors.append("--cleanup-faq-id must be a non-empty FAQ id")
+        return errors
     if not str(args.corpus_id or "").strip():
         errors.append("--corpus-id is required")
     if not str(args.target_id or "").strip():
@@ -214,6 +223,7 @@ async def seed_saas_demo_faq(
     if not matched_seeded_faq:
         errors.append("Seeded SaaS FAQ id was not present in verification search results")
     return {
+        "phase": "seed",
         "ok": not errors,
         "errors": errors,
         "account_id": account_id,
@@ -237,9 +247,57 @@ async def seed_saas_demo_faq(
     }
 
 
+def _deleted_row_count(delete_status: Any) -> int | None:
+    parts = str(delete_status or "").split()
+    if len(parts) != 2 or parts[0] != "DELETE":
+        return None
+    try:
+        return int(parts[1])
+    except ValueError:
+        return None
+
+
+async def cleanup_saas_demo_faq(
+    pool: Any,
+    *,
+    account_id: str,
+    faq_id: str,
+) -> dict[str, Any]:
+    delete_status = await pool.execute(
+        """
+        DELETE FROM ticket_faq_markdown
+         WHERE id = $1::uuid
+           AND account_id = $2
+        """,
+        faq_id,
+        account_id,
+    )
+    deleted_faq_ids = _deleted_row_count(delete_status)
+    error = None
+    if deleted_faq_ids is None:
+        error = f"cleanup delete status is not parseable: {delete_status!r}"
+    elif deleted_faq_ids != 1:
+        error = f"cleanup deleted {deleted_faq_ids} FAQ rows but expected 1"
+    return {
+        "phase": "cleanup",
+        "ok": error is None,
+        "account_id": account_id,
+        "faq_id": faq_id,
+        "deleted_faq_ids": deleted_faq_ids,
+        "delete_status": delete_status,
+        "error": error,
+    }
+
+
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
     pool = await _create_pool(str(args.database_url))
     try:
+        if args.cleanup_faq_id is not None:
+            return await cleanup_saas_demo_faq(
+                pool,
+                account_id=str(args.account_id),
+                faq_id=str(args.cleanup_faq_id),
+            )
         return await seed_saas_demo_faq(
             pool,
             account_id=str(args.account_id),
@@ -264,6 +322,14 @@ def _write_result(path: Path | None, payload: dict[str, Any]) -> None:
 def _print_result(payload: dict[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    if payload.get("phase") == "cleanup":
+        print(
+            "SaaS FAQ demo cleanup: "
+            f"ok={payload['ok']} faq_id={payload['faq_id']} "
+            f"deleted_faq_ids={payload['deleted_faq_ids']} "
+            f"error={payload['error'] or ''}"
+        )
         return
     print(
         "SaaS FAQ demo seed: "

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -183,6 +183,31 @@ def test_saas_demo_seed_args_fail_closed_for_missing_required_values() -> None:
     ]
 
 
+def test_saas_demo_cleanup_args_skip_seed_only_required_values() -> None:
+    errors = seeder._validate_args(
+        SimpleNamespace(
+            database_url="postgresql://example",
+            account_id="acct-demo",
+            cleanup_faq_id="",
+            corpus_id="",
+            target_id="",
+            status="",
+            query="",
+            limit=0,
+        )
+    )
+
+    assert errors == ["--cleanup-faq-id must be a non-empty FAQ id"]
+
+
+def test_saas_demo_cleanup_delete_status_parser() -> None:
+    assert seeder._deleted_row_count("DELETE 1") == 1
+    assert seeder._deleted_row_count("DELETE 0") == 0
+    assert seeder._deleted_row_count("UPDATE 1") is None
+    assert seeder._deleted_row_count("DELETE nope") is None
+    assert seeder._deleted_row_count(None) is None
+
+
 @pytest.mark.asyncio
 async def test_saas_demo_seeder_saves_approves_projects_and_searches(monkeypatch) -> None:
     class _Pool:
@@ -275,3 +300,74 @@ async def test_saas_demo_seeder_rejects_search_results_for_different_faq(monkeyp
         "Seeded SaaS FAQ id was not present in verification search results"
     ]
     assert payload["search"]["matched_seeded_faq"] is False
+
+
+@pytest.mark.asyncio
+async def test_saas_demo_cleanup_deletes_single_faq_for_account() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def execute(self, query, *args):
+            self.calls.append({"query": query, "args": args})
+            return "DELETE 1"
+
+    pool = _Pool()
+
+    payload = await seeder.cleanup_saas_demo_faq(
+        pool,
+        account_id="acct-demo",
+        faq_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    assert payload == {
+        "phase": "cleanup",
+        "ok": True,
+        "account_id": "acct-demo",
+        "faq_id": "11111111-1111-1111-1111-111111111111",
+        "deleted_faq_ids": 1,
+        "delete_status": "DELETE 1",
+        "error": None,
+    }
+    assert "WHERE id = $1::uuid" in pool.calls[0]["query"]
+    assert "AND account_id = $2" in pool.calls[0]["query"]
+    assert pool.calls[0]["args"] == (
+        "11111111-1111-1111-1111-111111111111",
+        "acct-demo",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("delete_status", "expected"),
+    [
+        (
+            "DELETE 0",
+            {
+                "deleted_faq_ids": 0,
+                "error": "cleanup deleted 0 FAQ rows but expected 1",
+            },
+        ),
+        (
+            "UPDATE 1",
+            {
+                "deleted_faq_ids": None,
+                "error": "cleanup delete status is not parseable: 'UPDATE 1'",
+            },
+        ),
+    ],
+)
+async def test_saas_demo_cleanup_fails_on_bad_delete_result(delete_status, expected) -> None:
+    class _Pool:
+        async def execute(self, _query, *_args):
+            return delete_status
+
+    payload = await seeder.cleanup_saas_demo_faq(
+        _Pool(),
+        account_id="acct-demo",
+        faq_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    assert payload["ok"] is False
+    assert payload["deleted_faq_ids"] == expected["deleted_faq_ids"]
+    assert payload["error"] == expected["error"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md
Slice phase: Production hardening

Adds explicit FAQ-id cleanup mode to the SaaS FAQ demo seeder so shared environments can reseed safely without broad deletes.

## Intentional
- Cleanup is by explicit FAQ id plus account id only; no broad demo-account or corpus-wide cleanup.
- No migration or live route validation is embedded in this script.
- Search-document rowcount is not queried; the database FK cascade remains the integration contract.

## Deferred
- Future PR: route-level live validation against a deployed host after seeding and cleaning up the SaaS demo in the target environment.
- Future PR: optional cleanup by manifest file if the demo flow starts seeding multiple FAQ ids per run.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q - 12 passed.
- python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py - passed.
- Cleanup CLI validation with an empty cleanup id returned exit 1 with the expected fail-closed error.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Cleanup.md - passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - passed.
- git diff --check - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- Live DB cleanup not run: this checkout does not expose EXTRACTED_DATABASE_URL or DATABASE_URL.

## Diff size
3 files, +249 / -0
