### PR TITLE
Wire hosted Content Ops LLM tracing

### DIFF
--- a/atlas_brain/_content_ops_infrastructure.py
+++ b/atlas_brain/_content_ops_infrastructure.py
@@ -15,10 +15,9 @@ The host already has equivalent infrastructure:
 - `atlas_brain.skills.SkillRegistry.get(name) -> Optional[Skill]`,
   via `get_skill_registry()`.
 
-This module provides thin adapters and factories so the next
-slices (E2 / E3+) can wire LLM-needing generators
-(`landing_page`, `campaign`, etc.) into the Content Ops bundle
-without re-deriving the bridge each time.
+This module provides thin adapters and factories so Content Ops
+generators (`landing_page`, `campaign`, etc.) can use the host's LLM
+and skill infrastructure without re-deriving the bridge each time.
 
 This module is deliberately at `atlas_brain/_content_ops_infrastructure.py`
 (not inside `atlas_brain/api/`) so the test harness can import
@@ -42,6 +41,7 @@ from extracted_content_pipeline.campaign_ports import (
     LLMResponse,
     SkillStore,
 )
+from extracted_content_pipeline.campaign_llm_client import PipelineLLMClient
 
 
 class _HostLLMClient:
@@ -185,14 +185,20 @@ def build_content_ops_llm_client(
 
         pipeline_llm_resolver = get_pipeline_llm
 
+    pipeline_kwargs = {
+        "workload": "openrouter",
+        "prefer_cloud": True,
+        "try_openrouter": True,
+        "auto_activate_ollama": False,
+        "openrouter_model": None,
+    }
     if pipeline_llm_resolver is not None:
-        host_llm = pipeline_llm_resolver(
-            workload="openrouter",
-            try_openrouter=True,
-            auto_activate_ollama=False,
-        )
+        host_llm = pipeline_llm_resolver(**pipeline_kwargs)
         if host_llm is not None:
-            return _HostLLMClient(host_llm)
+            return PipelineLLMClient(
+                resolver=pipeline_llm_resolver,
+                **pipeline_kwargs,
+            )
 
     if llm_registry is None:
         # Lazy import: only production callers reach here. Tests
@@ -206,7 +212,10 @@ def build_content_ops_llm_client(
     host_llm = llm_registry.get_active()
     if host_llm is None:
         return None
-    return _HostLLMClient(host_llm)
+    return PipelineLLMClient(
+        resolver=lambda **_kwargs: host_llm,
+        **pipeline_kwargs,
+    )
 
 
 _HOST_SKILLS_DIR = Path(__file__).resolve().parent / "skills"

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import os
 import time
@@ -133,12 +134,16 @@ class PipelineLLMClient:
 
         started = time.monotonic()
         try:
-            result = self._call_llm(
-                llm,
-                list(messages),
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            call_args = {
+                "llm": llm,
+                "messages": list(messages),
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            if _llm_call_is_async(llm):
+                result = self._call_llm(**call_args)
+            else:
+                result = await asyncio.to_thread(self._call_llm, **call_args)
             if inspect.isawaitable(result):
                 result = await result
             response = _to_response(result, llm=llm)
@@ -286,6 +291,14 @@ def _to_chat_messages(messages: Sequence[LLMMessage]) -> list[Any]:
         )
         for message in messages
     ]
+
+
+def _llm_call_is_async(llm: Any) -> bool:
+    if hasattr(llm, "chat"):
+        return inspect.iscoroutinefunction(getattr(llm, "chat"))
+    if hasattr(llm, "generate"):
+        return inspect.iscoroutinefunction(getattr(llm, "generate"))
+    return False
 
 
 def _to_response(result: Any, *, llm: Any) -> LLMResponse:

--- a/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
+++ b/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
@@ -27,6 +27,8 @@ Slice phase: Production hardening
    production factory return.
 4. Add a hosted-factory test proving Content Ops metadata reaches the
    content_ops.llm.complete trace instead of being dropped.
+5. Preserve the existing event-loop safety for synchronous hosted providers by
+   offloading sync LLM calls before tracing normalizes the response.
 
 ### Files touched
 
@@ -34,7 +36,9 @@ Slice phase: Production hardening
 |---|---|
 | `plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md` | Plan doc for closing the hosted LLM trace wiring gap. |
 | `atlas_brain/_content_ops_infrastructure.py` | Return PipelineLLMClient from the hosted Content Ops LLM factory. |
+| `extracted_content_pipeline/campaign_llm_client.py` | Offload synchronous provider calls inside the shared tracing client. |
 | `tests/test_atlas_content_ops_infrastructure.py` | Update factory tests and pin metadata-preserving trace behavior. |
+| `tests/test_extracted_campaign_llm_client.py` | Pin sync-provider offload behavior for the shared tracing client. |
 
 ## Mechanism
 
@@ -42,9 +46,10 @@ build_content_ops_llm_client() keeps the current preflight behavior by asking
 the host resolver whether an LLM is routable. When the resolver returns a
 provider, the factory returns PipelineLLMClient configured with the same
 resolver and the same OpenRouter-oriented routing kwargs already used today.
-`PipelineLLMClient.complete()` then resolves the provider per call and emits the
-existing content_ops.llm.complete trace with the metadata supplied by the
-generation services.
+PipelineLLMClient.complete() then resolves the provider per call, offloads
+synchronous chat/generate methods with asyncio.to_thread, awaits native async
+providers directly, and emits the existing content_ops.llm.complete trace with
+the metadata supplied by the generation services.
 
 For the active-registry fallback, the factory still checks get_active() first.
 If a provider exists, it returns a PipelineLLMClient with a small resolver that
@@ -60,6 +65,9 @@ the call through the same tracing path.
   OpenRouter workload and auto_activate_ollama=False routing shape.
 - _HostLLMClient remains in place because its direct adapter behavior is still
   tested, but it is no longer the production Content Ops factory path.
+- The sync-provider offload lives in PipelineLLMClient instead of the hosted
+  factory so the shared tracing path stays non-blocking for every sync
+  provider, not just this factory.
 - This does not add UI, budget gates, or cache controls.
 
 ## Deferred
@@ -74,10 +82,14 @@ the call through the same tracing path.
 
 ## Verification
 
-- python -m pytest tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py -q — 27 passed.
-- python -m compileall -q atlas_brain/_content_ops_infrastructure.py tests/test_atlas_content_ops_infrastructure.py — passed.
+- python -m pytest tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py -q — 28 passed, 1 warning.
+- python -m compileall -q atlas_brain/_content_ops_infrastructure.py extracted_content_pipeline/campaign_llm_client.py tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
 - git diff --check — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
 
 ## Estimated diff size
 
@@ -85,7 +97,8 @@ the call through the same tracing path.
 |---|---:|
 | Plan doc | ~80 |
 | Hosted LLM factory | ~35 |
-| Tests | ~70 |
-| **Total** | **~185** |
+| Shared LLM client | ~25 |
+| Tests | ~110 |
+| **Total** | **~250** |
 
 Under the 400 LOC soft cap.

--- a/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
+++ b/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
@@ -89,7 +89,7 @@ the call through the same tracing path.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
 - git diff --check — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-1000-body.md — passed.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
+++ b/plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
@@ -1,0 +1,91 @@
+# PR: Content Ops Hosted LLM Trace Wiring
+
+## Why this slice exists
+
+PR-Content-Ops-LLM-Usage-Tracing made the product PipelineLLMClient emit
+content_ops.llm.complete rows, and PR-Content-Ops-Usage-Summary added the
+operator usage read path over those rows. The hosted Atlas Content Ops factory
+still returns _HostLLMClient, which routes through Atlas LLM services but
+drops per-call metadata and does not use the product tracing client.
+
+That means the read path can exist while hosted /content-ops/execute calls do
+not reliably write the Content Ops usage rows the read path summarizes. This
+slice fixes that integration at the LLM factory source before UI cost cards,
+tenant-scoped usage, budget gates, or cache controls build on top of it.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Make build_content_ops_llm_client() return the product
+   PipelineLLMClient for both pipeline-routed and active-registry Atlas LLMs.
+2. Preserve the existing factory contract: return None when no provider is
+   routable, so execution slots stay disabled instead of failing later.
+3. Keep the existing _HostLLMClient adapter available for direct adapter tests
+   and any future non-tracing host-only use, but stop using it as the hosted
+   production factory return.
+4. Add a hosted-factory test proving Content Ops metadata reaches the
+   content_ops.llm.complete trace instead of being dropped.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md` | Plan doc for closing the hosted LLM trace wiring gap. |
+| `atlas_brain/_content_ops_infrastructure.py` | Return PipelineLLMClient from the hosted Content Ops LLM factory. |
+| `tests/test_atlas_content_ops_infrastructure.py` | Update factory tests and pin metadata-preserving trace behavior. |
+
+## Mechanism
+
+build_content_ops_llm_client() keeps the current preflight behavior by asking
+the host resolver whether an LLM is routable. When the resolver returns a
+provider, the factory returns PipelineLLMClient configured with the same
+resolver and the same OpenRouter-oriented routing kwargs already used today.
+`PipelineLLMClient.complete()` then resolves the provider per call and emits the
+existing content_ops.llm.complete trace with the metadata supplied by the
+generation services.
+
+For the active-registry fallback, the factory still checks get_active() first.
+If a provider exists, it returns a PipelineLLMClient with a small resolver that
+returns that provider. This preserves the previous fallback shape while moving
+the call through the same tracing path.
+
+## Intentional
+
+- This does not add tenant-scoped usage yet. It makes hosted calls write the
+  trace rows first; account metadata can be added as the next safe tenant-card
+  prerequisite.
+- This does not change model routing defaults. The factory keeps the current
+  OpenRouter workload and auto_activate_ollama=False routing shape.
+- _HostLLMClient remains in place because its direct adapter behavior is still
+  tested, but it is no longer the production Content Ops factory path.
+- This does not add UI, budget gates, or cache controls.
+
+## Deferred
+
+- Future PR: add account_id to Content Ops LLM trace metadata so tenant-facing
+  usage cards can filter by metadata ->> 'account_id'.
+- Future PR: add UI/control-surface cards against the usage summary route.
+- Future PR: wire BudgetGate once hosted usage rows are known to be emitted.
+- Future PR: add exact-cache integration with explicit support-ticket privacy
+  policy and account scoping.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py -q — 27 passed.
+- python -m compileall -q atlas_brain/_content_ops_infrastructure.py tests/test_atlas_content_ops_infrastructure.py — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Hosted LLM factory | ~35 |
+| Tests | ~70 |
+| **Total** | **~185** |
+
+Under the 400 LOC soft cap.

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -50,7 +50,9 @@ from atlas_brain._content_ops_infrastructure import (
     build_content_ops_llm_client,
     build_content_ops_skill_store,
 )
+from extracted_content_pipeline.campaign_llm_client import PipelineLLMClient
 from extracted_content_pipeline.campaign_ports import LLMMessage
+import extracted_content_pipeline.pipelines.llm as pipeline_llm_module
 
 _ROOT = Path(__file__).resolve().parents[1]
 
@@ -260,32 +262,92 @@ def test_build_content_ops_llm_client_returns_none_when_no_llm_routable() -> Non
     )
 
 
-def test_build_content_ops_llm_client_wraps_pipeline_routed_service() -> None:
+@pytest.mark.asyncio
+async def test_build_content_ops_llm_client_uses_pipeline_tracing_client(
+    monkeypatch,
+) -> None:
     """Factory resolves through Atlas pipeline routing before
     looking at the active registry slot. This is the production
     path for configured OpenRouter Claude models that are not
     pre-activated globally."""
 
     calls: list[dict[str, Any]] = []
-    fake_service = SimpleNamespace(model_info=None, chat=lambda *a, **k: {})
+    trace_calls: list[tuple[str, dict[str, Any]]] = []
+
+    class _TracingFakeService:
+        model = "anthropic/claude-haiku-4-5"
+        name = "openrouter"
+
+        def chat(self, messages, *, max_tokens, temperature):
+            del messages, max_tokens, temperature
+            return {
+                "response": "ok",
+                "model": "anthropic/claude-haiku-4-5",
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+            }
+
+    fake_service = _TracingFakeService()
 
     def _resolver(**kwargs: Any) -> Any:
         calls.append(dict(kwargs))
         return fake_service
+
+    monkeypatch.setattr(
+        pipeline_llm_module,
+        "trace_llm_call",
+        lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+    )
 
     client = build_content_ops_llm_client(
         llm_registry=SimpleNamespace(get_active=lambda: None),
         pipeline_llm_resolver=_resolver,
     )
 
-    assert isinstance(client, _HostLLMClient)
-    # The wrapped service is the one we patched.
-    assert client._host is fake_service  # type: ignore[attr-defined]
+    assert isinstance(client, PipelineLLMClient)
     assert calls == [{
         "workload": "openrouter",
+        "prefer_cloud": True,
         "try_openrouter": True,
         "auto_activate_ollama": False,
+        "openrouter_model": None,
     }]
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="Draft")],
+        max_tokens=32,
+        temperature=0.2,
+        metadata={"asset_type": "blog_post", "request_id": "req-hosted"},
+    )
+
+    assert response.content == "ok"
+    assert calls == [
+        {
+            "workload": "openrouter",
+            "prefer_cloud": True,
+            "try_openrouter": True,
+            "auto_activate_ollama": False,
+            "openrouter_model": None,
+        },
+        {
+            "workload": "openrouter",
+            "prefer_cloud": True,
+            "try_openrouter": True,
+            "auto_activate_ollama": False,
+            "openrouter_model": None,
+        },
+    ]
+    assert len(trace_calls) == 1
+    span_name, trace = trace_calls[0]
+    assert span_name == "content_ops.llm.complete"
+    assert trace["input_tokens"] == 11
+    assert trace["output_tokens"] == 7
+    assert trace["metadata"] == {
+        "product": "content_ops",
+        "workload": "openrouter",
+        "llm_adapter": "pipeline",
+        "asset_type": "blog_post",
+        "request_id": "req-hosted",
+    }
 
 
 def test_build_content_ops_llm_client_falls_back_to_active_registry_service() -> None:
@@ -298,8 +360,8 @@ def test_build_content_ops_llm_client_falls_back_to_active_registry_service() ->
         llm_registry=stub_registry,
         pipeline_llm_resolver=lambda **_kwargs: None,
     )
-    assert isinstance(client, _HostLLMClient)
-    assert client._host is fake_service  # type: ignore[attr-defined]
+    assert isinstance(client, PipelineLLMClient)
+    assert client.resolver() is fake_service
 
 
 def test_build_content_ops_skill_store_uses_injected_registry() -> None:

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import pytest
 
 from extracted_content_pipeline.campaign_llm_client import (
@@ -118,6 +121,43 @@ async def test_pipeline_llm_client_resolves_and_normalizes_chat_response():
     assert response.usage == {"input_tokens": 10, "output_tokens": 4}
     assert llm.calls[0]["max_tokens"] == 200
     assert resolver_calls[0]["workload"] == "draft"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_offloads_sync_chat_without_blocking_event_loop():
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingChatLLM:
+        model = "blocking-chat-model"
+
+        def chat(self, messages, *, max_tokens, temperature):
+            del messages, max_tokens, temperature
+            started.set()
+            release.wait(timeout=0.25)
+            return {"response": "released"}
+
+    client = PipelineLLMClient(resolver=lambda **_: _BlockingChatLLM())
+    task = asyncio.create_task(
+        client.complete(
+            [LLMMessage(role="user", content="Write the email")],
+            max_tokens=200,
+            temperature=0.2,
+        )
+    )
+
+    for _ in range(50):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.01)
+
+    assert started.is_set()
+    await asyncio.wait_for(asyncio.sleep(0), timeout=0.1)
+    assert task.done() is False
+    release.set()
+    response = await asyncio.wait_for(task, timeout=1)
+
+    assert response.content == "released"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Hosted-LLM-Trace-Wiring.md
Ownership lane: content-ops/cost-surfacing
Slice phase: Production hardening

Wire hosted Atlas Content Ops execution through the product PipelineLLMClient so /content-ops/execute calls emit content_ops.llm.complete usage rows, while preserving the existing disabled-slot behavior when no provider is routable and the existing non-blocking behavior for synchronous hosted providers.

## Intentional

- The hosted factory now returns PipelineLLMClient for both pipeline-routed and active-registry providers so tracing happens at the production factory source.
- _HostLLMClient stays in place for direct adapter coverage and any future host-only adapter use, but it is no longer the hosted Content Ops factory return.
- Sync provider offload is handled inside PipelineLLMClient with asyncio.to_thread so the shared tracing path remains event-loop safe for every sync chat/generate provider.
- This slice does not add tenant-facing usage cards, budget gates, cache controls, or model-routing default changes.

## Deferred

- Future PR: add account_id to Content Ops LLM trace metadata so tenant-facing usage cards can filter by metadata ->> 'account_id'.
- Future PR: add UI/control-surface cards against the usage summary route.
- Future PR: wire BudgetGate once hosted usage rows are known to be emitted.
- Future PR: add exact-cache integration with explicit support-ticket privacy policy and account scoping.

## Parked hardening

None.

## Verification

- python -m pytest tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py -q — 28 passed, 1 warning.
- python -m compileall -q atlas_brain/_content_ops_infrastructure.py extracted_content_pipeline/campaign_llm_client.py tests/test_atlas_content_ops_infrastructure.py tests/test_extracted_campaign_llm_client.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-1000-body.md — passed.

## Diff size

~250 LOC, under the 400 LOC soft cap.
