### PR TITLE
Add Content Ops usage account metadata

### DIFF
--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import time
 from collections.abc import Callable, Mapping, Sequence
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -19,6 +20,10 @@ class LLMUnavailableError(RuntimeError):
 
 LLMResolver = Callable[..., Any]
 LLMTraceCallable = Callable[..., None]
+_TRACE_CONTEXT: ContextVar[Mapping[str, Any]] = ContextVar(
+    "content_ops_llm_trace_context",
+    default={},
+)
 
 
 def _default_resolver(**kwargs: Any) -> Any:
@@ -44,6 +49,33 @@ def _to_bool(value: Any, default: bool) -> bool:
 def _optional_text(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def set_content_ops_llm_trace_context(
+    metadata: Mapping[str, Any] | None,
+) -> Token[Mapping[str, Any]]:
+    """Set request/tenant metadata that all Content Ops LLM traces should carry."""
+
+    return _TRACE_CONTEXT.set(_clean_trace_context(metadata))
+
+
+def reset_content_ops_llm_trace_context(token: Token[Mapping[str, Any]]) -> None:
+    _TRACE_CONTEXT.reset(token)
+
+
+def current_content_ops_llm_trace_context() -> dict[str, Any]:
+    return dict(_TRACE_CONTEXT.get({}))
+
+
+def _clean_trace_context(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(metadata, Mapping):
+        return {}
+    cleaned: dict[str, Any] = {}
+    for key, value in metadata.items():
+        text = _optional_text(value)
+        if text:
+            cleaned[str(key)] = text
+    return cleaned
 
 
 @dataclass(frozen=True)
@@ -185,6 +217,7 @@ class PipelineLLMClient:
             "workload": self.workload or "default",
             "llm_adapter": "pipeline",
         }
+        trace_metadata.update(current_content_ops_llm_trace_context())
         trace_metadata.update(dict(metadata or {}))
         try:
             self.tracer(

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -222,8 +222,12 @@ class PipelineLLMClient:
             "workload": self.workload or "default",
             "llm_adapter": "pipeline",
         }
-        trace_metadata.update(current_content_ops_llm_trace_context())
-        trace_metadata.update(dict(metadata or {}))
+        scoped_metadata = current_content_ops_llm_trace_context()
+        call_metadata = dict(metadata or {})
+        call_metadata.pop("account_id", None)
+        call_metadata.pop("user_id", None)
+        trace_metadata.update(scoped_metadata)
+        trace_metadata.update(call_metadata)
         try:
             self.tracer(
                 "content_ops.llm.complete",

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -10,6 +10,10 @@ from types import MappingProxyType
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .campaign_llm_client import (
+    reset_content_ops_llm_trace_context,
+    set_content_ops_llm_trace_context,
+)
 from .control_surfaces import OUTPUT_CATALOG, ContentOpsRequest, request_from_mapping
 from .generation_plan import GenerationPlan, GenerationPlanStep, build_generation_plan
 from .landing_page_input_contract import LANDING_PAGE_CONTEXT_INPUT_KEYS
@@ -310,6 +314,9 @@ async def _execute_step(
             ),
             error,
         )
+    trace_context_token = set_content_ops_llm_trace_context(
+        _scope_trace_metadata(scope)
+    )
     try:
         result = await _run_step(
             step,
@@ -329,6 +336,8 @@ async def _execute_step(
             ),
             error,
         )
+    finally:
+        reset_content_ops_llm_trace_context(trace_context_token)
     result_dict = _result_dict(result)
     return (
         ContentOpsStepExecution(
@@ -345,6 +354,17 @@ async def _execute_step(
         ),
         None,
     )
+
+
+def _scope_trace_metadata(scope: TenantScope) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    account_id = str(scope.account_id or "").strip()
+    user_id = str(scope.user_id or "").strip()
+    if account_id:
+        metadata["account_id"] = account_id
+    if user_id:
+        metadata["user_id"] = user_id
+    return metadata
 
 
 async def execute_content_ops_from_mapping(

--- a/plans/PR-Content-Ops-Usage-Account-Metadata.md
+++ b/plans/PR-Content-Ops-Usage-Account-Metadata.md
@@ -83,7 +83,7 @@ asset_type, request_id, run_id, skill_name, and attempt_no.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Ops-Usage-Account-Metadata.md
+++ b/plans/PR-Content-Ops-Usage-Account-Metadata.md
@@ -22,7 +22,8 @@ Slice phase: Production hardening
 2. Set that context around each Content Ops execution step from the resolved
    TenantScope.
 3. Preserve explicit per-call metadata precedence for existing generator
-   metadata such as asset_type, request_id, and run_id.
+   labels such as asset_type, request_id, and run_id, while keeping scoped
+   account_id and user_id authoritative.
 4. Add focused tests proving account_id and user_id reach successful and failed
    LLM traces without leaking across calls.
 
@@ -45,9 +46,10 @@ a finally block after the step finishes, so concurrent steps do not leave stale
 scope behind for later calls.
 
 Trace metadata merge order is base Content Ops metadata, scoped execution
-metadata, then explicit generator metadata. That lets the execution boundary add
-account_id while preserving existing per-call labels such as asset_type,
-request_id, run_id, skill_name, and attempt_no.
+metadata, then explicit generator metadata after stripping account_id and
+user_id from the per-call mapping. That lets the execution boundary add trusted
+account_id and user_id while preserving existing per-call labels such as
+asset_type, request_id, run_id, skill_name, and attempt_no.
 
 ## Intentional
 
@@ -57,6 +59,8 @@ request_id, run_id, skill_name, and attempt_no.
   slice.
 - This does not modify every generator. The executor and tracing client are the
   shared source of truth for execution-scope metadata.
+- Per-call metadata cannot override scoped account_id or user_id. Those fields
+  are the tenant attribution anchor for future tenant-facing usage filters.
 - This does not add UI, budget gates, or cache controls.
 
 ## Deferred
@@ -72,14 +76,14 @@ request_id, run_id, skill_name, and attempt_no.
 
 ## Verification
 
-- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py -q — 68 passed.
+- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py -q — 69 passed, 1 warning.
 - python -m compileall -q extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py — passed.
 - git diff --check — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
 
 ## Estimated diff size
 

--- a/plans/PR-Content-Ops-Usage-Account-Metadata.md
+++ b/plans/PR-Content-Ops-Usage-Account-Metadata.md
@@ -1,0 +1,94 @@
+# PR: Content Ops Usage Account Metadata
+
+## Why this slice exists
+
+The operator usage summary can now read Content Ops LLM usage rows, and the
+hosted LLM factory slice wires hosted generation into the product tracing
+client. The next prerequisite for tenant-facing spend cards is account scope in
+the trace metadata. Without account metadata, any tenant-facing route or UI card
+would either be impossible to filter correctly or would risk exposing global
+spend.
+
+This slice adds the account metadata at the execution boundary where TenantScope
+is already known, instead of patching every individual generator call site.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a scoped Content Ops LLM trace metadata context to the product
+   PipelineLLMClient.
+2. Set that context around each Content Ops execution step from the resolved
+   TenantScope.
+3. Preserve explicit per-call metadata precedence for existing generator
+   metadata such as asset_type, request_id, and run_id.
+4. Add focused tests proving account_id and user_id reach successful and failed
+   LLM traces without leaking across calls.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Usage-Account-Metadata.md` | Plan doc for tenant/account usage metadata. |
+| `extracted_content_pipeline/campaign_llm_client.py` | Add scoped trace metadata and merge it into Content Ops trace rows. |
+| `extracted_content_pipeline/content_ops_execution.py` | Set scoped trace metadata around each executed generation step. |
+| `tests/test_extracted_campaign_llm_client.py` | Pin scoped metadata merge and reset behavior. |
+| `tests/test_extracted_content_ops_execution.py` | Pin execution-scope account metadata around service calls. |
+
+## Mechanism
+
+PipelineLLMClient reads a ContextVar-backed metadata mapping at trace time. The
+executor sets that context for each step using the resolved TenantScope:
+account_id and user_id are included only when non-empty. The context is reset in
+a finally block after the step finishes, so concurrent steps do not leave stale
+scope behind for later calls.
+
+Trace metadata merge order is base Content Ops metadata, scoped execution
+metadata, then explicit generator metadata. That lets the execution boundary add
+account_id while preserving existing per-call labels such as asset_type,
+request_id, run_id, skill_name, and attempt_no.
+
+## Intentional
+
+- This does not add a tenant-facing usage summary route yet. It only makes the
+  underlying usage rows filterable by metadata ->> 'account_id'.
+- This does not change the operator-only global usage route from the previous
+  slice.
+- This does not modify every generator. The executor and tracing client are the
+  shared source of truth for execution-scope metadata.
+- This does not add UI, budget gates, or cache controls.
+
+## Deferred
+
+- Future PR: add a tenant-scoped usage summary path that filters by metadata ->>
+  'account_id' from the authenticated TenantScope.
+- Future PR: add UI/control-surface cards against the correct operator or tenant
+  usage route.
+- Future PR: wire BudgetGate once account-scoped usage is queryable.
+- Future PR: add exact-cache integration with explicit support-ticket privacy
+  policy and account scoping.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py -q — 68 passed.
+- python -m compileall -q extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py — passed.
+- git diff --check — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Pipeline LLM trace context | ~55 |
+| Executor context wiring | ~30 |
+| Tests | ~115 |
+| **Total** | **~285** |
+
+Under the 400 LOC soft cap.

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -293,7 +293,12 @@ async def test_pipeline_llm_client_merges_scoped_trace_metadata_and_resets():
             [LLMMessage(role="user", content="customer ticket text")],
             max_tokens=200,
             temperature=0.2,
-            metadata={"asset_type": "blog_post", "request_id": "req_123"},
+            metadata={
+                "account_id": "spoofed-account",
+                "user_id": "spoofed-user",
+                "asset_type": "blog_post",
+                "request_id": "req_123",
+            },
         )
     finally:
         reset_content_ops_llm_trace_context(token)

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -7,6 +7,8 @@ from extracted_content_pipeline.campaign_llm_client import (
     PipelineLLMClient,
     PipelineLLMClientConfig,
     create_pipeline_llm_client,
+    reset_content_ops_llm_trace_context,
+    set_content_ops_llm_trace_context,
 )
 from extracted_content_pipeline.campaign_ports import LLMMessage
 from extracted_content_pipeline.settings import build_settings
@@ -233,6 +235,54 @@ async def test_pipeline_llm_client_traces_successful_provider_usage_without_io_c
 
 
 @pytest.mark.asyncio
+async def test_pipeline_llm_client_merges_scoped_trace_metadata_and_resets():
+    trace_calls = []
+    client = PipelineLLMClient(
+        workload="draft",
+        resolver=lambda **_: _TraceLLM(),
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+    )
+
+    token = set_content_ops_llm_trace_context({
+        "account_id": "acct-1",
+        "user_id": "user-1",
+        "asset_type": "scope-default",
+    })
+    try:
+        await client.complete(
+            [LLMMessage(role="user", content="customer ticket text")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={"asset_type": "blog_post", "request_id": "req_123"},
+        )
+    finally:
+        reset_content_ops_llm_trace_context(token)
+
+    await client.complete(
+        [LLMMessage(role="user", content="customer ticket text")],
+        max_tokens=200,
+        temperature=0.2,
+        metadata={"asset_type": "landing_page"},
+    )
+
+    assert trace_calls[0][1]["metadata"] == {
+        "product": "content_ops",
+        "workload": "draft",
+        "llm_adapter": "pipeline",
+        "account_id": "acct-1",
+        "user_id": "user-1",
+        "asset_type": "blog_post",
+        "request_id": "req_123",
+    }
+    assert trace_calls[1][1]["metadata"] == {
+        "product": "content_ops",
+        "workload": "draft",
+        "llm_adapter": "pipeline",
+        "asset_type": "landing_page",
+    }
+
+
+@pytest.mark.asyncio
 async def test_pipeline_llm_client_traces_failed_provider_calls_without_io_capture():
     trace_calls = []
     client = PipelineLLMClient(
@@ -240,13 +290,17 @@ async def test_pipeline_llm_client_traces_failed_provider_calls_without_io_captu
         tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
     )
 
-    with pytest.raises(RuntimeError, match="provider timeout"):
-        await client.complete(
-            [LLMMessage(role="user", content="customer ticket text")],
-            max_tokens=200,
-            temperature=0.2,
-            metadata={"asset_type": "landing_page"},
-        )
+    token = set_content_ops_llm_trace_context({"account_id": "acct-failed"})
+    try:
+        with pytest.raises(RuntimeError, match="provider timeout"):
+            await client.complete(
+                [LLMMessage(role="user", content="customer ticket text")],
+                max_tokens=200,
+                temperature=0.2,
+                metadata={"asset_type": "landing_page"},
+            )
+    finally:
+        reset_content_ops_llm_trace_context(token)
 
     assert len(trace_calls) == 1
     span_name, trace = trace_calls[0]
@@ -259,6 +313,7 @@ async def test_pipeline_llm_client_traces_failed_provider_calls_without_io_captu
     assert trace["error_type"] == "RuntimeError"
     assert trace["error_message"] == "provider timeout"
     assert trace["metadata"]["product"] == "content_ops"
+    assert trace["metadata"]["account_id"] == "acct-failed"
     assert trace["metadata"]["asset_type"] == "landing_page"
     assert "input_data" not in trace
     assert "output_data" not in trace

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -8,6 +8,9 @@ from typing import Any, Mapping
 import pytest
 
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_llm_client import (
+    current_content_ops_llm_trace_context,
+)
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -134,6 +137,13 @@ class _StrictCampaignService:
         del quality_prompt_proof_term_limit
         del parse_retry_response_excerpt_chars
         self.calls += 1
+        return _Result()
+
+
+class _TraceContextCaptureService(_OpportunityService):
+    async def generate(self, **kwargs: Any) -> _Result:
+        await super().generate(**kwargs)
+        self.calls[-1]["trace_context"] = current_content_ops_llm_trace_context()
         return _Result()
 
 
@@ -360,6 +370,30 @@ async def test_execute_runs_email_and_report_services_with_scope_and_filters() -
     assert report_call["channels"] is None
     assert report_call["opportunity_defaults"] == {}
     assert report_call["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_sets_content_ops_llm_trace_context_from_scope() -> None:
+    campaign = _TraceContextCaptureService()
+    scope = TenantScope(account_id="acct-1", user_id="user-1")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["email_campaign"],
+            "target_mode": "vendor_retention",
+            "limit": 1,
+            "inputs": {"target_account": "Acme", "offer": "Churn audit"},
+        },
+        services=ContentOpsExecutionServices(campaign=campaign),
+        scope=scope,
+    )
+
+    assert result["status"] == "completed"
+    assert campaign.calls[0]["trace_context"] == {
+        "account_id": "acct-1",
+        "user_id": "user-1",
+    }
+    assert current_content_ops_llm_trace_context() == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Usage-Account-Metadata.md
Ownership lane: content-ops/cost-surfacing
Slice phase: Production hardening

Add authenticated account/user metadata to Content Ops LLM traces at the execution boundary so future tenant-facing usage summaries can filter by metadata ->> 'account_id' without patching every generator call site.

## Intentional

- The trace context is set from the resolved TenantScope around each execution step and reset in a finally block to avoid cross-request leakage.
- account_id and user_id are scoped metadata only; per-call generator metadata cannot override them.
- Per-call labels such as asset_type, request_id, run_id, skill_name, and attempt_no still win over scoped non-trust labels.
- This does not add tenant usage routes, UI cards, budget gates, or cache controls.

## Deferred

- Future PR: add a tenant-scoped usage summary path that filters by metadata ->> 'account_id' from the authenticated TenantScope.
- Future PR: add UI/control-surface cards against the correct operator or tenant usage route.
- Future PR: wire BudgetGate once account-scoped usage is queryable.
- Future PR: add exact-cache integration with explicit support-ticket privacy policy and account scoping.

## Parked hardening

None.

## Verification

- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py -q — 69 passed, 1 warning.
- python -m compileall -q extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_campaign_llm_client.py tests/test_extracted_content_ops_execution.py — passed.
- git diff --check — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.

## Diff size

~285 LOC, under the 400 LOC soft cap.
