### PR TITLE
Align SaaS FAQ demo seeder result errors

### DIFF
--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope
+
+## Why this slice exists
+
+PR #999 added a cleanup path for the SaaS FAQ demo seeder, but review caught a
+result-contract drift: seed mode reports failures through an `errors` list while
+cleanup mode reports a scalar `error`. Operators and scripts should be able to
+read one fail-closed result envelope regardless of mode.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Normalize the cleanup result payload to use the same `errors: list[str]`
+   convention as seed mode.
+2. Update the human-readable cleanup summary to report the shared error count.
+3. Pin success and failure tests for the cleanup envelope.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md`
+- `scripts/seed_content_ops_faq_saas_demo.py`
+- `tests/test_content_ops_faq_saas_demo_corpus.py`
+
+## Mechanism
+
+`cleanup_saas_demo_faq` now builds an `errors` list from the delete-status
+parser and derives `ok` from whether that list is empty. `_print_result` reads
+the same `errors` key that seed mode already exposes. The focused tests assert
+the exact success envelope and the bad-delete branches.
+
+## Intentional
+
+- No live database run in this slice; this only normalizes the result contract
+  around an already-tested fake pool boundary.
+- No seed-path behavior change beyond preserving the existing shared
+  `errors` convention.
+- No route or search-projection changes; this is operator-script output
+  hardening.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` has no active content-ops FAQ entries
+touching this script.
+
+Live database verification remains deferred until a real database URL is
+available in the local environment.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` (12
+  passed)
+- `python -m py_compile` with `scripts/seed_content_ops_faq_saas_demo.py`
+  and `tests/test_content_ops_faq_saas_demo_corpus.py`
+- `python` `scripts/audit_plan_code_consistency.py` with
+  `plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching
+  tests enrolled)
+- `git diff --check`
+- `bash` `scripts/validate_extracted_content_pipeline.sh`
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- `bash` `scripts/check_ascii_python.sh`
+- `bash` `scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)
+
+## Estimated diff size
+
+| Area | LOC |
+| --- | ---: |
+| Plan doc | ~70 |
+| Script/test changes | ~20 |
+| **Total** | **90** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -273,19 +273,19 @@ async def cleanup_saas_demo_faq(
         account_id,
     )
     deleted_faq_ids = _deleted_row_count(delete_status)
-    error = None
+    errors: list[str] = []
     if deleted_faq_ids is None:
-        error = f"cleanup delete status is not parseable: {delete_status!r}"
+        errors.append(f"cleanup delete status is not parseable: {delete_status!r}")
     elif deleted_faq_ids != 1:
-        error = f"cleanup deleted {deleted_faq_ids} FAQ rows but expected 1"
+        errors.append(f"cleanup deleted {deleted_faq_ids} FAQ rows but expected 1")
     return {
         "phase": "cleanup",
-        "ok": error is None,
+        "ok": not errors,
+        "errors": errors,
         "account_id": account_id,
         "faq_id": faq_id,
         "deleted_faq_ids": deleted_faq_ids,
         "delete_status": delete_status,
-        "error": error,
     }
 
 
@@ -328,7 +328,7 @@ def _print_result(payload: dict[str, Any], *, as_json: bool) -> None:
             "SaaS FAQ demo cleanup: "
             f"ok={payload['ok']} faq_id={payload['faq_id']} "
             f"deleted_faq_ids={payload['deleted_faq_ids']} "
-            f"error={payload['error'] or ''}"
+            f"errors={len(payload['errors'])}"
         )
         return
     print(

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -323,11 +323,11 @@ async def test_saas_demo_cleanup_deletes_single_faq_for_account() -> None:
     assert payload == {
         "phase": "cleanup",
         "ok": True,
+        "errors": [],
         "account_id": "acct-demo",
         "faq_id": "11111111-1111-1111-1111-111111111111",
         "deleted_faq_ids": 1,
         "delete_status": "DELETE 1",
-        "error": None,
     }
     assert "WHERE id = $1::uuid" in pool.calls[0]["query"]
     assert "AND account_id = $2" in pool.calls[0]["query"]
@@ -345,14 +345,14 @@ async def test_saas_demo_cleanup_deletes_single_faq_for_account() -> None:
             "DELETE 0",
             {
                 "deleted_faq_ids": 0,
-                "error": "cleanup deleted 0 FAQ rows but expected 1",
+                "errors": ["cleanup deleted 0 FAQ rows but expected 1"],
             },
         ),
         (
             "UPDATE 1",
             {
                 "deleted_faq_ids": None,
-                "error": "cleanup delete status is not parseable: 'UPDATE 1'",
+                "errors": ["cleanup delete status is not parseable: 'UPDATE 1'"],
             },
         ),
     ],
@@ -370,4 +370,4 @@ async def test_saas_demo_cleanup_fails_on_bad_delete_result(delete_status, expec
 
     assert payload["ok"] is False
     assert payload["deleted_faq_ids"] == expected["deleted_faq_ids"]
-    assert payload["error"] == expected["error"]
+    assert payload["errors"] == expected["errors"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md
Slice phase: Production hardening

Normalize the SaaS FAQ demo seeder result envelope so seed and cleanup modes both report failures through `errors: list[str]` instead of forcing operators to handle `errors` in one mode and scalar `error` in the other.

## Intentional
- No live database run in this slice; this normalizes the result contract around the fake-pool boundary already covered by tests.
- No seed-path behavior change beyond preserving the existing shared `errors` convention.
- No route or search-projection changes; this is operator-script output hardening.

## Deferred
- Live database verification remains deferred until a real database URL is available locally.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` (12 passed)
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py`
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Result-Envelope.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching tests enrolled)
- `git diff --check`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)

## Diff size
3 files, +84 / -10
