### PR TITLE
Surface FAQ search detail not-run reason

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md
@@ -1,0 +1,78 @@
+# PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason
+
+## Why this slice exists
+
+The seeded hosted FAQ search e2e runner now checks search and detail hydration,
+but its result JSON can make an unattempted detail check look like a detail
+contract failure. When seed or route fails first, `detail` stays `ok=false`
+without saying that the phase was never run. Operators need that distinction
+while debugging hosted demo readiness.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add an explicit `not_run_reason` to seeded e2e detail summaries when the
+   detail phase is skipped or blocked by an earlier phase.
+2. Preserve existing pass/fail behavior: skipped-by-flag detail remains
+   non-blocking, while seed/route/preflight-blocked detail remains failed.
+3. Add focused tests for skip-by-flag and route-failure detail visibility.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+
+## Mechanism
+
+A small helper builds the canonical detail-not-run payload:
+`ok`, `returncode`, `skipped`, and `not_run_reason`. Preflight, explicit
+`--skip-detail-check`, seed failure, and route failure use that helper. The
+actual detail contract checker path is unchanged.
+
+## Intentional
+
+- No hosted route behavior changes; this only improves the smoke result
+  artifact.
+- No cleanup behavior changes; cleanup still runs after seed/route failures
+  whenever a manifest exists.
+- No broad result-envelope refactor in this slice.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` has no active FAQ search items touching
+this runner.
+
+Route not-run visibility can be handled in a separate slice if operators need
+the same explicit phase reason there; this slice is limited to the detail
+ambiguity already called out in the FAQ search plans.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (47
+  passed)
+- `python -m py_compile` with
+  `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` and
+  `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `python` `scripts/audit_plan_code_consistency.py` with
+  `plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching
+  tests enrolled)
+- `git diff --check`
+- `bash` `scripts/validate_extracted_content_pipeline.sh`
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- `bash` `scripts/check_ascii_python.sh`
+- `bash` `scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Plan doc | 78 |
+| Runner | 31 |
+| Tests | 23 |
+| **Total** | **132** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -418,11 +418,10 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
         "artifacts": {},
         "seed": {"ok": False, "returncode": None},
         "route": {"ok": False, "returncode": None},
-        "detail": {
-            "ok": bool(args.skip_detail_check),
-            "returncode": None,
-            "skipped": bool(args.skip_detail_check),
-        },
+        "detail": _detail_not_run(
+            "skip_detail_check" if args.skip_detail_check else "preflight_failed",
+            ok=bool(args.skip_detail_check),
+        ),
         "cleanup": {
             "ok": False,
             "requested_faq_ids": 0,
@@ -455,11 +454,10 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     route_result = artifact_dir / "route-result.json"
     detail_result = artifact_dir / "detail-result.json"
 
-    detail = {
-        "ok": bool(args.skip_detail_check),
-        "returncode": None,
-        "skipped": bool(args.skip_detail_check),
-    }
+    detail = _detail_not_run(
+        "skip_detail_check" if args.skip_detail_check else "waiting_for_seed_and_route",
+        ok=bool(args.skip_detail_check),
+    )
     cleanup = {
         "ok": True,
         "requested_faq_ids": 0,
@@ -479,6 +477,10 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         route = {"ok": False, "returncode": None, "stdout_tail": "", "stderr_tail": ""}
         if seed["ok"]:
             route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
+        elif not bool(args.skip_detail_check):
+            detail = _detail_not_run("seed_failed", ok=False)
+        if bool(seed["ok"]) and not bool(route["ok"]) and not bool(args.skip_detail_check):
+            detail = _detail_not_run("route_failed", ok=False)
         if bool(seed["ok"] and route["ok"]) and not bool(args.skip_detail_check):
             detail_case, detail_errors = _detail_case_from_route_cases(case_file)
             if detail_errors:
@@ -533,6 +535,15 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     finally:
         if temp_context is not None:
             temp_context.cleanup()
+
+
+def _detail_not_run(reason: str, *, ok: bool) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "returncode": None,
+        "skipped": True,
+        "not_run_reason": reason,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -437,6 +437,12 @@ def test_main_writes_preflight_result(tmp_path, capsys):
     assert payload["preflight_errors"] == [
         "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
     ]
+    assert payload["detail"] == {
+        "ok": False,
+        "returncode": None,
+        "skipped": True,
+        "not_run_reason": "preflight_failed",
+    }
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 
 
@@ -550,6 +556,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
     monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
 
     code = smoke.main([
         "--database-url",
@@ -562,9 +569,18 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
         "acct-1",
         "--artifact-dir",
         str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
     ])
 
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 1
+    assert payload["detail"] == {
+        "ok": False,
+        "returncode": None,
+        "skipped": True,
+        "not_run_reason": "route_failed",
+    }
     assert len(calls) == 2
     assert all(str(smoke.CONTRACT_SCRIPT) not in command for command in calls)
 
@@ -613,7 +629,12 @@ def test_main_can_skip_detail_check_for_liveness_runs(tmp_path, monkeypatch):
 
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 0
-    assert payload["detail"] == {"ok": True, "returncode": None, "skipped": True}
+    assert payload["detail"] == {
+        "ok": True,
+        "returncode": None,
+        "skipped": True,
+        "not_run_reason": "skip_detail_check",
+    }
     assert len(calls) == 2
     assert all(str(smoke.CONTRACT_SCRIPT) not in command for command in calls)
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md
Slice phase: Production hardening

Make the seeded hosted FAQ search e2e result artifact distinguish a real detail-contract failure from a detail phase that was never run because preflight, seed, or route failed first.

## Intentional
- No hosted route behavior changes; this only improves the smoke result artifact.
- No cleanup behavior changes; cleanup still runs after seed/route failures when a manifest exists.
- No broad result-envelope refactor in this slice.

## Deferred
- Route not-run visibility can be handled separately if operators need the same explicit phase reason there.

## Parked hardening
- None.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (47 passed)
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Detail-Not-Run-Reason.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching tests enrolled)
- `git diff --check`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)

## Diff size
3 files, +121 / -11
