### PR TITLE
Normalize FAQ search e2e cleanup errors

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md
+++ b/plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors
+
+## Why this slice exists
+
+The FAQ search seeded e2e runner now has clearer detail-phase visibility, but
+its cleanup phase still reports failures with a scalar `error` field. Recent FAQ
+operator artifacts use `errors: list[str]` so callers can consume one failure
+surface across modes and phases. This slice aligns the seeded e2e cleanup
+payload with that convention.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Change seeded e2e cleanup summaries from scalar `error` to
+   `errors: list[str]`.
+2. Normalize all cleanup branches: no IDs, import failure, database exception,
+   malformed delete status, rowcount mismatch, manifest parse failure, and
+   success.
+3. Update focused tests to assert the new cleanup envelope.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+
+## Mechanism
+
+A small `_cleanup_result(...)` helper builds the cleanup phase payload with
+`ok = not errors`, row counts, delete status, and `errors`. Existing cleanup
+call sites keep their control flow but pass failure messages as list entries.
+The route/detail/seed phases are unchanged.
+
+## Intentional
+
+- No database query change; the cleanup DELETE and cascade behavior stay the
+  same.
+- No hosted-route behavior change; this is result-artifact hardening.
+- No broad e2e result-envelope refactor beyond the cleanup phase.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` has no active FAQ search entries touching
+this runner.
+
+Route phase result normalization is left for a later slice if it becomes a
+consumer pain point; this slice only closes the scalar cleanup error drift.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (47
+  passed)
+- `python -m py_compile` with
+  `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` and
+  `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `python` `scripts/audit_plan_code_consistency.py` with
+  `plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching
+  tests enrolled)
+- `git diff --check`
+- `bash` `scripts/validate_extracted_content_pipeline.sh`
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- `bash` `scripts/check_ascii_python.sh`
+- `bash` `scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Plan doc | 77 |
+| Runner | 101 |
+| Tests | 18 |
+| **Total** | **196** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -327,23 +327,20 @@ def _deleted_row_count(delete_status: object) -> int | None:
 async def _cleanup_seeded_faqs(database_url: str, faq_ids: Sequence[str]) -> dict[str, Any]:
     requested_faq_ids = len(faq_ids)
     if not faq_ids:
-        return {
-            "ok": True,
-            "requested_faq_ids": 0,
-            "deleted_faq_ids": 0,
-            "delete_status": None,
-            "error": None,
-        }
+        return _cleanup_result(
+            requested_faq_ids=0,
+            deleted_faq_ids=0,
+            delete_status=None,
+        )
     try:
         import asyncpg  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - host dependency
-        return {
-            "ok": False,
-            "requested_faq_ids": requested_faq_ids,
-            "deleted_faq_ids": 0,
-            "delete_status": None,
-            "error": f"ImportError: {exc}",
-        }
+        return _cleanup_result(
+            requested_faq_ids=requested_faq_ids,
+            deleted_faq_ids=0,
+            delete_status=None,
+            errors=[f"ImportError: {exc}"],
+        )
 
     delete_status = None
     try:
@@ -356,39 +353,50 @@ async def _cleanup_seeded_faqs(database_url: str, faq_ids: Sequence[str]) -> dic
         finally:
             await pool.close()
     except Exception as exc:
-        return {
-            "ok": False,
-            "requested_faq_ids": requested_faq_ids,
-            "deleted_faq_ids": 0,
-            "delete_status": delete_status,
-            "error": f"{type(exc).__name__}: {exc}",
-        }
+        return _cleanup_result(
+            requested_faq_ids=requested_faq_ids,
+            deleted_faq_ids=0,
+            delete_status=delete_status,
+            errors=[f"{type(exc).__name__}: {exc}"],
+        )
     deleted_faq_ids = _deleted_row_count(delete_status)
     if deleted_faq_ids is None:
-        return {
-            "ok": False,
-            "requested_faq_ids": requested_faq_ids,
-            "deleted_faq_ids": None,
-            "delete_status": delete_status,
-            "error": f"cleanup delete status is not parseable: {delete_status!r}",
-        }
+        return _cleanup_result(
+            requested_faq_ids=requested_faq_ids,
+            deleted_faq_ids=None,
+            delete_status=delete_status,
+            errors=[f"cleanup delete status is not parseable: {delete_status!r}"],
+        )
     if deleted_faq_ids != requested_faq_ids:
-        return {
-            "ok": False,
-            "requested_faq_ids": requested_faq_ids,
-            "deleted_faq_ids": deleted_faq_ids,
-            "delete_status": delete_status,
-            "error": (
+        return _cleanup_result(
+            requested_faq_ids=requested_faq_ids,
+            deleted_faq_ids=deleted_faq_ids,
+            delete_status=delete_status,
+            errors=[
                 "cleanup deleted "
                 f"{deleted_faq_ids} FAQ rows but requested {requested_faq_ids}"
-            ),
-        }
+            ],
+        )
+    return _cleanup_result(
+        requested_faq_ids=requested_faq_ids,
+        deleted_faq_ids=deleted_faq_ids,
+        delete_status=delete_status,
+    )
+
+
+def _cleanup_result(
+    *,
+    requested_faq_ids: int,
+    deleted_faq_ids: int | None,
+    delete_status: object,
+    errors: Sequence[str] = (),
+) -> dict[str, Any]:
     return {
-        "ok": True,
+        "ok": not errors,
         "requested_faq_ids": requested_faq_ids,
         "deleted_faq_ids": deleted_faq_ids,
         "delete_status": delete_status,
-        "error": None,
+        "errors": list(errors),
     }
 
 
@@ -427,7 +435,7 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
             "requested_faq_ids": 0,
             "deleted_faq_ids": 0,
             "delete_status": None,
-            "error": None,
+            "errors": [],
         },
         "preflight_errors": list(errors),
         "keep_data": bool(args.keep_data),
@@ -463,7 +471,7 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "requested_faq_ids": 0,
         "deleted_faq_ids": 0,
         "delete_status": None,
-        "error": None,
+        "errors": [],
     }
     try:
         seed = _run_command(
@@ -502,13 +510,12 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             else ([], [])
         )
         if manifest_errors:
-            cleanup = {
-                "ok": False,
-                "requested_faq_ids": len(faq_ids),
-                "deleted_faq_ids": 0,
-                "delete_status": None,
-                "error": "; ".join(manifest_errors),
-            }
+            cleanup = _cleanup_result(
+                requested_faq_ids=len(faq_ids),
+                deleted_faq_ids=0,
+                delete_status=None,
+                errors=manifest_errors,
+            )
         elif not bool(args.keep_data):
             cleanup = await _cleanup_seeded_faqs(str(args.database_url), faq_ids)
         ok = bool(seed["ok"] and route["ok"] and detail["ok"] and cleanup["ok"])

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -308,7 +308,7 @@ async def test_cleanup_seeded_faqs_noops_without_ids():
         "requested_faq_ids": 0,
         "deleted_faq_ids": 0,
         "delete_status": None,
-        "error": None,
+        "errors": [],
     }
 
 
@@ -346,7 +346,7 @@ async def test_cleanup_seeded_faqs_reports_actual_delete_rowcount(monkeypatch):
         "requested_faq_ids": 2,
         "deleted_faq_ids": 2,
         "delete_status": "DELETE 2",
-        "error": None,
+        "errors": [],
     }
     assert fake_pool.deleted_ids == [
         "11111111-1111-1111-1111-111111111111",
@@ -382,7 +382,7 @@ async def test_cleanup_seeded_faqs_fails_when_delete_rowcount_mismatches(monkeyp
         "requested_faq_ids": 2,
         "deleted_faq_ids": 1,
         "delete_status": "DELETE 1",
-        "error": "cleanup deleted 1 FAQ rows but requested 2",
+        "errors": ["cleanup deleted 1 FAQ rows but requested 2"],
     }
 
 
@@ -410,7 +410,7 @@ async def test_cleanup_seeded_faqs_surfaces_malformed_delete_status(monkeypatch)
         "requested_faq_ids": 1,
         "deleted_faq_ids": None,
         "delete_status": "UPDATE 1",
-        "error": "cleanup delete status is not parseable: 'UPDATE 1'",
+        "errors": ["cleanup delete status is not parseable: 'UPDATE 1'"],
     }
 
 
@@ -482,7 +482,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
             "requested_faq_ids": len(faq_ids),
             "deleted_faq_ids": len(faq_ids),
             "delete_status": f"DELETE {len(faq_ids)}",
-            "error": None,
+            "errors": [],
         }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
@@ -551,7 +551,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
             "requested_faq_ids": len(faq_ids),
             "deleted_faq_ids": len(faq_ids),
             "delete_status": f"DELETE {len(faq_ids)}",
-            "error": None,
+            "errors": [],
         }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
@@ -604,7 +604,7 @@ def test_main_can_skip_detail_check_for_liveness_runs(tmp_path, monkeypatch):
             "requested_faq_ids": len(faq_ids),
             "deleted_faq_ids": len(faq_ids),
             "delete_status": f"DELETE {len(faq_ids)}",
-            "error": None,
+            "errors": [],
         }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
@@ -672,7 +672,7 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
             "requested_faq_ids": 1,
             "deleted_faq_ids": 0,
             "delete_status": None,
-            "error": "cleanup failed",
+            "errors": ["cleanup failed"],
         }
 
     monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
@@ -701,5 +701,5 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
         "requested_faq_ids": 1,
         "deleted_faq_ids": 0,
         "delete_status": None,
-        "error": "cleanup failed",
+        "errors": ["cleanup failed"],
     }


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md
Slice phase: Production hardening

Normalize the seeded hosted FAQ search e2e cleanup phase so result artifacts expose `errors: list[str]` instead of a scalar `error`, matching the newer FAQ operator-result convention.

## Intentional
- No database query change; the cleanup DELETE and cascade behavior stay the same.
- No hosted-route behavior change; this is result-artifact hardening.
- No broad e2e result-envelope refactor beyond the cleanup phase.

## Deferred
- Route phase result normalization is left for a later slice if it becomes a consumer pain point.

## Parked hardening
- None.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (47 passed)
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Cleanup-Errors.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching tests enrolled)
- `git diff --check`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (2456 passed, 6 skipped)

## Diff size
3 files, +140 / -56
