### PR TITLE
Add Content Ops tenant usage summary

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -613,6 +613,24 @@ def create_content_ops_control_surface_router(
             request_id=request_id,
         )
 
+    @router.get("/usage/summary/tenant")
+    async def tenant_usage_summary(
+        days: int = Query(default=7, ge=1, le=90),
+        asset_type: str | None = Query(default=None, max_length=80),
+        run_id: str | None = Query(default=None, max_length=200),
+        request_id: str | None = Query(default=None, max_length=200),
+    ) -> dict[str, Any]:
+        pool = await _resolve_usage_pool(usage_pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        return await summarize_content_ops_llm_usage(
+            pool,
+            days=days,
+            account_id=_required_scope_account_id(scope),
+            asset_type=asset_type,
+            run_id=run_id,
+            request_id=request_id,
+        )
+
     @router.post("/preview")
     async def preview_generation(
         payload: ContentOpsRequestModel = Body(...),
@@ -1425,6 +1443,13 @@ async def _resolve_scope(provider: ScopeProvider | None) -> TenantScope | None:
             detail="Content Ops scope provider is unavailable.",
         ) from exc
     return _scope_from_value(value)
+
+
+def _required_scope_account_id(scope: TenantScope | None) -> str:
+    account_id = _clean(getattr(scope, "account_id", None))
+    if not account_id:
+        raise HTTPException(status_code=400, detail="account_id is required")
+    return account_id
 
 
 async def _resolve_import_pool(provider: PoolProvider | None) -> Any:

--- a/extracted_content_pipeline/content_ops_usage_summary.py
+++ b/extracted_content_pipeline/content_ops_usage_summary.py
@@ -13,6 +13,7 @@ async def summarize_content_ops_llm_usage(
     pool: Any,
     *,
     days: int = 7,
+    account_id: str | None = None,
     asset_type: str | None = None,
     run_id: str | None = None,
     request_id: str | None = None,
@@ -22,6 +23,7 @@ async def summarize_content_ops_llm_usage(
     resolved_days = _bounded_days(days)
     filters = _UsageFilters(
         days=resolved_days,
+        account_id=_clean_filter(account_id),
         asset_type=_clean_filter(asset_type),
         run_id=_clean_filter(run_id),
         request_id=_clean_filter(request_id),
@@ -96,17 +98,20 @@ class _UsageFilters:
         self,
         *,
         days: int,
+        account_id: str | None,
         asset_type: str | None,
         run_id: str | None,
         request_id: str | None,
     ) -> None:
         self.days = days
+        self.account_id = account_id
         self.asset_type = asset_type
         self.run_id = run_id
         self.request_id = request_id
 
     def as_dict(self) -> dict[str, Any]:
         return {
+            "account_id": self.account_id,
             "asset_type": self.asset_type,
             "run_id": self.run_id,
             "request_id": self.request_id,
@@ -122,6 +127,9 @@ def _usage_where_clause(filters: _UsageFilters) -> tuple[str, list[Any]]:
             "OR metadata ->> 'product' = 'content_ops')"
         ),
     ]
+    if filters.account_id:
+        args.append(filters.account_id)
+        clauses.append(f"metadata ->> 'account_id' = ${len(args)}")
     if filters.asset_type:
         args.append(filters.asset_type)
         clauses.append(f"metadata ->> 'asset_type' = ${len(args)}")

--- a/extracted_content_pipeline/content_ops_usage_summary.py
+++ b/extracted_content_pipeline/content_ops_usage_summary.py
@@ -110,12 +110,14 @@ class _UsageFilters:
         self.request_id = request_id
 
     def as_dict(self) -> dict[str, Any]:
-        return {
-            "account_id": self.account_id,
+        filters = {
             "asset_type": self.asset_type,
             "run_id": self.run_id,
             "request_id": self.request_id,
         }
+        if self.account_id is not None:
+            filters["account_id"] = self.account_id
+        return filters
 
 
 def _usage_where_clause(filters: _UsageFilters) -> tuple[str, list[Any]]:

--- a/plans/PR-Content-Ops-Tenant-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Tenant-Usage-Summary.md
@@ -64,14 +64,14 @@ for global spend analysis.
 
 ## Verification
 
-- python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py -q — 10 passed, 1 skipped, 1 warning.
-- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
+- python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters tests/test_atlas_content_ops_generated_assets_api.py -q — 11 passed, 2 skipped, 1 warning.
+- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_content_control_surface_api.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
 - git diff --check — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
 
 ## Estimated diff size
 
@@ -80,7 +80,7 @@ for global spend analysis.
 | Plan doc | ~75 |
 | Usage summary query | ~20 |
 | Control-surface route | ~30 |
-| Tests | ~80 |
-| **Total** | **~205** |
+| Tests | ~230 |
+| **Total** | **~355** |
 
 Under the 400 LOC soft cap.

--- a/plans/PR-Content-Ops-Tenant-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Tenant-Usage-Summary.md
@@ -1,0 +1,86 @@
+# PR: Content Ops Tenant Usage Summary
+
+## Why this slice exists
+
+Content Ops hosted generation now writes usage rows, and those rows carry
+trusted account_id/user_id metadata from the authenticated execution scope. The
+operator-only usage summary can show global spend, but tenants still do not have
+a scoped read path for their own Content Ops usage.
+
+This slice adds the thin tenant read path before UI cards, budget gates, or
+cache controls build on top of usage data.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add an account_id filter to the shared Content Ops usage summary query.
+2. Add a tenant-scoped usage route that resolves the authenticated
+   TenantScope.account_id and filters at SQL time.
+3. Keep the existing operator /usage/summary route global and
+   platform-admin-only.
+4. Add focused tests for account filtering and hosted route wiring.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Tenant-Usage-Summary.md` | Plan doc for tenant-scoped usage summary. |
+| `extracted_content_pipeline/content_ops_usage_summary.py` | Add account_id filtering to the shared usage summary query. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Add tenant-scoped usage summary route using the resolved scope. |
+| `tests/test_extracted_content_ops_usage_summary.py` | Pin SQL-level account filtering behavior. |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | Pin hosted tenant usage route auth/scope/pool wiring. |
+
+## Mechanism
+
+summarize_content_ops_llm_usage accepts an optional account_id and includes
+metadata ->> 'account_id' in the SQL WHERE clause when present. The new
+/usage/summary/tenant route resolves the same usage pool as the operator route,
+then resolves the request scope from the host scope provider. If no account_id
+is available, the route returns 400 instead of falling back to global data.
+
+The existing /usage/summary route is unchanged and keeps the operator dependency
+for global spend analysis.
+
+## Intentional
+
+- This does not add frontend cards yet. It creates the tenant-safe API surface
+  those cards can call.
+- This does not add budget enforcement. BudgetGate should consume this scoped
+  usage once the read path is stable.
+- This does not wire exact-cache controls. Cache policy needs a separate slice
+  because it has support-ticket privacy and account-scoping implications.
+- The tenant route filters in SQL rather than filtering the returned payload so
+  cross-account rows never enter the tenant summary calculation.
+
+## Deferred
+
+- Future PR: add UI/control-surface cards for tenant usage.
+- Future PR: wire BudgetGate against account-scoped usage.
+- Future PR: add exact-cache integration with explicit support-ticket privacy
+  policy and account scoping.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py -q — 10 passed, 1 skipped, 1 warning.
+- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Usage summary query | ~20 |
+| Control-surface route | ~30 |
+| Tests | ~80 |
+| **Total** | **~205** |
+
+Under the 400 LOC soft cap.

--- a/plans/PR-Content-Ops-Tenant-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Tenant-Usage-Summary.md
@@ -71,7 +71,7 @@ for global spend analysis.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
 - bash scripts/check_ascii_python.sh — passed.
 - git diff --check — passed.
-- bash scripts/local_pr_review.sh --current-pr-body-file <body> — pending final rerun before push.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
 
 ## Estimated diff size
 

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -101,6 +101,26 @@ def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
     assert "_require_content_ops_usage_operator" in dependency_names
 
 
+def test_content_ops_tenant_usage_summary_route_uses_shared_auth_scope_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/usage/summary/tenant")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["usage_pool_provider"].__name__ == "get_db_pool"
+    assert closure["scope_provider"].__name__ == "build_content_ops_scope"
+    assert "_capture_content_ops_auth_user" in dependency_names
+    assert "_require_content_ops_usage_operator" not in dependency_names
+
+
 @pytest.mark.asyncio
 async def test_content_ops_usage_summary_operator_gate_rejects_account_admin() -> None:
     api_pkg = _fresh_api_package()

--- a/tests/test_extracted_content_ops_usage_summary.py
+++ b/tests/test_extracted_content_ops_usage_summary.py
@@ -8,9 +8,77 @@ from uuid import uuid4
 
 import pytest
 
+from extracted_content_pipeline.api.control_surfaces import _required_scope_account_id
+from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_usage_summary import (
     summarize_content_ops_llm_usage,
 )
+
+
+class _UsageSummaryPool:
+    def __init__(self) -> None:
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object]:
+        self.fetchrow_calls.append((query, args))
+        return {
+            "total_cost_usd": Decimal("0"),
+            "input_tokens": 0,
+            "billable_input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "cached_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_calls": 0,
+            "failed_calls": 0,
+            "cache_hit_calls": 0,
+            "avg_duration_ms": 0,
+            "latest_call_at": None,
+        }
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        self.fetch_calls.append((query, args))
+        return []
+
+
+@pytest.mark.asyncio
+async def test_content_ops_usage_summary_filters_by_account_id_in_sql() -> None:
+    pool = _UsageSummaryPool()
+
+    payload = await summarize_content_ops_llm_usage(
+        pool,
+        days=14,
+        account_id="acct-123",
+        asset_type="landing_page",
+        run_id="run-1",
+        request_id="req-1",
+    )
+
+    query, args = pool.fetchrow_calls[0]
+    assert "metadata ->> 'account_id' = $2" in query
+    assert "metadata ->> 'asset_type' = $3" in query
+    assert "(run_id = $4 OR metadata ->> 'run_id' = $4)" in query
+    assert "metadata ->> 'request_id' = $5" in query
+    assert args == (14, "acct-123", "landing_page", "run-1", "req-1")
+    assert pool.fetch_calls[0][1] == args
+    assert pool.fetch_calls[1][1] == args
+    assert payload["filters"] == {
+        "account_id": "acct-123",
+        "asset_type": "landing_page",
+        "run_id": "run-1",
+        "request_id": "req-1",
+    }
+
+
+def test_content_ops_tenant_usage_requires_scope_account_id() -> None:
+    assert _required_scope_account_id(TenantScope(account_id="acct-123")) == "acct-123"
+
+    with pytest.raises(Exception) as exc:
+        _required_scope_account_id(TenantScope())
+
+    assert getattr(exc.value, "status_code", None) == 400
+    assert getattr(exc.value, "detail", None) == "account_id is required"
 
 
 @pytest.mark.integration

--- a/tests/test_extracted_content_ops_usage_summary.py
+++ b/tests/test_extracted_content_ops_usage_summary.py
@@ -219,3 +219,148 @@ async def test_content_ops_usage_summary_contract_against_postgres() -> None:
             request_id,
         )
         await pool.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_content_ops_usage_summary_isolates_accounts_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    request_id = f"usage-summary-isolation-{uuid4().hex}"
+    account_a = f"acct-a-{uuid4().hex}"
+    account_b = f"acct-b-{uuid4().hex}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/127_llm_usage.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/252_llm_usage_cache_breakdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/253_llm_usage_vendor_and_run_id.sql").read_text())
+        await pool.executemany(
+            """
+            INSERT INTO llm_usage (
+                span_name, operation_type, model_name, model_provider,
+                input_tokens, output_tokens, total_tokens, billable_input_tokens,
+                cached_tokens, cache_write_tokens, cost_usd, duration_ms, status,
+                metadata, run_id
+            )
+            VALUES (
+                $1, 'llm_call', $2, $3,
+                $4, $5, $6, $7,
+                $8, $9, $10, $11, $12,
+                $13::jsonb, $14
+            )
+            """,
+            [
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    100,
+                    40,
+                    140,
+                    90,
+                    10,
+                    5,
+                    Decimal("0.100000"),
+                    120,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "account_id": account_a,
+                        "asset_type": "blog_post",
+                        "request_id": request_id,
+                    }),
+                    "run-a",
+                ),
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    200,
+                    80,
+                    280,
+                    180,
+                    20,
+                    10,
+                    Decimal("0.200000"),
+                    240,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "account_id": account_a,
+                        "asset_type": "landing_page",
+                        "request_id": request_id,
+                    }),
+                    "run-a",
+                ),
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    500,
+                    100,
+                    600,
+                    500,
+                    0,
+                    0,
+                    Decimal("0.500000"),
+                    300,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "account_id": account_b,
+                        "asset_type": "blog_post",
+                        "request_id": request_id,
+                    }),
+                    "run-b",
+                ),
+            ],
+        )
+
+        account_a_payload = await summarize_content_ops_llm_usage(
+            pool,
+            days=1,
+            account_id=account_a,
+            request_id=request_id,
+        )
+        account_b_payload = await summarize_content_ops_llm_usage(
+            pool,
+            days=1,
+            account_id=account_b,
+            request_id=request_id,
+        )
+
+        assert account_a_payload["summary"]["total_cost_usd"] == 0.3
+        assert account_a_payload["summary"]["total_calls"] == 2
+        assert account_a_payload["summary"]["input_tokens"] == 300
+        assert account_a_payload["summary"]["output_tokens"] == 120
+        assert account_a_payload["filters"]["account_id"] == account_a
+        assert {row["asset_type"] for row in account_a_payload["by_asset_type"]} == {
+            "blog_post",
+            "landing_page",
+        }
+
+        assert account_b_payload["summary"]["total_cost_usd"] == 0.5
+        assert account_b_payload["summary"]["total_calls"] == 1
+        assert account_b_payload["summary"]["input_tokens"] == 500
+        assert account_b_payload["summary"]["output_tokens"] == 100
+        assert account_b_payload["filters"]["account_id"] == account_b
+        assert account_b_payload["by_asset_type"] == [
+            {
+                "asset_type": "blog_post",
+                "cost_usd": 0.5,
+                "calls": 1,
+                "input_tokens": 500,
+                "output_tokens": 100,
+            }
+        ]
+    finally:
+        await pool.execute(
+            "DELETE FROM llm_usage WHERE metadata ->> 'request_id' = $1",
+            request_id,
+        )
+        await pool.close()


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Tenant-Usage-Summary.md
Ownership lane: content-ops/cost-surfacing
Slice phase: Production hardening

Add the tenant-safe read path for Content Ops LLM usage now that hosted traces carry trusted account_id metadata. The existing operator summary remains global and platform-admin-only; the new tenant route filters by the authenticated TenantScope.account_id at SQL time.

## Intentional

- The new /usage/summary/tenant route uses the host scope provider and returns 400 when no account_id is available, rather than falling back to global usage.
- summarize_content_ops_llm_usage owns the account_id SQL filter so routes and future budget checks share the same source of truth.
- The existing /usage/summary route stays global and protected by the operator dependency.
- This slice does not add UI cards, BudgetGate wiring, or exact-cache controls.

## Deferred

- Future PR: add UI/control-surface cards for tenant usage.
- Future PR: wire BudgetGate against account-scoped usage.
- Future PR: add exact-cache integration with explicit support-ticket privacy policy and account scoping.

## Parked hardening

None.

## Verification

- python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters tests/test_atlas_content_ops_generated_assets_api.py -q — 11 passed, 2 skipped, 1 warning.
- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_usage_summary.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_extracted_content_control_surface_api.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.

## Diff size

~355 LOC, under the 400 LOC soft cap.
