### PR TITLE
Surface FAQ search route not-run reason

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md
@@ -1,0 +1,75 @@
+# PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason
+
+## Why this slice exists
+
+The seeded hosted FAQ search e2e runner now makes detail not-run states explicit,
+but the route phase still looks like a route failure when it was never attempted
+because preflight or seed failed first. That can send an operator toward hosted
+route debugging when the actual blocker is earlier in the e2e flow.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add an explicit route not-run payload with `skipped: true` and
+   `not_run_reason`.
+2. Use that payload for preflight and seed-failure route states.
+3. Add focused tests that distinguish route not-run from a real route command
+   failure.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md`
+- `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+
+## Mechanism
+
+A `_route_not_run(...)` helper builds the route phase payload:
+`ok`, `returncode`, `stdout_tail`, `stderr_tail`, `skipped`, and
+`not_run_reason`. Preflight and seed-failure paths use that helper. When the
+route command actually runs, `_run_command(...)` remains unchanged, so real
+hosted-route failures still carry the command return code and output tails.
+
+## Intentional
+
+- No hosted route behavior changes; this only improves the e2e result artifact.
+- No cleanup behavior changes.
+- No broad seed/detail/result refactor in this slice.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` has no active FAQ search entries touching
+this runner.
+
+Seed phase result normalization is left for a later slice if it becomes a
+consumer pain point; this slice only closes route-phase ambiguity.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (48
+  passed)
+- `python -m py_compile` with
+  `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` and
+  `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
+- `python` `scripts/audit_plan_code_consistency.py` with
+  `plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching
+  tests enrolled)
+- `git diff --check`
+- `bash` `scripts/validate_extracted_content_pipeline.sh`
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline`
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- `bash` `scripts/check_ascii_python.sh`
+- `bash` `scripts/run_extracted_pipeline_checks.sh` (2460 passed, 6 skipped)
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+| --- | ---: |
+| Plan doc | 75 |
+| Runner | 19 |
+| Tests | 71 |
+| **Total** | **165** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -425,7 +425,7 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
         "phase": "preflight",
         "artifacts": {},
         "seed": {"ok": False, "returncode": None},
-        "route": {"ok": False, "returncode": None},
+        "route": _route_not_run("preflight_failed", ok=False),
         "detail": _detail_not_run(
             "skip_detail_check" if args.skip_detail_check else "preflight_failed",
             ok=bool(args.skip_detail_check),
@@ -482,10 +482,12 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 seed_result=seed_result,
             )
         )
-        route = {"ok": False, "returncode": None, "stdout_tail": "", "stderr_tail": ""}
+        route = _route_not_run("waiting_for_seed", ok=False)
         if seed["ok"]:
             route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
-        elif not bool(args.skip_detail_check):
+        else:
+            route = _route_not_run("seed_failed", ok=False)
+        if not bool(seed["ok"]) and not bool(args.skip_detail_check):
             detail = _detail_not_run("seed_failed", ok=False)
         if bool(seed["ok"]) and not bool(route["ok"]) and not bool(args.skip_detail_check):
             detail = _detail_not_run("route_failed", ok=False)
@@ -548,6 +550,17 @@ def _detail_not_run(reason: str, *, ok: bool) -> dict[str, Any]:
     return {
         "ok": ok,
         "returncode": None,
+        "skipped": True,
+        "not_run_reason": reason,
+    }
+
+
+def _route_not_run(reason: str, *, ok: bool) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "returncode": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
         "skipped": True,
         "not_run_reason": reason,
     }

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -437,6 +437,14 @@ def test_main_writes_preflight_result(tmp_path, capsys):
     assert payload["preflight_errors"] == [
         "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL"
     ]
+    assert payload["route"] == {
+        "ok": False,
+        "returncode": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
+        "skipped": True,
+        "not_run_reason": "preflight_failed",
+    }
     assert payload["detail"] == {
         "ok": False,
         "returncode": None,
@@ -514,6 +522,63 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     assert str(smoke.CONTRACT_SCRIPT) in calls[2]
 
 
+def test_main_seed_failure_marks_route_not_run_and_still_cleans_up(tmp_path, monkeypatch):
+    calls = []
+
+    def _fake_run_command(command):
+        calls.append(command)
+        if str(smoke.SEED_SCRIPT) in command:
+            cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+            _write_cases(
+                cleanup_manifest,
+                {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
+            )
+            return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad seed"}
+        return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+    async def _fake_cleanup(_database_url, faq_ids):
+        return {
+            "ok": True,
+            "requested_faq_ids": len(faq_ids),
+            "deleted_faq_ids": len(faq_ids),
+            "delete_status": f"DELETE {len(faq_ids)}",
+            "errors": [],
+        }
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["route"] == {
+        "ok": False,
+        "returncode": None,
+        "stdout_tail": "",
+        "stderr_tail": "",
+        "skipped": True,
+        "not_run_reason": "seed_failed",
+    }
+    assert payload["detail"]["not_run_reason"] == "seed_failed"
+    assert payload["cleanup"]["ok"] is True
+    assert len(calls) == 1
+
+
 def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
     calls = []
 
@@ -575,6 +640,12 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
 
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 1
+    assert payload["route"] == {
+        "ok": False,
+        "returncode": 1,
+        "stdout_tail": "",
+        "stderr_tail": "bad route",
+    }
     assert payload["detail"] == {
         "ok": False,
         "returncode": None,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md
Slice phase: Production hardening

Make the seeded hosted FAQ search e2e result artifact distinguish a real route command failure from a route phase that never ran because preflight or seed failed first.

## Intentional
- No hosted route behavior changes; this only improves the e2e result artifact.
- No cleanup behavior changes.
- No broad seed/detail/result refactor in this slice.

## Deferred
- Seed phase result normalization is left for a later slice if it becomes a consumer pain point.

## Parked hardening
- None.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` (48 passed)
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py`
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Route-Not-Run-Reason.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` (121 matching tests enrolled)
- `git diff --check`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (2460 passed, 6 skipped)

## Diff size
3 files, +162 / -3
