### PR TITLE
Add Content Ops usage budget gate

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -47,6 +47,8 @@ from ..content_ops_input_provider import (
 from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
+    UsageBudgetEvaluation,
+    evaluate_usage_budget,
     preview_from_mapping,
     request_from_mapping,
     retry_adjusted_unit_cost_usd,
@@ -457,6 +459,8 @@ if BaseModel is not None:
         outputs: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
         limit: int = Field(1, ge=1, le=1000)
         max_cost_usd: float | None = Field(default=None, gt=0)
+        account_usage_budget_usd: float | None = Field(default=None, gt=0)
+        account_usage_budget_days: int = Field(7, ge=1, le=90)
         inputs: dict[str, Any] = Field(default_factory=dict, max_length=_MAX_INPUT_KEYS)
         ingestion_profile: str = Field("domain_specific", min_length=1, max_length=80)
         require_quality_gates: bool = True
@@ -640,8 +644,16 @@ def create_content_ops_control_surface_router(
             input_provider=input_provider,
             scope_provider=scope_provider,
         )
+        budget_evaluation = await _evaluate_account_usage_budget(
+            payload_mapping,
+            usage_pool_provider=usage_pool_provider,
+            scope_provider=scope_provider,
+        )
         return _with_input_provider_diagnostics(
-            preview_from_mapping(payload_mapping),
+            _apply_usage_budget_to_preview(
+                preview_from_mapping(payload_mapping),
+                budget_evaluation,
+            ),
             payload_mapping,
         )
 
@@ -655,8 +667,16 @@ def create_content_ops_control_surface_router(
                 input_provider=input_provider,
                 scope_provider=scope_provider,
             )
+            budget_evaluation = await _evaluate_account_usage_budget(
+                payload_mapping,
+                usage_pool_provider=usage_pool_provider,
+                scope_provider=scope_provider,
+            )
             return _with_input_provider_diagnostics(
-                build_generation_plan_from_mapping(payload_mapping),
+                _apply_usage_budget_to_plan(
+                    build_generation_plan_from_mapping(payload_mapping),
+                    budget_evaluation,
+                ),
                 payload_mapping,
             )
         except ValueError as exc:
@@ -813,6 +833,27 @@ def create_content_ops_control_surface_router(
                 },
             )
         try:
+            scope = await _resolve_scope(scope_provider)
+            payload_mapping = await _payload_with_input_provider(
+                payload_mapping,
+                input_provider=input_provider,
+                scope=scope,
+            )
+            _enforce_faq_execute_source_material_limit(
+                payload_mapping,
+                max_rows=resolved_config.faq_execute_max_source_material_rows,
+            )
+            budget_evaluation = await _evaluate_account_usage_budget(
+                payload_mapping,
+                usage_pool_provider=usage_pool_provider,
+                scope_provider=scope_provider,
+                scope=scope,
+            )
+            if budget_evaluation is not None and budget_evaluation.exceeded:
+                raise HTTPException(
+                    status_code=400,
+                    detail=_budget_exceeded_error(budget_evaluation),
+                )
             if execution_services_provider is None:
                 raise HTTPException(
                     status_code=503,
@@ -824,16 +865,6 @@ def create_content_ops_control_surface_router(
                     status_code=503,
                     detail="Content Ops execution services are not configured.",
                 )
-            scope = await _resolve_scope(scope_provider)
-            payload_mapping = await _payload_with_input_provider(
-                payload_mapping,
-                input_provider=input_provider,
-                scope=scope,
-            )
-            _enforce_faq_execute_source_material_limit(
-                payload_mapping,
-                max_rows=resolved_config.faq_execute_max_source_material_rows,
-            )
             # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
             # per-request reasoning provider and derive a reasoning-aware
             # bundle. The base services from execution_services_provider
@@ -1500,6 +1531,88 @@ async def _resolve_usage_pool(pool_provider: PoolProvider | None) -> Any:
             detail="Content Ops usage database is unavailable.",
         )
     return pool
+
+
+async def _evaluate_account_usage_budget(
+    payload: Mapping[str, Any],
+    *,
+    usage_pool_provider: PoolProvider | None,
+    scope_provider: ScopeProvider | None,
+    scope: TenantScope | None = None,
+) -> UsageBudgetEvaluation | None:
+    request = request_from_mapping(payload)
+    if request.account_usage_budget_usd is None:
+        return None
+    pool = await _resolve_usage_pool(usage_pool_provider)
+    resolved_scope = scope if scope is not None else await _resolve_scope(scope_provider)
+    usage = await summarize_content_ops_llm_usage(
+        pool,
+        days=request.account_usage_budget_days,
+        account_id=_required_scope_account_id(resolved_scope),
+    )
+    current_cost = usage.get("summary", {}).get("total_cost_usd", 0.0)
+    return evaluate_usage_budget(
+        budget_usd=request.account_usage_budget_usd,
+        period_days=request.account_usage_budget_days,
+        current_cost_usd=float(current_cost or 0.0),
+        estimated_cost_usd=preview_from_mapping(payload)["estimated_cost_usd"],
+    )
+
+
+def _budget_warning(evaluation: UsageBudgetEvaluation) -> str:
+    return (
+        "Projected account usage exceeds account_usage_budget_usd: "
+        f"{evaluation.period_days}-day projected "
+        f"{evaluation.projected_cost_usd:.2f} > {evaluation.budget_usd:.2f}"
+    )
+
+
+def _apply_usage_budget_to_preview(
+    preview: dict[str, Any],
+    evaluation: UsageBudgetEvaluation | None,
+) -> dict[str, Any]:
+    if evaluation is None:
+        return preview
+    preview = dict(preview)
+    preview["usage_budget"] = evaluation.as_dict()
+    if evaluation.exceeded:
+        preview["can_run"] = False
+        warnings = list(preview.get("warnings") or ())
+        warnings.append(_budget_warning(evaluation))
+        preview["warnings"] = warnings
+    return preview
+
+
+def _apply_usage_budget_to_plan(
+    plan: dict[str, Any],
+    evaluation: UsageBudgetEvaluation | None,
+) -> dict[str, Any]:
+    if evaluation is None:
+        return plan
+    plan = dict(plan)
+    preview = _apply_usage_budget_to_preview(
+        dict(plan.get("preview") or {}),
+        evaluation,
+    )
+    plan["preview"] = preview
+    if evaluation.exceeded:
+        plan["can_execute"] = False
+        blocked_steps: list[dict[str, Any]] = []
+        for step in plan.get("steps") or ():
+            next_step = dict(step)
+            next_step["status"] = "blocked"
+            next_step["reason"] = "account_usage_budget_exceeded"
+            blocked_steps.append(next_step)
+        plan["steps"] = blocked_steps
+    return plan
+
+
+def _budget_exceeded_error(evaluation: UsageBudgetEvaluation) -> dict[str, Any]:
+    return {
+        "reason": "account_usage_budget_exceeded",
+        "message": _budget_warning(evaluation),
+        "usage_budget": evaluation.as_dict(),
+    }
 
 
 async def _import_ingestion_rows_with_admission(

--- a/extracted_content_pipeline/content_ops_input_provider.py
+++ b/extracted_content_pipeline/content_ops_input_provider.py
@@ -24,6 +24,8 @@ _REQUEST_KEYS = frozenset({
     "outputs",
     "limit",
     "max_cost_usd",
+    "account_usage_budget_usd",
+    "account_usage_budget_days",
     "inputs",
     "ingestion_profile",
     "require_quality_gates",

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -57,6 +57,8 @@ class ContentOpsRequest:
     outputs: tuple[str, ...] = ()
     limit: int = 1
     max_cost_usd: float | None = None
+    account_usage_budget_usd: float | None = None
+    account_usage_budget_days: int = 7
     inputs: Mapping[str, Any] = field(default_factory=dict)
     ingestion_profile: str = "domain_specific"
     require_quality_gates: bool = True
@@ -92,10 +94,38 @@ class ControlSurfacePreview:
                 "outputs": list(self.normalized_request.outputs),
                 "limit": self.normalized_request.limit,
                 "max_cost_usd": self.normalized_request.max_cost_usd,
+                "account_usage_budget_usd": (
+                    self.normalized_request.account_usage_budget_usd
+                ),
+                "account_usage_budget_days": (
+                    self.normalized_request.account_usage_budget_days
+                ),
                 "ingestion_profile": self.normalized_request.ingestion_profile,
                 "require_quality_gates": self.normalized_request.require_quality_gates,
                 "allow_unimplemented_outputs": self.normalized_request.allow_unimplemented_outputs,
             },
+        }
+
+
+@dataclass(frozen=True)
+class UsageBudgetEvaluation:
+    """Account-period budget evaluation for a proposed Content Ops run."""
+
+    budget_usd: float
+    period_days: int
+    current_cost_usd: float
+    estimated_cost_usd: float
+    projected_cost_usd: float
+    exceeded: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "budget_usd": round(self.budget_usd, 6),
+            "period_days": self.period_days,
+            "current_cost_usd": round(self.current_cost_usd, 6),
+            "estimated_cost_usd": round(self.estimated_cost_usd, 6),
+            "projected_cost_usd": round(self.projected_cost_usd, 6),
+            "exceeded": self.exceeded,
         }
 
 
@@ -248,6 +278,28 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
     if max_cost_usd is not None and max_cost_usd <= 0:
         raise ValueError(f"max_cost_usd must be positive; got {max_cost_usd:g}")
 
+    account_usage_budget_usd = (
+        float(payload["account_usage_budget_usd"])
+        if payload.get("account_usage_budget_usd") is not None
+        else None
+    )
+    if account_usage_budget_usd is not None and account_usage_budget_usd <= 0:
+        raise ValueError(
+            "account_usage_budget_usd must be positive; "
+            f"got {account_usage_budget_usd:g}"
+        )
+
+    account_usage_budget_days = int(
+        payload.get("account_usage_budget_days")
+        if payload.get("account_usage_budget_days") is not None
+        else 7
+    )
+    if account_usage_budget_days < 1 or account_usage_budget_days > 90:
+        raise ValueError(
+            "account_usage_budget_days must be between 1 and 90; "
+            f"got {account_usage_budget_days}"
+        )
+
     raw_inputs = payload.get("inputs")
     if raw_inputs is not None and not isinstance(raw_inputs, Mapping):
         raise ValueError("inputs must be an object")
@@ -264,6 +316,8 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
         outputs=normalize_outputs(payload.get("outputs")),
         limit=limit,
         max_cost_usd=max_cost_usd,
+        account_usage_budget_usd=account_usage_budget_usd,
+        account_usage_budget_days=account_usage_budget_days,
         inputs=raw_inputs if isinstance(raw_inputs, Mapping) else {},
         ingestion_profile=str(payload.get("ingestion_profile") or "domain_specific").strip()
         or "domain_specific",
@@ -362,6 +416,32 @@ def estimate_cost_usd(
     return total
 
 
+def evaluate_usage_budget(
+    *,
+    budget_usd: float,
+    period_days: int,
+    current_cost_usd: float,
+    estimated_cost_usd: float,
+) -> UsageBudgetEvaluation:
+    """Return whether current account usage plus a proposed run exceeds budget."""
+
+    if budget_usd <= 0:
+        raise ValueError(f"budget_usd must be positive; got {budget_usd:g}")
+    if period_days < 1 or period_days > 90:
+        raise ValueError(f"period_days must be between 1 and 90; got {period_days}")
+    current = max(0.0, float(current_cost_usd))
+    estimated = max(0.0, float(estimated_cost_usd))
+    projected = current + estimated
+    return UsageBudgetEvaluation(
+        budget_usd=float(budget_usd),
+        period_days=int(period_days),
+        current_cost_usd=current,
+        estimated_cost_usd=estimated,
+        projected_cost_usd=projected,
+        exceeded=projected > float(budget_usd),
+    )
+
+
 def missing_required_inputs(
     outputs: Sequence[str],
     provided_inputs: Mapping[str, Any],
@@ -448,6 +528,8 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         outputs=selected_outputs,
         limit=request.limit,
         max_cost_usd=request.max_cost_usd,
+        account_usage_budget_usd=request.account_usage_budget_usd,
+        account_usage_budget_days=request.account_usage_budget_days,
         inputs=request.inputs,
         ingestion_profile=request.ingestion_profile,
         require_quality_gates=request.require_quality_gates,

--- a/plans/PR-Content-Ops-Usage-Budget-Gate.md
+++ b/plans/PR-Content-Ops-Usage-Budget-Gate.md
@@ -23,8 +23,11 @@ Slice phase: Production hardening
    account budget field is provided.
 4. Keep budget enforcement fail-closed when the usage pool or tenant account
    scope is unavailable.
-5. Add focused tests for request validation, preview/plan response shaping, and
-   execute blocking before generation services run.
+5. Preserve the budget fields through input-provider merges so provider-backed
+   flows use the same gate.
+6. Add focused tests for request validation, input-provider merging,
+   preview/plan response shaping, and execute blocking before generation
+   services run.
 
 ### Files touched
 
@@ -33,8 +36,10 @@ Slice phase: Production hardening
 | `plans/PR-Content-Ops-Usage-Budget-Gate.md` | Plan doc for the usage-backed budget gate. |
 | `extracted_content_pipeline/control_surfaces.py` | Add account-period budget fields and pure budget evaluation. |
 | `extracted_content_pipeline/api/control_surfaces.py` | Apply account-scoped usage budget checks to preview, plan, and execute routes. |
+| `extracted_content_pipeline/content_ops_input_provider.py` | Preserve account-period budget fields through input-provider request merges. |
 | `tests/test_extracted_content_control_surfaces.py` | Cover request validation and budget evaluation. |
 | `tests/test_extracted_content_control_surface_api.py` | Cover API preview/plan/execute budget gate wiring. |
+| `tests/test_extracted_content_ops_input_provider.py` | Cover budget fields surviving input-provider merge. |
 
 ## Mechanism
 
@@ -49,6 +54,10 @@ then evaluates projected spend with the pure control-surface helper and attaches
 an `usage_budget` payload to preview/plan output. If projected spend exceeds the
 budget, preview returns `can_run: false`, plan returns `can_execute: false`, and
 execute raises a 400 before resolving or calling generation services.
+
+The input-provider request allowlist includes the new budget fields so uploaded
+or provider-backed source flows cannot accidentally drop the caller's budget
+before the shared budget evaluation runs.
 
 ## Intentional
 
@@ -76,6 +85,8 @@ execute raises a 400 before resolving or calling generation services.
 
 - python -m pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_blocks_account_usage_budget tests/test_extracted_content_control_surface_api.py::test_plan_generation_route_marks_steps_blocked_when_account_budget_exceeds tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_blocks_account_usage_budget_before_generation -q — 35 passed.
 - python -m compileall -q extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
+- python -m pytest tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_blocks_account_usage_budget tests/test_extracted_content_control_surface_api.py::test_plan_generation_route_marks_steps_blocked_when_account_budget_exceeds tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_blocks_account_usage_budget_before_generation -q — 41 passed.
+- python -m compileall -q extracted_content_pipeline/content_ops_input_provider.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
@@ -87,11 +98,12 @@ execute raises a 400 before resolving or calling generation services.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~90 |
+| Plan doc | ~105 |
 | Control-surface request/evaluation | ~85 |
 | API route wiring | ~140 |
-| Tests | ~140 |
-| **Total** | **~455** |
+| Input-provider merge | ~5 |
+| Tests | ~170 |
+| **Total** | **~505** |
 
 This is over the 400 LOC soft cap because preview, plan, and execute all need to
 use the same budget contract in one slice for the gate to be load-bearing.

--- a/plans/PR-Content-Ops-Usage-Budget-Gate.md
+++ b/plans/PR-Content-Ops-Usage-Budget-Gate.md
@@ -1,0 +1,97 @@
+# PR: Content Ops Usage Budget Gate
+
+## Why this slice exists
+
+Content Ops now records hosted LLM usage, exposes tenant-scoped usage summaries,
+and shows recent usage in the run UI. The next production step is a load-bearing
+budget gate that uses the same account-scoped usage data before generation runs.
+
+This slice keeps the old `max_cost_usd` request cap intact as a per-run estimate
+cap, and adds a separate account-period budget contract for cumulative tenant
+spend.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add explicit `account_usage_budget_usd` and `account_usage_budget_days`
+   request fields.
+2. Add pure budget evaluation against current account spend plus the estimated
+   request cost.
+3. Wire the budget evaluation into `/preview`, `/plan`, and `/execute` when the
+   account budget field is provided.
+4. Keep budget enforcement fail-closed when the usage pool or tenant account
+   scope is unavailable.
+5. Add focused tests for request validation, preview/plan response shaping, and
+   execute blocking before generation services run.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Usage-Budget-Gate.md` | Plan doc for the usage-backed budget gate. |
+| `extracted_content_pipeline/control_surfaces.py` | Add account-period budget fields and pure budget evaluation. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Apply account-scoped usage budget checks to preview, plan, and execute routes. |
+| `tests/test_extracted_content_control_surfaces.py` | Cover request validation and budget evaluation. |
+| `tests/test_extracted_content_control_surface_api.py` | Cover API preview/plan/execute budget gate wiring. |
+
+## Mechanism
+
+`ContentOpsRequest` gains `account_usage_budget_usd` and
+`account_usage_budget_days`. `max_cost_usd` remains a per-request estimate cap;
+the new fields mean "current account usage over N days plus this request's
+estimated cost must stay under this account-period cap."
+
+The API layer reads the current tenant usage through
+`summarize_content_ops_llm_usage` with the authenticated scope account_id. It
+then evaluates projected spend with the pure control-surface helper and attaches
+an `usage_budget` payload to preview/plan output. If projected spend exceeds the
+budget, preview returns `can_run: false`, plan returns `can_execute: false`, and
+execute raises a 400 before resolving or calling generation services.
+
+## Intentional
+
+- This does not overload `max_cost_usd`; existing per-run behavior remains.
+- This does not add UI controls yet. The backend contract lands first so the
+  UI can call a stable field name in a follow-up.
+- This does not update frontend request controls or TypeScript domain fields in
+  this slice. The backend accepts and enforces the new fields now; the UI
+  control surface is the named follow-up.
+- This only enforces when `account_usage_budget_usd` is supplied. Accounts with
+  no explicit budget keep today's behavior.
+- The execute route checks the budget before LLM generation, not after usage is
+  already spent.
+
+## Deferred
+
+- Future PR: expose account usage budget controls in the Content Ops run UI.
+- Future PR: persist per-account default budget settings if product needs
+  always-on tenant caps instead of per-request caps.
+- Future PR: add exact-cache controls with explicit support-ticket privacy
+  policy and account scoping.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_blocks_account_usage_budget tests/test_extracted_content_control_surface_api.py::test_plan_generation_route_marks_steps_blocked_when_account_budget_exceeds tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_blocks_account_usage_budget_before_generation -q — 35 passed.
+- python -m compileall -q extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| Control-surface request/evaluation | ~85 |
+| API route wiring | ~140 |
+| Tests | ~140 |
+| **Total** | **~455** |
+
+This is over the 400 LOC soft cap because preview, plan, and execute all need to
+use the same budget contract in one slice for the gate to be load-bearing.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -817,6 +817,41 @@ async def test_preview_generation_route_blocks_budget_between_base_and_retry_cos
 
 
 @pytest.mark.asyncio
+async def test_preview_generation_route_blocks_account_usage_budget():
+    pool = _UsagePool()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        usage_pool_provider=lambda: pool,
+        scope_provider=lambda: {"account_id": " acct-1 "},
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+            "account_usage_budget_usd": 1.5,
+            "account_usage_budget_days": 7,
+        }
+    )
+
+    assert payload["can_run"] is False
+    assert payload["usage_budget"]["current_cost_usd"] == 1.234567
+    assert payload["usage_budget"]["estimated_cost_usd"] == 0.36
+    assert payload["usage_budget"]["projected_cost_usd"] == 1.594567
+    assert payload["usage_budget"]["exceeded"] is True
+    assert "metadata ->> 'account_id' = $2" in pool.fetchrow_calls[0][0]
+    assert pool.fetchrow_calls[0][1] == (7, "acct-1")
+    assert (
+        "Projected account usage exceeds account_usage_budget_usd: "
+        "7-day projected 1.59 > 1.50"
+    ) in payload["warnings"]
+
+
+@pytest.mark.asyncio
 async def test_plan_generation_route_returns_execution_plan():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
@@ -839,6 +874,33 @@ async def test_plan_generation_route_returns_execution_plan():
     assert payload["steps"][0]["status"] == "runnable"
     assert payload["preview"]["can_run"] is True
     assert "input_provider" not in payload
+
+
+@pytest.mark.asyncio
+async def test_plan_generation_route_marks_steps_blocked_when_account_budget_exceeds():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        usage_pool_provider=lambda: _UsagePool(),
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+
+    route = _route(router, "/ops/plan", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {
+                "target_account": "Acme",
+                "offer": "Churn audit",
+            },
+            "account_usage_budget_usd": 1.5,
+        }
+    )
+
+    assert payload["can_execute"] is False
+    assert payload["preview"]["can_run"] is False
+    assert payload["preview"]["usage_budget"]["exceeded"] is True
+    assert payload["steps"][0]["status"] == "blocked"
+    assert payload["steps"][0]["reason"] == "account_usage_budget_exceeded"
 
 
 @pytest.mark.asyncio
@@ -1810,6 +1872,42 @@ async def test_execute_generation_route_runs_configured_services():
     assert service.calls[0]["limit"] == 2
     assert service.calls[0]["filters"] == {"status": "ready"}
     assert "input_provider" not in payload
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_blocks_account_usage_budget_before_generation():
+    service = _CampaignService()
+    provider_calls = {"count": 0}
+
+    def execution_services_provider():
+        provider_calls["count"] += 1
+        return ContentOpsExecutionServices(campaign=service)
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=execution_services_provider,
+        usage_pool_provider=lambda: _UsagePool(),
+        scope_provider=lambda: {"account_id": "acct-1"},
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["email_campaign"],
+                "inputs": {
+                    "target_account": "Acme",
+                    "offer": "Churn audit",
+                },
+                "account_usage_budget_usd": 1.5,
+            }
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["reason"] == "account_usage_budget_exceeded"
+    assert exc.value.detail["usage_budget"]["projected_cost_usd"] == 1.594567
+    assert provider_calls["count"] == 0
+    assert service.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -1,6 +1,7 @@
 import pytest
 
 from extracted_content_pipeline.control_surfaces import (
+    evaluate_usage_budget,
     normalize_outputs,
     preview_from_mapping,
     request_from_mapping,
@@ -42,6 +43,8 @@ def test_preview_allows_implemented_outputs_under_budget():
     assert preview["estimated_cost_usd"] == 2.92
     assert preview["missing_inputs"] == []
     assert preview["blocked_outputs"] == []
+    assert preview["normalized_request"]["account_usage_budget_usd"] is None
+    assert preview["normalized_request"]["account_usage_budget_days"] == 7
 
 
 def test_preview_blocks_unknown_preset_instead_of_falling_back_to_email():
@@ -336,6 +339,41 @@ def test_request_from_mapping_rejects_zero_limit():
 def test_request_from_mapping_rejects_non_positive_budget():
     with pytest.raises(ValueError, match="max_cost_usd must be positive; got -1"):
         request_from_mapping({"max_cost_usd": -1})
+
+
+def test_request_from_mapping_rejects_non_positive_account_usage_budget():
+    with pytest.raises(
+        ValueError,
+        match="account_usage_budget_usd must be positive; got 0",
+    ):
+        request_from_mapping({"account_usage_budget_usd": 0})
+
+
+def test_request_from_mapping_rejects_account_usage_budget_days_out_of_range():
+    with pytest.raises(
+        ValueError,
+        match="account_usage_budget_days must be between 1 and 90; got 91",
+    ):
+        request_from_mapping({"account_usage_budget_days": 91})
+
+
+def test_evaluate_usage_budget_projects_current_plus_estimated_cost():
+    evaluation = evaluate_usage_budget(
+        budget_usd=2.0,
+        period_days=7,
+        current_cost_usd=1.2,
+        estimated_cost_usd=0.9,
+    )
+
+    assert evaluation.exceeded is True
+    assert evaluation.as_dict() == {
+        "budget_usd": 2.0,
+        "period_days": 7,
+        "current_cost_usd": 1.2,
+        "estimated_cost_usd": 0.9,
+        "projected_cost_usd": 2.1,
+        "exceeded": True,
+    }
 
 
 def test_request_from_mapping_rejects_non_object_inputs():

--- a/tests/test_extracted_content_ops_input_provider.py
+++ b/tests/test_extracted_content_ops_input_provider.py
@@ -114,6 +114,34 @@ def test_merge_input_package_keeps_explicit_request_inputs_authoritative() -> No
     assert preview.can_run is True
 
 
+def test_merge_input_package_preserves_explicit_account_usage_budget() -> None:
+    package = ContentOpsInputPackage(
+        provider="ticket_import",
+        outputs=("landing_page",),
+        inputs={
+            "source_material": _source_material(),
+            "offer": "Provider offer",
+            "audience": "Provider audience",
+        },
+    )
+
+    payload = merge_content_ops_input_package(
+        {
+            "outputs": ["landing_page"],
+            "account_usage_budget_usd": 1.5,
+            "account_usage_budget_days": 14,
+            "inputs": {"offer": "Operator offer"},
+        },
+        package,
+    )
+    request = request_from_mapping(payload)
+
+    assert payload["account_usage_budget_usd"] == 1.5
+    assert payload["account_usage_budget_days"] == 14
+    assert request.account_usage_budget_usd == 1.5
+    assert request.account_usage_budget_days == 14
+
+
 def test_merge_input_package_ignores_null_request_overrides() -> None:
     package = ContentOpsInputPackage(
         provider="ticket_import",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Usage-Budget-Gate.md
Slice phase: Production hardening

Add an explicit account-period budget gate for Content Ops so preview, plan, and execute can use account-scoped usage before generation spend happens.

## Intentional
- Keep max_cost_usd as the existing per-run estimate cap and add explicit account-period budget fields instead of overloading it.
- Enforce only when account_usage_budget_usd is supplied; accounts without explicit budgets keep current behavior.
- Execute checks the account budget before resolving or calling generation services.
- Frontend request controls and TypeScript domain fields are deferred to the UI follow-up.

## Deferred
- Future PR: expose account usage budget controls in the Content Ops run UI.
- Future PR: persist per-account default budget settings if product needs always-on tenant caps.
- Future PR: add exact-cache controls with explicit support-ticket privacy policy and account scoping.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_blocks_account_usage_budget tests/test_extracted_content_control_surface_api.py::test_plan_generation_route_marks_steps_blocked_when_account_budget_exceeds tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_blocks_account_usage_budget_before_generation -q — 35 passed.
- python -m compileall -q extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.

## Diff size
5 files, +440 / -12.
