### PR TITLE
Surface FAQ search DB setup failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,33 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-27
+
+### FAQ search DB smoke optional file-output failures lack result artifacts
+- File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
+  `_write_cleanup_manifest(...)` and `_write_route_case_file(...)` calls.
+- Description: Optional cleanup-manifest and route-case file write failures can
+  still abort the smoke before `--output-result` is written.
+- Why it matters: Operators running keep-data handoffs may lose the structured
+  smoke result when the failure is a bad local artifact path rather than a DB or
+  route issue.
+- Effort: S
+- Category: correctness
+- Owner/session: Codex FAQ lane
+- Found during: PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result
+
+### FAQ search DB smoke cleanup failures can mask original result
+- File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
+  `run_smoke(...)` cleanup `finally` block.
+- Description: Cleanup exceptions can still replace an earlier setup/search
+  result instead of being reported as cleanup metadata.
+- Why it matters: A failed cleanup could hide whether retrieval passed, failed,
+  or never ran, making go-live smoke artifacts harder to interpret.
+- Effort: M
+- Category: correctness
+- Owner/session: Codex FAQ lane
+- Found during: PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md
@@ -1,0 +1,93 @@
+# PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Search-DB-Preflight-Result made malformed DB FAQ search
+smoke invocations write `--output-result`, but setup failures after pool
+creation can still abort before the JSON artifact is written. Migration and
+seed failures are the next highest-value setup edges because they happen before
+retrieval starts and are the failures an operator most needs to distinguish
+from query latency or tenant-isolation failures.
+
+This production-hardening slice makes migration and seed setup failures visible
+without changing the successful DB search path, hosted route path, or cleanup
+policy.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Convert migration failures into a structured DB FAQ search result with
+   `setup.phase = "migrations"`.
+2. Convert seed failures into a structured DB FAQ search result with
+   `setup.phase = "seed"`.
+3. Keep the search execution, latency gates, route-case generation, and cleanup
+   policy unchanged.
+4. Add focused negative tests for both setup-failure branches.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md` | Plan contract for the setup-failure result slice. |
+| `HARDENING.md` | Park adjacent optional file-output and cleanup-result visibility gaps. |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | Return structured result artifacts for migration and seed failures. |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | Regression tests for migration and seed failure result artifacts. |
+
+## Mechanism
+
+Add a small `_setup_failure_summary(...)` helper that uses the existing
+`_summary_payload(...)` result shape with `ok = false`, no request results, and
+a phase-specific `setup.error` block. `run_smoke(...)` catches exceptions around
+only `_apply_migrations(...)` and `_seed(...)`, returns exit code `1`, and then
+lets the existing `finally` cleanup/close path run.
+
+The successful path still runs migrations, writes optional case/cleanup files,
+seeds documents, runs concurrent searches, applies latency budgets, and returns
+the existing success summary.
+
+## Intentional
+
+- No broad catch around the retrieval phase; worker failures are already
+  represented in `isolation`.
+- No cleanup behavior change. Cleanup still runs in `finally` unless
+  `--keep-data` is set.
+- Optional manifest and route-case file write failures are parked instead of
+  included so this PR stays focused on DB setup phases.
+
+## Deferred
+
+- Parked hardening: optional file-output failures in
+  `scripts/smoke_content_ops_faq_search_concurrency.py` can still abort before
+  result artifact writing.
+- Parked hardening: cleanup failures in
+  `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the
+  original setup/search result.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q` - 20
+  passed.
+- Py compile for `scripts/smoke_content_ops_faq_search_concurrency.py` and
+  `tests/test_smoke_content_ops_faq_search_concurrency.py` - passed.
+- Plan/code consistency audit for
+  `plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md` - passed.
+- Extracted pipeline CI enrollment audit - 121 matching tests enrolled.
+- `git diff --check` - passed.
+- Extracted content pipeline validation script - passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` for
+  `extracted_content_pipeline` - passed.
+- Extracted standalone audit with `--fail-on-debt` - passed.
+- Python ASCII check for extracted packages - passed.
+- Extracted pipeline CI mirror - 2467 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md` | 93 |
+| `HARDENING.md` | 27 |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | 51 |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | 126 |
+| **Total** | **297** |

--- a/plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md
@@ -40,8 +40,13 @@ Slice phase: Production hardening
 Add a small `_setup_failure_summary(...)` helper that uses the existing
 `_summary_payload(...)` result shape with `ok = false`, no request results, and
 a phase-specific `setup.error` block. `run_smoke(...)` catches exceptions around
-only `_apply_migrations(...)` and `_seed(...)`, returns exit code `1`, and then
-lets the existing `finally` cleanup/close path run.
+only `_apply_migrations(...)` and `_seed(...)`, returns exit code `1`, and keeps
+pool close in the existing `finally`.
+
+Cleanup is enabled only after migrations succeed. That prevents a fresh-DB
+migration failure from being masked by cleanup against tables that may not
+exist, while seed failures still run cleanup because the migration-created
+tables are available.
 
 The successful path still runs migrations, writes optional case/cleanup files,
 seeds documents, runs concurrent searches, applies latency budgets, and returns
@@ -51,8 +56,9 @@ the existing success summary.
 
 - No broad catch around the retrieval phase; worker failures are already
   represented in `isolation`.
-- No cleanup behavior change. Cleanup still runs in `finally` unless
-  `--keep-data` is set.
+- Cleanup still runs after migrations succeed unless `--keep-data` is set; it
+  is intentionally skipped for migration failures because the cleanup table may
+  not exist yet.
 - Optional manifest and route-case file write failures are parked instead of
   included so this PR stays focused on DB setup phases.
 
@@ -86,8 +92,8 @@ the existing success summary.
 
 | File | LOC |
 |---|---:|
-| `plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md` | 93 |
+| `plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md` | 99 |
 | `HARDENING.md` | 27 |
-| `scripts/smoke_content_ops_faq_search_concurrency.py` | 51 |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | 55 |
 | `tests/test_smoke_content_ops_faq_search_concurrency.py` | 126 |
-| **Total** | **297** |
+| **Total** | **307** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -536,6 +536,7 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         return 1, summary
     repo = PostgresTicketFAQSearchRepository(pool)
     results: list[dict[str, Any]] = []
+    cleanup_ready = False
     try:
         try:
             await _apply_migrations(pool)
@@ -548,6 +549,7 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 error=exc,
                 elapsed_seconds=time.perf_counter() - started,
             )
+        cleanup_ready = True
         _write_cleanup_manifest(args.cleanup_manifest_output, cases)
         try:
             await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
@@ -572,7 +574,7 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             concurrency=int(args.concurrency),
         )
     finally:
-        if not bool(args.keep_data):
+        if cleanup_ready and not bool(args.keep_data):
             await _cleanup(pool, cases)
         await pool.close()
     summary = _summary_payload(

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -477,6 +477,33 @@ def _summary_payload(
     }
 
 
+def _setup_failure_summary(
+    *,
+    run_id: str,
+    args: argparse.Namespace,
+    cases: Sequence[SearchCase],
+    phase: str,
+    error: BaseException,
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    return _summary_payload(
+        ok=False,
+        run_id=run_id,
+        args=args,
+        cases=cases,
+        results=[],
+        setup={
+            "ok": False,
+            "phase": phase,
+            "error": {
+                "type": type(error).__name__,
+                "message": str(error),
+            },
+        },
+        elapsed_seconds=elapsed_seconds,
+    )
+
+
 async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     _validate_args(args)
     run_id = uuid4().hex[:10]
@@ -510,9 +537,29 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     repo = PostgresTicketFAQSearchRepository(pool)
     results: list[dict[str, Any]] = []
     try:
-        await _apply_migrations(pool)
+        try:
+            await _apply_migrations(pool)
+        except Exception as exc:
+            return 1, _setup_failure_summary(
+                run_id=run_id,
+                args=args,
+                cases=cases,
+                phase="migrations",
+                error=exc,
+                elapsed_seconds=time.perf_counter() - started,
+            )
         _write_cleanup_manifest(args.cleanup_manifest_output, cases)
-        await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
+        try:
+            await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
+        except Exception as exc:
+            return 1, _setup_failure_summary(
+                run_id=run_id,
+                args=args,
+                cases=cases,
+                phase="seed",
+                error=exc,
+                elapsed_seconds=time.perf_counter() - started,
+            )
         _write_route_case_file(
             args.route_case_file_output,
             cases,

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -449,6 +449,132 @@ def test_main_writes_result_for_pool_creation_failure(tmp_path, monkeypatch) -> 
     }
 
 
+def test_main_writes_result_for_migration_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+            self.cleanup_calls = 0
+
+        async def execute(self, *_args):
+            self.cleanup_calls += 1
+            return "DELETE 0"
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _raise_migrations(_pool):
+        raise RuntimeError("migration failed")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _raise_migrations)
+    result_path = tmp_path / "faq-search-migrations.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert pool.cleanup_calls == 1
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "migrations",
+        "error": {
+            "type": "RuntimeError",
+            "message": "migration failed",
+        },
+    }
+
+
+def test_main_writes_result_for_seed_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+            self.cleanup_calls = 0
+
+        async def execute(self, *_args):
+            self.cleanup_calls += 1
+            return "DELETE 0"
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _raise_seed(*_args, **_kwargs):
+        raise RuntimeError("seed failed")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _raise_seed)
+    result_path = tmp_path / "faq-search-seed.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert pool.cleanup_calls == 1
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "seed",
+        "error": {
+            "type": "RuntimeError",
+            "message": "seed failed",
+        },
+    }
+
+
 def test_failure_summary_limits_output() -> None:
     results = [
         {

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -457,7 +457,7 @@ def test_main_writes_result_for_migration_failure(tmp_path, monkeypatch) -> None
 
         async def execute(self, *_args):
             self.cleanup_calls += 1
-            return "DELETE 0"
+            raise AssertionError("cleanup should not run before migrations succeed")
 
         async def close(self):
             self.closed = True
@@ -497,7 +497,7 @@ def test_main_writes_result_for_migration_failure(tmp_path, monkeypatch) -> None
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 1
     assert pool.closed is True
-    assert pool.cleanup_calls == 1
+    assert pool.cleanup_calls == 0
     assert payload["ok"] is False
     assert payload["requests"]["total"] == 0
     assert payload["setup"] == {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result.md
Slice phase: Production hardening

The DB FAQ search concurrency smoke now writes structured result artifacts for preflight and pool creation failures, but migration and seed setup failures could still abort before `--output-result`. This slice returns phase-specific setup summaries for those two DB setup failures without changing successful retrieval, latency gates, hosted route behavior, or cleanup policy. Migration failures skip cleanup until migrations have succeeded, so cleanup against missing tables cannot mask the original setup result.

## Intentional
- Catch only migration and seed setup failures; retrieval failures remain represented through existing `isolation` results.
- Cleanup still runs after migrations succeed unless `--keep-data` is set; migration failures skip cleanup because the cleanup table may not exist yet.
- Park optional manifest/route-case file write failures and cleanup-result masking instead of expanding this slice.

## Deferred
- Optional file-output failures in `scripts/smoke_content_ops_faq_search_concurrency.py` can still abort before result artifact writing; parked in `HARDENING.md`.
- Cleanup failures in `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the original setup/search result after migrations succeed; parked in `HARDENING.md`.

## Parked hardening
- `FAQ search DB smoke optional file-output failures lack result artifacts` — parked because this slice is scoped to DB migration/seed setup phases.
- `FAQ search DB smoke cleanup failures can mask original result` — parked because cleanup result modeling needs its own shape.

## Verification
- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q` — 20 passed.
- Py compile for `scripts/smoke_content_ops_faq_search_concurrency.py` and `tests/test_smoke_content_ops_faq_search_concurrency.py` — passed.
- Plan/code consistency audit — passed.
- Extracted pipeline CI enrollment audit — 121 matching tests enrolled.
- `git diff --check` — passed.
- Extracted guardrails passed: validate_extracted_content_pipeline, forbid_atlas_reasoning_imports, audit_extracted_standalone, check_ascii_python.
- `bash scripts/run_extracted_pipeline_checks.sh` — 2467 passed, 7 skipped, 1 warning.

## Diff size
4 files, +304 / -3
