### PR TITLE
Surface FAQ search DB file output failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,19 +32,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-27
 
-### FAQ search DB smoke optional file-output failures lack result artifacts
-- File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
-  `_write_cleanup_manifest(...)` and `_write_route_case_file(...)` calls.
-- Description: Optional cleanup-manifest and route-case file write failures can
-  still abort the smoke before `--output-result` is written.
-- Why it matters: Operators running keep-data handoffs may lose the structured
-  smoke result when the failure is a bad local artifact path rather than a DB or
-  route issue.
-- Effort: S
-- Category: correctness
-- Owner/session: Codex FAQ lane
-- Found during: PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result
-
 ### FAQ search DB smoke cleanup failures can mask original result
 - File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
   `run_smoke(...)` cleanup `finally` block.

--- a/plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md
@@ -1,0 +1,92 @@
+# PR-Content-Ops-FAQ-Search-DB-File-Output-Result
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result` made DB FAQ search smoke
+pool, migration, and seed setup failures write structured `--output-result`
+artifacts. It also parked one smaller adjacent gap: optional cleanup-manifest
+and route-case file writes can still abort the smoke before the result artifact
+is written.
+
+This production-hardening slice drains that parked file-output gap while keeping
+cleanup masking parked for a separate result-shape decision.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Convert cleanup-manifest write failures into a structured setup result with
+   `setup.phase = "cleanup_manifest_output"`.
+2. Convert route-case file write failures into a structured setup result with
+   `setup.phase = "route_case_file_output"`.
+3. Keep successful DB search execution, route-case payload shape, and cleanup
+   policy unchanged.
+4. Remove the drained file-output item from `HARDENING.md`; leave cleanup
+   masking parked.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md` | Plan contract for the file-output setup result slice. |
+| `HARDENING.md` | Remove the drained optional file-output hardening item. |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | Return structured result artifacts for optional file-output failures. |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | Regression tests for cleanup-manifest and route-case file output failures. |
+
+## Mechanism
+
+`run_smoke(...)` already has `_setup_failure_summary(...)` for setup phases.
+This slice wraps `_write_cleanup_manifest(...)` and `_write_route_case_file(...)`
+with narrow `try/except Exception` blocks. On failure, the smoke returns exit
+code `1` with no request results and a phase-specific `setup.error` payload.
+
+The existing `finally` block still closes the pool and runs cleanup after
+migrations succeed unless `--keep-data` is set.
+
+## Intentional
+
+- No new result shape is introduced; file-output failures use the same setup
+  summary used by pool, migration, and seed failures.
+- Cleanup failures are not fixed here. Modeling cleanup as metadata instead of
+  masking the original result is a separate, larger hardening slice.
+- Route-case and cleanup-manifest payload schemas are unchanged.
+
+## Deferred
+
+- Parked hardening: cleanup failures in
+  `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the
+  original setup/search result.
+
+## Verification
+
+- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
+  - 22 passed.
+- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
+  - Passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md
+  - Passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
+  - Passed: 121 matching tests enrolled.
+- Command: git diff --check
+  - Passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 2469 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md` | 92 |
+| `HARDENING.md` | 13 |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | 32 |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | 134 |
+| **Total** | **271** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -550,7 +550,17 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 elapsed_seconds=time.perf_counter() - started,
             )
         cleanup_ready = True
-        _write_cleanup_manifest(args.cleanup_manifest_output, cases)
+        try:
+            _write_cleanup_manifest(args.cleanup_manifest_output, cases)
+        except Exception as exc:
+            return 1, _setup_failure_summary(
+                run_id=run_id,
+                args=args,
+                cases=cases,
+                phase="cleanup_manifest_output",
+                error=exc,
+                elapsed_seconds=time.perf_counter() - started,
+            )
         try:
             await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
         except Exception as exc:
@@ -562,11 +572,21 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 error=exc,
                 elapsed_seconds=time.perf_counter() - started,
             )
-        _write_route_case_file(
-            args.route_case_file_output,
-            cases,
-            documents_per_corpus=int(args.documents_per_corpus),
-        )
+        try:
+            _write_route_case_file(
+                args.route_case_file_output,
+                cases,
+                documents_per_corpus=int(args.documents_per_corpus),
+            )
+        except Exception as exc:
+            return 1, _setup_failure_summary(
+                run_id=run_id,
+                args=args,
+                cases=cases,
+                phase="route_case_file_output",
+                error=exc,
+                elapsed_seconds=time.perf_counter() - started,
+            )
         results = await _run_concurrent_searches(
             repo,
             cases,

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -575,6 +575,140 @@ def test_main_writes_result_for_seed_failure(tmp_path, monkeypatch) -> None:
     }
 
 
+def test_main_writes_result_for_cleanup_manifest_output_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def execute(self, *_args):
+            raise AssertionError("cleanup should not run with --keep-data")
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    def _raise_manifest(*_args, **_kwargs):
+        raise OSError("manifest path bad")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_write_cleanup_manifest", _raise_manifest)
+    result_path = tmp_path / "faq-search-manifest.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--cleanup-manifest-output",
+        str(tmp_path / "cleanup-manifest.json"),
+        "--keep-data",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "cleanup_manifest_output",
+        "error": {
+            "type": "OSError",
+            "message": "manifest path bad",
+        },
+    }
+
+
+def test_main_writes_result_for_route_case_file_output_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def execute(self, *_args):
+            raise AssertionError("cleanup should not run with --keep-data")
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _seed_noop(*_args, **_kwargs):
+        return None
+
+    def _raise_route_cases(*_args, **_kwargs):
+        raise OSError("route case path bad")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _seed_noop)
+    monkeypatch.setattr(smoke, "_write_route_case_file", _raise_route_cases)
+    result_path = tmp_path / "faq-search-route-cases.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--route-case-file-output",
+        str(tmp_path / "route-cases.json"),
+        "--keep-data",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "route_case_file_output",
+        "error": {
+            "type": "OSError",
+            "message": "route case path bad",
+        },
+    }
+
+
 def test_failure_summary_limits_output() -> None:
     results = [
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md
Slice phase: Production hardening

This drains the parked FAQ search DB smoke gap where optional cleanup-manifest and route-case file write failures could abort before `--output-result` was written, making bad local artifact paths indistinguishable from missing smoke results.

## Intentional
- File-output failures reuse the existing setup result shape instead of adding a new envelope.
- Cleanup masking remains deferred because modeling cleanup as metadata is a larger result-shape decision.
- Route-case and cleanup-manifest payload schemas are unchanged.

## Deferred
- Cleanup failures in `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the original setup/search result.

## Parked hardening
- `FAQ search DB smoke cleanup failures can mask original result` remains parked in `HARDENING.md`; this slice only drains the smaller optional file-output result gap.

## Verification
- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
  - 22 passed.
- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
  - Passed.
- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-File-Output-Result.md
  - Passed.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
  - Passed: 121 matching tests enrolled.
- Command: git diff --check
  - Passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh
  - Passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
  - Passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
  - Passed.
- Command: bash scripts/check_ascii_python.sh
  - Passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 2469 passed, 7 skipped, 1 warning.

## Diff size
4 files, +252 / -19
