### PR TITLE
Surface FAQ search DB cleanup failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,17 +32,17 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-27
 
-### FAQ search DB smoke cleanup failures can mask original result
+### FAQ search DB smoke pool close failures can mask result
 - File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
-  `run_smoke(...)` cleanup `finally` block.
-- Description: Cleanup exceptions can still replace an earlier setup/search
-  result instead of being reported as cleanup metadata.
-- Why it matters: A failed cleanup could hide whether retrieval passed, failed,
+  `run_smoke(...)` pool `finally` block.
+- Description: `pool.close()` exceptions can still replace a prepared
+  setup/search result instead of being reported as lifecycle metadata.
+- Why it matters: A close failure could hide whether retrieval passed, failed,
   or never ran, making go-live smoke artifacts harder to interpret.
-- Effort: M
+- Effort: S
 - Category: correctness
 - Owner/session: Codex FAQ lane
-- Found during: PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result
+- Found during: PR-Content-Ops-FAQ-Search-DB-Cleanup-Result
 
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),

--- a/plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md
@@ -1,0 +1,92 @@
+# PR-Content-Ops-FAQ-Search-DB-Cleanup-Result
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-DB-Setup-Failure-Result` parked a remaining FAQ
+search DB smoke survivability gap: cleanup failures in `run_smoke(...)` can mask
+an earlier setup or search result because cleanup runs in `finally` after the
+smoke has already prepared a return value.
+
+This production-hardening slice drains that gap at the result-envelope source,
+so go-live operators can see both the primary setup/search outcome and whether
+cleanup succeeded.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add cleanup status metadata to FAQ search DB smoke result payloads.
+2. Convert `_cleanup(...)` failures into `cleanup.error` metadata instead of
+   letting them replace the original setup/search result.
+3. Make cleanup failure fail the smoke overall while preserving the original
+   `setup`, `requests`, `latency`, and `isolation` fields.
+4. Remove the drained cleanup-masking item from `HARDENING.md` and park the
+   smaller pool-close lifecycle edge surfaced during review.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md` | Plan contract for the cleanup-result hardening slice. |
+| `HARDENING.md` | Remove the drained cleanup masking item and park the pool-close lifecycle edge. |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | Preserve primary smoke results and report cleanup failures as metadata. |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | Regression tests for cleanup failure metadata on setup and search outcomes. |
+
+## Mechanism
+
+`_summary_payload(...)` gains a default not-attempted `cleanup` result object,
+so pool/preflight failures remain simple. When cleanup is attempted,
+`run_smoke(...)` catches `_cleanup(...)` exceptions, records their error type
+and message, and returns the already-built summary with cleanup metadata
+attached.
+
+Overall `ok` becomes false when cleanup fails, but the original setup/search
+phase and request evidence remain visible.
+
+## Intentional
+
+- This slice handles `_cleanup(...)` failures only; pool close failures are a
+  separate lifecycle edge and are not introduced by this change.
+- No search, seeding, routing, or cleanup SQL behavior changes.
+- Cleanup failure is treated as an overall smoke failure because leaked smoke
+  rows are operationally actionable even when retrieval itself passed.
+
+## Deferred
+
+- Parked hardening: pool close failures in
+  `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the
+  original setup/search result.
+
+## Verification
+
+- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
+  - 24 passed.
+- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
+  - Passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md
+  - Passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
+  - Passed: 121 matching tests enrolled.
+- Command: git diff --check
+  - Passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 2478 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md` | 92 |
+| `HARDENING.md` | 14 |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | 140 |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | 149 |
+| **Total** | **395** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -438,6 +438,29 @@ def _failure_summary(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _cleanup_result(*, attempted: bool, error: BaseException | None = None) -> dict[str, Any]:
+    return {
+        "ok": error is None,
+        "attempted": attempted,
+        "error": None
+        if error is None
+        else {
+            "type": type(error).__name__,
+            "message": str(error),
+        },
+    }
+
+
+def _with_cleanup_result(
+    summary: dict[str, Any],
+    cleanup: dict[str, Any],
+) -> dict[str, Any]:
+    updated = dict(summary)
+    updated["cleanup"] = cleanup
+    updated["ok"] = bool(summary["ok"]) and bool(cleanup["ok"])
+    return updated
+
+
 def _summary_payload(
     *,
     ok: bool,
@@ -456,7 +479,12 @@ def _summary_payload(
         max_single_request_ms=args.max_single_request_ms,
     )
     return {
-        "ok": ok and failure["count"] == 0 and latency_budget["ok"] and setup["ok"],
+        "ok": (
+            ok
+            and failure["count"] == 0
+            and latency_budget["ok"]
+            and setup["ok"]
+        ),
         "run_id": run_id,
         "requests": {
             "total": len(results),
@@ -470,6 +498,7 @@ def _summary_payload(
             "search_cases": len(cases),
         },
         "setup": setup,
+        "cleanup": _cleanup_result(attempted=False),
         "latency": latency,
         "latency_budget": latency_budget,
         "isolation": failure,
@@ -537,11 +566,13 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     repo = PostgresTicketFAQSearchRepository(pool)
     results: list[dict[str, Any]] = []
     cleanup_ready = False
+    summary: dict[str, Any] | None = None
+    cleanup = _cleanup_result(attempted=False)
     try:
         try:
             await _apply_migrations(pool)
         except Exception as exc:
-            return 1, _setup_failure_summary(
+            summary = _setup_failure_summary(
                 run_id=run_id,
                 args=args,
                 cases=cases,
@@ -549,63 +580,74 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 error=exc,
                 elapsed_seconds=time.perf_counter() - started,
             )
-        cleanup_ready = True
-        try:
-            _write_cleanup_manifest(args.cleanup_manifest_output, cases)
-        except Exception as exc:
-            return 1, _setup_failure_summary(
-                run_id=run_id,
-                args=args,
-                cases=cases,
-                phase="cleanup_manifest_output",
-                error=exc,
-                elapsed_seconds=time.perf_counter() - started,
-            )
-        try:
-            await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
-        except Exception as exc:
-            return 1, _setup_failure_summary(
-                run_id=run_id,
-                args=args,
-                cases=cases,
-                phase="seed",
-                error=exc,
-                elapsed_seconds=time.perf_counter() - started,
-            )
-        try:
-            _write_route_case_file(
-                args.route_case_file_output,
+        if summary is None:
+            cleanup_ready = True
+            try:
+                _write_cleanup_manifest(args.cleanup_manifest_output, cases)
+            except Exception as exc:
+                summary = _setup_failure_summary(
+                    run_id=run_id,
+                    args=args,
+                    cases=cases,
+                    phase="cleanup_manifest_output",
+                    error=exc,
+                    elapsed_seconds=time.perf_counter() - started,
+                )
+        if summary is None:
+            try:
+                await _seed(pool, repo, cases, documents_per_corpus=int(args.documents_per_corpus))
+            except Exception as exc:
+                summary = _setup_failure_summary(
+                    run_id=run_id,
+                    args=args,
+                    cases=cases,
+                    phase="seed",
+                    error=exc,
+                    elapsed_seconds=time.perf_counter() - started,
+                )
+        if summary is None:
+            try:
+                _write_route_case_file(
+                    args.route_case_file_output,
+                    cases,
+                    documents_per_corpus=int(args.documents_per_corpus),
+                )
+            except Exception as exc:
+                summary = _setup_failure_summary(
+                    run_id=run_id,
+                    args=args,
+                    cases=cases,
+                    phase="route_case_file_output",
+                    error=exc,
+                    elapsed_seconds=time.perf_counter() - started,
+                )
+        if summary is None:
+            results = await _run_concurrent_searches(
+                repo,
                 cases,
-                documents_per_corpus=int(args.documents_per_corpus),
+                iterations=int(args.iterations),
+                concurrency=int(args.concurrency),
             )
-        except Exception as exc:
-            return 1, _setup_failure_summary(
+            summary = _summary_payload(
+                ok=True,
                 run_id=run_id,
                 args=args,
                 cases=cases,
-                phase="route_case_file_output",
-                error=exc,
+                results=results,
+                setup={"ok": True, "phase": "complete", "error": None},
                 elapsed_seconds=time.perf_counter() - started,
             )
-        results = await _run_concurrent_searches(
-            repo,
-            cases,
-            iterations=int(args.iterations),
-            concurrency=int(args.concurrency),
-        )
     finally:
         if cleanup_ready and not bool(args.keep_data):
-            await _cleanup(pool, cases)
+            try:
+                await _cleanup(pool, cases)
+                cleanup = _cleanup_result(attempted=True)
+            except Exception as exc:
+                cleanup = _cleanup_result(attempted=True, error=exc)
         await pool.close()
-    summary = _summary_payload(
-        ok=True,
-        run_id=run_id,
-        args=args,
-        cases=cases,
-        results=results,
-        setup={"ok": True, "phase": "complete", "error": None},
-        elapsed_seconds=time.perf_counter() - started,
-    )
+    if summary is None:  # pragma: no cover - defensive guard for unexpected control flow.
+        raise RuntimeError("FAQ search smoke did not produce a summary")
+    summary = _with_cleanup_result(summary, cleanup)
     return (0 if summary["ok"] else 1), summary
 
 

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -709,6 +709,155 @@ def test_main_writes_result_for_route_case_file_output_failure(tmp_path, monkeyp
     }
 
 
+def test_main_reports_cleanup_failure_without_masking_seed_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def execute(self, *_args):
+            raise OSError("cleanup failed")
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _raise_seed(*_args, **_kwargs):
+        raise RuntimeError("seed failed")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _raise_seed)
+    result_path = tmp_path / "faq-search-seed-cleanup.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "seed",
+        "error": {
+            "type": "RuntimeError",
+            "message": "seed failed",
+        },
+    }
+    assert payload["cleanup"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "cleanup failed",
+        },
+    }
+
+
+def test_main_reports_cleanup_failure_without_masking_search_result(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def execute(self, *_args):
+            raise OSError("cleanup failed")
+
+        async def close(self):
+            self.closed = True
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _seed_noop(*_args, **_kwargs):
+        return None
+
+    async def _search_noop(*_args, **_kwargs):
+        return [
+            {
+                "account_id": "acct-1",
+                "corpus_id": "corpus-1",
+                "query": "export attribution report",
+                "expected_hit": True,
+                "result_count": 1,
+                "elapsed_ms": 12.0,
+                "failures": [],
+            }
+        ]
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _seed_noop)
+    monkeypatch.setattr(smoke, "_run_concurrent_searches", _search_noop)
+    result_path = tmp_path / "faq-search-cleanup.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.closed is True
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 1
+    assert payload["setup"] == {"ok": True, "phase": "complete", "error": None}
+    assert payload["latency"]["count"] == 1
+    assert payload["isolation"]["count"] == 0
+    assert payload["cleanup"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "cleanup failed",
+        },
+    }
+
+
 def test_failure_summary_limits_output() -> None:
     results = [
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md
Slice phase: Production hardening

This drains the parked FAQ search DB smoke cleanup gap: cleanup failures now appear as `cleanup.error` metadata instead of replacing the original setup/search result, while still failing the smoke overall when cleanup does not complete.

## Intentional
- This slice handles `_cleanup(...)` failures only; pool close failures are a separate lifecycle edge and are not introduced by this change.
- No search, seeding, routing, or cleanup SQL behavior changes.
- Cleanup failure is treated as an overall smoke failure because leaked smoke rows are operationally actionable even when retrieval itself passed.

## Deferred
- Pool close failures in `scripts/smoke_content_ops_faq_search_concurrency.py` can still mask the original setup/search result.

## Parked hardening
- `FAQ search DB smoke pool close failures can mask result` was added to `HARDENING.md`; wrapping close as lifecycle metadata is a follow-up edge, not required for the `_cleanup(...)` masking fix.

## Verification
- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
  - 24 passed.
- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
  - Passed.
- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-Cleanup-Result.md
  - Passed.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
  - Passed: 121 matching tests enrolled.
- Command: git diff --check
  - Passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh
  - Passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
  - Passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
  - Passed.
- Command: bash scripts/check_ascii_python.sh
  - Passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 2478 passed, 7 skipped, 1 warning.

## Diff size
4 files, +339 / -56
