### PR TITLE
Add Content Ops exact cache policy

### DIFF
--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -13,6 +13,10 @@ from types import SimpleNamespace
 from typing import Any
 
 from .campaign_ports import LLMMessage, LLMResponse
+from .content_ops_cache_policy import (
+    ContentOpsCacheDecision,
+    ContentOpsExactCachePolicy,
+)
 
 
 class LLMUnavailableError(RuntimeError):
@@ -88,6 +92,9 @@ class PipelineLLMClientConfig:
     try_openrouter: bool = True
     auto_activate_ollama: bool = True
     openrouter_model: str | None = None
+    exact_cache_enabled: bool = False
+    customer_data_exact_cache_enabled: bool = False
+    exact_cache_namespace_prefix: str = "content_ops"
 
     @classmethod
     def from_mapping(cls, values: Mapping[str, Any]) -> "PipelineLLMClientConfig":
@@ -97,6 +104,15 @@ class PipelineLLMClientConfig:
             try_openrouter=_to_bool(values.get("try_openrouter"), True),
             auto_activate_ollama=_to_bool(values.get("auto_activate_ollama"), True),
             openrouter_model=_optional_text(values.get("openrouter_model")),
+            exact_cache_enabled=_to_bool(values.get("exact_cache_enabled"), False),
+            customer_data_exact_cache_enabled=_to_bool(
+                values.get("customer_data_exact_cache_enabled"),
+                False,
+            ),
+            exact_cache_namespace_prefix=(
+                _optional_text(values.get("exact_cache_namespace_prefix"))
+                or "content_ops"
+            ),
         )
 
     @classmethod
@@ -111,6 +127,20 @@ class PipelineLLMClientConfig:
             ),
             openrouter_model=_optional_text(
                 getattr(settings_obj, "openrouter_model", None),
+            ),
+            exact_cache_enabled=_to_bool(
+                getattr(settings_obj, "exact_cache_enabled", None),
+                False,
+            ),
+            customer_data_exact_cache_enabled=_to_bool(
+                getattr(settings_obj, "customer_data_exact_cache_enabled", None),
+                False,
+            ),
+            exact_cache_namespace_prefix=(
+                _optional_text(
+                    getattr(settings_obj, "exact_cache_namespace_prefix", None),
+                )
+                or "content_ops"
             ),
         )
 
@@ -131,6 +161,15 @@ class PipelineLLMClientConfig:
                 True,
             ),
             openrouter_model=_optional_text(env.get(f"{prefix}OPENROUTER_MODEL")),
+            exact_cache_enabled=_to_bool(env.get(f"{prefix}EXACT_CACHE_ENABLED"), False),
+            customer_data_exact_cache_enabled=_to_bool(
+                env.get(f"{prefix}CUSTOMER_DATA_EXACT_CACHE_ENABLED"),
+                False,
+            ),
+            exact_cache_namespace_prefix=(
+                _optional_text(env.get(f"{prefix}EXACT_CACHE_NAMESPACE_PREFIX"))
+                or "content_ops"
+            ),
         )
 
 
@@ -145,6 +184,7 @@ class PipelineLLMClient:
     openrouter_model: str | None = None
     resolver: LLMResolver = _default_resolver
     tracer: LLMTraceCallable | None = _default_trace_llm_call
+    cache_policy: ContentOpsExactCachePolicy = ContentOpsExactCachePolicy()
 
     async def complete(
         self,
@@ -164,6 +204,10 @@ class PipelineLLMClient:
         if llm is None:
             raise LLMUnavailableError("No LLM route configured for campaign generation")
 
+        cache_decision = self.cache_policy.decide(
+            _cache_policy_metadata(metadata),
+            messages=messages,
+        )
         started = time.monotonic()
         try:
             call_args = {
@@ -185,6 +229,7 @@ class PipelineLLMClient:
                 response=None,
                 duration_ms=_duration_ms(started),
                 metadata=metadata,
+                cache_decision=cache_decision,
                 status="failed",
                 error_message=str(exc)[:500],
                 error_type=type(exc).__name__,
@@ -195,6 +240,7 @@ class PipelineLLMClient:
             response=response,
             duration_ms=_duration_ms(started),
             metadata=metadata,
+            cache_decision=cache_decision,
         )
         return response
 
@@ -205,6 +251,7 @@ class PipelineLLMClient:
         response: LLMResponse | None,
         duration_ms: float,
         metadata: Mapping[str, Any] | None,
+        cache_decision: ContentOpsCacheDecision | None,
         status: str = "completed",
         error_message: str | None = None,
         error_type: str | None = None,
@@ -226,8 +273,17 @@ class PipelineLLMClient:
         call_metadata = dict(metadata or {})
         call_metadata.pop("account_id", None)
         call_metadata.pop("user_id", None)
+        for key in (
+            "cache_mode",
+            "cache_reason",
+            "cache_namespace",
+            "cache_account_id",
+        ):
+            call_metadata.pop(key, None)
         trace_metadata.update(scoped_metadata)
         trace_metadata.update(call_metadata)
+        if cache_decision is not None:
+            trace_metadata.update(cache_decision.trace_metadata())
         try:
             self.tracer(
                 "content_ops.llm.complete",
@@ -301,6 +357,11 @@ def create_pipeline_llm_client(
         auto_activate_ollama=resolved.auto_activate_ollama,
         openrouter_model=resolved.openrouter_model,
         resolver=resolver,
+        cache_policy=ContentOpsExactCachePolicy(
+            exact_cache_enabled=resolved.exact_cache_enabled,
+            customer_data_exact_cache_enabled=resolved.customer_data_exact_cache_enabled,
+            namespace_prefix=resolved.exact_cache_namespace_prefix,
+        ),
     )
 
 
@@ -328,6 +389,16 @@ def _to_chat_messages(messages: Sequence[LLMMessage]) -> list[Any]:
         )
         for message in messages
     ]
+
+
+def _cache_policy_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    scoped_metadata = current_content_ops_llm_trace_context()
+    call_metadata = dict(metadata or {})
+    call_metadata.pop("account_id", None)
+    call_metadata.pop("user_id", None)
+    merged = dict(scoped_metadata)
+    merged.update(call_metadata)
+    return merged
 
 
 def _llm_call_is_async(llm: Any) -> bool:

--- a/extracted_content_pipeline/content_ops_cache_policy.py
+++ b/extracted_content_pipeline/content_ops_cache_policy.py
@@ -1,0 +1,160 @@
+"""Content Ops LLM cache policy decisions.
+
+This module decides whether a Content Ops LLM call is eligible for a future
+exact-cache lookup/store. It does not perform cache I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+ContentOpsCacheMode = Literal["exact", "no_store"]
+
+DEFAULT_CACHEABLE_ASSET_TYPES = (
+    "blog_post",
+    "landing_page",
+    "sales_brief",
+    "email_campaign",
+    "report",
+)
+CUSTOMER_DATA_SOURCE_MARKERS = (
+    "support_ticket",
+    "support_tickets",
+    "customer_data",
+    "customer_upload",
+)
+NO_STORE_POLICY_VALUES = {"off", "false", "no", "none", "no_store", "no-store"}
+EXACT_POLICY_VALUES = {"exact", "exact_cache", "exact-cache"}
+
+
+@dataclass(frozen=True)
+class ContentOpsCacheDecision:
+    """Decision metadata for one Content Ops LLM call."""
+
+    mode: ContentOpsCacheMode
+    reason: str
+    namespace: str | None = None
+    account_id: str | None = None
+
+    @property
+    def cacheable(self) -> bool:
+        return self.mode == "exact"
+
+    def trace_metadata(self) -> dict[str, str]:
+        metadata = {
+            "cache_mode": self.mode,
+            "cache_reason": self.reason,
+        }
+        if self.namespace:
+            metadata["cache_namespace"] = self.namespace
+        if self.account_id:
+            metadata["cache_account_id"] = self.account_id
+        return metadata
+
+
+@dataclass(frozen=True)
+class ContentOpsExactCachePolicy:
+    """Content Ops exact-cache eligibility policy.
+
+    The policy is conservative by design. Exact cache starts disabled, requires
+    tenant account scope, and refuses customer-upload/support-ticket markers.
+    """
+
+    exact_cache_enabled: bool = False
+    customer_data_exact_cache_enabled: bool = False
+    namespace_prefix: str = "content_ops"
+    cacheable_asset_types: tuple[str, ...] = DEFAULT_CACHEABLE_ASSET_TYPES
+
+    @classmethod
+    def from_settings(cls, settings_obj: Any) -> "ContentOpsExactCachePolicy":
+        return cls(
+            exact_cache_enabled=bool(
+                getattr(settings_obj, "exact_cache_enabled", False),
+            ),
+            customer_data_exact_cache_enabled=bool(
+                getattr(settings_obj, "customer_data_exact_cache_enabled", False),
+            ),
+            namespace_prefix=_clean_text(
+                getattr(settings_obj, "exact_cache_namespace_prefix", None),
+            )
+            or "content_ops",
+        )
+
+    def decide(
+        self,
+        metadata: Mapping[str, Any] | None,
+        *,
+        messages: Sequence[Any] | None = None,
+    ) -> ContentOpsCacheDecision:
+        del messages  # Future adapter may use a redacted/digest-only envelope.
+        values = dict(metadata or {})
+        requested_policy = _policy_value(
+            values.get("content_ops_cache_policy") or values.get("cache_policy")
+        )
+        asset_type = _clean_text(values.get("asset_type"))
+        account_id = _clean_text(values.get("account_id"))
+
+        if requested_policy in NO_STORE_POLICY_VALUES:
+            return ContentOpsCacheDecision("no_store", "policy_no_store")
+        if not self.exact_cache_enabled:
+            return ContentOpsCacheDecision("no_store", "exact_cache_disabled")
+        if not requested_policy:
+            return ContentOpsCacheDecision("no_store", "policy_no_store")
+        if requested_policy and requested_policy not in EXACT_POLICY_VALUES:
+            return ContentOpsCacheDecision("no_store", "unsupported_cache_policy")
+        if not account_id:
+            return ContentOpsCacheDecision("no_store", "missing_account_scope")
+        if not asset_type or asset_type not in self.cacheable_asset_types:
+            return ContentOpsCacheDecision("no_store", "unsupported_asset_type")
+        if (
+            not self.customer_data_exact_cache_enabled
+            and _has_customer_data_marker(values)
+        ):
+            return ContentOpsCacheDecision("no_store", "customer_data_no_store")
+
+        namespace = f"{self.namespace_prefix}.{asset_type}"
+        return ContentOpsCacheDecision(
+            "exact",
+            "eligible",
+            namespace=namespace,
+            account_id=account_id,
+        )
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _policy_value(value: Any) -> str:
+    return _clean_text(value).lower().replace(" ", "_")
+
+
+def _has_customer_data_marker(metadata: Mapping[str, Any]) -> bool:
+    candidates = (
+        metadata.get("source_type"),
+        metadata.get("source_types"),
+        metadata.get("source_material_type"),
+        metadata.get("source_material_types"),
+        metadata.get("input_provider"),
+        metadata.get("provider"),
+    )
+    markers = {_clean_text(marker).lower() for marker in CUSTOMER_DATA_SOURCE_MARKERS}
+    return any(_value_contains_marker(value, markers) for value in candidates)
+
+
+def _value_contains_marker(value: Any, markers: set[str]) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized in markers or any(
+            token.strip() in markers for token in normalized.split(",")
+        ) or any(marker in normalized for marker in markers)
+    if isinstance(value, Mapping):
+        return any(_value_contains_marker(item, markers) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return any(_value_contains_marker(item, markers) for item in value)
+    return False

--- a/extracted_content_pipeline/content_ops_cache_policy.py
+++ b/extracted_content_pipeline/content_ops_cache_policy.py
@@ -71,11 +71,13 @@ class ContentOpsExactCachePolicy:
     @classmethod
     def from_settings(cls, settings_obj: Any) -> "ContentOpsExactCachePolicy":
         return cls(
-            exact_cache_enabled=bool(
+            exact_cache_enabled=_to_bool(
                 getattr(settings_obj, "exact_cache_enabled", False),
+                False,
             ),
-            customer_data_exact_cache_enabled=bool(
+            customer_data_exact_cache_enabled=_to_bool(
                 getattr(settings_obj, "customer_data_exact_cache_enabled", False),
+                False,
             ),
             namespace_prefix=_clean_text(
                 getattr(settings_obj, "exact_cache_namespace_prefix", None),
@@ -126,6 +128,19 @@ class ContentOpsExactCachePolicy:
 
 def _clean_text(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _to_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = _clean_text(value).lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return default
 
 
 def _policy_value(value: Any) -> str:

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -24,8 +24,10 @@ from .support_ticket_context_contract import (
     SUPPORT_TICKET_DEFAULT_TOPIC,
     SUPPORT_TICKET_LAST_90_DAYS_REVIEW_PERIOD,
     SUPPORT_TICKET_SOURCE,
+    SUPPORT_TICKET_SOURCE_MARKER,
     UPLOADED_SUPPORT_TICKETS_SOURCE_PERIOD,
     UPLOADED_TICKETS_REVIEW_PERIOD,
+    is_support_ticket_context,
     is_support_ticket_topic_type,
 )
 from .ticket_faq_markdown import normalize_vocabulary_gap_rules
@@ -315,7 +317,7 @@ async def _execute_step(
             error,
         )
     trace_context_token = set_content_ops_llm_trace_context(
-        _scope_trace_metadata(scope)
+        _request_trace_metadata(scope=scope, request=request)
     )
     try:
         result = await _run_step(
@@ -364,6 +366,20 @@ def _scope_trace_metadata(scope: TenantScope) -> dict[str, str]:
         metadata["account_id"] = account_id
     if user_id:
         metadata["user_id"] = user_id
+    return metadata
+
+
+def _request_trace_metadata(
+    *,
+    scope: TenantScope,
+    request: ContentOpsRequest,
+) -> dict[str, str]:
+    metadata = _scope_trace_metadata(scope)
+    if _inputs_use_support_ticket_source(request.inputs):
+        metadata.update({
+            "source_type": SUPPORT_TICKET_SOURCE_MARKER,
+            "input_provider": SUPPORT_TICKET_SOURCE,
+        })
     return metadata
 
 
@@ -794,6 +810,28 @@ def _support_ticket_blog_data_context_from_inputs(
         for key, value in context.items()
         if value not in (None, "", [], {})
     }
+
+
+def _inputs_use_support_ticket_source(inputs: Mapping[str, Any]) -> bool:
+    filters = _filters_from_inputs(inputs) or {}
+    if is_support_ticket_topic_type(filters.get("topic_type")):
+        return True
+    if is_support_ticket_context(inputs):
+        return True
+    return _value_contains_support_ticket_source(inputs.get("source_material"))
+
+
+def _value_contains_support_ticket_source(value: Any) -> bool:
+    if value is None or isinstance(value, (str, bytes, bytearray)):
+        return False
+    if isinstance(value, Mapping):
+        source_type = str(value.get("source_type") or value.get("type") or "").lower()
+        if "ticket" in source_type or SUPPORT_TICKET_SOURCE_MARKER in source_type:
+            return True
+        return any(_value_contains_support_ticket_source(item) for item in value.values())
+    if isinstance(value, Sequence):
+        return any(_value_contains_support_ticket_source(item) for item in value)
+    return False
 
 
 def _mapping_list_input(value: Any) -> list[dict[str, Any]]:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -182,6 +182,9 @@
       "target": "extracted_content_pipeline/campaign_llm_client.py"
     },
     {
+      "target": "extracted_content_pipeline/content_ops_cache_policy.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_ports.py"
     },
     {

--- a/extracted_content_pipeline/settings.py
+++ b/extracted_content_pipeline/settings.py
@@ -142,6 +142,18 @@ def build_settings() -> SimpleNamespace:
             True,
         ),
         openrouter_model=os.getenv("EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL") or None,
+        exact_cache_enabled=_to_bool(
+            os.getenv("EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED"),
+            False,
+        ),
+        customer_data_exact_cache_enabled=_to_bool(
+            os.getenv("EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED"),
+            False,
+        ),
+        exact_cache_namespace_prefix=(
+            os.getenv("EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_NAMESPACE_PREFIX")
+            or "content_ops"
+        ),
     )
 
     b2b_campaign = SimpleNamespace(

--- a/plans/PR-Content-Ops-Exact-Cache-Policy.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Policy.md
@@ -1,0 +1,111 @@
+# PR: Content Ops Exact Cache Policy
+
+## Why this slice exists
+
+Content Ops now surfaces usage and account-period budget controls, but exact
+cache wiring is still only a deferred idea. The repo already has exact-cache
+infrastructure, but Content Ops generation often uses customer source material
+such as support tickets. Wiring cache lookup/store directly into generation
+would risk storing raw customer payloads before we have an explicit policy.
+
+This slice adds the source-side policy seam first: decide whether a Content Ops
+LLM call is cache-eligible, require account scope for exact cache, default to
+no-store, and make support-ticket/customer-data payloads no-store unless a later
+slice introduces a safer redacted/digest-only cache shape.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a Content Ops exact-cache policy helper that returns an explicit
+   cache/no-store decision with reason, namespace, and account scope.
+2. Add settings/config fields for the policy, defaulting exact cache off and
+   customer-data exact cache off.
+3. Wire `PipelineLLMClient` to evaluate the policy and include the decision in
+   trace metadata.
+4. Keep cache behavior read-only in this slice: no cache lookup, no cache store,
+   and no changes to generated output.
+5. Add focused tests for policy branches and LLM trace integration.
+6. Enroll the new policy tests in the extracted pipeline CI runner.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Exact-Cache-Policy.md` | Plan doc for the cache-policy seam. |
+| `extracted_content_pipeline/content_ops_cache_policy.py` | Add Content Ops exact-cache policy decisions. |
+| `extracted_content_pipeline/campaign_llm_client.py` | Evaluate policy and add cache decision metadata to LLM traces. |
+| `extracted_content_pipeline/settings.py` | Add extracted Content Ops cache settings defaults. |
+| `extracted_content_pipeline/manifest.json` | Register the new owned policy module. |
+| `tests/test_extracted_content_ops_cache_policy.py` | Cover policy branch decisions. |
+| `tests/test_extracted_campaign_llm_client.py` | Cover trace metadata carrying the cache decision. |
+| `scripts/run_extracted_pipeline_checks.sh` | Enroll the new extracted policy test. |
+
+## Mechanism
+
+`content_ops_cache_policy.py` introduces a small immutable
+`ContentOpsExactCachePolicy` plus `ContentOpsCacheDecision`. The policy accepts
+the LLM call metadata already threaded through `PipelineLLMClient.complete` and
+returns a decision:
+
+- `no_store` by default when exact cache is disabled.
+- `no_store` when account scope is missing, so Content Ops does not fall back
+  to the exact-cache sentinel account.
+- `no_store` for support-ticket/customer-data source markers, even when exact
+  cache is enabled.
+- `exact` only when the call explicitly requests exact cache, exact cache is
+  enabled, the asset type is supported, account scope is present, and no
+  customer-data marker blocks caching.
+
+`PipelineLLMClient` builds the policy from config/settings and evaluates it for
+each call. The result is added to trace metadata as decision fields such as
+`cache_mode`, `cache_reason`, and `cache_namespace`. This gives operators and
+follow-up slices a concrete signal without changing generation behavior.
+
+## Intentional
+
+- This does not call exact-cache lookup or store. Policy and observability land
+  before behavior.
+- This does not cache support-ticket prompts. Current prompts can include raw
+  customer data, so support-ticket/customer-data source markers remain no-store.
+- This does not add UI controls. The backend policy contract should exist
+  before product controls expose it.
+- This does not reuse the B2B cache-strategy registry. Content Ops needs a
+  separate policy because customer upload/source-material privacy is a first
+  order concern.
+
+## Deferred
+
+- Future PR: exact-cache adapter that can lookup/store only when this policy
+  returns `exact`.
+- Future PR: redacted/digest-only cache envelopes for support-ticket inputs if
+  we decide customer-source generation should be cacheable.
+- Future PR: UI controls once the backend cache behavior is live and safe.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 27 passed, 1 warning.
+- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/settings.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q — 9 passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~110 |
+| Policy module | ~150 |
+| LLM client/settings/manifest wiring | ~90 |
+| Tests and CI enrollment | ~205 |
+| **Total** | **~555** |
+
+This is above the 400 LOC soft cap because the policy module, integration
+wiring, and tests need to land together for the source-side cache contract to be
+meaningful and enforceable.

--- a/plans/PR-Content-Ops-Exact-Cache-Policy.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Policy.md
@@ -87,7 +87,8 @@ follow-up slices a concrete signal without changing generation behavior.
 
 ## Verification
 
-- python -m pytest tests/test_atlas_content_ops_infrastructure.py::test_build_content_ops_llm_client_uses_pipeline_tracing_client tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 28 passed, 1 warning.
+- python -m pytest tests/test_atlas_content_ops_infrastructure.py::test_build_content_ops_llm_client_uses_pipeline_tracing_client tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 29 passed, 1 warning.
+- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py tests/test_extracted_content_ops_cache_policy.py — passed.
 - python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 27 passed, 1 warning.
 - python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/settings.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
@@ -103,10 +104,10 @@ follow-up slices a concrete signal without changing generation behavior.
 | Area | Estimated LOC |
 |---|---:|
 | Plan doc | ~110 |
-| Policy module | ~150 |
+| Policy module | ~170 |
 | LLM client/settings/manifest wiring | ~90 |
-| Tests and CI enrollment | ~210 |
-| **Total** | **~560** |
+| Tests and CI enrollment | ~230 |
+| **Total** | **~595** |
 
 This is above the 400 LOC soft cap because the policy module, integration
 wiring, and tests need to land together for the source-side cache contract to be

--- a/plans/PR-Content-Ops-Exact-Cache-Policy.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Policy.md
@@ -26,8 +26,11 @@ Slice phase: Production hardening
    trace metadata.
 4. Keep cache behavior read-only in this slice: no cache lookup, no cache store,
    and no changes to generated output.
-5. Add focused tests for policy branches and LLM trace integration.
-6. Enroll the new policy tests in the extracted pipeline CI runner.
+5. Mark support-ticket-sourced execution requests in the shared LLM trace
+   context so the policy sees the real customer-data source marker.
+6. Add focused tests for policy branches, executor source-marker propagation,
+   and LLM trace integration.
+7. Enroll the new policy tests in the extracted pipeline CI runner.
 
 ### Files touched
 
@@ -36,11 +39,13 @@ Slice phase: Production hardening
 | `plans/PR-Content-Ops-Exact-Cache-Policy.md` | Plan doc for the cache-policy seam. |
 | `extracted_content_pipeline/content_ops_cache_policy.py` | Add Content Ops exact-cache policy decisions. |
 | `extracted_content_pipeline/campaign_llm_client.py` | Evaluate policy and add cache decision metadata to LLM traces. |
+| `extracted_content_pipeline/content_ops_execution.py` | Carry support-ticket source markers into the LLM trace context. |
 | `extracted_content_pipeline/settings.py` | Add extracted Content Ops cache settings defaults. |
 | `extracted_content_pipeline/manifest.json` | Register the new owned policy module. |
 | `tests/test_atlas_content_ops_infrastructure.py` | Update host infrastructure trace assertion for cache decision metadata. |
 | `tests/test_extracted_content_ops_cache_policy.py` | Cover policy branch decisions. |
 | `tests/test_extracted_campaign_llm_client.py` | Cover trace metadata carrying the cache decision. |
+| `tests/test_extracted_content_ops_execution.py` | Pin support-ticket execution marker propagation for cache policy decisions. |
 | `scripts/run_extracted_pipeline_checks.sh` | Enroll the new extracted policy test. |
 
 ## Mechanism
@@ -63,6 +68,11 @@ returns a decision:
 each call. The result is added to trace metadata as decision fields such as
 `cache_mode`, `cache_reason`, and `cache_namespace`. This gives operators and
 follow-up slices a concrete signal without changing generation behavior.
+
+`content_ops_execution.py` adds support-ticket source markers to the shared
+LLM trace context when the request inputs come from the support-ticket path.
+That makes the policy block the same metadata shape that real blog and landing
+generation calls see, instead of relying on synthetic per-call markers.
 
 ## Intentional
 
@@ -87,6 +97,8 @@ follow-up slices a concrete signal without changing generation behavior.
 
 ## Verification
 
+- python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_marks_support_ticket_trace_context_for_cache_policy tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 29 passed, 1 warning.
+- python -m compileall -q extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_execution.py — passed.
 - python -m pytest tests/test_atlas_content_ops_infrastructure.py::test_build_content_ops_llm_client_uses_pipeline_tracing_client tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 29 passed, 1 warning.
 - python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py tests/test_extracted_content_ops_cache_policy.py — passed.
 - python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 27 passed, 1 warning.
@@ -105,9 +117,10 @@ follow-up slices a concrete signal without changing generation behavior.
 |---|---:|
 | Plan doc | ~110 |
 | Policy module | ~170 |
+| Executor trace-source wiring | ~40 |
 | LLM client/settings/manifest wiring | ~90 |
-| Tests and CI enrollment | ~230 |
-| **Total** | **~595** |
+| Tests and CI enrollment | ~285 |
+| **Total** | **~695** |
 
 This is above the 400 LOC soft cap because the policy module, integration
 wiring, and tests need to land together for the source-side cache contract to be

--- a/plans/PR-Content-Ops-Exact-Cache-Policy.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Policy.md
@@ -38,6 +38,7 @@ Slice phase: Production hardening
 | `extracted_content_pipeline/campaign_llm_client.py` | Evaluate policy and add cache decision metadata to LLM traces. |
 | `extracted_content_pipeline/settings.py` | Add extracted Content Ops cache settings defaults. |
 | `extracted_content_pipeline/manifest.json` | Register the new owned policy module. |
+| `tests/test_atlas_content_ops_infrastructure.py` | Update host infrastructure trace assertion for cache decision metadata. |
 | `tests/test_extracted_content_ops_cache_policy.py` | Cover policy branch decisions. |
 | `tests/test_extracted_campaign_llm_client.py` | Cover trace metadata carrying the cache decision. |
 | `scripts/run_extracted_pipeline_checks.sh` | Enroll the new extracted policy test. |
@@ -86,6 +87,7 @@ follow-up slices a concrete signal without changing generation behavior.
 
 ## Verification
 
+- python -m pytest tests/test_atlas_content_ops_infrastructure.py::test_build_content_ops_llm_client_uses_pipeline_tracing_client tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 28 passed, 1 warning.
 - python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 27 passed, 1 warning.
 - python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/settings.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
@@ -103,8 +105,8 @@ follow-up slices a concrete signal without changing generation behavior.
 | Plan doc | ~110 |
 | Policy module | ~150 |
 | LLM client/settings/manifest wiring | ~90 |
-| Tests and CI enrollment | ~205 |
-| **Total** | **~555** |
+| Tests and CI enrollment | ~210 |
+| **Total** | **~560** |
 
 This is above the 400 LOC soft cap because the policy module, integration
 wiring, and tests need to land together for the source-side cache contract to be

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -63,6 +63,7 @@ pytest \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_reasoning_policy.py \
+  tests/test_extracted_content_ops_cache_policy.py \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_support_ticket_context_contract.py \
   tests/test_extracted_support_ticket_input_package.py \

--- a/tests/test_atlas_content_ops_infrastructure.py
+++ b/tests/test_atlas_content_ops_infrastructure.py
@@ -347,6 +347,8 @@ async def test_build_content_ops_llm_client_uses_pipeline_tracing_client(
         "llm_adapter": "pipeline",
         "asset_type": "blog_post",
         "request_id": "req-hosted",
+        "cache_mode": "no_store",
+        "cache_reason": "exact_cache_disabled",
     }
 
 

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -14,6 +14,9 @@ from extracted_content_pipeline.campaign_llm_client import (
     set_content_ops_llm_trace_context,
 )
 from extracted_content_pipeline.campaign_ports import LLMMessage
+from extracted_content_pipeline.content_ops_cache_policy import (
+    ContentOpsExactCachePolicy,
+)
 from extracted_content_pipeline.settings import build_settings
 
 
@@ -269,6 +272,8 @@ async def test_pipeline_llm_client_traces_successful_provider_usage_without_io_c
         "llm_adapter": "pipeline",
         "asset_type": "blog_post",
         "request_id": "req_123",
+        "cache_mode": "no_store",
+        "cache_reason": "exact_cache_disabled",
     }
     assert "input_data" not in trace
     assert "output_data" not in trace
@@ -318,13 +323,56 @@ async def test_pipeline_llm_client_merges_scoped_trace_metadata_and_resets():
         "user_id": "user-1",
         "asset_type": "blog_post",
         "request_id": "req_123",
+        "cache_mode": "no_store",
+        "cache_reason": "exact_cache_disabled",
     }
     assert trace_calls[1][1]["metadata"] == {
         "product": "content_ops",
         "workload": "draft",
         "llm_adapter": "pipeline",
         "asset_type": "landing_page",
+        "cache_mode": "no_store",
+        "cache_reason": "exact_cache_disabled",
     }
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_traces_exact_cache_policy_decision_from_scope():
+    trace_calls = []
+    client = PipelineLLMClient(
+        workload="draft",
+        resolver=lambda **_: _TraceLLM(),
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+        cache_policy=ContentOpsExactCachePolicy(exact_cache_enabled=True),
+    )
+
+    token = set_content_ops_llm_trace_context({
+        "account_id": "acct-cache",
+        "user_id": "user-cache",
+    })
+    try:
+        await client.complete(
+            [LLMMessage(role="user", content="non-customer brief")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={
+                "asset_type": "landing_page",
+                "cache_policy": "exact",
+                "cache_mode": "spoofed",
+                "cache_reason": "spoofed",
+                "cache_namespace": "spoofed",
+                "cache_account_id": "spoofed",
+            },
+        )
+    finally:
+        reset_content_ops_llm_trace_context(token)
+
+    trace_metadata = trace_calls[0][1]["metadata"]
+    assert trace_metadata["cache_mode"] == "exact"
+    assert trace_metadata["cache_reason"] == "eligible"
+    assert trace_metadata["cache_namespace"] == "content_ops.landing_page"
+    assert trace_metadata["cache_account_id"] == "acct-cache"
+    assert trace_metadata["account_id"] == "acct-cache"
 
 
 @pytest.mark.asyncio
@@ -360,6 +408,8 @@ async def test_pipeline_llm_client_traces_failed_provider_calls_without_io_captu
     assert trace["metadata"]["product"] == "content_ops"
     assert trace["metadata"]["account_id"] == "acct-failed"
     assert trace["metadata"]["asset_type"] == "landing_page"
+    assert trace["metadata"]["cache_mode"] == "no_store"
+    assert trace["metadata"]["cache_reason"] == "exact_cache_disabled"
     assert "input_data" not in trace
     assert "output_data" not in trace
 
@@ -390,6 +440,9 @@ def test_llm_client_config_from_mapping_parses_provider_routing_fields():
         "try_openrouter": "0",
         "auto_activate_ollama": "yes",
         "openrouter_model": "anthropic/claude-haiku-4-5",
+        "exact_cache_enabled": "true",
+        "customer_data_exact_cache_enabled": "false",
+        "exact_cache_namespace_prefix": "tenant_content_ops",
     })
 
     assert config == PipelineLLMClientConfig(
@@ -398,6 +451,9 @@ def test_llm_client_config_from_mapping_parses_provider_routing_fields():
         try_openrouter=False,
         auto_activate_ollama=True,
         openrouter_model="anthropic/claude-haiku-4-5",
+        exact_cache_enabled=True,
+        customer_data_exact_cache_enabled=False,
+        exact_cache_namespace_prefix="tenant_content_ops",
     )
 
 
@@ -429,6 +485,9 @@ def test_llm_client_config_from_settings_namespace():
         try_openrouter = True
         auto_activate_ollama = False
         openrouter_model = "openai/gpt-4o-mini"
+        exact_cache_enabled = True
+        customer_data_exact_cache_enabled = False
+        exact_cache_namespace_prefix = "tenant_content_ops"
 
     assert PipelineLLMClientConfig.from_settings(_Settings()) == PipelineLLMClientConfig(
         workload="campaign",
@@ -436,6 +495,9 @@ def test_llm_client_config_from_settings_namespace():
         try_openrouter=True,
         auto_activate_ollama=False,
         openrouter_model="openai/gpt-4o-mini",
+        exact_cache_enabled=True,
+        customer_data_exact_cache_enabled=False,
+        exact_cache_namespace_prefix="tenant_content_ops",
     )
 
 
@@ -448,6 +510,15 @@ def test_build_settings_exposes_campaign_llm_provider_config(monkeypatch):
         "EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL",
         "anthropic/claude-haiku-4-5",
     )
+    monkeypatch.setenv("EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED", "true")
+    monkeypatch.setenv(
+        "EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED",
+        "false",
+    )
+    monkeypatch.setenv(
+        "EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_NAMESPACE_PREFIX",
+        "tenant_content_ops",
+    )
 
     config = PipelineLLMClientConfig.from_settings(build_settings().campaign_llm)
 
@@ -457,6 +528,9 @@ def test_build_settings_exposes_campaign_llm_provider_config(monkeypatch):
         try_openrouter=True,
         auto_activate_ollama=False,
         openrouter_model="anthropic/claude-haiku-4-5",
+        exact_cache_enabled=True,
+        customer_data_exact_cache_enabled=False,
+        exact_cache_namespace_prefix="tenant_content_ops",
     )
 
 

--- a/tests/test_extracted_content_ops_cache_policy.py
+++ b/tests/test_extracted_content_ops_cache_policy.py
@@ -120,3 +120,21 @@ def test_policy_can_be_configured_from_settings_namespace():
 
     assert decision.mode == "exact"
     assert decision.namespace == "tenant_content_ops.blog_post"
+
+
+def test_policy_from_settings_parses_false_string_flags_as_disabled():
+    policy = ContentOpsExactCachePolicy.from_settings(SimpleNamespace(
+        exact_cache_enabled="false",
+        customer_data_exact_cache_enabled="false",
+        exact_cache_namespace_prefix="tenant_content_ops",
+    ))
+
+    decision = policy.decide({
+        "account_id": "acct-1",
+        "asset_type": "landing_page",
+        "input_provider": "atlas_support_ticket_request",
+        "cache_policy": "exact",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "exact_cache_disabled"

--- a/tests/test_extracted_content_ops_cache_policy.py
+++ b/tests/test_extracted_content_ops_cache_policy.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+from extracted_content_pipeline.content_ops_cache_policy import (
+    ContentOpsExactCachePolicy,
+)
+
+
+def test_policy_defaults_to_no_store_when_exact_cache_disabled():
+    decision = ContentOpsExactCachePolicy().decide({
+        "account_id": "acct-1",
+        "asset_type": "blog_post",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "exact_cache_disabled"
+    assert decision.trace_metadata() == {
+        "cache_mode": "no_store",
+        "cache_reason": "exact_cache_disabled",
+    }
+
+
+def test_policy_honors_explicit_no_store_request():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "blog_post",
+        "cache_policy": "no-store",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "policy_no_store"
+
+
+def test_policy_requires_explicit_exact_request_when_enabled():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "blog_post",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "policy_no_store"
+
+
+def test_policy_rejects_unknown_cache_policy_value():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "blog_post",
+        "cache_policy": "semantic",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "unsupported_cache_policy"
+
+
+def test_policy_requires_account_scope_before_exact_cache():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "asset_type": "blog_post",
+        "cache_policy": "exact",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "missing_account_scope"
+
+
+def test_policy_rejects_unsupported_asset_type():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "faq_markdown",
+        "cache_policy": "exact",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "unsupported_asset_type"
+
+
+def test_policy_blocks_support_ticket_customer_data_by_default():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "landing_page",
+        "cache_policy": "exact",
+        "input_provider": "atlas_support_ticket_request",
+    })
+
+    assert decision.mode == "no_store"
+    assert decision.reason == "customer_data_no_store"
+
+
+def test_policy_allows_exact_cache_for_account_scoped_non_customer_asset():
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        "account_id": "acct-1",
+        "asset_type": "landing_page",
+        "cache_policy": "exact",
+    })
+
+    assert decision.mode == "exact"
+    assert decision.cacheable is True
+    assert decision.reason == "eligible"
+    assert decision.namespace == "content_ops.landing_page"
+    assert decision.account_id == "acct-1"
+    assert decision.trace_metadata() == {
+        "cache_mode": "exact",
+        "cache_reason": "eligible",
+        "cache_namespace": "content_ops.landing_page",
+        "cache_account_id": "acct-1",
+    }
+
+
+def test_policy_can_be_configured_from_settings_namespace():
+    policy = ContentOpsExactCachePolicy.from_settings(SimpleNamespace(
+        exact_cache_enabled=True,
+        customer_data_exact_cache_enabled=True,
+        exact_cache_namespace_prefix="tenant_content_ops",
+    ))
+
+    decision = policy.decide({
+        "account_id": "acct-1",
+        "asset_type": "blog_post",
+        "source_type": "support_ticket",
+        "cache_policy": "exact",
+    })
+
+    assert decision.mode == "exact"
+    assert decision.namespace == "tenant_content_ops.blog_post"

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -11,6 +11,9 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.campaign_llm_client import (
     current_content_ops_llm_trace_context,
 )
+from extracted_content_pipeline.content_ops_cache_policy import (
+    ContentOpsExactCachePolicy,
+)
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -393,6 +396,47 @@ async def test_execute_sets_content_ops_llm_trace_context_from_scope() -> None:
         "account_id": "acct-1",
         "user_id": "user-1",
     }
+    assert current_content_ops_llm_trace_context() == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_support_ticket_trace_context_for_cache_policy() -> None:
+    blog = _TraceContextCaptureService()
+    scope = TenantScope(account_id="acct-1", user_id="user-1")
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {
+                "topic": "Support-ticket questions customers keep asking",
+                "filters": {"topic_type": "content_ops_support_ticket_faq"},
+                "included_ticket_row_count": 25,
+                "top_ticket_clusters": [{"intent": "billing", "count": 12}],
+            },
+        },
+        services=ContentOpsExecutionServices(blog_post=blog),
+        scope=scope,
+    )
+
+    assert result["status"] == "completed"
+    trace_context = blog.calls[0]["trace_context"]
+    assert trace_context == {
+        "account_id": "acct-1",
+        "user_id": "user-1",
+        "source_type": "support_ticket",
+        "input_provider": "support_ticket_provider",
+    }
+    decision = ContentOpsExactCachePolicy(exact_cache_enabled=True).decide({
+        **trace_context,
+        "target_mode": "vendor_retention",
+        "blueprint_id": "support-ticket-blog",
+        "skill_name": "digest/blog_post_generation",
+        "asset_type": "blog_post",
+        "attempt_no": 1,
+        "content_ops_cache_policy": "exact",
+    })
+    assert decision.mode == "no_store"
+    assert decision.reason == "customer_data_no_store"
     assert current_content_ops_llm_trace_context() == {}
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Exact-Cache-Policy.md
Slice phase: Production hardening

Add a source-side Content Ops exact-cache policy seam that defaults to no-store, requires account scope, blocks support-ticket/customer-data markers from the real execution path, and surfaces the decision in LLM trace metadata without performing cache lookup/store yet.

## Intentional
- This does not call exact-cache lookup or store; policy and observability land before behavior.
- This does not cache support-ticket prompts because current prompts can include raw customer data.
- This does not add UI controls.

## Deferred
- Future PR: exact-cache adapter that can lookup/store only when this policy returns exact.
- Future PR: redacted/digest-only cache envelopes for support-ticket inputs if needed.
- Future PR: UI controls once backend cache behavior is live and safe.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_content_ops_execution.py::test_execute_marks_support_ticket_trace_context_for_cache_policy tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 29 passed, 1 warning.
- python -m compileall -q extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_execution.py — passed.
- python -m pytest tests/test_atlas_content_ops_infrastructure.py::test_build_content_ops_llm_client_uses_pipeline_tracing_client tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 29 passed, 1 warning.
- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py tests/test_extracted_content_ops_cache_policy.py — passed.
- python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py -q — 27 passed, 1 warning.
- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/campaign_llm_client.py extracted_content_pipeline/settings.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_campaign_llm_client.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q — 9 passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.

## Diff size
11 files, +688 / -1.