### PR TITLE
Surface FAQ search DB pool close failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,20 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-27
-
-### FAQ search DB smoke pool close failures can mask result
-- File/location: `scripts/smoke_content_ops_faq_search_concurrency.py`
-  `run_smoke(...)` pool `finally` block.
-- Description: `pool.close()` exceptions can still replace a prepared
-  setup/search result instead of being reported as lifecycle metadata.
-- Why it matters: A close failure could hide whether retrieval passed, failed,
-  or never ran, making go-live smoke artifacts harder to interpret.
-- Effort: S
-- Category: correctness
-- Owner/session: Codex FAQ lane
-- Found during: PR-Content-Ops-FAQ-Search-DB-Cleanup-Result
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-FAQ-Search-DB-Close-Result
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-DB-Cleanup-Result` fixed cleanup failures masking the
+primary FAQ search DB smoke result, then parked the smaller adjacent lifecycle
+edge: `pool.close()` can still raise from the `finally` block and replace an
+already-built setup or search summary.
+
+This production-hardening slice drains that parked edge so the smoke result
+shows the primary outcome, cleanup status, and pool-close status separately.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add pool-close status metadata to FAQ search DB smoke result payloads.
+2. Convert `pool.close()` failures into `pool_close.error` metadata instead of
+   letting them replace the original setup/search result.
+3. Make pool-close failure fail the smoke overall while preserving the original
+   `setup`, `cleanup`, `requests`, `latency`, and `isolation` fields.
+4. Remove the drained pool-close hardening item from `HARDENING.md`.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md` | Plan contract for the pool-close result hardening slice. |
+| `HARDENING.md` | Remove the drained pool-close masking item. |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | Preserve primary smoke results and report pool-close failures as metadata. |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | Regression tests for pool-close failure metadata on setup and search outcomes. |
+
+## Mechanism
+
+The smoke result already has lifecycle-style cleanup metadata. This slice uses
+the same `{ok, attempted, error}` shape for a new `pool_close` result object.
+`run_smoke(...)` catches `pool.close()` exceptions, records the type and message,
+and applies the result to the already-built summary after cleanup metadata is
+attached.
+
+Overall `ok` becomes false when pool close fails, but the original setup/search
+phase and request evidence remain visible.
+
+## Intentional
+
+- No cleanup SQL, search, seeding, routing, or result request behavior changes.
+- `pool_close` is a separate top-level lifecycle object rather than overloading
+  `cleanup`, because closing the pool is not data cleanup.
+- This slice drains the last known result-masking edge in this smoke script.
+
+## Deferred
+
+- Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
+  - 26 passed.
+- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
+  - Passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md
+  - Passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
+  - Passed: 121 matching tests enrolled.
+- Command: git diff --check
+  - Passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 2480 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md` | 87 |
+| `HARDENING.md` | 14 |
+| `scripts/smoke_content_ops_faq_search_concurrency.py` | 30 |
+| `tests/test_smoke_content_ops_faq_search_concurrency.py` | 153 |
+| **Total** | **284** |

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -438,7 +438,7 @@ def _failure_summary(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _cleanup_result(*, attempted: bool, error: BaseException | None = None) -> dict[str, Any]:
+def _lifecycle_result(*, attempted: bool, error: BaseException | None = None) -> dict[str, Any]:
     return {
         "ok": error is None,
         "attempted": attempted,
@@ -451,13 +451,14 @@ def _cleanup_result(*, attempted: bool, error: BaseException | None = None) -> d
     }
 
 
-def _with_cleanup_result(
+def _with_lifecycle_result(
     summary: dict[str, Any],
-    cleanup: dict[str, Any],
+    name: str,
+    result: dict[str, Any],
 ) -> dict[str, Any]:
     updated = dict(summary)
-    updated["cleanup"] = cleanup
-    updated["ok"] = bool(summary["ok"]) and bool(cleanup["ok"])
+    updated[name] = result
+    updated["ok"] = bool(summary["ok"]) and bool(result["ok"])
     return updated
 
 
@@ -498,7 +499,8 @@ def _summary_payload(
             "search_cases": len(cases),
         },
         "setup": setup,
-        "cleanup": _cleanup_result(attempted=False),
+        "cleanup": _lifecycle_result(attempted=False),
+        "pool_close": _lifecycle_result(attempted=False),
         "latency": latency,
         "latency_budget": latency_budget,
         "isolation": failure,
@@ -567,7 +569,8 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     results: list[dict[str, Any]] = []
     cleanup_ready = False
     summary: dict[str, Any] | None = None
-    cleanup = _cleanup_result(attempted=False)
+    cleanup = _lifecycle_result(attempted=False)
+    pool_close = _lifecycle_result(attempted=False)
     try:
         try:
             await _apply_migrations(pool)
@@ -641,13 +644,18 @@ async def run_smoke(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         if cleanup_ready and not bool(args.keep_data):
             try:
                 await _cleanup(pool, cases)
-                cleanup = _cleanup_result(attempted=True)
+                cleanup = _lifecycle_result(attempted=True)
             except Exception as exc:
-                cleanup = _cleanup_result(attempted=True, error=exc)
-        await pool.close()
+                cleanup = _lifecycle_result(attempted=True, error=exc)
+        try:
+            await pool.close()
+            pool_close = _lifecycle_result(attempted=True)
+        except Exception as exc:
+            pool_close = _lifecycle_result(attempted=True, error=exc)
     if summary is None:  # pragma: no cover - defensive guard for unexpected control flow.
         raise RuntimeError("FAQ search smoke did not produce a summary")
-    summary = _with_cleanup_result(summary, cleanup)
+    summary = _with_lifecycle_result(summary, "cleanup", cleanup)
+    summary = _with_lifecycle_result(summary, "pool_close", pool_close)
     return (0 if summary["ok"] else 1), summary
 
 

--- a/tests/test_smoke_content_ops_faq_search_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_concurrency.py
@@ -858,6 +858,159 @@ def test_main_reports_cleanup_failure_without_masking_search_result(tmp_path, mo
     }
 
 
+def test_main_reports_pool_close_failure_without_masking_seed_failure(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def execute(self, *_args):
+            return "DELETE 0"
+
+        async def close(self):
+            self.close_calls += 1
+            raise OSError("pool close failed")
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _raise_seed(*_args, **_kwargs):
+        raise RuntimeError("seed failed")
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _raise_seed)
+    result_path = tmp_path / "faq-search-seed-close.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.close_calls == 1
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["setup"] == {
+        "ok": False,
+        "phase": "seed",
+        "error": {
+            "type": "RuntimeError",
+            "message": "seed failed",
+        },
+    }
+    assert payload["cleanup"] == {"ok": True, "attempted": True, "error": None}
+    assert payload["pool_close"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "pool close failed",
+        },
+    }
+
+
+def test_main_reports_pool_close_failure_without_masking_search_result(tmp_path, monkeypatch) -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def execute(self, *_args):
+            return "DELETE 0"
+
+        async def close(self):
+            self.close_calls += 1
+            raise OSError("pool close failed")
+
+    pool = _Pool()
+
+    async def _fake_pool(*_args, **_kwargs):
+        return pool
+
+    async def _apply_noop(_pool):
+        return None
+
+    async def _seed_noop(*_args, **_kwargs):
+        return None
+
+    async def _search_noop(*_args, **_kwargs):
+        return [
+            {
+                "account_id": "acct-1",
+                "corpus_id": "corpus-1",
+                "query": "export attribution report",
+                "expected_hit": True,
+                "result_count": 1,
+                "elapsed_ms": 12.0,
+                "failures": [],
+            }
+        ]
+
+    monkeypatch.setattr(smoke, "_create_pool", _fake_pool)
+    monkeypatch.setattr(smoke, "_apply_migrations", _apply_noop)
+    monkeypatch.setattr(smoke, "_seed", _seed_noop)
+    monkeypatch.setattr(smoke, "_run_concurrent_searches", _search_noop)
+    result_path = tmp_path / "faq-search-close.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example.invalid/atlas",
+        "--account-count",
+        "1",
+        "--corpora-per-account",
+        "1",
+        "--documents-per-corpus",
+        "1",
+        "--iterations",
+        "1",
+        "--concurrency",
+        "1",
+        "--pool-size",
+        "1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert pool.close_calls == 1
+    assert payload["ok"] is False
+    assert payload["requests"]["total"] == 1
+    assert payload["setup"] == {"ok": True, "phase": "complete", "error": None}
+    assert payload["latency"]["count"] == 1
+    assert payload["isolation"]["count"] == 0
+    assert payload["cleanup"] == {"ok": True, "attempted": True, "error": None}
+    assert payload["pool_close"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "pool close failed",
+        },
+    }
+
+
 def test_failure_summary_limits_output() -> None:
     results = [
         {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md
Slice phase: Production hardening

This drains the parked FAQ search DB smoke pool-close gap: `pool.close()` failures now appear as `pool_close.error` metadata instead of replacing the original setup/search result, while still failing the smoke overall when the pool does not close cleanly.

## Intentional
- No cleanup SQL, search, seeding, routing, or result request behavior changes.
- `pool_close` is a separate top-level lifecycle object rather than overloading `cleanup`, because closing the pool is not data cleanup.
- This slice drains the last known result-masking edge in this smoke script.

## Deferred
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_smoke_content_ops_faq_search_concurrency.py -q
  - 26 passed.
- Command: python -m py_compile scripts/smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_concurrency.py
  - Passed.
- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-DB-Close-Result.md
  - Passed.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
  - Passed: 121 matching tests enrolled.
- Command: git diff --check
  - Passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh
  - Passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
  - Passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
  - Passed.
- Command: bash scripts/check_ascii_python.sh
  - Passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 2480 passed, 7 skipped, 1 warning.

## Diff size
4 files, +259 / -25
