### PR TITLE
Surface FAQ search E2E artifact cleanup failures

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md
+++ b/plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md
@@ -1,0 +1,94 @@
+# PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result
+
+## Why this slice exists
+
+The FAQ search DB smoke result-observability series now preserves setup, search,
+cleanup, and pool-close outcomes. The adjacent seeded-route E2E smoke has one
+similar lifecycle edge: when it uses its default temporary artifact directory,
+`TemporaryDirectory.cleanup()` runs in `finally` and can replace an already-built
+summary before `--output-result` is written.
+
+This production-hardening slice preserves the E2E summary and reports temporary
+artifact cleanup failures as metadata.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add `artifact_cleanup` lifecycle metadata to seeded-route E2E smoke results.
+2. Convert temporary artifact cleanup failures into `artifact_cleanup.error`
+   metadata instead of letting them mask the primary seed/route/detail/cleanup
+   summary.
+3. Make artifact cleanup failure fail the smoke overall while preserving the
+   original `seed`, `route`, `detail`, and `cleanup` fields.
+4. Keep explicit `--artifact-dir` behavior unchanged; no cleanup is attempted
+   for caller-owned artifact directories.
+5. Include artifact cleanup status and error text in the default non-JSON
+   summary output.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md` | Plan contract for the seeded-route artifact cleanup result slice. |
+| `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` | Preserve E2E summaries and report temporary artifact cleanup failures as metadata. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Regression tests for temporary artifact cleanup failure metadata. |
+
+## Mechanism
+
+`_run(...)` builds the same summary as today, but stores it before leaving the
+`try` block. The `finally` catches temporary artifact cleanup failures into an
+`artifact_cleanup` lifecycle object. After cleanup runs, `_run(...)` attaches the
+lifecycle object and recomputes `ok` so cleanup failure is visible and fail-closed
+without replacing the original E2E result.
+
+Preflight summaries also include a not-attempted `artifact_cleanup` object so the
+result envelope is stable. The default non-JSON summary prints artifact cleanup
+status and the error type/message when artifact cleanup fails, so operators do
+not need `--json` to see why the smoke exited non-zero.
+
+## Intentional
+
+- No seed, hosted route, detail route, DB cleanup, or artifact payload behavior
+  changes.
+- Caller-owned `--artifact-dir` paths are not cleaned up by this script and keep
+  `artifact_cleanup.attempted = false`.
+- This is scoped to temporary artifact cleanup only; command execution exceptions
+  are not changed in this slice.
+
+## Deferred
+
+- Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q
+  - 49 passed.
+- Command: python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+  - Passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md
+  - Passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
+  - Passed: 121 matching tests enrolled.
+- Command: git diff --check
+  - Passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Passed: 2481 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| File | LOC |
+|---|---:|
+| `plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md` | 94 |
+| `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` | 51 |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | 66 |
+| **Total** | **211** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -400,6 +400,30 @@ def _cleanup_result(
     }
 
 
+def _lifecycle_result(*, attempted: bool, error: BaseException | None = None) -> dict[str, Any]:
+    return {
+        "ok": error is None,
+        "attempted": attempted,
+        "error": None
+        if error is None
+        else {
+            "type": type(error).__name__,
+            "message": str(error),
+        },
+    }
+
+
+def _with_lifecycle_result(
+    summary: dict[str, Any],
+    name: str,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    updated = dict(summary)
+    updated[name] = result
+    updated["ok"] = bool(summary["ok"]) and bool(result["ok"])
+    return updated
+
+
 def _write_result(path: Path | None, payload: Mapping[str, Any]) -> None:
     if path is None:
         return
@@ -411,11 +435,22 @@ def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(summary, indent=2, sort_keys=True))
         return
+    artifact_cleanup = summary["artifact_cleanup"]
+    artifact_cleanup_error = artifact_cleanup.get("error") or {}
+    artifact_cleanup_suffix = ""
+    if not artifact_cleanup["ok"]:
+        artifact_cleanup_suffix = (
+            " artifact_cleanup_error="
+            f"{artifact_cleanup_error.get('type', 'Error')}: "
+            f"{artifact_cleanup_error.get('message', '')}"
+        )
     print(
         "FAQ search seeded route e2e: "
         f"ok={summary['ok']} seed={summary['seed']['ok']} "
         f"route={summary['route']['ok']} detail={summary['detail']['ok']} "
-        f"cleanup={summary['cleanup']['ok']}"
+        f"cleanup={summary['cleanup']['ok']} "
+        f"artifact_cleanup={artifact_cleanup['ok']}"
+        f"{artifact_cleanup_suffix}"
     )
 
 
@@ -437,6 +472,7 @@ def _preflight_summary(args: argparse.Namespace, errors: Sequence[str], elapsed:
             "delete_status": None,
             "errors": [],
         },
+        "artifact_cleanup": _lifecycle_result(attempted=False),
         "preflight_errors": list(errors),
         "keep_data": bool(args.keep_data),
         "elapsed_seconds": round(elapsed, 6),
@@ -473,6 +509,8 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "delete_status": None,
         "errors": [],
     }
+    artifact_cleanup = _lifecycle_result(attempted=False)
+    summary: dict[str, Any] | None = None
     try:
         seed = _run_command(
             _seed_command(
@@ -540,10 +578,17 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             "keep_data": bool(args.keep_data),
             "elapsed_seconds": round(time.perf_counter() - started, 6),
         }
-        return (0 if ok else 1), summary
     finally:
         if temp_context is not None:
-            temp_context.cleanup()
+            try:
+                temp_context.cleanup()
+                artifact_cleanup = _lifecycle_result(attempted=True)
+            except Exception as exc:
+                artifact_cleanup = _lifecycle_result(attempted=True, error=exc)
+    if summary is None:  # pragma: no cover - defensive guard for unexpected control flow.
+        raise RuntimeError("FAQ search seeded route e2e did not produce a summary")
+    summary = _with_lifecycle_result(summary, "artifact_cleanup", artifact_cleanup)
+    return (0 if summary["ok"] else 1), summary
 
 
 def _detail_not_run(reason: str, *, ok: bool) -> dict[str, Any]:

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -459,6 +459,7 @@ def test_main_writes_preflight_result(tmp_path, capsys):
         "skipped": True,
         "not_run_reason": "preflight_failed",
     }
+    assert payload["artifact_cleanup"] == {"ok": True, "attempted": False, "error": None}
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 
 
@@ -526,6 +527,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     assert payload["detail"]["ok"] is True
     assert payload["artifacts"]["detail_result"].endswith("detail-result.json")
     assert payload["cleanup"]["deleted_faq_ids"] == 1
+    assert payload["artifact_cleanup"] == {"ok": True, "attempted": False, "error": None}
     assert len(calls) == 3
     assert str(smoke.CONTRACT_SCRIPT) in calls[2]
 
@@ -782,3 +784,67 @@ def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
         "delete_status": None,
         "errors": ["cleanup failed"],
     }
+
+
+def test_main_reports_artifact_cleanup_failure_without_masking_seed_failure(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    class _TempDirectory:
+        def __init__(self, **_kwargs):
+            self.name = str(tmp_path / "temp-artifacts")
+
+        def cleanup(self):
+            raise OSError("artifact cleanup failed")
+
+    def _fake_run_command(command):
+        assert str(smoke.SEED_SCRIPT) in command
+        return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad seed"}
+
+    monkeypatch.setattr(smoke.tempfile, "TemporaryDirectory", _TempDirectory)
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["seed"] == {
+        "ok": False,
+        "returncode": 1,
+        "stdout_tail": "",
+        "stderr_tail": "bad seed",
+    }
+    assert payload["route"]["not_run_reason"] == "seed_failed"
+    assert payload["detail"]["not_run_reason"] == "seed_failed"
+    assert payload["cleanup"] == {
+        "ok": True,
+        "requested_faq_ids": 0,
+        "deleted_faq_ids": 0,
+        "delete_status": None,
+        "errors": [],
+    }
+    assert payload["artifact_cleanup"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "artifact cleanup failed",
+        },
+    }
+    output = capsys.readouterr().out
+    assert "artifact_cleanup=False" in output
+    assert "artifact_cleanup_error=OSError: artifact cleanup failed" in output


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md
Slice phase: Production hardening

This preserves the seeded-route E2E smoke summary when temporary artifact cleanup fails. `TemporaryDirectory.cleanup()` failures now appear as `artifact_cleanup.error` metadata and in the default non-JSON summary output instead of replacing the original seed/route/detail/cleanup result, while still failing the smoke overall.

## Intentional
- No seed, hosted route, detail route, DB cleanup, or artifact payload behavior changes.
- Caller-owned `--artifact-dir` paths are not cleaned up by this script and keep `artifact_cleanup.attempted = false`.
- This is scoped to temporary artifact cleanup only; command execution exceptions are not changed in this slice.

## Deferred
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q
  - 49 passed.
- Command: python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
  - Passed.
- Command: python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Artifact-Cleanup-Result.md
  - Passed.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py .
  - Passed: 121 matching tests enrolled.
- Command: git diff --check
  - Passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh
  - Passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
  - Passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
  - Passed.
- Command: bash scripts/check_ascii_python.sh
  - Passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh
  - Passed: 2481 passed, 7 skipped, 1 warning.

## Diff size
3 files, +208 / -3
