### PR TITLE
Add Content Ops exact cache adapter

### DIFF
--- a/atlas_brain/services/b2b/llm_exact_cache.py
+++ b/atlas_brain/services/b2b/llm_exact_cache.py
@@ -267,6 +267,7 @@ async def lookup_cached_text(
     *,
     pool: Any | None = None,
     account_id: str = SENTINEL_ACCOUNT_ID,
+    require_namespace_enabled: bool = True,
 ) -> B2BLLMExactCacheHit | None:
     """Return the cached text for an exact request envelope.
 
@@ -276,7 +277,13 @@ async def lookup_cached_text(
     so cross-tenant hits are impossible -- the (cache_key, account_id)
     composite PK guarantees isolation at the storage layer.
     """
-    if not namespace or not _is_cache_enabled_for_namespace(namespace):
+    if (
+        not namespace
+        or (
+            require_namespace_enabled
+            and not _is_cache_enabled_for_namespace(namespace)
+        )
+    ):
         return None
 
     db_pool = _resolve_pool(pool)
@@ -329,6 +336,7 @@ async def store_cached_text(
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
     account_id: str = SENTINEL_ACCOUNT_ID,
+    require_namespace_enabled: bool = True,
 ) -> bool:
     """Store a successful exact-match response.
 
@@ -340,7 +348,10 @@ async def store_cached_text(
         not namespace
         or not response_text
         or not str(response_text).strip()
-        or not _is_cache_enabled_for_namespace(namespace)
+        or (
+            require_namespace_enabled
+            and not _is_cache_enabled_for_namespace(namespace)
+        )
     ):
         return False
 
@@ -396,10 +407,16 @@ def lookup_cached_text_sync(
     request_envelope: dict[str, Any],
     *,
     pool: Any | None = None,
+    require_namespace_enabled: bool = True,
 ) -> B2BLLMExactCacheHit | None:
     """Sync wrapper for exact-cache lookup."""
     return _run_coro_sync(
-        lookup_cached_text(namespace, request_envelope, pool=pool)
+        lookup_cached_text(
+            namespace,
+            request_envelope,
+            pool=pool,
+            require_namespace_enabled=require_namespace_enabled,
+        )
     )
 
 
@@ -413,6 +430,7 @@ def store_cached_text_sync(
     usage: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
+    require_namespace_enabled: bool = True,
 ) -> bool:
     """Sync wrapper for exact-cache store."""
     return bool(
@@ -426,6 +444,7 @@ def store_cached_text_sync(
                 usage=usage,
                 metadata=metadata,
                 pool=pool,
+                require_namespace_enabled=require_namespace_enabled,
             )
         )
     )

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -416,6 +416,13 @@ class PipelineLLMClient:
         trace_metadata.update(call_metadata)
         if cache_decision is not None:
             trace_metadata.update(cache_decision.trace_metadata())
+        for key in (
+            "cached_input_tokens",
+            "cached_output_tokens",
+            "billable_output_tokens",
+        ):
+            if key in trace_meta:
+                trace_metadata[key] = str(_usage_int(trace_meta.get(key)))
         if cache_metadata:
             trace_metadata.update({
                 str(key): str(value)
@@ -578,15 +585,25 @@ def _response_from_cache_hit(hit: Mapping[str, Any]) -> LLMResponse:
         or usage.get("prompt_tokens")
         or usage.get("total_tokens")
     )
+    output_tokens = _usage_int(
+        usage.get("output_tokens")
+        or usage.get("completion_tokens")
+    )
     raw_hit = dict(hit)
     raw_hit["_trace_meta"] = {
+        "cached_input_tokens": input_tokens,
+        "cached_output_tokens": output_tokens,
         "cached_tokens": input_tokens,
         "billable_input_tokens": 0,
+        "billable_output_tokens": 0,
     }
     return LLMResponse(
         content=str(hit.get("response_text") or ""),
         model=str(hit.get("model") or "") or None,
-        usage=dict(usage),
+        usage={
+            "input_tokens": 0,
+            "output_tokens": 0,
+        },
         raw=raw_hit,
     )
 

--- a/extracted_content_pipeline/campaign_llm_client.py
+++ b/extracted_content_pipeline/campaign_llm_client.py
@@ -8,7 +8,7 @@ import os
 import time
 from collections.abc import Callable, Mapping, Sequence
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any
 
@@ -174,6 +174,78 @@ class PipelineLLMClientConfig:
 
 
 @dataclass(frozen=True)
+class ContentOpsExactCacheAdapter:
+    """Thin adapter over the shared exact-cache helpers.
+
+    Content Ops owns the cache eligibility policy. Once that policy returns an
+    account-scoped exact decision, this adapter reuses the shared request
+    envelope and Postgres cache helpers without applying the legacy B2B/Gateway
+    namespace feature flag a second time.
+    """
+
+    def build_request_envelope(
+        self,
+        *,
+        provider: str,
+        model: str,
+        messages: Sequence[LLMMessage],
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        from extracted_llm_infrastructure.services.b2b import llm_exact_cache
+
+        return llm_exact_cache.build_request_envelope(
+            provider=provider,
+            model=model,
+            messages=list(messages),
+            max_tokens=max_tokens,
+            temperature=temperature,
+            extra={"product": "content_ops"},
+        )
+
+    async def lookup(
+        self,
+        decision: ContentOpsCacheDecision,
+        request_envelope: dict[str, Any],
+    ) -> Mapping[str, Any] | None:
+        from extracted_llm_infrastructure.services.b2b import llm_exact_cache
+
+        if not decision.namespace or not decision.account_id:
+            return None
+        return await llm_exact_cache.lookup_cached_text(
+            decision.namespace,
+            request_envelope,
+            account_id=decision.account_id,
+            require_namespace_enabled=False,
+        )
+
+    async def store(
+        self,
+        decision: ContentOpsCacheDecision,
+        request_envelope: dict[str, Any],
+        *,
+        provider: str,
+        model: str,
+        response: LLMResponse,
+    ) -> bool:
+        from extracted_llm_infrastructure.services.b2b import llm_exact_cache
+
+        if not decision.namespace or not decision.account_id:
+            return False
+        return bool(await llm_exact_cache.store_cached_text(
+            decision.namespace,
+            request_envelope,
+            provider=provider,
+            model=model,
+            response_text=response.content,
+            usage=dict(response.usage or {}),
+            metadata={"product": "content_ops"},
+            account_id=decision.account_id,
+            require_namespace_enabled=False,
+        ))
+
+
+@dataclass(frozen=True)
 class PipelineLLMClient:
     """Adapt extracted LLM infrastructure services to the product LLMClient port."""
 
@@ -185,6 +257,9 @@ class PipelineLLMClient:
     resolver: LLMResolver = _default_resolver
     tracer: LLMTraceCallable | None = _default_trace_llm_call
     cache_policy: ContentOpsExactCachePolicy = ContentOpsExactCachePolicy()
+    exact_cache: ContentOpsExactCacheAdapter | None = field(
+        default_factory=ContentOpsExactCacheAdapter,
+    )
 
     async def complete(
         self,
@@ -209,6 +284,38 @@ class PipelineLLMClient:
             messages=messages,
         )
         started = time.monotonic()
+        cache_request: dict[str, Any] | None = None
+        cache_metadata: dict[str, Any] = {}
+        provider = _provider_name(llm)
+        model = _model_name(llm) or ""
+        if cache_decision.cacheable and self.exact_cache is not None:
+            try:
+                cache_request = self.exact_cache.build_request_envelope(
+                    provider=provider,
+                    model=model,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+                cache_hit = await self.exact_cache.lookup(
+                    cache_decision,
+                    cache_request,
+                )
+                if cache_hit is not None:
+                    response = _response_from_cache_hit(cache_hit)
+                    self._trace_call(
+                        llm=llm,
+                        response=response,
+                        duration_ms=_duration_ms(started),
+                        metadata=metadata,
+                        cache_decision=cache_decision,
+                        cache_metadata={"cache_result": "hit"},
+                    )
+                    return response
+                cache_metadata["cache_result"] = "miss"
+            except Exception as exc:
+                cache_request = None
+                cache_metadata.update(_cache_error_metadata("lookup_error", exc))
         try:
             call_args = {
                 "llm": llm,
@@ -230,17 +337,37 @@ class PipelineLLMClient:
                 duration_ms=_duration_ms(started),
                 metadata=metadata,
                 cache_decision=cache_decision,
+                cache_metadata=cache_metadata,
                 status="failed",
                 error_message=str(exc)[:500],
                 error_type=type(exc).__name__,
             )
             raise
+        if (
+            cache_decision.cacheable
+            and self.exact_cache is not None
+            and cache_request is not None
+        ):
+            try:
+                stored = await self.exact_cache.store(
+                    cache_decision,
+                    cache_request,
+                    provider=provider,
+                    model=model,
+                    response=response,
+                )
+                cache_metadata["cache_store_result"] = (
+                    "stored" if stored else "skipped"
+                )
+            except Exception as exc:
+                cache_metadata.update(_cache_error_metadata("store_error", exc))
         self._trace_call(
             llm=llm,
             response=response,
             duration_ms=_duration_ms(started),
             metadata=metadata,
             cache_decision=cache_decision,
+            cache_metadata=cache_metadata,
         )
         return response
 
@@ -252,6 +379,7 @@ class PipelineLLMClient:
         duration_ms: float,
         metadata: Mapping[str, Any] | None,
         cache_decision: ContentOpsCacheDecision | None,
+        cache_metadata: Mapping[str, Any] | None = None,
         status: str = "completed",
         error_message: str | None = None,
         error_type: str | None = None,
@@ -278,12 +406,22 @@ class PipelineLLMClient:
             "cache_reason",
             "cache_namespace",
             "cache_account_id",
+            "cache_result",
+            "cache_store_result",
+            "cache_error_type",
+            "cache_error_message",
         ):
             call_metadata.pop(key, None)
         trace_metadata.update(scoped_metadata)
         trace_metadata.update(call_metadata)
         if cache_decision is not None:
             trace_metadata.update(cache_decision.trace_metadata())
+        if cache_metadata:
+            trace_metadata.update({
+                str(key): str(value)
+                for key, value in cache_metadata.items()
+                if value not in (None, "")
+            })
         try:
             self.tracer(
                 "content_ops.llm.complete",
@@ -431,6 +569,34 @@ def _to_response(result: Any, *, llm: Any) -> LLMResponse:
         usage=dict(usage),
         raw=result,
     )
+
+
+def _response_from_cache_hit(hit: Mapping[str, Any]) -> LLMResponse:
+    usage = hit.get("usage") if isinstance(hit.get("usage"), Mapping) else {}
+    input_tokens = _usage_int(
+        usage.get("input_tokens")
+        or usage.get("prompt_tokens")
+        or usage.get("total_tokens")
+    )
+    raw_hit = dict(hit)
+    raw_hit["_trace_meta"] = {
+        "cached_tokens": input_tokens,
+        "billable_input_tokens": 0,
+    }
+    return LLMResponse(
+        content=str(hit.get("response_text") or ""),
+        model=str(hit.get("model") or "") or None,
+        usage=dict(usage),
+        raw=raw_hit,
+    )
+
+
+def _cache_error_metadata(result: str, exc: Exception) -> dict[str, str]:
+    return {
+        "cache_result": result,
+        "cache_error_type": type(exc).__name__,
+        "cache_error_message": str(exc)[:200],
+    }
 
 
 def _duration_ms(started: float) -> float:

--- a/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
+++ b/extracted_llm_infrastructure/services/b2b/llm_exact_cache.py
@@ -267,6 +267,7 @@ async def lookup_cached_text(
     *,
     pool: Any | None = None,
     account_id: str = SENTINEL_ACCOUNT_ID,
+    require_namespace_enabled: bool = True,
 ) -> B2BLLMExactCacheHit | None:
     """Return the cached text for an exact request envelope.
 
@@ -276,7 +277,13 @@ async def lookup_cached_text(
     so cross-tenant hits are impossible -- the (cache_key, account_id)
     composite PK guarantees isolation at the storage layer.
     """
-    if not namespace or not _is_cache_enabled_for_namespace(namespace):
+    if (
+        not namespace
+        or (
+            require_namespace_enabled
+            and not _is_cache_enabled_for_namespace(namespace)
+        )
+    ):
         return None
 
     db_pool = _resolve_pool(pool)
@@ -329,6 +336,7 @@ async def store_cached_text(
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
     account_id: str = SENTINEL_ACCOUNT_ID,
+    require_namespace_enabled: bool = True,
 ) -> bool:
     """Store a successful exact-match response.
 
@@ -340,7 +348,10 @@ async def store_cached_text(
         not namespace
         or not response_text
         or not str(response_text).strip()
-        or not _is_cache_enabled_for_namespace(namespace)
+        or (
+            require_namespace_enabled
+            and not _is_cache_enabled_for_namespace(namespace)
+        )
     ):
         return False
 
@@ -396,10 +407,16 @@ def lookup_cached_text_sync(
     request_envelope: dict[str, Any],
     *,
     pool: Any | None = None,
+    require_namespace_enabled: bool = True,
 ) -> B2BLLMExactCacheHit | None:
     """Sync wrapper for exact-cache lookup."""
     return _run_coro_sync(
-        lookup_cached_text(namespace, request_envelope, pool=pool)
+        lookup_cached_text(
+            namespace,
+            request_envelope,
+            pool=pool,
+            require_namespace_enabled=require_namespace_enabled,
+        )
     )
 
 
@@ -413,6 +430,7 @@ def store_cached_text_sync(
     usage: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     pool: Any | None = None,
+    require_namespace_enabled: bool = True,
 ) -> bool:
     """Sync wrapper for exact-cache store."""
     return bool(
@@ -426,6 +444,7 @@ def store_cached_text_sync(
                 usage=usage,
                 metadata=metadata,
                 pool=pool,
+                require_namespace_enabled=require_namespace_enabled,
             )
         )
     )

--- a/plans/PR-Content-Ops-Exact-Cache-Adapter.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Adapter.md
@@ -1,0 +1,114 @@
+# PR: Content Ops Exact Cache Adapter
+
+## Why this slice exists
+
+PR-Content-Ops-Exact-Cache-Policy added the source-side safety gate for
+Content Ops LLM caching but deliberately did not perform cache lookup or store.
+The next slice should use that policy rather than creating another cache rule
+layer. It also needs to reuse the existing exact-cache infrastructure without
+coupling Content Ops to the B2B or LLM Gateway feature flags.
+
+This slice is intentionally narrow: when the Content Ops policy returns
+`exact`, the LLM client can look up and store exact-cache responses for
+account-scoped, non-customer-data calls. When the policy returns `no_store`, or
+when lookup/store fails, generation continues through the provider.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a Content Ops exact-cache adapter path in `PipelineLLMClient.complete`.
+2. Reuse the shared exact-cache request-envelope, lookup, and store helpers
+   instead of creating a separate cache table or hashing implementation.
+3. Let product-owned callers bypass the shared helper's legacy namespace flag
+   when their own policy has already returned `exact`; keep the existing default
+   behavior for B2B and LLM Gateway callers.
+4. Trace cache hit/miss/store/error outcomes without capturing raw prompt or
+   response payloads in LLM traces.
+5. Keep cache failures non-fatal. A cache outage should become a provider call,
+   not a generation failure.
+6. Add focused tests for hit, miss/store, no-store, and cache failure behavior.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Exact-Cache-Adapter.md` | Plan doc for the adapter slice. |
+| `extracted_content_pipeline/campaign_llm_client.py` | Add exact-cache adapter hooks to the Content Ops LLM client. |
+| `atlas_brain/services/b2b/llm_exact_cache.py` | Add an explicit namespace-flag bypass option for policy-gated callers. |
+| `extracted_llm_infrastructure/services/b2b/llm_exact_cache.py` | Synced extracted copy of the shared exact-cache helper. |
+| `tests/test_extracted_campaign_llm_client.py` | Cover Content Ops cache hit/miss/store/failure behavior. |
+| `tests/test_b2b_intelligence_validation.py` | Cover the shared exact-cache helper bypass option. |
+
+## Mechanism
+
+`PipelineLLMClient` gets an injected exact-cache adapter with lazy defaults that
+import the shared exact-cache helper only when needed. For each call:
+
+1. Resolve the LLM and evaluate `ContentOpsExactCachePolicy`.
+2. If the decision is not cacheable, call the provider exactly as today.
+3. If the decision is cacheable, build the same deterministic request envelope
+   the shared exact-cache helper uses, scoped by provider, model, messages,
+   max tokens, and temperature.
+4. Attempt lookup with the policy-provided namespace and account id.
+5. On hit, return an `LLMResponse` from the cached text and trace `cache_result=hit`.
+6. On miss, call the provider, then store the successful response under the same
+   namespace/account id and trace `cache_result=miss` plus the store result.
+7. On cache lookup/store error, trace the error metadata and continue generation.
+
+The shared exact-cache helper gets a keyword-only
+`require_namespace_enabled: bool = True`. Existing callers keep the default
+namespace flag behavior. Content Ops passes `False` only after its own policy
+returns `exact`, so B2B/Gateway behavior is unchanged while Content Ops remains
+controlled by the source-side policy from the previous slice.
+
+## Intentional
+
+- This does not cache support-ticket/customer-data prompts. The prior slice
+  makes those policy decisions `no_store`, and this adapter only runs on
+  cacheable decisions.
+- This does not add UI controls. Backend behavior should prove safe before the
+  UI exposes knobs.
+- This does not add a new cache table or new hash format. Reusing the shared
+  exact-cache helpers avoids a second cache implementation.
+- This does not fail generation when the cache is unavailable. Cache is an
+  optimization, not a dependency for generation.
+
+## Deferred
+
+- Future PR: UI/control-surface cache controls once the adapter is live and
+  review-approved.
+- Future PR: cache savings/cost rollup for Content Ops if the exact cache gets
+  meaningful traffic.
+- Future PR: affirmative `safe_to_cache` allowlist posture if Content Ops gains
+  non-executor LLM paths that do not inherit the support-ticket marker context.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_b2b_intelligence_validation.py::test_lookup_cached_text_can_bypass_namespace_flag_for_policy_gated_callers tests/test_b2b_intelligence_validation.py::test_store_cached_text_can_bypass_namespace_flag_for_policy_gated_callers -q — 24 passed.
+- python -m compileall -q extracted_content_pipeline/campaign_llm_client.py atlas_brain/services/b2b/llm_exact_cache.py extracted_llm_infrastructure/services/b2b/llm_exact_cache.py tests/test_extracted_campaign_llm_client.py tests/test_b2b_intelligence_validation.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_llm_infrastructure_checks.sh — 35 passed, 1 warning.
+- bash scripts/run_extracted_pipeline_checks.sh — 2496 passed, 7 skipped, 1 warning.
+- python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q — 9 passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <body> — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~100 |
+| LLM client adapter | ~170 |
+| Shared exact-cache helper | ~50 |
+| Tests | ~295 |
+| **Total** | **~615** |
+
+This is above the 400 LOC soft cap because the adapter, shared-helper seam, and
+tests need to land together; otherwise the PR would either add an unused helper
+or wire cache behavior without proving the safety contract.

--- a/plans/PR-Content-Ops-Exact-Cache-Adapter.md
+++ b/plans/PR-Content-Ops-Exact-Cache-Adapter.md
@@ -52,7 +52,9 @@ import the shared exact-cache helper only when needed. For each call:
    the shared exact-cache helper uses, scoped by provider, model, messages,
    max tokens, and temperature.
 4. Attempt lookup with the policy-provided namespace and account id.
-5. On hit, return an `LLMResponse` from the cached text and trace `cache_result=hit`.
+5. On hit, return an `LLMResponse` from the cached text and trace
+   `cache_result=hit`, zero provider usage for the current request, and
+   cache-specific token metadata for savings/diagnostics.
 6. On miss, call the provider, then store the successful response under the same
    namespace/account id and trace `cache_result=miss` plus the store result.
 7. On cache lookup/store error, trace the error metadata and continue generation.
@@ -104,10 +106,10 @@ controlled by the source-side policy from the previous slice.
 | Area | Estimated LOC |
 |---|---:|
 | Plan doc | ~100 |
-| LLM client adapter | ~170 |
+| LLM client adapter | ~190 |
 | Shared exact-cache helper | ~50 |
-| Tests | ~295 |
-| **Total** | **~615** |
+| Tests | ~300 |
+| **Total** | **~640** |
 
 This is above the 400 LOC soft cap because the adapter, shared-helper seam, and
 tests need to land together; otherwise the PR would either add an unused helper

--- a/tests/test_b2b_intelligence_validation.py
+++ b/tests/test_b2b_intelligence_validation.py
@@ -1003,6 +1003,99 @@ async def test_lookup_cached_text_parses_stringified_json_fields(monkeypatch):
     assert hit["hit_count"] == 4
 
 
+@pytest.mark.asyncio
+async def test_lookup_cached_text_can_bypass_namespace_flag_for_policy_gated_callers(
+    monkeypatch,
+):
+    class FakePool:
+        def __init__(self):
+            self.fetches = 0
+
+        async def fetchrow(self, *_args, **_kwargs):
+            self.fetches += 1
+            return {
+                "cache_key": "abc",
+                "namespace": "content_ops.landing_page",
+                "provider": "provider",
+                "model": "model",
+                "response_text": "cached",
+                "usage_json": {"input_tokens": 12},
+                "metadata": {"cache_version": "v1"},
+                "created_at": "2026-03-31T01:00:00Z",
+                "last_hit_at": "2026-03-31T01:05:00Z",
+                "hit_count": 4,
+            }
+
+    monkeypatch.setattr(
+        exact_cache_mod,
+        "_is_cache_enabled_for_namespace",
+        lambda _namespace: False,
+    )
+    pool = FakePool()
+
+    default_hit = await exact_cache_mod.lookup_cached_text(
+        "content_ops.landing_page",
+        {"messages": [{"role": "user", "content": "x"}]},
+        pool=pool,
+        account_id="acct-1",
+    )
+    bypass_hit = await exact_cache_mod.lookup_cached_text(
+        "content_ops.landing_page",
+        {"messages": [{"role": "user", "content": "x"}]},
+        pool=pool,
+        account_id="acct-1",
+        require_namespace_enabled=False,
+    )
+
+    assert default_hit is None
+    assert bypass_hit is not None
+    assert bypass_hit["response_text"] == "cached"
+    assert pool.fetches == 1
+
+
+@pytest.mark.asyncio
+async def test_store_cached_text_can_bypass_namespace_flag_for_policy_gated_callers(
+    monkeypatch,
+):
+    class FakePool:
+        def __init__(self):
+            self.executes = 0
+
+        async def execute(self, *_args, **_kwargs):
+            self.executes += 1
+
+    monkeypatch.setattr(
+        exact_cache_mod,
+        "_is_cache_enabled_for_namespace",
+        lambda _namespace: False,
+    )
+    pool = FakePool()
+
+    default_stored = await exact_cache_mod.store_cached_text(
+        "content_ops.landing_page",
+        {"messages": [{"role": "user", "content": "x"}]},
+        provider="provider",
+        model="model",
+        response_text="cached",
+        pool=pool,
+        account_id="acct-1",
+    )
+    bypass_stored = await exact_cache_mod.store_cached_text(
+        "content_ops.landing_page",
+        {"messages": [{"role": "user", "content": "x"}]},
+        provider="provider",
+        model="model",
+        response_text="cached",
+        pool=pool,
+        account_id="acct-1",
+        require_namespace_enabled=False,
+    )
+
+    assert default_stored is False
+    assert bypass_stored is True
+    assert pool.executes == 1
+
+
 class TestAccountIntelligenceHygiene:
     def test_build_company_signal_blocked_names_by_vendor_includes_vendors_integrations_and_alternatives(self):
         blocked = _build_company_signal_blocked_names_by_vendor(

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -473,12 +473,18 @@ async def test_pipeline_llm_client_returns_exact_cache_hit_without_provider_call
 
     assert response.content == "cached response"
     assert response.model == "cached-model"
+    assert response.usage == {"input_tokens": 0, "output_tokens": 0}
     assert llm.calls == []
     assert len(exact_cache.lookups) == 1
     assert exact_cache.stores == []
     trace_metadata = trace_calls[0][1]["metadata"]
     assert trace_metadata["cache_mode"] == "exact"
     assert trace_metadata["cache_result"] == "hit"
+    assert trace_metadata["cached_input_tokens"] == "8"
+    assert trace_metadata["cached_output_tokens"] == "3"
+    assert trace_metadata["billable_output_tokens"] == "0"
+    assert trace_calls[0][1]["input_tokens"] == 0
+    assert trace_calls[0][1]["output_tokens"] == 0
     assert trace_calls[0][1]["cached_tokens"] == 8
     assert trace_calls[0][1]["billable_input_tokens"] == 0
 

--- a/tests/test_extracted_campaign_llm_client.py
+++ b/tests/test_extracted_campaign_llm_client.py
@@ -104,6 +104,72 @@ class _FailingChatLLM:
         raise RuntimeError("provider timeout")
 
 
+class _FakeExactCache:
+    def __init__(
+        self,
+        *,
+        hit=None,
+        lookup_exc: Exception | None = None,
+        store_exc: Exception | None = None,
+        store_result: bool = True,
+    ):
+        self.hit = hit
+        self.lookup_exc = lookup_exc
+        self.store_exc = store_exc
+        self.store_result = store_result
+        self.envelopes = []
+        self.lookups = []
+        self.stores = []
+
+    def build_request_envelope(
+        self,
+        *,
+        provider,
+        model,
+        messages,
+        max_tokens,
+        temperature,
+    ):
+        envelope = {
+            "provider": provider,
+            "model": model,
+            "messages": [
+                {"role": item.role, "content": item.content}
+                for item in messages
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        self.envelopes.append(envelope)
+        return envelope
+
+    async def lookup(self, decision, request_envelope):
+        self.lookups.append((decision, request_envelope))
+        if self.lookup_exc is not None:
+            raise self.lookup_exc
+        return self.hit
+
+    async def store(
+        self,
+        decision,
+        request_envelope,
+        *,
+        provider,
+        model,
+        response,
+    ):
+        self.stores.append({
+            "decision": decision,
+            "request_envelope": request_envelope,
+            "provider": provider,
+            "model": model,
+            "response": response,
+        })
+        if self.store_exc is not None:
+            raise self.store_exc
+        return self.store_result
+
+
 @pytest.mark.asyncio
 async def test_pipeline_llm_client_resolves_and_normalizes_chat_response():
     llm = _ChatLLM()
@@ -373,6 +439,142 @@ async def test_pipeline_llm_client_traces_exact_cache_policy_decision_from_scope
     assert trace_metadata["cache_namespace"] == "content_ops.landing_page"
     assert trace_metadata["cache_account_id"] == "acct-cache"
     assert trace_metadata["account_id"] == "acct-cache"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_returns_exact_cache_hit_without_provider_call():
+    llm = _ChatLLM()
+    trace_calls = []
+    exact_cache = _FakeExactCache(hit={
+        "namespace": "content_ops.landing_page",
+        "model": "cached-model",
+        "response_text": "cached response",
+        "usage": {"input_tokens": 8, "output_tokens": 3},
+        "metadata": {"cache_version": "v1"},
+    })
+    client = PipelineLLMClient(
+        workload="draft",
+        resolver=lambda **_: llm,
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+        cache_policy=ContentOpsExactCachePolicy(exact_cache_enabled=True),
+        exact_cache=exact_cache,
+    )
+
+    token = set_content_ops_llm_trace_context({"account_id": "acct-cache"})
+    try:
+        response = await client.complete(
+            [LLMMessage(role="user", content="stable non-customer prompt")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={"asset_type": "landing_page", "cache_policy": "exact"},
+        )
+    finally:
+        reset_content_ops_llm_trace_context(token)
+
+    assert response.content == "cached response"
+    assert response.model == "cached-model"
+    assert llm.calls == []
+    assert len(exact_cache.lookups) == 1
+    assert exact_cache.stores == []
+    trace_metadata = trace_calls[0][1]["metadata"]
+    assert trace_metadata["cache_mode"] == "exact"
+    assert trace_metadata["cache_result"] == "hit"
+    assert trace_calls[0][1]["cached_tokens"] == 8
+    assert trace_calls[0][1]["billable_input_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_stores_exact_cache_miss_after_provider_call():
+    llm = _ChatLLM()
+    trace_calls = []
+    exact_cache = _FakeExactCache()
+    client = PipelineLLMClient(
+        workload="draft",
+        resolver=lambda **_: llm,
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+        cache_policy=ContentOpsExactCachePolicy(exact_cache_enabled=True),
+        exact_cache=exact_cache,
+    )
+
+    token = set_content_ops_llm_trace_context({"account_id": "acct-cache"})
+    try:
+        response = await client.complete(
+            [LLMMessage(role="user", content="stable non-customer prompt")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={"asset_type": "landing_page", "cache_policy": "exact"},
+        )
+    finally:
+        reset_content_ops_llm_trace_context(token)
+
+    assert response.content == "chat response"
+    assert len(llm.calls) == 1
+    assert len(exact_cache.lookups) == 1
+    assert len(exact_cache.stores) == 1
+    stored = exact_cache.stores[0]
+    assert stored["provider"] == "_ChatLLM"
+    assert stored["model"] == "chat-model"
+    assert stored["response"].content == "chat response"
+    trace_metadata = trace_calls[0][1]["metadata"]
+    assert trace_metadata["cache_result"] == "miss"
+    assert trace_metadata["cache_store_result"] == "stored"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_skips_adapter_when_policy_is_no_store():
+    llm = _ChatLLM()
+    exact_cache = _FakeExactCache()
+    client = PipelineLLMClient(
+        resolver=lambda **_: llm,
+        cache_policy=ContentOpsExactCachePolicy(exact_cache_enabled=False),
+        exact_cache=exact_cache,
+    )
+
+    response = await client.complete(
+        [LLMMessage(role="user", content="prompt")],
+        max_tokens=200,
+        temperature=0.2,
+        metadata={"asset_type": "landing_page", "cache_policy": "exact"},
+    )
+
+    assert response.content == "chat response"
+    assert len(llm.calls) == 1
+    assert exact_cache.envelopes == []
+    assert exact_cache.lookups == []
+    assert exact_cache.stores == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_llm_client_continues_when_cache_lookup_fails():
+    llm = _ChatLLM()
+    trace_calls = []
+    exact_cache = _FakeExactCache(lookup_exc=RuntimeError("cache unavailable"))
+    client = PipelineLLMClient(
+        resolver=lambda **_: llm,
+        tracer=lambda span_name, **kwargs: trace_calls.append((span_name, kwargs)),
+        cache_policy=ContentOpsExactCachePolicy(exact_cache_enabled=True),
+        exact_cache=exact_cache,
+    )
+
+    token = set_content_ops_llm_trace_context({"account_id": "acct-cache"})
+    try:
+        response = await client.complete(
+            [LLMMessage(role="user", content="stable non-customer prompt")],
+            max_tokens=200,
+            temperature=0.2,
+            metadata={"asset_type": "landing_page", "cache_policy": "exact"},
+        )
+    finally:
+        reset_content_ops_llm_trace_context(token)
+
+    assert response.content == "chat response"
+    assert len(llm.calls) == 1
+    assert len(exact_cache.lookups) == 1
+    assert exact_cache.stores == []
+    trace_metadata = trace_calls[0][1]["metadata"]
+    assert trace_metadata["cache_result"] == "lookup_error"
+    assert trace_metadata["cache_error_type"] == "RuntimeError"
+    assert trace_metadata["cache_error_message"] == "cache unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Exact-Cache-Adapter.md
Slice phase: Production hardening

Wire Content Ops LLM generation to the shared exact-cache helpers only after the Content Ops policy returns an account-scoped exact decision, while keeping cache failures non-fatal and support-ticket/customer-data calls no-store. Cache hits now report zero provider input/output usage for the current request and preserve cached token counts only as cache metadata.

## Intentional
- This does not cache support-ticket/customer-data prompts; the prior policy gate keeps those calls no-store.
- This does not add UI controls.
- This reuses the shared exact-cache table, envelope builder, lookup, and store helpers instead of adding a second cache implementation.
- Cache lookup/store failures are traced and generation continues through the provider.
- Cache hits return cached text but do not report fresh provider token usage for the current request.

## Deferred
- Future PR: UI/control-surface cache controls once backend behavior is live and reviewed.
- Future PR: cache savings/cost rollup for Content Ops if exact-cache traffic becomes meaningful.
- Future PR: affirmative safe_to_cache allowlist posture if Content Ops gains non-executor LLM paths.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_campaign_llm_client.py tests/test_b2b_intelligence_validation.py::test_lookup_cached_text_can_bypass_namespace_flag_for_policy_gated_callers tests/test_b2b_intelligence_validation.py::test_store_cached_text_can_bypass_namespace_flag_for_policy_gated_callers -q — 24 passed.
- python -m compileall -q extracted_content_pipeline/campaign_llm_client.py atlas_brain/services/b2b/llm_exact_cache.py extracted_llm_infrastructure/services/b2b/llm_exact_cache.py tests/test_extracted_campaign_llm_client.py tests/test_b2b_intelligence_validation.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- bash scripts/run_extracted_llm_infrastructure_checks.sh — 35 passed, 1 warning.
- bash scripts/run_extracted_pipeline_checks.sh — 2496 passed, 7 skipped, 1 warning.
- python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q — 9 passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_exact_cache_adapter_body.md — passed.

## Diff size
6 files, +645 / -7.