### PR TITLE
Surface SaaS FAQ demo seeder preflight failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-27
+
+### SaaS demo seeder runtime setup result artifact
+- File/location: `scripts/seed_content_ops_faq_saas_demo.py`, `_run(...)` / `main(...)`
+- Description: Pool creation or runtime seed/cleanup exceptions can still abort before `--output-result` is written.
+- Why it matters: Operators get a preflight artifact after this slice, but missing `asyncpg`, connection failures, or unexpected repository errors can still leave no machine-readable failure payload.
+- Effort: S
+- Category: correctness
+- Owner/session: content-ops/faq-generator
+- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result
+
+## Why this slice exists
+
+The SaaS FAQ demo seeder is now the operator handoff path for loading the
+synthetic B2B SaaS FAQ into DB-backed search, but validation failures still exit
+before writing the requested `--output-result` file. That recreates the same
+operator visibility gap we just closed in the FAQ search smoke runners: a
+failed setup leaves no machine-readable artifact for reviewers or deployment
+scripts.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Write a compact preflight result payload when seeder argument validation
+   fails.
+2. Keep the existing exit code and human-readable validation message.
+3. Add focused negative tests for seed-mode and cleanup-mode validation
+   failures writing `--output-result`.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md` | Plan contract for this hardening slice. |
+| `HARDENING.md` | Park runtime setup result-artifact follow-up. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Emit a preflight JSON result before validation exits. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover fail-closed preflight result artifacts for seed and cleanup modes. |
+
+## Mechanism
+
+`main()` already owns argument parsing, output-result writing, and final exit
+code selection. This slice keeps validation in `main()`, but when
+`_validate_args(...)` returns errors it builds:
+
+```python
+{
+    "phase": "preflight",
+    "ok": False,
+    "errors": [...],
+    "mode": "seed" | "cleanup",
+}
+```
+
+Then it writes the payload to `--output-result`, prints the same joined error
+message through `SystemExit`, and returns the same failure behavior.
+
+## Intentional
+
+- No database, generator, search projection, cleanup SQL, or route behavior
+  changes.
+- Runtime pool/connection failures stay deferred; this slice only closes the
+  validation path that is already locally reproducible without a database.
+- The preflight result omits token/database URL values so the artifact stays
+  safe to share.
+
+## Deferred
+
+- Runtime setup failures after validation can get their own result-artifact
+  slice if operators hit missing `asyncpg` or connection errors.
+- Parked hardening: `SaaS demo seeder runtime setup result artifact` in
+  `HARDENING.md`.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 14 passed.
+- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed with 122 matching tests enrolled.
+- `git diff --check` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed with 2495 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 87 |
+| Hardening note | 11 |
+| Script | 10 |
+| Tests | 57 |
+| **Total** | **165** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -319,6 +319,15 @@ def _write_result(path: Path | None, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _preflight_result(args: argparse.Namespace, errors: list[str]) -> dict[str, Any]:
+    return {
+        "phase": "preflight",
+        "ok": False,
+        "mode": "cleanup" if args.cleanup_faq_id is not None else "seed",
+        "errors": list(errors),
+    }
+
+
 def _print_result(payload: dict[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -343,6 +352,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     errors = _validate_args(args)
     if errors:
+        _write_result(args.output_result, _preflight_result(args, errors))
         raise SystemExit("; ".join(errors))
     payload = asyncio.run(_run(args))
     _write_result(args.output_result, payload)

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -1,6 +1,7 @@
 import csv
 from dataclasses import replace
 import importlib.util
+import json
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -198,6 +199,62 @@ def test_saas_demo_cleanup_args_skip_seed_only_required_values() -> None:
     )
 
     assert errors == ["--cleanup-faq-id must be a non-empty FAQ id"]
+
+
+def test_saas_demo_seed_preflight_writes_result_before_exit(tmp_path) -> None:
+    result_path = tmp_path / "seed-preflight.json"
+
+    with pytest.raises(SystemExit) as exc:
+        seeder.main([
+            "--database-url",
+            "",
+            "--account-id",
+            "",
+            "--output-result",
+            str(result_path),
+            "--json",
+        ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert str(exc.value) == (
+        "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL; "
+        "ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required"
+    )
+    assert payload == {
+        "phase": "preflight",
+        "ok": False,
+        "mode": "seed",
+        "errors": [
+            "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL",
+            "ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required",
+        ],
+    }
+
+
+def test_saas_demo_cleanup_preflight_writes_result_before_exit(tmp_path) -> None:
+    result_path = tmp_path / "cleanup-preflight.json"
+
+    with pytest.raises(SystemExit) as exc:
+        seeder.main([
+            "--database-url",
+            "postgresql://example",
+            "--account-id",
+            "acct-demo",
+            "--cleanup-faq-id",
+            "",
+            "--output-result",
+            str(result_path),
+            "--json",
+        ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert str(exc.value) == "--cleanup-faq-id must be a non-empty FAQ id"
+    assert payload == {
+        "phase": "preflight",
+        "ok": False,
+        "mode": "cleanup",
+        "errors": ["--cleanup-faq-id must be a non-empty FAQ id"],
+    }
 
 
 def test_saas_demo_cleanup_delete_status_parser() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md
Slice phase: Production hardening

The SaaS FAQ demo seeder is now the operator handoff for loading the synthetic B2B SaaS FAQ into DB-backed search, but validation failures exited before writing `--output-result`. This PR writes a compact preflight result artifact before preserving the existing fail-closed exit behavior.

## Intentional
- No database, generator, search projection, cleanup SQL, or route behavior changes.
- Runtime pool/connection failures stay deferred; this slice only closes validation failures that are locally reproducible without a database.
- The preflight result omits token/database URL values so the artifact stays safe to share.

## Deferred
- Runtime setup failures after validation can get their own result-artifact slice if operators hit missing `asyncpg` or connection errors.

## Parked hardening
- `HARDENING.md`: SaaS demo seeder runtime setup result artifact.

## Verification
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 14 passed.
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed with 122 matching tests enrolled.
- `git diff --check` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed with 2495 passed, 7 skipped, 1 warning.

## Diff size
4 files, +165 / -0