### PR TITLE
Surface SaaS FAQ demo seeder runtime failures

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,14 +32,14 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-27
 
-### SaaS demo seeder runtime setup result artifact
+### SaaS demo seeder pool-close result preservation
 - File/location: `scripts/seed_content_ops_faq_saas_demo.py`, `_run(...)` / `main(...)`
-- Description: Pool creation or runtime seed/cleanup exceptions can still abort before `--output-result` is written.
-- Why it matters: Operators get a preflight artifact after this slice, but missing `asyncpg`, connection failures, or unexpected repository errors can still leave no machine-readable failure payload.
+- Description: If seed or cleanup succeeds but `pool.close()` raises, the runtime failure payload can replace the successful operation payload instead of reporting close failure as lifecycle metadata.
+- Why it matters: Operators get a result artifact, but a successful seed could be obscured by a close-time failure during repeated demo setup.
 - Effort: S
 - Category: correctness
 - Owner/session: content-ops/faq-generator
-- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result
+- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result review
 
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md
@@ -1,0 +1,94 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Preflight-Result made validation failures
+write `--output-result`, then parked the adjacent runtime gap: after validation,
+missing `asyncpg`, pool creation failures, repository errors, or cleanup errors
+can still abort the SaaS FAQ demo seeder before a machine-readable artifact is
+written.
+
+This production-hardening slice drains that `HARDENING.md` item so deployment
+operators get a result artifact for runtime failures as well as preflight
+failures.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add a compact runtime-failure result payload for post-validation exceptions.
+2. Write and print that payload before returning exit code `1`.
+3. Redact the configured database URL from runtime error messages before they
+   are written to output.
+4. Add focused tests for seed-mode and cleanup-mode runtime failures.
+5. Remove the drained `HARDENING.md` entry.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md` | Plan contract for this hardening slice. |
+| `HARDENING.md` | Replace the drained runtime result-artifact item with the narrower pool-close preservation follow-up. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Emit safe runtime-failure result artifacts after validation. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover seed and cleanup runtime-failure result artifacts. |
+
+## Mechanism
+
+`main()` already owns validation, output writing, and exit-code selection. After
+validation passes, it now wraps `asyncio.run(_run(args))` in a narrow
+`except Exception` block. The failure payload keeps the same shared `errors`
+list convention:
+
+```python
+{
+    "phase": "runtime",
+    "ok": False,
+    "mode": "seed" | "cleanup",
+    "errors": ["RuntimeError: ..."],
+    "error": {"type": "RuntimeError", "message": "..."},
+}
+```
+
+The message is sanitized with the exact configured database URL replaced by
+`[redacted-database-url]` before printing or writing.
+
+## Intentional
+
+- No database, generator, search projection, cleanup SQL, or route behavior
+  changes.
+- No broad lifecycle refactor; this slice only guarantees a result artifact for
+  exceptions that currently escape `main()`.
+- Exit code `1` remains the runtime failure signal, matching the existing
+  seed/cleanup failure behavior.
+
+## Deferred
+
+- Pool-close lifecycle metadata that preserves a successful seed payload while
+  separately reporting close failure is deferred until operators hit that more
+  specific case. This slice captures the failure instead of leaving no artifact.
+- Parked hardening: `SaaS demo seeder pool-close result preservation` in
+  `HARDENING.md`.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 16 passed.
+- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed with 122 matching tests enrolled.
+- `git diff --check` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed with 2497 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 94 |
+| Hardening note update | 8 |
+| Script | 38 |
+| Tests | 86 |
+| **Total** | **226** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -328,9 +328,39 @@ def _preflight_result(args: argparse.Namespace, errors: list[str]) -> dict[str, 
     }
 
 
+def _safe_error_message(args: argparse.Namespace, exc: Exception) -> str:
+    message = str(exc)
+    database_url = str(getattr(args, "database_url", "") or "").strip()
+    if database_url:
+        message = message.replace(database_url, "[redacted-database-url]")
+    return message
+
+
+def _runtime_error_result(args: argparse.Namespace, exc: Exception) -> dict[str, Any]:
+    message = _safe_error_message(args, exc)
+    error = {
+        "type": type(exc).__name__,
+        "message": message,
+    }
+    return {
+        "phase": "runtime",
+        "ok": False,
+        "mode": "cleanup" if args.cleanup_faq_id is not None else "seed",
+        "errors": [f"{error['type']}: {message}"],
+        "error": error,
+    }
+
+
 def _print_result(payload: dict[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    if payload.get("phase") == "runtime":
+        print(
+            "SaaS FAQ demo runtime: "
+            f"ok={payload['ok']} mode={payload['mode']} "
+            f"errors={len(payload['errors'])}"
+        )
         return
     if payload.get("phase") == "cleanup":
         print(
@@ -354,7 +384,13 @@ def main(argv: list[str] | None = None) -> int:
     if errors:
         _write_result(args.output_result, _preflight_result(args, errors))
         raise SystemExit("; ".join(errors))
-    payload = asyncio.run(_run(args))
+    try:
+        payload = asyncio.run(_run(args))
+    except Exception as exc:
+        payload = _runtime_error_result(args, exc)
+        _write_result(args.output_result, payload)
+        _print_result(payload, as_json=bool(args.json))
+        return 1
     _write_result(args.output_result, payload)
     _print_result(payload, as_json=bool(args.json))
     return 0 if payload["ok"] else 1

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -257,6 +257,92 @@ def test_saas_demo_cleanup_preflight_writes_result_before_exit(tmp_path) -> None
     }
 
 
+def test_saas_demo_seed_runtime_failure_writes_sanitized_result(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    database_url = "postgresql://user:secret@example.invalid/atlas"
+    result_path = tmp_path / "seed-runtime.json"
+
+    async def _raise_pool(database_url_arg):
+        raise RuntimeError(f"could not connect to {database_url_arg}")
+
+    monkeypatch.setattr(seeder, "_create_pool", _raise_pool)
+
+    code = seeder.main([
+        "--database-url",
+        database_url,
+        "--account-id",
+        "acct-demo",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    output = capsys.readouterr().out
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert database_url not in output
+    assert database_url not in result_path.read_text(encoding="utf-8")
+    assert payload == {
+        "phase": "runtime",
+        "ok": False,
+        "mode": "seed",
+        "errors": [
+            "RuntimeError: could not connect to [redacted-database-url]"
+        ],
+        "error": {
+            "type": "RuntimeError",
+            "message": "could not connect to [redacted-database-url]",
+        },
+    }
+
+
+def test_saas_demo_cleanup_runtime_failure_writes_result(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class _Pool:
+        async def close(self):
+            return None
+
+    async def _fake_pool(_database_url):
+        return _Pool()
+
+    async def _raise_cleanup(*_args, **_kwargs):
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(seeder, "_create_pool", _fake_pool)
+    monkeypatch.setattr(seeder, "cleanup_saas_demo_faq", _raise_cleanup)
+    result_path = tmp_path / "cleanup-runtime.json"
+
+    code = seeder.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--account-id",
+        "acct-demo",
+        "--cleanup-faq-id",
+        "11111111-1111-1111-1111-111111111111",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload == {
+        "phase": "runtime",
+        "ok": False,
+        "mode": "cleanup",
+        "errors": ["RuntimeError: cleanup failed"],
+        "error": {
+            "type": "RuntimeError",
+            "message": "cleanup failed",
+        },
+    }
+
+
 def test_saas_demo_cleanup_delete_status_parser() -> None:
     assert seeder._deleted_row_count("DELETE 1") == 1
     assert seeder._deleted_row_count("DELETE 0") == 0


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md
Slice phase: Production hardening

This drains the parked SaaS demo seeder runtime-result gap from `HARDENING.md`: after validation succeeds, missing `asyncpg`, pool creation failures, repository errors, or cleanup exceptions now write a safe `--output-result` payload instead of escaping with no artifact.

## Intentional
- No database, generator, search projection, cleanup SQL, or route behavior changes.
- No broad lifecycle refactor; this slice only guarantees a result artifact for exceptions that currently escape `main()`.
- Exit code `1` remains the runtime failure signal, matching the existing seed/cleanup failure behavior.

## Deferred
- Pool-close lifecycle metadata that preserves a successful seed payload while separately reporting close failure is deferred until operators hit that more specific case.

## Parked hardening
- `HARDENING.md`: SaaS demo seeder pool-close result preservation.

## Verification
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 16 passed.
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed with 122 matching tests enrolled.
- `git diff --check` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed with 2497 passed, 7 skipped, 1 warning.

## Diff size
4 files, +221 / -5