### PR TITLE
Preserve SaaS FAQ demo seeder close results

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-27
-
-### SaaS demo seeder pool-close result preservation
-- File/location: `scripts/seed_content_ops_faq_saas_demo.py`, `_run(...)` / `main(...)`
-- Description: If seed or cleanup succeeds but `pool.close()` raises, the runtime failure payload can replace the successful operation payload instead of reporting close failure as lifecycle metadata.
-- Why it matters: Operators get a result artifact, but a successful seed could be obscured by a close-time failure during repeated demo setup.
-- Effort: S
-- Category: correctness
-- Owner/session: content-ops/faq-generator
-- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result review
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md
@@ -1,0 +1,89 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Runtime-Result made runtime failures write a
+safe result artifact, but review correctly parked one narrower edge: if a SaaS
+demo seed or cleanup succeeds and `pool.close()` then raises, the seeder can
+replace the successful operation payload with a generic runtime failure. That
+makes it harder for operators to know whether the demo data was actually seeded
+or cleaned up.
+
+This slice drains that `HARDENING.md` item by preserving the primary operation
+payload and reporting close failures as lifecycle metadata.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-generator
+Slice phase: Production hardening
+
+1. Add `pool_close` lifecycle metadata to SaaS demo seeder result payloads.
+2. Preserve successful seed and cleanup payloads when close fails, while marking
+   the overall result failed.
+3. Keep post-validation runtime exception handling for pool creation and
+   operation failures unchanged.
+4. Add focused seed and cleanup tests for close-failure result preservation.
+5. Remove the drained `HARDENING.md` pool-close item.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md` | Plan contract for this hardening slice. |
+| `HARDENING.md` | Remove the drained pool-close result preservation item. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Preserve primary seeder payloads and attach pool-close metadata. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover seed and cleanup close-failure result preservation. |
+
+## Mechanism
+
+`_run(...)` now builds the primary seed/cleanup payload before closing the pool.
+The close call is wrapped separately and converted into:
+
+```python
+{"ok": false, "attempted": true, "error": {"type": "...", "message": "..."}}
+```
+
+`_with_pool_close_result(...)` attaches that lifecycle object to the primary
+payload and combines `ok = payload["ok"] and pool_close["ok"]`. If seeding or
+cleanup itself raises, the existing `main()` runtime handler still writes the
+runtime failure artifact.
+
+Close-failure messages use the same configured database URL redaction helper as
+runtime failures before the lifecycle metadata is written to disk or stdout.
+
+## Intentional
+
+- No generator, database write, cleanup SQL, search projection, or route
+  behavior changes.
+- This preserves successful seed/cleanup details but does not add retry or
+  reconnect behavior.
+- The existing runtime exception artifact remains responsible for pool creation
+  and operation failures.
+
+## Deferred
+
+- Parked hardening: none. The matching `HARDENING.md` item is removed by this
+  slice.
+
+## Verification
+
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` — 18 passed.
+- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` — passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md` — passed.
+- `git diff --check` — passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` — 122 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
+- `bash scripts/check_ascii_python.sh` — passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` — 2503 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 89 |
+| Hardening note removal | 11 |
+| Script | 71 |
+| Tests | 119 |
+| **Total** | **290** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -291,25 +291,44 @@ async def cleanup_saas_demo_faq(
 
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
     pool = await _create_pool(str(args.database_url))
+    payload: dict[str, Any] | None = None
+    close_result = _lifecycle_result(attempted=False)
+    primary_error: Exception | None = None
     try:
         if args.cleanup_faq_id is not None:
-            return await cleanup_saas_demo_faq(
+            payload = await cleanup_saas_demo_faq(
                 pool,
                 account_id=str(args.account_id),
                 faq_id=str(args.cleanup_faq_id),
             )
-        return await seed_saas_demo_faq(
-            pool,
-            account_id=str(args.account_id),
-            user_id=str(args.user_id or ""),
-            corpus_id=str(args.corpus_id),
-            target_id=str(args.target_id),
-            status=str(args.status),
-            query=str(args.query),
-            limit=int(args.limit),
-        )
+        else:
+            payload = await seed_saas_demo_faq(
+                pool,
+                account_id=str(args.account_id),
+                user_id=str(args.user_id or ""),
+                corpus_id=str(args.corpus_id),
+                target_id=str(args.target_id),
+                status=str(args.status),
+                query=str(args.query),
+                limit=int(args.limit),
+            )
+    except Exception as exc:
+        primary_error = exc
     finally:
-        await pool.close()
+        try:
+            await pool.close()
+            close_result = _lifecycle_result(attempted=True)
+        except Exception as exc:
+            close_result = _lifecycle_result(
+                attempted=True,
+                error=exc,
+                message=_safe_error_message(args, exc),
+            )
+    if primary_error is not None:
+        raise primary_error
+    if payload is None:  # pragma: no cover - defensive guard for unexpected control flow.
+        raise RuntimeError("SaaS FAQ demo seeder did not produce a result payload")
+    return _with_pool_close_result(payload, close_result)
 
 
 def _write_result(path: Path | None, payload: dict[str, Any]) -> None:
@@ -326,6 +345,34 @@ def _preflight_result(args: argparse.Namespace, errors: list[str]) -> dict[str, 
         "mode": "cleanup" if args.cleanup_faq_id is not None else "seed",
         "errors": list(errors),
     }
+
+
+def _lifecycle_result(
+    *,
+    attempted: bool,
+    error: Exception | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": error is None,
+        "attempted": attempted,
+        "error": None
+        if error is None
+        else {
+            "type": type(error).__name__,
+            "message": message if message is not None else str(error),
+        },
+    }
+
+
+def _with_pool_close_result(
+    payload: dict[str, Any],
+    close_result: dict[str, Any],
+) -> dict[str, Any]:
+    updated = dict(payload)
+    updated["pool_close"] = close_result
+    updated["ok"] = bool(payload["ok"]) and bool(close_result["ok"])
+    return updated
 
 
 def _safe_error_message(args: argparse.Namespace, exc: Exception) -> str:

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -343,6 +343,125 @@ def test_saas_demo_cleanup_runtime_failure_writes_result(
     }
 
 
+def test_saas_demo_seed_preserves_payload_when_pool_close_fails(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    database_url = "postgresql://user:secret@example.invalid/atlas"
+
+    class _Pool:
+        async def close(self):
+            raise OSError(f"pool close failed for {database_url}")
+
+    async def _fake_pool(_database_url):
+        return _Pool()
+
+    async def _seed_success(*_args, **_kwargs):
+        return {
+            "phase": "seed",
+            "ok": True,
+            "errors": [],
+            "account_id": "acct-demo",
+            "corpus_id": "synthetic-b2b-saas-demo",
+            "faq_id": "11111111-1111-1111-1111-111111111111",
+            "status": "approved",
+            "source_count": 36,
+            "ticket_source_count": 36,
+            "generated_items": 7,
+            "projected_documents": 7,
+            "search": {"query": "export attribution reports", "count": 1},
+        }
+
+    monkeypatch.setattr(seeder, "_create_pool", _fake_pool)
+    monkeypatch.setattr(seeder, "seed_saas_demo_faq", _seed_success)
+    result_path = tmp_path / "seed-close.json"
+
+    code = seeder.main([
+        "--database-url",
+        database_url,
+        "--account-id",
+        "acct-demo",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    output = capsys.readouterr().out
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert database_url not in output
+    assert database_url not in result_path.read_text(encoding="utf-8")
+    assert payload["phase"] == "seed"
+    assert payload["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["search"] == {"query": "export attribution reports", "count": 1}
+    assert payload["ok"] is False
+    assert payload["errors"] == []
+    assert payload["pool_close"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "pool close failed for [redacted-database-url]",
+        },
+    }
+
+
+def test_saas_demo_cleanup_preserves_payload_when_pool_close_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class _Pool:
+        async def close(self):
+            raise OSError("pool close failed")
+
+    async def _fake_pool(_database_url):
+        return _Pool()
+
+    async def _cleanup_success(*_args, **_kwargs):
+        return {
+            "phase": "cleanup",
+            "ok": True,
+            "errors": [],
+            "account_id": "acct-demo",
+            "faq_id": "11111111-1111-1111-1111-111111111111",
+            "deleted_faq_ids": 1,
+            "delete_status": "DELETE 1",
+        }
+
+    monkeypatch.setattr(seeder, "_create_pool", _fake_pool)
+    monkeypatch.setattr(seeder, "cleanup_saas_demo_faq", _cleanup_success)
+    result_path = tmp_path / "cleanup-close.json"
+
+    code = seeder.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--account-id",
+        "acct-demo",
+        "--cleanup-faq-id",
+        "11111111-1111-1111-1111-111111111111",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["phase"] == "cleanup"
+    assert payload["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["deleted_faq_ids"] == 1
+    assert payload["ok"] is False
+    assert payload["errors"] == []
+    assert payload["pool_close"] == {
+        "ok": False,
+        "attempted": True,
+        "error": {
+            "type": "OSError",
+            "message": "pool close failed",
+        },
+    }
+
+
 def test_saas_demo_cleanup_delete_status_parser() -> None:
     assert seeder._deleted_row_count("DELETE 1") == 1
     assert seeder._deleted_row_count("DELETE 0") == 0


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md
Slice phase: Production hardening

Preserve successful SaaS FAQ demo seed/cleanup result payloads when `pool.close()` fails, and report the close failure as redacted `pool_close` lifecycle metadata instead of replacing the primary operation result with a generic runtime artifact.

## Intentional
- No generator, database write, cleanup SQL, search projection, or route behavior changes.
- Preserve successful seed/cleanup details without adding retry or reconnect behavior.
- Keep the existing runtime exception artifact for pool creation and operation failures.

## Deferred
- Parked hardening: none; the matching `HARDENING.md` item is removed by this slice.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` — 18 passed.
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py tests/test_content_ops_faq_saas_demo_corpus.py` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Seeder-Close-Result.md` — passed.
- `git diff --check` — passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` — 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 2503 passed, 7 skipped, 1 warning.

## Diff size
4 files, +267 / -23