### PR TITLE
Embed FAQ search e2e child result summaries

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md
+++ b/plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md
@@ -1,0 +1,90 @@
+# PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries
+
+## Why this slice exists
+
+The seeded hosted FAQ search e2e runner composes the real flow: DB seed,
+hosted route concurrency, detail hydration, and cleanup. Its top-level result
+currently keeps subprocess return codes plus artifact paths, but when the
+runner uses the default temporary artifact directory those child artifact files
+are cleaned up before operators can inspect them.
+
+This slice keeps the e2e result self-diagnostic by embedding compact seed,
+route, and detail summaries before temporary artifact cleanup runs.
+
+This slightly exceeds the 400 LOC target because the checker needs focused
+negative fixtures for missing and malformed child artifacts; without those
+fixtures the new fail-closed detector would be under-proven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add compact result-artifact summaries to seed, route, and detail phases.
+2. Fail closed when a child command reports success but its requested
+   `--output-result` artifact is missing, malformed, has non-boolean `ok`, or
+   is not an object.
+3. Keep full child payload bodies out of the top-level e2e result.
+4. Preserve existing seed, route, detail, cleanup, and artifact-cleanup control
+   flow.
+5. Add focused tests for success summaries and missing-artifact detection.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md` | Plan contract for this e2e visibility slice. |
+| `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` | Attach compact child result summaries to command phase results. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Cover embedded summaries and missing child artifacts. |
+
+## Mechanism
+
+The e2e runner already passes `--output-result` to each child script. A new
+helper reads those JSON files immediately after each child command returns and
+attaches a compact `result_artifact` object to the corresponding phase.
+
+Seed summaries keep request/setup/lifecycle/latency/isolation counts. Route
+summaries keep request/latency/error/budget/case counts. Detail summaries keep
+detail-check status, count, FAQ id, timings, and errors.
+
+If the child command exited zero but its artifact is missing, malformed, or has
+an invalid `ok` type, the phase is marked `ok=false` with a result-artifact
+error so the retained e2e summary cannot falsely pass without proof.
+
+## Intentional
+
+- No hosted route, detail route, seeding, cleanup SQL, or search behavior
+  changes.
+- The top-level result remains compact; it does not duplicate full route result
+  rows or full child JSON bodies.
+- Missing artifacts from an already-failing child are reported but do not change
+  the already-failed phase semantics.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this runner.
+- A separate detail-route concurrency runner remains deferred until we have a
+  concrete hosted detail latency target.
+
+## Verification
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q — 54 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py — passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md — passed.
+- git diff --check — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . — 122 matching tests enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2508 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 89 |
+| E2E runner | 121 |
+| Tests | 240 |
+| **Total** | **451** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -287,6 +287,124 @@ def _run_command(command: Sequence[str]) -> dict[str, Any]:
     }
 
 
+def _compact_error_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {"count": 0, "items": [], "truncated": False}
+    raw_items = value.get("items")
+    items = raw_items if isinstance(raw_items, list) else []
+    count = value.get("count")
+    return {
+        "count": count if type(count) is int else 0,
+        **({"rate": value.get("rate")} if "rate" in value else {}),
+        "items": items[:5],
+        "truncated": bool(value.get("truncated")) or len(items) > 5,
+    }
+
+
+def _child_result_artifact_error(path: Path, message: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "available": False,
+        "path": str(path),
+        "errors": [message],
+    }
+
+
+def _compact_child_result_artifact(path: Path, *, kind: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return _child_result_artifact_error(path, f"result artifact could not be read: {exc}")
+    except json.JSONDecodeError as exc:
+        return _child_result_artifact_error(path, f"result artifact must contain JSON: {exc.msg}")
+    if not isinstance(payload, Mapping):
+        return _child_result_artifact_error(path, "result artifact must contain a JSON object")
+
+    raw_ok = payload.get("ok")
+    artifact_errors = []
+    if type(raw_ok) is not bool:
+        artifact_errors.append("result artifact ok must be a boolean")
+    summary: dict[str, Any] = {
+        "ok": raw_ok is True and not artifact_errors,
+        "available": True,
+        "path": str(path),
+    }
+    if artifact_errors:
+        summary["artifact_errors"] = artifact_errors
+    if kind == "seed":
+        for key in (
+            "run_id",
+            "requests",
+            "seed",
+            "setup",
+            "cleanup",
+            "pool_close",
+            "latency",
+            "latency_budget",
+            "elapsed_seconds",
+        ):
+            if key in payload:
+                summary[key] = payload[key]
+        if isinstance(payload.get("isolation"), Mapping):
+            summary["isolation"] = _compact_error_summary(payload["isolation"])
+        return summary
+    if kind == "route":
+        for key in (
+            "phase",
+            "requests",
+            "latency",
+            "budgets",
+            "preflight_errors",
+            "elapsed_seconds",
+        ):
+            if key in payload:
+                summary[key] = payload[key]
+        if isinstance(payload.get("cases"), Mapping):
+            cases = payload["cases"]
+            total = cases.get("total")
+            summary["cases"] = {
+                "total": total if type(total) is int else 0,
+                "case_file": str(cases.get("case_file") or ""),
+                "truncated": bool(cases.get("truncated")),
+            }
+        if isinstance(payload.get("errors"), Mapping):
+            summary["errors"] = _compact_error_summary(payload["errors"])
+        return summary
+    if kind == "detail":
+        for key in (
+            "phase",
+            "count",
+            "detail_checked",
+            "detail_faq_id",
+            "search_elapsed_ms",
+            "detail_elapsed_ms",
+            "total_elapsed_ms",
+            "errors",
+        ):
+            if key in payload:
+                summary[key] = payload[key]
+        if isinstance(summary.get("errors"), list):
+            summary["errors"] = summary["errors"][:10]
+        return summary
+    summary["errors"] = [f"unknown child result kind: {kind}"]
+    summary["ok"] = False
+    return summary
+
+
+def _with_result_artifact(
+    phase: dict[str, Any],
+    path: Path,
+    *,
+    kind: str,
+) -> dict[str, Any]:
+    result_artifact = _compact_child_result_artifact(path, kind=kind)
+    updated = dict(phase)
+    updated["result_artifact"] = result_artifact
+    if bool(phase.get("ok")) and not bool(result_artifact["ok"]):
+        updated["ok"] = False
+    return updated
+
+
 def _faq_ids_from_cleanup_manifest(path: Path) -> tuple[list[str], list[str]]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -520,9 +638,11 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 seed_result=seed_result,
             )
         )
+        seed = _with_result_artifact(seed, seed_result, kind="seed")
         route = _route_not_run("waiting_for_seed", ok=False)
         if seed["ok"]:
             route = _run_command(_route_command(args, case_file=case_file, route_result=route_result))
+            route = _with_result_artifact(route, route_result, kind="route")
         else:
             route = _route_not_run("seed_failed", ok=False)
         if not bool(seed["ok"]) and not bool(args.skip_detail_check):
@@ -543,6 +663,7 @@ async def _run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 detail = _run_command(
                     _detail_command(args, detail_case=detail_case, detail_result=detail_result)
                 )
+                detail = _with_result_artifact(detail, detail_result, kind="detail")
                 detail["skipped"] = False
         faq_ids, manifest_errors = (
             _faq_ids_from_cleanup_manifest(cleanup_manifest)

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -49,6 +49,76 @@ def _write_cases(path: Path, payload) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_child_result(command, *, ok: bool = True) -> None:
+    if "--output-result" not in command:
+        return
+    result_path = Path(command[command.index("--output-result") + 1])
+    if str(smoke.SEED_SCRIPT) in command:
+        _write_cases(
+            result_path,
+            {
+                "ok": ok,
+                "run_id": "seed-run-1",
+                "requests": {"total": 12, "iterations": 12, "concurrency": 4},
+                "seed": {
+                    "accounts": 1,
+                    "corpora_per_account": 2,
+                    "documents_per_corpus": 3,
+                    "search_cases": 2,
+                },
+                "setup": {"ok": ok, "phase": "complete"},
+                "cleanup": {"ok": True, "attempted": False, "error": None},
+                "pool_close": {"ok": True, "attempted": True, "error": None},
+                "latency": {"count": 12, "p50_ms": 1.0, "p95_ms": 2.0, "max_ms": 3.0},
+                "latency_budget": {"ok": True, "checks": [], "failures": []},
+                "isolation": {"count": 0, "items": [], "truncated": False},
+                "elapsed_seconds": 1.25,
+            },
+        )
+        return
+    if str(smoke.ROUTE_SCRIPT) in command:
+        _write_cases(
+            result_path,
+            {
+                "ok": ok,
+                "phase": "complete",
+                "requests": {"total": 12, "configured": 12, "concurrency": 4},
+                "latency": {"count": 12, "p50_ms": 4.0, "p95_ms": 5.0, "max_ms": 6.0},
+                "errors": {
+                    "count": 0 if ok else 1,
+                    "rate": 0.0 if ok else 0.083333,
+                    "items": [] if ok else [{"index": 0, "errors": ["bad route"]}],
+                    "truncated": False,
+                },
+                "budgets": {"ok": ok, "checks": [], "failures": [] if ok else ["error_rate exceeded 0.0"]},
+                "cases": {
+                    "total": 1,
+                    "case_file": "route-cases.json",
+                    "items": [],
+                    "truncated": False,
+                },
+                "preflight_errors": [],
+                "elapsed_seconds": 0.75,
+            },
+        )
+        return
+    if str(smoke.CONTRACT_SCRIPT) in command:
+        _write_cases(
+            result_path,
+            {
+                "ok": ok,
+                "phase": "complete",
+                "count": 1 if ok else 0,
+                "detail_checked": ok,
+                "detail_faq_id": "11111111-1111-1111-1111-111111111111" if ok else "",
+                "search_elapsed_ms": 7.0,
+                "detail_elapsed_ms": 8.0,
+                "total_elapsed_ms": 15.0,
+                "errors": [] if ok else ["detail failed"],
+            },
+        )
+
+
 def test_validate_args_reports_missing_required_fields_and_bad_numbers():
     errors = smoke._validate_args(
         _args(
@@ -222,6 +292,89 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
     assert command[command.index("--expected-detail-title") + 1] == "FAQ Search Smoke"
     assert command[command.index("--expected-detail-status") + 1] == "approved"
     assert command[command.index("--output-result") + 1] == str(detail_result)
+
+
+def test_compact_child_result_artifact_summarizes_route_without_full_case_items(tmp_path):
+    artifact = tmp_path / "route-result.json"
+    _write_cases(
+        artifact,
+        {
+            "ok": True,
+            "phase": "complete",
+            "requests": {"total": 4, "configured": 4, "concurrency": 2},
+            "latency": {"count": 4, "p50_ms": 1.0, "p95_ms": 2.0, "max_ms": 3.0},
+            "errors": {
+                "count": 6,
+                "rate": 0.5,
+                "items": [{"index": index, "errors": [f"failure {index}"]} for index in range(6)],
+                "truncated": False,
+            },
+            "budgets": {"ok": False, "failures": ["error_rate exceeded 0.0"]},
+            "cases": {
+                "total": 2,
+                "case_file": "route-cases.json",
+                "items": [{"query": "one"}, {"query": "two"}],
+                "truncated": False,
+            },
+            "elapsed_seconds": 0.5,
+        },
+    )
+
+    payload = smoke._compact_child_result_artifact(artifact, kind="route")
+
+    assert payload["ok"] is True
+    assert payload["available"] is True
+    assert payload["requests"]["total"] == 4
+    assert payload["errors"]["count"] == 6
+    assert len(payload["errors"]["items"]) == 5
+    assert payload["errors"]["truncated"] is True
+    assert payload["cases"] == {
+        "total": 2,
+        "case_file": "route-cases.json",
+        "truncated": False,
+    }
+
+
+def test_compact_child_result_artifact_rejects_non_boolean_ok(tmp_path):
+    artifact = tmp_path / "route-result.json"
+    _write_cases(
+        artifact,
+        {
+            "ok": "false",
+            "phase": "complete",
+            "requests": {"total": 1, "configured": 1, "concurrency": 1},
+            "errors": {"count": 0, "rate": 0.0, "items": [], "truncated": False},
+        },
+    )
+
+    payload = smoke._compact_child_result_artifact(artifact, kind="route")
+
+    assert payload["ok"] is False
+    assert payload["available"] is True
+    assert payload["artifact_errors"] == ["result artifact ok must be a boolean"]
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected_error"),
+    [
+        ("{bad json", "result artifact must contain JSON"),
+        ("[]", "result artifact must contain a JSON object"),
+    ],
+)
+def test_compact_child_result_artifact_rejects_malformed_artifacts(
+    tmp_path,
+    contents,
+    expected_error,
+):
+    artifact = tmp_path / "child-result.json"
+    artifact.write_text(contents, encoding="utf-8")
+
+    payload = smoke._compact_child_result_artifact(artifact, kind="route")
+
+    assert payload["ok"] is False
+    assert payload["available"] is False
+    assert payload["path"] == str(artifact)
+    assert payload["errors"][0].startswith(expected_error)
 
 
 def test_faq_ids_from_cleanup_manifest_deduplicates_expected_ids(tmp_path):
@@ -468,6 +621,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
 
     def _fake_run_command(command):
         calls.append(command)
+        _write_child_result(command)
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             route_cases = Path(command[command.index("--route-case-file-output") + 1])
@@ -524,6 +678,9 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 0
     assert payload["ok"] is True
+    assert payload["seed"]["result_artifact"]["run_id"] == "seed-run-1"
+    assert payload["route"]["result_artifact"]["requests"]["total"] == 12
+    assert payload["detail"]["result_artifact"]["detail_checked"] is True
     assert payload["detail"]["ok"] is True
     assert payload["artifacts"]["detail_result"].endswith("detail-result.json")
     assert payload["cleanup"]["deleted_faq_ids"] == 1
@@ -532,12 +689,67 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     assert str(smoke.CONTRACT_SCRIPT) in calls[2]
 
 
+def test_main_fails_when_successful_seed_missing_result_artifact(tmp_path, monkeypatch):
+    calls = []
+
+    def _fake_run_command(command):
+        calls.append(command)
+        assert str(smoke.SEED_SCRIPT) in command
+        cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
+        _write_cases(
+            cleanup_manifest,
+            {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
+        )
+        return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+
+    async def _fake_cleanup(_database_url, faq_ids):
+        return {
+            "ok": True,
+            "requested_faq_ids": len(faq_ids),
+            "deleted_faq_ids": len(faq_ids),
+            "delete_status": f"DELETE {len(faq_ids)}",
+            "errors": [],
+        }
+
+    monkeypatch.setattr(smoke, "_run_command", _fake_run_command)
+    monkeypatch.setattr(smoke, "_cleanup_seeded_faqs", _fake_cleanup)
+    result_path = tmp_path / "result.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--artifact-dir",
+        str(tmp_path / "artifacts"),
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["seed"]["ok"] is False
+    assert payload["seed"]["returncode"] == 0
+    assert payload["seed"]["result_artifact"]["available"] is False
+    assert payload["seed"]["result_artifact"]["errors"][0].startswith(
+        "result artifact could not be read:"
+    )
+    assert payload["route"]["not_run_reason"] == "seed_failed"
+    assert payload["cleanup"]["deleted_faq_ids"] == 1
+    assert len(calls) == 1
+
+
 def test_main_seed_failure_marks_route_not_run_and_still_cleans_up(tmp_path, monkeypatch):
     calls = []
 
     def _fake_run_command(command):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
+            _write_child_result(command)
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             _write_cases(
                 cleanup_manifest,
@@ -595,6 +807,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
     def _fake_run_command(command):
         calls.append(command)
         if str(smoke.SEED_SCRIPT) in command:
+            _write_child_result(command)
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             route_cases = Path(command[command.index("--route-case-file-output") + 1])
             _write_cases(
@@ -618,6 +831,7 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
                 {"faq_ids": ["11111111-1111-1111-1111-111111111111"]},
             )
             return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
+        _write_child_result(command, ok=False)
         return {"ok": False, "returncode": 1, "stdout_tail": "", "stderr_tail": "bad route"}
 
     async def _fake_cleanup(_database_url, faq_ids):
@@ -650,12 +864,10 @@ def test_main_route_failure_still_cleans_up(tmp_path, monkeypatch):
 
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 1
-    assert payload["route"] == {
-        "ok": False,
-        "returncode": 1,
-        "stdout_tail": "",
-        "stderr_tail": "bad route",
-    }
+    assert payload["route"]["ok"] is False
+    assert payload["route"]["returncode"] == 1
+    assert payload["route"]["stderr_tail"] == "bad route"
+    assert payload["route"]["result_artifact"]["errors"]["count"] == 1
     assert payload["detail"] == {
         "ok": False,
         "returncode": None,
@@ -671,6 +883,7 @@ def test_main_can_skip_detail_check_for_liveness_runs(tmp_path, monkeypatch):
 
     def _fake_run_command(command):
         calls.append(command)
+        _write_child_result(command)
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             _write_cases(
@@ -722,6 +935,7 @@ def test_main_can_skip_detail_check_for_liveness_runs(tmp_path, monkeypatch):
 
 def test_main_reports_cleanup_failure(tmp_path, monkeypatch):
     def _fake_run_command(command):
+        _write_child_result(command)
         if str(smoke.SEED_SCRIPT) in command:
             cleanup_manifest = Path(command[command.index("--cleanup-manifest-output") + 1])
             route_cases = Path(command[command.index("--route-case-file-output") + 1])
@@ -822,12 +1036,14 @@ def test_main_reports_artifact_cleanup_failure_without_masking_seed_failure(
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 1
     assert payload["ok"] is False
-    assert payload["seed"] == {
-        "ok": False,
-        "returncode": 1,
-        "stdout_tail": "",
-        "stderr_tail": "bad seed",
-    }
+    assert payload["seed"]["ok"] is False
+    assert payload["seed"]["returncode"] == 1
+    assert payload["seed"]["stdout_tail"] == ""
+    assert payload["seed"]["stderr_tail"] == "bad seed"
+    assert payload["seed"]["result_artifact"]["available"] is False
+    assert payload["seed"]["result_artifact"]["errors"][0].startswith(
+        "result artifact could not be read:"
+    )
     assert payload["route"]["not_run_reason"] == "seed_failed"
     assert payload["detail"]["not_run_reason"] == "seed_failed"
     assert payload["cleanup"] == {


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md
Slice phase: Production hardening

Embed compact seed, route, and detail child result summaries into the retained seeded hosted FAQ search e2e result so operators can diagnose failures even when the default temporary artifact directory is cleaned up. Review update: child artifact `ok` must now be a real boolean, so malformed `{"ok":"false"}` artifacts fail closed instead of truthiness-passing.

## Intentional
- No hosted route, detail route, seeding, cleanup SQL, or search behavior changes.
- Keep the top-level result compact; do not duplicate full child JSON bodies.
- Report missing artifacts from an already-failing child without changing the already-failed phase semantics.

## Deferred
- Parked hardening: none. `HARDENING.md` has no active FAQ search entries touching this runner.
- Detail-route concurrency remains deferred until there is a concrete hosted detail latency target.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` — 54 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Child-Result-Summaries.md` — passed.
- `git diff --check` — passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` — 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 2508 passed, 7 skipped, 1 warning.

## Diff size
3 files, +439 / -12