### PR TITLE
PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md
@@ -1,0 +1,84 @@
+# PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency
+
+## Why this slice exists
+
+The hosted FAQ search concurrency smoke pressures compact search reads, and the
+seeded e2e proves one search result can hydrate through the detail route. The
+demo flow uses both together: concurrent users search, select a result, and
+hydrate the full generated FAQ report.
+
+This slice adds the thinnest opt-in hosted detail check to the existing route
+concurrency smoke so operators can pressure that real read path without a new
+runner or any data-seeding behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Add `--require-detail` and `--detail-route` to the hosted FAQ search route
+   concurrency smoke.
+2. When enabled, fetch the first result's FAQ detail after each successful
+   search response and validate the canonical detail envelope.
+3. Include compact detail status in per-request rows and the summary payload.
+4. Keep latency budgets opt-in and unchanged; elapsed request time includes any
+   detail fetch when detail mode is enabled.
+5. Add focused fixtures for successful detail hydration, missing FAQ ids, and
+   malformed detail envelopes.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md` | Plan contract for this detail-read concurrency slice. |
+| `scripts/smoke_content_ops_faq_search_route_concurrency.py` | Add opt-in detail hydration validation to the hosted concurrency smoke. |
+| `tests/test_smoke_content_ops_faq_search_route_concurrency.py` | Cover detail success and fail-closed detail branches. |
+
+## Mechanism
+
+`_run_one(...)` keeps its existing search request and envelope checks. If
+`--require-detail` is set and search validation produced no errors, it extracts
+`results[0].faq_id`, builds the detail URL with the shared contract checker, and
+validates the response with the same `contract._validate_detail(...)` helper
+used by the single-request checker.
+
+Per-request rows gain `detail_checked`, `detail_faq_id`, and
+`detail_elapsed_ms`. The summary reports how many requests attempted detail and
+how many detail checks failed.
+
+## Intentional
+
+- No new route, database, seeding, cleanup, or detail schema behavior.
+- No default detail mode; existing search-only concurrency behavior is
+  unchanged unless operators pass `--require-detail`.
+- No default latency SLO. Existing p95/max request budgets remain caller-owned
+  and include detail work when detail mode is enabled.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this runner.
+- Detail-specific latency budgets remain deferred until we have a concrete
+  hosted detail target.
+
+## Verification
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q — 46 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py — passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md — passed.
+- git diff --check — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . — 122 matching tests enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2515 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 84 |
+| Route concurrency smoke | 74 |
+| Tests | 190 |
+| **Total** | **348** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -69,6 +69,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--status", default=os.environ.get("ATLAS_FAQ_SEARCH_STATUS", ""))
     parser.add_argument("--limit", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_LIMIT", "5"))
     parser.add_argument("--route", default=contract.DEFAULT_ROUTE)
+    parser.add_argument("--detail-route", default=os.environ.get("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--timeout", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_TIMEOUT", "10"))
     parser.add_argument("--requests", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_REQUESTS", "12"))
     parser.add_argument("--concurrency", type=int, default=os.environ.get("ATLAS_FAQ_SEARCH_CONCURRENCY", "4"))
@@ -78,6 +79,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
+    parser.add_argument("--require-detail", action="store_true")
     parser.add_argument("--case-file", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
@@ -223,6 +225,10 @@ def _run_one(
     started = time.perf_counter()
     errors: list[str] = []
     count: int | None = None
+    detail_checked = False
+    detail_elapsed_ms: float | None = None
+    detail_errors: list[str] = []
+    detail_faq_id: str | None = None
     active_case = _default_case(args) if case is None else case
     try:
         url = contract._build_url(
@@ -243,10 +249,34 @@ def _run_one(
         errors.extend(_expected_case_errors(payload, active_case))
         if type(payload.get("count")) is int:
             count = int(payload["count"])
+        if bool(args.require_detail) and not errors:
+            detail_faq_id = contract._first_result_faq_id(payload)
+            if detail_faq_id is None:
+                detail_errors.append("results[0].faq_id is required when --require-detail is set")
+            else:
+                detail_url = contract._build_detail_url(
+                    base_url=str(args.base_url),
+                    route=str(args.route),
+                    detail_route=str(args.detail_route or ""),
+                    faq_id=detail_faq_id,
+                )
+                try:
+                    detail_payload, detail_elapsed_ms = contract._timed_fetch_json(
+                        detail_url,
+                        token=str(args.token).strip(),
+                        timeout=float(args.timeout),
+                    )
+                    detail_checked = True
+                    detail_errors.extend(
+                        contract._validate_detail(detail_payload, faq_id=detail_faq_id)
+                    )
+                except (RuntimeError, OSError, TypeError, ValueError) as exc:
+                    detail_errors.append(f"{type(exc).__name__}: {exc}")
+            errors.extend(detail_errors)
     except (RuntimeError, OSError, TypeError, ValueError) as exc:
         errors.append(f"{type(exc).__name__}: {exc}")
     elapsed_ms = max(0.0, (time.perf_counter() - started) * 1000)
-    return {
+    row = {
         "index": index,
         "ok": not errors,
         "count": count,
@@ -255,6 +285,18 @@ def _run_one(
         "case_index": int(active_case.get("case_index", 0)),
         "case": _case_snapshot(active_case),
     }
+    if bool(args.require_detail):
+        row.update(
+            {
+                "detail_checked": detail_checked,
+                "detail_faq_id": detail_faq_id,
+                "detail_elapsed_ms": (
+                    round(detail_elapsed_ms, 6) if detail_elapsed_ms is not None else None
+                ),
+                "detail_errors": detail_errors,
+            }
+        )
+    return row
 
 
 def _run_concurrent(
@@ -313,6 +355,30 @@ def _error_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _detail_summary(
+    results: Sequence[Mapping[str, Any]], *, required: bool
+) -> dict[str, Any]:
+    if not required:
+        return {"required": False, "checked": 0, "failures": 0, "items": []}
+
+    failures = [
+        {
+            "index": row.get("index"),
+            "faq_id": row.get("detail_faq_id"),
+            "errors": row.get("detail_errors"),
+        }
+        for row in results
+        if row.get("detail_errors")
+    ]
+    return {
+        "required": True,
+        "checked": sum(1 for row in results if row.get("detail_checked") is True),
+        "failures": len(failures),
+        "items": failures[:20],
+        "truncated": len(failures) > 20,
+    }
+
+
 def _budget_summary(
     *,
     latency: Mapping[str, Any],
@@ -366,6 +432,7 @@ def _summary_payload(
         "status": str(args.status or ""),
         "limit": int(args.limit),
         "require_results": bool(args.require_results),
+        "require_detail": bool(args.require_detail),
         "cases": {
             "total": len(active_cases),
             "case_file": str(args.case_file or ""),
@@ -379,6 +446,7 @@ def _summary_payload(
         },
         "latency": latency,
         "errors": errors,
+        "detail": _detail_summary(results, required=bool(args.require_detail)),
         "budgets": budgets,
         "preflight_errors": list(preflight_errors),
         "elapsed_seconds": round(elapsed_seconds, 6),
@@ -401,7 +469,9 @@ def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
         "FAQ search hosted concurrency smoke: "
         f"ok={summary['ok']} requests={summary['requests']['total']} "
         f"errors={summary['errors']['count']} p95_ms={latency['p95_ms']} "
-        f"max_ms={latency['max_ms']} budget_failures={len(summary['budgets']['failures'])}"
+        f"max_ms={latency['max_ms']} detail_checked={summary['detail']['checked']} "
+        f"detail_failures={summary['detail']['failures']} "
+        f"budget_failures={len(summary['budgets']['failures'])}"
     )
 
 

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -40,6 +40,7 @@ def _args(**overrides):
         "status": "",
         "limit": 5,
         "route": "/api/v1/content-ops/faq-deflection-search",
+        "detail_route": "",
         "timeout": 10.0,
         "requests": 4,
         "concurrency": 2,
@@ -47,6 +48,7 @@ def _args(**overrides):
         "max_p95_ms": None,
         "max_single_request_ms": None,
         "require_results": True,
+        "require_detail": False,
         "case_file": None,
         "output_result": None,
         "json": False,
@@ -72,6 +74,24 @@ def _valid_payload():
             }
         ],
         "count": 1,
+    }
+
+
+def _valid_detail_payload(faq_id="11111111-1111-1111-1111-111111111111"):
+    return {
+        "account_id": "acct-1",
+        "id": faq_id,
+        "target_id": "corpus-1",
+        "target_mode": "faq_report",
+        "title": "Mortgage servicing issues",
+        "markdown": "# Mortgage servicing issues\n\nDraft answer.",
+        "items": [],
+        "source_count": 1,
+        "ticket_source_count": 4,
+        "output_checks": {},
+        "warnings": [],
+        "metadata": {},
+        "status": "published",
     }
 
 
@@ -119,6 +139,21 @@ def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe()
 
     assert required.require_results is True
     assert liveness_only.require_results is False
+
+
+def test_parser_accepts_opt_in_detail_route_check():
+    parsed = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-detail",
+        "--detail-route",
+        "/api/v1/content-ops/faq-deflection-reports/{faq_id}",
+    ])
+
+    assert parsed.require_detail is True
+    assert parsed.detail_route == "/api/v1/content-ops/faq-deflection-reports/{faq_id}"
 
 
 def test_load_cases_defaults_to_cli_case():
@@ -267,6 +302,38 @@ def test_latency_and_error_summaries_are_compact():
     }
 
 
+def test_detail_summary_reports_required_detail_failures():
+    results = [
+        {"index": 0, "detail_checked": True, "detail_faq_id": "faq-1", "detail_errors": []},
+        {
+            "index": 1,
+            "detail_checked": False,
+            "detail_faq_id": "faq-2",
+            "detail_errors": ["RuntimeError: route request failed"],
+        },
+    ]
+
+    assert smoke._detail_summary(results, required=True) == {
+        "required": True,
+        "checked": 1,
+        "failures": 1,
+        "items": [
+            {
+                "index": 1,
+                "faq_id": "faq-2",
+                "errors": ["RuntimeError: route request failed"],
+            }
+        ],
+        "truncated": False,
+    }
+    assert smoke._detail_summary(results, required=False) == {
+        "required": False,
+        "checked": 0,
+        "failures": 0,
+        "items": [],
+    }
+
+
 def test_budget_summary_reports_error_and_latency_failures():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},
@@ -315,6 +382,129 @@ def test_run_one_validates_contract_and_records_count(monkeypatch):
             "require_results": True,
         },
     }
+
+
+def test_run_one_fetches_and_validates_detail_when_required(monkeypatch):
+    responses = iter([
+        _json_response(_valid_payload()),
+        _json_response(_valid_detail_payload()),
+    ])
+    urls = []
+
+    def _fake_urlopen(request, **_kwargs):
+        urls.append(request.full_url)
+        return next(responses)
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    result = smoke._run_one(0, _args(require_detail=True))
+
+    assert result["ok"] is True
+    assert result["detail_checked"] is True
+    assert result["detail_faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert result["detail_errors"] == []
+    assert urls == [
+        (
+            "https://atlas.example.com/api/v1/content-ops/faq-deflection-search"
+            "?q=mortgage+dispute&limit=5"
+        ),
+        (
+            "https://atlas.example.com/api/v1/content-ops/faq-deflection-search/"
+            "11111111-1111-1111-1111-111111111111"
+        ),
+    ]
+
+
+def test_run_one_uses_detail_route_template_when_required(monkeypatch):
+    responses = iter([
+        _json_response(_valid_payload()),
+        _json_response(_valid_detail_payload()),
+    ])
+    urls = []
+
+    def _fake_urlopen(request, **_kwargs):
+        urls.append(request.full_url)
+        return next(responses)
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    result = smoke._run_one(
+        0,
+        _args(
+            require_detail=True,
+            detail_route="/api/v1/content-ops/faq-deflection-reports/{faq_id}",
+        ),
+    )
+
+    assert result["ok"] is True
+    assert urls[-1] == (
+        "https://atlas.example.com/api/v1/content-ops/faq-deflection-reports/"
+        "11111111-1111-1111-1111-111111111111"
+    )
+
+
+def test_run_one_requires_faq_id_for_detail_check(monkeypatch):
+    payload = _valid_payload()
+    del payload["results"][0]["faq_id"]
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _json_response(payload),
+    )
+
+    result = smoke._run_one(0, _args(require_detail=True))
+
+    assert result["ok"] is False
+    assert result["detail_checked"] is False
+    assert result["detail_faq_id"] is None
+    assert result["detail_errors"] == [
+        "results[0].faq_id is required when --require-detail is set"
+    ]
+    assert result["errors"] == result["detail_errors"]
+
+
+def test_run_one_rejects_malformed_detail_envelope(monkeypatch):
+    responses = iter([
+        _json_response(_valid_payload()),
+        _json_response(_valid_detail_payload("22222222-2222-2222-2222-222222222222")),
+    ])
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: next(responses),
+    )
+
+    result = smoke._run_one(0, _args(require_detail=True))
+
+    assert result["ok"] is False
+    assert result["detail_checked"] is True
+    assert result["detail_errors"] == ["detail.id must match results[0].faq_id"]
+    assert result["errors"] == ["detail.id must match results[0].faq_id"]
+
+
+def test_run_one_records_detail_transport_failures(monkeypatch):
+    calls = iter([
+        _json_response(_valid_payload()),
+        smoke.contract.urllib.error.URLError("detail unavailable"),
+    ])
+
+    def _fake_urlopen(*_args, **_kwargs):
+        value = next(calls)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    result = smoke._run_one(0, _args(require_detail=True))
+
+    assert result["ok"] is False
+    assert result["detail_checked"] is False
+    assert result["detail_faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert result["detail_errors"] == [
+        "RuntimeError: route request failed: detail unavailable"
+    ]
+    assert result["errors"] == result["detail_errors"]
 
 
 def test_run_one_captures_fetch_and_contract_errors(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md
Slice phase: Robust testing

The hosted FAQ search concurrency smoke now has an opt-in detail hydration mode so operators can pressure the real demo read path: concurrent search, selected FAQ id extraction, and full generated FAQ detail validation.

## Intentional
- Detail hydration is opt-in behind --require-detail; search-only concurrency behavior remains unchanged.
- Existing p95/max request budgets stay caller-owned and include detail work only when detail mode is enabled.

## Deferred
- Detail-specific latency budgets remain deferred until there is a concrete hosted detail target.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 46 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py - passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md - passed.
- python scripts/audit_plan_doc_diff_size.py plans/PR-Content-Ops-FAQ-Search-Route-Detail-Concurrency.md origin/main - passed.
- git diff --check - passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - 122 matching tests enrolled.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 2515 passed, 7 skipped, 1 warning.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> - passed.

## Diff size
3 files, +346 / -2