### PR TITLE
Add Content Ops cache policy request contract

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -44,6 +44,7 @@ from ..content_ops_input_provider import (
     ContentOpsInputProvider,
     merge_content_ops_input_package,
 )
+from ..content_ops_cache_policy import normalize_content_ops_cache_policy
 from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
@@ -461,6 +462,7 @@ if BaseModel is not None:
         max_cost_usd: float | None = Field(default=None, gt=0)
         account_usage_budget_usd: float | None = Field(default=None, gt=0)
         account_usage_budget_days: int = Field(7, ge=1, le=90)
+        content_ops_cache_policy: str | None = Field(default=None, max_length=40)
         inputs: dict[str, Any] = Field(default_factory=dict, max_length=_MAX_INPUT_KEYS)
         ingestion_profile: str = Field("domain_specific", min_length=1, max_length=80)
         require_quality_gates: bool = True
@@ -484,6 +486,14 @@ if BaseModel is not None:
                 text = value.strip()
                 return text or None
             return value
+
+        @field_validator("content_ops_cache_policy")
+        @classmethod
+        def _normalize_content_ops_cache_policy(cls, value: Any) -> str | None:
+            try:
+                return normalize_content_ops_cache_policy(value)
+            except ValueError as exc:
+                raise ValueError(str(exc)) from exc
 
         @field_validator("inputs")
         @classmethod

--- a/extracted_content_pipeline/content_ops_cache_policy.py
+++ b/extracted_content_pipeline/content_ops_cache_policy.py
@@ -93,19 +93,22 @@ class ContentOpsExactCachePolicy:
     ) -> ContentOpsCacheDecision:
         del messages  # Future adapter may use a redacted/digest-only envelope.
         values = dict(metadata or {})
-        requested_policy = _policy_value(
-            values.get("content_ops_cache_policy") or values.get("cache_policy")
-        )
+        try:
+            requested_policy = normalize_content_ops_cache_policy(
+                values.get("content_ops_cache_policy") or values.get("cache_policy")
+            )
+        except ValueError:
+            requested_policy = "unsupported"
         asset_type = _clean_text(values.get("asset_type"))
         account_id = _clean_text(values.get("account_id"))
 
-        if requested_policy in NO_STORE_POLICY_VALUES:
+        if requested_policy == "no_store":
             return ContentOpsCacheDecision("no_store", "policy_no_store")
         if not self.exact_cache_enabled:
             return ContentOpsCacheDecision("no_store", "exact_cache_disabled")
         if not requested_policy:
             return ContentOpsCacheDecision("no_store", "policy_no_store")
-        if requested_policy and requested_policy not in EXACT_POLICY_VALUES:
+        if requested_policy != "exact":
             return ContentOpsCacheDecision("no_store", "unsupported_cache_policy")
         if not account_id:
             return ContentOpsCacheDecision("no_store", "missing_account_scope")
@@ -124,6 +127,19 @@ class ContentOpsExactCachePolicy:
             namespace=namespace,
             account_id=account_id,
         )
+
+
+def normalize_content_ops_cache_policy(value: Any) -> str | None:
+    """Return the canonical request cache policy, or raise for unsupported input."""
+
+    text = _policy_value(value)
+    if not text:
+        return None
+    if text in NO_STORE_POLICY_VALUES:
+        return "no_store"
+    if text in EXACT_POLICY_VALUES:
+        return "exact"
+    raise ValueError(f"unsupported content_ops_cache_policy: {value!r}")
 
 
 def _clean_text(value: Any) -> str:

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -375,6 +375,8 @@ def _request_trace_metadata(
     request: ContentOpsRequest,
 ) -> dict[str, str]:
     metadata = _scope_trace_metadata(scope)
+    if request.content_ops_cache_policy:
+        metadata["content_ops_cache_policy"] = request.content_ops_cache_policy
     if _inputs_use_support_ticket_source(request.inputs):
         metadata.update({
             "source_type": SUPPORT_TICKET_SOURCE_MARKER,

--- a/extracted_content_pipeline/content_ops_input_provider.py
+++ b/extracted_content_pipeline/content_ops_input_provider.py
@@ -26,6 +26,7 @@ _REQUEST_KEYS = frozenset({
     "max_cost_usd",
     "account_usage_budget_usd",
     "account_usage_budget_days",
+    "content_ops_cache_policy",
     "inputs",
     "ingestion_profile",
     "require_quality_gates",

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
+from .content_ops_cache_policy import normalize_content_ops_cache_policy
 from .landing_page_repair_contract import (
     LANDING_PAGE_QUALITY_REPAIR_ATTEMPTS_DEFAULT,
     landing_page_quality_repair_attempts_from_inputs,
@@ -59,6 +60,7 @@ class ContentOpsRequest:
     max_cost_usd: float | None = None
     account_usage_budget_usd: float | None = None
     account_usage_budget_days: int = 7
+    content_ops_cache_policy: str | None = None
     inputs: Mapping[str, Any] = field(default_factory=dict)
     ingestion_profile: str = "domain_specific"
     require_quality_gates: bool = True
@@ -99,6 +101,9 @@ class ControlSurfacePreview:
                 ),
                 "account_usage_budget_days": (
                     self.normalized_request.account_usage_budget_days
+                ),
+                "content_ops_cache_policy": (
+                    self.normalized_request.content_ops_cache_policy
                 ),
                 "ingestion_profile": self.normalized_request.ingestion_profile,
                 "require_quality_gates": self.normalized_request.require_quality_gates,
@@ -318,6 +323,9 @@ def request_from_mapping(payload: Mapping[str, Any]) -> ContentOpsRequest:
         max_cost_usd=max_cost_usd,
         account_usage_budget_usd=account_usage_budget_usd,
         account_usage_budget_days=account_usage_budget_days,
+        content_ops_cache_policy=normalize_content_ops_cache_policy(
+            payload.get("content_ops_cache_policy")
+        ),
         inputs=raw_inputs if isinstance(raw_inputs, Mapping) else {},
         ingestion_profile=str(payload.get("ingestion_profile") or "domain_specific").strip()
         or "domain_specific",
@@ -530,6 +538,7 @@ def preview_control_surface(request: ContentOpsRequest) -> ControlSurfacePreview
         max_cost_usd=request.max_cost_usd,
         account_usage_budget_usd=request.account_usage_budget_usd,
         account_usage_budget_days=request.account_usage_budget_days,
+        content_ops_cache_policy=request.content_ops_cache_policy,
         inputs=request.inputs,
         ingestion_profile=request.ingestion_profile,
         require_quality_gates=request.require_quality_gates,

--- a/plans/PR-Content-Ops-Cache-Policy-Request.md
+++ b/plans/PR-Content-Ops-Cache-Policy-Request.md
@@ -1,0 +1,105 @@
+# PR: Content Ops Cache Policy Request
+
+## Why this slice exists
+
+Content Ops exact-cache policy and adapter wiring now exist, and the usage UI
+shows cache savings once they are recorded. The remaining backend gap is the
+request contract: operators and upstream ingestion layers cannot explicitly ask
+for Content Ops exact cache or no-store behavior through the normal
+preview/plan/execute payload.
+
+This slice adds the first-class request field and routes it into the existing
+policy decision path. It does not add UI controls yet; the backend contract
+should be stable and tested before the UI exposes it.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a normalized `content_ops_cache_policy` request field to
+   `ContentOpsRequest`.
+2. Validate and normalize accepted policy values at the control-surface and API
+   boundary.
+3. Preserve the policy field through input-provider request merges.
+4. Thread the normalized policy into Content Ops LLM trace metadata so the
+   existing `ContentOpsExactCachePolicy` and adapter see the operator request.
+5. Keep support-ticket/customer-data no-store behavior unchanged.
+6. Add focused tests for request normalization, API response shaping,
+   input-provider preservation, and execution trace-policy handoff.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Policy-Request.md` | Plan doc for the backend cache policy request contract. |
+| `extracted_content_pipeline/content_ops_cache_policy.py` | Expose a canonical cache-policy request normalizer used by the request boundary and policy decision. |
+| `extracted_content_pipeline/control_surfaces.py` | Add the normalized request field and include it in preview/plan normalized request payloads. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Validate and normalize the API request model field. |
+| `extracted_content_pipeline/content_ops_input_provider.py` | Preserve the cache policy field through provider request merges. |
+| `extracted_content_pipeline/content_ops_execution.py` | Add the normalized policy to shared LLM trace context before generation calls. |
+| `tests/test_extracted_content_ops_cache_policy.py` | Cover canonical request-policy normalization. |
+| `tests/test_extracted_content_control_surfaces.py` | Cover request normalization and rejection of unsupported values. |
+| `tests/test_extracted_content_control_surface_api.py` | Cover API normalized-request response shaping for the cache policy field. |
+| `tests/test_extracted_content_ops_input_provider.py` | Cover cache policy preservation through input-provider merge. |
+| `tests/test_extracted_content_ops_execution.py` | Cover exact-cache request metadata reaching the existing policy path while support-ticket data remains no-store. |
+
+## Mechanism
+
+`content_ops_cache_policy.py` becomes the single source for normalizing request
+policy text. Accepted exact-cache spellings normalize to `exact`; accepted
+no-store spellings normalize to `no_store`; blank values remain `None`; unknown
+values raise `ValueError` at request boundaries.
+
+`ContentOpsRequest` carries `content_ops_cache_policy`. `request_from_mapping`
+normalizes it, `ContentOpsRequestModel` validates it for HTTP routes, and
+`ContentOpsInputProvider` keeps it in the request-level allowlist so upstream
+packages do not drop the operator's cache choice.
+
+Execution adds the normalized policy to the existing shared LLM trace context.
+`PipelineLLMClient` already merges scoped metadata into
+`ContentOpsExactCachePolicy.decide`, so this keeps the cache decision in one
+existing source of truth instead of adding a separate cache rule layer.
+
+## Intentional
+
+- This does not add frontend controls. The backend request field lands first so
+  a UI slice can call a stable contract.
+- This does not loosen support-ticket/customer-data cache safety. Even when an
+  operator requests `exact`, support-ticket markers still produce
+  `customer_data_no_store`.
+- This does not add a new cache policy implementation. The new request field is
+  routed into the existing `ContentOpsExactCachePolicy`.
+- This does not persist a tenant-level default cache setting. The field is
+  explicit per request.
+
+## Deferred
+
+- Future PR: Content Ops UI cache controls once the backend request contract is
+  merged and review-approved.
+- Future PR: persisted tenant defaults if operators need always-on cache
+  posture instead of per-run choices.
+- Future PR: redacted/digest-only cache envelopes for support-ticket/customer
+  source material if customer-data caching becomes a product requirement.
+- Parked hardening: none planned.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_normalizes_cache_policy_field tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_rejects_unknown_cache_policy_field tests/test_extracted_content_ops_input_provider.py::test_merge_input_package_preserves_explicit_cache_policy tests/test_extracted_content_ops_execution.py::test_execute_marks_support_ticket_trace_context_for_cache_policy -q — 50 passed.
+- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/content_ops_input_provider.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_ops_execution.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2515 passed, 7 skipped, 1 warning.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_policy_request_body.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~105 |
+| Request/policy/API/provider/execution wiring | ~95 |
+| Focused tests | ~150 |
+| **Total** | **~350** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -800,6 +800,45 @@ async def test_preview_generation_route_returns_preflight_plan():
 
 
 @pytest.mark.asyncio
+async def test_preview_generation_route_normalizes_cache_policy_field():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {"topic": "Support-ticket questions customers keep asking"},
+            "content_ops_cache_policy": "no-store",
+        }
+    )
+
+    assert payload["can_run"] is True
+    assert payload["normalized_request"]["content_ops_cache_policy"] == "no_store"
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_rejects_unknown_cache_policy_field():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["blog_post"],
+                "inputs": {"topic": "Support-ticket questions customers keep asking"},
+                "content_ops_cache_policy": "semantic",
+            }
+        )
+
+    assert exc.value.status_code == 422
+    assert "unsupported content_ops_cache_policy" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_preview_generation_route_blocks_budget_between_base_and_retry_cost():
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -45,6 +45,32 @@ def test_preview_allows_implemented_outputs_under_budget():
     assert preview["blocked_outputs"] == []
     assert preview["normalized_request"]["account_usage_budget_usd"] is None
     assert preview["normalized_request"]["account_usage_budget_days"] == 7
+    assert preview["normalized_request"]["content_ops_cache_policy"] is None
+
+
+def test_request_normalizes_content_ops_cache_policy():
+    request = request_from_mapping({
+        "outputs": ["blog_post"],
+        "content_ops_cache_policy": "exact-cache",
+        "inputs": {"topic": "Support ticket questions"},
+    })
+    preview = preview_from_mapping({
+        "outputs": ["blog_post"],
+        "content_ops_cache_policy": "exact-cache",
+        "inputs": {"topic": "Support ticket questions"},
+    })
+
+    assert request.content_ops_cache_policy == "exact"
+    assert preview["normalized_request"]["content_ops_cache_policy"] == "exact"
+
+
+def test_request_rejects_unsupported_content_ops_cache_policy():
+    with pytest.raises(ValueError, match="unsupported content_ops_cache_policy"):
+        request_from_mapping({
+            "outputs": ["blog_post"],
+            "content_ops_cache_policy": "semantic",
+            "inputs": {"topic": "Support ticket questions"},
+        })
 
 
 def test_preview_blocks_unknown_preset_instead_of_falling_back_to_email():

--- a/tests/test_extracted_content_ops_cache_policy.py
+++ b/tests/test_extracted_content_ops_cache_policy.py
@@ -2,7 +2,25 @@ from types import SimpleNamespace
 
 from extracted_content_pipeline.content_ops_cache_policy import (
     ContentOpsExactCachePolicy,
+    normalize_content_ops_cache_policy,
 )
+
+
+def test_normalize_content_ops_cache_policy_returns_canonical_values():
+    assert normalize_content_ops_cache_policy(None) is None
+    assert normalize_content_ops_cache_policy(" exact-cache ") == "exact"
+    assert normalize_content_ops_cache_policy("exact_cache") == "exact"
+    assert normalize_content_ops_cache_policy("no-store") == "no_store"
+    assert normalize_content_ops_cache_policy("off") == "no_store"
+
+
+def test_normalize_content_ops_cache_policy_rejects_unsupported_value():
+    try:
+        normalize_content_ops_cache_policy("semantic")
+    except ValueError as exc:
+        assert "unsupported content_ops_cache_policy" in str(exc)
+    else:
+        raise AssertionError("expected unsupported cache policy to raise")
 
 
 def test_policy_defaults_to_no_store_when_exact_cache_disabled():

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -407,6 +407,7 @@ async def test_execute_marks_support_ticket_trace_context_for_cache_policy() -> 
     result = await execute_content_ops_from_mapping(
         {
             "outputs": ["blog_post"],
+            "content_ops_cache_policy": "exact-cache",
             "inputs": {
                 "topic": "Support-ticket questions customers keep asking",
                 "filters": {"topic_type": "content_ops_support_ticket_faq"},
@@ -423,6 +424,7 @@ async def test_execute_marks_support_ticket_trace_context_for_cache_policy() -> 
     assert trace_context == {
         "account_id": "acct-1",
         "user_id": "user-1",
+        "content_ops_cache_policy": "exact",
         "source_type": "support_ticket",
         "input_provider": "support_ticket_provider",
     }
@@ -433,7 +435,6 @@ async def test_execute_marks_support_ticket_trace_context_for_cache_policy() -> 
         "skill_name": "digest/blog_post_generation",
         "asset_type": "blog_post",
         "attempt_no": 1,
-        "content_ops_cache_policy": "exact",
     })
     assert decision.mode == "no_store"
     assert decision.reason == "customer_data_no_store"

--- a/tests/test_extracted_content_ops_input_provider.py
+++ b/tests/test_extracted_content_ops_input_provider.py
@@ -142,6 +142,31 @@ def test_merge_input_package_preserves_explicit_account_usage_budget() -> None:
     assert request.account_usage_budget_days == 14
 
 
+def test_merge_input_package_preserves_explicit_cache_policy() -> None:
+    package = ContentOpsInputPackage(
+        provider="ticket_import",
+        outputs=("landing_page",),
+        inputs={
+            "source_material": _source_material(),
+            "offer": "Provider offer",
+            "audience": "Provider audience",
+        },
+    )
+
+    payload = merge_content_ops_input_package(
+        {
+            "outputs": ["landing_page"],
+            "content_ops_cache_policy": "exact-cache",
+            "inputs": {"offer": "Operator offer"},
+        },
+        package,
+    )
+    request = request_from_mapping(payload)
+
+    assert payload["content_ops_cache_policy"] == "exact-cache"
+    assert request.content_ops_cache_policy == "exact"
+
+
 def test_merge_input_package_ignores_null_request_overrides() -> None:
     package = ContentOpsInputPackage(
         provider="ticket_import",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Policy-Request.md
Slice phase: Production hardening

Add a first-class Content Ops cache policy request field so preview/plan/execute payloads and input-provider-backed flows can explicitly request exact cache or no-store behavior through the existing policy and adapter path.

## Intentional
- This does not add frontend controls; the backend request field lands first so the UI can call a stable contract.
- This does not loosen support-ticket/customer-data cache safety. Even with `exact`, support-ticket markers still produce `customer_data_no_store`.
- This does not add a new cache policy implementation. The request field routes into `ContentOpsExactCachePolicy`.
- This does not persist tenant-level cache defaults.

## Deferred
- Future PR: Content Ops UI cache controls once this backend request contract is merged.
- Future PR: persisted tenant defaults if operators need always-on cache posture.
- Future PR: redacted/digest-only cache envelopes for support-ticket/customer source material if customer-data caching becomes required.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_normalizes_cache_policy_field tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_rejects_unknown_cache_policy_field tests/test_extracted_content_ops_input_provider.py::test_merge_input_package_preserves_explicit_cache_policy tests/test_extracted_content_ops_execution.py::test_execute_marks_support_ticket_trace_context_for_cache_policy -q — 50 passed.
- python -m compileall -q extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/api/control_surfaces.py extracted_content_pipeline/content_ops_input_provider.py extracted_content_pipeline/content_ops_execution.py tests/test_extracted_content_ops_cache_policy.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_input_provider.py tests/test_extracted_content_ops_execution.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- bash scripts/run_extracted_pipeline_checks.sh — 2515 passed, 7 skipped, 1 warning.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_policy_request_body.md — passed.

## Diff size
11 files, +257 / -6.