### PR TITLE
Add Content Ops cache policy UI control

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -11,6 +11,7 @@
     "test:content-ops-ingestion-limits": "node --test scripts/content-ops-ingestion-limits.test.mjs",
     "test:content-ops-ingestion-routing": "node --test scripts/content-ops-ingestion-routing.test.mjs",
     "test:content-ops-input-display": "node --test scripts/content-ops-input-display.test.mjs",
+    "test:content-ops-cache-policy-ui": "node --test scripts/content-ops-cache-policy-ui.test.mjs",
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-cache-policy-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-cache-policy-ui.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function loadTsModule(path) {
+  const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fromWirePreview,
+  fromWireRequest,
+  toWireRequest,
+} = await loadTsModule('../src/domain/contentOps/fromWire.ts')
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+test('cache policy request field round-trips through domain mapping', () => {
+  const domain = fromWireRequest({
+    target_mode: 'vendor_retention',
+    outputs: ['landing_page'],
+    content_ops_cache_policy: 'exact',
+    inputs: { target_keyword: 'support tickets' },
+  })
+
+  assert.equal(domain.contentOpsCachePolicy, 'exact')
+
+  const wire = toWireRequest(domain)
+  assert.equal(wire.content_ops_cache_policy, 'exact')
+})
+
+test('cache policy defaults to no explicit request', () => {
+  const domain = fromWireRequest({})
+
+  assert.equal(domain.contentOpsCachePolicy, null)
+  assert.equal(toWireRequest(domain).content_ops_cache_policy, null)
+})
+
+test('preview mapper preserves normalized cache policy', () => {
+  const preview = fromWirePreview({
+    can_run: true,
+    outputs: ['blog_post'],
+    estimated_cost_usd: 0.75,
+    missing_inputs: [],
+    blocked_outputs: [],
+    warnings: [],
+    normalized_request: {
+      outputs: ['blog_post'],
+      content_ops_cache_policy: 'no_store',
+    },
+  })
+
+  assert.equal(preview.normalizedRequest?.contentOpsCachePolicy, 'no_store')
+})
+
+test('new run options panel exposes cache policy control', () => {
+  assert.ok(newRunSource.includes('Cache policy'))
+  assert.ok(newRunSource.includes('contentOpsCachePolicy'))
+  assert.ok(newRunSource.includes('<option value="exact">Exact cache</option>'))
+  assert.ok(newRunSource.includes('<option value="no_store">No store</option>'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -181,6 +181,7 @@ export interface ContentOpsRequestBody {
   max_cost_usd?: number | null
   account_usage_budget_usd?: number | null
   account_usage_budget_days?: number
+  content_ops_cache_policy?: string | null
   inputs?: Record<string, unknown>
   ingestion_profile?: string                       // default "domain_specific"
   require_quality_gates?: boolean                  // default true

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -45,6 +45,7 @@ import type {
   ContentOpsUsageSummaryBreakdown,
   ContentOpsUsageBudgetEvaluation,
   CampaignReasoningContextView,
+  ContentOpsCachePolicy,
   ContentOpsRequest,
   ContentOpsStepExecution,
   ControlSurfacePresetView,
@@ -248,6 +249,7 @@ export function fromWireRequest(
     maxCostUsd: wire.max_cost_usd ?? null,
     accountUsageBudgetUsd: wire.account_usage_budget_usd ?? null,
     accountUsageBudgetDays: wire.account_usage_budget_days ?? 7,
+    contentOpsCachePolicy: normalizedCachePolicy(wire.content_ops_cache_policy),
     inputs: { ...(wire.inputs ?? {}) },
     ingestionProfile: wire.ingestion_profile ?? 'domain_specific',
     requireQualityGates: wire.require_quality_gates ?? true,
@@ -270,11 +272,16 @@ export function toWireRequest(
     max_cost_usd: domain.maxCostUsd,
     account_usage_budget_usd: domain.accountUsageBudgetUsd,
     account_usage_budget_days: domain.accountUsageBudgetDays,
+    content_ops_cache_policy: domain.contentOpsCachePolicy,
     inputs: { ...domain.inputs },
     ingestion_profile: domain.ingestionProfile,
     require_quality_gates: domain.requireQualityGates,
     allow_unimplemented_outputs: domain.allowUnimplementedOutputs,
   }
+}
+
+function normalizedCachePolicy(value: unknown): ContentOpsCachePolicy | null {
+  return value === 'exact' || value === 'no_store' ? value : null
 }
 
 // ---------------------------------------------------------------------------
@@ -376,6 +383,9 @@ export function fromWirePreview(
             wire.normalized_request.account_usage_budget_usd ?? null,
           accountUsageBudgetDays:
             wire.normalized_request.account_usage_budget_days ?? 7,
+          contentOpsCachePolicy: normalizedCachePolicy(
+            wire.normalized_request.content_ops_cache_policy,
+          ),
           ingestionProfile:
             wire.normalized_request.ingestion_profile ?? 'domain_specific',
           requireQualityGates:

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -7,6 +7,7 @@
 
 export type {
   CampaignReasoningContextView,
+  ContentOpsCachePolicy,
   ContentOpsCatalog,
   ContentOpsIngestionDiagnostics,
   ContentOpsIngestionImportRequest,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -147,6 +147,8 @@ export interface ContentOpsUsageSummary {
 // Request (POST /content-ops/{preview, plan, execute} body)
 // ---------------------------------------------------------------------------
 
+export type ContentOpsCachePolicy = 'exact' | 'no_store'
+
 export interface ContentOpsRequest {
   targetMode: string
   preset: string | null
@@ -155,6 +157,7 @@ export interface ContentOpsRequest {
   maxCostUsd: number | null
   accountUsageBudgetUsd: number | null
   accountUsageBudgetDays: number
+  contentOpsCachePolicy: ContentOpsCachePolicy | null
   inputs: Record<string, unknown>
   ingestionProfile: string
   requireQualityGates: boolean

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -37,6 +37,7 @@ import {
   toWireIngestionImportRequest,
   toWireRequest,
   type ContentOpsCatalog,
+  type ContentOpsCachePolicy,
   type ContentOpsIngestionDiagnostics,
   type ContentOpsIngestionImportResponse,
   type ContentOpsExecutionResult,
@@ -1324,6 +1325,28 @@ export default function ContentOpsNewRun() {
               />
               <span className="mt-1 block text-xs text-slate-500">
                 Uses account-scoped Content Ops usage for this lookback window.
+              </span>
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Cache policy</span>
+              <select
+                value={request.contentOpsCachePolicy ?? ''}
+                onChange={(e) => {
+                  const value = e.target.value as ContentOpsCachePolicy | ''
+                  setRequest((p) => ({
+                    ...p,
+                    contentOpsCachePolicy: value === '' ? null : value,
+                  }))
+                  markStale()
+                }}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-slate-200 focus:border-cyan-500 focus:outline-none"
+              >
+                <option value="">Backend default</option>
+                <option value="no_store">No store</option>
+                <option value="exact">Exact cache</option>
+              </select>
+              <span className="mt-1 block text-xs text-slate-500">
+                Exact cache only applies when backend policy allows the request.
               </span>
             </label>
             <label className="block text-sm">

--- a/plans/PR-Content-Ops-Cache-Policy-UI.md
+++ b/plans/PR-Content-Ops-Cache-Policy-UI.md
@@ -1,0 +1,87 @@
+# PR: Content Ops Cache Policy UI
+
+## Why this slice exists
+
+PR-Content-Ops-Cache-Policy-Request added the backend
+`content_ops_cache_policy` contract and routed it into the existing Content Ops
+exact-cache policy. The New Run UI still cannot set that field, so operators
+cannot intentionally request exact cache or explicit no-store behavior from the
+product surface.
+
+This slice closes the UI half of that contract without changing backend cache
+behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Add frontend wire/domain support for `content_ops_cache_policy`.
+2. Preserve the field through request mapping and preview normalized-request
+   mapping.
+3. Add a compact cache-policy select to the existing New Run Options panel.
+4. Keep the default safe: no explicit cache request unless the operator selects
+   one.
+5. Add a focused Node test for request round-trip, preview mapping, and UI
+   control wiring.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Policy-UI.md` | Plan doc for the frontend cache-policy controls. |
+| `atlas-intel-ui/package.json` | Add a focused cache-policy UI contract test script. |
+| `atlas-intel-ui/scripts/content-ops-cache-policy-ui.test.mjs` | Cover request mapping, preview mapping, and New Run control wiring. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Add wire request field. |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | Add cache policy domain type and request field. |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | Map cache policy in request and preview normalized-request flows. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Export the cache policy domain type. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Add the Options-panel cache policy select. |
+
+## Mechanism
+
+The frontend keeps the backend's normalized values: `exact`, `no_store`, or
+`null`. `fromWireRequest` and `fromWirePreview` read
+`content_ops_cache_policy`; `toWireRequest` sends the camelCase domain field
+back as the backend snake-case field.
+
+`ContentOpsNewRun` renders a select in the existing Options grid. The blank
+option leaves `contentOpsCachePolicy` as `null`, preserving current behavior.
+Choosing no-store or exact sends the explicit backend value through the same
+preview/plan/execute request object.
+
+## Intentional
+
+- This does not change backend cache eligibility or support-ticket/customer-data
+  no-store rules.
+- This does not add tenant-level persisted defaults.
+- This does not expose namespace or customer-data cache toggles. The UI only
+  sends the existing safe request policy field.
+- This keeps the control in the existing Options panel instead of adding a new
+  section.
+
+## Deferred
+
+- Future PR: persisted tenant cache defaults if operators need always-on
+  posture instead of per-run choices.
+- Future PR: richer cache diagnostics if operators need to see why a request was
+  no-store after execution.
+- Parked hardening: none planned.
+
+## Verification
+
+- npm --prefix atlas-intel-ui run test:content-ops-cache-policy-ui — 4 passed.
+- npm --prefix atlas-intel-ui run build — passed.
+- npm --prefix atlas-intel-ui run lint — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_policy_ui_body.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| API/domain mapping | ~20 |
+| UI control | ~30 |
+| Test/package hook | ~85 |
+| **Total** | **~240** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Policy-UI.md
Slice phase: Product polish

Expose the backend `content_ops_cache_policy` request contract in the Content Ops New Run UI, with domain/wire mapping and a compact Options-panel select for backend default, no-store, or exact cache.

## Intentional
- This does not change backend cache eligibility or support-ticket/customer-data no-store rules.
- This does not add tenant-level persisted defaults.
- This does not expose namespace or customer-data cache toggles; it only sends the existing safe request policy field.
- This keeps the control in the existing Options panel.

## Deferred
- Future PR: persisted tenant cache defaults if operators need always-on posture instead of per-run choices.
- Future PR: richer cache diagnostics if operators need to see why a request was no-store after execution.

## Parked hardening
- None.

## Verification
- npm --prefix atlas-intel-ui run test:content-ops-cache-policy-ui — 4 passed.
- npm --prefix atlas-intel-ui run build — passed.
- npm --prefix atlas-intel-ui run lint — passed.
- git diff --check — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_policy_ui_body.md — passed.

## Diff size
8 files, +200 / -0.