### PR TITLE
PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-27
-
-### Reject Contradictory FAQ Route Detail Concurrency Flags
-- File/location: `scripts/smoke_content_ops_faq_search_route_concurrency.py` argument preflight.
-- Description: `--require-detail --allow-empty-results` currently fails loudly per request instead of rejecting the contradictory flags before the run starts.
-- Why it matters: Preflight rejection would make operator mistakes clearer and avoid spending concurrency requests on a configuration that cannot hydrate detail rows.
-- Effort: S
-- Category: polish
-- Owner/session: Codex FAQ lane
-- Found during: PR #1025 review follow-up while starting the next FAQ search slice.
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md
+++ b/plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md
@@ -1,0 +1,86 @@
+# PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight
+
+## Why this slice exists
+
+PR #1025 added opt-in hosted detail hydration to the FAQ search route
+concurrency smoke. Review flagged one non-blocking polish gap: operators can
+combine `--require-detail` with `--allow-empty-results`, which is
+self-contradictory because detail hydration requires `results[0].faq_id`.
+
+That gap was parked in `HARDENING.md`. This slice drains that parked item with a
+small preflight guard so the runner rejects the bad configuration before making
+concurrent hosted requests.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Product polish
+
+1. Add an argument preflight error when `--require-detail` is used while result
+   rows are not required.
+2. Cover the negative branch directly in `_validate_args(...)`.
+3. Cover the CLI `main(...)` preflight result artifact so the failure is visible
+   without issuing network requests.
+4. Remove the now-drained `HARDENING.md` entry.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md` | Plan contract for this polish slice. |
+| `HARDENING.md` | Remove the drained parked hardening item. |
+| `scripts/smoke_content_ops_faq_search_route_concurrency.py` | Add the contradictory flag preflight guard. |
+| `tests/test_smoke_content_ops_faq_search_route_concurrency.py` | Add focused preflight and result-artifact coverage. |
+
+## Mechanism
+
+`_validate_args(...)` already owns runner-level preflight validation. This slice
+adds one guard:
+
+```python
+if args.require_detail and not args.require_results:
+    errors.append("--require-detail requires result rows; remove --allow-empty-results")
+```
+
+`main(...)` already writes preflight summaries before returning exit code 2, so
+the existing result path will carry the new error without changing summary
+shape or runtime request behavior.
+
+## Intentional
+
+- No search route, detail route, contract checker, database, or concurrency
+  worker behavior changes.
+- No case-file semantic changes. Case rows still control per-query
+  `require_results`; this guard only rejects the impossible global detail mode
+  with globally allowed empty results.
+- No new hardening entries; this PR drains the only active FAQ/search parked
+  item.
+
+## Deferred
+
+- Parked hardening: none.
+- Per-case detail expectations remain out of scope; the route contract and
+  seeded e2e cover detail-field assertions.
+
+## Verification
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q — 48 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py — passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md — passed.
+- git diff --check — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py . — 122 matching tests enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2541 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 86 |
+| HARDENING cleanup | 11 |
+| Runner guard | 2 |
+| Tests | 41 |
+| **Total** | **140** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -105,6 +105,8 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("--timeout must be positive")
     if not 0 <= float(args.max_error_rate) <= 1:
         errors.append("--max-error-rate must be between 0 and 1")
+    if bool(args.require_detail) and not bool(args.require_results):
+        errors.append("--require-detail requires result rows; remove --allow-empty-results")
     for name in ("max_p95_ms", "max_single_request_ms"):
         value = getattr(args, name)
         if value is not None and float(value) <= 0:

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -147,6 +147,14 @@ def test_validate_args_reports_preflight_errors():
     ]
 
 
+def test_validate_args_rejects_detail_without_required_results():
+    errors = smoke._validate_args(_args(require_detail=True, require_results=False))
+
+    assert errors == [
+        "--require-detail requires result rows; remove --allow-empty-results"
+    ]
+
+
 def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe():
     required = smoke._build_parser().parse_args([
         "--base-url",
@@ -790,6 +798,39 @@ def test_main_writes_case_file_preflight_result(tmp_path, capsys):
     assert payload["cases"]["case_file"] == str(case_file)
     assert payload["cases"]["total"] == 0
     assert payload["preflight_errors"] == ["case[0].limit must be a positive integer"]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_rejects_detail_with_allowed_empty_results_before_network(tmp_path, monkeypatch, capsys):
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _unexpected_urlopen(*_args, **_kwargs):
+        raise AssertionError("preflight failures must not issue route requests")
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _unexpected_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-detail",
+        "--allow-empty-results",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["require_detail"] is True
+    assert payload["require_results"] is False
+    assert payload["requests"]["total"] == 0
+    assert payload["preflight_errors"] == [
+        "--require-detail requires result rows; remove --allow-empty-results"
+    ]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md
Slice phase: Product polish

The hosted FAQ search route concurrency smoke now rejects the contradictory --require-detail --allow-empty-results configuration during preflight instead of spending hosted requests on a run that cannot hydrate details.

## Intentional
- Only runner preflight behavior changes; no hosted route, detail route, contract checker, database, or worker behavior changes.
- Case-file semantics are unchanged; this guard rejects only the impossible global detail mode with globally allowed empty results.

## Deferred
- Per-case detail expectations remain out of scope; the route contract and seeded e2e cover detail-field assertions.

## Parked hardening
- None. This drains the only active FAQ/search HARDENING.md item.

## Verification
- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py -q - 48 passed.
- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py - passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Detail-Empty-Results-Preflight.md - passed.
- git diff --check - passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . - 122 matching tests enrolled.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - 2541 passed, 7 skipped, 1 warning.
- bash scripts/local_pr_review.sh --current-pr-body-file <body> - passed.

## Diff size
4 files, +129 / -11