### PR TITLE
Add Content Ops cache diagnostics summary

### DIFF
--- a/extracted_content_pipeline/content_ops_usage_summary.py
+++ b/extracted_content_pipeline/content_ops_usage_summary.py
@@ -103,6 +103,32 @@ async def summarize_content_ops_llm_usage(
         """,
         *args,
     )
+    by_cache_status = await pool.fetch(
+        f"""
+        SELECT
+            COALESCE(NULLIF(BTRIM(metadata ->> 'cache_mode'), ''), 'unknown') AS cache_mode,
+            COALESCE(NULLIF(BTRIM(metadata ->> 'cache_reason'), ''), 'unknown') AS cache_reason,
+            COALESCE(NULLIF(BTRIM(metadata ->> 'cache_result'), ''), 'unknown') AS cache_result,
+            COALESCE(NULLIF(BTRIM(metadata ->> 'cache_store_result'), ''), 'unknown') AS cache_store_result,
+            COALESCE(SUM(cost_usd), 0) AS cost_usd,
+            COALESCE(SUM(
+                CASE
+                    WHEN jsonb_typeof(metadata -> 'cache_savings_usd') = 'number'
+                    THEN (metadata ->> 'cache_savings_usd')::FLOAT
+                    ELSE 0
+                END
+            ), 0)::FLOAT AS cache_savings_usd,
+            COUNT(*)::BIGINT AS calls,
+            COALESCE(SUM(input_tokens), 0)::BIGINT AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT AS output_tokens
+        FROM llm_usage
+        WHERE {where_sql}
+        GROUP BY cache_mode, cache_reason, cache_result, cache_store_result
+        ORDER BY calls DESC, cost_usd DESC
+        LIMIT 20
+        """,
+        *args,
+    )
     return {
         "period_days": resolved_days,
         "filters": filters.as_dict(),
@@ -110,6 +136,18 @@ async def summarize_content_ops_llm_usage(
         "by_model": [_breakdown_payload(row, label_keys=("provider", "model")) for row in by_model],
         "by_asset_type": [
             _breakdown_payload(row, label_keys=("asset_type",)) for row in by_asset_type
+        ],
+        "by_cache_status": [
+            _breakdown_payload(
+                row,
+                label_keys=(
+                    "cache_mode",
+                    "cache_reason",
+                    "cache_result",
+                    "cache_store_result",
+                ),
+            )
+            for row in by_cache_status
         ],
     }
 

--- a/plans/PR-Content-Ops-Cache-Diagnostics-Summary.md
+++ b/plans/PR-Content-Ops-Cache-Diagnostics-Summary.md
@@ -1,0 +1,90 @@
+# PR: Content Ops Cache Diagnostics Summary
+
+## Why this slice exists
+
+Content Ops now has an exact-cache policy, adapter, savings rollup, and UI
+control. Operators can see total cache hits and avoided spend, but they still
+cannot tell why cache did or did not apply: disabled, explicit no-store,
+customer-data no-store, miss, hit, store error, and so on.
+
+This slice adds the backend read model for those diagnostics in the existing
+usage summary payload. The UI can render the breakdown in a follow-up without
+guessing from raw `llm_usage.metadata`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a `by_cache_status` breakdown to `summarize_content_ops_llm_usage`.
+2. Group by cache mode, cache reason, cache result, and cache store result from
+   Content Ops LLM trace metadata.
+3. Reuse the same account/run/request/asset filters as the existing summary,
+   model, and asset rollups.
+4. Include calls, cost, token totals, and cache savings in each diagnostic row.
+5. Add focused fake-pool and Postgres tests for payload shape, account
+   filtering, and numeric cache-savings guarding.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Diagnostics-Summary.md` | Plan doc for the cache diagnostics summary backend slice. |
+| `extracted_content_pipeline/content_ops_usage_summary.py` | Add the cache-status usage summary query and payload mapper. |
+| `tests/test_extracted_content_ops_usage_summary.py` | Cover summary query shape and Postgres diagnostic rollup payloads. |
+| `tests/test_extracted_content_control_surface_api.py` | Pin the API route payload shape with cache diagnostic rows. |
+
+## Mechanism
+
+The summary helper runs a third grouped query after `by_model` and
+`by_asset_type`. It projects:
+
+- `metadata ->> 'cache_mode'`
+- `metadata ->> 'cache_reason'`
+- `metadata ->> 'cache_result'`
+- `metadata ->> 'cache_store_result'`
+
+Blank values become `unknown`, matching existing model/asset breakdown
+conventions. Each row carries `cost_usd`, `cache_savings_usd`, `calls`,
+`input_tokens`, and `output_tokens`. The `cache_savings_usd` expression keeps
+the existing guarded numeric JSON check so malformed metadata cannot break the
+summary query.
+
+## Intentional
+
+- This does not add UI rendering yet. The backend read model lands first so the
+  next UI slice can consume a stable field.
+- This does not change cache policy, cache lookup/store behavior, or trace
+  metadata names.
+- This does not expose raw prompts, responses, or arbitrary metadata.
+- This keeps diagnostics in the existing usage summary endpoint instead of
+  adding a new route.
+
+## Deferred
+
+- Future PR: render `by_cache_status` in the Intel UI usage area.
+- Future PR: persisted tenant cache defaults if operators need always-on cache
+  posture.
+- Parked hardening: none. Root `HARDENING.md` was scanned; the current
+  parked item belongs to the FAQ lane, not this cost-surfacing slice.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters -q — 3 passed, 2 skipped.
+- python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2539 passed, 7 skipped, 1 warning.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_diagnostics_summary_body.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Usage summary query/payload | ~45 |
+| Tests | ~95 |
+| **Total** | **~235** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -180,14 +180,28 @@ class _UsagePool:
                     "output_tokens": 200,
                 }
             ]
+        if "GROUP BY asset_type" in str(query):
+            return [
+                {
+                    "asset_type": "blog_post",
+                    "cost_usd": Decimal("0.750000"),
+                    "cache_savings_usd": Decimal("0.0123"),
+                    "calls": 2,
+                    "input_tokens": 600,
+                    "output_tokens": 150,
+                }
+            ]
         return [
             {
-                "asset_type": "blog_post",
-                "cost_usd": Decimal("0.750000"),
+                "cache_mode": "exact",
+                "cache_reason": "eligible",
+                "cache_result": "hit",
+                "cache_store_result": "unknown",
+                "cost_usd": Decimal("0.000000"),
                 "cache_savings_usd": Decimal("0.0123"),
                 "calls": 2,
-                "input_tokens": 600,
-                "output_tokens": 150,
+                "input_tokens": 0,
+                "output_tokens": 0,
             }
         ]
 
@@ -434,6 +448,19 @@ async def test_usage_summary_route_returns_content_ops_llm_rollup_with_filters()
             "output_tokens": 150,
         }
     ]
+    assert payload["by_cache_status"] == [
+        {
+            "cache_mode": "exact",
+            "cache_reason": "eligible",
+            "cache_result": "hit",
+            "cache_store_result": "unknown",
+            "cost_usd": 0.0,
+            "cache_savings_usd": 0.0123,
+            "calls": 2,
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+    ]
     summary_query, summary_args = pool.fetchrow_calls[0]
     assert "span_name = 'content_ops.llm.complete'" in summary_query
     assert "metadata ->> 'product' = 'content_ops'" in summary_query
@@ -441,7 +468,7 @@ async def test_usage_summary_route_returns_content_ops_llm_rollup_with_filters()
     assert "(run_id = $3 OR metadata ->> 'run_id' = $3)" in summary_query
     assert "metadata ->> 'request_id' = $4" in summary_query
     assert summary_args == (14, "blog_post", "run-123", "req-456")
-    assert len(pool.fetch_calls) == 2
+    assert len(pool.fetch_calls) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_ops_usage_summary.py
+++ b/tests/test_extracted_content_ops_usage_summary.py
@@ -64,6 +64,11 @@ async def test_content_ops_usage_summary_filters_by_account_id_in_sql() -> None:
     assert args == (14, "acct-123", "landing_page", "run-1", "req-1")
     assert pool.fetch_calls[0][1] == args
     assert pool.fetch_calls[1][1] == args
+    assert pool.fetch_calls[2][1] == args
+    assert "metadata ->> 'cache_mode'" in pool.fetch_calls[2][0]
+    assert "GROUP BY cache_mode, cache_reason, cache_result, cache_store_result" in (
+        pool.fetch_calls[2][0]
+    )
     assert payload["filters"] == {
         "account_id": "acct-123",
         "asset_type": "landing_page",
@@ -131,6 +136,9 @@ async def test_content_ops_usage_summary_contract_against_postgres() -> None:
                         "product": "content_ops",
                         "asset_type": "blog_post",
                         "request_id": request_id,
+                        "cache_mode": "exact",
+                        "cache_reason": "eligible",
+                        "cache_result": "hit",
                         "cache_savings_usd": 0.0123,
                     }),
                     "run-a",
@@ -152,6 +160,8 @@ async def test_content_ops_usage_summary_contract_against_postgres() -> None:
                         "product": "content_ops",
                         "asset_type": "blog_post",
                         "request_id": request_id,
+                        "cache_mode": "no_store",
+                        "cache_reason": "exact_cache_disabled",
                         "cache_savings_usd": "not-a-number",
                     }),
                     "run-a",
@@ -219,6 +229,30 @@ async def test_content_ops_usage_summary_contract_against_postgres() -> None:
                 "output_tokens": 50,
             }
         ]
+        assert payload["by_cache_status"] == [
+            {
+                "cache_mode": "exact",
+                "cache_reason": "eligible",
+                "cache_result": "hit",
+                "cache_store_result": "unknown",
+                "cost_usd": 0.1,
+                "cache_savings_usd": 0.0123,
+                "calls": 1,
+                "input_tokens": 100,
+                "output_tokens": 40,
+            },
+            {
+                "cache_mode": "no_store",
+                "cache_reason": "exact_cache_disabled",
+                "cache_result": "unknown",
+                "cache_store_result": "unknown",
+                "cost_usd": 0.05,
+                "cache_savings_usd": 0.0,
+                "calls": 1,
+                "input_tokens": 30,
+                "output_tokens": 10,
+            },
+        ]
     finally:
         await pool.execute(
             "DELETE FROM llm_usage WHERE metadata ->> 'request_id' = $1",
@@ -279,6 +313,10 @@ async def test_content_ops_usage_summary_isolates_accounts_against_postgres() ->
                         "account_id": account_a,
                         "asset_type": "blog_post",
                         "request_id": request_id,
+                        "cache_mode": "exact",
+                        "cache_reason": "eligible",
+                        "cache_result": "miss",
+                        "cache_store_result": "stored",
                         "cache_savings_usd": 0.01,
                     }),
                     "run-a",
@@ -301,6 +339,9 @@ async def test_content_ops_usage_summary_isolates_accounts_against_postgres() ->
                         "account_id": account_a,
                         "asset_type": "landing_page",
                         "request_id": request_id,
+                        "cache_mode": "exact",
+                        "cache_reason": "eligible",
+                        "cache_result": "hit",
                         "cache_savings_usd": 0.02,
                     }),
                     "run-a",
@@ -323,6 +364,8 @@ async def test_content_ops_usage_summary_isolates_accounts_against_postgres() ->
                         "account_id": account_b,
                         "asset_type": "blog_post",
                         "request_id": request_id,
+                        "cache_mode": "no_store",
+                        "cache_reason": "customer_data_no_store",
                         "cache_savings_usd": 0.05,
                     }),
                     "run-b",
@@ -353,6 +396,10 @@ async def test_content_ops_usage_summary_isolates_accounts_against_postgres() ->
             "blog_post",
             "landing_page",
         }
+        assert {row["cache_result"] for row in account_a_payload["by_cache_status"]} == {
+            "hit",
+            "miss",
+        }
 
         assert account_b_payload["summary"]["total_cost_usd"] == 0.5
         assert account_b_payload["summary"]["total_cache_savings_usd"] == 0.05
@@ -363,6 +410,19 @@ async def test_content_ops_usage_summary_isolates_accounts_against_postgres() ->
         assert account_b_payload["by_asset_type"] == [
             {
                 "asset_type": "blog_post",
+                "cost_usd": 0.5,
+                "cache_savings_usd": 0.05,
+                "calls": 1,
+                "input_tokens": 500,
+                "output_tokens": 100,
+            }
+        ]
+        assert account_b_payload["by_cache_status"] == [
+            {
+                "cache_mode": "no_store",
+                "cache_reason": "customer_data_no_store",
+                "cache_result": "unknown",
+                "cache_store_result": "unknown",
                 "cost_usd": 0.5,
                 "cache_savings_usd": 0.05,
                 "calls": 1,


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Diagnostics-Summary.md
Slice phase: Production hardening

Content Ops usage now reports cache savings, but operators still cannot diagnose why exact cache did or did not apply. This PR adds the backend `by_cache_status` read model to the existing usage summary payload so a follow-up UI slice can render cache mode, reason, lookup result, store result, cost, savings, calls, and tokens without reading raw metadata.

## Intentional
- Backend read model only; UI rendering is deferred to the next slice.
- No cache policy, lookup, store, or trace metadata name changes.
- No raw prompt, response, or arbitrary metadata exposure.
- Diagnostics stay on the existing usage summary endpoint instead of adding a new route.

## Deferred
- Future PR: render `by_cache_status` in the Intel UI usage area.
- Future PR: persisted tenant cache defaults if operators need always-on cache posture.

## Parked hardening
- None. Root `HARDENING.md` was scanned; the current parked item belongs to the FAQ lane, not this cost-surfacing slice.

## Verification
- `python -m pytest tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters -q` — 3 passed, 2 skipped.
- `python -m compileall -q extracted_content_pipeline/content_ops_usage_summary.py tests/test_extracted_content_ops_usage_summary.py tests/test_extracted_content_control_surface_api.py` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 2539 passed, 7 skipped, 1 warning.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas_pr_cache_diagnostics_summary_body.md` — passed.

## Diff size
4 files, +219 / -5 (~235 LOC estimated).
