### PR TITLE
Show Content Ops cache diagnostics in usage card

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs
@@ -39,6 +39,11 @@ const { fromWireUsageSummary } = await loadTsModule(
   '../src/domain/contentOps/fromWire.ts',
 )
 
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
 function installBrowserStubs() {
   Object.defineProperty(globalThis, 'localStorage', {
     configurable: true,
@@ -107,6 +112,19 @@ function usageSummaryPayload() {
         output_tokens: 25,
       },
     ],
+    by_cache_status: [
+      {
+        cache_mode: 'exact',
+        cache_reason: 'eligible',
+        cache_result: 'hit',
+        cache_store_result: 'unknown',
+        cost_usd: 0,
+        cache_savings_usd: 0.1234,
+        calls: 3,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ],
   }
 }
 
@@ -160,4 +178,24 @@ test('fromWireUsageSummary maps usage payload to domain shape', () => {
   assert.equal(summary.byAssetType[0].assetType, 'landing_page')
   assert.equal(summary.byAssetType[0].cacheSavingsUsd, 0.3)
   assert.equal(summary.byAssetType[0].calls, 7)
+  assert.equal(summary.byCacheStatus[0].cacheMode, 'exact')
+  assert.equal(summary.byCacheStatus[0].cacheReason, 'eligible')
+  assert.equal(summary.byCacheStatus[0].cacheResult, 'hit')
+  assert.equal(summary.byCacheStatus[0].cacheStoreResult, 'unknown')
+  assert.equal(summary.byCacheStatus[0].cacheSavingsUsd, 0.1234)
+})
+
+test('fromWireUsageSummary defaults missing cache diagnostics to empty list', () => {
+  const payload = usageSummaryPayload()
+  delete payload.by_cache_status
+
+  const summary = fromWireUsageSummary(payload)
+
+  assert.deepEqual(summary.byCacheStatus, [])
+})
+
+test('new run usage card exposes cache diagnostics section', () => {
+  assert.ok(newRunSource.includes('Cache diagnostics'))
+  assert.ok(newRunSource.includes('formatCacheDiagnosticLabel'))
+  assert.ok(newRunSource.includes('byCacheStatus.slice(0, 3)'))
 })

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -137,6 +137,10 @@ export interface ContentOpsUsageSummaryBreakdownResponse {
   provider?: string
   model?: string
   asset_type?: string
+  cache_mode?: string
+  cache_reason?: string
+  cache_result?: string
+  cache_store_result?: string
   cost_usd: number
   cache_savings_usd: number
   calls: number
@@ -169,6 +173,7 @@ export interface ContentOpsUsageSummaryResponse {
   }
   by_model: ContentOpsUsageSummaryBreakdownResponse[]
   by_asset_type: ContentOpsUsageSummaryBreakdownResponse[]
+  by_cache_status?: ContentOpsUsageSummaryBreakdownResponse[]
 }
 
 // POST /content-ops/preview, /plan, /execute share this body shape.

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -211,6 +211,9 @@ export function fromWireUsageSummary(
     },
     byModel: wire.by_model.map(fromWireUsageSummaryBreakdown),
     byAssetType: wire.by_asset_type.map(fromWireUsageSummaryBreakdown),
+    byCacheStatus: (wire.by_cache_status ?? []).map(
+      fromWireUsageSummaryBreakdown,
+    ),
   }
 }
 
@@ -221,6 +224,10 @@ function fromWireUsageSummaryBreakdown(
     provider: wire.provider,
     model: wire.model,
     assetType: wire.asset_type,
+    cacheMode: wire.cache_mode,
+    cacheReason: wire.cache_reason,
+    cacheResult: wire.cache_result,
+    cacheStoreResult: wire.cache_store_result,
     costUsd: wire.cost_usd,
     cacheSavingsUsd: wire.cache_savings_usd,
     calls: wire.calls,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -128,6 +128,10 @@ export interface ContentOpsUsageSummaryBreakdown {
   provider?: string
   model?: string
   assetType?: string
+  cacheMode?: string
+  cacheReason?: string
+  cacheResult?: string
+  cacheStoreResult?: string
   costUsd: number
   cacheSavingsUsd: number
   calls: number
@@ -141,6 +145,7 @@ export interface ContentOpsUsageSummary {
   summary: ContentOpsUsageSummaryTotals
   byModel: ContentOpsUsageSummaryBreakdown[]
   byAssetType: ContentOpsUsageSummaryBreakdown[]
+  byCacheStatus: ContentOpsUsageSummaryBreakdown[]
 }
 
 // ---------------------------------------------------------------------------

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -44,6 +44,7 @@ import {
   type ContentOpsInputProviderDiagnostics,
   type ContentOpsInputContractView,
   type ContentOpsRequest,
+  type ContentOpsUsageSummaryBreakdown,
   type ContentOpsUsageSummary,
   type CampaignReasoningContextView,
   type ContentOpsStepReasoningAudit,
@@ -1488,6 +1489,7 @@ function UsageSummaryCard({
 }) {
   const totals = summary?.summary
   const topAssetType = summary?.byAssetType[0]
+  const cacheDiagnostics = summary?.byCacheStatus.slice(0, 3) ?? []
   return (
     <section className="mb-8 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
@@ -1536,19 +1538,69 @@ function UsageSummaryCard({
         />
       </div>
       {summary && (
-        <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-xs text-slate-500">
-          <span>Latest: {formatUsageDate(totals?.latestCallAt ?? null)}</span>
-          {topAssetType && (
-            <span>
-              Top asset: {topAssetType.assetType ?? 'unknown'} (
-              {formatUsd(topAssetType.costUsd)})
-            </span>
+        <>
+          <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-xs text-slate-500">
+            <span>Latest: {formatUsageDate(totals?.latestCallAt ?? null)}</span>
+            {topAssetType && (
+              <span>
+                Top asset: {topAssetType.assetType ?? 'unknown'} (
+                {formatUsd(topAssetType.costUsd)})
+              </span>
+            )}
+            <span>Avg latency: {formatDuration(totals?.avgDurationMs ?? 0)}</span>
+          </div>
+          {cacheDiagnostics.length > 0 && (
+            <div className="mt-3 rounded-md border border-slate-800 bg-slate-950/40 px-3 py-2">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                Cache diagnostics
+              </div>
+              <div className="mt-2 grid gap-2 md:grid-cols-3">
+                {cacheDiagnostics.map((row) => (
+                  <div
+                    key={cacheDiagnosticKey(row)}
+                    className="rounded border border-slate-800 bg-slate-950/60 px-2.5 py-2"
+                  >
+                    <div className="truncate text-xs font-medium text-slate-200">
+                      {formatCacheDiagnosticLabel(row)}
+                    </div>
+                    <div className="mt-1 text-[11px] text-slate-500">
+                      {formatCount(row.calls)} calls · {formatUsd(row.costUsd)} spend ·{' '}
+                      {formatUsd(row.cacheSavingsUsd)} saved
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           )}
-          <span>Avg latency: {formatDuration(totals?.avgDurationMs ?? 0)}</span>
-        </div>
+        </>
       )}
     </section>
   )
+}
+
+function cacheDiagnosticKey(row: ContentOpsUsageSummaryBreakdown): string {
+  return [
+    row.cacheMode ?? 'unknown',
+    row.cacheReason ?? 'unknown',
+    row.cacheResult ?? 'unknown',
+    row.cacheStoreResult ?? 'unknown',
+  ].join(':')
+}
+
+function formatCacheDiagnosticLabel(
+  row: ContentOpsUsageSummaryBreakdown,
+): string {
+  const mode = formatCacheDiagnosticPart(row.cacheMode)
+  const reason = formatCacheDiagnosticPart(row.cacheReason)
+  const result = formatCacheDiagnosticPart(row.cacheResult)
+  const store = formatCacheDiagnosticPart(row.cacheStoreResult)
+
+  return `${mode} / ${reason} / ${result} / ${store}`
+}
+
+function formatCacheDiagnosticPart(value: string | undefined): string {
+  if (!value) return 'unknown'
+  return value.replaceAll('_', ' ')
 }
 
 function UsageMetric({ label, value }: { label: string; value: string }) {

--- a/plans/PR-Content-Ops-Cache-Diagnostics-UI.md
+++ b/plans/PR-Content-Ops-Cache-Diagnostics-UI.md
@@ -4,9 +4,9 @@
 
 The Content Ops usage card now shows spend, savings, cache hits, and tokens, but
 operators still cannot see why the cache applied or skipped from the UI. The
-backend read model for cache diagnostics is in PR #1031; this slice prepares the
-Intel UI to consume that field without breaking against the current production
-response while the backend PR is still in review.
+backend read model for cache diagnostics landed in PR #1031; this slice prepares
+the Intel UI to consume that field without breaking against older deployed
+responses that do not include the new key yet.
 
 ## Scope (this PR)
 
@@ -17,7 +17,7 @@ Slice phase: Product polish
 2. Map cache mode, reason, lookup result, and store result into the Content Ops
    domain summary shape.
 3. Default missing backend cache diagnostics to an empty list so the UI stays
-   compatible before PR #1031 deploys.
+   compatible with older deployed responses.
 4. Render the top cache diagnostic rows in the existing Content Ops usage card.
 5. Add focused UI contract tests for mapping and rendering strings.
 
@@ -42,8 +42,8 @@ responses keep rendering.
 
 The existing usage card remains the only UI surface. When cache diagnostics are
 available, it shows the top three rows by backend sort order with a compact
-label, call count, spend, and savings. If the backend has not shipped the field
-yet, the section is omitted.
+label, call count, spend, and savings. If an older backend response omits the
+field, the section is omitted.
 
 ## Intentional
 
@@ -52,7 +52,7 @@ yet, the section is omitted.
 - This does not add a new route or separate cache dashboard; the diagnostics
   live with the existing 7-day usage card.
 - This renders top rows only so the card remains scannable.
-- The wire field is optional until PR #1031 is merged and deployed.
+- The wire field remains optional for deployment-order compatibility.
 
 ## Deferred
 

--- a/plans/PR-Content-Ops-Cache-Diagnostics-UI.md
+++ b/plans/PR-Content-Ops-Cache-Diagnostics-UI.md
@@ -1,0 +1,84 @@
+# PR: Content Ops Cache Diagnostics UI
+
+## Why this slice exists
+
+The Content Ops usage card now shows spend, savings, cache hits, and tokens, but
+operators still cannot see why the cache applied or skipped from the UI. The
+backend read model for cache diagnostics is in PR #1031; this slice prepares the
+Intel UI to consume that field without breaking against the current production
+response while the backend PR is still in review.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Add optional cache diagnostic rows to the usage-summary wire contract.
+2. Map cache mode, reason, lookup result, and store result into the Content Ops
+   domain summary shape.
+3. Default missing backend cache diagnostics to an empty list so the UI stays
+   compatible before PR #1031 deploys.
+4. Render the top cache diagnostic rows in the existing Content Ops usage card.
+5. Add focused UI contract tests for mapping and rendering strings.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Diagnostics-UI.md` | Plan doc for the cache diagnostics UI slice. |
+| `atlas-intel-ui/src/api/contentOps.ts` | Extend the usage summary response type with optional cache diagnostic labels. |
+| `atlas-intel-ui/src/domain/contentOps/types.ts` | Add domain fields for cache diagnostic breakdown rows. |
+| `atlas-intel-ui/src/domain/contentOps/fromWire.ts` | Map optional cache diagnostic rows and default missing data to an empty list. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Render cache diagnostic rows in the existing usage summary card. |
+| `atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs` | Pin mapping and source-level UI rendering contract. |
+
+## Mechanism
+
+`ContentOpsUsageSummaryResponse` accepts an optional `by_cache_status` list
+whose rows reuse the existing breakdown payload and add optional cache labels:
+mode, reason, lookup result, and store result. The domain mapper converts those
+labels to camelCase and uses `wire.by_cache_status ?? []` so old backend
+responses keep rendering.
+
+The existing usage card remains the only UI surface. When cache diagnostics are
+available, it shows the top three rows by backend sort order with a compact
+label, call count, spend, and savings. If the backend has not shipped the field
+yet, the section is omitted.
+
+## Intentional
+
+- This is a frontend-only compatibility slice. It does not change backend
+  usage-summary behavior.
+- This does not add a new route or separate cache dashboard; the diagnostics
+  live with the existing 7-day usage card.
+- This renders top rows only so the card remains scannable.
+- The wire field is optional until PR #1031 is merged and deployed.
+
+## Deferred
+
+- Future PR: deeper cache diagnostics view if operators need more than the top
+  three rows.
+- Future PR: persisted tenant cache defaults if operators need always-on cache
+  posture.
+- Parked hardening: none. Root `HARDENING.md` was scanned; the current parked
+  item belongs to the FAQ lane, not this cost-surfacing UI slice.
+
+## Verification
+
+- npm --prefix atlas-intel-ui run test:content-ops-usage-summary — 4 passed.
+- npm --prefix atlas-intel-ui run lint — passed.
+- npm --prefix atlas-intel-ui run build — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-diagnostics-ui.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Wire/domain mapper | ~25 |
+| Usage card UI | ~45 |
+| Tests | ~25 |
+| **Total** | **~180** |
+
+This stays below the 400 LOC soft cap.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Diagnostics-UI.md
Slice phase: Product polish

The Content Ops usage card shows spend, savings, and cache hits, but not why cache applied or skipped. Now that the backend cache diagnostics read model has landed, this PR adds frontend support for those rows and renders the top cache-status rows in the existing usage card while staying compatible with older deployed responses.

## Intentional
- Frontend-only compatibility slice; no backend usage-summary behavior changes.
- The wire field remains optional for deployment-order compatibility.
- Diagnostics stay in the existing 7-day usage card instead of becoming a separate dashboard.
- The UI renders top rows only so the card remains scannable.

## Deferred
- Future PR: deeper cache diagnostics view if operators need more than the top three rows.
- Future PR: persisted tenant cache defaults if operators need always-on cache posture.

## Parked hardening
- None. Root `HARDENING.md` was scanned; the current parked item belongs to the FAQ lane, not this cost-surfacing UI slice.

## Verification
- `npm --prefix atlas-intel-ui run test:content-ops-usage-summary` — 4 passed.
- `npm --prefix atlas-intel-ui run lint` — passed.
- `npm --prefix atlas-intel-ui run build` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-diagnostics-ui.md` — passed.

## Diff size
6 files, +200 / -9 (~180 LOC estimated).
