### PR TITLE
Add FAQ detail concurrency latency budget

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md
+++ b/plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget
+
+## Why this slice exists
+
+The hosted FAQ search concurrency smoke can now hydrate generated FAQ detail
+documents under load, but its latency budgets still only cover the combined
+request row timing. That proves the route returns valid detail payloads, but it
+does not give operators a focused fail-closed knob for slow detail fetches.
+This slice adds that detail-read budget while staying in robust testing for the
+already-built search/detail flow.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Add an optional `--max-detail-ms` budget to the hosted FAQ search concurrency
+   smoke.
+2. Validate the detail budget during preflight so impossible or misleading
+   invocations fail before network I/O.
+3. Include compact detail latency summary data in the smoke result artifact.
+4. Add focused negative and positive tests for the new detector branch.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The concurrency smoke already records `detail_elapsed_ms` for each detail fetch
+when `--require-detail` is set. This PR summarizes those values separately from
+the full row timing, then wires `--max-detail-ms` into the existing budget
+summary so a single slow detail hydration fails the run with a deterministic
+result artifact.
+
+`--max-detail-ms` is only valid with `--require-detail`; otherwise the run would
+claim to enforce a budget for work it never performs.
+
+## Intentional
+
+- The existing combined row latency budgets remain unchanged because they still
+  measure the full user-facing search-plus-detail request cost.
+- The new budget checks max detail fetch latency, not p95, matching the single
+  route contract checker's `--max-detail-ms` semantics.
+- This does not add a hosted live invocation because credentials and host
+  selection remain operator/runtime concerns.
+
+## Deferred
+
+Parked hardening: none.
+
+Per-case detail-required policy remains deferred. Mixed case files can still
+include expected miss cases when detail checking is disabled globally; tightening
+that shape is separate from measuring detail latency when detail checking is
+explicitly enabled.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py - 53 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py - passed.
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - passed, 122 matching tests enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh - 2546 passed, 7 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-content-ops-faq-detail-concurrency-latency-budget-body.md - passed.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 72 |
+| Runner budget | 58 |
+| Tests | 99 |
+| **Total** | **234** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -76,6 +76,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-error-rate", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_ERROR_RATE", "0"))
     parser.add_argument("--max-p95-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_P95_MS") or None)
     parser.add_argument("--max-single-request-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SINGLE_REQUEST_MS") or None)
+    parser.add_argument("--max-detail-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_DETAIL_MS") or None)
     parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
@@ -97,7 +98,7 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     for name in ("limit", "requests", "concurrency"):
         if int(getattr(args, name)) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
-    for name in ("timeout", "max_error_rate", "max_p95_ms", "max_single_request_ms"):
+    for name in ("timeout", "max_error_rate", "max_p95_ms", "max_single_request_ms", "max_detail_ms"):
         value = getattr(args, name)
         if value is not None and not math.isfinite(float(value)):
             errors.append(f"--{name.replace('_', '-')} must be finite")
@@ -107,7 +108,9 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("--max-error-rate must be between 0 and 1")
     if bool(args.require_detail) and not bool(args.require_results):
         errors.append("--require-detail requires result rows; remove --allow-empty-results")
-    for name in ("max_p95_ms", "max_single_request_ms"):
+    if args.max_detail_ms is not None and not bool(args.require_detail):
+        errors.append("--max-detail-ms requires --require-detail")
+    for name in ("max_p95_ms", "max_single_request_ms", "max_detail_ms"):
         value = getattr(args, name)
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
@@ -337,6 +340,15 @@ def _latency_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _detail_latency_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    detail_results = [
+        {"elapsed_ms": row.get("detail_elapsed_ms")}
+        for row in results
+        if row.get("detail_checked") is True and row.get("detail_elapsed_ms") is not None
+    ]
+    return _latency_summary(detail_results)
+
+
 def _error_summary(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     failures = [
         {
@@ -361,8 +373,15 @@ def _detail_summary(
     results: Sequence[Mapping[str, Any]], *, required: bool
 ) -> dict[str, Any]:
     if not required:
-        return {"required": False, "checked": 0, "failures": 0, "items": []}
+        return {
+            "required": False,
+            "checked": 0,
+            "failures": 0,
+            "items": [],
+            "latency": _latency_summary(()),
+        }
 
+    latency = _detail_latency_summary(results)
     failures = [
         {
             "index": row.get("index"),
@@ -378,16 +397,19 @@ def _detail_summary(
         "failures": len(failures),
         "items": failures[:20],
         "truncated": len(failures) > 20,
+        "latency": latency,
     }
 
 
 def _budget_summary(
     *,
     latency: Mapping[str, Any],
+    detail_latency: Mapping[str, Any],
     errors: Mapping[str, Any],
     max_error_rate: float,
     max_p95_ms: float | None,
     max_single_request_ms: float | None,
+    max_detail_ms: float | None,
 ) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
     failures: list[str] = []
@@ -403,6 +425,31 @@ def _budget_summary(
         checks.append({"metric": metric, "actual": actual, "max": limit_value, "ok": ok})
         if not ok:
             failures.append(f"{metric} exceeded {limit_value}")
+    if max_detail_ms is not None:
+        limit_value = round(float(max_detail_ms), 6)
+        if int(detail_latency.get("count") or 0) <= 0:
+            checks.append(
+                {
+                    "metric": "detail_max_ms",
+                    "actual": None,
+                    "max": limit_value,
+                    "ok": False,
+                }
+            )
+            failures.append("detail_max_ms had no checked detail rows")
+        else:
+            actual = float(detail_latency["max_ms"])
+            ok = actual <= limit_value
+            checks.append(
+                {
+                    "metric": "detail_max_ms",
+                    "actual": actual,
+                    "max": limit_value,
+                    "ok": ok,
+                }
+            )
+            if not ok:
+                failures.append(f"detail_max_ms exceeded {limit_value}")
     return {"ok": not failures, "checks": checks, "failures": failures}
 
 
@@ -417,12 +464,15 @@ def _summary_payload(
     active_cases = list(cases) if cases is not None else [_default_case(args)]
     errors = _error_summary(results)
     latency = _latency_summary(results)
+    detail = _detail_summary(results, required=bool(args.require_detail))
     budgets = _budget_summary(
         latency=latency,
+        detail_latency=detail["latency"],
         errors=errors,
         max_error_rate=float(args.max_error_rate),
         max_p95_ms=args.max_p95_ms,
         max_single_request_ms=args.max_single_request_ms,
+        max_detail_ms=args.max_detail_ms,
     )
     return {
         "ok": not preflight_errors and budgets["ok"],
@@ -448,7 +498,7 @@ def _summary_payload(
         },
         "latency": latency,
         "errors": errors,
-        "detail": _detail_summary(results, required=bool(args.require_detail)),
+        "detail": detail,
         "budgets": budgets,
         "preflight_errors": list(preflight_errors),
         "elapsed_seconds": round(elapsed_seconds, 6),

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -47,6 +47,7 @@ def _args(**overrides):
         "max_error_rate": 0.0,
         "max_p95_ms": None,
         "max_single_request_ms": None,
+        "max_detail_ms": None,
         "require_results": True,
         "require_detail": False,
         "case_file": None,
@@ -155,6 +156,18 @@ def test_validate_args_rejects_detail_without_required_results():
     ]
 
 
+def test_validate_args_rejects_detail_budget_without_detail_check():
+    errors = smoke._validate_args(_args(max_detail_ms=100.0, require_detail=False))
+
+    assert errors == ["--max-detail-ms requires --require-detail"]
+
+
+def test_validate_args_rejects_non_positive_detail_budget():
+    errors = smoke._validate_args(_args(max_detail_ms=0.0, require_detail=True))
+
+    assert errors == ["--max-detail-ms must be positive"]
+
+
 def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe():
     required = smoke._build_parser().parse_args([
         "--base-url",
@@ -187,6 +200,21 @@ def test_parser_accepts_opt_in_detail_route_check():
 
     assert parsed.require_detail is True
     assert parsed.detail_route == "/api/v1/content-ops/faq-deflection-reports/{faq_id}"
+
+
+def test_parser_accepts_detail_latency_budget_with_detail_check():
+    parsed = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--require-detail",
+        "--max-detail-ms",
+        "250",
+    ])
+
+    assert parsed.require_detail is True
+    assert parsed.max_detail_ms == 250.0
 
 
 def test_load_cases_defaults_to_cli_case():
@@ -337,11 +365,18 @@ def test_latency_and_error_summaries_are_compact():
 
 def test_detail_summary_reports_required_detail_failures():
     results = [
-        {"index": 0, "detail_checked": True, "detail_faq_id": "faq-1", "detail_errors": []},
+        {
+            "index": 0,
+            "detail_checked": True,
+            "detail_faq_id": "faq-1",
+            "detail_elapsed_ms": 12.0,
+            "detail_errors": [],
+        },
         {
             "index": 1,
             "detail_checked": False,
             "detail_faq_id": "faq-2",
+            "detail_elapsed_ms": None,
             "detail_errors": ["RuntimeError: route request failed"],
         },
     ]
@@ -358,22 +393,26 @@ def test_detail_summary_reports_required_detail_failures():
             }
         ],
         "truncated": False,
+        "latency": {"count": 1, "p50_ms": 12.0, "p95_ms": 12.0, "max_ms": 12.0},
     }
     assert smoke._detail_summary(results, required=False) == {
         "required": False,
         "checked": 0,
         "failures": 0,
         "items": [],
+        "latency": {"count": 0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0},
     }
 
 
 def test_budget_summary_reports_error_and_latency_failures():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},
+        detail_latency={"count": 2, "p95_ms": 25.0, "max_ms": 30.0},
         errors={"rate": 0.25},
         max_error_rate=0.0,
         max_p95_ms=40.0,
         max_single_request_ms=100.0,
+        max_detail_ms=20.0,
     )
 
     assert summary == {
@@ -382,11 +421,34 @@ def test_budget_summary_reports_error_and_latency_failures():
             {"metric": "error_rate", "actual": 0.25, "max": 0.0, "ok": False},
             {"metric": "p95_ms", "actual": 50.0, "max": 40.0, "ok": False},
             {"metric": "max_ms", "actual": 75.0, "max": 100.0, "ok": True},
+            {"metric": "detail_max_ms", "actual": 30.0, "max": 20.0, "ok": False},
         ],
         "failures": [
             "error_rate exceeded 0.0",
             "p95_ms exceeded 40.0",
+            "detail_max_ms exceeded 20.0",
         ],
+    }
+
+
+def test_budget_summary_fails_closed_when_detail_budget_has_no_detail_rows():
+    summary = smoke._budget_summary(
+        latency={"p95_ms": 50.0, "max_ms": 75.0},
+        detail_latency={"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+        errors={"rate": 0.0},
+        max_error_rate=0.0,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        max_detail_ms=20.0,
+    )
+
+    assert summary == {
+        "ok": False,
+        "checks": [
+            {"metric": "error_rate", "actual": 0.0, "max": 0.0, "ok": True},
+            {"metric": "detail_max_ms", "actual": None, "max": 20.0, "ok": False},
+        ],
+        "failures": ["detail_max_ms had no checked detail rows"],
     }
 
 
@@ -831,6 +893,41 @@ def test_main_rejects_detail_with_allowed_empty_results_before_network(tmp_path,
     assert payload["preflight_errors"] == [
         "--require-detail requires result rows; remove --allow-empty-results"
     ]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_rejects_detail_budget_without_detail_check_before_network(tmp_path, monkeypatch, capsys):
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _unexpected_urlopen(*_args, **_kwargs):
+        raise AssertionError("preflight failures must not issue route requests")
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _unexpected_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-detail-ms",
+        "250",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["require_detail"] is False
+    assert payload["detail"]["latency"] == {
+        "count": 0,
+        "p50_ms": 0.0,
+        "p95_ms": 0.0,
+        "max_ms": 0.0,
+    }
+    assert payload["preflight_errors"] == ["--max-detail-ms requires --require-detail"]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md
Slice phase: Robust testing

The hosted FAQ search concurrency smoke can hydrate generated FAQ detail documents under load, but its latency budgets only covered the combined request row timing. This adds an opt-in detail hydration latency budget so hosted read-path testing can fail closed when detail fetches are slow or not actually exercised.

## Intentional
- The existing combined row latency budgets remain unchanged because they still measure the full user-facing search-plus-detail request cost.
- The new budget checks max detail fetch latency, not p95, matching the single route contract checker's `--max-detail-ms` semantics.
- This does not add a hosted live invocation because credentials and host selection remain operator/runtime concerns.

## Deferred
- Per-case detail-required policy remains deferred; this slice measures detail latency when detail checking is explicitly enabled.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` - 53 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Detail-Concurrency-Latency-Budget.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 122 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2546 passed, 7 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-content-ops-faq-detail-concurrency-latency-budget-body.md` - passed.

## Diff size
3 files, +229 / -5
