### PR TITLE
Add Content Ops cache policy default provider

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -182,6 +182,7 @@ try:
         select_content_ops_reasoning_context_provider,
     )
     from ..auth.dependencies import AuthUser
+    from ..config import settings
     from ..storage.database import get_db_pool
 
     async def _capture_content_ops_auth_user(
@@ -208,6 +209,17 @@ try:
             return user
         raise HTTPException(status_code=403, detail="Platform admin access required")
 
+    def _content_ops_cache_policy_default(_scope: object) -> str | None:
+        policy = str(
+            getattr(
+                settings.b2b_campaign,
+                "content_ops_cache_policy_default",
+                "",
+            )
+            or ""
+        ).strip()
+        return policy or None
+
     content_ops_config = ContentOpsControlSurfaceApiConfig()
     content_ops_router = create_content_ops_control_surface_router(
         config=content_ops_config,
@@ -219,6 +231,7 @@ try:
         reasoning_context_provider=select_content_ops_reasoning_context_provider,
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
         input_provider=build_content_ops_input_provider(),
+        cache_policy_default_provider=_content_ops_cache_policy_default,
         opportunity_import_pool_provider=get_db_pool,
         usage_pool_provider=get_db_pool,
         usage_dependencies=[Depends(_require_content_ops_usage_operator)],

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4739,6 +4739,14 @@ class B2BCampaignConfig(BaseSettings):
             "precedence when set."
         ),
     )
+    content_ops_cache_policy_default: str = Field(
+        default="",
+        description=(
+            "Optional default Content Ops cache policy. Blank preserves the "
+            "per-run default; set ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT "
+            "to exact-cache or no-store to default hosted runs."
+        ),
+    )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -93,6 +93,10 @@ ReasoningStatusProvider = Callable[
 LLMProvider = Callable[[], Any | Awaitable[Any]]
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 ImportAdmissionProvider = Callable[[], Any | Awaitable[Any]]
+CachePolicyDefaultProvider = Callable[
+    [TenantScope],
+    str | None | Awaitable[str | None],
+]
 InputProvider = ContentOpsInputProvider
 
 logger = logging.getLogger(__name__)
@@ -560,6 +564,7 @@ def create_content_ops_control_surface_router(
     usage_pool_provider: PoolProvider | None = None,
     usage_dependencies: Sequence[Any] | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
+    cache_policy_default_provider: CachePolicyDefaultProvider | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
     """Create host-mounted AI Content Ops control-surface routes.
@@ -654,6 +659,11 @@ def create_content_ops_control_surface_router(
             input_provider=input_provider,
             scope_provider=scope_provider,
         )
+        payload_mapping = await _payload_with_cache_policy_default(
+            payload_mapping,
+            cache_policy_default_provider=cache_policy_default_provider,
+            scope_provider=scope_provider,
+        )
         budget_evaluation = await _evaluate_account_usage_budget(
             payload_mapping,
             usage_pool_provider=usage_pool_provider,
@@ -675,6 +685,11 @@ def create_content_ops_control_surface_router(
             payload_mapping = await _payload_with_input_provider(
                 _payload_to_mapping(payload, exclude_unset=input_provider is not None),
                 input_provider=input_provider,
+                scope_provider=scope_provider,
+            )
+            payload_mapping = await _payload_with_cache_policy_default(
+                payload_mapping,
+                cache_policy_default_provider=cache_policy_default_provider,
                 scope_provider=scope_provider,
             )
             budget_evaluation = await _evaluate_account_usage_budget(
@@ -847,6 +862,11 @@ def create_content_ops_control_surface_router(
             payload_mapping = await _payload_with_input_provider(
                 payload_mapping,
                 input_provider=input_provider,
+                scope=scope,
+            )
+            payload_mapping = await _payload_with_cache_policy_default(
+                payload_mapping,
+                cache_policy_default_provider=cache_policy_default_provider,
                 scope=scope,
             )
             _enforce_faq_execute_source_material_limit(
@@ -1138,6 +1158,47 @@ async def _payload_with_input_provider(
             status_code=503,
             detail="Content Ops input provider is unavailable.",
         ) from exc
+
+
+async def _payload_with_cache_policy_default(
+    payload: Mapping[str, Any],
+    *,
+    cache_policy_default_provider: CachePolicyDefaultProvider | None,
+    scope_provider: ScopeProvider | None = None,
+    scope: TenantScope | None = None,
+) -> dict[str, Any]:
+    out = dict(payload)
+    if cache_policy_default_provider is None:
+        return out
+    if _clean(out.get("content_ops_cache_policy")):
+        return out
+    resolved_scope = scope
+    if resolved_scope is None:
+        resolved_scope = await _resolve_scope(scope_provider)
+    try:
+        default_value = cache_policy_default_provider(resolved_scope or TenantScope())
+        if hasattr(default_value, "__await__"):
+            default_value = await default_value
+        normalized = normalize_content_ops_cache_policy(default_value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Content Ops cache policy default is invalid.",
+        ) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Content Ops cache policy default provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops cache policy default is unavailable.",
+        ) from exc
+    if normalized:
+        out["content_ops_cache_policy"] = normalized
+    return out
 
 
 def _with_input_provider_diagnostics(

--- a/plans/PR-Content-Ops-Cache-Policy-Default.md
+++ b/plans/PR-Content-Ops-Cache-Policy-Default.md
@@ -1,0 +1,93 @@
+# PR: Content Ops Cache Policy Default
+
+## Why this slice exists
+
+Content Ops can now request exact cache or no-store per run, and the usage
+surface can show savings and cache diagnostics. The remaining operator friction
+is that every run has to carry the cache choice explicitly. Hosts need a
+source-level way to apply an account/tenant default while preserving the
+existing per-run override and customer-data no-store protections.
+
+This slice adds that default at the request boundary. It does not create a new
+cache rule layer: the default is normalized into the existing
+`content_ops_cache_policy` request field before preview, plan, or execute.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add an optional cache-policy default provider to the Content Ops control
+   surface router.
+2. Resolve the default with tenant scope and apply it only when the merged
+   request has no explicit cache policy.
+3. Normalize provider values through the existing cache-policy normalizer.
+4. Preserve explicit per-run cache-policy overrides through input-provider merges.
+5. Add focused route tests for preview/execute defaulting, override precedence,
+   and invalid provider values.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Policy-Default.md` | Plan doc for the cache-policy default provider slice. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Add and apply the optional tenant-scoped cache-policy default provider. |
+| `tests/test_extracted_content_control_surface_api.py` | Cover default application, override precedence, and invalid provider values. |
+
+## Mechanism
+
+`create_content_ops_control_surface_router(...)` accepts an optional
+`cache_policy_default_provider`. When preview, plan, or execute builds the
+request payload, the route first lets the input provider merge data into the
+payload. Then it applies the cache default only if `content_ops_cache_policy`
+is still blank. The provider receives the resolved tenant scope and returns a
+policy value such as `exact` or `no_store`; unsupported values fail closed with
+an HTTP error instead of silently running with a surprising cache posture.
+
+Because the default is written to the existing request field, all downstream
+integration points stay source-aligned: `request_from_mapping`, preview/plan
+normalized output, execute trace context, and `ContentOpsExactCachePolicy`
+consume the same field they already use today.
+
+## Intentional
+
+- This does not add persistence or a settings table. The provider seam lets the
+  host plug in DB-backed tenant settings later without changing the product
+  request contract again.
+- This does not let defaults bypass explicit no-store requests, including when
+  the request also flows through an input provider.
+- This does not loosen support-ticket/customer-data cache safety; existing
+  source markers still make the exact-cache policy return no-store.
+- This does not add frontend controls. The current UI per-run control remains
+  the explicit override.
+
+## Deferred
+
+- Future PR: DB-backed tenant cache settings if operators need durable in-app
+  defaults.
+- Future PR: UI surface for editing that tenant default.
+- Parked hardening: none. Root `HARDENING.md` was scanned and has no active
+  cost-surfacing parked items.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_applies_cache_policy_default_from_scope tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_preserves_explicit_cache_policy_over_default tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_rejects_invalid_cache_policy_default tests/test_extracted_content_control_surface_api.py::test_execute_route_applies_cache_policy_default_to_trace_context -q — 4 passed.
+- python -m compileall -q extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- bash scripts/run_extracted_pipeline_checks.sh — 2545 passed, 7 skipped, 1 warning.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-policy-default.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Router default provider seam | ~65 |
+| Tests | ~120 |
+| **Total** | **~280** |
+
+This stays below the 400 LOC soft cap.

--- a/plans/PR-Content-Ops-Cache-Policy-Default.md
+++ b/plans/PR-Content-Ops-Cache-Policy-Default.md
@@ -23,7 +23,9 @@ Slice phase: Production hardening
    request has no explicit cache policy.
 3. Normalize provider values through the existing cache-policy normalizer.
 4. Preserve explicit per-run cache-policy overrides through input-provider merges.
-5. Add focused route tests for preview/execute defaulting, override precedence,
+5. Wire the Atlas host mount to an env-backed default provider so the seam is
+   active in production without adding DB settings in this slice.
+6. Add focused route tests for preview/execute defaulting, override precedence,
    and invalid provider values.
 
 ### Files touched
@@ -31,7 +33,10 @@ Slice phase: Production hardening
 | File | Change |
 |---|---|
 | `plans/PR-Content-Ops-Cache-Policy-Default.md` | Plan doc for the cache-policy default provider slice. |
+| `atlas_brain/api/__init__.py` | Pass the hosted Content Ops cache-policy default provider into the control-surface router. |
+| `atlas_brain/config.py` | Add the env-backed hosted Content Ops cache-policy default setting. |
 | `extracted_content_pipeline/api/control_surfaces.py` | Add and apply the optional tenant-scoped cache-policy default provider. |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | Pin the Atlas host route wiring for the cache-policy default provider. |
 | `tests/test_extracted_content_control_surface_api.py` | Cover default application, override precedence, and invalid provider values. |
 
 ## Mechanism
@@ -49,11 +54,18 @@ integration points stay source-aligned: `request_from_mapping`, preview/plan
 normalized output, execute trace context, and `ContentOpsExactCachePolicy`
 consume the same field they already use today.
 
+The Atlas host passes a provider backed by
+`ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT`. Blank keeps the existing
+per-run behavior. Nonblank values still flow through the extracted router's
+normalizer and customer-data cache safety checks before any execution path sees
+them.
+
 ## Intentional
 
-- This does not add persistence or a settings table. The provider seam lets the
-  host plug in DB-backed tenant settings later without changing the product
-  request contract again.
+- This does not add persistence or a settings table. The hosted env default
+  makes the seam live now, and the provider seam still lets the host plug in
+  DB-backed tenant settings later without changing the product request contract
+  again.
 - This does not let defaults bypass explicit no-store requests, including when
   the request also flows through an input provider.
 - This does not loosen support-ticket/customer-data cache safety; existing
@@ -73,6 +85,8 @@ consume the same field they already use today.
 
 - python -m pytest tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_applies_cache_policy_default_from_scope tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_preserves_explicit_cache_policy_over_default tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_rejects_invalid_cache_policy_default tests/test_extracted_content_control_surface_api.py::test_execute_route_applies_cache_policy_default_to_trace_context -q — 4 passed.
 - python -m compileall -q extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py — passed.
+- python -m pytest tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_preview_route_uses_host_cache_policy_default tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_cache_policy_default_provider_keeps_blank_unset -q — 2 passed, 1 warning.
+- python -m compileall -q atlas_brain/api/__init__.py atlas_brain/config.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
@@ -85,9 +99,11 @@ consume the same field they already use today.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~95 |
+| Plan doc | ~105 |
+| Atlas host config and route wiring | ~65 |
 | Router default provider seam | ~65 |
-| Tests | ~120 |
-| **Total** | **~280** |
+| Tests | ~165 |
+| **Total** | **~400** |
 
-This stays below the 400 LOC soft cap.
+This sits at the 400 LOC soft cap because the slice now includes the host
+integration point that makes the extracted provider live in production.

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -13,6 +13,7 @@ import sys
 import pytest
 
 from atlas_brain.auth.dependencies import AuthUser
+from extracted_content_pipeline.campaign_ports import TenantScope
 
 pytest.importorskip("asyncpg")
 
@@ -99,6 +100,48 @@ def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
     assert closure["usage_pool_provider"].__name__ == "get_db_pool"
     assert "_capture_content_ops_auth_user" in dependency_names
     assert "_require_content_ops_usage_operator" in dependency_names
+
+
+def test_content_ops_preview_route_uses_host_cache_policy_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(
+        settings.b2b_campaign,
+        "content_ops_cache_policy_default",
+        "exact-cache",
+    )
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/preview")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    provider = closure["cache_policy_default_provider"]
+
+    assert provider.__name__ == "_content_ops_cache_policy_default"
+    assert provider(TenantScope(account_id="account-1")) == "exact-cache"
+
+
+def test_content_ops_cache_policy_default_provider_keeps_blank_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.config import settings
+
+    monkeypatch.setattr(settings.b2b_campaign, "content_ops_cache_policy_default", " ")
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/preview")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+
+    assert closure["cache_policy_default_provider"](TenantScope()) is None
 
 
 def test_content_ops_tenant_usage_summary_route_uses_shared_auth_scope_and_pool() -> None:

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -10,6 +10,9 @@ from extracted_content_pipeline.api.control_surfaces import (
     ContentOpsControlSurfaceApiConfig,
     create_content_ops_control_surface_router,
 )
+from extracted_content_pipeline.campaign_llm_client import (
+    current_content_ops_llm_trace_context,
+)
 from extracted_content_pipeline.campaign_ports import CampaignReasoningContext
 from extracted_content_pipeline.content_ops_input_provider import ContentOpsInputPackage
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
@@ -76,6 +79,19 @@ class _CampaignService:
             "kwargs": dict(kwargs),
         })
         return {"generated": 1, "saved_ids": ["draft-1"]}
+
+
+class _TraceContextCampaignService(_CampaignService):
+    async def generate(self, *, scope, target_mode, limit=None, filters=None, **kwargs):
+        result = await super().generate(
+            scope=scope,
+            target_mode=target_mode,
+            limit=limit,
+            filters=filters,
+            **kwargs,
+        )
+        self.calls[-1]["trace_context"] = current_content_ops_llm_trace_context()
+        return result
 
 
 class _SyncInputProvider:
@@ -843,6 +859,88 @@ async def test_preview_generation_route_normalizes_cache_policy_field():
 
     assert payload["can_run"] is True
     assert payload["normalized_request"]["content_ops_cache_policy"] == "no_store"
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_applies_cache_policy_default_from_scope():
+    provider_calls = []
+
+    def cache_policy_default_provider(scope):
+        provider_calls.append(scope)
+        return "exact-cache"
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-cache-default"},
+        input_provider=_SyncInputProvider(ContentOpsInputPackage(
+            provider="atlas_support_ticket_request",
+            inputs={"topic": "Provider fallback topic"},
+            outputs=("blog_post",),
+        )),
+        cache_policy_default_provider=cache_policy_default_provider,
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {"topic": "Support-ticket questions customers keep asking"},
+        }
+    )
+
+    assert payload["can_run"] is True
+    assert provider_calls[0].account_id == "acct-cache-default"
+    assert payload["normalized_request"]["content_ops_cache_policy"] == "exact"
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_preserves_explicit_cache_policy_over_default():
+    provider_called = False
+
+    def cache_policy_default_provider(scope):
+        nonlocal provider_called
+        del scope
+        provider_called = True
+        return "exact"
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-cache-default"},
+        cache_policy_default_provider=cache_policy_default_provider,
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["blog_post"],
+            "inputs": {"topic": "Support-ticket questions customers keep asking"},
+            "content_ops_cache_policy": "no-store",
+        }
+    )
+
+    assert provider_called is False
+    assert payload["normalized_request"]["content_ops_cache_policy"] == "no_store"
+
+
+@pytest.mark.asyncio
+async def test_preview_generation_route_rejects_invalid_cache_policy_default():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        scope_provider=lambda: {"account_id": "acct-cache-default"},
+        cache_policy_default_provider=lambda _scope: "semantic",
+    )
+
+    route = _route(router, "/ops/preview", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["blog_post"],
+                "inputs": {"topic": "Support-ticket questions customers keep asking"},
+            }
+        )
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == "Content Ops cache policy default is invalid."
 
 
 @pytest.mark.asyncio
@@ -2758,6 +2856,32 @@ async def test_execute_route_without_reasoning_provider_passes_services_unchange
     # The original instance handled the request; no wrapping happened.
     assert len(base.calls) == 1
     assert base.calls[0]["reasoning_context"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_route_applies_cache_policy_default_to_trace_context():
+    campaign = _TraceContextCampaignService()
+    router = create_content_ops_control_surface_router(
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            campaign=campaign
+        ),
+        scope_provider=lambda: {"account_id": "acct-cache-default"},
+        cache_policy_default_provider=lambda _scope: "exact-cache",
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Audit"},
+        }
+    )
+
+    assert campaign.calls[0]["trace_context"] == {
+        "account_id": "acct-cache-default",
+        "content_ops_cache_policy": "exact",
+    }
+    assert current_content_ops_llm_trace_context() == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Policy-Default.md
Slice phase: Production hardening

Content Ops can request exact cache or no-store per run, but hosts still need a source-level way to apply an account/tenant default without adding a second cache rule path. This PR adds an optional tenant-scoped cache-policy default provider at the control-surface boundary, wires the Atlas host to an env-backed default, and normalizes the default into the existing `content_ops_cache_policy` request field.

## Intentional
- No persistence or settings table in this slice; the hosted env default makes the seam live now, and the provider seam lets the host plug in DB-backed tenant settings later.
- Defaults never bypass explicit no-store requests, including requests that also flow through an input provider.
- Existing support-ticket/customer-data no-store protections remain in `ContentOpsExactCachePolicy`.
- No frontend changes; the current UI control remains the explicit per-run override.

## Deferred
- Future PR: DB-backed tenant cache settings if operators need durable in-app defaults.
- Future PR: UI surface for editing that tenant default.

## Parked hardening
- None. Root `HARDENING.md` was scanned and has no active cost-surfacing parked items.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_applies_cache_policy_default_from_scope tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_preserves_explicit_cache_policy_over_default tests/test_extracted_content_control_surface_api.py::test_preview_generation_route_rejects_invalid_cache_policy_default tests/test_extracted_content_control_surface_api.py::test_execute_route_applies_cache_policy_default_to_trace_context -q` — 4 passed.
- `python -m compileall -q extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` — passed.
- `python -m pytest tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_preview_route_uses_host_cache_policy_default tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_cache_policy_default_provider_keeps_blank_unset -q` — 2 passed, 1 warning.
- `python -m compileall -q atlas_brain/api/__init__.py atlas_brain/config.py tests/test_atlas_content_ops_generated_assets_api.py` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash scripts/run_extracted_pipeline_checks.sh` — 2545 passed, 7 skipped, 1 warning.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-policy-default.md` — passed.

## Diff size
6 files, ~400 LOC estimated.
