### PR TITLE
Add FAQ route concurrency per-case summaries

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md
@@ -1,0 +1,75 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary
+
+## Why this slice exists
+
+The hosted FAQ search concurrency smoke can exercise mixed query/corpus cases,
+search-detail hydration, and route/detail latency budgets. Its result artifact
+still reports most behavior as one aggregate run, so a single slow or failing
+case can hide inside the total error rate and latency summary. For live demo
+and survivability testing, operators need enough per-case visibility to see
+which corpus/query shape failed under concurrent read traffic.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Add compact per-case result summaries to the hosted FAQ search concurrency
+   smoke result artifact.
+2. Report each case's request count, error count/rate, latency summary, detail
+   check count, detail failure count, and detail latency summary.
+3. Preserve existing aggregate budgets and pass/fail behavior.
+4. Add focused tests proving mixed-case failures and detail latency are visible
+   in the artifact.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The runner already stamps each request row with `case_index` and a case
+snapshot. This slice groups completed rows by case index inside
+`_summary_payload(...)` and writes a compact `cases.summaries` list alongside
+the existing case definitions. The rollups reuse the existing latency, error,
+and detail summary helpers so aggregate and per-case math stay aligned.
+
+## Intentional
+
+- This does not add per-case budgets. The goal is visibility for mixed traffic;
+  changing pass/fail semantics is a separate production-hardening decision.
+- The existing aggregate `errors`, `latency`, `detail`, and `budgets` fields are
+  unchanged for backward compatibility with current consumers.
+- The case summaries are compact counts and timings, not full duplicate error
+  item lists, because the aggregate `errors.items` already carries the first
+  failure rows with case snapshots.
+
+## Deferred
+
+Parked hardening: none.
+
+Per-case latency/error budgets remain deferred until a live hosted run shows a
+specific threshold worth enforcing. This slice adds the visibility needed to
+choose those thresholds from evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py - 55 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py - passed.
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - passed, 122 matching tests enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh - 2548 passed, 7 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-summary.md - passed.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 75 |
+| Runner summary | 42 |
+| Tests | 132 |
+| **Total** | **249** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -401,6 +401,43 @@ def _detail_summary(
     }
 
 
+def _case_result_summaries(
+    cases: Sequence[Mapping[str, Any]],
+    results: Sequence[Mapping[str, Any]],
+    *,
+    detail_required: bool,
+) -> list[dict[str, Any]]:
+    grouped: dict[int, list[Mapping[str, Any]]] = {index: [] for index in range(len(cases))}
+    for row in results:
+        case_index = row.get("case_index")
+        if type(case_index) is int and 0 <= case_index < len(cases):
+            grouped.setdefault(case_index, []).append(row)
+
+    summaries: list[dict[str, Any]] = []
+    for case_index, case in enumerate(cases):
+        rows = grouped.get(case_index, [])
+        errors = _error_summary(rows)
+        detail = _detail_summary(rows, required=detail_required)
+        summaries.append(
+            {
+                "case_index": case_index,
+                "case": _case_snapshot(case),
+                "requests": len(rows),
+                "errors": {
+                    "count": errors["count"],
+                    "rate": errors["rate"],
+                },
+                "latency": _latency_summary(rows),
+                "detail": {
+                    "checked": detail["checked"],
+                    "failures": detail["failures"],
+                    "latency": detail["latency"],
+                },
+            }
+        )
+    return summaries
+
+
 def _budget_summary(
     *,
     latency: Mapping[str, Any],
@@ -489,6 +526,11 @@ def _summary_payload(
             "total": len(active_cases),
             "case_file": str(args.case_file or ""),
             "items": [_case_snapshot(case) for case in active_cases[:20]],
+            "summaries": _case_result_summaries(
+                active_cases[:20],
+                results,
+                detail_required=bool(args.require_detail),
+            ),
             "truncated": len(active_cases) > 20,
         },
         "requests": {

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -404,6 +404,93 @@ def test_detail_summary_reports_required_detail_failures():
     }
 
 
+def test_case_result_summaries_group_mixed_case_visibility():
+    cases = [
+        {
+            "query": "credit report",
+            "corpus_id": "corp-a",
+            "status": "published",
+            "limit": 2,
+            "require_results": True,
+        },
+        {
+            "query": "mortgage dispute",
+            "corpus_id": "corp-b",
+            "status": "",
+            "limit": 3,
+            "require_results": True,
+        },
+    ]
+    results = [
+        {
+            "index": 0,
+            "case_index": 0,
+            "elapsed_ms": 10.0,
+            "errors": [],
+            "detail_checked": True,
+            "detail_elapsed_ms": 4.0,
+            "detail_errors": [],
+        },
+        {
+            "index": 1,
+            "case_index": 1,
+            "elapsed_ms": 30.0,
+            "errors": ["results must include at least one item"],
+            "detail_checked": False,
+            "detail_elapsed_ms": None,
+            "detail_errors": ["results[0].faq_id is required when --require-detail is set"],
+        },
+        {
+            "index": 2,
+            "case_index": 0,
+            "elapsed_ms": 20.0,
+            "errors": [],
+            "detail_checked": True,
+            "detail_elapsed_ms": 6.0,
+            "detail_errors": [],
+        },
+    ]
+
+    assert smoke._case_result_summaries(cases, results, detail_required=True) == [
+        {
+            "case_index": 0,
+            "case": {
+                "query": "credit report",
+                "corpus_id": "corp-a",
+                "status": "published",
+                "limit": 2,
+                "require_results": True,
+            },
+            "requests": 2,
+            "errors": {"count": 0, "rate": 0.0},
+            "latency": {"count": 2, "p50_ms": 15.0, "p95_ms": 20.0, "max_ms": 20.0},
+            "detail": {
+                "checked": 2,
+                "failures": 0,
+                "latency": {"count": 2, "p50_ms": 5.0, "p95_ms": 6.0, "max_ms": 6.0},
+            },
+        },
+        {
+            "case_index": 1,
+            "case": {
+                "query": "mortgage dispute",
+                "corpus_id": "corp-b",
+                "status": "",
+                "limit": 3,
+                "require_results": True,
+            },
+            "requests": 1,
+            "errors": {"count": 1, "rate": 1.0},
+            "latency": {"count": 1, "p50_ms": 30.0, "p95_ms": 30.0, "max_ms": 30.0},
+            "detail": {
+                "checked": 0,
+                "failures": 1,
+                "latency": {"count": 0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0},
+            },
+        },
+    ]
+
+
 def test_budget_summary_reports_error_and_latency_failures():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},
@@ -929,6 +1016,51 @@ def test_main_rejects_detail_budget_without_detail_check_before_network(tmp_path
     }
     assert payload["preflight_errors"] == ["--max-detail-ms requires --require-detail"]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_result_includes_case_summaries_for_mixed_cases(tmp_path, monkeypatch):
+    case_file = _write_case_file(
+        tmp_path,
+        [
+            {"query": "credit report", "corpus_id": "corp-a", "limit": 2},
+            {"query": "mortgage dispute", "corpus_id": "corp-b", "limit": 3},
+        ],
+    )
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _fake_urlopen(request, **_kwargs):
+        query = smoke.contract.urllib.parse.parse_qs(
+            smoke.contract.urllib.parse.urlsplit(request.full_url).query
+        )["q"][0]
+        if query == "credit report":
+            return _json_response(_valid_payload())
+        return _json_response({"query": query, "results": [], "count": 0})
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--case-file",
+        str(case_file),
+        "--requests",
+        "2",
+        "--concurrency",
+        "2",
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["cases"]["summaries"][0]["requests"] == 1
+    assert payload["cases"]["summaries"][0]["errors"] == {"count": 0, "rate": 0.0}
+    assert payload["cases"]["summaries"][0]["latency"]["count"] == 1
+    assert payload["cases"]["summaries"][1]["requests"] == 1
+    assert payload["cases"]["summaries"][1]["errors"] == {"count": 1, "rate": 1.0}
+    assert payload["cases"]["summaries"][1]["latency"]["count"] == 1
 
 
 def test_main_returns_exit_1_and_writes_result_for_contract_failures(tmp_path, monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md
Slice phase: Robust testing

The hosted FAQ search concurrency smoke can exercise mixed query/corpus cases, but its result artifact was mostly aggregate. This adds compact per-case rollups so live demo and survivability runs can show which query/corpus shape was slow or failing under concurrent read traffic.

## Intentional
- This does not add per-case budgets. The goal is visibility for mixed traffic; changing pass/fail semantics is a separate production-hardening decision.
- The existing aggregate `errors`, `latency`, `detail`, and `budgets` fields are unchanged for backward compatibility with current consumers.
- The case summaries are compact counts and timings, not full duplicate error item lists, because the aggregate `errors.items` already carries the first failure rows with case snapshots.

## Deferred
- Per-case latency/error budgets remain deferred until a live hosted run shows a specific threshold worth enforcing.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` - 55 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Summary.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 122 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2548 passed, 7 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-summary.md` - passed.

## Diff size
3 files, +249 / -0
