### PR TITLE
Show FAQ route concurrency worst case in CLI output

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary
+
+## Why this slice exists
+
+PR #1035 added per-case visibility to the hosted FAQ search concurrency smoke
+artifact, but the default terminal output still reports only aggregate errors
+and latency. Operators running a live mixed-query smoke without `--json` can
+miss which case is failing or slow unless they open the result file. This slice
+surfaces the worst per-case signal in the default one-line output while leaving
+the JSON artifact and pass/fail semantics unchanged.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Add a compact helper that selects the worst case summary from
+   `cases.summaries`.
+2. Include worst-case index, error count, p95 latency, and max latency in the
+   default non-JSON concurrency smoke output.
+3. Add focused tests for worst-case selection and printed output.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The runner already computes `cases.summaries` in the result payload. This PR
+adds a small pure helper that ranks case summaries by error count, p95 latency,
+max latency, and then case index. `_print_summary(...)` uses that helper only
+for the human-readable line. JSON output remains the complete structured
+payload.
+
+## Intentional
+
+- No pass/fail behavior changes. Existing aggregate budgets remain the only
+  budget enforcement in this slice.
+- No new command-line flags. The default output should include the operational
+  clue automatically.
+- The helper ranks by existing summary fields instead of reprocessing raw rows,
+  keeping the CLI line aligned with the artifact.
+
+## Deferred
+
+Parked hardening: none.
+
+Per-case pass/fail budgets remain deferred until a live hosted run provides
+evidence for thresholds worth enforcing.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py - 57 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py - passed.
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - passed, 122 matching tests enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh - 2550 passed, 7 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-worst-case-summary.md - pending.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 71 |
+| Runner output | 42 |
+| Tests | 85 |
+| **Total** | **198** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -438,6 +438,36 @@ def _case_result_summaries(
     return summaries
 
 
+def _worst_case_summary(summary: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    cases = summary.get("cases")
+    if not isinstance(cases, Mapping):
+        return None
+    case_summaries = cases.get("summaries")
+    if not isinstance(case_summaries, Sequence) or isinstance(case_summaries, (str, bytes)):
+        return None
+
+    best: Mapping[str, Any] | None = None
+    best_key: tuple[float, float, float, int] | None = None
+    for item in case_summaries:
+        if not isinstance(item, Mapping):
+            continue
+        errors = item.get("errors")
+        latency = item.get("latency")
+        if not isinstance(errors, Mapping) or not isinstance(latency, Mapping):
+            continue
+        case_index = int(item.get("case_index") or 0)
+        key = (
+            float(errors.get("count") or 0.0),
+            float(latency.get("p95_ms") or 0.0),
+            float(latency.get("max_ms") or 0.0),
+            -case_index,
+        )
+        if best_key is None or key > best_key:
+            best = item
+            best_key = key
+    return best
+
+
 def _budget_summary(
     *,
     latency: Mapping[str, Any],
@@ -559,6 +589,17 @@ def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
         print(json.dumps(summary, indent=2, sort_keys=True))
         return
     latency = summary["latency"]
+    worst_case = _worst_case_summary(summary)
+    worst_case_text = ""
+    if worst_case is not None:
+        worst_latency = worst_case["latency"]
+        worst_errors = worst_case["errors"]
+        worst_case_text = (
+            f" worst_case_index={worst_case['case_index']}"
+            f" worst_case_errors={worst_errors['count']}"
+            f" worst_case_p95_ms={worst_latency['p95_ms']}"
+            f" worst_case_max_ms={worst_latency['max_ms']}"
+        )
     print(
         "FAQ search hosted concurrency smoke: "
         f"ok={summary['ok']} requests={summary['requests']['total']} "
@@ -566,6 +607,7 @@ def _print_summary(summary: Mapping[str, Any], *, as_json: bool) -> None:
         f"max_ms={latency['max_ms']} detail_checked={summary['detail']['checked']} "
         f"detail_failures={summary['detail']['failures']} "
         f"budget_failures={len(summary['budgets']['failures'])}"
+        f"{worst_case_text}"
     )
 
 

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -491,6 +491,91 @@ def test_case_result_summaries_group_mixed_case_visibility():
     ]
 
 
+def test_worst_case_summary_prefers_errors_then_latency():
+    summary = {
+        "cases": {
+            "summaries": [
+                {
+                    "case_index": 0,
+                    "errors": {"count": 0, "rate": 0.0},
+                    "latency": {"p95_ms": 200.0, "max_ms": 250.0},
+                },
+                {
+                    "case_index": 1,
+                    "errors": {"count": 1, "rate": 0.5},
+                    "latency": {"p95_ms": 100.0, "max_ms": 120.0},
+                },
+                {
+                    "case_index": 2,
+                    "errors": {"count": 1, "rate": 0.5},
+                    "latency": {"p95_ms": 100.0, "max_ms": 120.0},
+                },
+                {
+                    "case_index": 3,
+                    "errors": {"count": 1, "rate": 0.5},
+                    "latency": {"p95_ms": 150.0, "max_ms": 160.0},
+                },
+            ]
+        }
+    }
+
+    tie_summary = {
+        "cases": {
+            "summaries": [
+                {
+                    "case_index": 1,
+                    "errors": {"count": 1, "rate": 0.5},
+                    "latency": {"p95_ms": 100.0, "max_ms": 120.0},
+                },
+                {
+                    "case_index": 2,
+                    "errors": {"count": 1, "rate": 0.5},
+                    "latency": {"p95_ms": 100.0, "max_ms": 120.0},
+                },
+            ]
+        }
+    }
+
+    assert smoke._worst_case_summary(summary)["case_index"] == 3
+    assert smoke._worst_case_summary(tie_summary)["case_index"] == 1
+    assert smoke._worst_case_summary({"cases": {"summaries": []}}) is None
+    assert smoke._worst_case_summary({"cases": {"summaries": "not-a-list"}}) is None
+
+
+def test_print_summary_includes_worst_case_signal(capsys):
+    summary = {
+        "ok": False,
+        "requests": {"total": 3},
+        "errors": {"count": 1},
+        "latency": {"p95_ms": 50.0, "max_ms": 75.0},
+        "detail": {"checked": 2, "failures": 1},
+        "budgets": {"failures": ["error_rate exceeded 0.0"]},
+        "cases": {
+            "summaries": [
+                {
+                    "case_index": 0,
+                    "errors": {"count": 0, "rate": 0.0},
+                    "latency": {"p95_ms": 15.0, "max_ms": 20.0},
+                },
+                {
+                    "case_index": 1,
+                    "errors": {"count": 1, "rate": 1.0},
+                    "latency": {"p95_ms": 30.0, "max_ms": 30.0},
+                },
+            ]
+        },
+    }
+
+    smoke._print_summary(summary, as_json=False)
+
+    assert capsys.readouterr().out.strip() == (
+        "FAQ search hosted concurrency smoke: ok=False requests=3 errors=1 "
+        "p95_ms=50.0 max_ms=75.0 detail_checked=2 detail_failures=1 "
+        "budget_failures=1 worst_case_index=1 worst_case_errors=1 "
+        "worst_case_p95_ms=30.0 worst_case_max_ms=30.0"
+    )
+
+
 def test_budget_summary_reports_error_and_latency_failures():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md
Slice phase: Robust testing

PR #1035 added per-case visibility to the hosted FAQ search concurrency smoke artifact, but default terminal output still reported only aggregate errors and latency. This surfaces the worst per-case signal in the normal one-line output so live mixed-query runs show the weak case without opening JSON.

## Intentional
- No pass/fail behavior changes. Existing aggregate budgets remain the only budget enforcement in this slice.
- No new command-line flags. The default output includes the operational clue automatically.
- The helper ranks by existing summary fields instead of reprocessing raw rows, keeping the CLI line aligned with the artifact.

## Deferred
- Per-case pass/fail budgets remain deferred until a live hosted run provides evidence for thresholds worth enforcing.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` - 57 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Worst-Case-Summary.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 122 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2550 passed, 7 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-worst-case-summary.md` - pending.

## Diff size
3 files, +198 / -0
