### PR TITLE
Document Content Ops cache default setup

### DIFF
--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -65,6 +65,38 @@ python scripts/check_extracted_content_install.py --profile all --sender resend 
 Use `--skip-webhook-secret` only for trusted webhook replay installs that will
 invoke `ingest_extracted_campaign_webhook.py --skip-signature-verification`.
 
+## Step 1a: Configure Hosted Cache Policy Defaults
+
+Atlas-hosted Content Ops routes can apply a default LLM cache policy before
+preview, plan, or execute. Leave the value blank to keep the existing per-run
+behavior:
+
+```bash
+export ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT=""
+```
+
+Accepted values are:
+
+| Value | Meaning |
+|---|---|
+| `exact`, `exact-cache`, `exact_cache` | Request exact-cache behavior when the downstream cache policy says the run is eligible. |
+| `no-store`, `no_store`, `off`, `false`, `no`, `none` | Force no-store unless a run explicitly sends another supported value. |
+| blank | Do not apply a hosted default. |
+
+The hosted default only fills `content_ops_cache_policy` when the request did
+not already choose one. A per-run UI or API value still wins, including
+`no-store`.
+
+If the env value is not in the accepted set, hosted Content Ops generation
+requests fail with a configuration error instead of silently falling back. Fix
+the env value and restart the host before retrying.
+
+Support-ticket and customer-upload runs remain no-store under the default
+privacy policy. Setting this env value to `exact-cache` is not enough to cache
+customer-upload prompts; that also requires the separate
+`EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED=true` setting and a
+deliberate privacy decision by the host.
+
 ## Step 2: Apply Migrations
 
 Preview pending migrations:

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -83,6 +83,10 @@ Accepted values are:
 | `no-store`, `no_store`, `off`, `false`, `no`, `none` | Force no-store unless a run explicitly sends another supported value. |
 | blank | Do not apply a hosted default. |
 
+An `exact-cache` default only requests cache use. The extracted LLM client still
+requires `EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED=true` before it will look
+up or store exact-cache entries.
+
 The hosted default only fills `content_ops_cache_policy` when the request did
 not already choose one. A per-run UI or API value still wins, including
 `no-store`.
@@ -93,7 +97,8 @@ the env value and restart the host before retrying.
 
 Support-ticket and customer-upload runs remain no-store under the default
 privacy policy. Setting this env value to `exact-cache` is not enough to cache
-customer-upload prompts; that also requires the separate
+customer-upload prompts; that also requires both
+`EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED=true` and the separate
 `EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED=true` setting and a
 deliberate privacy decision by the host.
 

--- a/plans/PR-Content-Ops-Cache-Default-Runbook.md
+++ b/plans/PR-Content-Ops-Cache-Default-Runbook.md
@@ -18,7 +18,9 @@ Slice phase: Product polish
 2. Document accepted default values and their normalized meanings.
 3. Document that invalid values fail hosted Content Ops generation requests
    loudly instead of falling back silently.
-4. Document that support-ticket/customer-upload runs remain no-store unless the
+4. Document that an `exact-cache` default also requires
+   `EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED=true` before cache I/O happens.
+5. Document that support-ticket/customer-upload runs remain no-store unless the
    separate customer-data exact-cache setting is enabled.
 
 ### Files touched
@@ -58,7 +60,7 @@ the existing request field when a run did not explicitly choose a cache policy.
 
 - python scripts/audit_plan_doc.py plans/PR-Content-Ops-Cache-Default-Runbook.md
   — passed.
-- rg -n "ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT|EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED|exact-cache|no-store" extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/content_ops_cache_policy.py atlas_brain/config.py
+- rg -n "ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT|EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED|EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED|exact-cache|no-store" extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/settings.py atlas_brain/config.py
   — confirmed the docs values match the implementation constants and host env
   name.
 - git diff --check — passed.

--- a/plans/PR-Content-Ops-Cache-Default-Runbook.md
+++ b/plans/PR-Content-Ops-Cache-Default-Runbook.md
@@ -1,0 +1,76 @@
+# PR: Content Ops Cache Default Runbook
+
+## Why this slice exists
+
+PR-Content-Ops-Cache-Policy-Default wired an env-backed hosted cache-policy
+default for Content Ops. The implementation deliberately fails loud when the
+global env value is invalid, because silently changing cache posture would be
+dangerous. Operators need the runbook to name the accepted values, the failure
+mode, and the customer-data privacy behavior before they set the env in a
+hosted environment.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Add a host runbook section for the Content Ops cache-policy default.
+2. Document accepted default values and their normalized meanings.
+3. Document that invalid values fail hosted Content Ops generation requests
+   loudly instead of falling back silently.
+4. Document that support-ticket/customer-upload runs remain no-store unless the
+   separate customer-data exact-cache setting is enabled.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Default-Runbook.md` | Plan doc for the operator runbook slice. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Document hosted Content Ops cache-policy default configuration and failure behavior. |
+
+## Mechanism
+
+The runbook gets a new configuration subsection near database and provider env
+setup. It names `ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT` as the
+Atlas host env default, lists the accepted spellings that flow through
+`normalize_content_ops_cache_policy`, and explains that the default only fills
+the existing request field when a run did not explicitly choose a cache policy.
+
+## Intentional
+
+- This is docs-only. The cache default behavior and host wiring already landed
+  in the prior production-hardening slice.
+- This does not add DB-backed tenant settings or UI editing. Those are larger
+  product decisions and remain separate from the runbook gap.
+- This does not recommend enabling exact cache for customer uploads by default.
+  The docs keep the same conservative privacy posture as the implementation.
+
+## Deferred
+
+- Future PR: DB-backed tenant cache settings if operators need durable in-app
+  defaults instead of an environment-level default.
+- Future PR: UI surface for editing or displaying the tenant cache default.
+- Parked hardening: none. Root `HARDENING.md` has no active
+  cost-surfacing parked items; `ATLAS-HARDENING.md` contains blog/deep-dive
+  content items outside this lane.
+
+## Verification
+
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-Cache-Default-Runbook.md
+  — passed.
+- rg -n "ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT|EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED|exact-cache|no-store" extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/content_ops_cache_policy.py atlas_brain/config.py
+  — confirmed the docs values match the implementation constants and host env
+  name.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-default-runbook.md
+  — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| Runbook docs | ~35 |
+| **Total** | **~100** |
+
+This stays below the 400 LOC soft cap.


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Default-Runbook.md
Slice phase: Product polish

PR #1034 made the hosted Content Ops cache-policy default live, but operators still needed the runbook to explain accepted values and the fail-loud invalid-env behavior. This PR documents the env-backed default, the valid spellings, explicit override precedence, the exact-cache enable flag, and the support-ticket/customer-upload no-store posture.

## Intentional
- Docs-only slice; the host wiring and extracted router behavior already landed.
- No DB-backed tenant settings or UI editing in this PR.
- The runbook does not recommend customer-upload exact cache by default.

## Deferred
- Future PR: DB-backed tenant cache settings if operators need durable in-app defaults.
- Future PR: UI surface for editing or displaying the tenant cache default.

## Parked hardening
- None. Root `HARDENING.md` has no active cost-surfacing parked items.

## Verification
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-Cache-Default-Runbook.md` — passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Content-Ops-Cache-Default-Runbook.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Content-Ops-Cache-Default-Runbook.md` — passed.
- `rg -n "ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT|EXTRACTED_CAMPAIGN_LLM_EXACT_CACHE_ENABLED|EXTRACTED_CAMPAIGN_LLM_CUSTOMER_DATA_EXACT_CACHE_ENABLED|exact-cache|no-store" extracted_content_pipeline/docs/host_install_runbook.md extracted_content_pipeline/content_ops_cache_policy.py extracted_content_pipeline/settings.py atlas_brain/config.py` — confirmed the documented values match the implementation constants and host env names.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/cache-default-runbook.md` — passed.

## Diff size
2 files, +106 / -0 (~100 LOC estimated).
