### PR TITLE
Summarize all FAQ route concurrency cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md
@@ -1,0 +1,68 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries
+
+## Why this slice exists
+
+PR #1035 added per-case summaries and PR #1036 surfaced the worst case in the
+default hosted FAQ search concurrency output. The summary wiring reused the
+`cases.items[:20]` preview cap, so case summaries and the worst-case signal can
+ignore case 21+ in a larger mixed-traffic case file. That weakens the operator
+visibility we just added. This slice keeps the preview cap but computes compact
+summaries for every loaded case.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Keep `cases.items` capped to the first 20 case definitions.
+2. Change `cases.summaries` to include all loaded cases, not the preview subset.
+3. Add a regression test proving a failing case beyond the preview cap appears
+   in summaries and drives the worst-case selection.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+`_summary_payload(...)` already has the full `active_cases` list. This PR passes
+that full list into `_case_result_summaries(...)` while leaving
+`cases.items[:20]` and `cases.truncated` unchanged. `_worst_case_summary(...)`
+then sees the complete compact summary set.
+
+## Intentional
+
+- The full raw case definitions remain capped in `cases.items`; only compact
+  per-case counts and timings are emitted for every case.
+- No new budgets or pass/fail behavior are introduced.
+- This fixes the visibility source instead of adding a special path in
+  `_worst_case_summary(...)`.
+
+## Deferred
+
+Parked hardening: none.
+
+Per-case pass/fail budgets remain deferred until live hosted runs provide
+threshold evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py - 58 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py - passed.
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - passed, 122 matching tests enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh - 2557 passed, 7 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-all-case-summaries.md - pending.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 68 |
+| Runner summary | 2 |
+| Tests | 50 |
+| **Total** | **120** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -557,7 +557,7 @@ def _summary_payload(
             "case_file": str(args.case_file or ""),
             "items": [_case_snapshot(case) for case in active_cases[:20]],
             "summaries": _case_result_summaries(
-                active_cases[:20],
+                active_cases,
                 results,
                 detail_required=bool(args.require_detail),
             ),

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -1148,6 +1148,56 @@ def test_main_result_includes_case_summaries_for_mixed_cases(tmp_path, monkeypat
     assert payload["cases"]["summaries"][1]["latency"]["count"] == 1
 
 
+def test_main_case_summaries_cover_cases_beyond_preview_cap(tmp_path, monkeypatch):
+    case_file = _write_case_file(
+        tmp_path,
+        [
+            {
+                "query": f"query {index}",
+                "corpus_id": f"corp-{index}",
+                "limit": 1,
+            }
+            for index in range(21)
+        ],
+    )
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _fake_urlopen(request, **_kwargs):
+        query = smoke.contract.urllib.parse.parse_qs(
+            smoke.contract.urllib.parse.urlsplit(request.full_url).query
+        )["q"][0]
+        if query == "query 20":
+            return _json_response({"query": query, "results": [], "count": 0})
+        return _json_response(_valid_payload())
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--case-file",
+        str(case_file),
+        "--requests",
+        "21",
+        "--concurrency",
+        "3",
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["cases"]["total"] == 21
+    assert len(payload["cases"]["items"]) == 20
+    assert payload["cases"]["truncated"] is True
+    assert len(payload["cases"]["summaries"]) == 21
+    assert payload["cases"]["summaries"][20]["case"]["query"] == "query 20"
+    assert payload["cases"]["summaries"][20]["errors"] == {"count": 1, "rate": 1.0}
+    assert smoke._worst_case_summary(payload)["case_index"] == 20
+
+
 def test_main_returns_exit_1_and_writes_result_for_contract_failures(tmp_path, monkeypatch):
     result_path = tmp_path / "hosted-concurrency.json"
     monkeypatch.setattr(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md
Slice phase: Robust testing

PR #1035 added per-case summaries and PR #1036 surfaced the worst case in CLI output, but summaries reused the `cases.items[:20]` preview cap. That meant case 21+ could be excluded from summaries and worst-case selection. This keeps the preview cap but summarizes every loaded case.

## Intentional
- The full raw case definitions remain capped in `cases.items`; only compact per-case counts and timings are emitted for every case.
- No new budgets or pass/fail behavior are introduced.
- This fixes the visibility source instead of adding a special path in `_worst_case_summary(...)`.

## Deferred
- Per-case pass/fail budgets remain deferred until live hosted runs provide threshold evidence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` - 58 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-All-Case-Summaries.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 122 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2557 passed, 7 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-all-case-summaries.md` - pending.

## Diff size
3 files, +119 / -1
