### PR TITLE
Add FAQ route concurrency per-case error budget

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md
@@ -1,0 +1,70 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget
+
+## Why this slice exists
+
+The hosted FAQ search concurrency smoke now reports every case summary and shows
+the worst case in the default output. The remaining survivability gap is that
+aggregate `--max-error-rate` can still pass when one query/corpus case fails but
+the overall request mix is large enough to dilute that failure. This slice adds
+an opt-in per-case error-rate budget so operators can fail closed on a bad case
+without changing default behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add `--max-case-error-rate` to the hosted FAQ search route concurrency smoke.
+2. Validate the new budget fail-closed during preflight.
+3. Evaluate the budget against every `cases.summaries[]` row.
+4. Add focused tests for preflight rejection and budget failure when aggregate
+   error rate passes but one case fails.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The runner already builds compact per-case summaries with each case's error
+rate. This PR passes those summaries into `_budget_summary(...)` and, when
+`--max-case-error-rate` is supplied, adds one check per case. A case whose
+`errors.rate` exceeds the configured value marks the run failed and records a
+deterministic budget failure string.
+
+## Intentional
+
+- The new budget is opt-in. No default hosted threshold is introduced.
+- This slice only gates per-case error rate. Per-case latency budgets remain
+  separate because latency thresholds need live route evidence.
+- The budget uses existing summaries instead of reprocessing raw rows, keeping
+  printed, JSON, and budget views aligned.
+
+## Deferred
+
+Parked hardening: none.
+
+Per-case latency budgets remain deferred until live hosted runs provide p95/max
+threshold evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py - 61 passed.
+- python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py - passed.
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md - passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py - passed, 122 matching tests enrolled.
+- bash scripts/run_extracted_pipeline_checks.sh - 2560 passed, 7 skipped.
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-error-budget.md - pending.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 70 |
+| Runner budget | 45 |
+| Tests | 108 |
+| **Total** | **223** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -77,6 +77,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-p95-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_P95_MS") or None)
     parser.add_argument("--max-single-request-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SINGLE_REQUEST_MS") or None)
     parser.add_argument("--max-detail-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_DETAIL_MS") or None)
+    parser.add_argument("--max-case-error-rate", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_CASE_ERROR_RATE") or None)
     parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
@@ -98,7 +99,14 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     for name in ("limit", "requests", "concurrency"):
         if int(getattr(args, name)) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
-    for name in ("timeout", "max_error_rate", "max_p95_ms", "max_single_request_ms", "max_detail_ms"):
+    for name in (
+        "timeout",
+        "max_error_rate",
+        "max_p95_ms",
+        "max_single_request_ms",
+        "max_detail_ms",
+        "max_case_error_rate",
+    ):
         value = getattr(args, name)
         if value is not None and not math.isfinite(float(value)):
             errors.append(f"--{name.replace('_', '-')} must be finite")
@@ -106,6 +114,8 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("--timeout must be positive")
     if not 0 <= float(args.max_error_rate) <= 1:
         errors.append("--max-error-rate must be between 0 and 1")
+    if args.max_case_error_rate is not None and not 0 <= float(args.max_case_error_rate) <= 1:
+        errors.append("--max-case-error-rate must be between 0 and 1")
     if bool(args.require_detail) and not bool(args.require_results):
         errors.append("--require-detail requires result rows; remove --allow-empty-results")
     if args.max_detail_ms is not None and not bool(args.require_detail):
@@ -472,8 +482,10 @@ def _budget_summary(
     *,
     latency: Mapping[str, Any],
     detail_latency: Mapping[str, Any],
+    case_summaries: Sequence[Mapping[str, Any]],
     errors: Mapping[str, Any],
     max_error_rate: float,
+    max_case_error_rate: float | None,
     max_p95_ms: float | None,
     max_single_request_ms: float | None,
     max_detail_ms: float | None,
@@ -517,6 +529,24 @@ def _budget_summary(
             )
             if not ok:
                 failures.append(f"detail_max_ms exceeded {limit_value}")
+    if max_case_error_rate is not None:
+        limit_value = round(float(max_case_error_rate), 6)
+        for case_summary in case_summaries:
+            case_index = int(case_summary.get("case_index") or 0)
+            case_errors = case_summary.get("errors")
+            actual = float(case_errors.get("rate") or 0.0) if isinstance(case_errors, Mapping) else 0.0
+            ok = actual <= limit_value
+            checks.append(
+                {
+                    "metric": "case_error_rate",
+                    "case_index": case_index,
+                    "actual": actual,
+                    "max": limit_value,
+                    "ok": ok,
+                }
+            )
+            if not ok:
+                failures.append(f"case_error_rate exceeded {limit_value} for case {case_index}")
     return {"ok": not failures, "checks": checks, "failures": failures}
 
 
@@ -532,11 +562,18 @@ def _summary_payload(
     errors = _error_summary(results)
     latency = _latency_summary(results)
     detail = _detail_summary(results, required=bool(args.require_detail))
+    case_summaries = _case_result_summaries(
+        active_cases,
+        results,
+        detail_required=bool(args.require_detail),
+    )
     budgets = _budget_summary(
         latency=latency,
         detail_latency=detail["latency"],
+        case_summaries=case_summaries,
         errors=errors,
         max_error_rate=float(args.max_error_rate),
+        max_case_error_rate=args.max_case_error_rate,
         max_p95_ms=args.max_p95_ms,
         max_single_request_ms=args.max_single_request_ms,
         max_detail_ms=args.max_detail_ms,
@@ -556,11 +593,7 @@ def _summary_payload(
             "total": len(active_cases),
             "case_file": str(args.case_file or ""),
             "items": [_case_snapshot(case) for case in active_cases[:20]],
-            "summaries": _case_result_summaries(
-                active_cases,
-                results,
-                detail_required=bool(args.require_detail),
-            ),
+            "summaries": case_summaries,
             "truncated": len(active_cases) > 20,
         },
         "requests": {

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -48,6 +48,7 @@ def _args(**overrides):
         "max_p95_ms": None,
         "max_single_request_ms": None,
         "max_detail_ms": None,
+        "max_case_error_rate": None,
         "require_results": True,
         "require_detail": False,
         "case_file": None,
@@ -168,6 +169,15 @@ def test_validate_args_rejects_non_positive_detail_budget():
     assert errors == ["--max-detail-ms must be positive"]
 
 
+def test_validate_args_rejects_case_error_budget_outside_rate_range():
+    assert smoke._validate_args(_args(max_case_error_rate=-0.1)) == [
+        "--max-case-error-rate must be between 0 and 1"
+    ]
+    assert smoke._validate_args(_args(max_case_error_rate=1.1)) == [
+        "--max-case-error-rate must be between 0 and 1"
+    ]
+
+
 def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe():
     required = smoke._build_parser().parse_args([
         "--base-url",
@@ -215,6 +225,19 @@ def test_parser_accepts_detail_latency_budget_with_detail_check():
 
     assert parsed.require_detail is True
     assert parsed.max_detail_ms == 250.0
+
+
+def test_parser_accepts_case_error_rate_budget():
+    parsed = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-case-error-rate",
+        "0.25",
+    ])
+
+    assert parsed.max_case_error_rate == 0.25
 
 
 def test_load_cases_defaults_to_cli_case():
@@ -580,8 +603,13 @@ def test_budget_summary_reports_error_and_latency_failures():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},
         detail_latency={"count": 2, "p95_ms": 25.0, "max_ms": 30.0},
+        case_summaries=[
+            {"case_index": 0, "errors": {"rate": 0.0}},
+            {"case_index": 1, "errors": {"rate": 0.5}},
+        ],
         errors={"rate": 0.25},
         max_error_rate=0.0,
+        max_case_error_rate=0.25,
         max_p95_ms=40.0,
         max_single_request_ms=100.0,
         max_detail_ms=20.0,
@@ -594,11 +622,26 @@ def test_budget_summary_reports_error_and_latency_failures():
             {"metric": "p95_ms", "actual": 50.0, "max": 40.0, "ok": False},
             {"metric": "max_ms", "actual": 75.0, "max": 100.0, "ok": True},
             {"metric": "detail_max_ms", "actual": 30.0, "max": 20.0, "ok": False},
+            {
+                "metric": "case_error_rate",
+                "case_index": 0,
+                "actual": 0.0,
+                "max": 0.25,
+                "ok": True,
+            },
+            {
+                "metric": "case_error_rate",
+                "case_index": 1,
+                "actual": 0.5,
+                "max": 0.25,
+                "ok": False,
+            },
         ],
         "failures": [
             "error_rate exceeded 0.0",
             "p95_ms exceeded 40.0",
             "detail_max_ms exceeded 20.0",
+            "case_error_rate exceeded 0.25 for case 1",
         ],
     }
 
@@ -607,8 +650,10 @@ def test_budget_summary_fails_closed_when_detail_budget_has_no_detail_rows():
     summary = smoke._budget_summary(
         latency={"p95_ms": 50.0, "max_ms": 75.0},
         detail_latency={"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+        case_summaries=[],
         errors={"rate": 0.0},
         max_error_rate=0.0,
+        max_case_error_rate=None,
         max_p95_ms=None,
         max_single_request_ms=None,
         max_detail_ms=20.0,
@@ -1146,6 +1191,69 @@ def test_main_result_includes_case_summaries_for_mixed_cases(tmp_path, monkeypat
     assert payload["cases"]["summaries"][1]["requests"] == 1
     assert payload["cases"]["summaries"][1]["errors"] == {"count": 1, "rate": 1.0}
     assert payload["cases"]["summaries"][1]["latency"]["count"] == 1
+
+
+def test_main_fails_case_error_budget_when_aggregate_error_budget_passes(tmp_path, monkeypatch):
+    case_file = _write_case_file(
+        tmp_path,
+        [
+            {"query": "credit report", "corpus_id": "corp-a", "limit": 2},
+            {"query": "mortgage dispute", "corpus_id": "corp-b", "limit": 3},
+        ],
+    )
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _fake_urlopen(request, **_kwargs):
+        query = smoke.contract.urllib.parse.parse_qs(
+            smoke.contract.urllib.parse.urlsplit(request.full_url).query
+        )["q"][0]
+        if query == "credit report":
+            return _json_response(_valid_payload())
+        return _json_response({"query": query, "results": [], "count": 0})
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _fake_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--case-file",
+        str(case_file),
+        "--requests",
+        "2",
+        "--concurrency",
+        "2",
+        "--max-error-rate",
+        "1",
+        "--max-case-error-rate",
+        "0",
+        "--output-result",
+        str(result_path),
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["errors"]["rate"] == 0.5
+    assert payload["budgets"]["checks"][-2:] == [
+        {
+            "metric": "case_error_rate",
+            "case_index": 0,
+            "actual": 0.0,
+            "max": 0.0,
+            "ok": True,
+        },
+        {
+            "metric": "case_error_rate",
+            "case_index": 1,
+            "actual": 1.0,
+            "max": 0.0,
+            "ok": False,
+        },
+    ]
+    assert payload["budgets"]["failures"] == [
+        "case_error_rate exceeded 0.0 for case 1"
+    ]
 
 
 def test_main_case_summaries_cover_cases_beyond_preview_cap(tmp_path, monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md
Slice phase: Production hardening

The hosted FAQ search concurrency smoke now reports every case summary and worst case, but aggregate `--max-error-rate` can still pass when one query/corpus case fails inside a larger request mix. This adds an opt-in per-case error-rate budget so operators can fail closed on a bad case without changing default behavior.

## Intentional
- The new budget is opt-in. No default hosted threshold is introduced.
- This slice only gates per-case error rate. Per-case latency budgets remain separate because latency thresholds need live route evidence.
- The budget uses existing summaries instead of reprocessing raw rows, keeping printed, JSON, and budget views aligned.

## Deferred
- Per-case latency budgets remain deferred until live hosted runs provide p95/max threshold evidence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` - 61 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Budget.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 122 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2560 passed, 7 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-error-budget.md` - pending.

## Diff size
3 files, +217 / -6
