### PR TITLE
Label Content Ops admin cost rows

### DIFF
--- a/atlas_brain/api/admin_costs.py
+++ b/atlas_brain/api/admin_costs.py
@@ -344,6 +344,9 @@ def _describe_recent_call(span_name: str, metadata: dict) -> tuple[str, str | No
     reasoning_mode = _recent_metadata_value(metadata, "reasoning_mode")
     phase = _recent_metadata_value(metadata, "phase")
     skill = _recent_metadata_value(metadata, "skill")
+    content_ops_description = _describe_content_ops_call(span_name, metadata)
+    if content_ops_description is not None:
+        return content_ops_description
 
     if span_name == "reasoning.stratified.reason":
         return "Stratified Reasoning", f"Full reason{f' for {vendor_name}' if vendor_name else ''}"
@@ -375,6 +378,42 @@ def _describe_recent_call(span_name: str, metadata: dict) -> tuple[str, str | No
     return span_name, detail
 
 
+def _describe_content_ops_call(
+    span_name: str,
+    metadata: dict,
+) -> tuple[str, str | None] | None:
+    product = str(_recent_metadata_value(metadata, "product") or "").strip().lower()
+    if span_name != "content_ops.llm.complete" and product != "content_ops":
+        return None
+
+    asset_type = _recent_metadata_value(metadata, "asset_type")
+    source_type = (
+        _recent_metadata_value(metadata, "source_material_type")
+        or _recent_metadata_value(metadata, "source_type")
+    )
+    cache_mode = _recent_metadata_value(metadata, "cache_mode")
+    cache_reason = _recent_metadata_value(metadata, "cache_reason")
+    cache_result = _recent_metadata_value(metadata, "cache_result")
+
+    title = "Content Ops"
+    if asset_type:
+        title = f"{title} {_humanize_identifier(asset_type)}"
+    else:
+        title = f"{title} LLM"
+
+    detail_parts = []
+    if source_type:
+        detail_parts.append(f"Source: {_humanize_identifier(source_type)}")
+    cache_parts = [
+        _humanize_identifier(value)
+        for value in (cache_mode, cache_reason, cache_result)
+        if value
+    ]
+    if cache_parts:
+        detail_parts.append(f"Cache: {' / '.join(cache_parts)}")
+    return title, " • ".join(detail_parts) or None
+
+
 def _serialize_recent_llm_call(row, *, run_id_override: str | None = None) -> dict:
     metadata = _normalize_metadata(row["metadata"])
     title, detail = _describe_recent_call(row["span_name"], metadata)
@@ -385,6 +424,16 @@ def _serialize_recent_llm_call(row, *, run_id_override: str | None = None) -> di
     event_type = str(_recent_metadata_value(metadata, "event_type") or "").strip() or None
     entity_type = str(_recent_metadata_value(metadata, "entity_type") or "").strip() or None
     entity_id = str(_recent_metadata_value(metadata, "entity_id") or "").strip() or None
+    content_ops_asset_type = str(_recent_metadata_value(metadata, "asset_type") or "").strip() or None
+    content_ops_source_type = str(
+        _recent_metadata_value(metadata, "source_material_type")
+        or _recent_metadata_value(metadata, "source_type")
+        or ""
+    ).strip() or None
+    cache_mode = str(_recent_metadata_value(metadata, "cache_mode") or "").strip() or None
+    cache_reason = str(_recent_metadata_value(metadata, "cache_reason") or "").strip() or None
+    cache_result = str(_recent_metadata_value(metadata, "cache_result") or "").strip() or None
+    cache_store_result = str(_recent_metadata_value(metadata, "cache_store_result") or "").strip() or None
     return {
         "id": str(row["id"]),
         "run_id": run_id,
@@ -397,6 +446,12 @@ def _serialize_recent_llm_call(row, *, run_id_override: str | None = None) -> di
         "event_type": event_type,
         "entity_type": entity_type,
         "entity_id": entity_id,
+        "content_ops_asset_type": content_ops_asset_type,
+        "content_ops_source_type": content_ops_source_type,
+        "cache_mode": cache_mode,
+        "cache_reason": cache_reason,
+        "cache_result": cache_result,
+        "cache_store_result": cache_store_result,
         "model": row["model_name"],
         "provider": row["model_provider"],
         "input_tokens": row["input_tokens"],

--- a/plans/PR-Content-Ops-Admin-Cost-Labels.md
+++ b/plans/PR-Content-Ops-Admin-Cost-Labels.md
@@ -1,0 +1,89 @@
+# PR: Content Ops Admin Cost Labels
+
+## Why this slice exists
+
+Content Ops LLM traces now carry asset, source, account, and cache metadata, and
+the Content Ops screen can show usage and cache diagnostics. The broader admin
+cost feed still renders those calls as generic `content_ops.llm.complete` rows,
+which makes the cross-product cost dashboard harder to scan when Content Ops
+traffic is mixed with enrichment, reasoning, and blog-generation traffic.
+
+This slice adds a narrow source-side labeling layer for Content Ops rows in the
+admin-cost recent-call serializer. It does not create a new dashboard or read
+path; it makes the existing recent-cost surface use the metadata already being
+recorded.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Teach the admin-cost recent-call description helper to recognize Content Ops
+   LLM rows by span name or `metadata.product`.
+2. Render a readable title such as `Content Ops Landing Page` from
+   `metadata.asset_type`.
+3. Include source/cache detail text from existing trace metadata.
+4. Surface Content Ops asset/source/cache fields as structured recent-call
+   fields for future UI use.
+5. Add a focused admin-cost route test for Content Ops recent-call labeling and
+   filtering.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Admin-Cost-Labels.md` | Plan doc for the admin cost labeling slice. |
+| `atlas_brain/api/admin_costs.py` | Add Content Ops recent-call labeling and structured metadata fields. |
+| `tests/test_admin_costs.py` | Cover Content Ops recent-call labeling through the hosted admin route. |
+
+## Mechanism
+
+`_describe_recent_call(...)` gets a Content Ops branch ahead of the generic
+pipeline fallback. It recognizes the canonical `content_ops.llm.complete` span
+or `metadata.product == content_ops`, then builds a title from `asset_type` and
+a compact detail string from `source_material_type`, `cache_mode`,
+`cache_reason`, and `cache_result`.
+
+`_serialize_recent_llm_call(...)` also exposes those same metadata values as
+nullable fields. This keeps the backend as the single place that understands
+Content Ops trace metadata, while the UI can remain a straightforward renderer.
+
+## Intentional
+
+- This only labels recent-call rows. It does not change cost aggregation,
+  billing math, cache policy, or Content Ops usage-summary routes.
+- This does not add a new admin endpoint. The existing `/admin/costs/recent`
+  route already has the filters operators need.
+- This does not parse prompts or generated content. It uses trace metadata
+  only.
+
+## Deferred
+
+- Future PR: add Content Ops-specific rollups to `/admin/costs/cache-health` if
+  operators need cross-product cache summaries outside the Content Ops screen.
+- Future PR: render the new structured fields in the Intel UI admin-cost page
+  if the current title/detail fields are not enough.
+- Parked hardening: none. Root `HARDENING.md` has no active
+  cost-surfacing parked items; `ATLAS-HARDENING.md` contains blog/deep-dive
+  content items outside this lane.
+
+## Verification
+
+- python -m pytest tests/test_admin_costs.py::test_recent_calls_labels_content_ops_trace_metadata tests/test_admin_costs.py::test_recent_calls_returns_granular_cache_fields tests/test_admin_costs.py::test_recent_calls_filters_and_surfaces_battle_card_context -q
+  — 3 passed, 1 warning.
+- python -m compileall -q atlas_brain/api/admin_costs.py tests/test_admin_costs.py
+  — passed.
+- git diff --check — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/admin-cost-labels.md
+  — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Admin-cost serializer | ~55 |
+| Tests | ~45 |
+| **Total** | **~180** |
+
+This stays below the 400 LOC soft cap.

--- a/tests/test_admin_costs.py
+++ b/tests/test_admin_costs.py
@@ -919,6 +919,40 @@ class _FakePool:
                 },
                 "created_at": datetime(2026, 3, 31, 22, 15, tzinfo=timezone.utc),
             }]
+        if "content_ops.llm.complete" in args:
+            return [{
+                "id": uuid4(),
+                "run_id": "content-ops-run-1",
+                "span_name": "content_ops.llm.complete",
+                "operation_type": "llm_call",
+                "model_name": "anthropic/claude-3-5-haiku",
+                "model_provider": "openrouter",
+                "input_tokens": 7200,
+                "billable_input_tokens": 0,
+                "cached_tokens": 7200,
+                "cache_write_tokens": 0,
+                "output_tokens": 900,
+                "total_tokens": 8100,
+                "cost_usd": Decimal("0"),
+                "duration_ms": 122,
+                "ttft_ms": 30,
+                "inference_time_ms": 80,
+                "queue_time_ms": 4,
+                "tokens_per_second": 40.5,
+                "status": "completed",
+                "api_endpoint": "exact-cache",
+                "provider_request_id": None,
+                "metadata": {
+                    "product": "content_ops",
+                    "asset_type": "landing_page",
+                    "source_material_type": "support_ticket",
+                    "cache_mode": "no_store",
+                    "cache_reason": "customer_data_no_store",
+                    "cache_result": "hit",
+                    "cache_store_result": "skipped",
+                },
+                "created_at": datetime(2026, 3, 31, 22, 20, tzinfo=timezone.utc),
+            }]
         return [{
             "id": uuid4(),
             "run_id": "run-blog-1",
@@ -1347,6 +1381,27 @@ def test_recent_calls_filters_and_surfaces_battle_card_context(monkeypatch):
     assert "source_name" in pool.last_fetch_query
     assert "event_type" in pool.last_fetch_query
     assert "entity_type" in pool.last_fetch_query
+
+
+def test_recent_calls_labels_content_ops_trace_metadata(monkeypatch):
+    client, pool = _client(monkeypatch)
+    with client:
+        res = client.get(
+            "/admin/costs/recent?span_name=content_ops.llm.complete&limit=10"
+        )
+    assert res.status_code == 200
+    row = res.json()["calls"][0]
+    assert row["title"] == "Content Ops Landing Page"
+    assert row["detail"] == (
+        "Source: Support Ticket • Cache: No Store / Customer Data No Store / Hit"
+    )
+    assert row["content_ops_asset_type"] == "landing_page"
+    assert row["content_ops_source_type"] == "support_ticket"
+    assert row["cache_mode"] == "no_store"
+    assert row["cache_reason"] == "customer_data_no_store"
+    assert row["cache_result"] == "hit"
+    assert row["cache_store_result"] == "skipped"
+    assert "span_name =" in pool.last_fetch_query
 
 
 def test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Admin-Cost-Labels.md
Slice phase: Product polish

Content Ops LLM traces now carry asset, source, and cache metadata, but the broader admin cost feed still rendered them as generic `content_ops.llm.complete` rows. This PR adds source-side labeling and structured fields to the existing recent-call serializer so operators can identify Content Ops spend in the cross-product cost feed without a new endpoint.

## Intentional
- Only labels recent-call rows; cost aggregation, billing math, cache policy, and Content Ops usage-summary routes are unchanged.
- No new admin endpoint.
- No prompt or generated-content parsing; this uses trace metadata only.

## Deferred
- Future PR: add Content Ops-specific rollups to `/admin/costs/cache-health` if operators need cross-product cache summaries outside the Content Ops screen.
- Future PR: render the new structured fields in the Intel UI admin-cost page if title/detail are not enough.

## Parked hardening
- None. Root `HARDENING.md` has no active cost-surfacing parked items.

## Verification
- `python -m pytest tests/test_admin_costs.py::test_recent_calls_labels_content_ops_trace_metadata tests/test_admin_costs.py::test_recent_calls_returns_granular_cache_fields tests/test_admin_costs.py::test_recent_calls_filters_and_surfaces_battle_card_context -q` — 3 passed, 1 warning.
- `python -m compileall -q atlas_brain/api/admin_costs.py tests/test_admin_costs.py` — passed.
- `python scripts/audit_plan_doc_files_touched.py plans/PR-Content-Ops-Admin-Cost-Labels.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-Content-Ops-Admin-Cost-Labels.md` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file <git-path>/codex-pr-bodies/admin-cost-labels.md` — passed.

## Diff size
3 files, +197 / -0 (~180 LOC estimated).
