### PR TITLE
Add Content Ops cache-health section

### DIFF
--- a/atlas_brain/api/admin_costs.py
+++ b/atlas_brain/api/admin_costs.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import psutil
+from extracted_content_pipeline.content_ops_usage_summary import summarize_content_ops_llm_usage
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..auth.dependencies import AuthUser, require_auth
@@ -2665,6 +2666,7 @@ async def cache_health(
         since,
         top_n,
     )
+    content_ops_usage = await summarize_content_ops_llm_usage(pool, days=days)
 
     batch_summary_row = await _safe_fetchrow(
         pool,
@@ -2969,6 +2971,7 @@ async def cache_health(
                 for row in prompt_cache_spans
             ],
         },
+        "content_ops": content_ops_usage,
         "anthropic_batching": {
             "enabled": bool(settings.b2b_churn.anthropic_batch_enabled),
             "stale_job_threshold_minutes": stale_threshold_minutes,

--- a/plans/PR-Content-Ops-Cache-Health-Section.md
+++ b/plans/PR-Content-Ops-Cache-Health-Section.md
@@ -1,0 +1,80 @@
+# PR: Content Ops Cache Health Section
+
+## Why this slice exists
+
+The Content Ops cost/caching lane now has cache policy defaults, exact-cache
+adapter behavior, cache savings, and Content Ops usage diagnostics. The broader
+admin `/admin/costs/cache-health` route still reports the legacy Atlas cache
+layers without a Content Ops section, so an operator has to know about the
+separate Content Ops summary route to see whether Content Ops cache policy is
+working.
+
+This slice wires the existing Content Ops usage read model into the admin cache
+health endpoint instead of reimplementing cache-status aggregation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Add a `content_ops` section to `/admin/costs/cache-health`.
+2. Reuse `summarize_content_ops_llm_usage` as the single source of truth for
+   Content Ops calls, cache hits, cache savings, and cache-status rows.
+3. Keep the existing cache-health sections unchanged.
+4. Add a focused route test that proves the admin endpoint returns the Content
+   Ops summary and calls the shared helper with the same `days` window.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Content-Ops-Cache-Health-Section.md` | Plan doc for the admin cache-health Content Ops section. |
+| `atlas_brain/api/admin_costs.py` | Add the shared Content Ops usage summary to the cache-health response. |
+| `tests/test_admin_costs.py` | Cover the new cache-health section and helper wiring. |
+
+## Mechanism
+
+`admin_costs.cache_health(...)` imports and awaits
+`summarize_content_ops_llm_usage(pool, days=days)`, then includes the returned
+payload under a new top-level `content_ops` key. The helper already owns the
+Content Ops `llm_usage` filters and cache-status grouping, so the broader admin
+endpoint does not duplicate query text or metadata field names.
+
+The route test monkeypatches the imported helper with an async fake. That keeps
+this PR focused on route integration while the existing
+`tests/test_extracted_content_ops_usage_summary.py` suite continues to prove
+the helper's SQL and payload details.
+
+## Intentional
+
+- This does not rewrite the existing exact/provider/semantic/batch sections.
+  They remain the broader Atlas cache-health view.
+- This does not add another Content Ops cache-status query in
+  `admin_costs.py`; duplicating the helper would create drift.
+- This does not add UI rendering yet. The endpoint payload lands first so the
+  admin UI can consume one stable field later.
+
+## Deferred
+
+- Future PR: render the new `content_ops` cache-health section in the admin
+  cost UI.
+- Future PR: fold #1040's recent-call labels into this view after that PR
+  merges, if the UI needs drill-down links from the cache-health card.
+- Parked hardening: none. Root `HARDENING.md` was scanned; there are no active
+  parked items for this ownership lane.
+
+## Verification
+
+- python -m pytest tests/test_admin_costs.py::test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse -q — 1 passed, 1 warning.
+- python -m compileall -q atlas_brain/api/admin_costs.py tests/test_admin_costs.py — passed.
+- python -m pytest tests/test_admin_costs.py::test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse tests/test_extracted_content_ops_usage_summary.py::test_content_ops_usage_summary_contract_against_postgres tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters -q — 2 passed, 1 skipped, 1 warning.
+- git diff --check — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| Route wiring | ~5 |
+| Test | ~25 |
+| **Total** | **~100** |

--- a/tests/test_admin_costs.py
+++ b/tests/test_admin_costs.py
@@ -1355,7 +1355,28 @@ def test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse(monkeypatch)
         True,
         raising=False,
     )
-    client, _ = _client(monkeypatch)
+    content_ops_summary = {
+        "period_days": 14,
+        "summary": {
+            "total_calls": 3,
+            "cache_hit_calls": 1,
+            "total_cache_savings_usd": 0.0123,
+        },
+        "by_cache_status": [{
+            "cache_mode": "exact",
+            "cache_reason": "eligible",
+            "cache_result": "hit",
+            "cache_store_result": "skipped",
+            "calls": 1,
+            "cache_savings_usd": 0.0123,
+        }],
+    }
+    summarize_content_ops = AsyncMock(return_value=content_ops_summary)
+    monkeypatch.setattr(
+        "atlas_brain.api.admin_costs.summarize_content_ops_llm_usage",
+        summarize_content_ops,
+    )
+    client, pool = _client(monkeypatch)
     with client:
         res = client.get("/admin/costs/cache-health?days=14&top_n=5")
     assert res.status_code == 200
@@ -1367,6 +1388,8 @@ def test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse(monkeypatch)
     assert body["exact_cache"]["total_hits"] == 19
     assert body["provider_prompt_cache"]["cache_hit_calls"] == 11
     assert body["provider_prompt_cache"]["top_spans"][0]["span_name"] == "task.b2b_blog_post_generation"
+    assert body["content_ops"] == content_ops_summary
+    summarize_content_ops.assert_awaited_once_with(pool, days=14)
     assert body["anthropic_batching"]["submitted_jobs"] == 2
     assert body["anthropic_batching"]["estimated_savings_usd"] == pytest.approx(0.6)
     assert body["anthropic_batching"]["stages"][0]["stage_id"] == "b2b_campaign_generation.content"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Cache-Health-Section.md
Slice phase: Product polish

The broader admin `/admin/costs/cache-health` route reports Atlas cache layers, but not the Content Ops cache policy/read-model that now owns Content Ops cache status and savings. This PR adds a top-level `content_ops` section by reusing `summarize_content_ops_llm_usage`, so the admin endpoint does not duplicate Content Ops cache-status SQL or metadata field names.

## Intentional
- Reuse `summarize_content_ops_llm_usage` as the single source of truth for Content Ops calls, cache hits, cache savings, and cache-status rows.
- Leave the existing exact/provider/semantic/batch cache-health sections unchanged.
- Do not add UI rendering in this slice.

## Deferred
- Future PR: render the new `content_ops` cache-health section in the admin cost UI.
- Future PR: fold #1040's recent-call labels into this view after that PR merges, if the UI needs drill-down links from the cache-health card.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_admin_costs.py::test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse -q` — 1 passed, 1 warning.
- `python -m compileall -q atlas_brain/api/admin_costs.py tests/test_admin_costs.py` — passed.
- `python -m pytest tests/test_admin_costs.py::test_cache_health_rolls_up_exact_prompt_semantic_and_task_reuse tests/test_extracted_content_ops_usage_summary.py::test_content_ops_usage_summary_contract_against_postgres tests/test_extracted_content_control_surface_api.py::test_usage_summary_route_returns_content_ops_llm_rollup_with_filters -q` — 2 passed, 1 skipped, 1 warning.
- `git diff --check` — passed.

## Diff size
3 files, about +107 / -1.
