### PR TITLE
Reject contradictory FAQ detail smoke case files

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md
@@ -1,0 +1,77 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight
+
+## Why this slice exists
+
+PR #1042 fixed the operator runbook so detail-required concurrency smoke cases
+are hit-only and miss/liveness cases run separately without detail hydration.
+The same contradictory input can still be supplied directly to the smoke CLI:
+`--require-detail` plus a case file where a case sets `require_results: false`.
+That shape cannot produce a valid detail hydration check because no first
+`faq_id` is expected. The tool should reject it during preflight instead of
+issuing hosted requests and reporting a later detail failure.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Extend case-file preflight validation for the hosted FAQ route concurrency
+   smoke.
+2. Reject any case-file row with `require_results: false` when `--require-detail`
+   is enabled.
+3. Add focused tests proving the detector fails closed and prevents hosted
+   request execution.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+`_load_cases(...)` already validates each case-file row before `main(...)`
+starts concurrency work. This slice adds one more row-level invariant: detail
+mode requires result rows, so a case-level `require_results: false` is invalid
+when `args.require_detail` is true. The existing `main(...)` preflight path then
+writes the result artifact and exits `2` without calling `_run_concurrent(...)`.
+
+## Intentional
+
+- No change to search-only miss/liveness probes; `require_results: false`
+  remains valid when detail hydration is not required.
+- No runtime route behavior changes. This only tightens the local smoke CLI
+  contract before requests leave the process.
+- No runbook changes; PR #1042 already documented the safe operator shape.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ search
+entries touching this runner.
+
+Live hosted threshold tuning remains deferred until repeated hosted runs provide
+stable latency evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py
+  (64 passed)
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md
+  (passed)
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  (122 matching tests enrolled)
+- bash scripts/run_extracted_pipeline_checks.sh
+  (2563 passed, 7 skipped)
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-detail-case-preflight.md
+  (passed)
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 77 |
+| Smoke script | 4 |
+| Tests | 51 |
+| **Total** | **132** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -167,6 +167,10 @@ def _load_cases(args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[st
         require_results = item.get("require_results", bool(args.require_results))
         if type(require_results) is not bool:
             errors.append(f"case[{index}].require_results must be a boolean")
+        elif bool(args.require_detail) and not require_results:
+            errors.append(
+                f"case[{index}].require_results cannot be false when --require-detail is set"
+            )
 
         expected_count = item.get("expected_count")
         if "expected_count" in item and (type(expected_count) is not int or expected_count < 0):

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -346,6 +346,20 @@ def test_load_cases_inherits_optional_cli_defaults(tmp_path):
     ]
 
 
+def test_load_cases_rejects_case_empty_results_with_detail_required(tmp_path):
+    case_file = _write_case_file(
+        tmp_path,
+        [{"query": "unknown billing workflow", "require_results": False}],
+    )
+
+    cases, errors = smoke._load_cases(_args(case_file=case_file, require_detail=True))
+
+    assert cases == []
+    assert errors == [
+        "case[0].require_results cannot be false when --require-detail is set"
+    ]
+
+
 @pytest.mark.parametrize(
     ("payload", "expected_error"),
     [
@@ -1161,6 +1175,43 @@ def test_main_rejects_detail_with_allowed_empty_results_before_network(tmp_path,
     assert payload["requests"]["total"] == 0
     assert payload["preflight_errors"] == [
         "--require-detail requires result rows; remove --allow-empty-results"
+    ]
+    assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
+
+
+def test_main_rejects_case_empty_results_with_detail_before_network(tmp_path, monkeypatch, capsys):
+    case_file = _write_case_file(
+        tmp_path,
+        [{"query": "unknown billing workflow", "require_results": False}],
+    )
+    result_path = tmp_path / "hosted-concurrency.json"
+
+    def _unexpected_urlopen(*_args, **_kwargs):
+        raise AssertionError("preflight failures must not issue route requests")
+
+    monkeypatch.setattr(smoke.contract.urllib.request, "urlopen", _unexpected_urlopen)
+
+    code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--case-file",
+        str(case_file),
+        "--require-detail",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["phase"] == "preflight"
+    assert payload["require_detail"] is True
+    assert payload["cases"]["total"] == 0
+    assert payload["preflight_errors"] == [
+        "case[0].require_results cannot be false when --require-detail is set"
     ]
     assert json.loads(capsys.readouterr().out)["phase"] == "preflight"
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md
Slice phase: Production hardening

PR #1042 fixed the operator runbook for detail-required hit cases versus miss/liveness cases. This slice hardens the smoke CLI itself so a case file cannot combine `--require-detail` with a row that sets `require_results: false`; the contradiction now fails at preflight before hosted requests are issued.

## Intentional
- Search-only miss/liveness probes still allow `require_results: false`.
- No route or database behavior changes; this only tightens the local smoke CLI contract.
- No runbook changes; #1042 already documented the safe operator shape.

## Deferred
- Live hosted threshold tuning remains deferred until repeated hosted runs provide stable latency evidence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` (64 passed)
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Detail-Case-Preflight.md` (passed)
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` (122 matching tests enrolled)
- `bash scripts/run_extracted_pipeline_checks.sh` (2563 passed, 7 skipped)
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-detail-case-preflight.md` (passed)

## Diff size
3 files, +132 / -0
