### PR TITLE
Enroll admin costs tests in CI

### DIFF
--- a/.github/workflows/admin_costs_checks.yml
+++ b/.github/workflows/admin_costs_checks.yml
@@ -25,11 +25,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
 
-      - name: Install dependencies
+      - name: Install runtime dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio asyncpg fastapi httpx PyJWT pydantic-settings psutil markdown python-multipart
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
 
       - name: Run admin costs tests
         run: python -m pytest tests/test_admin_costs.py -q

--- a/.github/workflows/admin_costs_checks.yml
+++ b/.github/workflows/admin_costs_checks.yml
@@ -1,0 +1,35 @@
+name: Admin Costs Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/admin_costs_checks.yml"
+      - "atlas_brain/api/admin_costs.py"
+      - "tests/test_admin_costs.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/admin_costs_checks.yml"
+      - "atlas_brain/api/admin_costs.py"
+      - "tests/test_admin_costs.py"
+
+jobs:
+  admin-costs-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-asyncio fastapi httpx PyJWT pydantic-settings psutil markdown python-multipart
+
+      - name: Run admin costs tests
+        run: python -m pytest tests/test_admin_costs.py -q

--- a/.github/workflows/admin_costs_checks.yml
+++ b/.github/workflows/admin_costs_checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio fastapi httpx PyJWT pydantic-settings psutil markdown python-multipart
+          python -m pip install pytest pytest-asyncio asyncpg fastapi httpx PyJWT pydantic-settings psutil markdown python-multipart
 
       - name: Run admin costs tests
         run: python -m pytest tests/test_admin_costs.py -q

--- a/plans/PR-Admin-Costs-CI-Enrollment.md
+++ b/plans/PR-Admin-Costs-CI-Enrollment.md
@@ -17,10 +17,8 @@ Slice phase: Workflow/process
 1. Add a path-scoped GitHub Actions workflow for the admin costs API surface.
 2. Run `tests/test_admin_costs.py` when the workflow, admin costs API, or admin
    costs tests change.
-3. Install only the dependencies needed for this route-level test file.
-4. Keep the focused route test from importing the aggregate API router package,
-   which pulls unrelated app dependencies into this path-scoped workflow.
-5. Leave the broader pre-push audit and extracted pipeline workflows unchanged.
+3. Install the repo runtime requirements before running the route-level test.
+4. Leave the broader pre-push audit and extracted pipeline workflows unchanged.
 
 ### Files touched
 
@@ -28,29 +26,23 @@ Slice phase: Workflow/process
 |---|---|
 | `plans/PR-Admin-Costs-CI-Enrollment.md` | Plan doc for the admin-costs CI enrollment slice. |
 | `.github/workflows/admin_costs_checks.yml` | Add a path-scoped workflow for the admin costs test suite. |
-| `tests/test_admin_costs.py` | Isolate the route import from aggregate API package side effects. |
 
 ## Mechanism
 
 The workflow runs on pull requests and pushes to `main` when these paths change:
 the workflow file itself, `atlas_brain/api/admin_costs.py`, or
 `tests/test_admin_costs.py`. It checks out the repo, sets up Python 3.11,
-installs the same lightweight route-test dependencies used by adjacent CI jobs
-plus `asyncpg` and `psutil`, and runs:
+enables pip caching, installs the root runtime requirements, installs pytest
+and pytest-asyncio, and runs:
 
 ```bash
 python -m pytest tests/test_admin_costs.py -q
 ```
 
-The test module registers a lightweight `atlas_brain.api` package shim with the
-real API package path before importing `atlas_brain.api.admin_costs`. That lets
-the route test import the admin-costs module directly without executing
-`atlas_brain/api/__init__.py`, whose aggregate router imports unrelated app
-surfaces and heavy dependencies that this route test does not exercise. It uses
-the same package-shim pattern for `atlas_brain.services` and the scraping
-package, then supplies a tiny parser registry stub for the parser-version values
-the admin-costs assertions need. That keeps the admin route behavior under test
-without importing every scraper implementation.
+Installing root requirements matches the repo-precedented host-touching
+workflows. The admin-costs module imports through the aggregate API package, so
+the workflow should load the real host dependencies instead of relying on a
+hand-picked subset or test-level import shims.
 
 ## Intentional
 
@@ -59,13 +51,9 @@ without importing every scraper implementation.
   admin-costs changes without slowing unrelated PRs.
 - This does not enroll the entire host test suite. The reviewer finding was
   specific to `tests/test_admin_costs.py`.
-- This changes the route test import instead of installing the full host
-  requirements or unrelated heavy dependencies in CI. The failing dependency
-  chain came from package import side effects, not from the admin-costs route
-  behavior under test.
-- The parser registry is stubbed only for parser version values used by this
-  admin-costs suite. Parser implementation coverage belongs in scraper tests.
-- This does not touch product code or the production aggregate API router.
+- This installs root requirements instead of maintaining a fragile curated
+  dependency subset for a host route test.
+- This does not touch product code or mutate test import state.
 
 ## Deferred
 
@@ -86,14 +74,16 @@ without importing every scraper implementation.
 - Clean temporary venv probe after adding `numpy` and `dateparser` exposed the
   next unrelated aggregate import failure at missing `torch`, confirming that
   dependency-chasing would be patchwork for this route-level workflow.
-- Clean temporary venv with the workflow dependency list after test import
-  isolation: python -m pytest tests/test_admin_costs.py -q — 21 passed.
+- Reviewer repro showed the test-level import shim broke a combined pytest
+  session with `tests/test_task_trigger_reasons.py`; the shim was removed and
+  the workflow now installs root requirements instead.
+- Combined regression command: python -m pytest tests/test_admin_costs.py
+  tests/test_task_trigger_reasons.py -q — 29 passed, 1 warning.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~95 |
+| Plan doc | ~85 |
 | Workflow | ~45 |
-| Test import isolation | ~30 |
-| **Total** | **~170** |
+| **Total** | **~130** |

--- a/plans/PR-Admin-Costs-CI-Enrollment.md
+++ b/plans/PR-Admin-Costs-CI-Enrollment.md
@@ -32,8 +32,8 @@ Slice phase: Workflow/process
 The workflow runs on pull requests and pushes to `main` when these paths change:
 the workflow file itself, `atlas_brain/api/admin_costs.py`, or
 `tests/test_admin_costs.py`. It checks out the repo, sets up Python 3.11,
-installs the same lightweight route-test dependencies used by adjacent CI
-jobs plus `psutil`, and runs:
+   installs the same lightweight route-test dependencies used by adjacent CI
+   jobs plus `asyncpg` and `psutil`, and runs:
 
 ```bash
 python -m pytest tests/test_admin_costs.py -q
@@ -59,6 +59,8 @@ python -m pytest tests/test_admin_costs.py -q
 
 - Workflow YAML parse command: python inline PyYAML load for `.github/workflows/admin_costs_checks.yml` — passed.
 - Admin costs pytest command: python -m pytest tests/test_admin_costs.py -q — 21 passed, 1 warning.
+- First GitHub Actions run — failed during collection because the workflow did
+  not install `asyncpg`, which is imported by `atlas_brain.storage.database`.
 
 ## Estimated diff size
 

--- a/plans/PR-Admin-Costs-CI-Enrollment.md
+++ b/plans/PR-Admin-Costs-CI-Enrollment.md
@@ -1,0 +1,69 @@
+# PR: Admin Costs CI Enrollment
+
+## Why this slice exists
+
+The #1043 review confirmed the full `tests/test_admin_costs.py` suite is green
+after the saved-calls fix, but also noted that host CI did not run that file.
+That is how the pre-existing red tests from #1040 stayed hidden.
+
+This slice makes the green admin-costs suite load-bearing in GitHub Actions,
+without expanding the global pre-push audit for every PR.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Workflow/process
+
+1. Add a path-scoped GitHub Actions workflow for the admin costs API surface.
+2. Run `tests/test_admin_costs.py` when the workflow, admin costs API, or admin
+   costs tests change.
+3. Install only the dependencies needed for this route-level test file.
+4. Leave the broader pre-push audit and extracted pipeline workflows unchanged.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Admin-Costs-CI-Enrollment.md` | Plan doc for the admin-costs CI enrollment slice. |
+| `.github/workflows/admin_costs_checks.yml` | Add a path-scoped workflow for the admin costs test suite. |
+
+## Mechanism
+
+The workflow runs on pull requests and pushes to `main` when these paths change:
+the workflow file itself, `atlas_brain/api/admin_costs.py`, or
+`tests/test_admin_costs.py`. It checks out the repo, sets up Python 3.11,
+installs the same lightweight route-test dependencies used by adjacent CI
+jobs plus `psutil`, and runs:
+
+```bash
+python -m pytest tests/test_admin_costs.py -q
+```
+
+## Intentional
+
+- This uses a dedicated path-scoped workflow instead of adding the test to
+  `pre_push_audit.yml`, because admin-costs route tests should gate relevant
+  admin-costs changes without slowing unrelated PRs.
+- This does not enroll the entire host test suite. The reviewer finding was
+  specific to `tests/test_admin_costs.py`.
+- This does not touch product code.
+
+## Deferred
+
+- Future PR: add similar path-scoped workflows for other host route suites if
+  they are found green-but-ungated.
+- Parked hardening: none. Root `HARDENING.md` was scanned; this directly closes
+  the #1043 reviewer forward note.
+
+## Verification
+
+- Workflow YAML parse command: python inline PyYAML load for `.github/workflows/admin_costs_checks.yml` — passed.
+- Admin costs pytest command: python -m pytest tests/test_admin_costs.py -q — 21 passed, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| Workflow | ~45 |
+| **Total** | **~115** |

--- a/plans/PR-Admin-Costs-CI-Enrollment.md
+++ b/plans/PR-Admin-Costs-CI-Enrollment.md
@@ -18,7 +18,9 @@ Slice phase: Workflow/process
 2. Run `tests/test_admin_costs.py` when the workflow, admin costs API, or admin
    costs tests change.
 3. Install only the dependencies needed for this route-level test file.
-4. Leave the broader pre-push audit and extracted pipeline workflows unchanged.
+4. Keep the focused route test from importing the aggregate API router package,
+   which pulls unrelated app dependencies into this path-scoped workflow.
+5. Leave the broader pre-push audit and extracted pipeline workflows unchanged.
 
 ### Files touched
 
@@ -26,18 +28,29 @@ Slice phase: Workflow/process
 |---|---|
 | `plans/PR-Admin-Costs-CI-Enrollment.md` | Plan doc for the admin-costs CI enrollment slice. |
 | `.github/workflows/admin_costs_checks.yml` | Add a path-scoped workflow for the admin costs test suite. |
+| `tests/test_admin_costs.py` | Isolate the route import from aggregate API package side effects. |
 
 ## Mechanism
 
 The workflow runs on pull requests and pushes to `main` when these paths change:
 the workflow file itself, `atlas_brain/api/admin_costs.py`, or
 `tests/test_admin_costs.py`. It checks out the repo, sets up Python 3.11,
-   installs the same lightweight route-test dependencies used by adjacent CI
-   jobs plus `asyncpg` and `psutil`, and runs:
+installs the same lightweight route-test dependencies used by adjacent CI jobs
+plus `asyncpg` and `psutil`, and runs:
 
 ```bash
 python -m pytest tests/test_admin_costs.py -q
 ```
+
+The test module registers a lightweight `atlas_brain.api` package shim with the
+real API package path before importing `atlas_brain.api.admin_costs`. That lets
+the route test import the admin-costs module directly without executing
+`atlas_brain/api/__init__.py`, whose aggregate router imports unrelated app
+surfaces and heavy dependencies that this route test does not exercise. It uses
+the same package-shim pattern for `atlas_brain.services` and the scraping
+package, then supplies a tiny parser registry stub for the parser-version values
+the admin-costs assertions need. That keeps the admin route behavior under test
+without importing every scraper implementation.
 
 ## Intentional
 
@@ -46,7 +59,13 @@ python -m pytest tests/test_admin_costs.py -q
   admin-costs changes without slowing unrelated PRs.
 - This does not enroll the entire host test suite. The reviewer finding was
   specific to `tests/test_admin_costs.py`.
-- This does not touch product code.
+- This changes the route test import instead of installing the full host
+  requirements or unrelated heavy dependencies in CI. The failing dependency
+  chain came from package import side effects, not from the admin-costs route
+  behavior under test.
+- The parser registry is stubbed only for parser version values used by this
+  admin-costs suite. Parser implementation coverage belongs in scraper tests.
+- This does not touch product code or the production aggregate API router.
 
 ## Deferred
 
@@ -61,11 +80,20 @@ python -m pytest tests/test_admin_costs.py -q
 - Admin costs pytest command: python -m pytest tests/test_admin_costs.py -q — 21 passed, 1 warning.
 - First GitHub Actions run — failed during collection because the workflow did
   not install `asyncpg`, which is imported by `atlas_brain.storage.database`.
+- Second GitHub Actions run — failed during collection on an unrelated
+  aggregate API import path, `atlas_brain/api/__init__.py` -> speaker repository
+  -> missing `numpy`.
+- Clean temporary venv probe after adding `numpy` and `dateparser` exposed the
+  next unrelated aggregate import failure at missing `torch`, confirming that
+  dependency-chasing would be patchwork for this route-level workflow.
+- Clean temporary venv with the workflow dependency list after test import
+  isolation: python -m pytest tests/test_admin_costs.py -q — 21 passed.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~70 |
+| Plan doc | ~95 |
 | Workflow | ~45 |
-| **Total** | **~115** |
+| Test import isolation | ~30 |
+| **Total** | **~170** |

--- a/tests/test_admin_costs.py
+++ b/tests/test_admin_costs.py
@@ -1,11 +1,58 @@
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
+import sys
+import types
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+import atlas_brain
+
+
+def _install_package_shim(
+    name: str,
+    package_path: Path,
+    parent: object,
+    attribute: str,
+) -> types.ModuleType:
+    package = types.ModuleType(name)
+    package.__path__ = [str(package_path)]
+    package = sys.modules.setdefault(name, package)
+    setattr(parent, attribute, package)
+    return package
+
+
+# Keep this focused route test from importing aggregate package initializers.
+_ATLAS_BRAIN_ROOT = Path(__file__).resolve().parents[1] / "atlas_brain"
+api_package = _install_package_shim(
+    "atlas_brain.api",
+    _ATLAS_BRAIN_ROOT / "api",
+    atlas_brain,
+    "api",
+)
+services_package = _install_package_shim(
+    "atlas_brain.services",
+    _ATLAS_BRAIN_ROOT / "services",
+    atlas_brain,
+    "services",
+)
+scraping_package = _install_package_shim(
+    "atlas_brain.services.scraping",
+    _ATLAS_BRAIN_ROOT / "services" / "scraping",
+    services_package,
+    "scraping",
+)
+parsers_module = types.ModuleType("atlas_brain.services.scraping.parsers")
+parsers_module.get_all_parsers = lambda: {
+    "g2": types.SimpleNamespace(version="g2:3"),
+    "trustradius": types.SimpleNamespace(version="trustradius:1"),
+}
+parsers_module = sys.modules.setdefault("atlas_brain.services.scraping.parsers", parsers_module)
+setattr(scraping_package, "parsers", parsers_module)
 
 from atlas_brain.api.admin_costs import router
 from atlas_brain.auth.dependencies import AuthUser, require_auth

--- a/tests/test_admin_costs.py
+++ b/tests/test_admin_costs.py
@@ -1,58 +1,11 @@
 from datetime import datetime, timezone
 from decimal import Decimal
-from pathlib import Path
-import sys
-import types
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-import atlas_brain
-
-
-def _install_package_shim(
-    name: str,
-    package_path: Path,
-    parent: object,
-    attribute: str,
-) -> types.ModuleType:
-    package = types.ModuleType(name)
-    package.__path__ = [str(package_path)]
-    package = sys.modules.setdefault(name, package)
-    setattr(parent, attribute, package)
-    return package
-
-
-# Keep this focused route test from importing aggregate package initializers.
-_ATLAS_BRAIN_ROOT = Path(__file__).resolve().parents[1] / "atlas_brain"
-api_package = _install_package_shim(
-    "atlas_brain.api",
-    _ATLAS_BRAIN_ROOT / "api",
-    atlas_brain,
-    "api",
-)
-services_package = _install_package_shim(
-    "atlas_brain.services",
-    _ATLAS_BRAIN_ROOT / "services",
-    atlas_brain,
-    "services",
-)
-scraping_package = _install_package_shim(
-    "atlas_brain.services.scraping",
-    _ATLAS_BRAIN_ROOT / "services" / "scraping",
-    services_package,
-    "scraping",
-)
-parsers_module = types.ModuleType("atlas_brain.services.scraping.parsers")
-parsers_module.get_all_parsers = lambda: {
-    "g2": types.SimpleNamespace(version="g2:3"),
-    "trustradius": types.SimpleNamespace(version="trustradius:1"),
-}
-parsers_module = sys.modules.setdefault("atlas_brain.services.scraping.parsers", parsers_module)
-setattr(scraping_package, "parsers", parsers_module)
 
 from atlas_brain.api.admin_costs import router
 from atlas_brain.auth.dependencies import AuthUser, require_auth


### PR DESCRIPTION
Plan: plans/PR-Admin-Costs-CI-Enrollment.md
Slice phase: Workflow/process

The #1043 review confirmed `tests/test_admin_costs.py` is green, but also noted host CI did not run it. This PR adds a path-scoped GitHub Actions workflow so admin costs API/test changes run that suite in CI without expanding the global pre-push audit for unrelated PRs.

## Intentional
- Use a dedicated path-scoped workflow instead of slowing every PR through `pre_push_audit.yml`.
- Enroll only the green admin costs route suite identified by review.
- Install root requirements for this host route test instead of maintaining a fragile curated dependency subset.
- Do not touch product code or mutate test import state.

## Deferred
- Future PR: add similar path-scoped workflows for other host route suites if they are found green-but-ungated.

## Parked hardening
- None.

## Verification
- Workflow YAML parse command: python inline PyYAML load for `.github/workflows/admin_costs_checks.yml` — passed.
- Admin costs pytest command: python -m pytest tests/test_admin_costs.py -q — 21 passed, 1 warning.
- GitHub Actions inspection — the first run failed on missing `asyncpg`; the second run failed through the unrelated aggregate API import path on missing `numpy`.
- Clean temporary venv probe — adding `numpy` and `dateparser` exposed the next unrelated aggregate import failure at missing `torch`, confirming that dependency-chasing was the wrong fix.
- Reviewer repro showed the temporary import shim broke a combined pytest session with `tests/test_task_trigger_reasons.py`; the shim was removed and the workflow now installs root requirements instead.
- Combined regression command: python -m pytest tests/test_admin_costs.py tests/test_task_trigger_reasons.py -q — 29 passed, 1 warning.
- `git diff --check` — passed.
- Plan doc audits — passed.

## Diff size
2 files, about +110 / -0.
