### PR TITLE
Add per-case FAQ route latency budgets

### DIFF
--- a/docs/extraction/validation/content_ops_faq_route_concurrency_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_route_concurrency_runbook.md
@@ -41,6 +41,8 @@ python scripts/smoke_content_ops_faq_search_route_concurrency.py \
   --max-case-error-rate 0 \
   --max-p95-ms 1500 \
   --max-single-request-ms 3000 \
+  --max-case-p95-ms 1500 \
+  --max-case-single-request-ms 3000 \
   --max-detail-ms 1000 \
   --output-result /tmp/faq-route-concurrency-result.json
 ```
@@ -57,6 +59,8 @@ python scripts/smoke_content_ops_faq_search_route_concurrency.py \
   --concurrency 4 \
   --max-error-rate 0 \
   --max-case-error-rate 0 \
+  --max-case-p95-ms 1500 \
+  --max-case-single-request-ms 3000 \
   --output-result /tmp/faq-route-miss-result.json
 ```
 

--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md
@@ -1,0 +1,78 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget
+
+## Why this slice exists
+
+The hosted FAQ route concurrency smoke now has aggregate latency budgets,
+detail latency budgets, and per-case error budgets. A slow query/corpus case can
+still hide when aggregate p95/max latency passes because the case is diluted by
+faster traffic. This slice adds opt-in per-case latency budgets so operators can
+fail closed on a slow case after mixed-case visibility is already available.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add opt-in per-case p95 and max latency budget flags to the hosted FAQ route
+   concurrency smoke.
+2. Validate those flags fail-closed during preflight.
+3. Evaluate the budgets against every `cases.summaries[]` latency row.
+4. Add the new opt-in flags to the hosted route concurrency runbook.
+5. Add focused tests for invalid budgets, per-case latency failure when
+   aggregate latency budgets pass, and zero-sample budgeted cases.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md`
+- `docs/extraction/validation/content_ops_faq_route_concurrency_runbook.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+The runner already builds one latency summary per case. This slice adds
+`--max-case-p95-ms` and `--max-case-single-request-ms`, threads those values into
+`_budget_summary(...)`, and emits deterministic budget checks per case. The new
+checks use the existing case summaries instead of recalculating raw request
+rows, keeping stdout, result JSON, and budget behavior aligned.
+When a case has no latency samples, the per-case latency budget fails closed
+with `actual: null` instead of treating missing latency as zero.
+
+## Intentional
+
+- The new budgets are opt-in. No default hosted latency threshold is introduced.
+- This does not change aggregate latency budgets or detail latency budgets.
+- No hosted route, database, or seed behavior changes.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ search
+entries touching this runner.
+
+Choosing production SLO values remains deferred until repeated hosted runs
+provide stable latency evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py
+  (68 passed)
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md
+  (passed)
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  (122 matching tests enrolled)
+- bash scripts/run_extracted_pipeline_checks.sh
+  (2567 passed, 7 skipped)
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-latency-budget.md
+  (passed)
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 78 |
+| Runbook | 4 |
+| Smoke script | 55 |
+| Tests | 156 |
+| **Total** | **293** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -78,6 +78,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-single-request-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_SINGLE_REQUEST_MS") or None)
     parser.add_argument("--max-detail-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_DETAIL_MS") or None)
     parser.add_argument("--max-case-error-rate", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_CASE_ERROR_RATE") or None)
+    parser.add_argument("--max-case-p95-ms", type=float, default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_CASE_P95_MS") or None)
+    parser.add_argument(
+        "--max-case-single-request-ms",
+        type=float,
+        default=os.environ.get("ATLAS_FAQ_SEARCH_MAX_CASE_SINGLE_REQUEST_MS") or None,
+    )
     parser.set_defaults(require_results=True)
     parser.add_argument("--require-results", action="store_true")
     parser.add_argument("--allow-empty-results", action="store_false", dest="require_results")
@@ -106,6 +112,8 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         "max_single_request_ms",
         "max_detail_ms",
         "max_case_error_rate",
+        "max_case_p95_ms",
+        "max_case_single_request_ms",
     ):
         value = getattr(args, name)
         if value is not None and not math.isfinite(float(value)):
@@ -120,7 +128,13 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("--require-detail requires result rows; remove --allow-empty-results")
     if args.max_detail_ms is not None and not bool(args.require_detail):
         errors.append("--max-detail-ms requires --require-detail")
-    for name in ("max_p95_ms", "max_single_request_ms", "max_detail_ms"):
+    for name in (
+        "max_p95_ms",
+        "max_single_request_ms",
+        "max_detail_ms",
+        "max_case_p95_ms",
+        "max_case_single_request_ms",
+    ):
         value = getattr(args, name)
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
@@ -493,6 +507,8 @@ def _budget_summary(
     max_p95_ms: float | None,
     max_single_request_ms: float | None,
     max_detail_ms: float | None,
+    max_case_p95_ms: float | None,
+    max_case_single_request_ms: float | None,
 ) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
     failures: list[str] = []
@@ -551,6 +567,41 @@ def _budget_summary(
             )
             if not ok:
                 failures.append(f"case_error_rate exceeded {limit_value} for case {case_index}")
+    for metric, latency_key, limit in (
+        ("case_p95_ms", "p95_ms", max_case_p95_ms),
+        ("case_max_ms", "max_ms", max_case_single_request_ms),
+    ):
+        if limit is None:
+            continue
+        limit_value = round(float(limit), 6)
+        for case_summary in case_summaries:
+            case_index = int(case_summary.get("case_index") or 0)
+            case_latency = case_summary.get("latency")
+            if not isinstance(case_latency, Mapping) or int(case_latency.get("count") or 0) <= 0:
+                checks.append(
+                    {
+                        "metric": metric,
+                        "case_index": case_index,
+                        "actual": None,
+                        "max": limit_value,
+                        "ok": False,
+                    }
+                )
+                failures.append(f"{metric} had no latency samples for case {case_index}")
+                continue
+            actual = float(case_latency.get(latency_key) or 0.0)
+            ok = actual <= limit_value
+            checks.append(
+                {
+                    "metric": metric,
+                    "case_index": case_index,
+                    "actual": actual,
+                    "max": limit_value,
+                    "ok": ok,
+                }
+            )
+            if not ok:
+                failures.append(f"{metric} exceeded {limit_value} for case {case_index}")
     return {"ok": not failures, "checks": checks, "failures": failures}
 
 
@@ -581,6 +632,8 @@ def _summary_payload(
         max_p95_ms=args.max_p95_ms,
         max_single_request_ms=args.max_single_request_ms,
         max_detail_ms=args.max_detail_ms,
+        max_case_p95_ms=args.max_case_p95_ms,
+        max_case_single_request_ms=args.max_case_single_request_ms,
     )
     return {
         "ok": not preflight_errors and budgets["ok"],

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -50,6 +50,8 @@ def _args(**overrides):
         "max_single_request_ms": None,
         "max_detail_ms": None,
         "max_case_error_rate": None,
+        "max_case_p95_ms": None,
+        "max_case_single_request_ms": None,
         "require_results": True,
         "require_detail": False,
         "case_file": None,
@@ -179,6 +181,15 @@ def test_validate_args_rejects_case_error_budget_outside_rate_range():
     ]
 
 
+def test_validate_args_rejects_non_positive_case_latency_budgets():
+    assert smoke._validate_args(_args(max_case_p95_ms=0.0)) == [
+        "--max-case-p95-ms must be positive"
+    ]
+    assert smoke._validate_args(_args(max_case_single_request_ms=-1.0)) == [
+        "--max-case-single-request-ms must be positive"
+    ]
+
+
 def test_parser_requires_results_by_default_and_allows_explicit_liveness_probe():
     required = smoke._build_parser().parse_args([
         "--base-url",
@@ -241,6 +252,22 @@ def test_parser_accepts_case_error_rate_budget():
     assert parsed.max_case_error_rate == 0.25
 
 
+def test_parser_accepts_case_latency_budgets():
+    parsed = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-123",
+        "--max-case-p95-ms",
+        "1500",
+        "--max-case-single-request-ms",
+        "3000",
+    ])
+
+    assert parsed.max_case_p95_ms == 1500.0
+    assert parsed.max_case_single_request_ms == 3000.0
+
+
 def test_route_concurrency_runbook_documents_current_budget_flags():
     text = RUNBOOK.read_text(encoding="utf-8")
     expected_flags = [
@@ -249,6 +276,8 @@ def test_route_concurrency_runbook_documents_current_budget_flags():
         "--max-case-error-rate",
         "--max-p95-ms",
         "--max-single-request-ms",
+        "--max-case-p95-ms",
+        "--max-case-single-request-ms",
         "--max-detail-ms",
         "--output-result",
     ]
@@ -281,6 +310,10 @@ def test_route_concurrency_runbook_documents_current_budget_flags():
         "1500",
         "--max-single-request-ms",
         "3000",
+        "--max-case-p95-ms",
+        "1500",
+        "--max-case-single-request-ms",
+        "3000",
         "--max-detail-ms",
         "1000",
         "--output-result",
@@ -289,6 +322,8 @@ def test_route_concurrency_runbook_documents_current_budget_flags():
 
     assert parsed.require_detail is True
     assert parsed.max_case_error_rate == 0.0
+    assert parsed.max_case_p95_ms == 1500.0
+    assert parsed.max_case_single_request_ms == 3000.0
     assert parsed.max_detail_ms == 1000.0
 
 
@@ -679,6 +714,8 @@ def test_budget_summary_reports_error_and_latency_failures():
         max_p95_ms=40.0,
         max_single_request_ms=100.0,
         max_detail_ms=20.0,
+        max_case_p95_ms=None,
+        max_case_single_request_ms=None,
     )
 
     assert summary == {
@@ -723,6 +760,8 @@ def test_budget_summary_fails_closed_when_detail_budget_has_no_detail_rows():
         max_p95_ms=None,
         max_single_request_ms=None,
         max_detail_ms=20.0,
+        max_case_p95_ms=None,
+        max_case_single_request_ms=None,
     )
 
     assert summary == {
@@ -732,6 +771,123 @@ def test_budget_summary_fails_closed_when_detail_budget_has_no_detail_rows():
             {"metric": "detail_max_ms", "actual": None, "max": 20.0, "ok": False},
         ],
         "failures": ["detail_max_ms had no checked detail rows"],
+    }
+
+
+def test_budget_summary_reports_case_latency_failures_when_aggregate_passes():
+    summary = smoke._budget_summary(
+        latency={"p95_ms": 80.0, "max_ms": 100.0},
+        detail_latency={"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+        case_summaries=[
+            {
+                "case_index": 0,
+                "errors": {"rate": 0.0},
+                "latency": {"count": 1, "p95_ms": 50.0, "max_ms": 60.0},
+            },
+            {
+                "case_index": 1,
+                "errors": {"rate": 0.0},
+                "latency": {"count": 1, "p95_ms": 120.0, "max_ms": 180.0},
+            },
+        ],
+        errors={"rate": 0.0},
+        max_error_rate=0.0,
+        max_case_error_rate=None,
+        max_p95_ms=200.0,
+        max_single_request_ms=200.0,
+        max_detail_ms=None,
+        max_case_p95_ms=100.0,
+        max_case_single_request_ms=150.0,
+    )
+
+    assert summary == {
+        "ok": False,
+        "checks": [
+            {"metric": "error_rate", "actual": 0.0, "max": 0.0, "ok": True},
+            {"metric": "p95_ms", "actual": 80.0, "max": 200.0, "ok": True},
+            {"metric": "max_ms", "actual": 100.0, "max": 200.0, "ok": True},
+            {
+                "metric": "case_p95_ms",
+                "case_index": 0,
+                "actual": 50.0,
+                "max": 100.0,
+                "ok": True,
+            },
+            {
+                "metric": "case_p95_ms",
+                "case_index": 1,
+                "actual": 120.0,
+                "max": 100.0,
+                "ok": False,
+            },
+            {
+                "metric": "case_max_ms",
+                "case_index": 0,
+                "actual": 60.0,
+                "max": 150.0,
+                "ok": True,
+            },
+            {
+                "metric": "case_max_ms",
+                "case_index": 1,
+                "actual": 180.0,
+                "max": 150.0,
+                "ok": False,
+            },
+        ],
+        "failures": [
+            "case_p95_ms exceeded 100.0 for case 1",
+            "case_max_ms exceeded 150.0 for case 1",
+        ],
+    }
+
+
+def test_budget_summary_fails_case_latency_budget_without_samples():
+    summary = smoke._budget_summary(
+        latency={"p95_ms": 50.0, "max_ms": 75.0},
+        detail_latency={"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+        case_summaries=[
+            {
+                "case_index": 0,
+                "errors": {"rate": 0.0},
+                "latency": {"count": 1, "p95_ms": 50.0, "max_ms": 75.0},
+            },
+            {
+                "case_index": 1,
+                "errors": {"rate": 0.0},
+                "latency": {"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+            },
+        ],
+        errors={"rate": 0.0},
+        max_error_rate=0.0,
+        max_case_error_rate=None,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        max_detail_ms=None,
+        max_case_p95_ms=100.0,
+        max_case_single_request_ms=None,
+    )
+
+    assert summary == {
+        "ok": False,
+        "checks": [
+            {"metric": "error_rate", "actual": 0.0, "max": 0.0, "ok": True},
+            {
+                "metric": "case_p95_ms",
+                "case_index": 0,
+                "actual": 50.0,
+                "max": 100.0,
+                "ok": True,
+            },
+            {
+                "metric": "case_p95_ms",
+                "case_index": 1,
+                "actual": None,
+                "max": 100.0,
+                "ok": False,
+            },
+        ],
+        "failures": ["case_p95_ms had no latency samples for case 1"],
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md
Slice phase: Production hardening

The hosted FAQ route concurrency smoke already has aggregate latency budgets and per-case error budgets, but a slow query/corpus case can still hide under a passing aggregate latency summary. This slice adds opt-in per-case p95 and max latency budgets, wired to the existing `cases.summaries[]` rows, failing closed on zero-sample budgeted cases, and documented in the operator runbook.

## Intentional
- The new budgets are opt-in; no default hosted latency threshold is introduced.
- Aggregate latency budgets and detail latency budgets keep their existing behavior.
- No hosted route, database, or seed behavior changes.

## Deferred
- Choosing production SLO values remains deferred until repeated hosted runs provide stable latency evidence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` (68 passed)
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Latency-Budget.md` (passed)
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` (122 matching tests enrolled)
- `bash scripts/run_extracted_pipeline_checks.sh` (2567 passed, 7 skipped)
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-latency-budget.md` (passed)

## Diff size
4 files, +292 / -1
