### PR TITLE
Fail FAQ case error budget without samples

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md
+++ b/plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md
@@ -1,0 +1,71 @@
+# PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples
+
+## Why this slice exists
+
+PR #1046 made per-case latency budgets fail closed when a budgeted case has no
+request samples. The older per-case error-rate budget still treats a zero-request
+case as `0.0` and passes. That leaves one budget path where `--requests` smaller
+than the case count can silently skip a case. This slice aligns per-case
+error-rate budget behavior with the per-case latency budget.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Make `--max-case-error-rate` fail closed for case summaries with zero
+   requests.
+2. Preserve the existing over-threshold per-case error behavior.
+3. Add focused tests for the zero-request error-budget branch.
+
+### Files touched
+
+- `plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md`
+- `scripts/smoke_content_ops_faq_search_route_concurrency.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+
+## Mechanism
+
+`_budget_summary(...)` already receives every `cases.summaries[]` row. This
+slice checks each case summary's `requests` count before reading
+`errors.rate`. If the count is zero, the budget emits `actual: null`, marks the
+check failed, and records a deterministic failure string. Cases with samples
+continue to use the existing error-rate comparison.
+
+## Intentional
+
+- The behavior changes only when `--max-case-error-rate` is supplied.
+- Search-only runs without a per-case error budget remain unchanged.
+- No route, database, seed, or runbook changes.
+
+## Deferred
+
+Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ search
+entries touching this runner.
+
+Choosing production budget values remains deferred until repeated hosted runs
+provide stable evidence.
+
+## Verification
+
+Local verification:
+
+- python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py
+  (69 passed)
+- python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md
+  (passed)
+- python scripts/audit_extracted_pipeline_ci_enrollment.py
+  (122 matching tests enrolled)
+- bash scripts/run_extracted_pipeline_checks.sh
+  (2568 passed, 7 skipped)
+- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-error-samples.md
+  (passed)
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 71 |
+| Smoke script | 12 |
+| Tests | 45 |
+| **Total** | **128** |

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -553,6 +553,18 @@ def _budget_summary(
         limit_value = round(float(max_case_error_rate), 6)
         for case_summary in case_summaries:
             case_index = int(case_summary.get("case_index") or 0)
+            if int(case_summary.get("requests") or 0) <= 0:
+                checks.append(
+                    {
+                        "metric": "case_error_rate",
+                        "case_index": case_index,
+                        "actual": None,
+                        "max": limit_value,
+                        "ok": False,
+                    }
+                )
+                failures.append(f"case_error_rate had no request samples for case {case_index}")
+                continue
             case_errors = case_summary.get("errors")
             actual = float(case_errors.get("rate") or 0.0) if isinstance(case_errors, Mapping) else 0.0
             ok = actual <= limit_value

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -705,8 +705,8 @@ def test_budget_summary_reports_error_and_latency_failures():
         latency={"p95_ms": 50.0, "max_ms": 75.0},
         detail_latency={"count": 2, "p95_ms": 25.0, "max_ms": 30.0},
         case_summaries=[
-            {"case_index": 0, "errors": {"rate": 0.0}},
-            {"case_index": 1, "errors": {"rate": 0.5}},
+            {"case_index": 0, "requests": 2, "errors": {"rate": 0.0}},
+            {"case_index": 1, "requests": 2, "errors": {"rate": 0.5}},
         ],
         errors={"rate": 0.25},
         max_error_rate=0.0,
@@ -771,6 +771,47 @@ def test_budget_summary_fails_closed_when_detail_budget_has_no_detail_rows():
             {"metric": "detail_max_ms", "actual": None, "max": 20.0, "ok": False},
         ],
         "failures": ["detail_max_ms had no checked detail rows"],
+    }
+
+
+def test_budget_summary_fails_case_error_budget_without_request_samples():
+    summary = smoke._budget_summary(
+        latency={"p95_ms": 50.0, "max_ms": 75.0},
+        detail_latency={"count": 0, "p95_ms": 0.0, "max_ms": 0.0},
+        case_summaries=[
+            {"case_index": 0, "requests": 1, "errors": {"rate": 0.0}},
+            {"case_index": 1, "requests": 0, "errors": {"rate": 0.0}},
+        ],
+        errors={"rate": 0.0},
+        max_error_rate=0.0,
+        max_case_error_rate=0.0,
+        max_p95_ms=None,
+        max_single_request_ms=None,
+        max_detail_ms=None,
+        max_case_p95_ms=None,
+        max_case_single_request_ms=None,
+    )
+
+    assert summary == {
+        "ok": False,
+        "checks": [
+            {"metric": "error_rate", "actual": 0.0, "max": 0.0, "ok": True},
+            {
+                "metric": "case_error_rate",
+                "case_index": 0,
+                "actual": 0.0,
+                "max": 0.0,
+                "ok": True,
+            },
+            {
+                "metric": "case_error_rate",
+                "case_index": 1,
+                "actual": None,
+                "max": 0.0,
+                "ok": False,
+            },
+        ],
+        "failures": ["case_error_rate had no request samples for case 1"],
     }
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md
Slice phase: Production hardening

PR #1046 made per-case latency budgets fail closed when a budgeted case has no samples. This slice applies the same fail-closed behavior to the older per-case error-rate budget so `--max-case-error-rate` cannot silently pass an unexercised case.

## Intentional
- The behavior changes only when `--max-case-error-rate` is supplied.
- Search-only runs without a per-case error budget remain unchanged.
- No route, database, seed, or runbook changes.

## Deferred
- Choosing production budget values remains deferred until repeated hosted runs provide stable evidence.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_route_concurrency.py` (69 passed)
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Route-Concurrency-Case-Error-Samples.md` (passed)
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` (122 matching tests enrolled)
- `bash scripts/run_extracted_pipeline_checks.sh` (2568 passed, 7 skipped)
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/pr-content-ops-faq-route-concurrency-case-error-samples.md` (passed)

## Diff size
3 files, +126 / -2
