### PR TITLE
Thread FAQ e2e case budgets

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md
+++ b/plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md
@@ -1,0 +1,83 @@
+# PR-Content-Ops-FAQ-Search-E2E-Case-Budgets
+
+## Why this slice exists
+
+Recent FAQ route-concurrency slices added per-case error and latency budgets to
+the hosted route smoke, including fail-closed handling when a budgeted case has
+no samples. The seeded hosted e2e runner composes that route smoke, but it still
+only exposes the aggregate route budgets. That wrapper drift lets the real
+seeded flow miss the stricter case-level gates operators now use to prove mixed
+corpora remain healthy under load.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add seeded e2e CLI flags for the route smoke's per-case error and latency
+   budgets.
+2. Validate those budgets in the seeded e2e preflight with the same bounds as
+   the child route smoke.
+3. Forward those budgets into the route concurrency child command.
+4. Add focused tests for validation, parser wiring, and command handoff.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md` | Plan contract for this wrapper-drift fix. |
+| `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` | Expose, validate, and forward per-case route budgets. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Prove the seeded e2e wrapper accepts and forwards the budgets, and rejects invalid values. |
+
+## Mechanism
+
+The seeded e2e parser gains:
+
+```text
+--max-case-error-rate
+--max-case-p95-ms
+--max-case-single-request-ms
+```
+
+`_validate_args(...)` checks `--max-case-error-rate` is between 0 and 1 and
+checks the two per-case latency values are positive when provided. The route
+child command appends the flags only when operators pass them, preserving the
+existing default behavior.
+
+## Intentional
+
+- No hosted route, database seed, cleanup, or detail-check behavior changes.
+- No default SLO values are introduced; budget selection remains operator-owned.
+- `--max-detail-ms` is not added to the seeded e2e wrapper in this slice because
+  route detail concurrency is not enabled by the seeded e2e route phase. The
+  seeded detail phase already uses the single-detail contract checker.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this wrapper.
+- Detail-specific budget threading for the seeded detail phase remains deferred
+  until operators have a concrete hosted detail latency target for that command.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 56 passed.
+- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - 122 matching tests enrolled.
+- `git diff --check` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2570 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 83 |
+| Seeded e2e runner | 28 |
+| Tests | 60 |
+| **Total** | **171** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import os
 from pathlib import Path
 import subprocess
@@ -67,6 +68,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-error-rate", type=float, default=0.0)
     parser.add_argument("--max-p95-ms", type=float)
     parser.add_argument("--max-single-request-ms", type=float)
+    parser.add_argument("--max-case-error-rate", type=float)
+    parser.add_argument("--max-case-p95-ms", type=float)
+    parser.add_argument("--max-case-single-request-ms", type=float)
     parser.add_argument("--detail-route", default=os.getenv("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--output-result", type=Path)
@@ -96,11 +100,30 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     ):
         if int(getattr(args, name)) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
+    for name in (
+        "timeout",
+        "max_error_rate",
+        "max_p95_ms",
+        "max_single_request_ms",
+        "max_case_error_rate",
+        "max_case_p95_ms",
+        "max_case_single_request_ms",
+    ):
+        value = getattr(args, name)
+        if value is not None and not math.isfinite(float(value)):
+            errors.append(f"--{name.replace('_', '-')} must be finite")
     if float(args.timeout) <= 0:
         errors.append("--timeout must be positive")
     if not 0 <= float(args.max_error_rate) <= 1:
         errors.append("--max-error-rate must be between 0 and 1")
-    for name in ("max_p95_ms", "max_single_request_ms"):
+    if args.max_case_error_rate is not None and not 0 <= float(args.max_case_error_rate) <= 1:
+        errors.append("--max-case-error-rate must be between 0 and 1")
+    for name in (
+        "max_p95_ms",
+        "max_single_request_ms",
+        "max_case_p95_ms",
+        "max_case_single_request_ms",
+    ):
         value = getattr(args, name)
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
@@ -171,6 +194,9 @@ def _route_command(args: argparse.Namespace, *, case_file: Path, route_result: P
     for arg_name, flag in (
         ("max_p95_ms", "--max-p95-ms"),
         ("max_single_request_ms", "--max-single-request-ms"),
+        ("max_case_error_rate", "--max-case-error-rate"),
+        ("max_case_p95_ms", "--max-case-p95-ms"),
+        ("max_case_single_request_ms", "--max-case-single-request-ms"),
     ):
         value = getattr(args, arg_name)
         if value is not None:

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -34,6 +34,9 @@ def _args(**overrides):
         "max_error_rate": 0.0,
         "max_p95_ms": None,
         "max_single_request_ms": None,
+        "max_case_error_rate": None,
+        "max_case_p95_ms": None,
+        "max_case_single_request_ms": None,
         "detail_route": "",
         "artifact_dir": None,
         "output_result": None,
@@ -145,6 +148,27 @@ def test_validate_args_reports_missing_required_fields_and_bad_numbers():
     ]
 
 
+def test_validate_args_rejects_invalid_case_budgets():
+    assert smoke._validate_args(_args(max_case_error_rate=-0.1)) == [
+        "--max-case-error-rate must be between 0 and 1"
+    ]
+    assert smoke._validate_args(_args(max_case_error_rate=1.1)) == [
+        "--max-case-error-rate must be between 0 and 1"
+    ]
+    assert smoke._validate_args(_args(max_case_p95_ms=0.0)) == [
+        "--max-case-p95-ms must be positive"
+    ]
+    assert smoke._validate_args(_args(max_case_single_request_ms=-1.0)) == [
+        "--max-case-single-request-ms must be positive"
+    ]
+    assert smoke._validate_args(_args(max_case_p95_ms=float("inf"))) == [
+        "--max-case-p95-ms must be finite"
+    ]
+    assert smoke._validate_args(_args(max_p95_ms=float("inf"))) == [
+        "--max-p95-ms must be finite"
+    ]
+
+
 def test_seed_command_keeps_data_and_writes_route_cases(tmp_path):
     args = _args(account_id="hosted-acct", artifact_dir=tmp_path)
     case_file = tmp_path / "cases.json"
@@ -167,7 +191,13 @@ def test_seed_command_keeps_data_and_writes_route_cases(tmp_path):
 
 
 def test_route_command_uses_seeded_case_file_and_budgets(tmp_path):
-    args = _args(max_p95_ms=50, max_single_request_ms=80)
+    args = _args(
+        max_p95_ms=50,
+        max_single_request_ms=80,
+        max_case_error_rate=0.25,
+        max_case_p95_ms=25,
+        max_case_single_request_ms=40,
+    )
     case_file = tmp_path / "cases.json"
     route_result = tmp_path / "route.json"
 
@@ -177,6 +207,34 @@ def test_route_command_uses_seeded_case_file_and_budgets(tmp_path):
     assert command[command.index("--case-file") + 1] == str(case_file)
     assert command[command.index("--max-p95-ms") + 1] == "50"
     assert command[command.index("--max-single-request-ms") + 1] == "80"
+    assert command[command.index("--max-case-error-rate") + 1] == "0.25"
+    assert command[command.index("--max-case-p95-ms") + 1] == "25"
+    assert command[command.index("--max-case-single-request-ms") + 1] == "40"
+
+
+def test_parser_accepts_case_budgets():
+    parsed = smoke._build_parser().parse_args(
+        [
+            "--database-url",
+            "postgresql://example/atlas",
+            "--base-url",
+            "https://atlas.example.com",
+            "--token",
+            "token-123",
+            "--account-id",
+            "acct-1",
+            "--max-case-error-rate",
+            "0",
+            "--max-case-p95-ms",
+            "1500",
+            "--max-case-single-request-ms",
+            "3000",
+        ]
+    )
+
+    assert parsed.max_case_error_rate == 0.0
+    assert parsed.max_case_p95_ms == 1500.0
+    assert parsed.max_case_single_request_ms == 3000.0
 
 
 def test_detail_case_from_route_cases_selects_first_hit_case(tmp_path):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md
Slice phase: Production hardening

The hosted route concurrency smoke now supports per-case error and latency budgets, but the seeded hosted e2e wrapper still only exposed aggregate route budgets. This closes that wrapper drift so the real seeded flow can enforce the same stricter per-case gates operators use for mixed corpora under load.

## Intentional
- No hosted route, database seed, cleanup, or detail-check behavior changes.
- No default SLO values are introduced; budget selection remains operator-owned.
- `--max-detail-ms` is not added here because the seeded e2e route phase does not enable route detail concurrency; the detail phase already uses the single-detail contract checker.

## Deferred
- Detail-specific budget threading for the seeded detail phase remains deferred until operators have a concrete hosted detail latency target for that command.

## Parked hardening
- None. `HARDENING.md` has no active FAQ search entries touching this wrapper.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 56 passed.
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Case-Budgets.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - 122 matching tests enrolled.
- `git diff --check` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2570 passed, 7 skipped, 1 warning.

## Diff size
3 files, +169 / -2
