### PR TITLE
Document support-ticket generated content acceptance

### DIFF
--- a/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json
+++ b/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json
@@ -1,0 +1,118 @@
+{
+  "count": 1,
+  "rows": [
+    {
+      "charts": [],
+      "content": "# Support-Ticket Questions Customers Keep Asking: What Your Uploaded Tickets Reveal\n\n## What do repeat support tickets reveal?\n\nYour uploaded support tickets show two clear clusters of repeated customer questions: email and profile updates (2 tickets), and reporting friction (2 tickets). These patterns emerge from 4 support-ticket rows included in this analysis. When customers ask the same question multiple times, it signals a gap in your customer-facing documentation\u2014an opportunity to move answers out of the support queue and into a self-service FAQ or help center. Support ticket FAQ gaps occur when the same customer question appears across multiple tickets, revealing that your current help documentation does not address that need.\n\nThe 4 uploaded tickets contain 2 direct customer questions that can become FAQ entries. The first cluster centers on account management: customers need to change their login email and update account email addresses. The second cluster focuses on data export: customers want to export campaign attribution data and reporting dashboards, but report friction in doing so. Identifying these clusters is the first step toward building a customer-facing FAQ that addresses the most common support requests.\n\n## Which FAQ gaps should a small team fix first?\n\nPrioritize FAQ work by observed ticket volume in your uploaded support tickets. In your data, the highest-volume clusters are tied: email and profile updates (2 tickets), and reporting friction (2 tickets). Both clusters should be reviewed before lower-volume or one-off questions.\n\n**Email and profile updates** (2 tickets) is the most immediate priority. Customers are asking how to change their login email and update account email addresses. These are foundational account-management tasks that should have clear, discoverable answers. The customer wording is direct: \"Change login email. How do I change my login email?\" and \"Update account email. I need to update the email on my account.\" Your FAQ should mirror this language so customers recognize themselves in the answer.\n\n**Reporting friction** (2 tickets) is equally important. Customers want to export campaign attribution data before renewal and export reporting dashboards for analyst review. Both requests suggest that your product's export functionality is either unclear or hard to find. The customer wording reflects this need: \"How do we export campaign attribution data before renewal?\" and \"We cannot export the reporting dashboard for analysts.\" Before publishing an FAQ answer, your support team should verify whether this export is available in your current product version and what the exact steps are.\n\nBoth clusters have equal weight (2 tickets each), so your team can tackle them in parallel or in order of implementation ease. The email and profile updates cluster may be faster to document if the process is straightforward; the reporting friction cluster may require product clarification first.\n\n## How should old tickets become customer-ready answers?\n\nThe operational path from uploaded CSV to published FAQ is straightforward: cluster, extract customer wording, draft answers, and review.\n\n**Step 1: Cluster the tickets.** Your 4 uploaded support tickets naturally group into 2 clusters: email and profile updates (2 tickets), and reporting friction (2 tickets). Clustering reveals which questions repeat and which are one-offs. Repeat clusters become FAQ priorities; one-off questions stay in the support backlog.\n\n**Step 2: Extract customer wording.** Preserve the exact language customers use when they ask the question. Your uploaded tickets contain these customer phrases:\n\n- \"Change login email. How do I change my login email?\"\n- \"Update account email. I need to update the email on my account.\"\n- \"Export campaign reports. How do we export campaign attribution data before renewal?\"\n- \"Reporting dashboard export. We cannot export the reporting dashboard for analysts.\"\n\nWhen you draft FAQ answers, use this wording in your question headings and opening sentences. Customers will recognize their own language and trust that the answer is relevant to them.\n\n**Step 3: Draft answers from support resolution.** For each clustered question, your support team should write a short answer (2-3 sentences) that summarizes how they resolved the ticket. Your uploaded tickets do not include documented resolutions\u2014only the customer questions. This means each draft answer should be a placeholder: \"Draft answer - support team should add the verified resolution before publishing.\"\n\nBefore publishing, your team should:\n\n- Verify the capability exists in your product (e.g., can users change their login email? Can they export reporting dashboards?)\n- Document the exact steps or menu path\n- Note any permission, plan-level, or browser requirements\n- Test the steps yourself to ensure they work\n- Preserve customer wording in the final answer\n\n**Step 4: Review and publish.** Once the support team has verified and written each answer, route it to a product or documentation owner for final review. Check that the answer is accurate, complete, and uses clear language. Then publish to your help center or FAQ page.\n\n**Tracking after publication.** After you publish these FAQ entries, you can track whether the same questions continue to appear in new support tickets. You can measure this by:\n\n- Tagging new support tickets with the same cluster labels (email and profile updates, reporting friction)\n- Counting how many new tickets arrive in each cluster after FAQ publication\n- Noting whether customers mention they found the FAQ answer before opening a ticket\n\nThis tracking will show whether your FAQ work is addressing the repeated questions and inform your next round of FAQ priorities.\n\n## Next steps for your support team\n\nYour uploaded tickets reveal 2 clear FAQ opportunities. The support team should:\n\n1. **Review the email and profile updates cluster.** Verify that the capability exists to change login email and update account email addresses. Document the exact steps, any verification requirements, and any plan-level restrictions. Draft a FAQ answer using the customer wording: \"How do I change my login email?\" and \"How do I update the email on my account?\"\n\n2. **Review the reporting friction cluster.** Verify whether the capability exists to export campaign attribution data and reporting dashboards. If the feature exists, document the steps and any permission requirements. If the feature is missing or limited, clarify what the support team should communicate to customers. Draft FAQ answers using the customer wording: \"How do we export campaign attribution data?\" and \"How do we export the reporting dashboard?\"\n\n3. **Publish and tag.** Once answers are verified, publish them to your help center or FAQ page. Tag new incoming support tickets with the same cluster labels so you can track whether FAQ publication changes the volume of repeat questions.\n\n4. **Iterate.** After publication, review new support tickets in these clusters. If the same questions continue to appear, the answer may need clarification or the feature may need product changes. Use this feedback to refine your FAQ and inform your next round of support-ticket analysis.",
+      "data_context": {
+        "_known_vendors": [],
+        "category": "support tickets",
+        "customer_wording_examples": [
+          {
+            "pain_category": "email and profile updates",
+            "source_id": "ticket-acme-1",
+            "source_title": "Change login email",
+            "text": "Change login email How do I change my login email?"
+          },
+          {
+            "pain_category": "email and profile updates",
+            "source_id": "ticket-acme-2",
+            "source_title": "Update account email",
+            "text": "Update account email I need to update the email on my account."
+          },
+          {
+            "pain_category": "reporting friction",
+            "source_id": "ticket-northstar-1",
+            "source_title": "Export campaign reports",
+            "text": "Export campaign reports How do we export campaign attribution data before renewal?"
+          },
+          {
+            "pain_category": "reporting friction",
+            "source_id": "ticket-northstar-2",
+            "source_title": "Reporting dashboard export",
+            "text": "Reporting dashboard export We cannot export the reporting dashboard for analysts."
+          }
+        ],
+        "deep_enriched_count": 4,
+        "faq_questions": [
+          "How do I change my login email?",
+          "How do we export campaign attribution data before renewal?"
+        ],
+        "has_dated_window": false,
+        "has_measured_outcomes": false,
+        "included_ticket_row_count": 4,
+        "measured_outcome_count": 0,
+        "measured_outcome_examples": [],
+        "question_like_ticket_count": 2,
+        "review_period": "uploaded tickets",
+        "scope": {
+          "account_id": "acct_support_ticket_blog_small_upload_live_validation_20260526_policy",
+          "user_id": ""
+        },
+        "source": "support_ticket_provider",
+        "source_period": "Uploaded support tickets",
+        "source_row_count": 4,
+        "support_ticket_resolution_evidence_count": 0,
+        "support_ticket_resolution_evidence_present": false,
+        "top_clusters": [
+          {
+            "count": 2,
+            "label": "email and profile updates"
+          },
+          {
+            "count": 2,
+            "label": "reporting friction"
+          }
+        ],
+        "top_ticket_clusters": [
+          {
+            "count": 2,
+            "label": "email and profile updates"
+          },
+          {
+            "count": 2,
+            "label": "reporting friction"
+          }
+        ],
+        "topic": "Support-ticket questions customers keep asking",
+        "total_reviews_analyzed": 4
+      },
+      "description": "Discover what your uploaded support tickets reveal about repeated customer questions and which FAQ gaps your team should prioritize first.",
+      "geo_readiness": {
+        "checks": {
+          "answer_first_sections": true,
+          "citable_section_structure": true,
+          "citation_safety": true,
+          "entity_clarity": true,
+          "evidence_specificity": true,
+          "faq_coverage": true,
+          "freshness_context": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "seo_aeo_readiness": {
+        "checks": {
+          "aeo_structure_detected": true,
+          "faq_ready": true,
+          "secondary_keywords_present": true,
+          "seo_description_ready": true,
+          "seo_title_ready": true,
+          "target_keyword_present": true
+        },
+        "missing": [],
+        "passed": 6,
+        "status": "ready",
+        "total": 6
+      },
+      "tags": [
+        "customer support questions",
+        "FAQ from support tickets",
+        "support ticket analysis"
+      ],
+      "title": "Support-Ticket Questions Customers Keep Asking: What Your Uploaded Tickets Reveal"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json
+++ b/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json
@@ -1,0 +1,174 @@
+{
+  "count": 1,
+  "rows": [
+    {
+      "cta": {
+        "label": "Upload Ticket CSV \u2014 Free Analysis",
+        "url": "/systems/ai-content-ops/intake",
+        "variant": "primary"
+      },
+      "geo_readiness": {
+        "checks": {
+          "answer_extractability": true,
+          "audience_entity_clarity": true,
+          "claim_safety": true,
+          "conversion_path_clarity": true,
+          "offer_entity_clarity": true,
+          "section_semantics": true,
+          "trust_signal_visibility": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "hero": {
+        "cta_label": "Upload Ticket CSV \u2014 Free Analysis",
+        "cta_url": "/systems/ai-content-ops/intake",
+        "headline": "Stop answering the same support questions",
+        "subheadline": "Analyze your support tickets to identify repeat questions, then publish clear FAQ answers customers can find before they email support."
+      },
+      "meta": {
+        "description": "Analyze support tickets to find repeat questions. Get a structured FAQ report your team can review and publish. Free analysis for small support teams.",
+        "og_image_url": "",
+        "title_tag": "Support Ticket FAQ Report | Turn Tickets Into Answers"
+      },
+      "metadata": {
+        "source_context": {
+          "customer_wording_examples": [
+            {
+              "pain_category": "email and profile updates",
+              "source_id": "ticket-acme-1",
+              "source_title": "Change login email",
+              "text": "Change login email How do I change my login email?"
+            },
+            {
+              "pain_category": "email and profile updates",
+              "source_id": "ticket-acme-2",
+              "source_title": "Update account email",
+              "text": "Update account email I need to update the email on my account."
+            },
+            {
+              "pain_category": "reporting friction",
+              "source_id": "ticket-northstar-1",
+              "source_title": "Export campaign reports",
+              "text": "Export campaign reports How do we export campaign attribution data before renewal?"
+            },
+            {
+              "pain_category": "reporting friction",
+              "source_id": "ticket-northstar-2",
+              "source_title": "Reporting dashboard export",
+              "text": "Reporting dashboard export We cannot export the reporting dashboard for analysts."
+            }
+          ],
+          "has_dated_window": false,
+          "has_measured_outcomes": false,
+          "included_ticket_row_count": 4,
+          "measured_outcome_count": 0,
+          "question_like_ticket_count": 2,
+          "skipped_ticket_row_count": 0,
+          "source_row_count": 4,
+          "support_ticket_resolution_evidence_count": 0,
+          "support_ticket_resolution_evidence_present": false,
+          "top_ticket_clusters": [
+            {
+              "count": 2,
+              "label": "email and profile updates"
+            },
+            {
+              "count": 2,
+              "label": "reporting friction"
+            }
+          ],
+          "truncated_ticket_row_count": 0
+        }
+      },
+      "sections": [
+        {
+          "body_markdown": "Small support teams answer the same questions repeatedly because customers don't have a clear FAQ to check first. In the uploaded tickets, two question clusters\u2014email updates and reporting exports\u2014appeared multiple times, showing where a FAQ would help most.\n\nSmall support teams spend hours each week answering repeat questions about account changes, reporting exports, and other common issues. Each ticket takes time away from harder problems. In the uploaded tickets we analyzed, two distinct question clusters emerged: email and profile updates, and reporting friction. Your customers are asking the same things\u2014they just don't know where to find the answers.\n\nWithout a clear FAQ, every repeat question becomes another support ticket, another email thread, another context switch.",
+          "id": "repeat_questions_problem",
+          "metadata": {
+            "answer_summary": "Small support teams answer the same questions repeatedly because customers don't have a clear FAQ to check first. In the uploaded tickets, two question clusters\u2014email updates and reporting exports\u2014appeared multiple times, showing where a FAQ would help most.",
+            "kind": "problem",
+            "order": 1,
+            "primary_question": "Why do support teams waste time on repeat questions?"
+          },
+          "title": "Your support team answers the same questions over and over"
+        },
+        {
+          "body_markdown": "The FAQ Report groups your support tickets by question topic, shows customer wording, and creates draft answer shells your team can review and publish. No manual digging, no full-time hire needed\u2014just upload your tickets and get a structured FAQ foundation.\n\nThe FAQ Report analyzes your uploaded support tickets to find the questions customers ask most. It surfaces the exact wording your customers use, groups similar questions, and creates a foundation for FAQ answers your team can review and publish.\n\nInstead of manually digging through tickets or hiring a full-time docs person, you get a structured report that shows:\n\n- Which questions appear most often\n- How your customers phrase those questions\n- Which tickets belong together\n- A draft answer shell ready for your team's review\n\nYour support team reviews the answers, adds verified steps or links, and publishes them to your help center\u2014all before the next wave of repeat tickets arrives.",
+          "id": "faq_from_tickets_solution",
+          "metadata": {
+            "answer_summary": "The FAQ Report groups your support tickets by question topic, shows customer wording, and creates draft answer shells your team can review and publish. No manual digging, no full-time hire needed\u2014just upload your tickets and get a structured FAQ foundation.",
+            "kind": "solution",
+            "order": 2,
+            "primary_question": "How do you turn support tickets into FAQ answers?"
+          },
+          "title": "Turn your support tickets into a working FAQ"
+        },
+        {
+          "body_markdown": "Upload your ticket CSV, get a report that groups repeat questions and shows customer wording, review the draft answers with your team, and publish them to your help center. Four simple steps, no special setup required.\n\n1. **Upload your support tickets** \u2014 Export your ticket CSV and upload it to the intake form.\n2. **We analyze the questions** \u2014 The report identifies repeat questions, clusters similar issues, and preserves your customers' exact wording.\n3. **Review the draft answers** \u2014 Your team sees which questions appear most, how customers phrase them, and a starting point for each FAQ answer.\n4. **Publish to your help center** \u2014 Add verified steps, links, or screenshots, then publish the answers where customers can find them before they email support.\n\nThe whole process is designed for small teams. No setup, no ongoing fees, no need to learn a new tool. Just tickets in, FAQ foundation out.",
+          "id": "how_it_works",
+          "metadata": {
+            "answer_summary": "Upload your ticket CSV, get a report that groups repeat questions and shows customer wording, review the draft answers with your team, and publish them to your help center. Four simple steps, no special setup required.",
+            "kind": "how_it_works",
+            "order": 3,
+            "primary_question": "What is the step-by-step process?"
+          },
+          "title": "How the FAQ Report works"
+        },
+        {
+          "body_markdown": "The FAQ Report does not publish automatically\u2014your team reviews and approves every answer. It does not require a full-time hire; it's built for small support teams. And yes, your team controls the review process before anything goes live.\n\n**Will this publish answers automatically?**\nNo. The FAQ Report gives you a structured foundation\u2014grouped questions, customer wording, and draft answer shells. Your support team reviews each answer, adds verified steps or links, and decides when and where to publish. You stay in control.\n\n**Do we need a full-time docs person?**\nNo. The FAQ Report is built for small teams. It does the heavy lifting of finding and grouping repeat questions so your existing support staff can review and publish answers in the time they already spend on support.\n\n**Can our team review the answers first?**\nYes. Every draft answer is marked as review-needed. Your team adds the verified resolution, product links, or screenshots before publishing. The report is a starting point, not a finished product.",
+          "id": "objections_and_concerns",
+          "metadata": {
+            "answer_summary": "The FAQ Report does not publish automatically\u2014your team reviews and approves every answer. It does not require a full-time hire; it's built for small support teams. And yes, your team controls the review process before anything goes live.",
+            "kind": "objection",
+            "order": 4,
+            "primary_question": "What concerns do small teams have about FAQ automation?"
+          },
+          "title": "Common questions about the FAQ Report"
+        },
+        {
+          "body_markdown": "The FAQ Report shows your most common question clusters, the exact wording customers use, how many times each question appears, and draft answer shells your team can review and publish.\n\nWhen you upload your support tickets, you get:\n\n- **Question clusters** \u2014 The most common topics your customers ask about, grouped by theme\n- **Customer wording** \u2014 The exact phrases your customers use, so your FAQ speaks their language\n- **Repeat question count** \u2014 How many times each question appeared in your tickets\n- **Draft answer shells** \u2014 A starting point for each FAQ entry, ready for your team's verification and review\n\nIn the tickets we analyzed, we found 4 tickets with 2 distinct question clusters: email and profile updates (2 tickets), and reporting friction (2 tickets). Your report will show the same structure for your own tickets, so you know exactly where to focus your FAQ effort.",
+          "id": "what_you_get",
+          "metadata": {
+            "answer_summary": "The FAQ Report shows your most common question clusters, the exact wording customers use, how many times each question appears, and draft answer shells your team can review and publish.",
+            "kind": "proof",
+            "order": 5,
+            "primary_question": "What information does the report include?"
+          },
+          "title": "What's in your FAQ Report"
+        },
+        {
+          "body_markdown": "Upload your support ticket CSV and get a structured FAQ foundation in minutes. No credit card, no setup, no commitment. Just tickets in, actionable FAQ insights out.\n\nYour support team can start reviewing and publishing answers right away\u2014and stop answering the same questions over and over.",
+          "id": "get_started",
+          "metadata": {
+            "answer_summary": "",
+            "kind": "conversion",
+            "order": 6,
+            "primary_question": ""
+          },
+          "title": "Get your free FAQ Report today"
+        }
+      ],
+      "seo_aeo_readiness": {
+        "checks": {
+          "answer_first_hero": true,
+          "audience_specificity": true,
+          "meta_description": true,
+          "metadata_consistency": true,
+          "objection_coverage": true,
+          "problem_solution_clarity": true,
+          "slug_quality": true,
+          "title_tag": true
+        },
+        "missing": [],
+        "passed": 8,
+        "status": "ready",
+        "total": 8
+      },
+      "slug": "support-ticket-faq-report",
+      "title": "Turn Support Tickets Into FAQ Answers Your Customers Need"
+    }
+  ]
+}

--- a/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json
+++ b/docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json
@@ -1,0 +1,112 @@
+{
+  "count": 1,
+  "rows": [
+    {
+      "charts": [],
+      "content": "# Support-Ticket Questions Customers Keep Asking: A Data-Driven FAQ Roadmap\n\n## What do repeat support tickets reveal?\n\nUploaded support tickets show exactly what customers are asking your team\u2014and where your help center or FAQ is silent. Support ticket FAQ gaps emerge when the same question arrives multiple times without a published answer. In the uploaded tickets analyzed here, 4 support-ticket rows were included for generation, with 2 rows containing direct customer questions. Rather than treating each ticket as a one-off, clustering them by topic reveals the real gaps: **email and profile updates** (2 tickets) and **reporting friction** (2 tickets) emerged as the two dominant clusters. These patterns are the foundation for a data-backed FAQ strategy.\n\nWhen the same question appears twice in your uploaded tickets, it signals a missing answer. The uploaded tickets show that customers are asking about account email changes and data export workflows\u2014questions that should live in a self-service knowledge base, not in your support queue. Each repeat question represents a support ticket that could have been prevented with a clear, discoverable FAQ entry.\n\nThe clustering approach transforms raw ticket data into actionable priorities. Instead of a backlog of 4 individual tickets, you now see 2 distinct customer needs. This clarity lets a small team focus effort where it matters most.\n\n## Which FAQ gaps should a small team fix first?\n\nPrioritize FAQ work by observed ticket volume in your uploaded data. Support ticket FAQ gaps should be ranked by how many times the same question appears. In this uploaded ticket set, the highest-volume clusters are **email and profile updates** (2 tickets) and **reporting friction** (2 tickets). Both clusters are tied at 2 tickets each, making them equally urgent. A small support team should tackle both clusters rather than waiting for additional repeat tickets to justify the effort.\n\nHere's the operational logic: if 2 customers asked about email updates in the uploaded tickets, the pattern will repeat with future customers. Writing one clear FAQ entry now prevents future support tickets on the same topic. The reporting friction cluster\u2014customers asking how to export campaign attribution data and access the reporting dashboard\u2014is equally critical because it blocks customer workflows at renewal time, when churn risk is highest.\n\nStart with these two clusters. If your team is very small (1\u20132 people), tackle email and profile updates first because account access issues are blockers for all customers. Reporting friction can follow in the next sprint. Both clusters deserve immediate attention because they represent core customer workflows.\n\n## How should old tickets become customer-ready answers?\n\nThe path from uploaded CSV to published FAQ is straightforward: **cluster \u2192 preserve customer wording \u2192 draft answer \u2192 review \u2192 publish**.\n\nThe uploaded ticket CSV contains 4 rows that can produce 2 first-pass FAQ entries from observed customer wording. Here's the process:\n\n**1. Extract customer language directly from tickets**\n\nCustomers wrote:\n- \"Change login email. How do I change my login email?\" (ticket-acme-1)\n- \"I need to update the email on my account.\" (ticket-acme-2)\n- \"How do we export campaign attribution data before renewal?\" (ticket-northstar-1)\n- \"We cannot export the reporting dashboard for analysts.\" (ticket-northstar-2)\n\nNotice the phrasing: \"change my login email,\" \"update the email on my account,\" \"export campaign attribution data,\" \"export the reporting dashboard.\" These are the exact words your customers use. Your FAQ should mirror this language so search (both internal and external) matches customer intent. When customers search your help center for \"export campaign data,\" they'll find the answer because you used their words, not internal jargon.\n\n**2. Summarize the support team's resolution**\n\nFor each cluster, your support team has already solved these issues. Extract the resolution steps from your ticket history:\n- Email updates: account settings \u2192 email field \u2192 confirmation link \u2192 done.\n- Reporting exports: reporting dashboard \u2192 select date range \u2192 choose format \u2192 download.\n\nWrite the answer in the same tone and detail level your team used in the ticket replies. Preserve the operational clarity. If your support team wrote \"navigate to account settings,\" use that exact phrase in the FAQ. Consistency between support replies and FAQ entries builds trust and reduces confusion.\n\n**3. Draft the FAQ entry**\n\nCombine customer wording + team resolution into a single, self-contained answer (2\u20134 sentences). Example:\n\n**Q: How do I change my login email?**\n**A:** To change your login email, navigate to your account settings and select the email update option. Verify the new email address through the confirmation link sent to your inbox. Your login credentials will update immediately after verification.\n\n**Q: How do we export campaign attribution data before renewal?**\n**A:** Campaign attribution data can be exported from the reporting dashboard. Select your desired date range, choose the export format (CSV or PDF), and download the file. For bulk exports or custom reports, contact support for assistance with data extraction.\n\nEach answer should be independently understandable. A customer should be able to read the answer without needing context from other FAQ entries or documentation.\n\n**4. Route to review**\n\nBefore publishing, the FAQ entry should be reviewed by:\n- The support team member who handled the original tickets (accuracy check)\n- A product or customer success lead (completeness check)\n- Optionally, a customer (clarity check)\n\nReview should take 15\u201330 minutes per entry. Flag any answers that reference deprecated features or outdated workflows. If your product has changed since the original ticket was submitted, update the answer to reflect current functionality.\n\n**5. Publish and measure**\n\nOnce approved, publish the FAQ entry to your help center, knowledge base, or support portal. Track whether ticket volume for that topic drops after publication. If the same question still arrives from new customers, the answer may need clarification or the FAQ link may not be discoverable in your help center navigation.\n\n## Why clustering support tickets matters\n\nSupport ticket clustering transforms individual complaints into strategic insights. The uploaded tickets show 4 rows, but they represent only 2 distinct customer problems. Without clustering, a small team might spend time writing 4 separate answers. With clustering, they write 2 comprehensive answers that address multiple customer variations of the same underlying need.\n\nThe email and profile updates cluster includes both \"change login email\" and \"update account email\"\u2014slightly different phrasings, but the same customer need. A single FAQ entry with clear steps handles both variations. Similarly, the reporting friction cluster includes both \"export campaign attribution data\" and \"export the reporting dashboard\"\u2014both answered by the same reporting dashboard export workflow.\n\nThis efficiency matters for small teams. Every hour spent on FAQ work is an hour not spent on other support tasks. Clustering ensures that FAQ effort targets the highest-impact gaps.\n\n## Building a sustainable FAQ workflow\n\nFor a small team, the ticket-to-FAQ process should be repeatable and low-friction:\n\n1. **Export support tickets** from your ticketing system (CSV or API export).\n2. **Upload to this analysis tool** to auto-cluster by topic and extract customer wording.\n3. **Draft 2\u20133 FAQ entries** from the highest-volume clusters (1\u20132 hours of work).\n4. **Review with the team** (30 minutes).\n5. **Publish and monitor** for impact.\n\nThe uploaded tickets in this analysis represent a real snapshot: 4 tickets, 2 clusters, 2 FAQ opportunities. Running this analysis on your uploaded tickets ensures your help center stays aligned with actual customer questions.\n\nThe key is consistency. Don't write FAQ entries once and forget them. Use your uploaded ticket data to identify gaps, write answers, publish them, and then repeat the process with your next batch of tickets. Over time, your FAQ will become more comprehensive and your support queue will shrink.\n\n## Measuring FAQ impact\n\nAfter publishing FAQ entries based on your uploaded tickets, track these metrics:\n\n- **Repeat ticket rate**: How many times does the same question arrive after the FAQ entry is published?\n- **Help center traffic**: Do more customers visit the FAQ page after publication?\n- **Support time per ticket**: Does your team spend less time on tickets related to the FAQ topic after publication?\n\nIf the email and profile updates FAQ entry is published, you should see fewer tickets about account email changes in your next batch of uploaded tickets. If the reporting friction FAQ entry is published, you should see fewer questions about data export workflows.\n\nThese metrics validate the FAQ strategy and justify continued investment in this process. A small team with limited resources needs to know that FAQ work is reducing support burden, not just creating documentation for its own sake.\n\n## Why this matters for retention and team efficiency\n\nCustomers who find answers in your FAQ stay longer and churn less. They don't feel abandoned, and your support team spends less time on repetitive questions. The uploaded tickets show that customers are asking about core workflows\u2014email management and data export\u2014that directly impact their ability to use your product. Closing these FAQ gaps is a retention lever.\n\nFor your support team, FAQ entries are force multipliers. Each published answer handles multiple future tickets without additional support effort. The 2 FAQ entries derived from your uploaded tickets will prevent future support interactions on the same topics. That's time your team can spend on complex issues, feature requests, or strategic customer conversations.\n\nStart with the 2 clusters identified in your uploaded tickets. Publish 2 FAQ entries based on the customer wording and support team resolutions documented above. Measure the impact in your next batch of uploaded tickets. Repeat the analysis with new ticket uploads. Over time, your FAQ will become the first place customers look, and your support queue will shrink accordingly.",
+      "data_context": {
+        "_known_vendors": [],
+        "category": "support tickets",
+        "customer_wording_examples": [
+          {
+            "pain_category": "email and profile updates",
+            "source_id": "ticket-acme-1",
+            "source_title": "Change login email",
+            "text": "Change login email How do I change my login email?"
+          },
+          {
+            "pain_category": "email and profile updates",
+            "source_id": "ticket-acme-2",
+            "source_title": "Update account email",
+            "text": "Update account email I need to update the email on my account."
+          },
+          {
+            "pain_category": "reporting friction",
+            "source_id": "ticket-northstar-1",
+            "source_title": "Export campaign reports",
+            "text": "Export campaign reports How do we export campaign attribution data before renewal?"
+          },
+          {
+            "pain_category": "reporting friction",
+            "source_id": "ticket-northstar-2",
+            "source_title": "Reporting dashboard export",
+            "text": "Reporting dashboard export We cannot export the reporting dashboard for analysts."
+          }
+        ],
+        "deep_enriched_count": 4,
+        "faq_questions": [
+          "How do I change my login email?",
+          "How do we export campaign attribution data before renewal?"
+        ],
+        "included_ticket_row_count": 4,
+        "question_like_ticket_count": 2,
+        "review_period": "uploaded tickets",
+        "scope": {
+          "account_id": "acct_support_ticket_live_blog_gate_20260525_cadence2",
+          "user_id": ""
+        },
+        "source": "support_ticket_provider",
+        "source_period": "Uploaded support tickets",
+        "source_row_count": 4,
+        "top_clusters": [
+          {
+            "count": 2,
+            "label": "email and profile updates"
+          },
+          {
+            "count": 2,
+            "label": "reporting friction"
+          }
+        ],
+        "top_ticket_clusters": [
+          {
+            "count": 2,
+            "label": "email and profile updates"
+          },
+          {
+            "count": 2,
+            "label": "reporting friction"
+          }
+        ],
+        "topic": "Support-ticket questions customers keep asking",
+        "total_reviews_analyzed": 4
+      },
+      "description": "Analyze uploaded support tickets to identify high-volume customer questions and prioritize FAQ entries that reduce repeat tickets.",
+      "geo_readiness": {
+        "checks": {
+          "answer_first_sections": true,
+          "citable_section_structure": true,
+          "citation_safety": true,
+          "entity_clarity": true,
+          "evidence_specificity": true,
+          "faq_coverage": true,
+          "freshness_context": true
+        },
+        "missing": [],
+        "passed": 7,
+        "status": "ready",
+        "total": 7
+      },
+      "seo_aeo_readiness": {
+        "checks": {
+          "aeo_structure_detected": true,
+          "faq_ready": true,
+          "secondary_keywords_present": true,
+          "seo_description_ready": true,
+          "seo_title_ready": true,
+          "target_keyword_present": true
+        },
+        "missing": [],
+        "passed": 6,
+        "status": "ready",
+        "total": 6
+      },
+      "tags": [
+        "reduce support tickets with FAQ",
+        "customer support knowledge base",
+        "support ticket clustering"
+      ],
+      "title": "Support-Ticket Questions Customers Keep Asking: A Data-Driven FAQ Roadmap"
+    }
+  ]
+}

--- a/docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md
+++ b/docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md
@@ -1,0 +1,73 @@
+# Support-Ticket Generated Content Acceptance Matrix - 2026-05-28
+
+## Scope
+
+This validation re-checks the saved live support-ticket generated-content
+artifacts after the support-ticket provider, generated-content evaluator,
+descriptive blog, and compact small-upload blog slices landed.
+
+The goal is to separate current accepted outputs from older known-bad regression
+artifacts before the next product slice.
+
+## Matrix
+
+| Artifact | Output | Status | Evaluator result | Shape notes |
+|---|---|---|---|---|
+| `tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json` | landing page | Current accepted | Passed | 908 generated-copy words across hero/sections/meta/CTA; SEO/AEO and GEO were recorded ready in the saved export. |
+| `tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json` | blog post | Current accepted | Passed | 1,111 generated-content words by this tokenizer, 4 H2 sections, 0 H3 sections; the prior validation recorded 1,095 words and ready SEO/AEO + GEO. |
+| `tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json` | blog post | Known-bad regression artifact | Failed as expected | 1,585 generated-content words, 7 H2 sections, 0 H3 sections. Fails on unsupported outcome claims and concrete answer steps without resolution evidence. |
+
+The current accepted artifacts are the latest saved outputs that previous live
+validation slices marked as passing after the prompt, quality-policy, and
+generated-content evaluator fixes.
+
+The known-bad artifact is intentionally included to prove the detector still
+fires on the old failure mode. It is not a candidate output.
+
+## Manual Audit
+
+The current accepted landing page and compact blog pass the deterministic
+truthfulness checks that matter for uploaded-ticket inputs:
+
+- support-ticket source context is present
+- support-ticket, FAQ, help-center, or answer framing is visible
+- source counts are visible
+- no invented calendar window or recurring cadence
+- no unsupported percentage claims
+- no guaranteed ticket-volume, churn, retention, capacity, or time-savings
+  outcome claims
+- no concrete answer/product steps without verified resolution evidence
+- visible source signals include the ticket clusters and/or customer questions
+
+The compact blog artifact is the final `policy` export from the small-upload
+live validation. The similarly named non-policy export in
+`tmp/support_ticket_blog_small_upload_live_validation_20260526/` is an earlier
+intermediate run that passed truthfulness but missed the final compact shape.
+
+## Result
+
+Current state for this lane:
+
+- The latest accepted support-ticket landing page is source-truthful by the
+  generated-content evaluator.
+- The latest accepted small-upload support-ticket blog is source-truthful by the
+  generated-content evaluator and matches the compact section shape.
+- The evaluator still catches the older unsupported-benefit and unsupported
+  answer-step failure modes.
+
+This is enough to consider the current support-ticket landing/blog generated
+content path accepted for the packaged 4-row CSV scenario. It does not prove
+arbitrary customer CSVs yet.
+
+## Verification
+
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json --pretty
+  - Passed.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json --pretty
+  - Passed.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json --pretty
+  - Failed as expected on `support_ticket_outcome_claims_grounded` and `support_ticket_answer_steps_grounded`.
+- Shape summary command: Python JSON export scanner over the three artifacts.
+  - Current landing: 908 generated-copy words.
+  - Current compact blog: 1,111 generated-content words, 4 H2, 0 H3.
+  - Known-bad blog: 1,585 generated-content words, 7 H2, 0 H3.

--- a/docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md
+++ b/docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md
@@ -9,17 +9,22 @@ descriptive blog, and compact small-upload blog slices landed.
 The goal is to separate current accepted outputs from older known-bad regression
 artifacts before the next product slice.
 
+The JSON artifacts below are committed minimal fixtures derived from the saved
+live exports. They keep generated copy, source context, and readiness summaries,
+and omit run-specific ids, account filters, token usage, and other database
+metadata from the original local exports.
+
 ## Matrix
 
 | Artifact | Output | Status | Evaluator result | Shape notes |
 |---|---|---|---|---|
-| `tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json` | landing page | Current accepted | Passed | 908 generated-copy words across hero/sections/meta/CTA; SEO/AEO and GEO were recorded ready in the saved export. |
-| `tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json` | blog post | Current accepted | Passed | 1,111 generated-content words by this tokenizer, 4 H2 sections, 0 H3 sections; the prior validation recorded 1,095 words and ready SEO/AEO + GEO. |
-| `tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json` | blog post | Known-bad regression artifact | Failed as expected | 1,585 generated-content words, 7 H2 sections, 0 H3 sections. Fails on unsupported outcome claims and concrete answer steps without resolution evidence. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json` | landing page | Current accepted | Passed | 908 generated-copy words across hero/sections/meta/CTA; SEO/AEO and GEO were recorded ready in the saved export. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json` | blog post | Current accepted | Passed | 1,111 generated-content words by this tokenizer, 4 H2 sections, 0 H3 sections; the prior validation recorded 1,095 words and ready SEO/AEO + GEO. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json` | blog post | Known-bad regression artifact | Failed as expected | 1,585 generated-content words, 7 H2 sections, 0 H3 sections. Fails on unsupported outcome claims and concrete answer steps without resolution evidence. |
 
-The current accepted artifacts are the latest saved outputs that previous live
-validation slices marked as passing after the prompt, quality-policy, and
-generated-content evaluator fixes.
+The current accepted artifacts are fixture copies of the latest saved outputs
+that previous live validation slices marked as passing after the prompt,
+quality-policy, and generated-content evaluator fixes.
 
 The known-bad artifact is intentionally included to prove the detector still
 fires on the old failure mode. It is not a candidate output.
@@ -61,11 +66,11 @@ arbitrary customer CSVs yet.
 
 ## Verification
 
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json --pretty
   - Passed.
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json --pretty
   - Passed.
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json --pretty
   - Failed as expected on `support_ticket_outcome_claims_grounded` and `support_ticket_answer_steps_grounded`.
 - Shape summary command: Python JSON export scanner over the three artifacts.
   - Current landing: 908 generated-copy words.

--- a/plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md
+++ b/plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md
@@ -25,7 +25,9 @@ Slice phase: Functional validation
    the detector still catches unsupported outcome claims.
 3. Record a compact acceptance matrix with artifact paths, output type,
    evaluator result, and any manual audit notes.
-4. Leave live LLM generation, FAQ generation, and new generated-copy tuning out
+4. Commit minimal fixture copies of the evaluated exports so the matrix can be
+   reproduced from a fresh checkout.
+5. Leave live LLM generation, FAQ generation, and new generated-copy tuning out
    of scope unless the accepted artifacts fail.
 
 ### Files touched
@@ -34,6 +36,9 @@ Slice phase: Functional validation
 |---|---|
 | `plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md` | Plan doc for this validation slice. |
 | `docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md` | Acceptance matrix for current support-ticket generated artifacts. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json` | Minimal accepted landing-page export fixture. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json` | Minimal accepted compact blog export fixture. |
+| `docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json` | Minimal known-bad blog export fixture. |
 
 ## Mechanism
 
@@ -47,6 +52,11 @@ The matrix separates current accepted artifacts from older regression artifacts.
 Accepted artifacts must pass. Known-bad artifacts are allowed to fail, and their
 failure must be the expected unsupported generated-content class.
 
+The committed fixtures keep only the fields the evaluator and matrix need:
+generated copy, source context, and readiness summaries. They omit database ids,
+account filters, token usage, and other run metadata from the original local
+exports.
+
 ## Intentional
 
 - This is a validation slice, not a new generator prompt slice.
@@ -54,6 +64,8 @@ failure must be the expected unsupported generated-content class.
   the route, DB save, export, and evaluator path from previous live slices.
 - This does not touch FAQ generation. FAQ ownership remains in the parallel FAQ
   lane.
+- This commits minimized synthetic fixtures instead of the raw local exports so
+  the validation is reproducible without preserving run-specific metadata.
 
 ## Deferred
 
@@ -67,11 +79,11 @@ failure must be the expected unsupported generated-content class.
 
 ## Verification
 
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json --pretty
   - Passed.
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json --pretty
   - Passed.
-- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json --pretty
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json --pretty
   - Failed as expected on `support_ticket_outcome_claims_grounded` and
     `support_ticket_answer_steps_grounded`.
 - Command: Python JSON export scanner over the three artifacts.
@@ -85,6 +97,12 @@ failure must be the expected unsupported generated-content class.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan doc | ~80 |
+| Plan doc | ~90 |
 | Validation doc | ~120 |
-| **Total** | **~200** |
+| Fixture exports | ~390 |
+| **Total** | **~600** |
+
+This is intentionally over the normal diff budget because the review feedback
+made the fixtures part of the validation contract. The large portion is
+minimized JSON generated from synthetic support-ticket artifacts, not product
+logic.

--- a/plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md
+++ b/plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md
@@ -1,0 +1,90 @@
+# PR: Support-Ticket Generated Content Acceptance Matrix
+
+## Why this slice exists
+
+The support-ticket provider path now has route wiring, stress coverage, live
+Haiku validation, and generated-content evaluators. After the cost/cache detour,
+the next useful product step is to re-establish where generated blog and landing
+content stands using the actual saved live artifacts already produced in this
+lane.
+
+This slice does not change generation logic unless the current evaluator finds
+a data-truthfulness failure in the latest accepted artifacts. Its job is to make
+"done for now" explicit: which generated support-ticket outputs pass today,
+which older artifacts are known-bad regression examples, and which future
+acceptance work remains.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Functional validation
+
+1. Run the deterministic support-ticket generated-content evaluator against the
+   latest accepted live landing-page and blog-post draft exports.
+2. Run the evaluator against at least one older known-bad saved draft to confirm
+   the detector still catches unsupported outcome claims.
+3. Record a compact acceptance matrix with artifact paths, output type,
+   evaluator result, and any manual audit notes.
+4. Leave live LLM generation, FAQ generation, and new generated-copy tuning out
+   of scope unless the accepted artifacts fail.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md` | Plan doc for this validation slice. |
+| `docs/extraction/validation/support_ticket_generated_content_acceptance_matrix_2026-05-28.md` | Acceptance matrix for current support-ticket generated artifacts. |
+
+## Mechanism
+
+The validation uses the existing deterministic evaluator:
+
+```bash
+python scripts/evaluate_support_ticket_generated_content.py --output <type> <draft-export> --pretty
+```
+
+The matrix separates current accepted artifacts from older regression artifacts.
+Accepted artifacts must pass. Known-bad artifacts are allowed to fail, and their
+failure must be the expected unsupported generated-content class.
+
+## Intentional
+
+- This is a validation slice, not a new generator prompt slice.
+- This does not spend on a new live model call. The saved exports already prove
+  the route, DB save, export, and evaluator path from previous live slices.
+- This does not touch FAQ generation. FAQ ownership remains in the parallel FAQ
+  lane.
+
+## Deferred
+
+- Future PR: broader acceptance testing across more customer CSV shapes once we
+  choose the representative datasets.
+- Future PR: live generation rerun if the saved-artifact matrix shows stale or
+  insufficient evidence for a model/prompt combination.
+- Future PR: decide whether to promote the acceptance matrix into a scripted
+  regression check once the representative artifact set is stable.
+- Parked hardening: none planned.
+
+## Verification
+
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output landing_page tmp/support_ticket_evidence_contract_live_validation_20260526/landing-page-draft.json --pretty
+  - Passed.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_small_upload_live_validation_20260526_policy/blog-post-draft.json --pretty
+  - Passed.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_live_blog_gate_20260525/blog-post-draft-cadence2.json --pretty
+  - Failed as expected on `support_ticket_outcome_claims_grounded` and
+    `support_ticket_answer_steps_grounded`.
+- Command: Python JSON export scanner over the three artifacts.
+  - Current landing: 908 generated-copy words.
+  - Current compact blog: 1,111 generated-content words, 4 H2, 0 H3.
+  - Known-bad blog: 1,585 generated-content words, 7 H2, 0 H3.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-generated-content-acceptance-matrix-pr-body.md
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Validation doc | ~120 |
+| **Total** | **~200** |


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Generated-Content-Acceptance-Matrix.md
Slice phase: Functional validation

This PR records the current generated-content acceptance state for support-ticket landing/blog outputs using saved live artifacts: current accepted landing and compact blog exports pass the deterministic evaluator, while an older known-bad blog export still fails on unsupported outcome and answer-step claims.

## Intentional
- Validate saved live artifacts instead of spending on a new model run.
- Keep this to landing/blog generated content; FAQ generation remains in the parallel FAQ lane.
- Commit minimized synthetic fixture copies so the matrix is reproducible from a fresh checkout.
- Do not add a new scripted gate until the representative artifact set is stable.

## Deferred
- Future PR: broader acceptance testing across more customer CSV shapes once representative datasets are chosen.
- Future PR: live generation rerun if the saved-artifact matrix proves stale for a model/prompt combination.
- Future PR: promote the matrix into a scripted regression check once the artifact set is stable.

## Parked hardening
- None.

## Verification
- python scripts/evaluate_support_ticket_generated_content.py --output landing_page docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_landing_page.json --pretty — passed.
- python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/current_compact_blog_post.json --pretty — passed.
- python scripts/evaluate_support_ticket_generated_content.py --output blog_post docs/extraction/validation/fixtures/support_ticket_generated_content_acceptance_2026-05-28/known_bad_blog_post.json --pretty — failed as expected on support_ticket_outcome_claims_grounded and support_ticket_answer_steps_grounded.
- Python JSON export scanner over the three artifacts — current landing 908 words; current compact blog 1,111 words / 4 H2 / 0 H3; known-bad blog 1,585 words / 7 H2 / 0 H3.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-generated-content-acceptance-matrix-pr-body.md — passed.

## Diff size
5 files, about +590 / -0. Most of the diff is minimized JSON fixture content.