### PR TITLE
Document FAQ seeded route e2e smoke

### DIFF
--- a/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
@@ -1,0 +1,102 @@
+# Content Ops FAQ Seeded Route E2E Runbook
+
+Use this runbook to seed FAQ search rows into Postgres, exercise the hosted FAQ
+search route, hydrate one generated FAQ detail, and clean up the seeded rows in
+one command.
+
+This is the preferred go-live probe when you need to prove the real search path,
+not just route liveness. It composes the seeded DB smoke, hosted route
+concurrency smoke, detail contract checker, and cleanup guard.
+
+## Required Inputs
+
+- `EXTRACTED_DATABASE_URL` or `DATABASE_URL`: Postgres database used by the
+  deployed Atlas API.
+- `ATLAS_API_BASE_URL`: deployed Atlas API host, for example
+  `https://atlas-api.example.com`.
+- `ATLAS_B2B_JWT` or `ATLAS_TOKEN`: bearer token for the account under test.
+- `ATLAS_FAQ_SEARCH_ACCOUNT_ID`: account ID matching the bearer token. The
+  runner does not decode the token; it seeds rows under the account you provide.
+
+Run the FAQ search migrations before this smoke:
+
+```bash
+python extracted_content_pipeline/storage/migration_runner.py --apply
+```
+
+## Recommended Seeded E2E Smoke
+
+```bash
+python scripts/smoke_content_ops_faq_search_seeded_route_e2e.py \
+  --database-url "$EXTRACTED_DATABASE_URL" \
+  --base-url "$ATLAS_API_BASE_URL" \
+  --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
+  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --corpora-per-account 2 \
+  --documents-per-corpus 3 \
+  --seed-iterations 12 \
+  --route-requests 40 \
+  --concurrency 8 \
+  --pool-size 2 \
+  --max-error-rate 0 \
+  --max-case-error-rate 0 \
+  --max-p95-ms 1500 \
+  --max-single-request-ms 3000 \
+  --max-case-p95-ms 1500 \
+  --max-case-single-request-ms 3000 \
+  --output-result /tmp/faq-search-seeded-route-e2e-result.json
+```
+
+Use `--json` when stdout should be machine-readable. Without `--json`, stdout is
+a compact status line; the full proof lives in `--output-result`.
+
+## What The Runner Does
+
+1. Seeds approved generated FAQ rows into Postgres for the supplied account.
+2. Writes a route case file with expected hit and miss cases for each seeded
+   corpus.
+3. Runs the hosted FAQ search route concurrency smoke against the seeded cases.
+4. Runs one detail contract check for the first seeded hit case.
+5. Deletes the seeded FAQ rows by emitted FAQ IDs unless `--keep-data` is set.
+6. Writes one compact JSON result with seed, route, detail, cleanup, and child
+   artifact summaries.
+
+## Result Checks
+
+Open the result artifact and inspect:
+
+- `ok`: overall pass/fail across seed, route, detail, cleanup, and artifact
+  cleanup.
+- `seed.result_artifact`: compact seed counts, setup status, latency, and
+  cleanup-manifest proof from the DB smoke.
+- `route.result_artifact.requests`: hosted route request count and concurrency
+  used by the child route smoke.
+- `route.result_artifact.cases`: number of route cases loaded from the seeded
+  case file.
+- `route.result_artifact.budgets`: aggregate and per-case route budget checks.
+- `detail.result_artifact`: detail contract status, hydrated FAQ ID, and search
+  plus detail timings.
+- `cleanup.requested_faq_ids` and `cleanup.deleted_faq_ids`: cleanup row-count
+  proof for seeded FAQ drafts.
+- `artifact_cleanup`: whether temporary child artifacts were removed after the
+  top-level summary embedded compact child results.
+
+## Interpreting Failures
+
+- Preflight failures exit with code `2` and do not seed or call the hosted
+  route.
+- Seed, route, detail, cleanup, or budget failures exit with code `1` and still
+  write the top-level result artifact.
+- A route aggregate error budget can pass while one query/corpus case fails. Use
+  `--max-case-error-rate`, `--max-case-p95-ms`, and
+  `--max-case-single-request-ms` to fail closed per case.
+- Cleanup failure makes the run fail unless `--keep-data` is set. Use
+  `--keep-data` only when you intentionally want to inspect seeded rows after
+  the run.
+- Detail checking is enabled by default in this seeded e2e runner. Use
+  `--skip-detail-check` only for a search-only liveness probe.
+
+## Deferred Thresholds
+
+The sample latency values above are placeholders. Replace them with thresholds
+from repeated hosted runs before treating them as production SLOs.

--- a/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
@@ -28,7 +28,7 @@ python extracted_content_pipeline/storage/migration_runner.py --apply
 
 ```bash
 python scripts/smoke_content_ops_faq_search_seeded_route_e2e.py \
-  --database-url "$EXTRACTED_DATABASE_URL" \
+  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
   --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \

--- a/plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md
+++ b/plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-FAQ-Search-E2E-Runbook
+
+## Why this slice exists
+
+The seeded hosted FAQ search e2e runner now composes DB seed, hosted route
+concurrency, detail hydration, cleanup, child-result summaries, and per-case
+route budgets. Operators can run the real flow from the CLI, but the validation
+docs only cover the route concurrency child smoke. That leaves the safest
+one-command go-live probe under-documented and makes it easier to run the route
+smoke without seeding/cleanup proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Add an operator runbook for the seeded hosted FAQ search e2e runner.
+2. Document the required inputs, recommended command, budget flags, detail
+   behavior, cleanup behavior, and result fields.
+3. Add a doc contract test that parses the documented command flags against the
+   real seeded e2e parser.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md` | Plan contract for this operator-doc slice. |
+| `docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md` | Operator runbook for the seeded hosted e2e command. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Verify the runbook command stays parseable by the actual CLI. |
+
+## Mechanism
+
+The new runbook shows a single recommended command for
+`scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` using environment
+variables for database URL, deployed API host, token, and account ID. The
+command includes aggregate route budgets and the per-case route budgets added in
+the previous slice.
+
+The test extracts the first fenced bash command containing the seeded e2e script,
+normalizes shell continuations and environment substitutions into concrete
+placeholder values, then parses the resulting arguments with the real
+`_build_parser()`. It asserts the expected budget, detail, cleanup, and artifact
+flags survive the documentation example.
+
+## Intentional
+
+- No runner behavior changes; this is documentation plus a parser-backed doc
+  contract.
+- No hosted live invocation is added because credentials and deployed hosts are
+  operator/runtime concerns.
+- No production SLO values are introduced. The runbook labels sample latency
+  values as placeholders that should be replaced with repeated hosted baselines.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this runner or docs.
+- A host-install-runbook cross-link can follow if operators want the seeded
+  route e2e command repeated outside the validation docs.
+
+## Verification
+
+- `pytest` on `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - 57 passed.
+- `py_compile` on `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
+- `scripts/audit_plan_doc.py` on `plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md` - passed.
+- `scripts/audit_plan_code_consistency.py` on `plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md` - passed.
+- `scripts/audit_extracted_pipeline_ci_enrollment.py` - 122 matching tests enrolled.
+- `git diff --check` - passed.
+- `scripts/validate_extracted_content_pipeline.sh` - passed.
+- `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py` on `extracted_content_pipeline` - passed.
+- `scripts/audit_extracted_standalone.py` with fail-on-debt - passed.
+- `scripts/check_ascii_python.sh` - passed.
+- `scripts/run_extracted_pipeline_checks.sh` - 2571 passed, 7 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 82 |
+| Runbook | 102 |
+| Tests | 38 |
+| **Total** | **222** |

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -167,7 +167,7 @@ def test_validate_args_reports_missing_required_fields_and_bad_numbers():
 def test_seeded_route_e2e_runbook_command_matches_parser():
     parsed = smoke._build_parser().parse_args(_runbook_seeded_e2e_command_args())
 
-    assert parsed.database_url == "$EXTRACTED_DATABASE_URL"
+    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
     assert parsed.base_url == "$ATLAS_API_BASE_URL"
     assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
     assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import shlex
 import sys
 from types import SimpleNamespace
 
@@ -11,6 +12,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_seeded_route_e2e.py"
+RUNBOOK = ROOT / "docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md"
 SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_seeded_route_e2e", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 smoke = importlib.util.module_from_spec(SPEC)
@@ -50,6 +52,20 @@ def _args(**overrides):
 
 def _write_cases(path: Path, payload) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _runbook_seeded_e2e_command_args() -> list[str]:
+    doc = RUNBOOK.read_text(encoding="utf-8")
+    marker = "python scripts/smoke_content_ops_faq_search_seeded_route_e2e.py"
+    start = doc.index(marker)
+    end = doc.index("```", start)
+    command = doc[start:end].replace("\\\n", " ")
+    parts = shlex.split(command)
+    assert parts[:2] == [
+        "python",
+        "scripts/smoke_content_ops_faq_search_seeded_route_e2e.py",
+    ]
+    return parts[2:]
 
 
 def _write_child_result(command, *, ok: bool = True) -> None:
@@ -146,6 +162,28 @@ def test_validate_args_reports_missing_required_fields_and_bad_numbers():
         "--max-error-rate must be between 0 and 1",
         "--max-p95-ms must be positive",
     ]
+
+
+def test_seeded_route_e2e_runbook_command_matches_parser():
+    parsed = smoke._build_parser().parse_args(_runbook_seeded_e2e_command_args())
+
+    assert parsed.database_url == "$EXTRACTED_DATABASE_URL"
+    assert parsed.base_url == "$ATLAS_API_BASE_URL"
+    assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
+    assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"
+    assert parsed.corpora_per_account == 2
+    assert parsed.documents_per_corpus == 3
+    assert parsed.seed_iterations == 12
+    assert parsed.route_requests == 40
+    assert parsed.concurrency == 8
+    assert parsed.pool_size == 2
+    assert parsed.max_error_rate == 0.0
+    assert parsed.max_case_error_rate == 0.0
+    assert parsed.max_p95_ms == 1500.0
+    assert parsed.max_single_request_ms == 3000.0
+    assert parsed.max_case_p95_ms == 1500.0
+    assert parsed.max_case_single_request_ms == 3000.0
+    assert str(parsed.output_result) == "/tmp/faq-search-seeded-route-e2e-result.json"
 
 
 def test_validate_args_rejects_invalid_case_budgets():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md
Slice phase: Production hardening

The seeded hosted FAQ search e2e runner is now the safest one-command go-live probe, but the validation docs only covered the route concurrency child smoke. This adds an operator runbook for the full seeded flow and pins the documented command against the real CLI parser.

## Intentional
- No runner behavior changes; this is documentation plus a parser-backed doc contract.
- No hosted live invocation is added because credentials and deployed hosts are operator/runtime concerns.
- No production SLO values are introduced. The runbook labels sample latency values as placeholders that should be replaced with repeated hosted baselines.

## Deferred
- A host-install-runbook cross-link can follow if operators want the seeded route e2e command repeated outside the validation docs.

## Parked hardening
- None. `HARDENING.md` has no active FAQ search entries touching this runner or docs.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 57 passed.
- `python -m py_compile tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Search-E2E-Runbook.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - 122 matching tests enrolled.
- `git diff --check` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2571 passed, 7 skipped, 1 warning.

## Diff size
3 files, +222 / -0
