### PR TITLE
Fix FAQ seeded e2e migration command

### DIFF
--- a/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
@@ -21,7 +21,7 @@ concurrency smoke, detail contract checker, and cleanup guard.
 Run the FAQ search migrations before this smoke:
 
 ```bash
-python extracted_content_pipeline/storage/migration_runner.py --apply
+python scripts/run_extracted_content_pipeline_migrations.py
 ```
 
 ## Recommended Seeded E2E Smoke

--- a/plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md
+++ b/plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md
@@ -1,0 +1,80 @@
+# PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-E2E-Runbook` added a seeded hosted FAQ search e2e
+runbook, but its migration prerequisite points operators at
+`extracted_content_pipeline/storage/migration_runner.py --apply`. That file is
+the library implementation, not the host CLI, and it does not define an
+`--apply` flag. Following the runbook can therefore fail before the actual e2e
+smoke starts.
+
+This slice fixes the operator command at the source and pins it with a doc test.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Replace the seeded e2e runbook migration command with the real host-facing
+   migration CLI.
+2. Add a focused doc test that verifies the migration command uses
+   `scripts/run_extracted_content_pipeline_migrations.py` and does not include
+   the invalid library-module command.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md` | Plan contract for this operator-command correction. |
+| `docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md` | Fix the migration prerequisite command. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Pin the migration command in the seeded e2e runbook. |
+
+## Mechanism
+
+The runbook's migration prerequisite now matches the host install runbook and
+the existing migration CLI:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py
+```
+
+The new test reads the seeded e2e runbook and asserts that command is present,
+that `scripts/run_extracted_content_pipeline_migrations.py` exists, and that the
+invalid `extracted_content_pipeline/storage/migration_runner.py --apply` string
+is absent.
+
+## Intentional
+
+- No migration runner behavior changes; this is a documentation contract fix.
+- No dry-run command is added here. The seeded e2e runbook is a concise go-live
+  validation runbook, while the host install runbook already documents migration
+  preview and custom migration-table options.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this docs surface.
+- No broader migration-doc cleanup outside the seeded e2e runbook.
+
+## Verification
+
+- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 59 passed.
+- `python -m py_compile tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2573 passed, 7 skipped.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 80 |
+| Seeded e2e runbook | 2 |
+| Tests | 9 |
+| **Total** | **91** |

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_seeded_route_e2e.py"
 RUNBOOK = ROOT / "docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md"
 HOST_RUNBOOK = ROOT / "extracted_content_pipeline/docs/host_install_runbook.md"
+MIGRATION_CLI = ROOT / "scripts/run_extracted_content_pipeline_migrations.py"
 SPEC = importlib.util.spec_from_file_location("smoke_content_ops_faq_search_seeded_route_e2e", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 smoke = importlib.util.module_from_spec(SPEC)
@@ -193,6 +194,14 @@ def test_host_runbook_links_seeded_route_e2e_validation_runbook():
 
     assert relative_path in doc
     assert RUNBOOK.exists()
+
+
+def test_seeded_route_e2e_runbook_uses_host_migration_cli():
+    doc = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "python scripts/run_extracted_content_pipeline_migrations.py" in doc
+    assert "extracted_content_pipeline/storage/migration_runner.py --apply" not in doc
+    assert MIGRATION_CLI.exists()
 
 
 def test_validate_args_rejects_invalid_case_budgets():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md
Slice phase: Production hardening

The seeded hosted FAQ search e2e runbook pointed operators at `extracted_content_pipeline/storage/migration_runner.py --apply`, but that file is the library migration runner and has no `--apply` CLI. This updates the runbook to use the existing host-facing migration command and pins the command with a focused doc test.

## Intentional
- No migration runner behavior changes; this is a documentation contract fix.
- No dry-run command is added here. The seeded e2e runbook is a concise go-live validation runbook, while the host install runbook already documents migration preview and custom migration-table options.

## Deferred
- No broader migration-doc cleanup outside the seeded e2e runbook.

## Parked hardening
- None. `HARDENING.md` was scanned and has no active FAQ search entries touching this docs surface.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 59 passed.
- `python -m py_compile tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Migration-Command.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2573 passed, 7 skipped.
- `git diff --check` - passed.

## Diff size
3 files, +90 / -1
