### PR TITLE
Thread FAQ seeded e2e detail budget

### DIFF
--- a/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md
@@ -44,6 +44,7 @@ python scripts/smoke_content_ops_faq_search_seeded_route_e2e.py \
   --max-single-request-ms 3000 \
   --max-case-p95-ms 1500 \
   --max-case-single-request-ms 3000 \
+  --max-detail-ms 2500 \
   --output-result /tmp/faq-search-seeded-route-e2e-result.json
 ```
 
@@ -75,7 +76,7 @@ Open the result artifact and inspect:
   case file.
 - `route.result_artifact.budgets`: aggregate and per-case route budget checks.
 - `detail.result_artifact`: detail contract status, hydrated FAQ ID, and search
-  plus detail timings.
+  plus detail timings, including the applied `max_detail_ms` budget when set.
 - `cleanup.requested_faq_ids` and `cleanup.deleted_faq_ids`: cleanup row-count
   proof for seeded FAQ drafts.
 - `artifact_cleanup`: whether temporary child artifacts were removed after the
@@ -90,6 +91,8 @@ Open the result artifact and inspect:
 - A route aggregate error budget can pass while one query/corpus case fails. Use
   `--max-case-error-rate`, `--max-case-p95-ms`, and
   `--max-case-single-request-ms` to fail closed per case.
+- `--max-detail-ms` fails the run when the hydrated FAQ detail request exceeds
+  the configured budget.
 - Cleanup failure makes the run fail unless `--keep-data` is set. Use
   `--keep-data` only when you intentionally want to inspect seeded rows after
   the run.

--- a/plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md
+++ b/plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md
@@ -1,0 +1,93 @@
+# PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget
+
+## Why this slice exists
+
+`PR-Content-Ops-FAQ-Search-E2E-Case-Budgets` threaded aggregate and per-case
+search-route latency budgets into the seeded hosted FAQ search e2e wrapper, but
+explicitly deferred the detail-specific budget. The detail contract checker now
+already supports `--max-detail-ms`, so the seeded e2e command should expose that
+budget instead of leaving operators to run a second command when they want to
+prove search-to-detail survivability.
+
+This is a small robust-testing slice: it closes the existing wrapper gap without
+changing the hosted route, the DB seed shape, or the detail contract checker.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Robust testing
+
+1. Add `--max-detail-ms` to the seeded hosted FAQ search e2e runner.
+2. Validate the budget is finite and positive, and fail closed if it is provided
+   while detail checking is disabled.
+3. Forward the budget to the existing detail contract checker.
+4. Preserve the configured detail budget in the compact detail result artifact.
+5. Document the budget in the seeded e2e runbook command and result checklist.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md` | Plan contract for this robust-testing slice. |
+| `scripts/smoke_content_ops_faq_search_seeded_route_e2e.py` | Expose, validate, forward, and summarize the detail latency budget. |
+| `tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` | Cover parser, validation, forwarding, result-summary, and runbook command behavior. |
+| `docs/extraction/validation/content_ops_faq_seeded_route_e2e_runbook.md` | Add the recommended detail latency budget to the hosted seeded e2e command. |
+
+## Mechanism
+
+The seeded e2e parser gains:
+
+```bash
+--max-detail-ms <milliseconds>
+```
+
+When present, `_validate_args` enforces a finite positive value and rejects the
+combination with `--skip-detail-check` so a configured detail budget cannot be
+silently ignored. `_detail_command(...)` passes the value through to
+`check_content_ops_faq_search_route_contract.py`, which already enforces detail
+latency after hydrating the selected FAQ.
+
+The top-level e2e result still stores a compact child artifact rather than the
+full detail checker payload, but the compact detail summary now includes
+`max_detail_ms` so operators can prove which threshold was applied.
+
+## Intentional
+
+- No new detail timing implementation. The contract checker already measures
+  `detail_elapsed_ms`; this wrapper only wires the existing budget into the
+  seeded end-to-end path.
+- No `--max-total-ms` wrapper flag in this slice. The deferred gap was
+  detail-specific latency; route aggregate and per-case budgets are already
+  wired separately.
+- The runbook uses a placeholder threshold, consistent with the existing route
+  latency placeholders, until repeated hosted runs establish production SLOs.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this wrapper surface.
+- Production SLO selection remains deferred until repeated hosted runs produce
+  stable search/detail latency baselines.
+
+## Verification
+
+- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
+- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 61 passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2575 passed, 7 skipped.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 93 |
+| Seeded e2e runner | 8 |
+| Tests | 55 |
+| Runbook | 5 |
+| **Total** | **161** |

--- a/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -71,6 +71,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-case-error-rate", type=float)
     parser.add_argument("--max-case-p95-ms", type=float)
     parser.add_argument("--max-case-single-request-ms", type=float)
+    parser.add_argument("--max-detail-ms", type=float)
     parser.add_argument("--detail-route", default=os.getenv("ATLAS_FAQ_DETAIL_ROUTE", ""))
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--output-result", type=Path)
@@ -108,6 +109,7 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         "max_case_error_rate",
         "max_case_p95_ms",
         "max_case_single_request_ms",
+        "max_detail_ms",
     ):
         value = getattr(args, name)
         if value is not None and not math.isfinite(float(value)):
@@ -123,10 +125,13 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         "max_single_request_ms",
         "max_case_p95_ms",
         "max_case_single_request_ms",
+        "max_detail_ms",
     ):
         value = getattr(args, name)
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
+    if args.max_detail_ms is not None and bool(args.skip_detail_check):
+        errors.append("--max-detail-ms requires detail checks; remove --skip-detail-check")
     return errors
 
 
@@ -290,6 +295,8 @@ def _detail_command(
         command.extend(["--status", str(detail_case["status"])])
     if str(args.detail_route or "").strip():
         command.extend(["--detail-route", str(args.detail_route)])
+    if args.max_detail_ms is not None:
+        command.extend(["--max-detail-ms", str(args.max_detail_ms)])
     for key, flag in (
         ("expected_detail_account_id", "--expected-detail-account-id"),
         ("expected_detail_target_id", "--expected-detail-target-id"),
@@ -405,6 +412,7 @@ def _compact_child_result_artifact(path: Path, *, kind: str) -> dict[str, Any]:
             "search_elapsed_ms",
             "detail_elapsed_ms",
             "total_elapsed_ms",
+            "max_detail_ms",
             "errors",
         ):
             if key in payload:

--- a/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py
@@ -41,6 +41,7 @@ def _args(**overrides):
         "max_case_error_rate": None,
         "max_case_p95_ms": None,
         "max_case_single_request_ms": None,
+        "max_detail_ms": None,
         "detail_route": "",
         "artifact_dir": None,
         "output_result": None,
@@ -135,6 +136,15 @@ def _write_child_result(command, *, ok: bool = True) -> None:
                 "search_elapsed_ms": 7.0,
                 "detail_elapsed_ms": 8.0,
                 "total_elapsed_ms": 15.0,
+                **(
+                    {
+                        "max_detail_ms": float(
+                            command[command.index("--max-detail-ms") + 1]
+                        )
+                    }
+                    if "--max-detail-ms" in command
+                    else {}
+                ),
                 "errors": [] if ok else ["detail failed"],
             },
         )
@@ -185,6 +195,7 @@ def test_seeded_route_e2e_runbook_command_matches_parser():
     assert parsed.max_single_request_ms == 3000.0
     assert parsed.max_case_p95_ms == 1500.0
     assert parsed.max_case_single_request_ms == 3000.0
+    assert parsed.max_detail_ms == 2500.0
     assert str(parsed.output_result) == "/tmp/faq-search-seeded-route-e2e-result.json"
 
 
@@ -222,6 +233,18 @@ def test_validate_args_rejects_invalid_case_budgets():
     ]
     assert smoke._validate_args(_args(max_p95_ms=float("inf"))) == [
         "--max-p95-ms must be finite"
+    ]
+
+
+def test_validate_args_rejects_invalid_detail_budget():
+    assert smoke._validate_args(_args(max_detail_ms=0.0)) == [
+        "--max-detail-ms must be positive"
+    ]
+    assert smoke._validate_args(_args(max_detail_ms=float("inf"))) == [
+        "--max-detail-ms must be finite"
+    ]
+    assert smoke._validate_args(_args(max_detail_ms=2500, skip_detail_check=True)) == [
+        "--max-detail-ms requires detail checks; remove --skip-detail-check"
     ]
 
 
@@ -373,7 +396,7 @@ def test_detail_case_from_route_cases_reports_unreadable_file():
 
 
 def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
-    args = _args(detail_route="/api/v2/faqs/{faq_id}/full")
+    args = _args(detail_route="/api/v2/faqs/{faq_id}/full", max_detail_ms=2500)
     detail_result = tmp_path / "detail.json"
 
     command = smoke._detail_command(
@@ -400,6 +423,7 @@ def test_detail_command_uses_contract_checker_and_seeded_case(tmp_path):
     assert "--require-results" in command
     assert "--require-detail" in command
     assert command[command.index("--detail-route") + 1] == "/api/v2/faqs/{faq_id}/full"
+    assert command[command.index("--max-detail-ms") + 1] == "2500"
     assert command[command.index("--expected-detail-account-id") + 1] == "acct-1"
     assert command[command.index("--expected-detail-target-id") + 1] == "support-corp-1"
     assert command[command.index("--expected-detail-target-mode") + 1] == "support_account"
@@ -447,6 +471,32 @@ def test_compact_child_result_artifact_summarizes_route_without_full_case_items(
         "case_file": "route-cases.json",
         "truncated": False,
     }
+
+
+def test_compact_child_result_artifact_keeps_detail_budget(tmp_path):
+    artifact = tmp_path / "detail-result.json"
+    _write_cases(
+        artifact,
+        {
+            "ok": True,
+            "phase": "contract",
+            "count": 1,
+            "detail_checked": True,
+            "detail_faq_id": "11111111-1111-1111-1111-111111111111",
+            "search_elapsed_ms": 7.0,
+            "detail_elapsed_ms": 8.0,
+            "total_elapsed_ms": 15.0,
+            "max_detail_ms": 2500.0,
+            "errors": [],
+        },
+    )
+
+    payload = smoke._compact_child_result_artifact(artifact, kind="detail")
+
+    assert payload["ok"] is True
+    assert payload["detail_checked"] is True
+    assert payload["detail_elapsed_ms"] == 8.0
+    assert payload["max_detail_ms"] == 2500.0
 
 
 def test_compact_child_result_artifact_rejects_non_boolean_ok(tmp_path):
@@ -785,6 +835,8 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
         "acct-1",
         "--artifact-dir",
         str(tmp_path / "artifacts"),
+        "--max-detail-ms",
+        "2500",
         "--output-result",
         str(result_path),
     ])
@@ -795,6 +847,7 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch):
     assert payload["seed"]["result_artifact"]["run_id"] == "seed-run-1"
     assert payload["route"]["result_artifact"]["requests"]["total"] == 12
     assert payload["detail"]["result_artifact"]["detail_checked"] is True
+    assert payload["detail"]["result_artifact"]["max_detail_ms"] == 2500.0
     assert payload["detail"]["ok"] is True
     assert payload["artifacts"]["detail_result"].endswith("detail-result.json")
     assert payload["cleanup"]["deleted_faq_ids"] == 1


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md
Slice phase: Robust testing

The seeded hosted FAQ search e2e wrapper already forwards aggregate and per-case search-route budgets, but it did not expose the detail-specific latency budget that the detail contract checker already supports. This wires `--max-detail-ms` through the seeded e2e path so one go-live smoke can fail closed on the hydrated FAQ detail request too.

## Intentional
- No new detail timing implementation. The contract checker already measures `detail_elapsed_ms`; this wrapper only wires the existing budget into the seeded end-to-end path.
- No `--max-total-ms` wrapper flag in this slice. The deferred gap was detail-specific latency; route aggregate and per-case budgets are already wired separately.
- The runbook uses a placeholder threshold, consistent with the existing route latency placeholders, until repeated hosted runs establish production SLOs.

## Deferred
- Production SLO selection remains deferred until repeated hosted runs produce stable search/detail latency baselines.

## Parked hardening
- None. `HARDENING.md` was scanned and has no active FAQ search entries touching this wrapper surface.

## Verification
- `python -m py_compile scripts/smoke_content_ops_faq_search_seeded_route_e2e.py tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_faq_search_seeded_route_e2e.py -q` - 61 passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-Seeded-E2E-Detail-Budget.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2575 passed, 7 skipped.
- `git diff --check` - passed.

## Diff size
4 files, +159 / -2
