### PR TITLE
Emit SaaS demo FAQ route cases

### DIFF
--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md
@@ -1,0 +1,103 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output
+
+## Why this slice exists
+
+The SaaS FAQ demo seeder can generate the checked B2B SaaS FAQ, save it, approve
+it, and verify DB-backed search. The hosted route concurrency smoke can validate
+deployed search/detail behavior from a case file. The handoff between those two
+steps is still manual: operators must copy the seeded FAQ id, corpus id, query,
+status, and detail expectations into a route case by hand.
+
+This slice adds the thinnest end-to-end handoff between the existing seeder and
+the existing hosted route smoke. It does not call the hosted API itself; it emits
+the route-case artifact the existing smoke consumes and wires that smoke to
+enforce the emitted detail expectations when `--require-detail` is enabled.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Vertical slice
+
+1. Add an optional `--route-case-file-output` flag to the SaaS FAQ demo seeder.
+2. Reject route-case output in cleanup mode, where no seeded FAQ id is produced.
+3. Write a deterministic route case containing the seeded query, corpus/status,
+   expected first FAQ/account/corpus ids, and expected detail fields.
+4. Teach the hosted route concurrency smoke to load and enforce the emitted
+   detail expectation fields during detail hydration.
+5. Include route-case output metadata in the seeder result payload.
+6. Add focused tests for validation, payload shape, successful case-file
+   emission.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md` | Plan contract for this route-case handoff slice. |
+| `scripts/seed_content_ops_faq_saas_demo.py` | Emit optional hosted-route case files from the seeded SaaS FAQ id. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover validation and route-case artifact generation. |
+| `scripts/smoke_content_ops_faq_search_route_concurrency.py` | Consume expected detail fields from route case files. |
+| `tests/test_smoke_content_ops_faq_search_route_concurrency.py` | Prove expected detail fields fail closed when the hydrated detail drifts. |
+
+## Mechanism
+
+The seeder parser gains:
+
+```bash
+--route-case-file-output /tmp/saas-demo-route-cases.json
+```
+
+When seeding succeeds, `seed_saas_demo_faq(...)` builds one route case from the
+actual saved FAQ id and the configured corpus/query/status. The case uses the
+same fields consumed by `smoke_content_ops_faq_search_route_concurrency.py`:
+`expected_first_account_id`, `expected_first_corpus_id`,
+`expected_first_faq_id`, and the detail expectation fields. The file is written
+as sorted, indented JSON for deterministic diffs and operator inspection.
+
+If the file write fails, the seeder still returns the seed/search payload with
+the FAQ id, but marks the overall result failed and records the route-case error.
+
+The route concurrency smoke now loads the emitted `expected_detail_*` keys into
+each case and maps them to the detail envelope fields already supported by
+`check_content_ops_faq_search_route_contract._validate_detail(...)`. With
+`--require-detail`, a hydrated detail response whose account, target, title, or
+status no longer matches the seeded FAQ fails the route smoke.
+
+## Intentional
+
+- No hosted route call is added to the seeder. The existing route concurrency
+  smoke owns HTTP requests, auth, case-level budgets, and optional detail
+  hydration.
+- No cleanup behavior changes. Cleanup mode deletes an explicit FAQ id and does
+  not have a new seeded route case to emit.
+- The route case contains one known hit case only; miss-case coverage remains in
+  the generic seeded e2e runner.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned; no active FAQ-search item
+  is required for this handoff.
+- A future runbook slice can document the two-command SaaS demo route validation
+  flow after this artifact exists.
+
+## Verification
+
+- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_search_route_concurrency.py` - passed.
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_search_route_concurrency.py -q` - 92 passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2580 passed, 7 skipped.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 103 |
+| Seeder script | 54 |
+| Route concurrency smoke | 43 |
+| Tests | 167 |
+| **Total** | **367** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -89,6 +89,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Delete one seeded FAQ id for this account instead of seeding.",
     )
+    parser.add_argument("--route-case-file-output", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args(argv)
@@ -103,6 +104,8 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     if getattr(args, "cleanup_faq_id", None) is not None:
         if not str(args.cleanup_faq_id or "").strip():
             errors.append("--cleanup-faq-id must be a non-empty FAQ id")
+        if getattr(args, "route_case_file_output", None) is not None:
+            errors.append("--route-case-file-output is only available in seed mode")
         return errors
     if not str(args.corpus_id or "").strip():
         errors.append("--corpus-id is required")
@@ -184,6 +187,7 @@ async def seed_saas_demo_faq(
     status: str = DEFAULT_STATUS,
     query: str = DEFAULT_QUERY,
     limit: int = 5,
+    route_case_file_output: Path | None = None,
 ) -> dict[str, Any]:
     scope = TenantScope(account_id=account_id, user_id=user_id)
     draft = build_saas_demo_faq_draft(corpus_id=corpus_id, target_id=target_id)
@@ -222,14 +226,17 @@ async def seed_saas_demo_faq(
     )
     if not matched_seeded_faq:
         errors.append("Seeded SaaS FAQ id was not present in verification search results")
-    return {
+    payload = {
         "phase": "seed",
         "ok": not errors,
         "errors": errors,
         "account_id": account_id,
         "corpus_id": corpus_id,
+        "target_id": target_id,
+        "target_mode": DEFAULT_TARGET_MODE,
         "faq_id": faq_id,
         "status": status,
+        "limit": limit,
         "source_count": draft.source_count,
         "ticket_source_count": draft.ticket_source_count,
         "generated_items": len(draft.items),
@@ -245,6 +252,50 @@ async def seed_saas_demo_faq(
             ),
         },
     }
+    if route_case_file_output is not None and faq_id:
+        try:
+            _write_route_case_file(route_case_file_output, payload)
+        except OSError as exc:
+            payload["ok"] = False
+            payload["errors"].append(f"route case file could not be written: {exc}")
+            payload["route_case_file"] = {
+                "ok": False,
+                "path": str(route_case_file_output),
+                "error": str(exc),
+            }
+        else:
+            payload["route_case_file"] = {
+                "ok": True,
+                "path": str(route_case_file_output),
+                "cases": 1,
+            }
+    return payload
+
+
+def _route_case_payload(seed_result: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{
+        "query": seed_result["search"]["query"],
+        "corpus_id": seed_result["corpus_id"],
+        "status": seed_result["status"],
+        "limit": seed_result["limit"],
+        "require_results": True,
+        "expected_first_account_id": seed_result["account_id"],
+        "expected_first_corpus_id": seed_result["corpus_id"],
+        "expected_first_faq_id": seed_result["faq_id"],
+        "expected_detail_account_id": seed_result["account_id"],
+        "expected_detail_target_id": seed_result["target_id"],
+        "expected_detail_target_mode": seed_result["target_mode"],
+        "expected_detail_title": DEMO_TITLE,
+        "expected_detail_status": seed_result["status"],
+    }]
+
+
+def _write_route_case_file(path: Path, seed_result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_route_case_payload(seed_result), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _deleted_row_count(delete_status: Any) -> int | None:
@@ -311,6 +362,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 status=str(args.status),
                 query=str(args.query),
                 limit=int(args.limit),
+                route_case_file_output=args.route_case_file_output,
             )
     except Exception as exc:
         primary_error = exc

--- a/scripts/smoke_content_ops_faq_search_route_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_route_concurrency.py
@@ -36,6 +36,11 @@ def _case_snapshot(case: Mapping[str, Any]) -> dict[str, Any]:
         "expected_first_account_id",
         "expected_first_corpus_id",
         "expected_first_faq_id",
+        "expected_detail_account_id",
+        "expected_detail_target_id",
+        "expected_detail_target_mode",
+        "expected_detail_title",
+        "expected_detail_status",
     ):
         if key in case:
             snapshot[key] = case[key]
@@ -204,6 +209,22 @@ def _load_cases(args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[st
             else:
                 expected_first[key] = value.strip()
 
+        expected_detail: dict[str, str] = {}
+        for key in (
+            "expected_detail_account_id",
+            "expected_detail_target_id",
+            "expected_detail_target_mode",
+            "expected_detail_title",
+            "expected_detail_status",
+        ):
+            if key not in item:
+                continue
+            value = item.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"case[{index}].{key} must be a non-empty string")
+            else:
+                expected_detail[key] = value.strip()
+
         if errors and any(error.startswith(f"case[{index}].") for error in errors):
             continue
 
@@ -217,8 +238,24 @@ def _load_cases(args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[st
         if "expected_count" in item:
             case["expected_count"] = expected_count
         case.update(expected_first)
+        case.update(expected_detail)
         cases.append(case)
     return cases, errors
+
+
+def _expected_detail_from_case(case: Mapping[str, Any]) -> dict[str, str]:
+    mapping = {
+        "expected_detail_account_id": "account_id",
+        "expected_detail_target_id": "target_id",
+        "expected_detail_target_mode": "target_mode",
+        "expected_detail_title": "title",
+        "expected_detail_status": "status",
+    }
+    return {
+        detail_field: str(case[key])
+        for key, detail_field in mapping.items()
+        if key in case
+    }
 
 
 def _expected_case_errors(payload: Mapping[str, Any], case: Mapping[str, Any]) -> list[str]:
@@ -301,7 +338,11 @@ def _run_one(
                     )
                     detail_checked = True
                     detail_errors.extend(
-                        contract._validate_detail(detail_payload, faq_id=detail_faq_id)
+                        contract._validate_detail(
+                            detail_payload,
+                            faq_id=detail_faq_id,
+                            expected=_expected_detail_from_case(active_case),
+                        )
                     )
                 except (RuntimeError, OSError, TypeError, ValueError) as exc:
                     detail_errors.append(f"{type(exc).__name__}: {exc}")

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -201,6 +201,24 @@ def test_saas_demo_cleanup_args_skip_seed_only_required_values() -> None:
     assert errors == ["--cleanup-faq-id must be a non-empty FAQ id"]
 
 
+def test_saas_demo_route_case_output_is_seed_only() -> None:
+    errors = seeder._validate_args(
+        SimpleNamespace(
+            database_url="postgresql://example",
+            account_id="acct-demo",
+            cleanup_faq_id="11111111-1111-1111-1111-111111111111",
+            route_case_file_output=Path("route-cases.json"),
+            corpus_id="",
+            target_id="",
+            status="",
+            query="",
+            limit=0,
+        )
+    )
+
+    assert errors == ["--route-case-file-output is only available in seed mode"]
+
+
 def test_saas_demo_seed_preflight_writes_result_before_exit(tmp_path) -> None:
     result_path = tmp_path / "seed-preflight.json"
 
@@ -471,7 +489,10 @@ def test_saas_demo_cleanup_delete_status_parser() -> None:
 
 
 @pytest.mark.asyncio
-async def test_saas_demo_seeder_saves_approves_projects_and_searches(monkeypatch) -> None:
+async def test_saas_demo_seeder_saves_approves_projects_and_searches(
+    monkeypatch,
+    tmp_path,
+) -> None:
     class _Pool:
         draft = None
         scope = None
@@ -511,16 +532,43 @@ async def test_saas_demo_seeder_saves_approves_projects_and_searches(monkeypatch
         _Pool(),
         account_id="acct-demo",
         corpus_id="synthetic-b2b-saas-demo",
+        limit=7,
+        route_case_file_output=tmp_path / "route-cases.json",
     )
 
     assert payload["ok"] is True
     assert payload["errors"] == []
     assert payload["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["target_id"] == "support-synthetic-b2b-saas-demo"
+    assert payload["target_mode"] == "support_account"
+    assert payload["limit"] == 7
     assert payload["source_count"] >= MIN_ROWS
     assert payload["projected_documents"] == payload["generated_items"]
     assert payload["search"]["count"] >= 1
     assert payload["search"]["matched_seeded_faq"] is True
     assert payload["search"]["first_result"]["faq_id"] == payload["faq_id"]
+    assert payload["route_case_file"] == {
+        "ok": True,
+        "path": str(tmp_path / "route-cases.json"),
+        "cases": 1,
+    }
+    assert json.loads((tmp_path / "route-cases.json").read_text(encoding="utf-8")) == [
+        {
+            "corpus_id": "synthetic-b2b-saas-demo",
+            "expected_detail_account_id": "acct-demo",
+            "expected_detail_status": "approved",
+            "expected_detail_target_id": "support-synthetic-b2b-saas-demo",
+            "expected_detail_target_mode": "support_account",
+            "expected_detail_title": "Synthetic B2B SaaS Support FAQ Demo",
+            "expected_first_account_id": "acct-demo",
+            "expected_first_corpus_id": "synthetic-b2b-saas-demo",
+            "expected_first_faq_id": "11111111-1111-1111-1111-111111111111",
+            "limit": 7,
+            "query": "export attribution reports",
+            "require_results": True,
+            "status": "approved",
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -562,6 +610,59 @@ async def test_saas_demo_seeder_rejects_search_results_for_different_faq(monkeyp
         "Seeded SaaS FAQ id was not present in verification search results"
     ]
     assert payload["search"]["matched_seeded_faq"] is False
+
+
+@pytest.mark.asyncio
+async def test_saas_demo_seeder_reports_route_case_write_failure(monkeypatch, tmp_path) -> None:
+    class _Response:
+        def as_dict(self):
+            return {
+                "query": "export attribution reports",
+                "count": 1,
+                "results": [{"faq_id": "11111111-1111-1111-1111-111111111111"}],
+            }
+
+    class _FAQRepo:
+        def __init__(self, _pool):
+            pass
+
+        async def save_drafts(self, _drafts, *, scope: TenantScope):
+            assert scope.account_id == "acct-demo"
+            return ("11111111-1111-1111-1111-111111111111",)
+
+        async def update_status(self, _faq_id, _status, *, scope: TenantScope):
+            assert scope.account_id == "acct-demo"
+            return True
+
+    class _SearchRepo:
+        def __init__(self, _pool):
+            pass
+
+        async def search(self, **_kwargs):
+            return _Response()
+
+    def _raise_write(_path, _payload):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(seeder, "PostgresTicketFAQRepository", _FAQRepo)
+    monkeypatch.setattr(seeder, "PostgresTicketFAQSearchRepository", _SearchRepo)
+    monkeypatch.setattr(seeder, "_write_route_case_file", _raise_write)
+
+    route_case_file = tmp_path / "route-cases.json"
+    payload = await seeder.seed_saas_demo_faq(
+        object(),
+        account_id="acct-demo",
+        route_case_file_output=route_case_file,
+    )
+
+    assert payload["ok"] is False
+    assert payload["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["errors"] == ["route case file could not be written: disk full"]
+    assert payload["route_case_file"] == {
+        "ok": False,
+        "path": str(route_case_file),
+        "error": "disk full",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -425,6 +425,14 @@ def test_load_cases_rejects_case_empty_results_with_detail_required(tmp_path):
             [{"query": "x", "expected_first_faq_id": []}],
             "case[0].expected_first_faq_id must be a non-empty string",
         ),
+        (
+            [{"query": "x", "expected_detail_account_id": ""}],
+            "case[0].expected_detail_account_id must be a non-empty string",
+        ),
+        (
+            [{"query": "x", "expected_detail_target_id": 1}],
+            "case[0].expected_detail_target_id must be a non-empty string",
+        ),
     ],
 )
 def test_load_cases_rejects_bad_case_file_shapes(tmp_path, payload, expected_error):
@@ -453,6 +461,11 @@ def test_load_cases_accepts_seeded_expectations(tmp_path):
             "expected_first_account_id": "acct-1",
             "expected_first_corpus_id": "corpus-1",
             "expected_first_faq_id": "11111111-1111-1111-1111-111111111111",
+            "expected_detail_account_id": "acct-1",
+            "expected_detail_target_id": "support-corpus-1",
+            "expected_detail_target_mode": "support_account",
+            "expected_detail_title": "Seeded FAQ",
+            "expected_detail_status": "approved",
         }],
     )
 
@@ -463,6 +476,11 @@ def test_load_cases_accepts_seeded_expectations(tmp_path):
     assert cases[0]["expected_first_account_id"] == "acct-1"
     assert cases[0]["expected_first_corpus_id"] == "corpus-1"
     assert cases[0]["expected_first_faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert cases[0]["expected_detail_account_id"] == "acct-1"
+    assert cases[0]["expected_detail_target_id"] == "support-corpus-1"
+    assert cases[0]["expected_detail_target_mode"] == "support_account"
+    assert cases[0]["expected_detail_title"] == "Seeded FAQ"
+    assert cases[0]["expected_detail_status"] == "approved"
 
 
 def test_latency_and_error_summaries_are_compact():
@@ -1226,6 +1244,52 @@ def test_run_one_rejects_missing_expected_first_result(monkeypatch):
 
     assert result["ok"] is False
     assert result["errors"] == ["expected first result but none was returned"]
+
+
+def test_run_one_rejects_seeded_detail_expectation_drift(monkeypatch):
+    responses = iter([
+        _json_response(_valid_payload()),
+        _json_response(_valid_detail_payload()),
+    ])
+    monkeypatch.setattr(
+        smoke.time,
+        "perf_counter",
+        iter([1.0, 1.001, 1.002, 1.003, 1.004]).__next__,
+    )
+    monkeypatch.setattr(
+        smoke.contract.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: next(responses),
+    )
+
+    result = smoke._run_one(
+        0,
+        _args(require_detail=True),
+        {
+            "query": "mortgage dispute",
+            "corpus_id": "corpus-1",
+            "status": "",
+            "limit": 5,
+            "require_results": True,
+            "expected_first_faq_id": "11111111-1111-1111-1111-111111111111",
+            "expected_detail_account_id": "acct-2",
+            "expected_detail_target_id": "support-corpus-1",
+            "expected_detail_target_mode": "support_account",
+            "expected_detail_title": "Expected SaaS FAQ",
+            "expected_detail_status": "approved",
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["detail_checked"] is True
+    assert result["errors"] == [
+        "detail.account_id expected 'acct-2' but got 'acct-1'",
+        "detail.target_id expected 'support-corpus-1' but got 'corpus-1'",
+        "detail.target_mode expected 'support_account' but got 'faq_report'",
+        "detail.title expected 'Expected SaaS FAQ' but got 'Mortgage servicing issues'",
+        "detail.status expected 'approved' but got 'published'",
+    ]
+    assert result["case"]["expected_detail_title"] == "Expected SaaS FAQ"
 
 
 def test_run_concurrent_sorts_results(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md
Slice phase: Vertical slice

The SaaS FAQ demo seeder can already create and verify the DB-backed search row, while the hosted route smoke already consumes case files. This connects those two pieces by letting the seeder emit a route-case JSON artifact with the actual seeded FAQ id and by wiring the hosted route smoke to enforce the emitted detail expectations when `--require-detail` is enabled.

## Intentional
- No hosted route call is added to the seeder. The existing route concurrency smoke owns HTTP requests, auth, case-level budgets, and optional detail hydration.
- No cleanup behavior changes. Cleanup mode deletes an explicit FAQ id and does not have a new seeded route case to emit.
- The route case contains one known hit case only; miss-case coverage remains in the generic seeded e2e runner.

## Deferred
- A future runbook slice can document the two-command SaaS demo route validation flow after this artifact exists.

## Parked hardening
- None. `HARDENING.md` was scanned; no active FAQ-search item is required for this handoff.

## Verification
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_search_route_concurrency.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_search_route_concurrency.py` - passed.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_search_route_concurrency.py -q` - 92 passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md && python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2580 passed, 7 skipped.
- `git diff --check` - passed.

## Diff size
5 files, +364 / -3
