### PR TITLE
Record support-ticket SaaS demo blog retry

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,6 +32,15 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-28
 
+### Support-ticket SaaS demo blog still fails GEO entity clarity after descriptive contract
+- File/location: `extracted_quality_gate/blog_pack.py`, `extracted_content_pipeline/blog_generation.py`, live run in `tmp/support_ticket_saas_demo_blog_acceptance_20260528_retry2/blog-post-result.json`.
+- Description: After the support-ticket descriptive contract landed, the 36-row SaaS demo blog retry got past support-ticket outcome checks but failed `geo_entity_clarity_missing` after two repair attempts. The failed candidate title and target keyword both used "Support Ticket FAQ Gaps", so the next slice needs to inspect the prompt/quality-gate interaction rather than adding another live retry.
+- Why it matters: The SaaS demo blog path still cannot produce an accepted saved draft, so the accepted fixture and future regression gate remain blocked.
+- Effort: M
+- Category: correctness
+- Owner/session: content-ops/support-ticket-provider
+- Found during: PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture
+
 ### LLM usage storage schema mismatch hides per-run cost telemetry
 - File/location: `content_ops.llm.complete` usage-storage path, live smoke stderr during `scripts/smoke_content_ops_live_generation.py`.
 - Description: Live landing/blog generation succeeded, but each LLM call logged `_store_local failed for span=content_ops.llm.complete: column "account_id" of relation "llm_usage" does not exist`.

--- a/docs/extraction/validation/support_ticket_saas_demo_blog_acceptance_2026-05-28.md
+++ b/docs/extraction/validation/support_ticket_saas_demo_blog_acceptance_2026-05-28.md
@@ -1,0 +1,61 @@
+# Support-Ticket SaaS Demo Blog Acceptance Retry - 2026-05-28
+
+## Scope
+
+This validation retried the 36-row SaaS demo support-ticket blog path after the
+structural `descriptive_no_outcome` contract landed.
+
+Source CSV:
+
+`extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv`
+
+The run used Haiku test routing and the existing live generation smoke harness.
+
+## Result
+
+Status: not accepted.
+
+No blog draft was saved, so there is no accepted fixture in this slice.
+
+| Attempt | Status | Blocking result |
+|---|---|---|
+| 1 | Failed before save | `support_ticket_generated_content` blocked the unsupported outcome sentence: "The next step is to turn those clusters into published, verified, and measurable FAQ entries that help customers find answers." |
+| 2 | Failed before save | `geo_entity_clarity_missing` after quality repair budget was exhausted. |
+
+## What Changed During Validation
+
+Attempt 1 exposed a small mismatch between the new descriptive contract and the
+existing deterministic evaluator. The contract already forbade ticket reduction,
+deflection, retention, and faster-resolution claims, but it did not explicitly
+forbid the broader unsupported outcome phrasing "help customers find answers."
+The evaluator blocks that phrasing for no-outcome support-ticket data, so this
+slice added that wording to the structural `forbidden_claims` contract and
+covered it with a focused test.
+
+Attempt 2 got past the support-ticket outcome detector but failed the blog GEO
+entity clarity gate. The generated title contained "Support Ticket FAQ Gaps,"
+but the quality gate still returned `geo_entity_clarity_missing` after two
+repair attempts. That is now the next source blocker before this SaaS demo blog
+path can be accepted.
+
+## Acceptance Notes
+
+The descriptive contract reduced the failure from unsupported outcome claims to
+a general blog quality blocker, which is progress, but the 36-row SaaS demo blog
+path is still not accepted. The next slice should inspect the support-ticket
+blog prompt/quality gate interaction for `geo_entity_clarity_missing` and fix
+that source issue before another live acceptance retry.
+
+The repeated `_store_local failed for span=content_ops.llm.complete: column
+"account_id" of relation "llm_usage" does not exist` warning also appeared
+during both live attempts. That is already parked in `HARDENING.md` as a cost
+telemetry schema issue and did not block generation.
+
+## Verification
+
+- Command: python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env --export-saved-draft tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-draft.json --output-result tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-result.json --evaluate-generated-content --json
+  - Failed before save on unsupported "help customers find answers" outcome language.
+- Command: python -m pytest tests/test_extracted_blog_generation.py tests/test_smoke_content_ops_live_generation.py -q
+  - Passed, 102 tests, after adding the contract forbidden-claim fixture.
+- Command: python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528_retry2 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env --export-saved-draft tmp/support_ticket_saas_demo_blog_acceptance_20260528_retry2/blog-post-draft.json --output-result tmp/support_ticket_saas_demo_blog_acceptance_20260528_retry2/blog-post-result.json --evaluate-generated-content --json
+  - Failed before save on `geo_entity_clarity_missing`.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -57,6 +57,7 @@ _SUPPORT_TICKET_DESCRIPTIVE_FORBIDDEN_CLAIMS = (
     "future ticket reduction or deflection",
     "prevented tickets or fewer repeat questions",
     "churn, retention, upgrade, referral, ROI, or capacity outcomes",
+    "claims that FAQ entries help customers find answers or avoid tickets",
     "faster resolution or customers finding answers without opening tickets",
     "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence",
 )

--- a/plans/PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture.md
+++ b/plans/PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture.md
@@ -1,0 +1,116 @@
+# PR: Support-Ticket SaaS Demo Blog Accepted Fixture
+
+## Why this slice exists
+
+PR-Support-Ticket-SaaS-Demo-Generated-Content-Acceptance accepted the 36-row
+SaaS demo landing-page path but left the blog path unaccepted because Haiku kept
+turning observed support-ticket clusters into unsupported outcome claims.
+PR-Support-Ticket-Blog-Descriptive-Contract then added the structural
+`descriptive_no_outcome` contract that should steer no-outcome/no-resolution
+support-ticket blogs before the evaluator has to catch them.
+
+This slice tests that fix against the same 36-row SaaS demo CSV with a live
+Haiku retry. If the generated blog passes the deterministic support-ticket
+generated-content evaluator, this PR commits a minimized accepted blog fixture.
+If it still fails, this PR records the failure and parks only the next source
+gap.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Functional validation
+
+1. Run a live Haiku `blog_post` generation through
+   `scripts/smoke_content_ops_live_generation.py` using
+   `extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv`.
+2. Export the saved draft and smoke result to `tmp/`.
+3. Re-run the deterministic evaluator against the exported draft.
+4. Add the small contract forbidden-claim fix exposed by the first retry.
+5. Add a short validation report documenting the command, evaluator result, and
+   fixture shape.
+6. Park the remaining source blocker if the blog path is still not accepted.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture.md` - Plan doc for this validation slice.
+- `docs/extraction/validation/support_ticket_saas_demo_blog_acceptance_2026-05-28.md` - Validation report for the post-contract live blog retry.
+- `extracted_content_pipeline/blog_generation.py` - Tighten the descriptive contract's forbidden claims for the unsupported "help customers find answers" phrasing exposed by the first retry.
+- `tests/test_extracted_blog_generation.py` - Focused assertion that the structural contract includes the forbidden customer-answer outcome phrasing.
+- `HARDENING.md` - Park the remaining GEO entity clarity blocker exposed by the second retry.
+
+## Mechanism
+
+The live command uses the existing smoke harness, real support-ticket provider
+packaging, real DB save/export, and the Haiku model routing env:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528 \
+  --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-draft.json \
+  --output-result tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+Attempt 1 failed before save on unsupported "help customers find answers"
+outcome language. That phrasing is already blocked by the deterministic
+evaluator, so this PR adds it to the structural descriptive contract's
+`forbidden_claims` and pins it with a focused test. Attempt 2 then failed before
+save on `geo_entity_clarity_missing`, so no accepted fixture is committed.
+
+## Intentional
+
+- This is a bounded Haiku acceptance retry, not another prompt-tuning loop.
+- The only generation code change is the small structural contract mismatch
+  exposed by attempt 1.
+- This stays out of FAQ Markdown/article ownership.
+- This does not resolve the cost telemetry schema mismatch; that remains parked.
+
+## Deferred
+
+- Future PR: inspect and fix the support-ticket blog
+  `geo_entity_clarity_missing` failure before another live acceptance retry.
+- Future PR: commit an accepted SaaS demo blog fixture after the GEO blocker is
+  fixed and the live retry saves a passing draft.
+- Future PR: add a scripted regression gate after the accepted fixture exists.
+- Future PR: validate the same shape against a sanitized real customer export.
+- Parked hardening:
+  - Support-ticket SaaS demo blog still fails GEO entity clarity after
+    descriptive contract.
+
+## Verification
+
+- Command: python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env --export-saved-draft tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-draft.json --output-result tmp/support_ticket_saas_demo_blog_acceptance_20260528/blog-post-result.json --evaluate-generated-content --json
+  - Failed before save on unsupported "help customers find answers" outcome language.
+- Command: python -m pytest tests/test_extracted_blog_generation.py tests/test_smoke_content_ops_live_generation.py -q
+  - Passed, 102 tests.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528_retry2 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env --export-saved-draft tmp/support_ticket_saas_demo_blog_acceptance_20260528_retry2/blog-post-draft.json --output-result tmp/support_ticket_saas_demo_blog_acceptance_20260528_retry2/blog-post-result.json --evaluate-generated-content --json
+  - Failed before save on `geo_entity_clarity_missing`.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-saas-demo-blog-accepted-fixture-pr-body.md
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~116 |
+| Validation report | ~61 |
+| Contract test/fix | ~5 |
+| HARDENING note | ~9 |
+| **Total** | **~191** |
+
+This stays focused on validation evidence and avoids changing generator code in
+the same slice unless the run proves a small source-level correctness issue.

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -416,6 +416,10 @@ def test_support_ticket_descriptive_blog_contract_requires_no_outcome_or_resolut
     assert contract["support_ticket_blog_mode"] == "descriptive_no_outcome"
     assert "observed support-ticket clusters" in contract["allowed_claims"][0]
     assert "future ticket reduction or deflection" in contract["forbidden_claims"]
+    assert (
+        "claims that FAQ entries help customers find answers or avoid tickets"
+        in contract["forbidden_claims"]
+    )
     assert contract["draft_answer_guidance"].startswith("Draft answer -")
     assert support_ticket_descriptive_blog_contract({
         "source": "support_ticket_provider",


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture.md
Slice phase: Functional validation

This PR runs the post-contract 36-row SaaS demo blog acceptance retry with Haiku, records that no accepted fixture was produced, keeps the small forbidden-claim contract fix exposed by the first attempt, and parks the remaining GEO entity clarity blocker.

## Intentional
- Records failed live retries instead of claiming an accepted fixture.
- Stops after the second retry rather than looping on model output.
- Keeps the small source-contract fix for unsupported "help customers find answers" phrasing.
- Stays out of FAQ Markdown/article ownership.

## Deferred
- Future PR: inspect and fix the support-ticket blog geo_entity_clarity_missing failure before another live acceptance retry.
- Future PR: commit an accepted SaaS demo blog fixture after the GEO blocker is fixed and a live retry saves a passing draft.
- Future PR: add a scripted regression gate after the accepted fixture exists.

## Parked hardening
- Support-ticket SaaS demo blog still fails GEO entity clarity after descriptive contract.

## Verification
- python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528 ... --evaluate-generated-content --json - failed before save on unsupported "help customers find answers" outcome language.
- python -m pytest tests/test_extracted_blog_generation.py tests/test_smoke_content_ops_live_generation.py -q - passed, 102 tests.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_saas_demo_blog_acceptance_20260528_retry2 ... --evaluate-generated-content --json - failed before save on geo_entity_clarity_missing.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-saas-demo-blog-accepted-fixture-pr-body.md - passed.

## Diff size
5 files, +191 / -0.