### PR TITLE
Document SaaS FAQ route case validation

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -1,0 +1,133 @@
+# Content Ops FAQ SaaS Demo Route Case Runbook
+
+Use this runbook to prove the checked synthetic B2B SaaS FAQ demo can be seeded
+into the FAQ search tables and read back through the deployed hosted FAQ search
+route.
+
+This is the demo-specific validation path. For generic multi-corpus seeded route
+coverage, use `content_ops_faq_seeded_route_e2e_runbook.md`.
+
+## Required Inputs
+
+- `EXTRACTED_DATABASE_URL` or `DATABASE_URL`: Postgres database used by the
+  deployed Atlas API.
+- `ATLAS_API_BASE_URL`: deployed Atlas API host, for example
+  `https://atlas-api.example.com`.
+- `ATLAS_B2B_JWT` or `ATLAS_TOKEN`: bearer token for the account under test.
+- `ATLAS_FAQ_SEARCH_ACCOUNT_ID`: account ID matching the bearer token. The
+  seeder writes the demo FAQ under this account, and the hosted route smoke uses
+  the token to query it.
+
+Run the FAQ search migrations before this smoke:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py
+```
+
+## Step 1: Seed The SaaS Demo And Write Route Cases
+
+```bash
+python scripts/seed_content_ops_faq_saas_demo.py \
+  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
+  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --route-case-file-output /tmp/faq-saas-demo-route-cases.json \
+  --output-result /tmp/faq-saas-demo-seed-result.json
+```
+
+Use `--json` when stdout should be machine-readable. Without `--json`, stdout is
+a compact status line; the full seed proof lives in `--output-result`.
+
+The route case file contains the generated FAQ's expected first-result identity
+and expected hydrated detail fields:
+
+- `expected_first_account_id`
+- `expected_first_corpus_id`
+- `expected_first_faq_id`
+- `expected_detail_account_id`
+- `expected_detail_target_id`
+- `expected_detail_target_mode`
+- `expected_detail_title`
+- `expected_detail_status`
+
+## Step 2: Validate The Hosted Route Against The Seeded Case
+
+```bash
+python scripts/smoke_content_ops_faq_search_route_concurrency.py \
+  --base-url "$ATLAS_API_BASE_URL" \
+  --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
+  --case-file /tmp/faq-saas-demo-route-cases.json \
+  --requests 40 \
+  --concurrency 8 \
+  --require-detail \
+  --max-error-rate 0 \
+  --max-case-error-rate 0 \
+  --max-p95-ms 1500 \
+  --max-single-request-ms 3000 \
+  --max-case-p95-ms 1500 \
+  --max-case-single-request-ms 3000 \
+  --max-detail-ms 2500 \
+  --output-result /tmp/faq-saas-demo-route-result.json
+```
+
+Use `--json` when stdout should be machine-readable. Without `--json`, stdout is
+a compact status line with aggregate and worst-case route signals.
+
+## What This Proves
+
+- The checked synthetic B2B SaaS FAQ can be generated from the local source CSV.
+- The FAQ draft can be saved and approved in the configured Postgres database.
+- The approval path writes the FAQ search projection used by the hosted route.
+- The hosted route returns the seeded FAQ as the first result for the demo query.
+- The hosted detail path hydrates the same FAQ, account, target, title, and
+  status emitted by the seeder.
+
+## Result Checks
+
+Open `/tmp/faq-saas-demo-seed-result.json` and inspect:
+
+- `ok`: seed, approval, projection, verification search, and route-case write
+  status.
+- `faq_id`: generated FAQ id used for route and cleanup checks.
+- `search.matched_seeded_faq`: whether the DB search repository found the seeded
+  FAQ id before route validation.
+- `route_case_file`: path and case count for the emitted route case artifact.
+
+Open `/tmp/faq-saas-demo-route-result.json` and inspect:
+
+- `ok`: route, detail, and budget status.
+- `requests.total`: hosted route request count.
+- `cases.summaries[]`: per-case route and detail health.
+- `detail.failures`: hydrated detail mismatches or route/detail errors.
+- `budgets.failures[]`: deterministic latency or error budget failures.
+
+## Cleanup
+
+If the seeded FAQ should not remain in the host database, delete it with the FAQ
+id from the seed result:
+
+```bash
+python scripts/seed_content_ops_faq_saas_demo.py \
+  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
+  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --cleanup-faq-id "<faq_id_from_seed_result>" \
+  --output-result /tmp/faq-saas-demo-cleanup-result.json
+```
+
+Cleanup mode does not accept `--route-case-file-output` because no new seeded
+FAQ id is produced.
+
+## Interpreting Failures
+
+- Seeder preflight failures exit with code `1` and do not connect to Postgres.
+- Seeder runtime failures still write the result artifact when
+  `--output-result` is provided.
+- Route preflight failures exit with code `2` and do not issue hosted requests.
+- Route contract, detail, or budget failures exit with code `1` and still write
+  the result artifact.
+- A passing aggregate route error rate does not prove each case is healthy. Keep
+  `--max-case-error-rate 0` for demo validation.
+
+## Deferred Thresholds
+
+The sample latency values above are placeholders. Replace them with thresholds
+from repeated hosted demo runs before treating them as production SLOs.

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md
@@ -1,0 +1,94 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output closed the code handoff between
+the SaaS FAQ demo seeder and the hosted FAQ search route smoke by emitting a
+route case file with search and detail expectations. The operator path is still
+implicit: a host operator has to infer which two commands prove the seeded SaaS
+demo through the deployed route.
+
+This slice documents that thinnest validation path and pins the commands against
+the actual parsers so future flag drift does not break the demo handoff quietly.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation
+
+1. Add a SaaS demo route-case validation runbook that shows the two-command
+   flow: seed the checked SaaS FAQ into Postgres while writing a route case
+   file, then run the hosted route concurrency smoke against that case file.
+2. State what the route case proves: first-result identity and hydrated detail
+   fields for the generated FAQ.
+3. Add focused tests proving both runbook commands parse with the real CLIs and
+   share the same route case path.
+4. Keep runtime seeder, route smoke, and API code unchanged.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md` | Plan contract for this runbook validation slice. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md` | Operator runbook for seeded SaaS demo hosted route validation. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Parser-backed tests for the runbook commands and shared route-case handoff path. |
+
+## Mechanism
+
+The runbook uses the seeder's existing `--route-case-file-output` flag:
+
+```bash
+python scripts/seed_content_ops_faq_saas_demo.py \
+  --route-case-file-output /tmp/faq-saas-demo-route-cases.json
+```
+
+The second command passes the same file to
+`scripts/smoke_content_ops_faq_search_route_concurrency.py` with
+`--require-detail` and fail-closed aggregate/per-case budgets. The smoke already
+loads the emitted `expected_first_*` and `expected_detail_*` fields; this slice
+only documents the operational composition.
+
+The test imports both scripts and parses the documented commands through their
+real argparse parsers. It also asserts the route smoke's `--case-file` value
+matches the seeder's `--route-case-file-output` value, so a future doc edit
+cannot silently split the handoff.
+
+## Intentional
+
+- No new one-command wrapper. The seeded e2e runner already covers the generic
+  DB-backed hosted route path; this runbook is specifically for the checked
+  SaaS demo artifact and the emitted route case file.
+- No live DB or hosted route invocation in unit tests. This slice validates the
+  documented operator contract; live execution remains host/environment work.
+- No cleanup helper changes. The seeder already returns the FAQ id and cleanup
+  mode can remove it when an operator intentionally keeps seeded data.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned; no active FAQ-search item
+  is required for this runbook slice.
+- Future robust-testing slices can use this runbook as the operator entry point
+  for repeated hosted demo runs with real latency thresholds.
+
+## Verification
+
+- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 23 passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - 2590 passed, 7 skipped.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 94 |
+| Runbook doc | 133 |
+| Tests | 66 |
+| **Total** | **293** |

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 import importlib.util
 import json
 from pathlib import Path
+import shlex
 import sys
 from types import SimpleNamespace
 
@@ -22,7 +23,9 @@ from extracted_content_pipeline.ticket_faq_search import (
 ROOT = Path(__file__).resolve().parents[1]
 DEMO_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv"
 DEMO_FAQ_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_faq.md"
+RUNBOOK_PATH = ROOT / "docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md"
 SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
+ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
 SEED_SPEC = importlib.util.spec_from_file_location(
     "seed_content_ops_faq_saas_demo",
     SEED_SCRIPT,
@@ -31,6 +34,13 @@ assert SEED_SPEC is not None and SEED_SPEC.loader is not None
 seeder = importlib.util.module_from_spec(SEED_SPEC)
 sys.modules["seed_content_ops_faq_saas_demo"] = seeder
 SEED_SPEC.loader.exec_module(seeder)
+ROUTE_SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_faq_search_route_concurrency_for_saas_demo_test",
+    ROUTE_SCRIPT,
+)
+assert ROUTE_SPEC is not None and ROUTE_SPEC.loader is not None
+route_smoke = importlib.util.module_from_spec(ROUTE_SPEC)
+ROUTE_SPEC.loader.exec_module(route_smoke)
 
 EXPECTED_LABEL = "synthetic_b2b_saas_demo"
 MIN_ROWS = 36
@@ -80,6 +90,16 @@ def _generated_demo_faq():
         support_contact="https://example.com/support",
     )
     return rows, normalized, result
+
+
+def _runbook_command_args(marker: str) -> list[str]:
+    doc = RUNBOOK_PATH.read_text(encoding="utf-8")
+    start = doc.index(marker)
+    end = doc.index("```", start)
+    command = doc[start:end].replace("\\\n", " ")
+    parts = shlex.split(command)
+    assert parts[:2] == ["python", marker.removeprefix("python ")]
+    return parts[2:]
 
 
 def test_saas_demo_corpus_is_labeled_and_domain_clean() -> None:
@@ -158,6 +178,52 @@ def test_saas_demo_faq_draft_projects_to_search_documents() -> None:
     assert first["account_id"] == "acct-demo"
     assert first["corpus_id"] == "synthetic-b2b-saas-demo"
     assert "export" in first["question"].lower()
+
+
+def test_saas_demo_route_case_runbook_seed_command_matches_parser() -> None:
+    args = _runbook_command_args("python scripts/seed_content_ops_faq_saas_demo.py")
+
+    parsed = seeder._parse_args(args)
+
+    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"
+    assert parsed.route_case_file_output == Path("/tmp/faq-saas-demo-route-cases.json")
+    assert parsed.output_result == Path("/tmp/faq-saas-demo-seed-result.json")
+    assert parsed.cleanup_faq_id is None
+    assert seeder._validate_args(parsed) == []
+
+
+def test_saas_demo_route_case_runbook_route_command_matches_parser() -> None:
+    args = _runbook_command_args(
+        "python scripts/smoke_content_ops_faq_search_route_concurrency.py"
+    )
+
+    parsed = route_smoke._build_parser().parse_args(args)
+
+    assert parsed.base_url == "$ATLAS_API_BASE_URL"
+    assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
+    assert parsed.case_file == Path("/tmp/faq-saas-demo-route-cases.json")
+    assert parsed.require_detail is True
+    assert parsed.max_error_rate == 0
+    assert parsed.max_case_error_rate == 0
+    assert parsed.max_detail_ms == 2500
+    assert parsed.output_result == Path("/tmp/faq-saas-demo-route-result.json")
+    assert route_smoke._validate_args(parsed) == []
+
+
+def test_saas_demo_route_case_runbook_commands_share_case_file() -> None:
+    seed_args = seeder._parse_args(
+        _runbook_command_args("python scripts/seed_content_ops_faq_saas_demo.py")
+    )
+    route_args = route_smoke._build_parser().parse_args(
+        _runbook_command_args(
+            "python scripts/smoke_content_ops_faq_search_route_concurrency.py"
+        )
+    )
+
+    assert seed_args.route_case_file_output == route_args.case_file
+    assert route_args.require_detail is True
+    assert route_args.max_case_single_request_ms == 3000
 
 
 def test_saas_demo_seed_args_fail_closed_for_missing_required_values() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md
Slice phase: Functional validation

PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Output made the SaaS demo seeder emit route cases the hosted route smoke can enforce, but the operator path was still implicit. This PR adds the demo-specific two-command runbook and pins both commands against the real CLIs so the seed-to-route handoff cannot drift quietly.

## Intentional
- No new one-command wrapper. The generic seeded e2e runner already owns that path; this runbook documents the checked SaaS demo handoff.
- No live DB or hosted route call in unit tests. The tests validate the documented operator contract with the real parsers.
- No cleanup helper change. Existing cleanup mode remains the path for deleting a seeded FAQ id.

## Deferred
- Future robust-testing slices can use this runbook as the operator entry point for repeated hosted demo runs with real latency thresholds.

## Parked hardening
- None. `HARDENING.md` was scanned; no active FAQ-search item is required for this runbook slice.

## Verification
- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 23 passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Route-Case-Runbook.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 122 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2590 passed, 7 skipped.
- `git diff --check` - passed.

## Diff size
3 files, +293 / -0
