### PR TITLE
Document SaaS FAQ route e2e smoke

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -24,7 +24,36 @@ Run the FAQ search migrations before this smoke:
 python scripts/run_extracted_content_pipeline_migrations.py
 ```
 
-## Step 1: Seed The SaaS Demo And Write Route Cases
+## Recommended One-Command Smoke
+
+```bash
+python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
+  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
+  --base-url "$ATLAS_API_BASE_URL" \
+  --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
+  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --route-requests 40 \
+  --concurrency 8 \
+  --max-error-rate 0 \
+  --max-case-error-rate 0 \
+  --max-p95-ms 1500 \
+  --max-single-request-ms 3000 \
+  --max-case-p95-ms 1500 \
+  --max-case-single-request-ms 3000 \
+  --max-detail-ms 2500 \
+  --output-result /tmp/faq-saas-demo-route-e2e-result.json
+```
+
+Use `--json` when stdout should be machine-readable. Without `--json`, stdout is
+a compact status line; the full proof lives in `--output-result`.
+
+The smoke writes a temporary route case file, validates the hosted search and
+detail path against it, then deletes the seeded FAQ unless `--keep-data` is set.
+
+## Manual Fallback: Seed The SaaS Demo And Write Route Cases
+
+Use the manual steps when you need to inspect or preserve the emitted route case
+file between seed and route validation.
 
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \
@@ -49,7 +78,7 @@ and expected hydrated detail fields:
 - `expected_detail_title`
 - `expected_detail_status`
 
-## Step 2: Validate The Hosted Route Against The Seeded Case
+## Manual Fallback: Validate The Hosted Route Against The Seeded Case
 
 ```bash
 python scripts/smoke_content_ops_faq_search_route_concurrency.py \
@@ -83,6 +112,14 @@ a compact status line with aggregate and worst-case route signals.
 
 ## Result Checks
 
+Open `/tmp/faq-saas-demo-route-e2e-result.json` and inspect:
+
+- `ok`: seed, hosted route/detail, cleanup, and artifact-read status.
+- `seed.result_artifact.faq_id`: generated FAQ id used for route and cleanup.
+- `route.result_artifact.requests`: hosted route request count.
+- `route.result_artifact.detail`: hydrated detail checks and failures.
+- `cleanup`: cleanup status, or `not_run_reason` when `--keep-data` is set.
+
 Open `/tmp/faq-saas-demo-seed-result.json` and inspect:
 
 - `ok`: seed, approval, projection, verification search, and route-case write
@@ -102,8 +139,9 @@ Open `/tmp/faq-saas-demo-route-result.json` and inspect:
 
 ## Cleanup
 
-If the seeded FAQ should not remain in the host database, delete it with the FAQ
-id from the seed result:
+The recommended one-command smoke cleans up the seeded FAQ by default. If you
+use the manual fallback and the seeded FAQ should not remain in the host
+database, delete it with the FAQ id from the seed result:
 
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md
@@ -1,0 +1,82 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Route-E2E-Smoke added a one-command SaaS demo
+hosted route smoke that composes seeding, route/detail validation, and cleanup.
+The SaaS demo route-case runbook still presents the older manual seed and route
+commands first, so operators can miss the safer cleanup-aware wrapper.
+
+This slice updates the runbook to make the one-command smoke the recommended
+path and pins that documented command against the actual wrapper parser.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation
+
+1. Add the one-command SaaS demo hosted route e2e smoke to the SaaS demo
+   validation runbook.
+2. Make the existing manual seed/route commands a fallback for inspecting
+   intermediate artifacts.
+3. Add a focused parser-backed test for the documented wrapper command.
+4. Keep runtime scripts, API, repository, and CI enrollment unchanged.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md` | Plan contract for this runbook update. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md` | Document the cleanup-aware one-command SaaS demo route e2e smoke. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Parser-pin the documented one-command smoke invocation. |
+
+## Mechanism
+
+The runbook gains a new recommended command:
+
+```bash
+python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py ...
+```
+
+The previous seed/route commands remain in the file as a manual fallback when an
+operator needs to inspect the route-case artifact between steps. The test imports
+the wrapper script, extracts the fenced command from the runbook, parses it with
+`_build_parser()`, and asserts `_validate_args(parsed) == []`.
+
+## Intentional
+
+- No wrapper behavior changes. The previous slice already tested the subprocess
+  composition and fail-closed branches.
+- No host install runbook change. It already links to this SaaS demo validation
+  runbook.
+- No live hosted run. Required hosted inputs are not present in this checkout.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned; no active FAQ-search item
+  is required for this documentation slice.
+- Future robust-testing slice: execute the documented wrapper against a deployed
+  host and save the result artifact once the required hosted inputs are
+  available.
+
+## Verification
+
+- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 24 passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 123 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 82 |
+| Runbook doc | 46 |
+| Test | 28 |
+| **Total** | **156** |

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -26,6 +26,7 @@ DEMO_FAQ_PATH = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_
 RUNBOOK_PATH = ROOT / "docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md"
 SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
 ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
+E2E_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_saas_demo_route_e2e.py"
 SEED_SPEC = importlib.util.spec_from_file_location(
     "seed_content_ops_faq_saas_demo",
     SEED_SCRIPT,
@@ -41,6 +42,13 @@ ROUTE_SPEC = importlib.util.spec_from_file_location(
 assert ROUTE_SPEC is not None and ROUTE_SPEC.loader is not None
 route_smoke = importlib.util.module_from_spec(ROUTE_SPEC)
 ROUTE_SPEC.loader.exec_module(route_smoke)
+E2E_SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_faq_saas_demo_route_e2e_for_saas_demo_test",
+    E2E_SCRIPT,
+)
+assert E2E_SPEC is not None and E2E_SPEC.loader is not None
+e2e_smoke = importlib.util.module_from_spec(E2E_SPEC)
+E2E_SPEC.loader.exec_module(e2e_smoke)
 
 EXPECTED_LABEL = "synthetic_b2b_saas_demo"
 MIN_ROWS = 36
@@ -178,6 +186,26 @@ def test_saas_demo_faq_draft_projects_to_search_documents() -> None:
     assert first["account_id"] == "acct-demo"
     assert first["corpus_id"] == "synthetic-b2b-saas-demo"
     assert "export" in first["question"].lower()
+
+
+def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
+    args = _runbook_command_args(
+        "python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py"
+    )
+
+    parsed = e2e_smoke._build_parser().parse_args(args)
+
+    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert parsed.base_url == "$ATLAS_API_BASE_URL"
+    assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
+    assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"
+    assert parsed.route_requests == 40
+    assert parsed.concurrency == 8
+    assert parsed.max_error_rate == 0
+    assert parsed.max_case_error_rate == 0
+    assert parsed.max_detail_ms == 2500
+    assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-result.json")
+    assert e2e_smoke._validate_args(parsed) == []
 
 
 def test_saas_demo_route_case_runbook_seed_command_matches_parser() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md
Slice phase: Functional validation

PR-Content-Ops-FAQ-SaaS-Demo-Route-E2E-Smoke added the cleanup-aware one-command SaaS demo hosted route smoke, but the runbook still led with the older manual seed and route commands. This PR makes the one-command smoke the recommended operator path and keeps the manual commands as the artifact-inspection fallback.

## Intentional
- No wrapper behavior changes. The previous slice already tested subprocess composition and fail-closed branches.
- No host install runbook change. It already links to this SaaS demo validation runbook.
- No live hosted run. Required hosted inputs are not present in this checkout.

## Deferred
- Future robust-testing slice: execute the documented wrapper against a deployed host and save the result artifact once the required hosted inputs are available.

## Parked hardening
- None. `HARDENING.md` was scanned; no active FAQ-search item is required for this documentation slice.

## Verification
- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 24 passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-E2E-Runbook.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 123 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `git diff --check` - passed.

## Diff size
3 files, +152 / -4
