### PR TITLE
Align blog GEO citable readiness gate

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,15 +32,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-28
 
-### Blog save-time GEO gate and export readiness disagree on citable sections
-- File/location: `extracted_quality_gate/blog_pack.py`, `extracted_content_pipeline/blog_post_export.py`, live run in `tmp/support_ticket_saas_demo_blog_acceptance_20260528_after_geo/blog-post-draft.json`.
-- Description: After the GEO repair guidance landed, the 36-row SaaS demo blog saved and passed support-ticket generated-content evaluation, but the exported draft still reported GEO `needs_review` because `citable_section_structure` was missing. Diagnostic replay showed the save-time quality pack passed the same draft with only a warning, so save-time and export citable-section rules are not equivalent.
-- Why it matters: The blog path can save a draft that is not export-ready for GEO, which would let an apparently successful generation miss the SEO/GEO/AEO acceptance bar.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/support-ticket-provider
-- Found during: PR-Support-Ticket-SaaS-Demo-Blog-Accepted-Fixture
-
 ### LLM usage storage schema mismatch hides per-run cost telemetry
 - File/location: `content_ops.llm.complete` usage-storage path, live smoke stderr during `scripts/smoke_content_ops_live_generation.py`.
 - Description: Live landing/blog generation succeeded, but each LLM call logged `_store_local failed for span=content_ops.llm.complete: column "account_id" of relation "llm_usage" does not exist`.

--- a/extracted_quality_gate/blog_pack.py
+++ b/extracted_quality_gate/blog_pack.py
@@ -717,8 +717,7 @@ def _geo_self_contained_section(
         return False
     if topic_terms:
         searchable = f"{heading} {first_paragraph}".lower()
-        if any(term.lower() in searchable for term in topic_terms):
-            return True
+        return any(term.lower() in searchable for term in topic_terms)
     return _visible_entity_present(heading, first_paragraph)
 
 

--- a/plans/PR-Blog-GEO-Citable-Readiness-Alignment.md
+++ b/plans/PR-Blog-GEO-Citable-Readiness-Alignment.md
@@ -1,0 +1,90 @@
+# PR: Blog GEO Citable Readiness Alignment
+
+## Why this slice exists
+
+The 36-row SaaS demo support-ticket blog retry saved a draft and passed the
+deterministic support-ticket truthfulness evaluator, but the exported draft was
+still not acceptable: `geo_readiness.status` was `needs_review` because
+`citable_section_structure` was missing.
+
+The source issue is a validator mismatch. Save-time blog quality uses
+`extracted_quality_gate.blog_pack` and currently lets a citable section pass
+when a 40-120 word opening paragraph contains a visible capitalized entity,
+even if it does not contain the topic terms or target keyword. Export readiness
+uses `extracted_content_pipeline.blog_post_export` and requires the topic terms
+when they are available. That means a blog can save as quality-passed and then
+fail the exported GEO/AEO/SEO acceptance bar.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Production hardening
+
+1. Promote the parked citable-section mismatch from `HARDENING.md`.
+2. Align save-time GEO citable-section validation with export readiness by
+   requiring topic terms when topic terms exist.
+3. Add a focused save-time quality-gate regression for visible-entity-only H2
+   sections.
+4. Do not run another live Haiku retry in this source-fix slice.
+
+### Files touched
+
+- `plans/PR-Blog-GEO-Citable-Readiness-Alignment.md` - Plan doc for this source fix.
+- `HARDENING.md` - Remove the promoted validator mismatch item.
+- `extracted_quality_gate/blog_pack.py` - Align save-time GEO citable-section logic with export readiness.
+- `tests/test_extracted_quality_gate_blog_pack.py` - Pin the stricter citable-section behavior.
+- `tests/test_extracted_blog_generation.py` - Update the shared valid blog fixture so generator tests satisfy the stricter save-time citable-section contract.
+
+## Mechanism
+
+`_geo_self_contained_section` is the save-time helper behind
+`geo_citable_section_structure_missing`. This PR changes it to match export
+readiness:
+
+- keep the 40-120 word first-paragraph requirement;
+- if `topic_terms` exist, require at least one topic term in the H2 heading or
+  first paragraph;
+- only use the visible-entity fallback when no topic terms exist.
+
+That makes save-time validation at least as strict as the exported readiness
+contract for the same citable-section signal, so the generation repair loop can
+fix the issue before a draft is saved.
+
+## Intentional
+
+- This changes the save-time gate rather than weakening export readiness. The
+  product acceptance bar is the exported SEO/AEO/GEO readiness output.
+- This does not touch prompt copy or repair guidance. After this lands, the
+  existing repair loop should receive `geo_citable_section_structure_missing`
+  for this class of draft.
+- This does not run a live model retry; the next validation slice should do that
+  after the source gate alignment lands.
+
+## Deferred
+
+- Future PR: rerun the 36-row SaaS demo blog path with Haiku and accept the
+  fixture only if it saves, generated-content evaluation passes, and exported
+  SEO/AEO plus GEO readiness are ready.
+- Parked hardening:
+  - LLM usage storage schema mismatch hides per-run cost telemetry.
+
+## Verification
+
+- python -m pytest tests/test_extracted_quality_gate_blog_pack.py -q - passed, 43 tests.
+- python -m pytest tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py tests/test_extracted_blog_post_export.py -q - passed, 120 tests.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- python -m py_compile extracted_quality_gate/blog_pack.py tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py - passed.
+- Local PR review with the blog GEO citable readiness alignment PR body - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Quality gate | ~3 |
+| Tests | ~40 |
+| HARDENING cleanup | ~9 |
+| **Total** | **~132** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -142,7 +142,8 @@ def _valid_content() -> str:
         "proof that every buyer has the same problem. The useful pattern is that "
         "customers keep using similar wording about budget pressure, contract terms, "
         "and alternative comparisons when they explain why pricing has become harder "
-        "to justify."
+        "to justify, so HubSpot pricing pressure stays visible in the section's "
+        "answer before the supporting details continue."
     )
     return body + "\n\n{{chart:pricing}}\n"
 

--- a/tests/test_extracted_quality_gate_blog_pack.py
+++ b/tests/test_extracted_quality_gate_blog_pack.py
@@ -263,6 +263,29 @@ def test_geo_context_blocks_missing_draft_contract_pieces():
     }
 
 
+def test_geo_context_requires_topic_terms_for_citable_sections():
+    body = (
+        "## What does Atlas Support Desk show in the ticket sample?\n\n"
+        "Atlas Support Desk shows 36 uploaded tickets with repeated customer "
+        "questions across export, dashboard, login, permissions, API, and sync "
+        "topics. The opening answer is long enough to look independently "
+        "citable, and it names a visible entity, but it intentionally omits the "
+        "configured topic terms so save-time validation matches export "
+        "readiness.\n\n"
+        "## How should Atlas Support Desk teams read the pattern?\n\n"
+        "Atlas Support Desk teams should treat the ticket sample as source "
+        "evidence for FAQ planning during the last 90 days. The paragraph is "
+        "again long enough and visibly entity-specific, but it still omits the "
+        "configured topic terms that export readiness requires for citable "
+        "sections.\n\n"
+        + _LONG_GOOD_BODY
+    )
+
+    report = evaluate_blog_post(_make_input(body, **_geo_context()))
+
+    assert "geo_citable_section_structure_missing" in report.metadata["blocking_codes"]
+
+
 def test_geo_context_blocks_citation_safety_when_existing_findings_fail():
     body = _GEO_READY_BODY + "\n\nSee {{todo}} before publishing."
 


### PR DESCRIPTION
Plan: plans/PR-Blog-GEO-Citable-Readiness-Alignment.md
Slice phase: Production hardening

The SaaS demo blog retry proved a validator mismatch: save-time blog quality passed a draft that exported as GEO `needs_review` because `citable_section_structure` was missing. This aligns save-time GEO citable-section validation with export readiness by requiring topic terms when topic terms exist.

## Intentional
- Tightens the save-time gate instead of weakening export readiness.
- Leaves prompt and repair guidance unchanged; the existing repair loop should now see the blocker before save.
- Does not run a live Haiku retry in this source-fix slice.

## Deferred
- Future PR: rerun the 36-row SaaS demo blog path with Haiku and accept the fixture only if it saves, support-ticket evaluation passes, and exported SEO/AEO plus GEO readiness are ready.

## Parked hardening
- LLM usage storage schema mismatch hides per-run cost telemetry.

## Verification
- python -m pytest tests/test_extracted_quality_gate_blog_pack.py -q - passed, 43 tests.
- python -m pytest tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py tests/test_extracted_blog_post_export.py -q - passed, 120 tests.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- python -m py_compile extracted_quality_gate/blog_pack.py tests/test_extracted_quality_gate_blog_pack.py tests/test_extracted_blog_generation.py - passed.
- Local PR review passed.

## Diff size
5 files, ~+116 / -12.