### PR TITLE
Pin SaaS FAQ runbook migration command

### DIFF
--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md
@@ -1,0 +1,76 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin
+
+## Why this slice exists
+
+The SaaS demo route-case runbook now documents the one-command hosted route e2e
+smoke, and parser-pins the seed, route, and wrapper commands. Review has twice
+noted the remaining unpinned command: the migration preamble. This lane already
+had one migration-command drift bug, so leaving the preamble unpinned keeps a
+known operator footgun open.
+
+This slice adds the smallest parser-backed guard for the migration command in
+the SaaS demo runbook.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation
+
+1. Import the migration CLI in the SaaS demo runbook test file.
+2. Parse the documented migration command with the real migration parser.
+3. Assert the runbook does not mention the old invalid migration-runner command.
+4. Keep runbook prose and runtime behavior unchanged.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md` | Plan contract for this parser-pin slice. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Add migration preamble parser coverage for the SaaS demo runbook. |
+
+## Mechanism
+
+The test extracts:
+
+```bash
+python scripts/run_extracted_content_pipeline_migrations.py
+```
+
+from `content_ops_faq_saas_demo_route_case_runbook.md`, parses it with
+`scripts/run_extracted_content_pipeline_migrations.py`'s `_parse_args`, and
+asserts the obsolete `extracted_content_pipeline/storage/migration_runner.py
+--apply` command is absent.
+
+## Intentional
+
+- No docs edit. The command is already correct; this slice pins it.
+- No live migration run. The parser guard proves CLI shape without requiring a
+  database.
+- No broad runbook command helper refactor. The existing test extraction helper
+  is enough for this narrow check.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` was scanned; no active FAQ-search item
+  is required for this parser-pin slice.
+
+## Verification
+
+- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 25 passed.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md` - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md` - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 123 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `git diff --check` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Test | 23 |
+| **Total** | **99** |

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -27,6 +27,7 @@ RUNBOOK_PATH = ROOT / "docs/extraction/validation/content_ops_faq_saas_demo_rout
 SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
 ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
 E2E_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_saas_demo_route_e2e.py"
+MIGRATION_SCRIPT = ROOT / "scripts/run_extracted_content_pipeline_migrations.py"
 SEED_SPEC = importlib.util.spec_from_file_location(
     "seed_content_ops_faq_saas_demo",
     SEED_SCRIPT,
@@ -49,6 +50,13 @@ E2E_SPEC = importlib.util.spec_from_file_location(
 assert E2E_SPEC is not None and E2E_SPEC.loader is not None
 e2e_smoke = importlib.util.module_from_spec(E2E_SPEC)
 E2E_SPEC.loader.exec_module(e2e_smoke)
+MIGRATION_SPEC = importlib.util.spec_from_file_location(
+    "run_extracted_content_pipeline_migrations_for_saas_demo_test",
+    MIGRATION_SCRIPT,
+)
+assert MIGRATION_SPEC is not None and MIGRATION_SPEC.loader is not None
+migration_cli = importlib.util.module_from_spec(MIGRATION_SPEC)
+MIGRATION_SPEC.loader.exec_module(migration_cli)
 
 EXPECTED_LABEL = "synthetic_b2b_saas_demo"
 MIN_ROWS = 36
@@ -186,6 +194,21 @@ def test_saas_demo_faq_draft_projects_to_search_documents() -> None:
     assert first["account_id"] == "acct-demo"
     assert first["corpus_id"] == "synthetic-b2b-saas-demo"
     assert "export" in first["question"].lower()
+
+
+def test_saas_demo_route_case_runbook_migration_command_matches_parser() -> None:
+    args = _runbook_command_args(
+        "python scripts/run_extracted_content_pipeline_migrations.py"
+    )
+
+    parsed = migration_cli._parse_args(args)
+    doc = RUNBOOK_PATH.read_text(encoding="utf-8")
+
+    assert parsed.database_url is None
+    assert parsed.dry_run is False
+    assert parsed.json is False
+    assert "extracted_content_pipeline/storage/migration_runner.py --apply" not in doc
+    assert MIGRATION_SCRIPT.exists()
 
 
 def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md
Slice phase: Functional validation

The SaaS demo runbook now parser-pins the seed, route, and one-command wrapper invocations, but the migration preamble was still unpinned. This PR adds the smallest parser-backed guard for that command and asserts the old invalid migration-runner command is absent.

## Intentional
- No docs edit. The command is already correct; this slice pins it.
- No live migration run. The parser guard proves CLI shape without requiring a database.
- No broad runbook command helper refactor. The existing test extraction helper is enough for this narrow check.

## Deferred
- None.

## Parked hardening
- None. `HARDENING.md` was scanned; no active FAQ-search item is required for this parser-pin slice.

## Verification
- `python -m py_compile tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py -q` - 25 passed.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-FAQ-SaaS-Demo-Migration-Pin.md` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed; 123 matching tests enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed; 0 Atlas runtime import findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `git diff --check` - passed.

## Diff size
2 files, +99 / -0
