### PR TITLE
Strengthen blog GEO citable repair guidance

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,15 +32,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-28
 
-### Support-ticket SaaS demo blog still fails the GEO citable-section gate after repair
-- File/location: `extracted_content_pipeline/blog_generation.py`, `extracted_quality_gate/blog_pack.py`, live run in `tmp/support_ticket_saas_demo_blog_acceptance_20260528_after_citable/blog-post-result.json`.
-- Description: After save-time/export citable-section validation was aligned, the 36-row SaaS demo blog retry failed before save on `geo_citable_section_structure_missing` after two repair attempts. The failed candidate had the target keyword in the title/opening, but the repaired H2 opening sections still did not produce two citable 40-120 word openings containing the exact target keyword or required topic terms.
-- Why it matters: The blog path now blocks correctly before save, but it still cannot produce an accepted SaaS demo fixture until the repair contract teaches the model to satisfy the stricter citable-section rule.
-- Effort: S
-- Category: correctness
-- Owner/session: content-ops/support-ticket-provider
-- Found during: PR-Support-Ticket-SaaS-Demo-Blog-Accepted-After-GEO
-
 ### LLM usage storage schema mismatch hides per-run cost telemetry
 - File/location: `content_ops.llm.complete` usage-storage path, live smoke stderr during `scripts/smoke_content_ops_live_generation.py`.
 - Description: Live landing/blog generation succeeded, but each LLM call logged `_store_local failed for span=content_ops.llm.complete: column "account_id" of relation "llm_usage" does not exist`.

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -228,9 +228,13 @@ def _blog_quality_repair_guidance(blockers: Sequence[str]) -> str:
             )
         elif code == "geo_citable_section_structure_missing":
             instructions.append(
-                "- Make at least two H2 sections independently citable. Each of "
-                "those sections must start with a 40-120 word answer paragraph "
-                "that includes the exact `target_keyword` or clearest named subject."
+                "- Rewrite at least two H2 sections so each one is independently "
+                "citable. The first paragraph immediately after each of those H2 "
+                "headings must be 40-120 words and must include the exact "
+                "`target_keyword` string from the previous JSON. If no "
+                "`target_keyword` exists, include the exact clearest named topic "
+                "term. Do not rely on the title, introduction, blockquotes, "
+                "bullets, or later paragraphs to satisfy this check."
             )
         elif code == "geo_citation_safety_failed":
             instructions.append(

--- a/plans/PR-Blog-GEO-Citable-Repair-Contract.md
+++ b/plans/PR-Blog-GEO-Citable-Repair-Contract.md
@@ -1,0 +1,86 @@
+# PR: Blog GEO Citable Repair Contract
+
+## Why this slice exists
+
+After save-time and export GEO citable-section validation were aligned, the
+36-row SaaS demo support-ticket blog no longer false-saves. It now correctly
+fails before save on `geo_citable_section_structure_missing` after two repair
+attempts.
+
+The remaining source gap is the repair contract. The current repair instruction
+asks for two independently citable H2 sections, but it does not make the exact
+shape mechanical enough for the model: the first paragraph immediately after
+each of at least two H2 headings must be 40-120 words and must include the exact
+target keyword or topic term the gate checks.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Production hardening
+
+1. Promote the parked citable-section repair-contract item from `HARDENING.md`.
+2. Tighten the `geo_citable_section_structure_missing` repair guidance so it
+   tells the model to rewrite at least two H2 sections in the exact shape the
+   save-time gate requires.
+3. Pin the repair guidance with focused assertions.
+4. Do not run another live Haiku retry in this source-fix slice.
+
+### Files touched
+
+- `plans/PR-Blog-GEO-Citable-Repair-Contract.md` - Plan doc for this source fix.
+- `HARDENING.md` - Remove the promoted citable-section repair-contract item.
+- `extracted_content_pipeline/blog_generation.py` - Strengthen citable-section repair guidance.
+- `tests/test_extracted_blog_generation.py` - Assert the repair prompt names the exact citable-section shape.
+
+## Mechanism
+
+`_blog_quality_repair_guidance` maps quality blocker codes into LLM repair
+instructions. This PR keeps the existing citable-section blocker mapping, but
+makes it explicit that repair must:
+
+- rewrite at least two H2 sections;
+- make the first paragraph immediately after each H2 40-120 words;
+- include the exact `target_keyword` from the previous JSON in both opening
+  paragraphs, or the exact named topic term if no target keyword exists;
+- avoid relying on the title, intro, blockquotes, bullets, or later paragraphs
+  to satisfy the citable-section check.
+
+That matches the save-time gate's citable-section scope and gives the repair
+loop a mechanical target.
+
+## Intentional
+
+- This does not weaken the save-time gate or export readiness.
+- This does not run another live model retry; the next validation slice should
+  rerun the 36-row SaaS demo blog path after this source fix lands.
+- This does not touch FAQ article generation or FAQ report ownership.
+
+## Deferred
+
+- Future PR: rerun the 36-row SaaS demo blog path with Haiku and accept the
+  fixture only if it saves, support-ticket evaluation passes, and exported
+  SEO/AEO plus GEO readiness are ready.
+- Future PR: add a scripted regression gate after an accepted SaaS demo blog
+  fixture lands.
+- Parked hardening:
+  - LLM usage storage schema mismatch hides per-run cost telemetry.
+
+## Verification
+
+- python -m pytest tests/test_extracted_blog_generation.py -q - passed, 68 tests.
+- python -m py_compile extracted_content_pipeline/blog_generation.py tests/test_extracted_blog_generation.py - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- Local PR review with the blog GEO citable repair contract PR body - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Repair guidance | ~8 |
+| Test | ~5 |
+| HARDENING cleanup | ~9 |
+| **Total** | **~107** |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -1052,7 +1052,11 @@ async def test_generate_quality_repair_prompt_explains_known_blockers() -> None:
     assert "Replace vague H2 headings" in retry_prompt
     assert "`Summary`" in retry_prompt
     assert "specific question or answer headings" in retry_prompt
-    assert "Make at least two H2 sections independently citable" in retry_prompt
+    assert "Rewrite at least two H2 sections" in retry_prompt
+    assert "first paragraph immediately after each of those H2 headings" in retry_prompt
+    assert "must be 40-120 words" in retry_prompt
+    assert "exact `target_keyword` string from the previous JSON" in retry_prompt
+    assert "Do not rely on the title, introduction, blockquotes, bullets" in retry_prompt
 
 
 def test_blog_quality_repair_guidance_uses_compact_support_ticket_word_floor() -> None:


### PR DESCRIPTION
Plan: plans/PR-Blog-GEO-Citable-Repair-Contract.md
Slice phase: Production hardening

The SaaS demo blog now blocks before save on `geo_citable_section_structure_missing`, but the repair prompt was still too soft. This tightens the repair contract so the model is told to rewrite at least two H2 sections whose immediate first paragraphs are 40-120 words and contain the exact previous `target_keyword`.

## Intentional
- Tightens the repair guidance instead of weakening the save-time gate or export readiness.
- Does not run another live Haiku retry in this source-fix slice.
- Does not touch FAQ article generation or FAQ report ownership.

## Deferred
- Future PR: rerun the 36-row SaaS demo blog path with Haiku and accept the fixture only if it saves, support-ticket evaluation passes, and exported SEO/AEO plus GEO readiness are ready.
- Future PR: add a scripted regression gate after an accepted SaaS demo blog fixture lands.

## Parked hardening
- LLM usage storage schema mismatch hides per-run cost telemetry.

## Verification
- python -m pytest tests/test_extracted_blog_generation.py -q - passed, 68 tests.
- python -m py_compile extracted_content_pipeline/blog_generation.py tests/test_extracted_blog_generation.py - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- Local PR review passed.

## Diff size
4 files, ~+98 / -13.