### PR TITLE
Expose SaaS FAQ cleanup summary

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -121,6 +121,9 @@ Open `/tmp/faq-saas-demo-route-e2e-result.json` and inspect:
 - `route.result_artifact.requests`: hosted route request count.
 - `route.result_artifact.detail`: hydrated detail checks and failures.
 - `cleanup`: cleanup status, or `not_run_reason` when `--keep-data` is set.
+- `cleanup.result_artifact.account_id`: account used for cleanup.
+- `cleanup.result_artifact.deleted_faq_ids`: deleted FAQ rowcount.
+- `cleanup.result_artifact.delete_status`: raw Postgres delete status.
 
 Open `/tmp/faq-saas-demo-seed-result.json` and inspect:
 

--- a/plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md
+++ b/plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md
@@ -1,0 +1,86 @@
+# PR-FAQ-SaaS-Demo-Cleanup-Summary
+
+## Why this slice exists
+
+The SaaS demo one-command FAQ route smoke now preserves child artifacts, but the
+top-level cleanup summary only carries generic identifiers. The cleanup child
+artifact already reports the account, deleted FAQ rowcount, and raw delete
+status; hiding those fields from the compact e2e result makes a hosted demo run
+harder to audit after cleanup.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation.
+
+1. Preserve cleanup-specific proof fields in the compact child artifact shown
+   in the one-command SaaS demo e2e result.
+2. Pin the wrapper test so the result JSON exposes the cleanup account, deleted
+   FAQ rowcount, and raw delete status.
+3. Update the runbook result checks to tell operators where to inspect that
+   cleanup proof.
+
+### Files touched
+
+- `plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md`
+- `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md`
+
+## Mechanism
+
+`_compact_artifact(...)` already copies a small allowlist of stable child
+result keys into the top-level e2e summary. This slice extends that allowlist
+with cleanup proof fields that are already emitted by
+`seed_content_ops_faq_saas_demo.py` cleanup mode:
+
+```python
+for key in (..., "account_id", "deleted_faq_ids", "delete_status"):
+    if key in payload:
+        summary[key] = payload[key]
+```
+
+The wrapper still avoids duplicating large child artifacts; it only exposes the
+small fields needed to prove cleanup ran against the expected account and row.
+
+## Intentional
+
+- No seeder cleanup behavior changes. Rowcount parsing and fail-closed cleanup
+  already live in the seeder path.
+- No live hosted route behavior changes. This is result visibility for the
+  existing validation wrapper.
+- No broad compact-artifact dump is added; the e2e summary stays bounded and
+  deterministic.
+
+## Deferred
+
+- Parked hardening: none.
+- Broader live-host threshold tuning remains deferred until repeated hosted
+  route runs produce real latency baselines.
+
+## Verification
+
+- `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
+  - passed.
+- `python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q`
+  - 6 passed.
+- `git diff --check`
+  - passed.
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md`
+  - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md`
+  - passed.
+- `bash scripts/check_ascii_python.sh`
+  - passed.
+- `ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-saas-demo-cleanup-summary.md bash scripts/local_pr_review.sh`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 86 |
+| E2E wrapper | 12 |
+| Tests | 14 |
+| Runbook | 3 |
+| **Total** | **115** |

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -216,7 +216,18 @@ def _compact_artifact(path: Path, *, label: str) -> dict[str, Any]:
         "ok": payload.get("ok") is True,
         "path": str(path),
     }
-    for key in ("phase", "faq_id", "corpus_id", "target_id", "status", "source_count", "generated_items"):
+    for key in (
+        "phase",
+        "account_id",
+        "faq_id",
+        "corpus_id",
+        "target_id",
+        "status",
+        "source_count",
+        "generated_items",
+        "deleted_faq_ids",
+        "delete_status",
+    ):
         if key in payload:
             summary[key] = payload[key]
     if isinstance(payload.get("search"), Mapping):

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -94,7 +94,17 @@ def _fake_runner(calls: list[list[str]], *, route_ok: bool = True, seed_faq_id: 
             return {"ok": route_ok, "returncode": 0 if route_ok else 1, "stdout_tail": "", "stderr_tail": ""}
         if str(smoke.SEED_SCRIPT) in command and "--cleanup-faq-id" in command:
             cleanup_result = Path(command[command.index("--output-result") + 1])
-            _write_json(cleanup_result, {"ok": True, "phase": "cleanup", "faq_id": command[command.index("--cleanup-faq-id") + 1]})
+            _write_json(
+                cleanup_result,
+                {
+                    "ok": True,
+                    "phase": "cleanup",
+                    "account_id": "acct-1",
+                    "faq_id": command[command.index("--cleanup-faq-id") + 1],
+                    "deleted_faq_ids": 1,
+                    "delete_status": "DELETE 1",
+                },
+            )
             return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
         raise AssertionError(f"unexpected command: {command}")
 
@@ -164,6 +174,9 @@ def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch) -> None:
     assert payload["seed"]["result_artifact"]["faq_id"] == "faq-123"
     assert payload["route"]["result_artifact"]["detail"]["checked"] == 40
     assert payload["cleanup"]["result_artifact"]["faq_id"] == "faq-123"
+    assert payload["cleanup"]["result_artifact"]["account_id"] == "acct-1"
+    assert payload["cleanup"]["result_artifact"]["deleted_faq_ids"] == 1
+    assert payload["cleanup"]["result_artifact"]["delete_status"] == "DELETE 1"
     assert "--route-case-file-output" in calls[0]
     assert calls[1][calls[1].index("--case-file") + 1] == calls[0][calls[0].index("--route-case-file-output") + 1]
     assert calls[2][calls[2].index("--cleanup-faq-id") + 1] == "faq-123"


### PR DESCRIPTION
Plan: plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md
Slice phase: Functional validation.

The SaaS demo one-command FAQ route smoke preserves child artifacts, but the
top-level cleanup summary hid cleanup-specific proof already emitted by the
seeder. This exposes the cleanup account, deleted FAQ rowcount, and raw delete
status in the compact e2e result so hosted demo runs are easier to audit after
cleanup.

## Intentional
- No seeder cleanup behavior changes.
- No live hosted route behavior changes.
- No broad child-artifact dump; the compact result stays bounded.

## Deferred
- Broader live-host threshold tuning remains deferred until repeated hosted
  route runs produce real latency baselines.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` - 6 passed.
- `git diff --check` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-SaaS-Demo-Cleanup-Summary.md` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-saas-demo-cleanup-summary.md bash scripts/local_pr_review.sh` - passed.

## Diff size
4 files, +115 / -2.
