### PR TITLE
Close support-ticket blog false-green outcome claims

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -58,7 +58,11 @@ _SUPPORT_TICKET_DESCRIPTIVE_FORBIDDEN_CLAIMS = (
     "prevented tickets or fewer repeat questions",
     "churn, retention, upgrade, referral, ROI, or capacity outcomes",
     "claims that FAQ entries help customers find answers or avoid tickets",
+    "claims that customers can find answers themselves because an FAQ exists",
     "faster resolution or customers finding answers without opening tickets",
+    "claims that FAQ entries reduce how often the team answers a question",
+    "claims that FAQ entries perform better in search without measured evidence",
+    "claims that lower repeat tickets prove an FAQ entry is working",
     "concrete answer steps, UI paths, menu names, or capability claims without resolution evidence",
 )
 _SUPPORT_TICKET_DRAFT_ANSWER_GUIDANCE = (
@@ -248,7 +252,10 @@ def _blog_quality_repair_guidance(blockers: Sequence[str]) -> str:
                 "counts, timeframes, clusters, and customer wording present in the "
                 "blueprint. Do not invent calendar windows, ticket-reduction "
                 "percentages, ROI math, future impact claims, or claims that "
-                "customers will or could find answers without opening support tickets."
+                "customers will or could find answers without opening support tickets. "
+                "Do not say FAQ entries reduce support load, reduce how often the "
+                "team answers a question, perform better in search, or prove they "
+                "are working when repeat tickets decline."
             )
             instructions.append(
                 "- If `data_context.support_ticket_blog_mode` is "

--- a/extracted_content_pipeline/support_ticket_generated_content_eval.py
+++ b/extracted_content_pipeline/support_ticket_generated_content_eval.py
@@ -117,6 +117,10 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
+        r"\bcustomers\s+can\s+find\s+it\s+themselves\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
         r"\bfind\s+answers\s+without\s+opening\s+a\s+(?:support\s+)?ticket\b",
         re.IGNORECASE,
     ),
@@ -150,6 +154,10 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
     ),
     re.compile(
         r"\breduces?\s+support\s+load\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bfaq\b[^.!?\n]{0,120}\breduc(?:e|es|ing)\s+support\s+load\b",
         re.IGNORECASE,
     ),
     re.compile(
@@ -269,6 +277,11 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
+        r"\breduces?\s+the\s+number\s+of\s+times\b[^.!?\n]{0,120}"
+        r"\b(?:team|support\s+team)\b[^.!?\n]{0,80}\banswer\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
         r"\breduce\s+the\s+number\s+of\s+tickets\b",
         re.IGNORECASE,
     ),
@@ -356,6 +369,33 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
     ),
     re.compile(
         r"\bsame\s+questions\s+stop\s+appearing\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\ba\s+single\s+faq\s+entry\s+answers\s+it\s+once\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bfixing\s+the\s+faq\s+gap\s+addresses\s+the\s+root\s+cause\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bfaq\s+entries\s+are\s+force\s+multipliers\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bfaq\s+entries\b[^.!?\n]{0,120}\bperform\s+better\s+in\s+search\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bif\s+repeat\s+tickets?\b[^.!?\n]{0,160}\bdecline\b"
+        r"[^.!?\n]{0,160}\bfaq\s+entry\b[^.!?\n]{0,120}"
+        r"\b(?:being\s+found|being\s+used|working)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bif\s+a\s+cluster\s+shows\s+declining\s+repeat\s+tickets\b"
+        r"[^.!?\n]{0,160}\bfaq\s+entry\s+is\s+working\b",
         re.IGNORECASE,
     ),
     re.compile(

--- a/extracted_content_pipeline/support_ticket_generated_content_eval.py
+++ b/extracted_content_pipeline/support_ticket_generated_content_eval.py
@@ -121,6 +121,10 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
+        r"\bcustomers\s+can\s+find\s+answers\s+themselves\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
         r"\bfind\s+answers\s+without\s+opening\s+a\s+(?:support\s+)?ticket\b",
         re.IGNORECASE,
     ),
@@ -278,7 +282,12 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
     ),
     re.compile(
         r"\breduces?\s+the\s+number\s+of\s+times\b[^.!?\n]{0,120}"
-        r"\b(?:team|support\s+team)\b[^.!?\n]{0,80}\banswer\b",
+        r"\b(?:team|support\s+team)\b[^.!?\n]{0,80}\banswers?\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\breduces?\s+how\s+often\b[^.!?\n]{0,120}"
+        r"\b(?:team|support\s+team)\b[^.!?\n]{0,80}\banswers?\b",
         re.IGNORECASE,
     ),
     re.compile(
@@ -396,6 +405,11 @@ _UNSUPPORTED_SUPPORT_OUTCOME_CLAIM_PATTERNS = (
     re.compile(
         r"\bif\s+a\s+cluster\s+shows\s+declining\s+repeat\s+tickets\b"
         r"[^.!?\n]{0,160}\bfaq\s+entry\s+is\s+working\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:declining|lower)\s+repeat\s+tickets\b[^.!?\n]{0,120}"
+        r"\bprove\b[^.!?\n]{0,120}\bfaq\s+entry\s+is\s+working\b",
         re.IGNORECASE,
     ),
     re.compile(

--- a/plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md
+++ b/plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md
@@ -45,6 +45,11 @@ the specific uncovered claim shapes:
 - Publishing FAQ entries reducing support load over time.
 - Customer-wording FAQ entries performing better in search without evidence.
 
+Reviewer follow-up tightened the same categories for direct variants: customers
+finding answers themselves, FAQ entries reducing how often the support team
+answers a question, and lower or declining repeat tickets proving an FAQ entry
+works.
+
 The blog prompt's descriptive support-ticket contract gets matching forbidden
 language so the generator is told not to produce those claims in the first place.
 
@@ -81,7 +86,7 @@ language so the generator is told not to produce those claims in the first place
 - Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
   - Passed; extracted package refreshed from atlas_brain sources.
 - Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-false-green-outcome-claims-pr-body.md
-  - Passed.
+  - Passed after the initial push and again after the review-comment fix.
 
 ## Estimated diff size
 
@@ -91,4 +96,4 @@ language so the generator is told not to produce those claims in the first place
 | Prompt contract | ~10 |
 | Tests | ~45 |
 | Plan doc | ~75 |
-| Total | ~175 |
+| Total | ~195 |

--- a/plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md
+++ b/plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md
@@ -1,0 +1,94 @@
+# Support-Ticket Blog False Green Outcome Claims
+
+## Why this slice exists
+
+The live SaaS demo blog retry after the citable repair contract saved a draft
+and passed the current support-ticket generated-content evaluator, but a manual
+read still found unsupported benefit claims. The draft said FAQ entries reduce
+the number of times the team must answer a question, customers can find answers
+themselves, and declining repeat tickets prove the FAQ entry is working.
+
+That is a false green. The support-ticket blog contract allows observed ticket
+clusters, customer wording, review-needed FAQ shells, verification work, and
+metrics to watch. It does not allow unsupported outcomes or causality claims
+from questions-only ticket data.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+
+Slice phase: Functional validation
+
+1. Add evaluator coverage for the newly observed false-green SaaS demo claims.
+2. Tighten the unsupported-outcome detector so those claims fail before a draft
+   can be accepted.
+3. Tighten the support-ticket descriptive blog prompt so repair attempts avoid
+   the same unsupported benefit phrasing.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py` - prompt contract wording for support-ticket descriptive blogs.
+- `extracted_content_pipeline/support_ticket_generated_content_eval.py` - unsupported outcome claim patterns.
+- `tests/test_evaluate_support_ticket_generated_content.py` - regression coverage for the false-green claims.
+- `plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md` - this plan.
+
+## Mechanism
+
+The evaluator already sentence-splits generated output and tests each sentence
+against unsupported support-ticket outcome patterns. This slice adds patterns for
+the specific uncovered claim shapes:
+
+- FAQ entries reducing how many times the team answers a question.
+- Customers finding answers themselves from the FAQ.
+- Repeat-ticket decline or fewer tickets being treated as proof that the FAQ is
+  being found, used, or working.
+- Publishing FAQ entries reducing support load over time.
+- Customer-wording FAQ entries performing better in search without evidence.
+
+The blog prompt's descriptive support-ticket contract gets matching forbidden
+language so the generator is told not to produce those claims in the first place.
+
+## Intentional
+
+- This does not commit the latest live draft as accepted. The draft exposed the
+  false green and should not become the current passing fixture.
+- This keeps the detector as a regression backstop, not the only control. The
+  prompt contract is updated in the same slice so generation and validation move
+  together.
+- The live retry itself is deferred until this stricter contract lands.
+
+## Deferred
+
+- A follow-up PR should run the SaaS demo blog live smoke again with Haiku after
+  this stricter contract lands, then record an accepted fixture only if the
+  generated content passes both evaluator and manual truthfulness review.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q
+  - Passed, 47 tests.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_saas_demo_blog_acceptance_20260528_after_repair_contract/blog-post-draft.json --pretty
+  - Failed as expected on `support_ticket_outcome_claims_grounded`, including the newly caught unsupported claims from the false-green live draft.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Passed.
+- Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - Passed; extracted package refreshed from atlas_brain sources.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-false-green-outcome-claims-pr-body.md
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Evaluator patterns | ~25 |
+| Prompt contract | ~10 |
+| Tests | ~45 |
+| Plan doc | ~75 |
+| Total | ~175 |

--- a/tests/test_evaluate_support_ticket_generated_content.py
+++ b/tests/test_evaluate_support_ticket_generated_content.py
@@ -938,12 +938,14 @@ def test_blog_export_fails_saas_demo_false_green_outcome_claims() -> None:
 def test_blog_export_fails_final_saas_demo_false_green_outcome_claims() -> None:
     claims = [
         "A single FAQ entry answers it once, and customers can find it themselves.",
+        "Customers can find answers themselves because the FAQ exists.",
         "Fixing the FAQ gap addresses the root cause of repeated support requests.",
         "FAQ entries are force multipliers.",
         (
             "Each FAQ entry you publish reduces the number of times your team "
             "must answer that question."
         ),
+        "FAQ entries reduce how often your support team answers that question.",
         (
             "Customers search for answers using their own language, so FAQ "
             "entries that match customer wording perform better in search and "
@@ -957,6 +959,8 @@ def test_blog_export_fails_final_saas_demo_false_green_outcome_claims() -> None:
             "If a cluster shows declining repeat tickets and high FAQ views, "
             "that FAQ entry is working."
         ),
+        "Declining repeat tickets prove an FAQ entry is working.",
+        "Lower repeat tickets prove an FAQ entry is working.",
         (
             "This prioritized, measurement-focused approach ensures your FAQ "
             "work addresses the highest-volume customer questions first and "

--- a/tests/test_evaluate_support_ticket_generated_content.py
+++ b/tests/test_evaluate_support_ticket_generated_content.py
@@ -935,6 +935,56 @@ def test_blog_export_fails_saas_demo_false_green_outcome_claims() -> None:
     assert outcome_check["details"]["unsupported_claims"] == claims
 
 
+def test_blog_export_fails_final_saas_demo_false_green_outcome_claims() -> None:
+    claims = [
+        "A single FAQ entry answers it once, and customers can find it themselves.",
+        "Fixing the FAQ gap addresses the root cause of repeated support requests.",
+        "FAQ entries are force multipliers.",
+        (
+            "Each FAQ entry you publish reduces the number of times your team "
+            "must answer that question."
+        ),
+        (
+            "Customers search for answers using their own language, so FAQ "
+            "entries that match customer wording perform better in search and "
+            "feel more natural to readers."
+        ),
+        (
+            "If repeat tickets in a cluster decline, the FAQ entry is being "
+            "found and used."
+        ),
+        (
+            "If a cluster shows declining repeat tickets and high FAQ views, "
+            "that FAQ entry is working."
+        ),
+        (
+            "This prioritized, measurement-focused approach ensures your FAQ "
+            "work addresses the highest-volume customer questions first and "
+            "that you can track whether the FAQ is reducing support load over "
+            "time."
+        ),
+    ]
+    export = _blog_export(
+        content_override=(
+            "The uploaded 36 support tickets show reporting and dashboard "
+            "clusters. " + " ".join(claims)
+        )
+    )
+
+    result = evaluator.evaluate_support_ticket_generated_content(
+        export,
+        output="blog_post",
+    )
+
+    assert result["ok"] is False
+    outcome_check = next(
+        check for check in result["checks"]
+        if check["name"] == "support_ticket_outcome_claims_grounded"
+    )
+    assert outcome_check["passed"] is False
+    assert outcome_check["details"]["unsupported_claims"] == claims
+
+
 def test_blog_export_fails_procedural_answer_steps_without_resolution_evidence() -> None:
     export = _blog_export(
         content_override=(


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Blog-False-Green-Outcome-Claims.md
Slice phase: Functional validation

The latest SaaS demo blog live retry passed the current evaluator, but manual review found unsupported benefit claims. This PR closes that false green by tightening both the support-ticket blog prompt contract and the evaluator patterns for the newly observed claim shapes, including the reviewer-identified direct variants.

## Intentional
- The latest live draft is not committed as accepted because it exposed a detector gap.
- The detector remains a regression backstop; the prompt contract is updated in the same slice so generation and validation move together.
- The next live Haiku retry is deferred until this stricter contract lands.

## Deferred
- Follow-up: rerun the 36-row SaaS demo blog live smoke with Haiku after merge, then record an accepted fixture only if the output passes evaluator and manual truthfulness review.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_evaluate_support_ticket_generated_content.py -q` — passed, 47 tests.
- `python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_saas_demo_blog_acceptance_20260528_after_repair_contract/blog-post-draft.json --pretty` — failed as expected on `support_ticket_outcome_claims_grounded`.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-false-green-outcome-claims-pr-body.md` — passed after the initial push and again after the review-comment fix.

## Diff size
4 files, ~195 LOC.
