### PR TITLE
Pin SaaS FAQ malformed artifact gate

### DIFF
--- a/plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md
+++ b/plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md
@@ -1,0 +1,77 @@
+# PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate
+
+## Why this slice exists
+
+#1072 made SaaS demo e2e child artifacts load-bearing and pinned two detector
+paths: a missing result artifact and a present artifact with `ok: false`. The
+same fail-closed branch also handles malformed JSON and non-object JSON, but
+those parser inputs are not pinned by a focused fixture. Atlas' checker/gate
+contract says parser/type checks should reject malformed JSON and unrelated
+envelopes explicitly, so this slice locks that behavior before more hosted demo
+work builds on the wrapper.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation.
+
+1. Add a focused negative fixture for a route command that exits 0 while writing
+   malformed JSON to its result artifact.
+2. Prove the wrapper exits 1 from artifact-read status, not from route process
+   status.
+3. Keep production wrapper behavior unchanged.
+
+### Files touched
+
+- `plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md`
+- `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
+
+## Mechanism
+
+The existing `_read_json_object(...)` helper returns a compact artifact with
+`available: False`, `ok: False`, and a JSON parse diagnostic when a child result
+artifact cannot be decoded. `_artifact_status_errors(...)` already folds that
+diagnostic into the top-level `errors` list and makes `summary["ok"]` false.
+
+This slice drives that path through the wrapper-level test harness by making
+the fake route subprocess exit successfully while writing invalid JSON to
+the route result artifact.
+
+## Intentional
+
+- No production code changes; #1072 already implemented the behavior.
+- No live hosted route behavior changes.
+- No broad malformed-artifact matrix is added. This pins the parser-specific
+  branch with the smallest representative fixture.
+
+## Deferred
+
+- Parked hardening: none.
+- Non-object JSON rejection is the same `_read_json_object(...)` unavailable
+  artifact branch and remains covered by the helper's branch shape rather than
+  a second near-duplicate wrapper fixture.
+
+## Verification
+
+- python -m py_compile tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+  - passed.
+- python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q
+  - 9 passed.
+- git diff --check
+  - passed.
+- python scripts/audit_plan_doc.py plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md
+  - passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md
+  - passed.
+- bash scripts/check_ascii_python.sh
+  - passed.
+- ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-saas-demo-malformed-artifact-gate.md bash scripts/local_pr_review.sh
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 77 |
+| Tests | 22 |
+| **Total** | **99** |

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -43,6 +43,7 @@ def _fake_runner(
     *,
     route_ok: bool = True,
     route_artifact_ok: bool | None = None,
+    route_artifact_body: str | None = None,
     route_writes_artifact: bool = True,
     seed_faq_id: str = "faq-123",
 ):
@@ -94,7 +95,10 @@ def _fake_runner(
             return {"ok": True, "returncode": 0, "stdout_tail": "", "stderr_tail": ""}
         if str(smoke.ROUTE_SCRIPT) in command:
             route_result = Path(command[command.index("--output-result") + 1])
-            if route_writes_artifact:
+            if route_artifact_body is not None:
+                route_result.parent.mkdir(parents=True, exist_ok=True)
+                route_result.write_text(route_artifact_body, encoding="utf-8")
+            elif route_writes_artifact:
                 _write_json(
                     route_result,
                     {
@@ -230,6 +234,22 @@ def test_main_fails_when_successful_route_omits_result_artifact(tmp_path, monkey
     assert len(payload["errors"]) == 1
     assert payload["errors"][0].startswith("route result could not be read:")
     assert str(tmp_path / "artifacts" / "route-result.json") in payload["errors"][0]
+    assert payload["cleanup"]["ok"] is True
+    assert len(calls) == 3
+
+
+def test_main_fails_when_successful_route_writes_malformed_artifact(tmp_path, monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(smoke, "_run_command", _fake_runner(calls, route_artifact_body="{"))
+
+    code = smoke.main(_base_args(tmp_path))
+
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert code == 1
+    assert payload["route"]["ok"] is True
+    assert payload["route"]["result_artifact"]["available"] is False
+    assert payload["route"]["result_artifact"]["ok"] is False
+    assert payload["errors"] == ["route result must contain JSON: Expecting property name enclosed in double quotes"]
     assert payload["cleanup"]["ok"] is True
     assert len(calls) == 3
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md
Slice phase: Functional validation.

#1072 made SaaS demo e2e child artifacts load-bearing. This test-only slice
pins the malformed JSON parser path so a route subprocess that exits 0 but
writes invalid result JSON still fails the wrapper from artifact-read status.

## Intentional
- No production code changes.
- No live hosted route behavior changes.
- No broad malformed-artifact matrix; one representative parser fixture pins
  the branch.

## Deferred
- Non-object JSON rejection is the same unavailable-artifact branch and remains
  covered by the helper's branch shape rather than a second near-duplicate
  wrapper fixture.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` - 9 passed.
- `git diff --check` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-SaaS-Demo-Malformed-Artifact-Gate.md` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-saas-demo-malformed-artifact-gate.md bash scripts/local_pr_review.sh` - passed.

## Diff size
2 files, +98 / -1.
