### PR TITLE
Add FAQ live run blocker preflight

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -14,15 +14,37 @@ coverage, use `content_ops_faq_seeded_route_e2e_runbook.md`.
 - `ATLAS_API_BASE_URL`: deployed Atlas API host, for example
   `https://atlas-api.example.com`.
 - `ATLAS_B2B_JWT` or `ATLAS_TOKEN`: bearer token for the account under test.
-- `ATLAS_FAQ_SEARCH_ACCOUNT_ID`: account ID matching the bearer token. The
-  seeder writes the demo FAQ under this account, and the hosted route smoke uses
-  the token to query it.
+- `ATLAS_FAQ_SEARCH_ACCOUNT_ID` or `ATLAS_ACCOUNT_ID`: account ID matching the
+  bearer token. The seeder writes the demo FAQ under this account, and the
+  hosted route smoke uses the token to query it.
 
 Run the FAQ search migrations before this smoke:
 
 ```bash
 python scripts/run_extracted_content_pipeline_migrations.py
 ```
+
+## Hosted Run Blocker Preflight
+
+Run this before the live smoke to classify whether issue #1075 is blocked by
+missing hosted inputs or ready for the DB write plus hosted route measurement:
+
+```bash
+python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
+  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
+  --base-url "$ATLAS_API_BASE_URL" \
+  --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
+  --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
+  --preflight-only \
+  --json \
+  --output-result /tmp/faq-saas-demo-route-e2e-preflight.json
+```
+
+Exit code `2` means one or more required inputs are missing. Inspect
+`preflight_errors` and `required_inputs` in the result artifact; the payload
+only reports present/missing booleans and does not include secret values. Exit
+code `0` means the blocker has moved from input availability to running the
+recommended one-command smoke below.
 
 ## Recommended One-Command Smoke
 
@@ -31,7 +53,7 @@ python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
   --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
-  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
   --route-requests 40 \
   --concurrency 8 \
   --max-error-rate 0 \
@@ -60,7 +82,7 @@ file between seed and route validation.
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \
   --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
-  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
   --route-case-file-output /tmp/faq-saas-demo-route-cases.json \
   --output-result /tmp/faq-saas-demo-seed-result.json
 ```
@@ -153,7 +175,7 @@ database, delete it with the FAQ id from the seed result:
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \
   --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
-  --account-id "$ATLAS_FAQ_SEARCH_ACCOUNT_ID" \
+  --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
   --cleanup-faq-id "<faq_id_from_seed_result>" \
   --output-result /tmp/faq-saas-demo-cleanup-result.json
 ```

--- a/plans/PR-FAQ-Live-Run-Blocker-Preflight.md
+++ b/plans/PR-FAQ-Live-Run-Blocker-Preflight.md
@@ -1,0 +1,93 @@
+# PR-FAQ-Live-Run-Blocker-Preflight
+
+## Why this slice exists
+
+Issue #1075 calls out that the FAQ hosted route e2e harness is ready, but the
+live run has stayed deferred because the blocking hosted inputs are not explicit
+enough. The next useful slice is not another result-envelope field; it is a
+safe preflight that answers whether the deployed host inputs are present before
+an operator attempts the DB write plus hosted route smoke.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Functional validation.
+
+1. Add a `--preflight-only` mode to the SaaS demo route e2e wrapper.
+2. Emit a redacted required-input status summary for the DB URL, API base URL,
+   bearer token, and FAQ account id.
+3. Prove preflight-only success exits 0 without invoking seed, route, or cleanup
+   subprocesses.
+4. Update the runbook so issue #1075 has an explicit blocker-classification
+   command before the live run.
+5. Pin the documented preflight command and disambiguate the existing
+   one-command smoke parser pin so multiple e2e wrapper commands can coexist in
+   the runbook.
+
+### Files touched
+
+- `plans/PR-FAQ-Live-Run-Blocker-Preflight.md`
+- `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `tests/test_content_ops_faq_saas_demo_corpus.py`
+- `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md`
+
+## Mechanism
+
+The existing `_validate_args(...)` already knows the required hosted inputs.
+This slice adds `_required_input_status(...)`, which reports only booleans:
+
+```python
+{"database_url": {"present": True}, "token": {"present": False}}
+```
+
+`--preflight-only` runs validation, writes the same result file path when
+requested, prints JSON when `--json` is set, and exits before `run(args)`.
+Missing inputs still exit 2; ready inputs exit 0 with seed/route/cleanup marked
+as skipped for `preflight_only`.
+
+## Intentional
+
+- No live hosted route behavior changes.
+- No secret values are printed or written to the result artifact.
+- No DB or HTTP connectivity probe is added here; this is only the blocker
+  classification step before the live smoke.
+- Runbook commands now use the script-supported `ATLAS_ACCOUNT_ID` fallback so
+  preflight classification does not false-negative when only the generic account
+  variable is configured.
+
+## Deferred
+
+- Parked hardening: none.
+- The actual hosted run remains the next operator step once the preflight shows
+  all required inputs are present.
+
+## Verification
+
+- `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py`
+  - passed.
+- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q`
+  - 36 passed.
+- `python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --database-url postgresql://example/atlas --base-url https://atlas.example.com --token token-123 --account-id acct-1 --preflight-only --json --output-result /tmp/faq-preflight-proof.json`
+  - passed; result had `ok: true`, `phase: preflight`, all required inputs present, and seed/route/cleanup skipped for `preflight_only`.
+- `git diff --check`
+  - passed.
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-Live-Run-Blocker-Preflight.md`
+  - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Live-Run-Blocker-Preflight.md`
+  - passed.
+- `bash scripts/check_ascii_python.sh`
+  - passed.
+- `ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-live-run-blocker-preflight.md bash scripts/local_pr_review.sh`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 93 |
+| E2E wrapper | 40 |
+| Corpus/runbook tests | 31 |
+| Wrapper tests | 36 |
+| Runbook | 34 |
+| **Total** | **234** |

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -63,6 +63,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--artifact-dir", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--keep-data", action="store_true")
+    parser.add_argument("--preflight-only", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -110,6 +111,15 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
     return errors
+
+
+def _required_input_status(args: argparse.Namespace) -> dict[str, dict[str, bool]]:
+    return {
+        "database_url": {"present": bool(str(args.database_url or "").strip())},
+        "base_url": {"present": bool(str(args.base_url or "").strip())},
+        "token": {"present": bool(str(args.token or "").strip())},
+        "account_id": {"present": bool(str(args.account_id or "").strip())},
+    }
 
 
 def _seed_command(args: argparse.Namespace, *, case_file: Path, seed_result: Path) -> list[str]:
@@ -305,14 +315,22 @@ def _not_run(reason: str) -> dict[str, Any]:
     }
 
 
-def _preflight_summary(errors: Sequence[str], elapsed: float) -> dict[str, Any]:
+def _preflight_summary(
+    args: argparse.Namespace,
+    errors: Sequence[str],
+    elapsed: float,
+    *,
+    reason: str = "preflight_failed",
+) -> dict[str, Any]:
+    ok = not errors
     return {
-        "ok": False,
+        "ok": ok,
         "phase": "preflight",
         "preflight_errors": list(errors),
-        "seed": _not_run("preflight_failed"),
-        "route": _not_run("preflight_failed"),
-        "cleanup": {"ok": True, "skipped": True, "not_run_reason": "preflight_failed"},
+        "required_inputs": _required_input_status(args),
+        "seed": _not_run(reason),
+        "route": _not_run(reason),
+        "cleanup": {"ok": True, "skipped": True, "not_run_reason": reason},
         "elapsed_seconds": elapsed,
     }
 
@@ -405,10 +423,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     errors = _validate_args(args)
     if errors:
-        summary = _preflight_summary(errors, time.perf_counter() - start)
+        summary = _preflight_summary(args, errors, time.perf_counter() - start)
         _write_result(args.output_result, summary)
         _print_summary(summary, as_json=args.json)
         return 2
+    if args.preflight_only:
+        summary = _preflight_summary(
+            args,
+            (),
+            time.perf_counter() - start,
+            reason="preflight_only",
+        )
+        _write_result(args.output_result, summary)
+        _print_summary(summary, as_json=args.json)
+        return 0
 
     summary = run(args)
     _write_result(args.output_result, summary)

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -108,9 +108,10 @@ def _generated_demo_faq():
     return rows, normalized, result
 
 
-def _runbook_command_args(marker: str) -> list[str]:
+def _runbook_command_args(marker: str, *, section: str | None = None) -> list[str]:
     doc = RUNBOOK_PATH.read_text(encoding="utf-8")
-    start = doc.index(marker)
+    search_from = doc.index(section) if section is not None else 0
+    start = doc.index(marker, search_from)
     end = doc.index("```", start)
     command = doc[start:end].replace("\\\n", " ")
     parts = shlex.split(command)
@@ -213,7 +214,8 @@ def test_saas_demo_route_case_runbook_migration_command_matches_parser() -> None
 
 def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
     args = _runbook_command_args(
-        "python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py"
+        "python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py",
+        section="## Recommended One-Command Smoke",
     )
 
     parsed = e2e_smoke._build_parser().parse_args(args)
@@ -221,7 +223,7 @@ def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
     assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
     assert parsed.base_url == "$ATLAS_API_BASE_URL"
     assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
-    assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"
+    assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
     assert parsed.route_requests == 40
     assert parsed.concurrency == 8
     assert parsed.max_error_rate == 0
@@ -232,13 +234,32 @@ def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
     assert e2e_smoke._validate_args(parsed) == []
 
 
+def test_saas_demo_route_case_runbook_preflight_command_matches_parser() -> None:
+    args = _runbook_command_args(
+        "python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py",
+        section="## Hosted Run Blocker Preflight",
+    )
+
+    parsed = e2e_smoke._build_parser().parse_args(args)
+
+    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert parsed.base_url == "$ATLAS_API_BASE_URL"
+    assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
+    assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
+    assert parsed.preflight_only is True
+    assert parsed.json is True
+    assert parsed.artifact_dir is None
+    assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-preflight.json")
+    assert e2e_smoke._validate_args(parsed) == []
+
+
 def test_saas_demo_route_case_runbook_seed_command_matches_parser() -> None:
     args = _runbook_command_args("python scripts/seed_content_ops_faq_saas_demo.py")
 
     parsed = seeder._parse_args(args)
 
     assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
-    assert parsed.account_id == "$ATLAS_FAQ_SEARCH_ACCOUNT_ID"
+    assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
     assert parsed.route_case_file_output == Path("/tmp/faq-saas-demo-route-cases.json")
     assert parsed.output_result == Path("/tmp/faq-saas-demo-seed-result.json")
     assert parsed.cleanup_faq_id is None

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -177,9 +177,45 @@ def test_main_writes_preflight_result_before_exit(tmp_path, capsys) -> None:
     payload = json.loads(result_path.read_text(encoding="utf-8"))
     assert code == 2
     assert payload["phase"] == "preflight"
+    assert payload["required_inputs"] == {
+        "database_url": {"present": False},
+        "base_url": {"present": False},
+        "token": {"present": False},
+        "account_id": {"present": False},
+    }
     assert payload["seed"]["not_run_reason"] == "preflight_failed"
     assert payload["route"]["not_run_reason"] == "preflight_failed"
     assert json.loads(capsys.readouterr().out)["ok"] is False
+
+
+def test_main_preflight_only_reports_ready_inputs_without_running_children(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(smoke, "_run_command", _fake_runner(calls))
+    result_path = tmp_path / "preflight-ready.json"
+
+    code = smoke.main([*_base_args(tmp_path), "--preflight-only", "--output-result", str(result_path), "--json"])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    stdout_payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["phase"] == "preflight"
+    assert payload["preflight_errors"] == []
+    assert payload["required_inputs"] == {
+        "database_url": {"present": True},
+        "base_url": {"present": True},
+        "token": {"present": True},
+        "account_id": {"present": True},
+    }
+    assert payload["seed"]["not_run_reason"] == "preflight_only"
+    assert payload["route"]["not_run_reason"] == "preflight_only"
+    assert payload["cleanup"]["not_run_reason"] == "preflight_only"
+    assert stdout_payload["required_inputs"] == payload["required_inputs"]
+    assert calls == []
 
 
 def test_main_runs_seed_route_and_cleanup(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Live-Run-Blocker-Preflight.md
Slice phase: Functional validation.

Issue #1075 calls out that the FAQ hosted route harness is ready, but the live
run is still blocked by unclear hosted inputs. This adds a safe `--preflight-only`
mode that reports whether the DB URL, API base URL, bearer token, and FAQ
account id are present without printing secret values or touching the DB/API.

## Intentional
- No live hosted route behavior changes.
- No secret values are printed or written to the result artifact.
- No DB or HTTP connectivity probe is added here; this only classifies input
  availability before the live smoke.
- Runbook commands use the script-supported `ATLAS_ACCOUNT_ID` fallback.

## Deferred
- The actual hosted run remains the next operator step once the preflight shows
  all required inputs are present.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py` - passed.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` - 36 passed.
- `python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --database-url postgresql://example/atlas --base-url https://atlas.example.com --token token-123 --account-id acct-1 --preflight-only --json --output-result /tmp/faq-preflight-proof.json` - passed; result had `ok: true`, `phase: preflight`, all required inputs present, and seed/route/cleanup skipped for `preflight_only`.
- `git diff --check` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Live-Run-Blocker-Preflight.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Live-Run-Blocker-Preflight.md` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `ATLAS_CURRENT_PR_BODY_FILE=/home/juan-canfield/Desktop/atlas-pr-bodies/faq-live-run-blocker-preflight.md bash scripts/local_pr_review.sh` - passed.

## Diff size
5 files, +217 / -17.
