### PR TITLE
Tighten support-ticket blog descriptive prompt

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -72,6 +72,12 @@ _SUPPORT_TICKET_DESCRIPTIVE_FORBIDDEN_CLAIMS = (
 _SUPPORT_TICKET_DRAFT_ANSWER_GUIDANCE = (
     "Draft answer - support team should add the verified resolution before publishing."
 )
+_SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS = (
+    "support_ticket_blog_mode",
+    "allowed_claims",
+    "forbidden_claims",
+    "draft_answer_guidance",
+)
 
 
 @dataclass(frozen=True)
@@ -939,13 +945,16 @@ def _blueprint_with_support_ticket_blog_contract(
     blueprint: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     data_context = _mapping_dict(blueprint.get("data_context"))
-    contract = support_ticket_descriptive_blog_contract(data_context)
-    if not contract:
+    if not _is_support_ticket_blog_context(data_context):
         return blueprint
+    contract = support_ticket_descriptive_blog_contract(data_context)
     enriched = dict(blueprint)
     merged = dict(data_context)
-    for key, value in contract.items():
-        merged.setdefault(key, value)
+    for key in _SUPPORT_TICKET_DESCRIPTIVE_CONTRACT_KEYS:
+        merged.pop(key, None)
+    merged.update(contract)
+    if merged == data_context:
+        return blueprint
     enriched["data_context"] = merged
     return enriched
 
@@ -1004,7 +1013,7 @@ def _with_support_ticket_descriptive_prompt_addendum(
     blueprint: Mapping[str, Any],
 ) -> str:
     data_context = _mapping_dict(blueprint.get("data_context"))
-    if data_context.get("support_ticket_blog_mode") != SUPPORT_TICKET_DESCRIPTIVE_BLOG_MODE:
+    if not support_ticket_descriptive_blog_contract(data_context):
         return prompt
     return (
         f"{prompt}\n\n"

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -991,7 +991,42 @@ def _blog_generation_prompts(
     # on the prior prompt (without ``{topic}``) are unaffected -- the
     # ``replace()`` is a no-op when the placeholder isn't present.
     system_prompt = system_prompt.replace("{topic}", topic)
+    base_user_prompt = _with_support_ticket_descriptive_prompt_addendum(
+        base_user_prompt,
+        blueprint=blueprint,
+    )
     return system_prompt, base_user_prompt
+
+
+def _with_support_ticket_descriptive_prompt_addendum(
+    prompt: str,
+    *,
+    blueprint: Mapping[str, Any],
+) -> str:
+    data_context = _mapping_dict(blueprint.get("data_context"))
+    if data_context.get("support_ticket_blog_mode") != SUPPORT_TICKET_DESCRIPTIVE_BLOG_MODE:
+        return prompt
+    return (
+        f"{prompt}\n\n"
+        "Support-ticket descriptive mode instructions:\n"
+        "- Write a descriptive support-ticket FAQ planning brief, not a "
+        "persuasive ROI article.\n"
+        "- Use only observed ticket counts, observed clusters, copied customer "
+        "wording, and review-needed FAQ shells from the blueprint.\n"
+        "- If clusters have the same count, say they are tied. Do not rank tied "
+        "clusters by business impact, activation risk, workflow blocking, "
+        "friction reduction, deal impact, or customer value unless the blueprint "
+        "contains measured outcome evidence for that ranking.\n"
+        "- If the blueprint lacks resolution evidence, keep answer content as "
+        "draft placeholders for support-team review. Do not invent UI paths, "
+        "setup steps, feature behavior, or exact resolutions.\n"
+        "- Measurement language must be observational only: say what to watch or "
+        "compare after publishing, but do not say ticket volume will decline, "
+        "the FAQ entry is working, customers will find it, search visibility will "
+        "improve, or the entry will rank for keywords.\n"
+        "- Apply the same limits to title, description, metadata, FAQ metadata, "
+        "tags, and chart copy."
+    )
 
 
 def _public_blog_json(parsed: Mapping[str, Any]) -> str:

--- a/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
+++ b/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
@@ -1,0 +1,81 @@
+# Support-Ticket Blog Descriptive Prompt Contract
+
+## Why this slice exists
+
+The representative SaaS demo blog still fails manual truthfulness review after
+the evaluator catches the latest false-green claims. The source issue is that
+the generator receives a structured descriptive contract, but the user prompt
+still asks for a normal persuasive blog. Haiku keeps filling that genre with
+speculative activation, prioritization, discoverability, search, and
+post-publication outcome claims.
+
+This slice makes the descriptive support-ticket contract explicit in the prompt
+surface before the next live retry.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+
+Slice phase: Functional validation
+
+1. Add a support-ticket descriptive prompt addendum for blogs generated from
+   questions-only ticket evidence.
+2. Tell the generator to use only observed counts, clusters, customer wording,
+   and review-needed FAQ shells; neutralize tied-cluster ranking; and keep
+   post-publication measurement language non-promissory.
+3. Pin that the addendum appears in both first-pass and repair prompts.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py` - descriptive support-ticket prompt addendum.
+- `plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md` - this plan.
+- `tests/test_extracted_blog_generation.py` - prompt contract coverage.
+
+## Mechanism
+
+`_blog_generation_prompts` already receives the enriched blueprint, including
+`data_context.support_ticket_blog_mode`. This PR appends a small, explicit user
+prompt addendum when that mode is `descriptive_no_outcome`.
+
+The addendum repeats the contract in plain instructions the model sees right
+before generation: describe what the uploaded tickets show, avoid business
+impact ranking unless the input has outcome evidence, treat tied clusters as
+tied, use draft-answer placeholders when resolution evidence is absent, and do
+not claim FAQ entries will be discoverable, rank, reduce tickets, or prove they
+are working.
+
+Because repair prompts reuse the original base user prompt, the same addendum
+also carries into quality repair attempts.
+
+## Intentional
+
+- This PR does not run another live generation. It first fixes the prompt
+  contract source that caused the last live retries to drift.
+- The evaluator backstop remains unchanged here; the previous slice already
+  proved it catches the observed bad drafts.
+- The addendum is only applied for support-ticket blogs without measured
+  outcomes or resolution evidence.
+
+## Deferred
+
+- Run the 36-row SaaS demo Haiku blog live retry after this prompt contract
+  lands.
+- If Haiku still drifts after this, the next source fix should narrow the
+  section outline or add a deterministic FAQ-shell scaffold before generation.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_extracted_blog_generation.py::test_generate_puts_support_ticket_descriptive_contract_in_prompt tests/test_extracted_blog_generation.py::test_quality_repair_prompt_keeps_support_ticket_descriptive_contract -q
+  - Passed, 2 tests.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-descriptive-prompt-contract-pr-body.md
+  - Pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Prompt addendum | ~45 |
+| Tests | ~25 |
+| Plan doc | ~70 |
+| Total | ~140 |

--- a/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
+++ b/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
@@ -37,7 +37,7 @@ Slice phase: Functional validation
 
 `_blog_generation_prompts` already receives the enriched blueprint, including
 the support-ticket data context. This PR appends a small, explicit user prompt
-addendum when recomputing `support_ticket_descriptive_blog_contract()` says the
+addendum when recomputing the support-ticket descriptive blog contract says the
 context is questions-only support-ticket evidence.
 
 The addendum repeats the contract in plain instructions the model sees right

--- a/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
+++ b/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
@@ -75,7 +75,7 @@ repair attempts.
 - Command: python -m pytest tests/test_extracted_blog_generation.py::test_generate_puts_support_ticket_descriptive_contract_in_prompt tests/test_extracted_blog_generation.py::test_generate_recomputes_stale_support_ticket_descriptive_contract tests/test_extracted_blog_generation.py::test_generate_clears_stale_descriptive_contract_for_outcome_backed_context tests/test_extracted_blog_generation.py::test_quality_repair_prompt_keeps_support_ticket_descriptive_contract -q
   - Passed, 4 tests.
 - Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-descriptive-prompt-contract-pr-body.md
-  - Pending.
+  - Passed.
 
 ## Estimated diff size
 

--- a/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
+++ b/plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
@@ -23,7 +23,9 @@ Slice phase: Functional validation
 2. Tell the generator to use only observed counts, clusters, customer wording,
    and review-needed FAQ shells; neutralize tied-cluster ranking; and keep
    post-publication measurement language non-promissory.
-3. Pin that the addendum appears in both first-pass and repair prompts.
+3. Recompute the full descriptive contract before applying the addendum so stale
+   caller-provided mode flags cannot suppress or force it.
+4. Pin that the addendum appears in both first-pass and repair prompts.
 
 ### Files touched
 
@@ -34,8 +36,9 @@ Slice phase: Functional validation
 ## Mechanism
 
 `_blog_generation_prompts` already receives the enriched blueprint, including
-`data_context.support_ticket_blog_mode`. This PR appends a small, explicit user
-prompt addendum when that mode is `descriptive_no_outcome`.
+the support-ticket data context. This PR appends a small, explicit user prompt
+addendum when recomputing `support_ticket_descriptive_blog_contract()` says the
+context is questions-only support-ticket evidence.
 
 The addendum repeats the contract in plain instructions the model sees right
 before generation: describe what the uploaded tickets show, avoid business
@@ -44,8 +47,11 @@ tied, use draft-answer placeholders when resolution evidence is absent, and do
 not claim FAQ entries will be discoverable, rank, reduce tickets, or prove they
 are working.
 
-Because repair prompts reuse the original base user prompt, the same addendum
-also carries into quality repair attempts.
+The blueprint enrichment now also clears stale descriptive contract fields for
+support-ticket contexts that no longer qualify and overwrites stale non-matching
+mode fields for questions-only contexts that do qualify. Because repair prompts
+reuse the original base user prompt, the same addendum also carries into quality
+repair attempts.
 
 ## Intentional
 
@@ -53,8 +59,8 @@ also carries into quality repair attempts.
   contract source that caused the last live retries to drift.
 - The evaluator backstop remains unchanged here; the previous slice already
   proved it catches the observed bad drafts.
-- The addendum is only applied for support-ticket blogs without measured
-  outcomes or resolution evidence.
+- The addendum is only applied after recomputing the full evidence contract, so
+  stale caller-provided mode fields do not decide prompt behavior.
 
 ## Deferred
 
@@ -66,8 +72,8 @@ also carries into quality repair attempts.
 
 ## Verification
 
-- Command: python -m pytest tests/test_extracted_blog_generation.py::test_generate_puts_support_ticket_descriptive_contract_in_prompt tests/test_extracted_blog_generation.py::test_quality_repair_prompt_keeps_support_ticket_descriptive_contract -q
-  - Passed, 2 tests.
+- Command: python -m pytest tests/test_extracted_blog_generation.py::test_generate_puts_support_ticket_descriptive_contract_in_prompt tests/test_extracted_blog_generation.py::test_generate_recomputes_stale_support_ticket_descriptive_contract tests/test_extracted_blog_generation.py::test_generate_clears_stale_descriptive_contract_for_outcome_backed_context tests/test_extracted_blog_generation.py::test_quality_repair_prompt_keeps_support_ticket_descriptive_contract -q
+  - Passed, 4 tests.
 - Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-descriptive-prompt-contract-pr-body.md
   - Pending.
 
@@ -75,7 +81,7 @@ also carries into quality repair attempts.
 
 | Area | Estimated LOC |
 |---|---:|
-| Prompt addendum | ~45 |
-| Tests | ~25 |
-| Plan doc | ~70 |
-| Total | ~140 |
+| Prompt addendum | ~55 |
+| Tests | ~70 |
+| Plan doc | ~80 |
+| Total | ~205 |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -846,10 +846,15 @@ async def test_generate_puts_support_ticket_descriptive_contract_in_prompt() -> 
 
     assert result.generated == 1
     system_prompt = llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
     assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in system_prompt
     assert '"allowed_claims":' in system_prompt
     assert '"forbidden_claims":' in system_prompt
     assert '"draft_answer_guidance":' in system_prompt
+    assert "Support-ticket descriptive mode instructions:" in user_prompt
+    assert "Do not rank tied clusters by business impact" in user_prompt
+    assert "Measurement language must be observational only" in user_prompt
+    assert "metadata, FAQ metadata, tags, and chart copy" in user_prompt
 
 
 @pytest.mark.asyncio
@@ -882,6 +887,8 @@ async def test_quality_repair_prompt_keeps_support_ticket_descriptive_contract()
     retry_prompt = llm.calls[1]["messages"][1].content
     assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in repair_system_prompt
     assert "follow its `allowed_claims`, `forbidden_claims`, and `draft_answer_guidance`" in retry_prompt
+    assert "Support-ticket descriptive mode instructions:" in retry_prompt
+    assert "Do not rank tied clusters by business impact" in retry_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -858,6 +858,63 @@ async def test_generate_puts_support_ticket_descriptive_contract_in_prompt() -> 
 
 
 @pytest.mark.asyncio
+async def test_generate_recomputes_stale_support_ticket_descriptive_contract() -> None:
+    blueprint = _support_ticket_blueprint()
+    blueprint["data_context"]["support_ticket_blog_mode"] = "stale_non_descriptive"
+    service, _blueprints, _blog_posts, llm, _skills = _service(
+        rows=[blueprint],
+        responses=[_valid_support_ticket_blog_json()],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in system_prompt
+    assert "stale_non_descriptive" not in system_prompt
+    assert "Support-ticket descriptive mode instructions:" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_clears_stale_descriptive_contract_for_outcome_backed_context() -> None:
+    blueprint = _support_ticket_blueprint()
+    blueprint["data_context"].update({
+        "has_measured_outcomes": True,
+        "support_ticket_blog_mode": "descriptive_no_outcome",
+        "allowed_claims": ["stale allowed"],
+        "forbidden_claims": ["stale forbidden"],
+        "draft_answer_guidance": "stale draft guidance",
+    })
+    service, _blueprints, blog_posts, llm, _skills = _service(
+        rows=[blueprint],
+        responses=[_valid_support_ticket_blog_json()],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    system_prompt = llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert "support_ticket_blog_mode" not in draft.data_context
+    assert "allowed_claims" not in draft.data_context
+    assert "forbidden_claims" not in draft.data_context
+    assert "draft_answer_guidance" not in draft.data_context
+    assert "descriptive_no_outcome" not in system_prompt
+    assert "stale allowed" not in system_prompt
+    assert "Support-ticket descriptive mode instructions:" not in user_prompt
+
+
+@pytest.mark.asyncio
 async def test_quality_repair_prompt_keeps_support_ticket_descriptive_contract() -> None:
     bad_content = _valid_support_ticket_content(
         "These answers can reduce repeat tickets by 30-45%."


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Blog-Descriptive-Prompt-Contract.md
Slice phase: Functional validation

This PR makes the questions-only support-ticket blog contract explicit in the user prompt before the next live Haiku retry. The generator now receives direct instructions to write a descriptive FAQ planning brief, keep tied clusters tied, avoid unsupported business-impact prioritization, keep measurement language observational, and apply the same limits to metadata/FAQ metadata/tags/chart copy. The addendum is gated by recomputing the full support-ticket descriptive contract, and stale descriptive contract fields are cleared or overwritten during blueprint enrichment.

## Intentional
- No live retry in this slice; this fixes the source prompt contract first.
- The evaluator backstop is unchanged here because the previous slice already pinned the observed false-green claims.
- The addendum only applies after recomputing the full evidence contract, so stale caller-provided mode fields do not decide prompt behavior.

## Deferred
- Run the 36-row SaaS demo Haiku blog live retry after this lands.
- If Haiku still drifts, narrow the section outline or add a deterministic FAQ-shell scaffold before generation.

## Parked hardening
None.

## Verification
- `python -m pytest tests/test_extracted_blog_generation.py::test_generate_puts_support_ticket_descriptive_contract_in_prompt tests/test_extracted_blog_generation.py::test_generate_recomputes_stale_support_ticket_descriptive_contract tests/test_extracted_blog_generation.py::test_generate_clears_stale_descriptive_contract_for_outcome_backed_context tests/test_extracted_blog_generation.py::test_quality_repair_prompt_keeps_support_ticket_descriptive_contract -q` — passed, 4 tests.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/support-ticket-blog-descriptive-prompt-contract-pr-body.md` — passed after the review fixes.

## Diff size
~205 LOC.