### PR TITLE
Harden blog prompt cache stability

### DIFF
--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -989,17 +989,21 @@ def _blog_generation_prompts(
     topic: str = "",
 ) -> tuple[str, str]:
     blueprint_json = json.dumps(dict(blueprint), separators=(",", ":"), default=str)
-    if "{blueprint_json}" in prompt_template:
-        system_prompt = prompt_template.replace("{blueprint_json}", blueprint_json)
-        base_user_prompt = "Generate one blog post from the blueprint above."
-    else:
-        system_prompt = prompt_template
-        base_user_prompt = f"Generate one blog post from this blueprint JSON:\n{blueprint_json}"
-    # PR-Blog-Topic-Per-Call: operator-supplied topic substitutes into
-    # the ``{topic}`` placeholder. Empty topic resolves to "" so hosts
-    # on the prior prompt (without ``{topic}``) are unaffected -- the
-    # ``replace()`` is a no-op when the placeholder isn't present.
-    system_prompt = system_prompt.replace("{topic}", topic)
+    system_prompt = (
+        prompt_template
+        .replace("{blueprint_json}", "the blueprint JSON supplied in the user message")
+        .replace("{topic}", "the operator-supplied topic provided in the user message")
+    )
+    base_user_prompt_parts = [
+        "Generate one blog post from this blueprint JSON:",
+        blueprint_json,
+    ]
+    if topic:
+        base_user_prompt_parts.extend((
+            "",
+            f"Operator-supplied topic focus: {topic}",
+        ))
+    base_user_prompt = "\n".join(base_user_prompt_parts)
     base_user_prompt = _with_support_ticket_descriptive_prompt_addendum(
         base_user_prompt,
         blueprint=blueprint,

--- a/plans/PR-Blog-Prompt-Cache-Stability.md
+++ b/plans/PR-Blog-Prompt-Cache-Stability.md
@@ -1,0 +1,76 @@
+# PR-Blog-Prompt-Cache-Stability
+
+## Why this slice exists
+
+The live support-ticket SaaS demo retry proved provider prompt caching is
+hitting (`cached_tokens=9814`, `cache_write_tokens=17434`), but the blog prompt
+builder still allows stored skill templates to place per-run `{topic}` and
+`{blueprint_json}` values in the system prompt. That can silently collapse the
+cache for any template that uses those placeholders in the static prompt block.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Production hardening
+
+1. Keep the blog generation system prompt static by replacing dynamic
+   placeholders with stable handoff text.
+2. Put the actual blueprint JSON and operator topic in the user message for
+   initial generation and quality repair.
+3. Update tests so support-ticket descriptive contracts, stale-contract cleanup,
+   per-call topic handling, and repair prompts prove the dynamic values stay out
+   of the system prompt.
+
+### Files touched
+
+- `extracted_content_pipeline/blog_generation.py` - move dynamic blog prompt values to the user message.
+- `tests/test_extracted_blog_generation.py` - update and add prompt-shape regression coverage.
+- `tests/test_extracted_content_ops_live_execute_harness.py` - keep execute harness assertions aligned with the static system prompt contract.
+- `plans/PR-Blog-Prompt-Cache-Stability.md` - plan for this slice.
+
+## Mechanism
+
+The blog prompt helper now treats the skill prompt as the cacheable system
+instruction block. It replaces `{blueprint_json}` and `{topic}` with stable
+phrases that point to the user message, then builds a user prompt that always
+contains the serialized blueprint JSON and, when supplied, the operator topic.
+The support-ticket descriptive addendum remains attached to the user prompt so
+the large static denylist stays outside the per-run blueprint JSON while still
+travelling with the generation request.
+
+## Intentional
+
+- The stored markdown prompt still contains `{topic}` for operator-readable
+  placement, but the runtime no longer substitutes the per-run topic into the
+  system prompt.
+- This does not change the LLM provider, cache-control machinery, or cost
+  storage schema. The live result already proves cache metrics are being
+  surfaced in generation output; this slice hardens the prompt shape that makes
+  those cache hits repeatable.
+
+## Deferred
+
+- `HARDENING.md` still carries `LLM usage storage schema mismatch hides per-run cost telemetry`; that is a separate local schema/cost-surfacing slice, not required to keep the provider prompt cache stable.
+- Parked hardening: none
+
+## Verification
+
+- pytest tests/test_extracted_blog_generation.py -q -> 71 passed.
+- pytest tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q -> 1 passed.
+- pytest tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q -> 72 passed.
+- python -m py_compile extracted_content_pipeline/blog_generation.py tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_live_execute_harness.py -> passed.
+- bash scripts/validate_extracted_content_pipeline.sh -> passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
+- bash scripts/check_ascii_python.sh -> passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-blog-prompt-cache-stability-body.md -> passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `extracted_content_pipeline/blog_generation.py` | ~26 |
+| `tests/test_extracted_blog_generation.py` | ~69 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | ~6 |
+| `plans/PR-Blog-Prompt-Cache-Stability.md` | ~74 |
+| Total | ~175 |

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -589,6 +589,21 @@ async def test_generate_sends_blueprint_in_user_message_when_template_has_no_pla
 
 
 @pytest.mark.asyncio
+async def test_generate_keeps_dynamic_blueprint_out_of_system_prompt() -> None:
+    service, _blueprints, _blog_posts, llm, _skills = _service(
+        prompts={"digest/blog_post_generation": "Write from {blueprint_json}"}
+    )
+
+    await service.generate(scope=TenantScope(), target_mode="vendor_retention", limit=1)
+
+    system_prompt = llm.calls[0]["messages"][0].content
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "the blueprint JSON supplied in the user message" in system_prompt
+    assert "HubSpot pricing pressure" not in system_prompt
+    assert '"topic":"HubSpot pricing pressure"' in user_prompt
+
+
+@pytest.mark.asyncio
 async def test_generate_blocks_low_quality_posts_without_saving() -> None:
     service, _blueprints, blog_posts, _llm, _skills = _service(
         responses=[_valid_blog_json(content="Too short.")],
@@ -847,10 +862,11 @@ async def test_generate_puts_support_ticket_descriptive_contract_in_prompt() -> 
     assert result.generated == 1
     system_prompt = llm.calls[0]["messages"][0].content
     user_prompt = llm.calls[0]["messages"][1].content
-    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in system_prompt
-    assert '"allowed_claims":' in system_prompt
-    assert '"forbidden_claims":' in system_prompt
-    assert '"draft_answer_guidance":' in system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' not in system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in user_prompt
+    assert '"allowed_claims":' in user_prompt
+    assert '"forbidden_claims":' in user_prompt
+    assert '"draft_answer_guidance":' in user_prompt
     assert "Support-ticket descriptive mode instructions:" in user_prompt
     assert "Do not rank tied clusters by business impact" in user_prompt
     assert "Measurement language must be observational only" in user_prompt
@@ -875,8 +891,10 @@ async def test_generate_recomputes_stale_support_ticket_descriptive_contract() -
     assert result.generated == 1
     system_prompt = llm.calls[0]["messages"][0].content
     user_prompt = llm.calls[0]["messages"][1].content
-    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' not in system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in user_prompt
     assert "stale_non_descriptive" not in system_prompt
+    assert "stale_non_descriptive" not in user_prompt
     assert "Support-ticket descriptive mode instructions:" in user_prompt
 
 
@@ -910,7 +928,9 @@ async def test_generate_clears_stale_descriptive_contract_for_outcome_backed_con
     assert "forbidden_claims" not in draft.data_context
     assert "draft_answer_guidance" not in draft.data_context
     assert "descriptive_no_outcome" not in system_prompt
+    assert "descriptive_no_outcome" not in user_prompt
     assert "stale allowed" not in system_prompt
+    assert "stale allowed" not in user_prompt
     assert "Support-ticket descriptive mode instructions:" not in user_prompt
 
 
@@ -942,7 +962,8 @@ async def test_quality_repair_prompt_keeps_support_ticket_descriptive_contract()
     assert result.generated == 1
     repair_system_prompt = llm.calls[1]["messages"][0].content
     retry_prompt = llm.calls[1]["messages"][1].content
-    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in repair_system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' not in repair_system_prompt
+    assert '"support_ticket_blog_mode":"descriptive_no_outcome"' in retry_prompt
     assert "follow its `allowed_claims`, `forbidden_claims`, and `draft_answer_guidance`" in retry_prompt
     assert "Support-ticket descriptive mode instructions:" in retry_prompt
     assert "Do not rank tied clusters by business impact" in retry_prompt
@@ -1511,15 +1532,12 @@ def test_parse_blog_post_response_accepts_missing_content_for_quality_pack_to_ju
 
 
 # -----------------------
-# PR-Blog-Topic-Per-Call: per-call topic kwarg substitutes into the prompt
+# PR-Blog-Prompt-Cache-Stability: per-call topic stays in the user prompt
 # -----------------------
 
 
 @pytest.mark.asyncio
-async def test_generate_per_call_topic_substitutes_into_prompt():
-    """Operator-supplied topic reaches the system prompt via the
-    ``{topic}`` placeholder."""
-
+async def test_generate_per_call_topic_stays_out_of_system_prompt():
     service, _bps, _drafts, llm, _skills = _service(
         prompts={
             "digest/blog_post_generation": "Focus: {topic}\n\nWrite from {blueprint_json}"
@@ -1534,14 +1552,14 @@ async def test_generate_per_call_topic_substitutes_into_prompt():
     )
 
     system_prompt = llm.calls[0]["messages"][0].content
-    assert "Focus: Renewal pricing pressure on mid-market SaaS" in system_prompt
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "the operator-supplied topic provided in the user message" in system_prompt
+    assert "Renewal pricing pressure on mid-market SaaS" not in system_prompt
+    assert "Operator-supplied topic focus: Renewal pricing pressure on mid-market SaaS" in user_prompt
 
 
 @pytest.mark.asyncio
-async def test_generate_no_topic_resolves_placeholder_to_empty_string():
-    """No-topic case: the ``{topic}`` placeholder still gets substituted
-    (to ``""``), keeping the prompt structurally clean."""
-
+async def test_generate_no_topic_keeps_system_prompt_stable_without_user_topic():
     service, _bps, _drafts, llm, _skills = _service(
         prompts={
             "digest/blog_post_generation": "Focus: {topic}\n\nWrite from {blueprint_json}"
@@ -1556,9 +1574,10 @@ async def test_generate_no_topic_resolves_placeholder_to_empty_string():
     )
 
     system_prompt = llm.calls[0]["messages"][0].content
-    # Placeholder substituted with empty string -- "Focus: \n\n..." remains.
+    user_prompt = llm.calls[0]["messages"][1].content
     assert "{topic}" not in system_prompt
-    assert "Focus: \n" in system_prompt or "Focus:\n" in system_prompt
+    assert "Focus: the operator-supplied topic provided in the user message" in system_prompt
+    assert "Operator-supplied topic focus:" not in user_prompt
 
 
 @pytest.mark.asyncio
@@ -1577,7 +1596,9 @@ async def test_generate_topic_no_placeholder_no_op():
     )
 
     system_prompt = llm.calls[0]["messages"][0].content
-    assert "Some topic" not in system_prompt  # no placeholder, no substitution
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "Some topic" not in system_prompt
+    assert "Operator-supplied topic focus: Some topic" in user_prompt
     assert "{topic}" not in system_prompt
 
 
@@ -1636,11 +1657,13 @@ async def test_generate_with_reasoning_provider_merges_context_into_blueprint() 
     assert call["target_id"] == "bp-1"
     assert call["target_mode"] == "blog_blueprint"
 
-    # LLM saw the merged blueprint JSON.
+    # LLM saw the merged blueprint JSON in the per-run user prompt.
     system_prompt = llm.calls[0]["messages"][0].content
-    assert "reasoning_context" in system_prompt
-    assert "campaign_reasoning_context" in system_prompt
-    assert "Renewal pricing rose 22 percent" in system_prompt
+    user_prompt = llm.calls[0]["messages"][1].content
+    assert "reasoning_context" not in system_prompt
+    assert "reasoning_context" in user_prompt
+    assert "campaign_reasoning_context" in user_prompt
+    assert "Renewal pricing rose 22 percent" in user_prompt
     result_dict = result.as_dict()
     assert result_dict["reasoning_contexts_used"] == 1
     assert result_dict["consumed_reasoning_contexts"][0]["top_theses"][0]["claim"] == (

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -454,10 +454,11 @@ async def test_support_ticket_provider_feeds_real_blog_post_generation() -> None
     assert call["metadata"]["skill_name"] == "digest/blog_post_generation"
     assert call["metadata"]["asset_type"] == "blog_post"
     system_prompt, user_prompt = _message_texts(call)
-    assert "Support-ticket questions customers keep asking" in system_prompt
-    assert "content_ops_support_ticket_faq" in system_prompt
-    assert "support_ticket_provider" in system_prompt
-    assert "included_ticket_row_count" in system_prompt
+    assert "Support-ticket questions customers keep asking" not in system_prompt
+    assert "Support-ticket questions customers keep asking" in user_prompt
+    assert "content_ops_support_ticket_faq" in user_prompt
+    assert "support_ticket_provider" in user_prompt
+    assert "included_ticket_row_count" in user_prompt
     assert "Generate one blog post" in user_prompt
 
 


### PR DESCRIPTION
Plan: plans/PR-Blog-Prompt-Cache-Stability.md
Slice phase: Production hardening

This hardens blog generation prompt construction so the cacheable system prompt stays static even when stored templates contain `{topic}` or `{blueprint_json}`. The live retry already showed provider cache metrics; this slice prevents template placement from silently turning per-run topic or blueprint data into system-prompt cache churn.

## Intentional
- The stored markdown prompt can keep `{topic}` and `{blueprint_json}` placement markers; runtime replaces them with stable handoff text and sends actual values in the user prompt.
- This does not change provider routing, cache-control conversion, or the local `llm_usage` schema issue parked in `HARDENING.md`.

## Deferred
- `HARDENING.md` still carries `LLM usage storage schema mismatch hides per-run cost telemetry`; that is a separate local schema/cost-surfacing slice.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_blog_generation.py -q -> 71 passed.
- pytest tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q -> 1 passed.
- pytest tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_live_execute_harness.py::test_support_ticket_provider_feeds_real_blog_post_generation -q -> 72 passed.
- python -m py_compile extracted_content_pipeline/blog_generation.py tests/test_extracted_blog_generation.py tests/test_extracted_content_ops_live_execute_harness.py -> passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-blog-prompt-cache-stability-body.md -> passed.

## Diff size
4 files, +~112 / -39
