### PR TITLE
Harden LLM usage schema cache telemetry

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -50,15 +50,6 @@ register under `docs/technical-debt/`.
 - Owner/session: content-ops/faq-search
 - Found during: PR-Content-Ops-FAQ-SaaS-Demo-Local-Route-Proof
 
-### LLM usage storage schema mismatch hides per-run cost telemetry
-- File/location: `content_ops.llm.complete` usage-storage path, live smoke stderr during `scripts/smoke_content_ops_live_generation.py`.
-- Description: Live landing/blog generation succeeded, but each LLM call logged `_store_local failed for span=content_ops.llm.complete: column "account_id" of relation "llm_usage" does not exist`.
-- Why it matters: Generation still works, but local cost/usage surfacing is incomplete, which blocks the cost visibility work the product needs before heavier validation and production use.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/support-ticket-provider
-- Found during: PR-Support-Ticket-SaaS-Demo-Generated-Content-Acceptance
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/atlas_brain/services/tracing.py
+++ b/atlas_brain/services/tracing.py
@@ -44,6 +44,11 @@ _TRACE_BUSINESS_KEYS = (
     "subscription_id",
 )
 
+_LLM_USAGE_ACCOUNT_ID_MISSING_TEXT = (
+    'column "account_id" of relation "llm_usage" does not exist'
+)
+_POSTGRES_UNDEFINED_COLUMN_SQLSTATE = "42703"
+
 
 def _metadata_text_value(metadata: object, key: str) -> str | None:
     if not isinstance(metadata, dict):
@@ -65,6 +70,93 @@ def _metadata_text_value(metadata: object, key: str) -> str | None:
     if isinstance(business, dict):
         return _normalize(business.get(key))
     return None
+
+
+def _is_missing_llm_usage_account_id(exc: Exception) -> bool:
+    sqlstate = str(
+        getattr(exc, "sqlstate", "")
+        or getattr(exc, "pgcode", "")
+        or ""
+    )
+    if sqlstate and sqlstate != _POSTGRES_UNDEFINED_COLUMN_SQLSTATE:
+        return False
+    return _LLM_USAGE_ACCOUNT_ID_MISSING_TEXT in str(exc)
+
+
+def _llm_usage_insert_statement(
+    payload: dict[str, Any],
+    *,
+    vendor_name: str | None,
+    run_id: str | None,
+    source_name: str | None,
+    event_type: str | None,
+    entity_type: str | None,
+    entity_id: str | None,
+    account_id: str,
+    include_account_id: bool,
+) -> tuple[str, tuple[Any, ...]]:
+    columns = [
+        "span_name",
+        "operation_type",
+        "model_name",
+        "model_provider",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cost_usd",
+        "duration_ms",
+        "ttft_ms",
+        "inference_time_ms",
+        "queue_time_ms",
+        "tokens_per_second",
+        "billable_input_tokens",
+        "cached_tokens",
+        "cache_write_tokens",
+        "api_endpoint",
+        "provider_request_id",
+        "status",
+        "metadata",
+        "vendor_name",
+        "run_id",
+        "source_name",
+        "event_type",
+        "entity_type",
+        "entity_id",
+    ]
+    args: list[Any] = [
+        payload.get("span_name", ""),
+        payload.get("operation_type", "llm_call"),
+        payload.get("model_name"),
+        payload.get("model_provider"),
+        payload.get("input_tokens", 0),
+        payload.get("output_tokens", 0),
+        payload.get("total_tokens", 0),
+        payload.get("cost_usd", 0),
+        payload.get("duration_ms", 0),
+        payload.get("ttft_ms"),
+        payload.get("inference_time_ms"),
+        payload.get("queue_time_ms"),
+        payload.get("tokens_per_second"),
+        payload.get("billable_input_tokens", payload.get("input_tokens", 0)),
+        payload.get("cached_tokens", 0),
+        payload.get("cache_write_tokens", 0),
+        payload.get("api_endpoint"),
+        payload.get("provider_request_id"),
+        payload.get("status", "completed"),
+        json.dumps(payload.get("metadata", {})),
+        vendor_name,
+        run_id,
+        source_name,
+        event_type,
+        entity_type,
+        entity_id,
+    ]
+    if include_account_id:
+        columns.append("account_id")
+        args.append(account_id)
+    placeholders = ",".join(f"${index}" for index in range(1, len(args) + 1))
+    query = f"INSERT INTO llm_usage ({','.join(columns)}) VALUES ({placeholders})"
+    return query, tuple(args)
 
 
 @dataclass
@@ -511,52 +603,39 @@ class FTLTracingClient:
             # LLM Gateway router) or sentinel for atlas's internal
             # pipeline.
             account_id = account_id_str or "00000000-0000-0000-0000-000000000000"
-            query = """INSERT INTO llm_usage
-                       (span_name, operation_type, model_name, model_provider,
-                        input_tokens, output_tokens, total_tokens, cost_usd,
-                        duration_ms, ttft_ms, inference_time_ms, queue_time_ms,
-                        tokens_per_second, billable_input_tokens, cached_tokens,
-                        cache_write_tokens, api_endpoint, provider_request_id,
-                        status, metadata, vendor_name, run_id, source_name,
-                        event_type, entity_type, entity_id, account_id)
-                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)"""
-            args = (
-                payload.get("span_name", ""),
-                payload.get("operation_type", "llm_call"),
-                payload.get("model_name"),
-                payload.get("model_provider"),
-                payload.get("input_tokens", 0),
-                payload.get("output_tokens", 0),
-                payload.get("total_tokens", 0),
-                payload.get("cost_usd", 0),
-                payload.get("duration_ms", 0),
-                payload.get("ttft_ms"),
-                payload.get("inference_time_ms"),
-                payload.get("queue_time_ms"),
-                payload.get("tokens_per_second"),
-                payload.get("billable_input_tokens", payload.get("input_tokens", 0)),
-                payload.get("cached_tokens", 0),
-                payload.get("cache_write_tokens", 0),
-                payload.get("api_endpoint"),
-                payload.get("provider_request_id"),
-                payload.get("status", "completed"),
-                json.dumps(payload.get("metadata", {})),
-                vendor_name,
-                run_id,
-                source_name,
-                event_type,
-                entity_type,
-                entity_id,
-                account_id,
+            query, args = _llm_usage_insert_statement(
+                payload,
+                vendor_name=vendor_name,
+                run_id=run_id,
+                source_name=source_name,
+                event_type=event_type,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                account_id=account_id,
+                include_account_id=True,
             )
-            if use_shared_pool:
-                await pool.execute(query, *args)
-                return
-            conn = await pool.acquire_raw()
+            executor = pool if use_shared_pool else await pool.acquire_raw()
             try:
-                await conn.execute(query, *args)
+                try:
+                    await executor.execute(query, *args)
+                except Exception as exc:
+                    if not _is_missing_llm_usage_account_id(exc):
+                        raise
+                    fallback_query, fallback_args = _llm_usage_insert_statement(
+                        payload,
+                        vendor_name=vendor_name,
+                        run_id=run_id,
+                        source_name=source_name,
+                        event_type=event_type,
+                        entity_type=entity_type,
+                        entity_id=entity_id,
+                        account_id=account_id,
+                        include_account_id=False,
+                    )
+                    await executor.execute(fallback_query, *fallback_args)
             finally:
-                await conn.close()
+                if not use_shared_pool:
+                    await executor.close()
         except Exception as exc:
             logger.warning("_store_local failed for span=%s: %s", payload.get("span_name"), exc)
 

--- a/extracted_llm_infrastructure/services/tracing.py
+++ b/extracted_llm_infrastructure/services/tracing.py
@@ -44,6 +44,11 @@ _TRACE_BUSINESS_KEYS = (
     "subscription_id",
 )
 
+_LLM_USAGE_ACCOUNT_ID_MISSING_TEXT = (
+    'column "account_id" of relation "llm_usage" does not exist'
+)
+_POSTGRES_UNDEFINED_COLUMN_SQLSTATE = "42703"
+
 
 def _metadata_text_value(metadata: object, key: str) -> str | None:
     if not isinstance(metadata, dict):
@@ -65,6 +70,93 @@ def _metadata_text_value(metadata: object, key: str) -> str | None:
     if isinstance(business, dict):
         return _normalize(business.get(key))
     return None
+
+
+def _is_missing_llm_usage_account_id(exc: Exception) -> bool:
+    sqlstate = str(
+        getattr(exc, "sqlstate", "")
+        or getattr(exc, "pgcode", "")
+        or ""
+    )
+    if sqlstate and sqlstate != _POSTGRES_UNDEFINED_COLUMN_SQLSTATE:
+        return False
+    return _LLM_USAGE_ACCOUNT_ID_MISSING_TEXT in str(exc)
+
+
+def _llm_usage_insert_statement(
+    payload: dict[str, Any],
+    *,
+    vendor_name: str | None,
+    run_id: str | None,
+    source_name: str | None,
+    event_type: str | None,
+    entity_type: str | None,
+    entity_id: str | None,
+    account_id: str,
+    include_account_id: bool,
+) -> tuple[str, tuple[Any, ...]]:
+    columns = [
+        "span_name",
+        "operation_type",
+        "model_name",
+        "model_provider",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cost_usd",
+        "duration_ms",
+        "ttft_ms",
+        "inference_time_ms",
+        "queue_time_ms",
+        "tokens_per_second",
+        "billable_input_tokens",
+        "cached_tokens",
+        "cache_write_tokens",
+        "api_endpoint",
+        "provider_request_id",
+        "status",
+        "metadata",
+        "vendor_name",
+        "run_id",
+        "source_name",
+        "event_type",
+        "entity_type",
+        "entity_id",
+    ]
+    args: list[Any] = [
+        payload.get("span_name", ""),
+        payload.get("operation_type", "llm_call"),
+        payload.get("model_name"),
+        payload.get("model_provider"),
+        payload.get("input_tokens", 0),
+        payload.get("output_tokens", 0),
+        payload.get("total_tokens", 0),
+        payload.get("cost_usd", 0),
+        payload.get("duration_ms", 0),
+        payload.get("ttft_ms"),
+        payload.get("inference_time_ms"),
+        payload.get("queue_time_ms"),
+        payload.get("tokens_per_second"),
+        payload.get("billable_input_tokens", payload.get("input_tokens", 0)),
+        payload.get("cached_tokens", 0),
+        payload.get("cache_write_tokens", 0),
+        payload.get("api_endpoint"),
+        payload.get("provider_request_id"),
+        payload.get("status", "completed"),
+        json.dumps(payload.get("metadata", {})),
+        vendor_name,
+        run_id,
+        source_name,
+        event_type,
+        entity_type,
+        entity_id,
+    ]
+    if include_account_id:
+        columns.append("account_id")
+        args.append(account_id)
+    placeholders = ",".join(f"${index}" for index in range(1, len(args) + 1))
+    query = f"INSERT INTO llm_usage ({','.join(columns)}) VALUES ({placeholders})"
+    return query, tuple(args)
 
 
 @dataclass
@@ -511,52 +603,39 @@ class FTLTracingClient:
             # LLM Gateway router) or sentinel for atlas's internal
             # pipeline.
             account_id = account_id_str or "00000000-0000-0000-0000-000000000000"
-            query = """INSERT INTO llm_usage
-                       (span_name, operation_type, model_name, model_provider,
-                        input_tokens, output_tokens, total_tokens, cost_usd,
-                        duration_ms, ttft_ms, inference_time_ms, queue_time_ms,
-                        tokens_per_second, billable_input_tokens, cached_tokens,
-                        cache_write_tokens, api_endpoint, provider_request_id,
-                        status, metadata, vendor_name, run_id, source_name,
-                        event_type, entity_type, entity_id, account_id)
-                       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)"""
-            args = (
-                payload.get("span_name", ""),
-                payload.get("operation_type", "llm_call"),
-                payload.get("model_name"),
-                payload.get("model_provider"),
-                payload.get("input_tokens", 0),
-                payload.get("output_tokens", 0),
-                payload.get("total_tokens", 0),
-                payload.get("cost_usd", 0),
-                payload.get("duration_ms", 0),
-                payload.get("ttft_ms"),
-                payload.get("inference_time_ms"),
-                payload.get("queue_time_ms"),
-                payload.get("tokens_per_second"),
-                payload.get("billable_input_tokens", payload.get("input_tokens", 0)),
-                payload.get("cached_tokens", 0),
-                payload.get("cache_write_tokens", 0),
-                payload.get("api_endpoint"),
-                payload.get("provider_request_id"),
-                payload.get("status", "completed"),
-                json.dumps(payload.get("metadata", {})),
-                vendor_name,
-                run_id,
-                source_name,
-                event_type,
-                entity_type,
-                entity_id,
-                account_id,
+            query, args = _llm_usage_insert_statement(
+                payload,
+                vendor_name=vendor_name,
+                run_id=run_id,
+                source_name=source_name,
+                event_type=event_type,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                account_id=account_id,
+                include_account_id=True,
             )
-            if use_shared_pool:
-                await pool.execute(query, *args)
-                return
-            conn = await pool.acquire_raw()
+            executor = pool if use_shared_pool else await pool.acquire_raw()
             try:
-                await conn.execute(query, *args)
+                try:
+                    await executor.execute(query, *args)
+                except Exception as exc:
+                    if not _is_missing_llm_usage_account_id(exc):
+                        raise
+                    fallback_query, fallback_args = _llm_usage_insert_statement(
+                        payload,
+                        vendor_name=vendor_name,
+                        run_id=run_id,
+                        source_name=source_name,
+                        event_type=event_type,
+                        entity_type=entity_type,
+                        entity_id=entity_id,
+                        account_id=account_id,
+                        include_account_id=False,
+                    )
+                    await executor.execute(fallback_query, *fallback_args)
             finally:
-                await conn.close()
+                if not use_shared_pool:
+                    await executor.close()
         except Exception as exc:
             logger.warning("_store_local failed for span=%s: %s", payload.get("span_name"), exc)
 

--- a/plans/PR-LLM-Usage-Schema-Cache-Telemetry.md
+++ b/plans/PR-LLM-Usage-Schema-Cache-Telemetry.md
@@ -1,0 +1,84 @@
+# PR-LLM-Usage-Schema-Cache-Telemetry
+
+## Why this slice exists
+
+`HARDENING.md` parks a Content Ops cost telemetry gap: live generation can
+surface `generation_usage` with cache hits, but local `llm_usage` persistence
+logged `_store_local failed for span=content_ops.llm.complete: column
+"account_id" of relation "llm_usage" does not exist`. The canonical schema has
+`account_id` after migration 313, but partially migrated local/host databases
+with migrations 127/252/253 can still store token, cache, cost, and tenant
+metadata if the insert does not hard-fail on the missing top-level column.
+This is slightly over the 400-LOC soft cap because `tracing.py` is a synced
+LLM-infrastructure file, so the source fix must ship with the extracted copy in
+the same PR.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Production hardening
+
+1. Keep the canonical llm_usage account_id insert for migrated databases.
+2. Add a narrow retry path only for Postgres undefined-column failures where the
+   missing column is llm_usage account_id.
+3. Preserve cache metrics and metadata on the fallback insert so Content Ops
+   usage summaries can still filter by metadata account_id.
+4. Remove the parked hardening item this slice closes.
+
+### Files touched
+
+- `atlas_brain/services/tracing.py` - add account-column fallback for local usage writes.
+- `extracted_llm_infrastructure/services/tracing.py` - synced extracted tracing copy.
+- `tests/test_llm_tracing.py` - cover cache metrics persistence when the account column is missing.
+- `tests/test_account_scoping.py` - keep account-scoped insert assertions pointed at the SQL builder.
+- `HARDENING.md` - remove the closed parked telemetry item.
+- `plans/PR-LLM-Usage-Schema-Cache-Telemetry.md` - plan for this slice.
+
+## Mechanism
+
+The tracing client still builds the full modern `llm_usage` insert first. If
+Postgres rejects that statement because the `account_id` column is missing, the
+client retries the same payload without the top-level `account_id` column. That
+fallback keeps the original metadata JSON, including tenant/run/cache metadata,
+and keeps `billable_input_tokens`, `cached_tokens`, `cache_write_tokens`,
+endpoint, and provider request IDs in the persisted row.
+
+## Intentional
+
+- This does not replace migration 313 or weaken the canonical schema. Fully
+  migrated production databases continue using the `account_id` column.
+- The fallback is limited to the known undefined-column shape. Other write
+  failures still log and do not retry, so real schema or data issues do not get
+  silently hidden.
+
+## Deferred
+
+- A separate migration-readiness diagnostic could warn operators before live
+  generation starts when local cost telemetry columns are missing, but this
+  slice fixes the data-loss path for the known partial-schema case.
+- Parked hardening: none
+
+## Verification
+
+- pytest tests/test_llm_tracing.py -q -> 5 passed, 1 warning.
+- pytest tests/test_llm_tracing.py tests/test_tracing_context.py::test_store_local_uses_standalone_connection_when_shared_pool_disabled -q -> 6 passed, 1 warning.
+- pytest tests/test_llm_tracing.py tests/test_account_scoping.py::test_tracing_store_local_insert_includes_account_id_column -q -> 7 passed, 1 warning.
+- pytest tests/test_account_scoping.py tests/test_llm_gateway_router.py::test_cache_hit_insert_sql_does_not_route_through_tracer_drop_filter tests/test_llm_tracing.py -q -> 32 passed, 1 warning.
+- python -m py_compile atlas_brain/services/tracing.py extracted_llm_infrastructure/services/tracing.py tests/test_llm_tracing.py tests/test_account_scoping.py -> passed.
+- bash scripts/validate_extracted_llm_infrastructure.sh -> passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_llm_infrastructure -> passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
+- bash scripts/check_ascii_python.sh -> passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-llm-usage-schema-cache-telemetry-body.md -> passed after review fix.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `atlas_brain/services/tracing.py` | ~165 |
+| `extracted_llm_infrastructure/services/tracing.py` | ~165 |
+| `tests/test_llm_tracing.py` | ~109 |
+| `tests/test_account_scoping.py` | ~13 |
+| `HARDENING.md` | ~9 |
+| `plans/PR-LLM-Usage-Schema-Cache-Telemetry.md` | ~83 |
+| Total | ~544 |

--- a/tests/test_account_scoping.py
+++ b/tests/test_account_scoping.py
@@ -230,12 +230,11 @@ def test_tracing_store_local_insert_includes_account_id_column():
     /api/v1/llm/usage``) return the right numbers."""
     from atlas_brain.services import tracing
 
-    src = inspect.getsource(tracing.FTLTracingClient._store_local)
+    src = inspect.getsource(tracing._llm_usage_insert_statement)
     assert "INSERT INTO llm_usage" in src
-    # Column list must include account_id
-    assert "account_id)" in src
-    # 27 placeholders (was 26 + new account_id)
-    assert "$27" in src
+    assert 'columns.append("account_id")' in src
+    assert 'args.append(account_id)' in src
+    assert 'f"${index}"' in src
 
 
 def test_tracing_store_local_reads_account_id_from_metadata():
@@ -326,5 +325,7 @@ def test_extracted_tracing_synced_with_account_id():
         / "tracing.py"
     )
     src = extracted_path.read_text(encoding="utf-8")
-    assert "$27" in src  # the new account_id placeholder
+    assert "def _llm_usage_insert_statement(" in src
+    assert 'columns.append("account_id")' in src
+    assert 'args.append(account_id)' in src
     assert '_metadata_text_value(meta, "account_id")' in src

--- a/tests/test_llm_tracing.py
+++ b/tests/test_llm_tracing.py
@@ -1,3 +1,5 @@
+import logging
+
 from atlas_brain.config import ModelPricingConfig
 from atlas_brain.pipelines.llm import trace_llm_call
 from atlas_brain.services.tracing import FTLTracingClient
@@ -11,6 +13,20 @@ class _FakePool:
     async def execute(self, query, *args):
         self.calls.append((query, args))
         return "INSERT 0 1"
+
+
+class _MissingAccountIdColumn(Exception):
+    sqlstate = "42703"
+
+    def __str__(self):
+        return 'column "account_id" of relation "llm_usage" does not exist'
+
+
+class _DifferentUndefinedColumn(Exception):
+    sqlstate = "42703"
+
+    def __str__(self):
+        return 'column "provider_request_id" of relation "llm_usage" does not exist'
 
 
 async def test_store_local_persists_cache_breakdown(monkeypatch):
@@ -47,6 +63,99 @@ async def test_store_local_persists_cache_breakdown(monkeypatch):
     assert args[15] == 1000
     assert args[16] == "https://openrouter.ai/api/v1/chat/completions"
     assert args[17] == "req_456"
+
+
+async def test_store_local_retries_without_account_id_column(monkeypatch):
+    class _LegacyPool:
+        is_initialized = True
+
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, query, *args):
+            self.calls.append((query, args))
+            if len(self.calls) == 1:
+                raise _MissingAccountIdColumn()
+            return "INSERT 0 1"
+
+    pool = _LegacyPool()
+    monkeypatch.setattr("atlas_brain.storage.database.get_db_pool", lambda: pool)
+    tracer = FTLTracingClient()
+    await tracer._store_local(
+        {
+            "span_name": "content_ops.llm.complete",
+            "operation_type": "llm_call",
+            "model_name": "anthropic/claude-haiku-4-5",
+            "model_provider": "openrouter",
+            "input_tokens": 27257,
+            "output_tokens": 9282,
+            "total_tokens": 36539,
+            "cost_usd": 0.021,
+            "duration_ms": 1200,
+            "billable_input_tokens": 9,
+            "cached_tokens": 9814,
+            "cache_write_tokens": 17434,
+            "api_endpoint": "https://openrouter.ai/api/v1/chat/completions",
+            "provider_request_id": "req_cache",
+            "status": "completed",
+            "metadata": {
+                "account_id": "12345678-1234-4234-8234-123456789abc",
+                "asset_type": "blog_post",
+                "request_id": "req-support-ticket",
+            },
+        }
+    )
+
+    assert len(pool.calls) == 2
+    modern_query, modern_args = pool.calls[0]
+    legacy_query, legacy_args = pool.calls[1]
+    assert "account_id" in modern_query
+    assert modern_args[26] == "12345678-1234-4234-8234-123456789abc"
+    assert "account_id" not in legacy_query
+    assert legacy_args[13] == 9
+    assert legacy_args[14] == 9814
+    assert legacy_args[15] == 17434
+    metadata = legacy_args[19]
+    assert '"account_id": "12345678-1234-4234-8234-123456789abc"' in metadata
+
+
+async def test_store_local_does_not_fallback_for_other_write_failures(monkeypatch, caplog):
+    class _BrokenPool:
+        is_initialized = True
+
+        def __init__(self):
+            self.calls = []
+
+        async def execute(self, query, *args):
+            self.calls.append((query, args))
+            raise _DifferentUndefinedColumn()
+
+    pool = _BrokenPool()
+    monkeypatch.setattr("atlas_brain.storage.database.get_db_pool", lambda: pool)
+    tracer = FTLTracingClient()
+
+    with caplog.at_level(logging.WARNING, logger="atlas.tracing"):
+        await tracer._store_local(
+            {
+                "span_name": "content_ops.llm.complete",
+                "operation_type": "llm_call",
+                "model_name": "anthropic/claude-haiku-4-5",
+                "model_provider": "openrouter",
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "cached_tokens": 40,
+                "cache_write_tokens": 10,
+                "metadata": {
+                    "account_id": "12345678-1234-4234-8234-123456789abc",
+                },
+            }
+        )
+
+    assert len(pool.calls) == 1
+    assert "account_id" in pool.calls[0][0]
+    assert "_store_local failed for span=content_ops.llm.complete" in caplog.text
+    assert "provider_request_id" in caplog.text
 
 
 async def test_store_local_promotes_business_attribution_fields(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-LLM-Usage-Schema-Cache-Telemetry.md
Slice phase: Production hardening

This closes the parked Content Ops cost telemetry gap where `content_ops.llm.complete` calls could report cache usage in generation metadata but fail to persist into `llm_usage` on partially migrated databases missing the top-level `account_id` column.

## Intentional
- Fully migrated databases still use the canonical `llm_usage.account_id` insert.
- The fallback is narrow: it retries only the known Postgres undefined-column shape for `llm_usage.account_id`; other write failures still log and do not get hidden.
- Diff is above the soft cap because `atlas_brain/services/tracing.py` is synced into `extracted_llm_infrastructure/services/tracing.py` and both copies must ship together.

## Deferred
- A separate migration-readiness diagnostic could warn operators before live generation starts when local cost telemetry columns are missing.

## Parked hardening
- None. This removes `LLM usage storage schema mismatch hides per-run cost telemetry` from `HARDENING.md`.

## Verification
- pytest tests/test_llm_tracing.py -q -> 5 passed, 1 warning.
- pytest tests/test_llm_tracing.py tests/test_tracing_context.py::test_store_local_uses_standalone_connection_when_shared_pool_disabled -q -> 6 passed, 1 warning.
- pytest tests/test_llm_tracing.py tests/test_account_scoping.py::test_tracing_store_local_insert_includes_account_id_column -q -> 7 passed, 1 warning.
- pytest tests/test_account_scoping.py tests/test_llm_gateway_router.py::test_cache_hit_insert_sql_does_not_route_through_tracer_drop_filter tests/test_llm_tracing.py -q -> 32 passed, 1 warning.
- python -m py_compile atlas_brain/services/tracing.py extracted_llm_infrastructure/services/tracing.py tests/test_llm_tracing.py tests/test_account_scoping.py -> passed.
- bash scripts/validate_extracted_llm_infrastructure.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_llm_infrastructure -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-llm-usage-schema-cache-telemetry-body.md -> passed after review fix.

## Diff size
6 files, +~443 / -~101
