### PR TITLE
Record support-ticket blog observed-shell live telemetry

### DIFF
--- a/docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md
+++ b/docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md
@@ -1,0 +1,153 @@
+# Support-Ticket Blog Observed-Shell Live Telemetry - 2026-05-28
+
+## Scope
+
+This validation reran the 36-row SaaS demo support-ticket blog path after the
+observed-section and draft-FAQ-shell contract landed.
+
+Source CSV:
+
+`extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv`
+
+The run used the Claude Haiku OpenRouter override and the existing live
+generation smoke harness. It also verifies that the `llm_usage` schema fallback
+from `PR-LLM-Usage-Schema-Cache-Telemetry` lets Content Ops cost/cache telemetry
+persist for the same account.
+
+## Result
+
+Status: accepted.
+
+| Check | Result |
+|---|---|
+| Live generation | Passed |
+| Saved draft id | `4792bdf3-5520-40f9-bfb3-79e2112d5624` |
+| Generated-content evaluator | Passed |
+| SEO/AEO readiness | `ready` |
+| GEO readiness | `ready` |
+| Model | `anthropic/claude-haiku-4-5` through OpenRouter |
+| Generated content shape | 1,526 words, 5 H2 sections, 3 H3 sections |
+
+The generated draft stayed inside the no-outcome support-ticket contract:
+
+- source context showed 36 uploaded rows, 36 included rows, and 35 question-like
+  rows
+- all 9 tied ticket clusters were visible
+- FAQ shells stayed review-needed where no resolution evidence existed
+- generated-content evaluation found no unsupported outcome claims
+- generated-content evaluation found no concrete answer steps without
+  resolution evidence
+
+## Telemetry Result
+
+Generation metadata in the saved draft:
+
+| Metric | Value |
+|---|---:|
+| `input_tokens` | 29,013 |
+| `billable_input_tokens` | 9 |
+| `cached_tokens` | 9,788 |
+| `cache_write_tokens` | 19,216 |
+| `output_tokens` | 8,056 |
+
+Persisted `llm_usage` summary for account
+`acct_support_ticket_blog_observed_shell_live_telemetry_20260528` and asset type
+`blog_post`:
+
+| Metric | Value |
+|---|---:|
+| `total_calls` | 3 |
+| `failed_calls` | 0 |
+| `total_cost_usd` | 0.016131 |
+| `input_tokens` | 29,013 |
+| `billable_input_tokens` | 9 |
+| `cached_tokens` | 9,788 |
+| `cache_write_tokens` | 19,216 |
+| `output_tokens` | 8,056 |
+| `cache_hit_calls` | 2 |
+
+The persisted totals match the saved draft `generation_usage`, which proves the
+cache-token telemetry survived the local `llm_usage` storage path. The cache
+status breakdown still reports `cache_mode=no_store` and
+`cache_reason=exact_cache_disabled` because that field describes the Content Ops
+exact-cache policy, not provider prompt-caching tokens.
+
+Raw `llm_usage` rows were 3 completed Haiku calls. The first wrote 7,646 cache
+tokens and had 0 cached tokens; the next two reused 4,894 cached tokens each.
+Each row stored the account id and `blog_post` asset type in metadata.
+
+## Commands
+
+```bash
+mkdir -p tmp/support_ticket_blog_observed_shell_live_telemetry_20260528
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_blog_observed_shell_live_telemetry_20260528 \
+  --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json \
+  --output-result tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+Result: passed; saved one draft.
+
+```bash
+python scripts/evaluate_support_ticket_generated_content.py \
+  --output blog_post \
+  tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json \
+  --pretty
+```
+
+Result: passed.
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from dotenv import load_dotenv
+import asyncio
+
+ROOT = Path.cwd()
+load_dotenv(ROOT / ".env")
+load_dotenv(ROOT / ".env.local", override=True)
+load_dotenv(Path("/home/juan-canfield/Desktop/Atlas/.env"), override=True)
+load_dotenv(Path("/home/juan-canfield/Desktop/Atlas/.env.local"), override=True)
+
+ACCOUNT = "acct_support_ticket_blog_observed_shell_live_telemetry_20260528"
+
+async def main():
+    from atlas_brain.storage.database import close_database, get_db_pool, init_database
+    from extracted_content_pipeline.content_ops_usage_summary import summarize_content_ops_llm_usage
+
+    await init_database()
+    try:
+        summary = await summarize_content_ops_llm_usage(
+            get_db_pool(),
+            days=1,
+            account_id=ACCOUNT,
+            asset_type="blog_post",
+        )
+        print(summary["summary"])
+    finally:
+        await close_database()
+
+asyncio.run(main())
+PY
+```
+
+Result: returned the persisted totals shown above.
+
+## Follow-Up
+
+No blocking product follow-up from this validation. The 36-row SaaS demo blog is
+accepted for the current no-outcome support-ticket contract.
+
+Next useful slices:
+
+- broaden live validation across more customer CSV shapes
+- decide whether to promote this accepted artifact into a minimized regression
+  fixture
+- surface per-run Content Ops usage/cost in the product UI

--- a/plans/PR-Support-Ticket-Blog-Observed-Shell-Live-Telemetry.md
+++ b/plans/PR-Support-Ticket-Blog-Observed-Shell-Live-Telemetry.md
@@ -1,0 +1,104 @@
+# PR: Support-Ticket Blog Observed-Shell Live Telemetry
+
+## Why this slice exists
+
+PR-Support-Ticket-Blog-Observed-Shell changed the support-ticket blog contract
+so the no-outcome path receives deterministic observed sections and review-needed
+FAQ shells. PR-LLM-Usage-Schema-Cache-Telemetry fixed the local `llm_usage`
+schema mismatch that previously hid Content Ops cache telemetry.
+
+The next useful validation slice is to rerun the representative 36-row SaaS demo
+blog path with Haiku, then prove the generated draft result and the persisted
+usage telemetry line up. This keeps the work source-first: verify the real
+support-ticket provider, generation, save/export, generated-content evaluator,
+and usage-summary path together before adding more product surface.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Functional validation
+
+1. Run a live Claude Haiku blog-post smoke with the 36-row SaaS demo
+   support-ticket CSV after the observed-shell contract landed.
+2. Export the saved draft if generation saves one.
+3. Run the deterministic support-ticket generated-content evaluator against the
+   saved export.
+4. Query the Content Ops `llm_usage` summary for the run account/output to prove
+   persisted cache/cost telemetry survives the schema fallback.
+5. Record commands, artifact paths, generated-content result, cache-token
+   metrics, and any follow-up in a committed validation doc.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Blog-Observed-Shell-Live-Telemetry.md` - plan doc for this validation slice.
+- `docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md` - live validation and telemetry record.
+
+## Mechanism
+
+Use the existing live smoke harness with the Haiku override and generated-content
+evaluation enabled:
+
+```bash
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id acct_support_ticket_blog_observed_shell_live_telemetry_20260528 \
+  --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env \
+  --export-saved-draft tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json \
+  --output-result tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-result.json \
+  --evaluate-generated-content \
+  --json
+```
+
+The saved JSON artifacts stay under `tmp/`. The committed doc records the
+artifact paths and summarizes the result. Usage proof reads the same database
+through `summarize_content_ops_llm_usage`, filtered by account and `blog_post`,
+so the doc can confirm whether persisted `cached_tokens`,
+`cache_write_tokens`, `billable_input_tokens`, and call counts match the
+generation metadata.
+
+## Intentional
+
+- This is validation, not a new generator rewrite, unless the live output still
+  exposes a truthfulness blocker.
+- The run uses Haiku because it is the cheaper test model and has been the
+  stricter support-ticket prompt stress case.
+- This does not add FAQ Article output or customer-language keyword promotion;
+  those remain future product slices owned outside this validation PR.
+- Raw live artifacts are not committed because they contain run-specific ids and
+  full generated content. The validation doc commits the reproducible commands
+  and the relevant metrics.
+
+## Deferred
+
+- Future PR: broader live acceptance across more representative customer CSV
+  shapes after this 36-row SaaS demo path is accepted.
+- Future PR: product UI for showing per-run Content Ops cost/cache telemetry.
+- Future PR: deterministic renderer if free-form blog generation keeps leaking
+  unsupported no-outcome support-ticket claims.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python scripts/smoke_content_ops_live_generation.py --output blog_post --account-id acct_support_ticket_blog_observed_shell_live_telemetry_20260528 --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --env-file /home/juan-canfield/Desktop/Atlas/.env --env-file /home/juan-canfield/Desktop/Atlas/.env.local --env-file tmp/support_ticket_live_haiku_eval_20260525/haiku.env --export-saved-draft tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json --output-result tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-result.json --evaluate-generated-content --json
+  - Passed; saved blog draft `4792bdf3-5520-40f9-bfb3-79e2112d5624`.
+- Command: python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json --pretty
+  - Passed; generated-content evaluator returned `ok: true`.
+- Command: Content Ops usage summary query filtered to account
+  `acct_support_ticket_blog_observed_shell_live_telemetry_20260528` and
+  `asset_type=blog_post`.
+  - Passed; summary returned 3 calls, 0 failures, 29,013 input tokens, 9
+    billable input tokens, 9,788 cached tokens, 19,216 cache-write tokens, 8,056
+    output tokens, and $0.016131 cost.
+- Command: `bash scripts/local_pr_review.sh --current-pr-body-file <PR body file>`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~95 |
+| Validation doc | ~120 |
+| **Total** | **~215** |


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Blog-Observed-Shell-Live-Telemetry.md
Slice phase: Functional validation

This PR records the live Haiku validation after the support-ticket observed-shell blog contract and llm_usage schema telemetry fix landed. The 36-row SaaS demo blog path now saves a draft, passes generated-content evaluation, reports ready SEO/AEO and GEO readiness, and persists matching cache/cost telemetry in llm_usage.

## Intentional
- Docs-only validation slice; no generator rewrite because the live output passed the support-ticket truthfulness gate.
- Raw live artifacts stay under tmp; the committed doc records reproducible commands and metrics.
- This validates provider prompt-cache telemetry, while Content Ops exact-cache remains disabled for this customer-data run.

## Deferred
- Future PR: broader live validation across more customer CSV shapes.
- Future PR: product UI for per-run Content Ops usage/cost telemetry.
- Future PR: deterministic renderer if free-form blog generation keeps leaking unsupported no-outcome support-ticket claims.

## Parked hardening
- None.

## Verification
- Live Haiku smoke with 36-row SaaS demo support-ticket CSV and generated-content evaluation - passed; saved draft `4792bdf3-5520-40f9-bfb3-79e2112d5624`.
- `python scripts/evaluate_support_ticket_generated_content.py --output blog_post tmp/support_ticket_blog_observed_shell_live_telemetry_20260528/blog-post-draft.json --pretty` - passed.
- Content Ops usage summary filtered to validation account and `blog_post` - passed; totals matched generation metadata: 29,013 input, 9 billable input, 9,788 cached, 19,216 cache-write, 8,056 output, 3 calls, 0 failures, $0.016131 cost.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/support-ticket-blog-observed-shell-live-telemetry-pr-body.md` - passed.

## Diff size
2 files, +257 / -0.
