### PR TITLE
PR-Content-Ops-FAQ-Hosted-Route-Preflight-URL-Guard

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -32,15 +32,6 @@ register under `docs/technical-debt/`.
 
 ## 2026-05-28
 
-### FAQ hosted route proof preflight accepts local API URLs
-- File/location: `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py` preflight and `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md`
-- Description: The hosted FAQ route proof preflight passed with `ATLAS_API_BASE_URL` set to a local HTTP host with a port, then the route phase failed all requests with connection refused.
-- Why it matters: Operators can think the deployed-host proof is ready while the configured URL only points to a stopped local server.
-- Effort: S
-- Category: correctness
-- Owner/session: content-ops/faq-search
-- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Hosted-Route-Proof
-
 ### FAQ route concurrency result top-level query can disagree with case-file query
 - File/location: `scripts/smoke_content_ops_faq_search_route_concurrency.py` result payload summary
 - Description: A case-file run used the SaaS demo query, but the route result's top-level `query` field still reflected the default/env query.

--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -12,7 +12,9 @@ coverage, use `content_ops_faq_seeded_route_e2e_runbook.md`.
 - `EXTRACTED_DATABASE_URL` or `DATABASE_URL`: Postgres database used by the
   deployed Atlas API.
 - `ATLAS_API_BASE_URL`: deployed Atlas API host, for example
-  `https://atlas-api.example.com`.
+  `https://atlas-api.example.com`. Hosted proof mode rejects local hosts such
+  as `localhost`, `127.*`, `0.0.0.0`, and `::1` because those targets cannot
+  prove deployed-route behavior.
 - `ATLAS_B2B_JWT` or `ATLAS_TOKEN`: bearer token for the account under test.
 - `ATLAS_FAQ_SEARCH_ACCOUNT_ID` or `ATLAS_ACCOUNT_ID`: account ID matching the
   bearer token. The seeder writes the demo FAQ under this account, and the
@@ -40,11 +42,12 @@ python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
   --output-result /tmp/faq-saas-demo-route-e2e-preflight.json
 ```
 
-Exit code `2` means one or more required inputs are missing. Inspect
-`preflight_errors` and `required_inputs` in the result artifact; the payload
-only reports present/missing booleans and does not include secret values. Exit
-code `0` means the blocker has moved from input availability to running the
-recommended one-command smoke below.
+Exit code `2` means one or more required inputs are missing or the configured
+base URL is not a deployed HTTP(S) API host. Inspect `preflight_errors` and
+`required_inputs` in the result artifact; the payload only reports
+present/missing booleans and does not include secret values. Exit code `0`
+means the blocker has moved from input availability to running the recommended
+one-command smoke below.
 
 ## Recommended One-Command Smoke
 

--- a/plans/PR-Content-Ops-FAQ-Hosted-Route-Preflight-URL-Guard.md
+++ b/plans/PR-Content-Ops-FAQ-Hosted-Route-Preflight-URL-Guard.md
@@ -1,0 +1,97 @@
+# Content Ops FAQ Hosted Route Preflight URL Guard
+
+## Why this slice exists
+
+PR #1091 recorded that the SaaS demo hosted-route proof preflight passed even
+though `ATLAS_API_BASE_URL` pointed at `http://127.0.0.1:8000` with no server
+listening. The proof then seeded and cleaned the database successfully but
+failed all route requests with connection refused, which means the preflight was
+only checking input presence and not whether the route target could represent a
+deployed-host proof.
+
+This promotes the parked hardening item `FAQ hosted route proof preflight
+accepts local API URLs` from `HARDENING.md`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Production hardening
+
+1. Make the SaaS demo hosted-route proof fail preflight when `--base-url` is a
+   local host such as `localhost`, `127.*`, `0.0.0.0`, or `::1`.
+2. Make malformed or scheme-less route base URLs fail preflight before any seed
+   or route command runs.
+3. Keep the existing preflight result artifact behavior so operators still get
+   a JSON explanation before exit.
+4. Update the SaaS demo route runbook to state that hosted proof mode requires a
+   deployed HTTP(S) API host.
+5. Remove the resolved `HARDENING.md` entry; leave unrelated parked items
+   parked.
+
+### Files touched
+
+- `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py` - hosted URL
+  preflight validation.
+- `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py` - fail-closed
+  local/malformed URL fixtures and artifact assertion.
+- `tests/test_content_ops_faq_saas_demo_corpus.py` - runbook parser
+  integration expectation after shell-placeholder expansion.
+- `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md` -
+  hosted base URL requirement.
+- `HARDENING.md` - remove the resolved URL-preflight parked item.
+- `plans/PR-Content-Ops-FAQ-Hosted-Route-Preflight-URL-Guard.md` - this plan.
+
+## Mechanism
+
+`_validate_args` keeps the existing required-input checks, then parses
+`args.base_url` with `urllib.parse.urlparse`. If the URL lacks an `http` or
+`https` scheme, lacks a host, or targets a local host, validation returns a
+preflight error. `main()` already writes `_preflight_summary` and returns exit
+code `2` before child commands run, so the slice uses that existing fail-closed
+path instead of adding a second control flow.
+
+## Intentional
+
+- This does not probe network liveness in preflight. A liveness check would
+  require tokened route behavior and can become flaky; this slice only blocks
+  URL shapes that can never prove deployed-host behavior.
+- This does not remove the separate parked top-level query-summary issue from
+  `HARDENING.md`; that item is unrelated to local URL preflight.
+- Non-local `http` URLs remain allowed. Some internal deployed environments use
+  HTTP behind trusted networking, so the guard is scoped to local/non-absolute
+  targets rather than enforcing HTTPS.
+
+## Deferred
+
+- Parked hardening resolved by this slice: `FAQ hosted route proof preflight
+  accepts local API URLs`.
+- Parked hardening considered but left parked: `FAQ route concurrency result
+  top-level query can disagree with case-file query`; it affects compact result
+  readability, not hosted target readiness.
+
+## Verification
+
+- Command: python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+  - Passed.
+- Command: python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q
+  - Passed, 17 tests.
+- Command: python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_e2e_command_matches_parser tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_preflight_command_matches_parser tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q
+  - Passed, 19 tests.
+- Review follow-up command: python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py && python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_e2e_command_matches_parser tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_preflight_command_matches_parser -q
+  - Passed, 21 tests.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - First run failed on stale runbook parser expectations that validated the
+    literal `$ATLAS_API_BASE_URL` placeholder as a URL.
+  - Rerun passed with 2,627 passed, 8 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| URL preflight validation | ~30 |
+| Tests | ~90 |
+| Runbook | ~10 |
+| Hardening cleanup | ~10 |
+| Plan doc | ~90 |
+| Total | ~230 |

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -13,12 +13,14 @@ import sys
 import tempfile
 import time
 from collections.abc import Mapping, Sequence
+from urllib.parse import urlparse
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
 ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
+LOCAL_BASE_URL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
 
 try:
     from dotenv import load_dotenv
@@ -78,6 +80,8 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
     ):
         if not str(getattr(args, name) or "").strip():
             errors.append(message)
+    if str(args.base_url or "").strip():
+        errors.extend(_base_url_preflight_errors(str(args.base_url)))
     for name in ("route_requests", "concurrency"):
         if int(getattr(args, name)) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
@@ -111,6 +115,21 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         if value is not None and float(value) <= 0:
             errors.append(f"--{name.replace('_', '-')} must be positive")
     return errors
+
+
+def _base_url_preflight_errors(base_url: str) -> list[str]:
+    try:
+        parsed = urlparse(base_url.strip())
+    except ValueError:
+        return ["--base-url must be an absolute HTTP(S) URL for hosted proof"]
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        return ["--base-url must be an absolute HTTP(S) URL for hosted proof"]
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return ["--base-url must include a host for hosted proof"]
+    if host in LOCAL_BASE_URL_HOSTS or host.startswith("127."):
+        return ["--base-url must point to a deployed host; local hosts are not accepted for hosted proof"]
+    return []
 
 
 def _required_input_status(args: argparse.Namespace) -> dict[str, dict[str, bool]]:

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -235,6 +235,7 @@ def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
     assert parsed.max_detail_ms == 2500
     assert parsed.artifact_dir == Path("/tmp/faq-saas-demo-route-e2e-artifacts")
     assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-result.json")
+    parsed.base_url = "https://atlas.example.com"
     assert e2e_smoke._validate_args(parsed) == []
 
 
@@ -254,6 +255,7 @@ def test_saas_demo_route_case_runbook_preflight_command_matches_parser() -> None
     assert parsed.json is True
     assert parsed.artifact_dir is None
     assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-preflight.json")
+    parsed.base_url = "https://atlas.example.com"
     assert e2e_smoke._validate_args(parsed) == []
 
 

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -157,6 +157,128 @@ def test_validate_args_fails_closed_for_missing_host_inputs() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("base_url", "expected_error"),
+    [
+        (
+            "atlas.example.com",
+            "--base-url must be an absolute HTTP(S) URL for hosted proof",
+        ),
+        (
+            "ftp://atlas.example.com",
+            "--base-url must be an absolute HTTP(S) URL for hosted proof",
+        ),
+        (
+            "http://[::1",
+            "--base-url must be an absolute HTTP(S) URL for hosted proof",
+        ),
+        (
+            "http://localhost:8000",
+            "--base-url must point to a deployed host; local hosts are not accepted for hosted proof",
+        ),
+        (
+            "http://127.0.0.1:8000",
+            "--base-url must point to a deployed host; local hosts are not accepted for hosted proof",
+        ),
+        (
+            "http://0.0.0.0:8000",
+            "--base-url must point to a deployed host; local hosts are not accepted for hosted proof",
+        ),
+        (
+            "http://[::1]:8000",
+            "--base-url must point to a deployed host; local hosts are not accepted for hosted proof",
+        ),
+    ],
+)
+def test_validate_args_fails_closed_for_non_hosted_base_url(
+    base_url: str,
+    expected_error: str,
+) -> None:
+    args = smoke._build_parser().parse_args([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        base_url,
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+    ])
+
+    assert smoke._validate_args(args) == [expected_error]
+
+
+def test_main_local_base_url_writes_preflight_result_before_exit(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(smoke, "_run_command", _fake_runner(calls))
+    result_path = tmp_path / "local-base-url-preflight.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "http://127.0.0.1:8000",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["phase"] == "preflight"
+    assert payload["preflight_errors"] == [
+        "--base-url must point to a deployed host; local hosts are not accepted for hosted proof"
+    ]
+    assert payload["required_inputs"]["base_url"] == {"present": True}
+    assert payload["seed"]["not_run_reason"] == "preflight_failed"
+    assert payload["route"]["not_run_reason"] == "preflight_failed"
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    assert calls == []
+
+
+def test_main_malformed_base_url_writes_preflight_result_before_exit(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(smoke, "_run_command", _fake_runner(calls))
+    result_path = tmp_path / "malformed-base-url-preflight.json"
+
+    code = smoke.main([
+        "--database-url",
+        "postgresql://example/atlas",
+        "--base-url",
+        "http://[::1",
+        "--token",
+        "token-123",
+        "--account-id",
+        "acct-1",
+        "--output-result",
+        str(result_path),
+        "--json",
+    ])
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert payload["phase"] == "preflight"
+    assert payload["preflight_errors"] == [
+        "--base-url must be an absolute HTTP(S) URL for hosted proof"
+    ]
+    assert payload["seed"]["not_run_reason"] == "preflight_failed"
+    assert payload["route"]["not_run_reason"] == "preflight_failed"
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    assert calls == []
+
+
 def test_main_writes_preflight_result_before_exit(tmp_path, capsys) -> None:
     result_path = tmp_path / "preflight.json"
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Hosted-Route-Preflight-URL-Guard.md
Slice phase: Production hardening

This promotes the parked FAQ hosted-route hardening item from #1091: the SaaS demo hosted-route preflight now fails before seeding data when `--base-url` is malformed, scheme-less, or points at a local host such as `localhost`, `127.*`, `0.0.0.0`, or `::1`.

## Intentional
- No network liveness probe is added; this only blocks URL shapes that can never prove deployed-host behavior.
- Non-local `http` URLs remain allowed for internal deployed environments.
- The unrelated top-level query-summary hardening item remains parked.

## Deferred
- Parked hardening resolved by this slice: `FAQ hosted route proof preflight accepts local API URLs`.
- Parked hardening left parked: `FAQ route concurrency result top-level query can disagree with case-file query`.

## Parked hardening
- None added.

## Verification
- `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
  - Passed.
- `python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q`
  - Passed, 17 tests.
- `python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_e2e_command_matches_parser tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_preflight_command_matches_parser tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q`
  - Passed, 19 tests.
- Review follow-up: `python -m py_compile scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py && python -m pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_e2e_command_matches_parser tests/test_content_ops_faq_saas_demo_corpus.py::test_saas_demo_route_case_runbook_preflight_command_matches_parser -q`
  - Passed, 21 tests.
- `bash scripts/run_extracted_pipeline_checks.sh`
  - First run failed on stale runbook parser expectations that validated the literal `$ATLAS_API_BASE_URL` placeholder as a URL.
  - Rerun passed with 2,627 passed, 8 skipped, 1 warning.

## Diff size
6 files, +247 / -15
