### PR TITLE
Codify evaluator-pattern precision coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,9 +434,9 @@ Before LGTM, the reviewer confirms:
       has a focused negative fixture, OR predicates have one-marker
       fixtures, and false-positive surfaces are covered or explicitly
       deferred with a named future slice. If the PR adds or changes
-      denylist/regex/pattern-list detection, the coverage includes an
-      allowed near-miss fixture or the plan names the future PR that will add
-      it.
+      denylist/regex/phrase-matcher/pattern-list detection, the coverage
+      includes an allowed near-miss fixture or the plan names the future PR
+      that will add it.
 - [ ] No drift from the plan's stated scope (no scope creep, no
       "while I was at it" cleanups beyond the slice's contract).
 - [ ] Defensible trade-offs are explained in **Intentional**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,11 +365,19 @@ Required coverage shape:
    checks need tests for lookalikes: strings that are `Sequence`, empty lists,
    malformed-but-realistic JSON, unknown headings, missing keys, or unrelated
    route envelopes.
-4. **I/O checkers mock the transport, not the checker.** For network/file/DB
+4. **Evaluator pattern changes prove precision.** If a PR adds or changes a
+   denylist, regex, phrase matcher, or pattern list in an evaluator/checker,
+   pair the bad-input fixture with at least one allowed near-miss fixture that
+   should still pass. Example: a support-ticket claim detector that blocks
+   "traffic suggests customers found the answer" also needs a neutral
+   measurement sentence such as "use page views as one signal" that remains
+   allowed. If the near-miss is intentionally omitted, the plan must name the
+   risk, why it is safe for this slice, and the future PR that will add it.
+5. **I/O checkers mock the transport, not the checker.** For network/file/DB
    checkers, test the real fetch/read path by mocking `urlopen`, file handles,
    DB cursors, or equivalent transport boundaries. Replacing the checker’s
    own fetch helper with a fake is not enough.
-5. **Result-envelope drift fails closed.** If a checker returns `ok`,
+6. **Result-envelope drift fails closed.** If a checker returns `ok`,
    `errors`, `count`, `results`, or similar contract fields, tests must cover
    malformed or contradictory envelopes so missing error lists, count
    mismatches, or non-object payloads do not silently pass.
@@ -425,7 +433,10 @@ Before LGTM, the reviewer confirms:
 - [ ] For checker/evaluator/validator/gate PRs, each detection branch
       has a focused negative fixture, OR predicates have one-marker
       fixtures, and false-positive surfaces are covered or explicitly
-      deferred with a named future slice.
+      deferred with a named future slice. If the PR adds or changes
+      denylist/regex/pattern-list detection, the coverage includes an
+      allowed near-miss fixture or the plan names the future PR that will add
+      it.
 - [ ] No drift from the plan's stated scope (no scope creep, no
       "while I was at it" cleanups beyond the slice's contract).
 - [ ] Defensible trade-offs are explained in **Intentional**.

--- a/plans/PR-Evaluator-Pattern-Precision-Contract.md
+++ b/plans/PR-Evaluator-Pattern-Precision-Contract.md
@@ -10,7 +10,7 @@ pattern does not reject neutral language.
 AGENTS.md already says false-positive surfaces need rejection fixtures, but the
 rule is broad enough that evaluator-pattern slices keep treating it as
 optional. This workflow/process slice makes the requirement explicit for
-denylist, regex, and pattern-list evaluator changes.
+denylist, regex, phrase-matcher, and pattern-list evaluator changes.
 
 ## Scope (this PR)
 
@@ -18,8 +18,8 @@ Ownership lane: workflow/process
 Slice phase: Workflow/process
 
 1. Update the checker/evaluator coverage contract to require at least one
-   allowed near-miss fixture whenever a PR adds or changes denylist, regex, or
-   pattern-list detection.
+   allowed near-miss fixture whenever a PR adds or changes denylist, regex,
+   phrase-matcher, or pattern-list detection.
 2. Update the reviewer checklist so reviewers can enforce that precision
    requirement directly instead of re-raising it as a recurring NIT.
 3. Keep this to workflow documentation only; no product code, evaluator code,
@@ -36,8 +36,8 @@ The existing `3i. Checkers prove their failure detection` section already
 requires negative fixtures and false-positive rejection fixtures. This slice
 adds a specific sub-rule for evaluator pattern work:
 
-- new or changed denylist/regex/pattern-list detectors need one bad fixture
-  that must fail and one allowed near-miss fixture that must pass
+- new or changed denylist/regex/phrase-matcher/pattern-list detectors need one
+  bad fixture that must fail and one allowed near-miss fixture that must pass
 - the plan must explicitly defer the near-miss only when it names why that is
   safe and what future PR owns it
 

--- a/plans/PR-Evaluator-Pattern-Precision-Contract.md
+++ b/plans/PR-Evaluator-Pattern-Precision-Contract.md
@@ -1,0 +1,73 @@
+# PR: Evaluator Pattern Precision Contract
+
+## Why this slice exists
+
+Recent support-ticket generated-content evaluator slices repeatedly added
+narrow denylist/regex patterns with negative fixtures, but review kept catching
+the same missing precision half: no allowed near-miss fixture proving the new
+pattern does not reject neutral language.
+
+AGENTS.md already says false-positive surfaces need rejection fixtures, but the
+rule is broad enough that evaluator-pattern slices keep treating it as
+optional. This workflow/process slice makes the requirement explicit for
+denylist, regex, and pattern-list evaluator changes.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Update the checker/evaluator coverage contract to require at least one
+   allowed near-miss fixture whenever a PR adds or changes denylist, regex, or
+   pattern-list detection.
+2. Update the reviewer checklist so reviewers can enforce that precision
+   requirement directly instead of re-raising it as a recurring NIT.
+3. Keep this to workflow documentation only; no product code, evaluator code,
+   or test behavior changes.
+
+### Files touched
+
+- `AGENTS.md` - codify the evaluator-pattern precision-test requirement.
+- `plans/PR-Evaluator-Pattern-Precision-Contract.md` - this plan.
+
+## Mechanism
+
+The existing `3i. Checkers prove their failure detection` section already
+requires negative fixtures and false-positive rejection fixtures. This slice
+adds a specific sub-rule for evaluator pattern work:
+
+- new or changed denylist/regex/pattern-list detectors need one bad fixture
+  that must fail and one allowed near-miss fixture that must pass
+- the plan must explicitly defer the near-miss only when it names why that is
+  safe and what future PR owns it
+
+The reviewer checklist is updated to mirror the builder-side rule so both
+sessions share the same expected coverage shape.
+
+## Intentional
+
+- This is documentation-only because the recurring gap is a workflow contract
+  gap, not a runtime behavior gap after PR #1092.
+- No mechanical audit is added. A CI rule that detects evaluator-pattern diffs
+  and verifies paired tests would be larger and more brittle than this slice.
+- `AUDITOR_PROMPT.md` is left unchanged because AGENTS.md is the active PR
+  contract both builder and reviewer sessions are instructed to read.
+
+## Deferred
+
+- Future PR: add a mechanical audit if this explicit AGENTS.md rule still does
+  not stop evaluator-pattern slices from shipping without near-miss coverage.
+- Parked hardening: none.
+
+## Verification
+
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file <PR body file>
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| AGENTS.md contract update | ~20 |
+| Plan doc | ~70 |
+| **Total** | **~90** |


### PR DESCRIPTION
Plan: plans/PR-Evaluator-Pattern-Precision-Contract.md
Ownership lane: workflow/process
Slice phase: Workflow/process

This codifies the recurring reviewer ask from evaluator-pattern slices: denylist, regex, phrase-matcher, and pattern-list changes need an allowed near-miss precision fixture, not only bad-input fixtures.

## Intentional
- Documentation-only workflow/process slice; no product code or evaluator behavior changes.
- No mechanical audit yet; the plan defers that unless the explicit AGENTS.md rule still fails to stick.
- AUDITOR_PROMPT.md is unchanged because AGENTS.md is the active PR contract for builder and reviewer sessions.

## Deferred
- Future PR: add a mechanical audit if evaluator-pattern slices continue shipping without near-miss coverage.

## Parked hardening
None.

## Verification
- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/evaluator-pattern-precision-contract-pr-body.md -- passed.

## Diff size
~90 LOC estimated; under the 400 LOC soft cap.
