### PR TITLE
Clear stale LLM usage hardening item

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -41,15 +41,6 @@ register under `docs/technical-debt/`.
 - Owner/session: content-ops/faq-search
 - Found during: PR-Content-Ops-FAQ-SaaS-Demo-Hosted-Route-Proof
 
-### LLM usage storage schema mismatch hides per-run cost telemetry
-- File/location: `atlas_brain/observability` LLM usage storage path, local `llm_usage` table schema.
-- Description: Live support-ticket blog generation logged LLM usage storage failures, including `column "account_id" of relation "llm_usage" does not exist` and `pool is closing`.
-- Why it matters: Generation can still run, but per-run model/cost telemetry is incomplete and warning noise can hide other live-generation issues.
-- Effort: M
-- Category: tech-debt
-- Owner/session: content-ops/support-ticket-provider
-- Found during: PR-Support-Ticket-Blog-Observed-Shell-Live-Retry
-
 ### Atlas startup migration check warns on missing b2b_campaigns.updated_at
 - File/location: `atlas_brain/storage/migrations/309_campaign_sequences_unique_active_recipient.sql`, Atlas startup migration check.
 - Description: Local API startup logged `column "updated_at" of relation "b2b_campaigns" does not exist` while checking pending host migrations.

--- a/plans/PR-Clear-Stale-LLM-Usage-Hardening.md
+++ b/plans/PR-Clear-Stale-LLM-Usage-Hardening.md
@@ -1,0 +1,70 @@
+# PR: Clear Stale LLM Usage Hardening
+
+## Why this slice exists
+
+`HARDENING.md` still lists `LLM usage storage schema mismatch hides per-run cost
+telemetry`, but that parked item has already been closed by
+`PR-LLM-Usage-Schema-Cache-Telemetry` and then proven by the live
+support-ticket observed-shell telemetry validation.
+
+Leaving the closed item in the active queue makes the support-ticket/provider
+lane look more blocked than it is and can cause future sessions to re-scope a
+fixed issue instead of moving to the next real hardening gap.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-provider
+Slice phase: Production hardening
+
+1. Remove the stale LLM usage schema mismatch entry from `HARDENING.md`.
+2. Verify the merged plan and live validation doc still contain the closure
+   evidence for traceability.
+3. Keep this to hardening queue cleanup; no runtime code or schema changes.
+
+### Files touched
+
+- `HARDENING.md` - remove the closed support-ticket/provider telemetry item.
+- `plans/PR-Clear-Stale-LLM-Usage-Hardening.md` - this plan.
+
+## Mechanism
+
+The hardening item is removed because the repository already contains:
+
+- `plans/PR-LLM-Usage-Schema-Cache-Telemetry.md`, which documents the schema
+  fallback fix and says the parked item was closed
+- `docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md`,
+  which records a live support-ticket blog generation run where persisted
+  `llm_usage` totals matched `generation_usage`
+
+This slice does not change the runtime path. It only reconciles the active
+hardening queue with the already-merged implementation and validation evidence.
+
+## Intentional
+
+- No new telemetry test is added because this slice does not alter telemetry
+  behavior. Existing tests and the live validation doc are the evidence.
+- The FAQ-search owned hardening entries remain untouched.
+- The broader product UI for surfacing per-run cost remains a separate product
+  slice.
+
+## Deferred
+
+- Future PR: surface per-run Content Ops usage/cost in the product UI.
+- Parked hardening: none.
+
+## Verification
+
+- Command: if rg -n '^### LLM usage storage schema mismatch hides per-run cost telemetry' HARDENING.md; then exit 1; fi
+  - Passed; no active hardening entry remains.
+- Command: rg -n 'PR-LLM-Usage-Schema-Cache-Telemetry|Persisted `llm_usage` summary|cache-token telemetry survived' plans/PR-LLM-Usage-Schema-Cache-Telemetry.md docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md
+  - Passed; merged plan and live validation evidence remain in-tree.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file <PR body file>
+  - Passed; advisory overlap with #1094 on `HARDENING.md`, no blocking drift.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Hardening cleanup | ~9 |
+| Plan doc | ~70 |
+| **Total** | **~79** |


### PR DESCRIPTION
Plan: plans/PR-Clear-Stale-LLM-Usage-Hardening.md
Ownership lane: content-ops/support-ticket-provider
Slice phase: Production hardening

This clears the stale active HARDENING.md entry for the LLM usage schema mismatch after the fix and live support-ticket telemetry proof already landed.

## Intentional
- Hardening queue cleanup only; no runtime code or schema changes.
- Historical plan docs that mention the old item remain untouched as audit history.
- Per-run cost UI remains a separate product slice.

## Deferred
- Future PR: surface per-run Content Ops usage/cost in the product UI.

## Parked hardening
None.

## Verification
- if rg -n '^### LLM usage storage schema mismatch hides per-run cost telemetry' HARDENING.md; then exit 1; fi -- passed; no active hardening entry remains.
- rg -n 'PR-LLM-Usage-Schema-Cache-Telemetry|Persisted `llm_usage` summary|cache-token telemetry survived' plans/PR-LLM-Usage-Schema-Cache-Telemetry.md docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md -- passed; closure evidence remains.
- bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/clear-stale-llm-usage-hardening-pr-body.md -- passed; advisory overlap with #1094 on HARDENING.md, no blocking drift.

## Diff size
~79 LOC estimated; under the 400 LOC soft cap.
