### PR TITLE
PR-Content-Ops-FAQ-Voice-Startup-Guard

### DIFF
--- a/.github/workflows/atlas_main_voice_startup_checks.yml
+++ b/.github/workflows/atlas_main_voice_startup_checks.yml
@@ -1,0 +1,37 @@
+name: Atlas Main Voice Startup Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_main_voice_startup_checks.yml"
+      - "atlas_brain/main.py"
+      - "tests/test_atlas_main_voice_startup.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_main_voice_startup_checks.yml"
+      - "atlas_brain/main.py"
+      - "tests/test_atlas_main_voice_startup.py"
+
+jobs:
+  atlas-main-voice-startup-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Atlas main voice startup tests
+        run: python -m pytest tests/test_atlas_main_voice_startup.py -q

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -41,15 +41,6 @@ register under `docs/technical-debt/`.
 - Owner/session: content-ops/faq-search
 - Found during: PR-Content-Ops-FAQ-SaaS-Demo-Local-Route-Proof
 
-### Voice ASR auto-start blocks non-voice route validation on CUDA-less hosts
-- File/location: `atlas_brain/main.py` lifespan voice startup, `atlas_brain/config.py` voice defaults.
-- Description: Starting Atlas without voice overrides attempted to auto-start ASR on CUDA and failed because no CUDA GPU was available.
-- Why it matters: Non-voice route validation can waste time or appear broken unless operators know to set `ATLAS_VOICE_ENABLED=false ATLAS_VOICE_AUTO_START_ASR=false`.
-- Effort: S
-- Category: polish
-- Owner/session: content-ops/faq-search
-- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Local-Route-Proof
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/atlas_brain/main.py
+++ b/atlas_brain/main.py
@@ -36,6 +36,35 @@ logging.basicConfig(
 logger = logging.getLogger("atlas.main")
 
 
+def _asr_autostart_blocked_reason(device: str) -> str | None:
+    normalized_device = str(device or "").strip().lower()
+    if not normalized_device.startswith("cuda"):
+        return None
+
+    try:
+        import torch
+    except Exception as exc:
+        return (
+            "Skipping ASR auto-start because device "
+            f"{device!r} requires CUDA but torch could not be imported: {exc}"
+        )
+
+    try:
+        cuda_available = bool(torch.cuda.is_available())
+    except Exception as exc:
+        return (
+            "Skipping ASR auto-start because device "
+            f"{device!r} requires CUDA but CUDA availability could not be checked: {exc}"
+        )
+
+    if cuda_available:
+        return None
+    return (
+        "Skipping ASR auto-start because device "
+        f"{device!r} requires CUDA but CUDA is not available"
+    )
+
+
 async def _start_asr_server() -> subprocess.Popen | None:
     """Start the ASR server as a subprocess if not already running."""
     import sys
@@ -56,6 +85,12 @@ async def _start_asr_server() -> subprocess.Popen | None:
     except Exception:
         pass
 
+    device = settings.voice.asr_device
+    blocked_reason = _asr_autostart_blocked_reason(device)
+    if blocked_reason:
+        logger.warning("%s", blocked_reason)
+        return None
+
     # Find the asr_server.py script
     project_root = Path(__file__).parent.parent
     asr_script = project_root / "asr_server.py"
@@ -65,7 +100,6 @@ async def _start_asr_server() -> subprocess.Popen | None:
 
     port = parsed.port or 8081
     model = settings.voice.asr_model
-    device = settings.voice.asr_device
 
     logger.info("Starting ASR server: model=%s port=%d device=%s", model, port, device)
 

--- a/plans/PR-Content-Ops-FAQ-Voice-Startup-Guard.md
+++ b/plans/PR-Content-Ops-FAQ-Voice-Startup-Guard.md
@@ -1,0 +1,74 @@
+# PR-Content-Ops-FAQ-Voice-Startup-Guard
+
+## Why this slice exists
+
+`HARDENING.md` records that local FAQ route validation can look broken on CUDA-less hosts because Atlas startup tries to auto-start the voice ASR subprocess with `asr_device="cuda"`. Non-voice Content Ops route validation should not wait on or fail because a local machine cannot spawn the optional CUDA ASR server.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+Slice phase: Production hardening
+
+1. Guard ASR subprocess auto-start when the configured ASR device requires CUDA but local CUDA is unavailable.
+2. Preserve existing behavior when an external ASR server is already running.
+3. Enroll the focused regression test in a dedicated CI workflow.
+4. Remove the resolved `HARDENING.md` entry.
+
+### Files touched
+
+- `atlas_brain/main.py`
+- `tests/test_atlas_main_voice_startup.py`
+- `.github/workflows/atlas_main_voice_startup_checks.yml`
+- `HARDENING.md`
+- `plans/PR-Content-Ops-FAQ-Voice-Startup-Guard.md`
+
+## Mechanism
+
+`_start_asr_server` already checks whether the configured ASR endpoint is healthy before spawning `asr_server.py`. This slice keeps that order, then adds a device guard before `subprocess.Popen`:
+
+```python
+reason = _asr_autostart_blocked_reason(settings.voice.asr_device)
+if reason:
+    logger.warning("%s", reason)
+    return None
+```
+
+The guard only applies to `cuda*` devices. CPU ASR and already-running external ASR endpoints remain unaffected.
+
+## Intentional
+
+- This does not change the default voice settings; it only prevents an impossible local CUDA spawn.
+- This does not disable the voice pipeline globally. The issue being drained is the blocking ASR subprocess auto-start path.
+- This does not solve the separate startup migration warning entry.
+
+## Deferred
+
+- Future PR: handle `b2b_campaigns.updated_at` startup migration drift.
+- Parked hardening: none. This slice removes the voice ASR startup item from `HARDENING.md`.
+
+## Verification
+
+Passed locally:
+
+```bash
+python -m py_compile atlas_brain/main.py tests/test_atlas_main_voice_startup.py
+python -m pytest tests/test_atlas_main_voice_startup.py -q
+4 passed, 1 torch CUDA import deprecation warning from the local environment
+```
+
+To be run before PR:
+
+```bash
+bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-voice-startup-guard-pr-body.md
+```
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan doc | 74 |
+| ASR startup guard | 36 |
+| Tests | 89 |
+| CI workflow | 37 |
+| Hardening cleanup | 9 |
+| **Total** | **245** |

--- a/tests/test_atlas_main_voice_startup.py
+++ b/tests/test_atlas_main_voice_startup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from atlas_brain import main
+
+
+def test_asr_autostart_allows_cpu_device():
+    assert main._asr_autostart_blocked_reason("cpu") is None
+
+
+def test_asr_autostart_blocks_cuda_when_unavailable(monkeypatch):
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    reason = main._asr_autostart_blocked_reason("cuda")
+
+    assert reason is not None
+    assert "requires CUDA" in reason
+    assert "CUDA is not available" in reason
+
+
+def test_start_asr_server_skips_popen_when_cuda_unavailable(monkeypatch):
+    class FakeAsyncClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            raise RuntimeError("ASR endpoint is down")
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+    fake_httpx = SimpleNamespace(AsyncClient=FakeAsyncClient)
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(main.settings.voice, "asr_url", "http://localhost:8081")
+    monkeypatch.setattr(main.settings.voice, "asr_device", "cuda")
+    monkeypatch.setattr(
+        main.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("ASR subprocess should not start"),
+    )
+
+    assert asyncio.run(main._start_asr_server()) is None
+
+
+def test_start_asr_server_keeps_running_external_asr_before_cuda_guard(monkeypatch):
+    class FakeResponse:
+        status_code = 200
+
+    class FakeAsyncClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+        async def get(self, _url):
+            return FakeResponse()
+
+    fake_httpx = SimpleNamespace(AsyncClient=FakeAsyncClient)
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+    monkeypatch.setattr(main.settings.voice, "asr_url", "http://localhost:8081")
+    monkeypatch.setattr(main.settings.voice, "asr_device", "cuda")
+    monkeypatch.setattr(
+        main,
+        "_asr_autostart_blocked_reason",
+        lambda _device: pytest.fail("CUDA guard should not run for healthy external ASR"),
+    )
+    monkeypatch.setattr(
+        main.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("ASR subprocess should not start"),
+    )
+
+    assert asyncio.run(main._start_asr_server()) is None


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Voice-Startup-Guard.md
Ownership lane: content-ops/faq-search
Slice phase: Production hardening

Local FAQ route validation can look broken on CUDA-less hosts because Atlas startup tries to auto-start the optional ASR subprocess with a CUDA device. This keeps voice defaults intact, preserves existing external-ASR health-check behavior, and skips only the impossible local CUDA ASR subprocess spawn.

## Intentional
- The default voice settings are unchanged; the guard only prevents an impossible local CUDA spawn.
- Existing external ASR endpoints still win because the health check runs before the CUDA guard.
- The focused regression test is enrolled in a dedicated CI workflow instead of the extracted pipeline lane.
- This does not address the separate `b2b_campaigns.updated_at` startup migration warning.

## Deferred
- Future PR: handle `b2b_campaigns.updated_at` startup migration drift.

## Parked hardening
- None. Removed the `Voice ASR auto-start blocks non-voice route validation on CUDA-less hosts` entry from `HARDENING.md`.

## Verification
- `python -m py_compile atlas_brain/main.py tests/test_atlas_main_voice_startup.py`
- `python -m pytest tests/test_atlas_main_voice_startup.py -q` (4 passed, 1 local torch CUDA import deprecation warning)

## Diff size
5 files, +235 / -10
