### PR TITLE
Surface per-run Content Ops usage

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs
@@ -35,7 +35,7 @@ const {
   ],
 ])
 
-const { fromWireUsageSummary } = await loadTsModule(
+const { fromWireExecution, fromWireUsageSummary } = await loadTsModule(
   '../src/domain/contentOps/fromWire.ts',
 )
 
@@ -194,8 +194,43 @@ test('fromWireUsageSummary defaults missing cache diagnostics to empty list', ()
   assert.deepEqual(summary.byCacheStatus, [])
 })
 
+test('fromWireExecution maps run request id and usage summary', () => {
+  const execution = fromWireExecution({
+    status: 'completed',
+    request_id: 'content-ops-req-123',
+    usage_summary: usageSummaryPayload(),
+    plan: {
+      can_execute: true,
+      target_mode: 'vendor_retention',
+      limit: 1,
+      steps: [],
+      preview: {
+        can_run: true,
+        outputs: ['blog_post'],
+        estimated_cost_usd: 0.12,
+        missing_inputs: [],
+        blocked_outputs: [],
+        warnings: [],
+        normalized_request: null,
+      },
+    },
+    steps: [],
+    errors: [],
+  })
+
+  assert.equal(execution.requestId, 'content-ops-req-123')
+  assert.equal(execution.usageSummary.summary.totalCostUsd, 1.2345)
+  assert.equal(execution.usageSummary.summary.totalCacheSavingsUsd, 0.4321)
+})
+
 test('new run usage card exposes cache diagnostics section', () => {
   assert.ok(newRunSource.includes('Cache diagnostics'))
   assert.ok(newRunSource.includes('formatCacheDiagnosticLabel'))
   assert.ok(newRunSource.includes('byCacheStatus.slice(0, 3)'))
+})
+
+test('new run execution panel exposes run usage section', () => {
+  assert.ok(newRunSource.includes('function RunUsageSummary'))
+  assert.ok(newRunSource.includes('This run'))
+  assert.ok(newRunSource.includes('Usage summary unavailable for this run.'))
 })

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -373,6 +373,8 @@ export interface ContentOpsExecutionResult {
   plan: GenerationPlanResponse
   steps: ContentOpsStepExecution[]
   errors: Array<Record<string, unknown>>
+  request_id?: string
+  usage_summary?: ContentOpsUsageSummaryResponse
   input_provider?: ContentOpsInputProviderDiagnostics
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -590,6 +590,12 @@ export function fromWireExecution(
     steps: wire.steps.map(fromWireStepExecution),
     errors: wire.errors.map((e) => ({ ...e })),
   }
+  if (typeof wire.request_id === 'string' && wire.request_id.trim()) {
+    result.requestId = wire.request_id
+  }
+  if (wire.usage_summary) {
+    result.usageSummary = fromWireUsageSummary(wire.usage_summary)
+  }
   const inputProvider = fromWireInputProviderDiagnostics(wire.input_provider)
   if (inputProvider) {
     result.inputProvider = inputProvider

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -336,6 +336,8 @@ export interface ContentOpsExecutionResult {
   plan: GenerationPlan
   steps: ContentOpsStepExecution[]
   errors: Array<Record<string, unknown>>
+  requestId?: string
+  usageSummary?: ContentOpsUsageSummary
   inputProvider?: ContentOpsInputProviderDiagnostics
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -2614,6 +2614,11 @@ function ExecutionPanel({ result }: { result: ContentOpsExecutionResult }) {
         </div>
       </div>
 
+      <RunUsageSummary
+        requestId={result.requestId}
+        summary={result.usageSummary}
+      />
+
       <div className="space-y-3">
         {result.steps.map((step) => (
           <div
@@ -2667,6 +2672,44 @@ function ExecutionPanel({ result }: { result: ContentOpsExecutionResult }) {
 
       <InputProviderDiagnosticsSection diagnostics={result.inputProvider} />
     </section>
+  )
+}
+
+function RunUsageSummary({
+  requestId,
+  summary,
+}: {
+  requestId?: string
+  summary?: ContentOpsUsageSummary
+}) {
+  if (!requestId && !summary) return null
+  const totals = summary?.summary
+  return (
+    <div className="mb-4 rounded-md border border-slate-800 bg-slate-950/40 px-3 py-3">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+          This run
+        </div>
+        {requestId && (
+          <span className="font-mono text-[11px] text-slate-600">
+            {requestId}
+          </span>
+        )}
+      </div>
+      {totals ? (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+          <UsageMetric label="Spend" value={formatUsd(totals.totalCostUsd)} />
+          <UsageMetric label="Saved" value={formatUsd(totals.totalCacheSavingsUsd)} />
+          <UsageMetric label="Calls" value={formatCount(totals.totalCalls)} />
+          <UsageMetric label="Cache hits" value={formatCount(totals.cacheHitCalls)} />
+          <UsageMetric label="Tokens" value={formatCount(totals.totalTokens)} />
+        </div>
+      ) : (
+        <div className="text-xs text-slate-500">
+          Usage summary unavailable for this run.
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md
+++ b/docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md
@@ -150,4 +150,5 @@ Next useful slices:
 - broaden live validation across more customer CSV shapes
 - decide whether to promote this accepted artifact into a minimized regression
   fixture
-- surface per-run Content Ops usage/cost in the product UI
+- per-run Content Ops usage/cost in the product UI is addressed by
+  `plans/PR-Content-Ops-Run-Usage-Summary.md`

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
+from uuid import uuid4
 
 try:
     from fastapi import APIRouter, Body, File, Form, HTTPException, Query, UploadFile
@@ -895,6 +896,7 @@ def create_content_ops_control_surface_router(
                     status_code=503,
                     detail="Content Ops execution services are not configured.",
                 )
+            request_id = f"content-ops-{uuid4().hex}"
             # PR-ControlSurfaces-Reasoning-Provider: resolve the optional
             # per-request reasoning provider and derive a reasoning-aware
             # bundle. The base services from execution_services_provider
@@ -933,11 +935,20 @@ def create_content_ops_control_surface_router(
                     payload_mapping,
                     services=services,
                     scope=scope,
+                    trace_metadata={"request_id": request_id},
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             result = _sanitize_execution_result(result)
             result = _with_input_provider_diagnostics(result, payload_mapping)
+            result["request_id"] = request_id
+            usage_summary = await _execute_usage_summary(
+                usage_pool_provider=usage_pool_provider,
+                scope=scope,
+                request_id=request_id,
+            )
+            if usage_summary is not None:
+                result["usage_summary"] = usage_summary
             if result["status"] == "blocked":
                 raise HTTPException(status_code=400, detail=result)
             if result["status"] == "failed":
@@ -1602,6 +1613,34 @@ async def _resolve_usage_pool(pool_provider: PoolProvider | None) -> Any:
             detail="Content Ops usage database is unavailable.",
         )
     return pool
+
+
+async def _execute_usage_summary(
+    *,
+    usage_pool_provider: PoolProvider | None,
+    scope: TenantScope,
+    request_id: str,
+) -> dict[str, Any] | None:
+    if usage_pool_provider is None:
+        return None
+    account_id = _clean(getattr(scope, "account_id", None))
+    if not account_id:
+        return None
+    try:
+        pool = await _resolve_usage_pool(usage_pool_provider)
+        return await summarize_content_ops_llm_usage(
+            pool,
+            days=1,
+            account_id=account_id,
+            request_id=request_id,
+        )
+    except Exception:
+        logger.warning(
+            "Content Ops execute usage summary unavailable",
+            exc_info=True,
+            extra={"request_id": request_id},
+        )
+        return None
 
 
 async def _evaluate_account_usage_budget(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -238,6 +238,7 @@ async def execute_content_ops_request(
     *,
     services: ContentOpsExecutionServices,
     scope: TenantScope | None = None,
+    trace_metadata: Mapping[str, Any] | None = None,
 ) -> ContentOpsExecutionResult:
     """Execute a runnable content-ops plan using host-provided services.
 
@@ -269,6 +270,7 @@ async def execute_content_ops_request(
             request=request,
             service=services.for_output(step.output),
             scope=resolved_scope,
+            trace_metadata=trace_metadata,
             filters=filters,
             reasoning_provider_configured=services.reasoning_provider_active_for(
                 step.output
@@ -302,6 +304,7 @@ async def _execute_step(
     request: ContentOpsRequest,
     service: Any | None,
     scope: TenantScope,
+    trace_metadata: Mapping[str, Any] | None,
     filters: Mapping[str, Any] | None,
     reasoning_provider_configured: bool,
 ) -> tuple[ContentOpsStepExecution, Mapping[str, Any] | None]:
@@ -317,7 +320,11 @@ async def _execute_step(
             error,
         )
     trace_context_token = set_content_ops_llm_trace_context(
-        _request_trace_metadata(scope=scope, request=request)
+        _request_trace_metadata(
+            scope=scope,
+            request=request,
+            extra=trace_metadata,
+        )
     )
     try:
         result = await _run_step(
@@ -373,6 +380,7 @@ def _request_trace_metadata(
     *,
     scope: TenantScope,
     request: ContentOpsRequest,
+    extra: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     metadata = _scope_trace_metadata(scope)
     if request.content_ops_cache_policy:
@@ -382,6 +390,11 @@ def _request_trace_metadata(
             "source_type": SUPPORT_TICKET_SOURCE_MARKER,
             "input_provider": SUPPORT_TICKET_SOURCE,
         })
+    if isinstance(extra, Mapping):
+        for key, value in extra.items():
+            text = str(value or "").strip()
+            if text:
+                metadata.setdefault(str(key), text)
     return metadata
 
 
@@ -390,6 +403,7 @@ async def execute_content_ops_from_mapping(
     *,
     services: ContentOpsExecutionServices,
     scope: TenantScope | None = None,
+    trace_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Dict-friendly execution wrapper for host API routes."""
 
@@ -397,6 +411,7 @@ async def execute_content_ops_from_mapping(
         request_from_mapping(payload),
         services=services,
         scope=scope,
+        trace_metadata=trace_metadata,
     )
     return result.as_dict()
 

--- a/plans/PR-Content-Ops-Run-Usage-Summary.md
+++ b/plans/PR-Content-Ops-Run-Usage-Summary.md
@@ -1,0 +1,103 @@
+# PR: Content Ops Run Usage Summary
+
+## Why this slice exists
+
+Content Ops now records LLM usage, exposes account-scoped usage summaries, and
+shows a 7-day usage card. The remaining operator gap is per-run visibility:
+after an execute call completes, the screen still does not connect that specific
+generation to the usage rows it created.
+
+The source fix is to stamp each hosted execute request with a stable request id,
+carry that id into Content Ops LLM trace metadata, summarize usage for that
+request, and render the result beside the execution output.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Product polish
+
+1. Add hosted execute request-id tracing without changing customer inputs.
+2. Return an optional run-scoped usage summary from `/content-ops/execute` when
+   the usage database is configured.
+3. Map and render that usage summary in the Content Ops execution panel.
+4. Pin the backend trace/request contract and frontend mapper/UI contract.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Run-Usage-Summary.md` - Plan doc for this slice.
+- `extracted_content_pipeline/content_ops_execution.py` - Accept extra trace metadata and merge it into per-step LLM trace context.
+- `extracted_content_pipeline/api/control_surfaces.py` - Stamp execute requests, summarize matching usage, and return it.
+- `tests/test_extracted_content_control_surface_api.py` - Cover request-id trace context and execute usage-summary response wiring.
+- `atlas-intel-ui/src/api/contentOps.ts` - Add execute response usage-summary wire fields.
+- `atlas-intel-ui/src/domain/contentOps/types.ts` - Add execute response request id and usage summary domain fields.
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts` - Map execute usage summary into the domain model.
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` - Render run usage inside the execution panel.
+- `atlas-intel-ui/scripts/content-ops-usage-summary.test.mjs` - Pin execution mapper and UI labels for run usage.
+- `docs/extraction/validation/support_ticket_blog_observed_shell_live_telemetry_2026-05-28.md` - Mark the per-run usage UI follow-up addressed by this slice.
+
+## Mechanism
+
+The hosted `/execute` route generates a request id before calling the execution
+engine. The execution engine accepts an optional `trace_metadata` mapping and
+merges it into the same context that already carries account and cache policy
+metadata. That keeps request tracking in infrastructure code instead of adding a
+user-facing input field.
+
+After execution, the route resolves the account-scoped usage pool if one is
+configured and calls `summarize_content_ops_llm_usage(..., request_id=<id>)`.
+The usage summary is returned as `usage_summary`; failures to read usage do not
+fail generation, because generation may be valid even if telemetry is
+temporarily unavailable.
+
+The UI reuses the existing usage-summary wire/domain types and renders a compact
+"This run" usage block in the execution panel.
+
+## Intentional
+
+- This does not expose prompts, responses, or support-ticket bodies. The result
+  only returns aggregate tokens, calls, cost, savings, and cache counters.
+- This does not infer per-run usage from the 7-day card. The request id is
+  written into the trace context and the summary reads by that id.
+- This does not require the usage database for execute to succeed. Missing usage
+  infrastructure omits the run summary instead of blocking generation.
+
+## Deferred
+
+- Future PR: add a deeper per-run model/cache breakdown drawer if the compact
+  metrics are not enough.
+- Future PR: add a manual refresh for run usage if async usage persistence ever
+  becomes delayed.
+- Parked hardening: none. Root `HARDENING.md` has no active cost-surfacing
+  parked items; `ATLAS-HARDENING.md` contains older blog/deep-dive content
+  items outside this lane.
+
+## Verification
+
+- Focused backend route pytest for the execute usage summary and trace-context
+  tests - 2 passed.
+- Frontend usage-summary contract test script - 6 passed.
+- Python compile over the touched backend route, executor, and backend test file
+  - passed.
+- Broader executor/control-surface pytest covering direct executor callers and
+  hosted execute route behavior - 57 passed.
+- Intel UI lint - passed.
+- Whitespace check - passed.
+- Intel UI production build - passed.
+- Recurring/stale-value grep for the old per-run usage follow-up and stale LLM
+  usage hardening title - no matches.
+- Plan placeholder grep for the old "pending implementation" marker - no
+  matches.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~88 |
+| Backend request-id/usage response | ~70 |
+| Backend tests | ~55 |
+| Frontend types/mapper/UI | ~85 |
+| Frontend test updates | ~35 |
+| Validation follow-up doc | ~3 |
+| **Total** | **~336** |
+
+This stays below the 400 LOC soft cap.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2045,6 +2045,40 @@ async def test_execute_generation_route_runs_configured_services():
 
 
 @pytest.mark.asyncio
+async def test_execute_generation_route_returns_request_usage_summary():
+    service = _CampaignService()
+    usage_pool = _UsagePool()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(campaign=service),
+        usage_pool_provider=lambda: usage_pool,
+        scope_provider=lambda: {"account_id": "acct-run-usage"},
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["email_campaign"],
+            "inputs": {"target_account": "Acme", "offer": "Churn audit"},
+        }
+    )
+
+    assert payload["status"] == "completed"
+    assert payload["request_id"].startswith("content-ops-")
+    assert payload["usage_summary"]["filters"] == {
+        "asset_type": None,
+        "run_id": None,
+        "request_id": payload["request_id"],
+        "account_id": "acct-run-usage",
+    }
+    assert payload["usage_summary"]["summary"]["total_cost_usd"] == 1.234567
+    query, args = usage_pool.fetchrow_calls[0]
+    assert "metadata ->> 'account_id' = $2" in query
+    assert "metadata ->> 'request_id' = $3" in query
+    assert args == (1, "acct-run-usage", payload["request_id"])
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_blocks_account_usage_budget_before_generation():
     service = _CampaignService()
     provider_calls = {"count": 0}
@@ -2877,7 +2911,10 @@ async def test_execute_route_applies_cache_policy_default_to_trace_context():
         }
     )
 
-    assert campaign.calls[0]["trace_context"] == {
+    trace_context = campaign.calls[0]["trace_context"]
+    assert trace_context["request_id"].startswith("content-ops-")
+    del trace_context["request_id"]
+    assert trace_context == {
         "account_id": "acct-cache-default",
         "content_ops_cache_policy": "exact",
     }


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Run-Usage-Summary.md
Ownership lane: content-ops/cost-surfacing
Slice phase: Product polish

This slice closes the per-run cost visibility gap in Content Ops: hosted execute requests now get a stable request id, LLM usage traces carry that id, the execute response includes a tenant-safe usage summary when the usage DB is wired, and the new-run execution panel shows the run's spend, savings, calls, cache hits, and tokens.

## Intentional

- This does not expose prompts, responses, or support-ticket bodies.
- This does not infer run cost from the 7-day aggregate; it summarizes usage by the stamped request id.
- This does not make usage telemetry required for generation success.

## Deferred

- Future PR: add a deeper per-run model/cache breakdown drawer if compact metrics are not enough.
- Future PR: add a manual refresh if async usage persistence ever becomes delayed.

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_request_usage_summary tests/test_extracted_content_control_surface_api.py::test_execute_route_applies_cache_policy_default_to_trace_context -q` - 2 passed.
- `npm --prefix atlas-intel-ui run test:content-ops-usage-summary` - 6 passed.
- `python -m py_compile extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` - passed.
- `python -m pytest tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_runs_configured_services tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_request_usage_summary tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_blocks_account_usage_budget_before_generation tests/test_extracted_content_control_surface_api.py::test_execute_route_applies_cache_policy_default_to_trace_context -q` - 57 passed.
- `npm --prefix atlas-intel-ui run lint` - passed.
- `git diff --check` - passed.
- `npm --prefix atlas-intel-ui run build` - passed.
- Stale-value greps in the plan - no matches.

## Diff size

~336 LOC estimated; actual diff is below the 400 LOC soft cap.
