### PR TITLE
Prove Content Ops run usage route isolation

### DIFF
--- a/plans/PR-Content-Ops-Run-Usage-Route-Isolation.md
+++ b/plans/PR-Content-Ops-Run-Usage-Route-Isolation.md
@@ -1,0 +1,83 @@
+# PR: Content Ops Run Usage Route Isolation
+
+## Why this slice exists
+
+PR-Content-Ops-Run-Usage-Summary added per-run usage summaries to the hosted
+Content Ops execute response. The reviewer correctly noted that the new route
+path is covered by mocked-pool tests, while the real Postgres account isolation
+coverage lives one layer lower in the shared usage-summary helper.
+
+This slice adds the missing route-level proof: when the execute route stamps a
+request id and reads usage for that id, the summary remains scoped to the
+authenticated account even if another account has usage rows with the same
+request id.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/cost-surfacing
+Slice phase: Production hardening
+
+1. Add a real-Postgres integration test for the hosted execute usage-summary
+   path.
+2. Keep the implementation unchanged unless the test reveals a source bug.
+3. Prove the route uses scope account id plus request id when attaching
+   `usage_summary`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Run-Usage-Route-Isolation.md` - Plan doc for this
+  hardening proof.
+- `tests/test_extracted_content_control_surface_api.py` - Add route-level
+  Postgres isolation coverage for execute response usage summaries.
+
+## Mechanism
+
+The test seeds `llm_usage` rows for two different accounts with the same
+request id, monkeypatches the execute route's request-id generator to that id,
+and calls the hosted `/execute` route as account A. The returned
+`usage_summary` must include only account A's row.
+
+That verifies the full route wiring:
+
+- authenticated scope resolution
+- request-id stamping
+- execute response usage-summary attachment
+- SQL account/request filtering through the shared summary helper
+
+## Intentional
+
+- This is a test-only slice. The implementation from the previous PR is left
+  alone because the route already passes account id and request id into the
+  shared helper.
+- The integration test skips when `EXTRACTED_DATABASE_URL` / `DATABASE_URL` is
+  unavailable, matching the existing Postgres integration tests.
+
+## Deferred
+
+- No new product behavior is deferred.
+- Parked hardening: none.
+
+## Verification
+
+- Focused hosted execute route pytest for mocked usage summary, route-level
+  Postgres isolation, and trace context - 2 passed, 1 skipped. The integration
+  test skipped locally because neither `EXTRACTED_DATABASE_URL` nor
+  `DATABASE_URL` is exported in this clean worktree shell.
+- Focused Postgres isolation pytest for the shared usage helper and the new
+  hosted route isolation test - 2 skipped for the same missing database URL.
+- Python compile over the touched backend test file - passed.
+- Full extracted content control-surface API pytest file - 117 passed, 1
+  skipped.
+- Environment lookup for database URLs in repo-local env files - no
+  `EXTRACTED_DATABASE_URL` / `DATABASE_URL` entries found.
+- Whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~75 |
+| Integration test | ~135 |
+| **Total** | **~210** |
+
+This stays below the 400 LOC soft cap.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
+import os
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
@@ -2076,6 +2078,135 @@ async def test_execute_generation_route_returns_request_usage_summary():
     assert "metadata ->> 'account_id' = $2" in query
     assert "metadata ->> 'request_id' = $3" in query
     assert args == (1, "acct-run-usage", payload["request_id"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_execute_generation_route_usage_summary_isolates_account_against_postgres(
+    monkeypatch,
+):
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    class _FixedUuid:
+        hex = "routeusageisolation0000000000000000"
+
+    root = Path(__file__).resolve().parents[1]
+    request_id = f"content-ops-{_FixedUuid.hex}"
+    account_a = "acct-route-usage-a"
+    account_b = "acct-route-usage-b"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    monkeypatch.setattr(api_module, "uuid4", lambda: _FixedUuid())
+
+    try:
+        await pool.execute((root / "atlas_brain/storage/migrations/127_llm_usage.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/252_llm_usage_cache_breakdown.sql").read_text())
+        await pool.execute((root / "atlas_brain/storage/migrations/253_llm_usage_vendor_and_run_id.sql").read_text())
+        await pool.execute(
+            "DELETE FROM llm_usage WHERE metadata ->> 'request_id' = $1",
+            request_id,
+        )
+        await pool.executemany(
+            """
+            INSERT INTO llm_usage (
+                span_name, operation_type, model_name, model_provider,
+                input_tokens, output_tokens, total_tokens, billable_input_tokens,
+                cached_tokens, cache_write_tokens, cost_usd, duration_ms, status,
+                metadata, run_id
+            )
+            VALUES (
+                $1, 'llm_call', $2, $3,
+                $4, $5, $6, $7,
+                $8, $9, $10, $11, $12,
+                $13::jsonb, $14
+            )
+            """,
+            [
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    100,
+                    40,
+                    140,
+                    90,
+                    10,
+                    5,
+                    Decimal("0.100000"),
+                    120,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "account_id": account_a,
+                        "asset_type": "email_campaign",
+                        "request_id": request_id,
+                    }),
+                    "run-route-a",
+                ),
+                (
+                    "content_ops.llm.complete",
+                    "anthropic/claude-haiku-4-5",
+                    "openrouter",
+                    900,
+                    90,
+                    990,
+                    900,
+                    0,
+                    0,
+                    Decimal("9.000000"),
+                    180,
+                    "completed",
+                    json.dumps({
+                        "product": "content_ops",
+                        "account_id": account_b,
+                        "asset_type": "email_campaign",
+                        "request_id": request_id,
+                    }),
+                    "run-route-b",
+                ),
+            ],
+        )
+        router = create_content_ops_control_surface_router(
+            config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+            execution_services_provider=lambda: ContentOpsExecutionServices(
+                campaign=_CampaignService()
+            ),
+            usage_pool_provider=lambda: pool,
+            scope_provider=lambda: {"account_id": account_a},
+        )
+
+        route = _route(router, "/ops/execute", "POST")
+        payload = await route.endpoint(
+            {
+                "outputs": ["email_campaign"],
+                "inputs": {"target_account": "Acme", "offer": "Churn audit"},
+            }
+        )
+
+        assert payload["request_id"] == request_id
+        assert payload["usage_summary"]["filters"]["account_id"] == account_a
+        assert payload["usage_summary"]["filters"]["request_id"] == request_id
+        assert payload["usage_summary"]["summary"]["total_cost_usd"] == 0.1
+        assert payload["usage_summary"]["summary"]["total_calls"] == 1
+        assert payload["usage_summary"]["summary"]["input_tokens"] == 100
+        assert payload["usage_summary"]["by_asset_type"] == [
+            {
+                "asset_type": "email_campaign",
+                "cost_usd": 0.1,
+                "cache_savings_usd": 0.0,
+                "calls": 1,
+                "input_tokens": 100,
+                "output_tokens": 40,
+            }
+        ]
+    finally:
+        await pool.execute(
+            "DELETE FROM llm_usage WHERE metadata ->> 'request_id' = $1",
+            request_id,
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Run-Usage-Route-Isolation.md
Ownership lane: content-ops/cost-surfacing
Slice phase: Production hardening

This slice adds the route-level isolation proof for the per-run Content Ops usage summary added in #1098. It seeds two accounts with the same request id, runs the hosted execute route as account A, and asserts the returned usage summary only includes account A's row.

## Intentional

- Test-only slice; the implementation from #1098 is unchanged because the source path already passes account id plus request id to the shared usage helper.
- The Postgres test follows the existing optional integration pattern and skips without `EXTRACTED_DATABASE_URL` or `DATABASE_URL`.

## Deferred

No new product behavior is deferred.

## Parked hardening

None.

## Verification

- Focused hosted execute route pytest for mocked usage summary, route-level Postgres isolation, and trace context - 2 passed, 1 skipped.
- Focused Postgres isolation pytest for shared usage helper plus hosted route - 2 skipped locally because no database URL is exported.
- Python compile over the touched backend test file - passed.
- Full extracted content control-surface API pytest file - 117 passed, 1 skipped.
- Whitespace check - passed.

## Diff size

~210 LOC estimated; actual diff is below the 400 LOC soft cap.
