### PR TITLE
PR-Content-Ops-FAQ-Startup-Migration-Drift

### DIFF
--- a/.github/workflows/atlas_b2b_campaign_migration_checks.yml
+++ b/.github/workflows/atlas_b2b_campaign_migration_checks.yml
@@ -1,0 +1,62 @@
+name: Atlas B2B Campaign Migration Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_b2b_campaign_migration_checks.yml"
+      - "atlas_brain/storage/migrations/**"
+      - "extracted_content_pipeline/storage/migrations/**"
+      - "extracted_content_pipeline/manifest.json"
+      - "tests/test_atlas_b2b_campaign_migrations.py"
+      - "tests/test_extracted_campaign_manifest.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_b2b_campaign_migration_checks.yml"
+      - "atlas_brain/storage/migrations/**"
+      - "extracted_content_pipeline/storage/migrations/**"
+      - "extracted_content_pipeline/manifest.json"
+      - "tests/test_atlas_b2b_campaign_migrations.py"
+      - "tests/test_extracted_campaign_manifest.py"
+
+jobs:
+  atlas-b2b-campaign-migration-checks:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: atlas
+          POSTGRES_PASSWORD: atlas
+          POSTGRES_DB: atlas_migration_tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U atlas -d atlas_migration_tests"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ATLAS_MIGRATION_TEST_DATABASE_URL: postgresql://atlas:atlas@localhost:5432/atlas_migration_tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install asyncpg pytest pytest-asyncio
+
+      - name: Run B2B campaign migration tests
+        run: |
+          python -m pytest \
+            tests/test_atlas_b2b_campaign_migrations.py \
+            tests/test_extracted_campaign_manifest.py \
+            -q

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-28
-
-### Atlas startup migration check warns on missing b2b_campaigns.updated_at
-- File/location: `atlas_brain/storage/migrations/309_campaign_sequences_unique_active_recipient.sql`, Atlas startup migration check.
-- Description: Local API startup logged `column "updated_at" of relation "b2b_campaigns" does not exist` while checking pending host migrations.
-- Why it matters: The FAQ route still starts and passes, but startup migration noise can hide real route-readiness issues and suggests local/host B2B campaign schema drift.
-- Effort: M
-- Category: correctness
-- Owner/session: content-ops/faq-search
-- Found during: PR-Content-Ops-FAQ-SaaS-Demo-Local-Route-Proof
-
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/atlas_brain/storage/migrations/067_b2b_campaigns_updated_at.sql
+++ b/atlas_brain/storage/migrations/067_b2b_campaigns_updated_at.sql
@@ -1,0 +1,8 @@
+-- 067: Backfill the timestamp column expected by sequence migrations.
+--
+-- Migration 066 created b2b_campaigns without updated_at. Migration 068's
+-- CREATE TABLE IF NOT EXISTS fallback includes it only for first-time setup,
+-- so existing 066-created tables need the column before 309 cancels campaigns.
+
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -93,6 +93,10 @@
       "target": "extracted_content_pipeline/storage/migrations/066_b2b_campaigns.sql"
     },
     {
+      "source": "atlas_brain/storage/migrations/067_b2b_campaigns_updated_at.sql",
+      "target": "extracted_content_pipeline/storage/migrations/067_b2b_campaigns_updated_at.sql"
+    },
+    {
       "source": "atlas_brain/storage/migrations/068_campaign_sequences.sql",
       "target": "extracted_content_pipeline/storage/migrations/068_campaign_sequences.sql"
     },

--- a/extracted_content_pipeline/storage/migrations/067_b2b_campaigns_updated_at.sql
+++ b/extracted_content_pipeline/storage/migrations/067_b2b_campaigns_updated_at.sql
@@ -1,0 +1,8 @@
+-- 067: Backfill the timestamp column expected by sequence migrations.
+--
+-- Migration 066 created b2b_campaigns without updated_at. Migration 068's
+-- CREATE TABLE IF NOT EXISTS fallback includes it only for first-time setup,
+-- so existing 066-created tables need the column before 309 cancels campaigns.
+
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/plans/PR-Content-Ops-FAQ-Startup-Migration-Drift.md
+++ b/plans/PR-Content-Ops-FAQ-Startup-Migration-Drift.md
@@ -1,0 +1,114 @@
+# PR-Content-Ops-FAQ-Startup-Migration-Drift
+
+## Why this slice exists
+
+The content-ops FAQ route now depends on Atlas API startup being quiet enough
+to reveal real readiness failures. A parked hardening item records startup
+noise from host migrations:
+`column "updated_at" of relation "b2b_campaigns" does not exist`.
+
+The schema drift is in the migration chain itself. Migration 066 creates
+`b2b_campaigns` without `updated_at`, migration 068 only includes
+`updated_at` in a `CREATE TABLE IF NOT EXISTS` fallback, and migration 309 later
+assumes the column exists while cancelling campaigns attached to superseded
+sequences. This slice fixes the migration source instead of suppressing the
+warning.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Production hardening
+
+1. Add a missing pre-068 migration that adds `b2b_campaigns.updated_at` for
+   existing 066-created tables before later campaign-sequence migrations run.
+2. Add a focused migration-chain test that proves the new migration fills the
+   exact column required by migration 309, sorts before it, and executes against
+   Postgres when `ATLAS_MIGRATION_TEST_DATABASE_URL` is set.
+3. Enroll that test in a path-triggered GitHub Actions job with a Postgres
+   service so CI executes the migration repair instead of only string-checking
+   the SQL.
+4. Sync the migration into `extracted_content_pipeline` through the package
+   manifest so standalone content-pipeline installs get the same schema repair.
+5. Remove the corresponding parked `HARDENING.md` item.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/atlas_b2b_campaign_migration_checks.yml` | Path-triggered CI lane with a Postgres service for campaign migration tests. |
+| `atlas_brain/storage/migrations/067_b2b_campaigns_updated_at.sql` | Backfill the missing timestamp column in the canonical migration chain. |
+| `extracted_content_pipeline/manifest.json` | Map the new host migration into the standalone content pipeline package. |
+| `extracted_content_pipeline/storage/migrations/067_b2b_campaigns_updated_at.sql` | Synced package copy of the migration. |
+| `tests/test_atlas_b2b_campaign_migrations.py` | Lock the migration ordering, 309 dependency, and executable Postgres repair. |
+| `tests/test_extracted_campaign_manifest.py` | Lock the package manifest copy with the other core campaign migrations. |
+| `HARDENING.md` | Drain the startup migration warning item. |
+| `plans/PR-Content-Ops-FAQ-Startup-Migration-Drift.md` | Slice contract. |
+
+## Mechanism
+
+The new migration runs between 066 and 068:
+
+```sql
+ALTER TABLE b2b_campaigns
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+```
+
+On databases where 066 already created the table and 068 is already recorded,
+the new 067 migration is still pending and sorts before 309, so it repairs the
+schema before 309 reaches `SET updated_at = NOW()`. On first-time databases,
+066 creates the table, 067 adds the column, and later migrations keep the same
+shape.
+
+The static test verifies that `067_b2b_campaigns_updated_at.sql` is ordered
+after 066 and before 309, adds `updated_at`, and that 309 still depends on that
+column. The executable test uses `asyncpg` when `ATLAS_MIGRATION_TEST_DATABASE_URL`
+is configured: it applies 066 in a temporary schema, proves the 309-style
+`updated_at = NOW()` update fails before 067, applies 067, asserts the column is
+`TIMESTAMPTZ NOT NULL` with no null backfill rows, proves the 309-style update
+succeeds, and reapplies 067 to prove idempotency.
+
+The new workflow provisions Postgres 16 and sets
+`ATLAS_MIGRATION_TEST_DATABASE_URL`, so CI always runs the executable branch.
+The same migration is mapped into `extracted_content_pipeline/manifest.json`,
+then synced into `extracted_content_pipeline/storage/migrations/067_b2b_campaigns_updated_at.sql`.
+
+## Intentional
+
+- This does not edit migration 309. The failure is caused by an earlier schema
+  omission, and adding a missing pre-309 migration lets pending host databases
+  repair themselves before 309 runs.
+- This does not add a broad full-chain migration runner. The executable test is
+  intentionally scoped to the exact 066 -> 067 -> 309-style failure and repair
+  that produced the startup warning.
+
+## Deferred
+
+Parked hardening: none.
+
+## Verification
+
+To run before opening the PR:
+
+```bash
+python -m py_compile tests/test_atlas_b2b_campaign_migrations.py tests/test_extracted_campaign_manifest.py
+python -m pytest tests/test_atlas_b2b_campaign_migrations.py tests/test_extracted_campaign_manifest.py -q
+bash scripts/validate_extracted_content_pipeline.sh
+python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+python scripts/audit_extracted_standalone.py --fail-on-debt
+bash scripts/check_ascii_python.sh
+bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-startup-migration-drift-pr-body.md
+```
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 114 |
+| Workflow | 62 |
+| Host migration | 8 |
+| Extracted package sync | 12 |
+| Tests | 101 |
+| Hardening cleanup | 11 |
+| **Total** | **308** |

--- a/tests/test_atlas_b2b_campaign_migrations.py
+++ b/tests/test_atlas_b2b_campaign_migrations.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS_DIR = ROOT / "atlas_brain" / "storage" / "migrations"
+DATABASE_URL_ENV = "ATLAS_MIGRATION_TEST_DATABASE_URL"
+
+
+def _migration(name: str) -> str:
+    return (MIGRATIONS_DIR / name).read_text()
+
+
+def test_b2b_campaign_updated_at_migration_runs_before_sequence_unique_migration():
+    migration_names = [path.name for path in sorted(MIGRATIONS_DIR.glob("*.sql"))]
+
+    updated_at_index = migration_names.index("067_b2b_campaigns_updated_at.sql")
+    sequence_setup_index = migration_names.index("068_campaign_sequences.sql")
+    unique_recipient_index = migration_names.index(
+        "309_campaign_sequences_unique_active_recipient.sql"
+    )
+
+    assert migration_names.index("066_b2b_campaigns.sql") < updated_at_index
+    assert updated_at_index < sequence_setup_index
+    assert updated_at_index < unique_recipient_index
+
+
+def test_b2b_campaign_updated_at_migration_fills_column_required_by_309():
+    updated_at_sql = _migration("067_b2b_campaigns_updated_at.sql")
+    sequence_unique_sql = _migration("309_campaign_sequences_unique_active_recipient.sql")
+
+    assert "ALTER TABLE b2b_campaigns" in updated_at_sql
+    assert "ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()" in (
+        updated_at_sql
+    )
+    assert "UPDATE b2b_campaigns bc" in sequence_unique_sql
+    assert "SET status = 'cancelled', updated_at = NOW()" in sequence_unique_sql
+
+
+@pytest.mark.asyncio
+async def test_b2b_campaign_updated_at_migration_repairs_066_table_for_309_update():
+    asyncpg = pytest.importorskip("asyncpg")
+
+    import os
+    import uuid
+
+    database_url = os.getenv(DATABASE_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{DATABASE_URL_ENV} is not configured")
+
+    schema_name = f"atlas_migration_test_{uuid.uuid4().hex}"
+    conn = await asyncpg.connect(database_url)
+    try:
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+        await conn.execute(f'CREATE SCHEMA "{schema_name}"')
+        await conn.execute(f'SET search_path TO "{schema_name}", public')
+
+        await conn.execute(_migration("066_b2b_campaigns.sql"))
+        await conn.execute(
+            """
+            INSERT INTO b2b_campaigns
+                (id, company_name, vendor_name, channel, body, status)
+            VALUES
+                ('11111111-1111-1111-1111-111111111111',
+                 'Atlas Demo', 'Zendesk', 'email_cold', 'Body', 'draft')
+            """
+        )
+
+        with pytest.raises(asyncpg.UndefinedColumnError):
+            await conn.execute(
+                "UPDATE b2b_campaigns SET status = 'expired', updated_at = NOW()"
+            )
+
+        await conn.execute(_migration("067_b2b_campaigns_updated_at.sql"))
+
+        column = await conn.fetchrow(
+            """
+            SELECT data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name = 'b2b_campaigns'
+              AND column_name = 'updated_at'
+            """,
+            schema_name,
+        )
+        assert column is not None
+        assert column["data_type"] == "timestamp with time zone"
+        assert column["is_nullable"] == "NO"
+        assert await conn.fetchval(
+            "SELECT count(*) FROM b2b_campaigns WHERE updated_at IS NULL"
+        ) == 0
+
+        await conn.execute(
+            "UPDATE b2b_campaigns SET status = 'expired', updated_at = NOW()"
+        )
+        await conn.execute(_migration("067_b2b_campaigns_updated_at.sql"))
+    finally:
+        await conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE')
+        await conn.close()

--- a/tests/test_extracted_campaign_manifest.py
+++ b/tests/test_extracted_campaign_manifest.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 CORE_CAMPAIGN_MIGRATIONS = {
     "066_b2b_campaigns.sql",
+    "067_b2b_campaigns_updated_at.sql",
     "068_campaign_sequences.sql",
     "069_campaign_analytics.sql",
     "070_campaign_suppressions.sql",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Startup-Migration-Drift.md
Slice phase: Production hardening

The FAQ route now relies on Atlas API startup being quiet enough to surface real readiness failures. This drains the parked startup migration warning by fixing the migration chain that let 066-created `b2b_campaigns` tables reach migration 309 without `updated_at`, and syncs the same repair into the standalone content-pipeline package.

## Intentional
- Adds a missing pre-068 migration instead of suppressing the startup warning or editing 309. Pending host databases can repair the schema before 309 runs.
- Adds a dedicated Postgres-backed CI lane because this is a schema-migration hardening fix, not just a static SQL-shape change.

## Deferred
- None.

## Parked hardening
- None. Drains `Atlas startup migration check warns on missing b2b_campaigns.updated_at`.

## Verification
- `python -m py_compile tests/test_atlas_b2b_campaign_migrations.py tests/test_extracted_campaign_manifest.py`
- `python -m pytest tests/test_atlas_b2b_campaign_migrations.py tests/test_extracted_campaign_manifest.py -q` -> 9 passed, 1 skipped locally because `ATLAS_MIGRATION_TEST_DATABASE_URL` is not configured; CI sets it with a Postgres service.
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-startup-migration-drift-pr-body.md`

## Diff size
8 files, +297 / -11
