### PR TITLE
Add support-ticket platform CSV smoke

### DIFF
--- a/extracted_content_pipeline/examples/support_ticket_platform_export_shapes.csv
+++ b/extracted_content_pipeline/examples/support_ticket_platform_export_shapes.csv
@@ -1,0 +1,4 @@
+Id,Ticket ID,Conversation ID,Subject,Ticket Subject,Conversation title,Description,Message,Latest message,Conversation body,Created at,Created time,Conversation created at,Requester email,Contact email address,User email,Pain Category
+zd-100,,,How do I reset MFA?,,,I cannot get the login code on my new phone.,,,,2026-05-01T09:00:00Z,,,maya@example.test,,,login access
+,fd-200,,,Where do I export my invoice?,,,Where do I export my invoice before month-end?,Agent reply: use the billing export menu.,,,2026-05-02 10:15:00,,,ops@example.test,,billing export
+,,ic-300,,,"Cancellation before renewal",,,,"Can I cancel my account before it renews?",,,2026-05-03,,,founder@example.test,cancellation

--- a/plans/PR-Support-Ticket-Platform-CSV-Smoke.md
+++ b/plans/PR-Support-Ticket-Platform-CSV-Smoke.md
@@ -1,0 +1,73 @@
+# PR: Support Ticket Platform CSV Smoke
+
+## Why this slice exists
+
+PR-Support-Ticket-CSV-Shape-Coverage broadened support-ticket header aliases
+with dict-row tests. The remaining gap is the file boundary: the operator-facing
+package smoke should prove those platform-shaped headers survive real CSV
+loading before any DB or LLM work starts.
+
+This slice adds a tiny committed export-shaped fixture and runs it through the
+existing support-ticket package smoke path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Robust testing
+
+1. Add a small synthetic CSV fixture with Zendesk-, Freshdesk-, and
+   Intercom-shaped headers.
+2. Pin the existing smoke summary against that fixture.
+3. Keep package semantics, prompts, FAQ generation, and live LLM paths unchanged.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Platform-CSV-Smoke.md` - Plan doc for this slice.
+- `extracted_content_pipeline/examples/support_ticket_platform_export_shapes.csv` - Synthetic platform-shaped CSV fixture.
+- `tests/test_smoke_content_ops_support_ticket_package.py` - Smoke test that loads the fixture through the file path.
+
+## Mechanism
+
+The fixture uses common support-platform export names such as `Requester email`,
+`Ticket Subject`, `Message`, `Latest message`, `Conversation title`, and
+`Conversation body`. The smoke test calls
+`build_support_ticket_package_smoke_summary(...)` on the committed CSV and
+asserts the included row count, dated-window label, FAQ questions, contact
+examples, and the customer-message-before-latest-reply precedence.
+
+## Intentional
+
+- This is not a real customer export. It is a deterministic fixture for the
+  file-loader boundary.
+- This does not add another parser or provider branch. The existing CSV loader
+  and support-ticket normalizer remain the source of truth.
+- This does not touch FAQ output generation, which remains owned by the FAQ
+  session.
+
+## Deferred
+
+- Future PR: run the same smoke against anonymized real customer exports when
+  samples are available.
+- Future PR: add upload-screen copy for useful export columns when that UI is
+  revisited.
+- Parked hardening: none.
+
+## Verification
+
+- Fixture smoke command - passed and printed 3 included rows, 3 FAQ questions,
+  dated-window metadata, and zero warnings.
+- Focused fixture smoke pytest - passed.
+- Support-ticket smoke + input-package pytest - 33 passed.
+- Python compile over the smoke script and smoke test - passed.
+- Whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| CSV fixture | ~5 |
+| Smoke test | ~40 |
+| **Total** | **~110** |
+
+This stays below the 400 LOC soft cap.

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -10,6 +10,7 @@ _SCRIPT_PATH = (
     / "scripts"
     / "smoke_content_ops_support_ticket_package.py"
 )
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPT_SPEC = importlib.util.spec_from_file_location(
     "smoke_content_ops_support_ticket_package",
     _SCRIPT_PATH,
@@ -150,6 +151,40 @@ def test_support_ticket_package_smoke_reports_resolution_evidence(
             "text": "Open Reports, choose Export, then select CSV.",
         }
     ]
+
+
+def test_support_ticket_package_smoke_accepts_platform_export_fixture() -> None:
+    fixture = (
+        _REPO_ROOT
+        / "extracted_content_pipeline"
+        / "examples"
+        / "support_ticket_platform_export_shapes.csv"
+    )
+
+    summary = build_support_ticket_package_smoke_summary(
+        fixture,
+        require_included_rows=True,
+    )
+
+    assert summary["source_row_count"] == 3
+    assert summary["included_ticket_row_count"] == 3
+    assert summary["skipped_ticket_row_count"] == 0
+    assert summary["source_period"] == "Last 90 days of support tickets"
+    assert summary["has_dated_window"] is True
+    assert summary["faq_questions"] == [
+        "How do I reset MFA?",
+        "Where do I export my invoice?",
+        "Can I cancel my account before it renews?",
+    ]
+    assert summary["customer_wording_examples"][1] == {
+        "source_id": "fd-200",
+        "source_title": "Where do I export my invoice?",
+        "pain_category": "billing export",
+        "text": (
+            "Where do I export my invoice? "
+            "Where do I export my invoice before month-end?"
+        ),
+    }
 
 
 def test_support_ticket_package_smoke_reports_measured_outcome_evidence(


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Platform-CSV-Smoke.md
Ownership lane: content-ops/support-ticket-input-provider
Slice phase: Robust testing

This slice adds a committed platform-shaped support-ticket CSV fixture and runs it through the existing operator-facing package smoke. It proves Zendesk/Freshdesk/Intercom-style headers survive real CSV loading before DB or LLM work starts.

## Intentional

- No new parser or provider branch; the existing CSV loader and support-ticket normalizer remain the source of truth.
- The fixture is synthetic, not a real customer export.
- No prompt, FAQ generation, generated-content, or live LLM behavior changes.

## Deferred

- Future PR: run the same smoke against anonymized real customer exports when samples are available.
- Future PR: upload-screen copy for useful export columns when that UI is revisited.

## Parked hardening

None.

## Verification

- Fixture smoke command - passed and printed 3 included rows, 3 FAQ questions, dated-window metadata, and zero warnings.
- Focused fixture smoke pytest - passed.
- Support-ticket smoke + input-package pytest - 33 passed.
- Python compile over the smoke script and smoke test - passed.
- Whitespace check - passed.

## Diff size

~110 LOC estimated; actual diff is below the 400 LOC soft cap.