### PR TITLE
Document support-ticket platform CSV smoke

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -166,6 +166,18 @@ python scripts/build_extracted_campaign_opportunities_from_sources.py \
   --output support_ticket_bundle_opportunities.json
 ```
 
+Before spending DB or LLM time on a help desk export, run the support-ticket
+package smoke. The platform-shaped fixture uses common Zendesk-, Freshdesk-, and
+Intercom-style headers and proves the CSV loader can still find ticket ids,
+subjects, customer wording, dates, contact emails, and intent labels:
+
+```bash
+python scripts/smoke_content_ops_support_ticket_package.py \
+  extracted_content_pipeline/examples/support_ticket_platform_export_shapes.csv \
+  --require-included-rows \
+  --pretty
+```
+
 To produce a quick grounded FAQ artifact from those same support-ticket rows,
 write Markdown directly:
 

--- a/extracted_content_pipeline/STATUS.md
+++ b/extracted_content_pipeline/STATUS.md
@@ -56,7 +56,11 @@ source of truth for what remains.
   for common CSV/export variants such as `Ticket ID`, `Ticket Number`,
   `Account Name`, `Organization Name`, `Requester Email`, `Issue Description`,
   `Pain Category`, and `Open Ended Response`; source-type precedence is
-  explicit and provider-style field lookups are cached per row.
+  explicit and provider-style field lookups are cached per row. The package
+  smoke also covers
+  `examples/support_ticket_platform_export_shapes.csv`, a synthetic
+  Zendesk-/Freshdesk-/Intercom-shaped fixture for checking common help desk
+  exports before DB or LLM execution.
 - `signal_extraction` exposes source-row normalization as a runnable AI Content
   Ops output. It converts inline source material into normalized opportunities
   without LLM, database, or Atlas dependencies.

--- a/plans/PR-Support-Ticket-Platform-Smoke-Docs.md
+++ b/plans/PR-Support-Ticket-Platform-Smoke-Docs.md
@@ -1,0 +1,66 @@
+# PR: Support Ticket Platform Smoke Docs
+
+## Why this slice exists
+
+PR-Support-Ticket-Platform-CSV-Smoke added a checked platform-shaped CSV fixture
+and pinned the operator-facing package smoke against it. The code path is now
+covered, but the Content Ops docs still only point operators at the older
+packaged support-ticket CSV examples.
+
+This slice documents the cheap pre-LLM smoke so a host can verify common help
+desk export headers before running live blog or landing-page generation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Product polish
+
+1. Add the platform-shaped CSV smoke command to the Content Ops README.
+2. Update Content Ops status to mention the checked platform-export fixture.
+3. Keep runtime code, fixtures, tests, prompts, and FAQ generation unchanged.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Platform-Smoke-Docs.md` - Plan doc for this slice.
+- `extracted_content_pipeline/README.md` - Document the platform-shaped CSV smoke command.
+- `extracted_content_pipeline/STATUS.md` - Record the platform-export fixture in current package status.
+
+## Mechanism
+
+The README now shows
+`python scripts/smoke_content_ops_support_ticket_package.py extracted_content_pipeline/examples/support_ticket_platform_export_shapes.csv --require-included-rows --pretty`
+as the pre-LLM check for common support-platform exports. The STATUS note
+records that the package smoke covers a fixture with Zendesk-, Freshdesk-, and
+Intercom-style headers.
+
+## Intentional
+
+- Docs-only. The smoke behavior was implemented and tested in the prior slice.
+- This does not claim arbitrary customer exports are proven. Real anonymized
+  customer exports remain the follow-up when samples are available.
+- This does not update FAQ-owned docs or generation behavior.
+
+## Deferred
+
+- Future PR: run the same smoke against anonymized real customer exports when
+  samples are available.
+- Future PR: add upload-screen copy for useful export columns when that UI is
+  revisited.
+- Parked hardening: none.
+
+## Verification
+
+- Platform CSV package smoke command - passed; summary reported 3 included
+  rows, 3 FAQ questions, and 0 warnings.
+- Whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| README | ~20 |
+| STATUS | ~10 |
+| **Total** | **~95** |
+
+This stays below the 400 LOC soft cap.


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Platform-Smoke-Docs.md
Ownership lane: content-ops/support-ticket-input-provider
Slice phase: Product polish

This docs slice points operators at the support-ticket platform CSV package smoke added by the prior PR. It explains the cheap pre-LLM command for checking Zendesk/Freshdesk/Intercom-style exports before DB or LLM execution.

## Intentional

- Docs-only; runtime behavior was covered by the prior smoke slice.
- No prompt, FAQ generation, generated-content, or live LLM behavior changes.
- This does not claim arbitrary customer exports are proven.

## Deferred

- Future PR: run the same smoke against anonymized real customer exports when samples are available.
- Future PR: upload-screen copy for useful export columns when that UI is revisited.

## Parked hardening

None.

## Verification

- Platform CSV package smoke command - passed; summary reported 3 included rows, 3 FAQ questions, and 0 warnings.
- Whitespace check - passed.

## Diff size

~95 LOC estimated; actual diff is below the 400 LOC soft cap.