### PR TITLE
Surface support-ticket smoke contact count

### DIFF
--- a/plans/PR-Support-Ticket-Smoke-Contact-Summary.md
+++ b/plans/PR-Support-Ticket-Smoke-Contact-Summary.md
@@ -1,0 +1,70 @@
+# PR: Support Ticket Smoke Contact Summary
+
+## Why this slice exists
+
+The platform CSV smoke now proves common help desk export headers survive file
+loading, and the docs say the smoke can verify contact-email fields before DB or
+LLM work. The smoke summary, however, reports ticket counts and customer wording
+but not whether contact email columns were actually recognized.
+
+This slice closes that visibility gap at the source by adding a non-PII contact
+email count to the existing support-ticket package smoke summary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Product polish
+
+1. Add `contact_email_count` to the support-ticket package smoke summary.
+2. Count only included normalized source rows that have a non-empty
+   `contact_email`.
+3. Pin the existing platform CSV fixture so the smoke proves all three platform
+   contact-email aliases are recognized without printing the email addresses.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Smoke-Contact-Summary.md` - Plan doc for this slice.
+- `scripts/smoke_content_ops_support_ticket_package.py` - Add a non-PII contact email count to the summary.
+- `tests/test_smoke_content_ops_support_ticket_package.py` - Pin the count for the platform-shaped fixture and existing no-email scenarios.
+
+## Mechanism
+
+`build_support_ticket_package_smoke_summary(...)` already has access to the
+normalized `source_material` rows emitted by the support-ticket package. This
+slice counts included rows where `contact_email` is present after normalization
+and adds only the integer count to the JSON summary.
+
+## Intentional
+
+- The smoke does not print contact email values. Customer exports can contain
+  PII, so the operator-facing diagnostic stays count-only.
+- This does not change package generation inputs, prompts, FAQ generation, live
+  LLM behavior, or persisted draft shape.
+- This does not add a new parser; it observes the existing normalized package.
+
+## Deferred
+
+- Future PR: run the platform smoke against anonymized real customer exports
+  when samples are available.
+- Future PR: add upload-screen copy for useful export columns when that UI is
+  revisited.
+- Parked hardening: none.
+
+## Verification
+
+- Platform CSV package smoke command - passed; summary reported
+  `contact_email_count: 3` without printing email values.
+- Support-ticket package smoke pytest - 9 passed.
+- Python compile over the smoke script and smoke test - passed.
+- Whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~70 |
+| Smoke summary | ~10 |
+| Tests | ~10 |
+| **Total** | **~90** |
+
+This stays below the 400 LOC soft cap.

--- a/scripts/smoke_content_ops_support_ticket_package.py
+++ b/scripts/smoke_content_ops_support_ticket_package.py
@@ -49,6 +49,12 @@ def build_support_ticket_package_smoke_summary(
     resolution_examples = list(inputs.get("support_ticket_resolution_examples") or [])
     measured_outcome_examples = list(inputs.get("measured_outcome_examples") or [])
     faq_questions = list(inputs.get("faq_questions") or [])
+    source_rows = list(inputs.get("source_material") or [])
+    contact_email_count = sum(
+        1
+        for row in source_rows
+        if isinstance(row, dict) and str(row.get("contact_email") or "").strip()
+    )
     return {
         "path": str(Path(path)),
         "provider": package.provider,
@@ -65,6 +71,7 @@ def build_support_ticket_package_smoke_summary(
         "faq_questions": faq_questions,
         "question_like_ticket_count": int(inputs.get("question_like_ticket_count") or 0),
         "top_ticket_clusters": list(inputs.get("top_ticket_clusters") or []),
+        "contact_email_count": contact_email_count,
         "customer_wording_example_count": len(customer_wording_examples),
         "customer_wording_examples": customer_wording_examples,
         "support_ticket_resolution_evidence_present": bool(

--- a/tests/test_smoke_content_ops_support_ticket_package.py
+++ b/tests/test_smoke_content_ops_support_ticket_package.py
@@ -73,6 +73,7 @@ def test_support_ticket_package_smoke_summarizes_undated_csv_without_window_filt
     assert summary["has_window_filter"] is False
     assert summary["faq_question_count"] == 2
     assert summary["question_like_ticket_count"] == 2
+    assert summary["contact_email_count"] == 0
     assert summary["top_ticket_clusters"] == [
         {"label": "profile updates", "count": 1},
         {"label": "Export dashboard", "count": 1},
@@ -171,6 +172,7 @@ def test_support_ticket_package_smoke_accepts_platform_export_fixture() -> None:
     assert summary["skipped_ticket_row_count"] == 0
     assert summary["source_period"] == "Last 90 days of support tickets"
     assert summary["has_dated_window"] is True
+    assert summary["contact_email_count"] == 3
     assert summary["faq_questions"] == [
         "How do I reset MFA?",
         "Where do I export my invoice?",


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Smoke-Contact-Summary.md
Ownership lane: content-ops/support-ticket-input-provider
Slice phase: Product polish

This slice adds a non-PII `contact_email_count` to the support-ticket package smoke summary so operators can verify contact-email columns were recognized before DB or LLM execution without printing customer email values.

## Intentional

- The smoke output is count-only; customer email values are not printed.
- No package input shape, prompt, FAQ generation, live LLM behavior, or persisted draft shape changes.
- The existing support-ticket normalizer remains the source of truth.

## Deferred

- Future PR: run the platform smoke against anonymized real customer exports when samples are available.
- Future PR: upload-screen copy for useful export columns when that UI is revisited.

## Parked hardening

None.

## Verification

- Platform CSV package smoke command - passed; summary reported `contact_email_count: 3` without printing email values.
- Support-ticket package smoke pytest - 9 passed.
- Python compile over the smoke script and smoke test - passed.
- Whitespace check - passed.

## Diff size

~90 LOC estimated; actual diff is below the 400 LOC soft cap.