### PR TITLE
PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -10,7 +10,10 @@ coverage, use `content_ops_faq_seeded_route_e2e_runbook.md`.
 ## Required Inputs
 
 - `EXTRACTED_DATABASE_URL` or `DATABASE_URL`: Postgres database used by the
-  deployed Atlas API.
+  deployed Atlas API. If neither is set, the scripts fall back to
+  `atlas_brain.storage.config.db_settings.dsn` only when an explicit
+  `ATLAS_DB_HOST` or `ATLAS_DB_SOCKET_PATH` target setting is present. Atlas'
+  localhost defaults do not satisfy hosted proof preflight by themselves.
 - `ATLAS_API_BASE_URL`: deployed Atlas API host, for example
   `https://atlas-api.example.com`. Hosted proof mode rejects local hosts such
   as `localhost`, `127.*`, `0.0.0.0`, and `::1` because those targets cannot

--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md
@@ -40,7 +40,7 @@ and cleanup was skipped because no seeded FAQ was created.
 
 | Input | Env names checked | Present |
 |---|---|---:|
-| Database URL | `EXTRACTED_DATABASE_URL`, `DATABASE_URL` | no |
+| Database URL | `EXTRACTED_DATABASE_URL`, `DATABASE_URL`, or `atlas_brain.storage.config.db_settings.dsn` from explicit `ATLAS_DB_HOST`/`ATLAS_DB_SOCKET_PATH` settings | no |
 | Deployed API base URL | `ATLAS_API_BASE_URL` | no |
 | Bearer token | `ATLAS_B2B_JWT`, `ATLAS_TOKEN` | no |
 | Account id | `ATLAS_FAQ_SEARCH_ACCOUNT_ID`, `ATLAS_ACCOUNT_ID` | no |
@@ -73,6 +73,11 @@ and cleanup was skipped because no seeded FAQ was created.
 
 Set the required inputs, then run:
 
+If `EXTRACTED_DATABASE_URL`/`DATABASE_URL` are not set, the scripts now use
+`atlas_brain.storage.config.db_settings.dsn` only when an explicit
+`ATLAS_DB_HOST` or `ATLAS_DB_SOCKET_PATH` target setting is present. This keeps
+Atlas' localhost defaults from satisfying hosted proof preflight by themselves.
+
 ```bash
 python scripts/run_extracted_content_pipeline_migrations.py
 python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
@@ -95,3 +100,36 @@ python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
 
 Keep the generated result artifact from that run; it is the proof needed before
 calling the hosted SaaS demo search path ready.
+
+## Follow-Up: DB Settings Fallback
+
+After adding the same `db_settings.dsn` fallback used by the other Content Ops
+Postgres smokes, the preflight was rerun without `EXTRACTED_DATABASE_URL` or
+`DATABASE_URL`:
+
+```bash
+python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
+  --preflight-only \
+  --json \
+  --output-result tmp/faq_saas_demo_route_preflight_db_settings_20260529/result3.json
+```
+
+Exit code remained `2`, but the database input is now present via explicit
+Atlas DB settings. The remaining blockers are the hosted API base URL, bearer
+token, and account id.
+
+```json
+{
+  "preflight_errors": [
+    "ATLAS_API_BASE_URL or --base-url is required",
+    "ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required",
+    "ATLAS_FAQ_SEARCH_ACCOUNT_ID, ATLAS_ACCOUNT_ID, or --account-id is required"
+  ],
+  "required_inputs": {
+    "database_url": {"present": true},
+    "base_url": {"present": false},
+    "token": {"present": false},
+    "account_id": {"present": false}
+  }
+}
+```

--- a/plans/PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback.md
+++ b/plans/PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback.md
@@ -1,0 +1,113 @@
+# PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-Route-Preflight proved the hosted SaaS FAQ route
+E2E cannot run from this checkout because required inputs are missing. One of
+those inputs is the database URL, but other Content Ops Postgres smokes already
+derive it from `atlas_brain.storage.config.db_settings.dsn` when
+`EXTRACTED_DATABASE_URL`/`DATABASE_URL` are not set.
+
+The SaaS demo seed/E2E scripts are out of line with that established pattern,
+so their preflight reports the database as missing even when explicit Atlas DB
+target settings are available. This slice removes that avoidable blocker
+without letting Atlas' localhost defaults satisfy hosted proof by themselves.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Functional validation
+
+1. Add a guarded `db_settings.dsn` fallback used by related FAQ/Postgres smokes
+   to the SaaS demo seeder and one-command E2E runner.
+2. Keep explicit `--database-url`, `EXTRACTED_DATABASE_URL`, and `DATABASE_URL`
+   precedence unchanged.
+3. Add focused tests for env precedence and fallback behavior on both scripts.
+4. Update the SaaS demo route validation notes/runbook to name the fallback.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/seed_content_ops_faq_saas_demo.py` | Derive the default database URL from explicit Atlas DB target settings when URL envs are absent. |
+| `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py` | Use the same guarded fallback for the one-command SaaS route E2E. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover seeder fallback and env precedence. |
+| `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py` | Cover E2E fallback and env precedence. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md` | Document accepted DB input forms. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md` | Refine the prior missing-input note with the new fallback behavior. |
+| `plans/PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback.md` | Slice contract. |
+
+## Mechanism
+
+Both scripts get a local `_default_database_url()` helper:
+
+```python
+raw = _env("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+if raw:
+    return raw
+if not _env("ATLAS_DB_HOST", "ATLAS_DB_SOCKET_PATH"):
+    return ""
+try:
+    spec = importlib.util.spec_from_file_location(
+        "_atlas_storage_config_for_saas_demo",
+        ROOT / "atlas_brain/storage/config.py",
+    )
+    ...
+    spec.loader.exec_module(module)
+except Exception:
+    return ""
+db_settings = getattr(module, "db_settings", None)
+return str(getattr(db_settings, "dsn", "") or "").strip()
+```
+
+The parser default changes from `_env("EXTRACTED_DATABASE_URL", "DATABASE_URL")`
+to `_default_database_url()`. Existing validation remains fail-closed if no URL
+or settings-derived DSN exists. The Atlas settings fallback only activates when
+an explicit `ATLAS_DB_HOST` or `ATLAS_DB_SOCKET_PATH` target setting is present,
+so the default `localhost:5433/atlas` settings cannot accidentally satisfy a
+hosted route proof. The config file is loaded directly so CI can read
+`db_settings.dsn` without importing `atlas_brain.storage.__init__` and its
+runtime DB dependencies.
+
+## Intentional
+
+- This does not set the deployed API base URL, bearer token, or account id.
+  Those are hosted proof inputs and should remain operator-provided.
+- This does not attempt a live DB connection. It only fixes default discovery;
+  connection success is still validated by the existing seed/E2E runtime path.
+- This treats only explicit Atlas DB target settings as fallback evidence. Other
+  `ATLAS_DB_*` tuning fields do not prove the operator selected a database
+  target for hosted proof.
+- This deliberately loads `atlas_brain/storage/config.py` by file path instead
+  of package import because the package initializer pulls in runtime database
+  modules that are not required for preflight discovery.
+
+## Deferred
+
+- Live seeded SaaS FAQ route E2E remains deferred until the deployed API base
+  URL, bearer token, and account id are configured.
+- Parked hardening: none.
+
+## Verification
+
+To run before opening the PR:
+
+```bash
+python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+EXTRACTED_PIPELINE_STANDALONE=1 python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q
+bash scripts/run_extracted_pipeline_checks.sh
+env -u EXTRACTED_DATABASE_URL -u DATABASE_URL -u ATLAS_API_BASE_URL -u ATLAS_B2B_JWT -u ATLAS_TOKEN -u ATLAS_FAQ_SEARCH_ACCOUNT_ID -u ATLAS_ACCOUNT_ID ATLAS_DB_HOST=db-settings-host ATLAS_DB_PORT=5432 ATLAS_DB_DATABASE=atlas_settings ATLAS_DB_USER=atlas_settings_user ATLAS_DB_PASSWORD=atlas_settings_password python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --preflight-only --json --output-result tmp/faq_saas_demo_route_preflight_db_settings_20260529/result5.json
+env -u EXTRACTED_DATABASE_URL -u DATABASE_URL -u ATLAS_API_BASE_URL -u ATLAS_B2B_JWT -u ATLAS_TOKEN -u ATLAS_FAQ_SEARCH_ACCOUNT_ID -u ATLAS_ACCOUNT_ID -u ATLAS_DB_HOST -u ATLAS_DB_SOCKET_PATH python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --preflight-only --json --output-result tmp/faq_saas_demo_route_preflight_db_settings_20260529/result5_no_target.json
+bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-saas-demo-db-settings-fallback-pr-body.md
+```
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 113 |
+| Script fallback | 59 |
+| Tests | 132 |
+| Docs | 43 |
+| **Total** | **347** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import csv
 from dataclasses import replace
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -49,6 +50,7 @@ DEFAULT_TARGET_MODE = "support_account"
 DEFAULT_STATUS = "approved"
 DEFAULT_SUPPORT_CONTACT = "https://example.com/support"
 DEFAULT_QUERY = "export attribution reports"
+ATLAS_DB_TARGET_ENV = ("ATLAS_DB_HOST", "ATLAS_DB_SOCKET_PATH")
 
 
 def _load_dotenv_files() -> None:
@@ -65,6 +67,31 @@ def _env(*names: str) -> str:
     return ""
 
 
+def _default_database_url() -> str:
+    raw = _env("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+    if raw:
+        return raw
+    if not _env(*ATLAS_DB_TARGET_ENV):
+        return ""
+    return _atlas_db_settings_dsn()
+
+
+def _atlas_db_settings_dsn() -> str:
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_atlas_storage_config_for_saas_demo_seed",
+            ROOT / "atlas_brain/storage/config.py",
+        )
+        if spec is None or spec.loader is None:
+            return ""
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception:
+        return ""
+    db_settings = getattr(module, "db_settings", None)
+    return str(getattr(db_settings, "dsn", "") or "").strip()
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     _load_dotenv_files()
     parser = argparse.ArgumentParser(
@@ -72,7 +99,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--database-url",
-        default=_env("EXTRACTED_DATABASE_URL", "DATABASE_URL"),
+        default=_default_database_url(),
     )
     parser.add_argument(
         "--account-id",

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import math
 import os
@@ -18,9 +19,13 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 SEED_SCRIPT = ROOT / "scripts/seed_content_ops_faq_saas_demo.py"
 ROUTE_SCRIPT = ROOT / "scripts/smoke_content_ops_faq_search_route_concurrency.py"
 LOCAL_BASE_URL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
+ATLAS_DB_TARGET_ENV = ("ATLAS_DB_HOST", "ATLAS_DB_SOCKET_PATH")
 
 try:
     from dotenv import load_dotenv
@@ -42,12 +47,37 @@ def _env(*names: str) -> str:
     return ""
 
 
+def _default_database_url() -> str:
+    raw = _env("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+    if raw:
+        return raw
+    if not _env(*ATLAS_DB_TARGET_ENV):
+        return ""
+    return _atlas_db_settings_dsn()
+
+
+def _atlas_db_settings_dsn() -> str:
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_atlas_storage_config_for_saas_demo_route",
+            ROOT / "atlas_brain/storage/config.py",
+        )
+        if spec is None or spec.loader is None:
+            return ""
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception:
+        return ""
+    db_settings = getattr(module, "db_settings", None)
+    return str(getattr(db_settings, "dsn", "") or "").strip()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     _load_dotenv_files()
     parser = argparse.ArgumentParser(
         description="Run the SaaS demo FAQ seed plus hosted route/detail smoke."
     )
-    parser.add_argument("--database-url", default=_env("EXTRACTED_DATABASE_URL", "DATABASE_URL"))
+    parser.add_argument("--database-url", default=_default_database_url())
     parser.add_argument("--base-url", default=_env("ATLAS_API_BASE_URL"))
     parser.add_argument("--token", default=_env("ATLAS_B2B_JWT", "ATLAS_TOKEN"))
     parser.add_argument("--account-id", default=_env("ATLAS_FAQ_SEARCH_ACCOUNT_ID", "ATLAS_ACCOUNT_ID"))

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -83,6 +83,18 @@ BLOCKED_CONSUMER_FINANCE_TERMS = {
 }
 
 
+def _clear_atlas_db_env(monkeypatch) -> None:
+    for name in (
+        "ATLAS_DB_HOST",
+        "ATLAS_DB_PORT",
+        "ATLAS_DB_DATABASE",
+        "ATLAS_DB_USER",
+        "ATLAS_DB_PASSWORD",
+        "ATLAS_DB_SOCKET_PATH",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 def _rows() -> list[dict[str, str]]:
     with DEMO_PATH.open(newline="", encoding="utf-8") as handle:
         return list(csv.DictReader(handle))
@@ -327,6 +339,37 @@ def test_saas_demo_seed_args_fail_closed_for_missing_required_values() -> None:
         "--query is required",
         "--limit must be positive",
     ]
+
+
+def test_saas_demo_seed_default_database_url_prefers_url_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_DATABASE_URL", "postgresql://env/atlas")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://database-url/atlas")
+
+    assert seeder._default_database_url() == "postgresql://env/atlas"
+
+
+def test_saas_demo_seed_default_database_url_falls_back_to_atlas_db_settings(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("ATLAS_DB_HOST", "settings-host")
+    monkeypatch.setenv("ATLAS_DB_PORT", "6543")
+    monkeypatch.setenv("ATLAS_DB_DATABASE", "atlas_settings")
+    monkeypatch.setenv("ATLAS_DB_USER", "atlas_user")
+    monkeypatch.setenv("ATLAS_DB_PASSWORD", "atlas_pass")
+    monkeypatch.delenv("ATLAS_DB_SOCKET_PATH", raising=False)
+
+    assert (
+        seeder._default_database_url()
+        == "postgresql://atlas_user:atlas_pass@settings-host:6543/atlas_settings"
+    )
+
+
+def test_saas_demo_seed_default_database_url_ignores_implicit_atlas_db_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
+
+    assert seeder._default_database_url() == ""
 
 
 def test_saas_demo_cleanup_args_skip_seed_only_required_values() -> None:

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 
 import pytest
@@ -36,6 +38,18 @@ def _base_args(tmp_path: Path) -> list[str]:
         "--output-result",
         str(tmp_path / "result.json"),
     ]
+
+
+def _clear_atlas_db_env(monkeypatch) -> None:
+    for name in (
+        "ATLAS_DB_HOST",
+        "ATLAS_DB_PORT",
+        "ATLAS_DB_DATABASE",
+        "ATLAS_DB_USER",
+        "ATLAS_DB_PASSWORD",
+        "ATLAS_DB_SOCKET_PATH",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _fake_runner(
@@ -155,6 +169,81 @@ def test_validate_args_fails_closed_for_missing_host_inputs() -> None:
         "--route-requests must be positive",
         "--max-detail-ms must be positive",
     ]
+
+
+def test_default_database_url_prefers_url_env(monkeypatch) -> None:
+    monkeypatch.setenv("EXTRACTED_DATABASE_URL", "postgresql://env/atlas")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://database-url/atlas")
+
+    assert smoke._default_database_url() == "postgresql://env/atlas"
+
+
+def test_default_database_url_falls_back_to_atlas_db_settings(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("ATLAS_DB_HOST", "settings-host")
+    monkeypatch.setenv("ATLAS_DB_PORT", "6543")
+    monkeypatch.setenv("ATLAS_DB_DATABASE", "atlas_settings")
+    monkeypatch.setenv("ATLAS_DB_USER", "atlas_user")
+    monkeypatch.setenv("ATLAS_DB_PASSWORD", "atlas_pass")
+    monkeypatch.delenv("ATLAS_DB_SOCKET_PATH", raising=False)
+
+    assert (
+        smoke._default_database_url()
+        == "postgresql://atlas_user:atlas_pass@settings-host:6543/atlas_settings"
+    )
+
+
+def test_default_database_url_ignores_implicit_atlas_db_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
+
+    assert smoke._default_database_url() == ""
+
+
+def test_script_preflight_uses_atlas_db_settings_fallback(tmp_path) -> None:
+    result_path = tmp_path / "preflight.json"
+    env = os.environ.copy()
+    env.pop("EXTRACTED_DATABASE_URL", None)
+    env.pop("DATABASE_URL", None)
+    env.pop("ATLAS_API_BASE_URL", None)
+    env.pop("ATLAS_B2B_JWT", None)
+    env.pop("ATLAS_TOKEN", None)
+    env.pop("ATLAS_FAQ_SEARCH_ACCOUNT_ID", None)
+    env.pop("ATLAS_ACCOUNT_ID", None)
+    env.update(
+        {
+            "ATLAS_DB_HOST": "db-settings-host",
+            "ATLAS_DB_PORT": "5432",
+            "ATLAS_DB_DATABASE": "atlas_settings",
+            "ATLAS_DB_USER": "atlas_settings_user",
+            "ATLAS_DB_PASSWORD": "atlas_settings_password",
+        }
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--preflight-only",
+            "--json",
+            "--output-result",
+            str(result_path),
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert completed.returncode == 2
+    assert payload["required_inputs"]["database_url"] == {"present": True}
+    assert "Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL" not in (
+        payload["preflight_errors"]
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback.md
Slice phase: Functional validation

The SaaS demo seed/E2E scripts were stricter than the surrounding Content Ops Postgres smokes: they required `EXTRACTED_DATABASE_URL`/`DATABASE_URL` even when explicit Atlas DB target settings could already build a DSN. This aligns the SaaS demo path with a guarded DB fallback pattern and reduces the live E2E blocker to the true hosted inputs: API base URL, token, and account id.

## Intentional
- Explicit `--database-url`, `EXTRACTED_DATABASE_URL`, and `DATABASE_URL` still take precedence over `db_settings.dsn`.
- Atlas DB settings fallback only activates when `ATLAS_DB_HOST` or `ATLAS_DB_SOCKET_PATH` is explicitly set, so localhost defaults do not satisfy hosted proof.
- This does not invent hosted route credentials or test against localhost; deployed API URL, token, and account id remain operator-provided.

## Deferred
- Live seeded SaaS FAQ route E2E remains deferred until deployed API base URL, bearer token, and account id are configured.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` -> 52 passed
- `bash scripts/run_extracted_pipeline_checks.sh` -> 2645 passed, 9 skipped
- `env -u EXTRACTED_DATABASE_URL -u DATABASE_URL -u ATLAS_API_BASE_URL -u ATLAS_B2B_JWT -u ATLAS_TOKEN -u ATLAS_FAQ_SEARCH_ACCOUNT_ID -u ATLAS_ACCOUNT_ID ATLAS_DB_HOST=db-settings-host ATLAS_DB_PORT=5432 ATLAS_DB_DATABASE=atlas_settings ATLAS_DB_USER=atlas_settings_user ATLAS_DB_PASSWORD=atlas_settings_password python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --preflight-only --json --output-result tmp/faq_saas_demo_route_preflight_db_settings_20260529/result5.json` -> exit code 2; database present, hosted API/token/account still missing
- `env -u EXTRACTED_DATABASE_URL -u DATABASE_URL -u ATLAS_API_BASE_URL -u ATLAS_B2B_JWT -u ATLAS_TOKEN -u ATLAS_FAQ_SEARCH_ACCOUNT_ID -u ATLAS_ACCOUNT_ID -u ATLAS_DB_HOST -u ATLAS_DB_SOCKET_PATH python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py --preflight-only --json --output-result tmp/faq_saas_demo_route_preflight_db_settings_20260529/result5_no_target.json` -> exit code 2; database missing
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-saas-demo-db-settings-fallback-pr-body.md`

## Diff size
7 files, +347 / -4
