### PR TITLE
Close out support-ticket synthetic smoke follow-ups

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -219,6 +219,14 @@ ingestion friction. PR #630 added optional live-provider mode to the CFPB
 support-ticket-like Postgres smoke, matching the review-source path. Further
 source breadth should still wait for a real host export fixture.
 
+**Support-ticket platform export closeout:** PRs #1101, #1102, #1103, and #1105
+closed the synthetic support-ticket export chain: common Zendesk/Freshdesk/
+Intercom-style aliases, a platform-shaped CSV fixture, operator docs for the
+pre-LLM package smoke, and count-only `contact_email_count` diagnostics. That
+is enough synthetic coverage for now. The next support-ticket source breadth
+slice should be a real anonymized customer export smoke, or no slice at all
+until samples exist.
+
 **FAQ output-contract update:** PR #666 proved the persisted support-ticket FAQ
 lifecycle: source rows -> generated Markdown draft -> export -> review/status
 update -> reviewed export. PR #667 tightened the packaged support-ticket FAQ

--- a/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
+++ b/docs/audits/content_ops_source_adapter_audit_2026-05-16.md
@@ -14,6 +14,11 @@ PR #550 made source-type precedence explicit in code/tests, and PR #551 added
 the per-row field lookup cache for provider-style aliases. Further source work
 should now require a real host export or field-loss risk.
 
+2026-05-29 update: support-ticket export coverage now has the synthetic platform
+path closed through PRs #1101, #1102, #1103, and #1105. Do not add more
+plausible help desk export shapes without an anonymized customer export or a
+specific field-loss bug.
+
 ## Current Surface
 
 The source adapter converts host source rows into the existing campaign
@@ -122,7 +127,9 @@ Do not add a new source family when:
 1. If a real host export is available, add only the minimal alias/source keys
    needed to load that file and include a fixture shaped like the export.
 2. If no export is available, do not add more source breadth. The current
-   consolidation items are complete; move to reasoning-policy depth instead.
+   consolidation items and synthetic support-ticket platform smoke are complete;
+   move to reasoning-policy depth or another concrete product runtime gap
+   instead.
 
 ## Performance Improvements
 

--- a/docs/extraction/coordination/state.md
+++ b/docs/extraction/coordination/state.md
@@ -1,6 +1,6 @@
 # Per-Product State
 
-Last updated: 2026-05-19T05:30Z by codex-2026-05-18
+Last updated: 2026-05-29T00:30Z by codex-2026-05-29
 
 Cross-product state-of-the-world for the extraction effort. Update when a PR merges or a product's phase advances. See [`../COORDINATION.md`](../COORDINATION.md) for the protocol that governs edits to this file.
 
@@ -8,7 +8,7 @@ Cross-product state-of-the-world for the extraction effort. Update when a PR mer
 |---|---|---|---|---|---|
 | `extracted_llm_infrastructure` | 3 (runtime-decoupled + 100% standalone-operational; no OSS publish — internal refactor only) | #171 | — | Extraction effort terminal. PR-A6a #169 carved `ProviderCostSubConfig` into `_standalone/config.py`; PR-A6b #171 ported `SkillRegistry` substrate. Customer-facing API/SaaS work tracks under product roadmap (P1/P5/P6), not this scaffold. | none |
 | `extracted_competitive_intelligence` | 2 in progress (standalone toggle surfaces landing) | #160 | — | Continue Phase 2 ownership of standalone-ready product surfaces | none |
-| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #630 | — | Source-row ingestion now covers review, CRM/call/support-style rows, common help desk export aliases, backend `default_fields`, Atlas Intel fallback-field entry, and optional live-provider Postgres smokes for review-source and CFPB support-ticket-like rows. Next Content Ops work should come from a real host export fixture or the separate reasoning-core productization track. | none |
+| `extracted_content_pipeline` | 2 in progress (host-operational productization seams) | #1105 | — | Source-row ingestion now covers review, CRM/call/support-style rows, backend `default_fields`, Atlas Intel fallback-field entry, optional live-provider Postgres smokes, and the synthetic support-ticket platform export smoke chain. Next support-ticket source work should wait for an anonymized real customer export fixture; otherwise move to a separate concrete runtime gap. | none |
 | `extracted_reasoning_core` | 2 in progress (public API, semantic-cache keys, pack registry, graph/state ports, manifest, standalone smoke, and partial product wrappers landed) | #577 | — | Reasoning-core checks now have a product-specific runner. Next work should come from a concrete product runtime need, not the old graph checklist. | none |
 | `extracted_quality_gate` | 1 (scaffold + 7 deterministic packs landed: product_claim core #85; safety-gate split #114; blog quality pack #118; campaign quality pack #120; witness specificity pack #125; evidence coverage gate #130; source-quality pack #132) | #154 | — | Decoupling work effectively complete; no OSS publish. Future quality-gate features land here as new packs when needed. | none |
 

--- a/plans/PR-Support-Ticket-Smoke-Closeout.md
+++ b/plans/PR-Support-Ticket-Smoke-Closeout.md
@@ -1,0 +1,72 @@
+# PR: Support Ticket Smoke Closeout
+
+## Why this slice exists
+
+The support-ticket input-provider lane just shipped the synthetic export chain:
+header aliases, platform-shaped CSV fixture, operator docs, and count-only
+contact-email diagnostics. The active backlog still reads like the next source
+work might be another generic export slice, even though the remaining useful
+proof is now blocked on real anonymized customer exports.
+
+This slice updates coordination docs so future sessions do not keep polishing
+synthetic smoke surfaces.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/support-ticket-input-provider
+Slice phase: Product polish
+
+1. Mark the synthetic support-ticket platform smoke chain as closed in the
+   active deferred backlog.
+2. Refresh the source-adapter audit recommendation to point away from further
+   synthetic source-shape work.
+3. Update per-product state so the next milestone reflects the real export
+   dependency.
+
+### Files touched
+
+- `plans/PR-Support-Ticket-Smoke-Closeout.md` - Plan doc for this slice.
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md` - Record the support-ticket smoke chain closeout.
+- `docs/audits/content_ops_source_adapter_audit_2026-05-16.md` - Refresh the source-adapter next-work recommendation.
+- `docs/extraction/coordination/state.md` - Update Content Ops state and next milestone.
+
+## Mechanism
+
+The docs now state that PRs #1101, #1102, #1103, and #1105 closed the synthetic
+support-ticket export coverage path. The remaining source-breadth task is
+explicitly waiting for anonymized real customer exports, not more plausible
+platform shapes.
+
+## Intentional
+
+- Docs-only closeout. No runtime, prompt, FAQ generation, or smoke behavior
+  changes.
+- This does not remove the real-export follow-up. It clarifies that the
+  follow-up needs real samples before another implementation slice makes sense.
+- This does not touch FAQ-owned work.
+
+## Deferred
+
+- Future PR: run the platform smoke against anonymized real customer exports
+  when samples are available.
+- Parked hardening: none.
+
+## Verification
+
+- Grep for closeout markers and stale next-step wording across the edited docs -
+  passed; the docs now reference PRs #1101/#1102/#1103/#1105 and no longer keep
+  the old "Next Content Ops work should come from a real host export fixture"
+  wording in coordination state.
+- Whitespace check - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~65 |
+| Deferred backlog | ~15 |
+| Source adapter audit | ~10 |
+| Coordination state | ~10 |
+| **Total** | **~100** |
+
+This stays below the 400 LOC soft cap.


### PR DESCRIPTION
Plan: plans/PR-Support-Ticket-Smoke-Closeout.md
Ownership lane: content-ops/support-ticket-input-provider
Slice phase: Product polish

This docs-only closeout records that the synthetic support-ticket export chain is complete and that the next support-ticket source-breadth step should wait for anonymized real customer exports instead of more plausible platform shapes.

## Intentional

- Docs-only closeout; runtime, prompt, FAQ generation, and smoke behavior stay unchanged.
- The real-export follow-up remains explicit, but it is blocked on sample availability.
- This does not touch FAQ-owned work.

## Deferred

- Future PR: run the platform smoke against anonymized real customer exports when samples are available.

## Parked hardening

None.

## Verification

- Grep for closeout markers and stale next-step wording across the edited docs - passed; the docs now reference PRs #1101/#1102/#1103/#1105 and no longer keep the old "Next Content Ops work should come from a real host export fixture" wording in coordination state.
- Whitespace check - passed.

## Diff size

~100 LOC estimated; actual diff is below the 400 LOC soft cap.