### PR TITLE
Normalize blank SaaS FAQ DB URL fallback

### DIFF
--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md
@@ -36,7 +36,6 @@ missing hosted inputs or ready for the DB write plus hosted route measurement:
 
 ```bash
 python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
@@ -56,7 +55,6 @@ one-command smoke below.
 
 ```bash
 python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
@@ -87,7 +85,6 @@ file between seed and route validation.
 
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
   --route-case-file-output /tmp/faq-saas-demo-route-cases.json \
   --output-result /tmp/faq-saas-demo-seed-result.json
@@ -180,7 +177,6 @@ database, delete it with the FAQ id from the seed result:
 
 ```bash
 python scripts/seed_content_ops_faq_saas_demo.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
   --cleanup-faq-id "<faq_id_from_seed_result>" \
   --output-result /tmp/faq-saas-demo-cleanup-result.json

--- a/docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md
+++ b/docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md
@@ -18,7 +18,6 @@ route traffic, so this slice ran the existing preflight-only mode first.
 ```bash
 mkdir -p tmp/faq_saas_demo_route_preflight_20260529
 python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \
@@ -81,7 +80,6 @@ Atlas' localhost defaults from satisfying hosted proof preflight by themselves.
 ```bash
 python scripts/run_extracted_content_pipeline_migrations.py
 python scripts/smoke_content_ops_faq_saas_demo_route_e2e.py \
-  --database-url "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}" \
   --base-url "$ATLAS_API_BASE_URL" \
   --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
   --account-id "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}" \

--- a/plans/PR-Content-Ops-FAQ-DB-Blank-Fallback.md
+++ b/plans/PR-Content-Ops-FAQ-DB-Blank-Fallback.md
@@ -1,0 +1,87 @@
+# PR-Content-Ops-FAQ-DB-Blank-Fallback
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-SaaS-Demo-DB-Settings-Fallback added a guarded Atlas DB
+settings fallback for the SaaS FAQ demo seed and hosted route smoke. The
+runbook examples still pass an explicit database URL argument built from
+`EXTRACTED_DATABASE_URL`/`DATABASE_URL`.
+When both URL env vars are empty, that explicit blank CLI value bypasses the
+parser default and defeats the fallback the prior slice introduced.
+
+This slice closes that integration gap before the next hosted proof attempt.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Functional validation
+
+1. Normalize blank database URL CLI values in the SaaS demo seed and one-command
+   route E2E scripts through the same guarded fallback used by parser defaults.
+2. Keep fail-closed behavior when neither URL envs nor explicit Atlas DB target
+   settings are present.
+3. Update the SaaS demo route runbook/preflight examples so they rely on script
+   defaults instead of passing an explicit empty database URL.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/seed_content_ops_faq_saas_demo.py` | Treat blank database URL CLI input as missing and re-run guarded default discovery. |
+| `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py` | Apply the same normalization before preflight validation. |
+| `tests/test_content_ops_faq_saas_demo_corpus.py` | Cover seed CLI blank database URL fallback and fail-closed behavior. |
+| `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py` | Cover route E2E blank database URL fallback and fail-closed behavior. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md` | Remove explicit empty DB URL arguments from examples. |
+| `docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md` | Align recorded next-run examples with fallback behavior. |
+| `plans/PR-Content-Ops-FAQ-DB-Blank-Fallback.md` | Slice contract. |
+
+## Mechanism
+
+Both scripts normalize parsed args before validation:
+
+```python
+def _normalize_args(args):
+    if not str(args.database_url or "").strip():
+        args.database_url = _default_database_url()
+    return args
+```
+
+The fallback itself remains guarded by explicit `ATLAS_DB_HOST` or
+`ATLAS_DB_SOCKET_PATH`, so blank CLI input cannot convert localhost defaults
+into a hosted-proof database.
+
+## Intentional
+
+- This does not broaden what counts as a valid DB fallback; it only makes blank
+  CLI input behave like an omitted database URL.
+- This does not change deployed API URL, token, or account-id handling. Those
+  remain required hosted proof inputs.
+- This keeps the examples short by relying on the scripts' existing env/default
+  discovery instead of adding shell conditionals.
+
+## Deferred
+
+- Live seeded SaaS FAQ route E2E remains deferred until deployed API base URL,
+  bearer token, and account id are configured.
+- Parked hardening: none.
+
+## Verification
+
+To run before opening the PR:
+
+```bash
+python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+EXTRACTED_PIPELINE_STANDALONE=1 python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q
+bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-db-blank-fallback-pr-body.md
+```
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 87 |
+| Script normalization | 16 |
+| Tests | 71 |
+| Docs | 6 |
+| **Total** | **180** |

--- a/scripts/seed_content_ops_faq_saas_demo.py
+++ b/scripts/seed_content_ops_faq_saas_demo.py
@@ -119,7 +119,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--route-case-file-output", type=Path)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--json", action="store_true")
-    return parser.parse_args(argv)
+    return _normalize_args(parser.parse_args(argv))
+
+
+def _normalize_args(args: argparse.Namespace) -> argparse.Namespace:
+    if not str(args.database_url or "").strip():
+        args.database_url = _default_database_url()
+    return args
 
 
 def _validate_args(args: argparse.Namespace) -> list[str]:

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -100,6 +100,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _normalize_args(args: argparse.Namespace) -> argparse.Namespace:
+    if not str(args.database_url or "").strip():
+        args.database_url = _default_database_url()
+    return args
+
+
 def _validate_args(args: argparse.Namespace) -> list[str]:
     errors: list[str] = []
     for name, message in (
@@ -469,7 +475,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 
 def main(argv: Sequence[str] | None = None) -> int:
     start = time.perf_counter()
-    args = _build_parser().parse_args(argv)
+    args = _normalize_args(_build_parser().parse_args(argv))
     errors = _validate_args(args)
     if errors:
         summary = _preflight_summary(args, errors, time.perf_counter() - start)

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -236,7 +236,7 @@ def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
 
     parsed = e2e_smoke._build_parser().parse_args(args)
 
-    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert "--database-url" not in args
     assert parsed.base_url == "$ATLAS_API_BASE_URL"
     assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
     assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
@@ -247,6 +247,7 @@ def test_saas_demo_route_case_runbook_e2e_command_matches_parser() -> None:
     assert parsed.max_detail_ms == 2500
     assert parsed.artifact_dir == Path("/tmp/faq-saas-demo-route-e2e-artifacts")
     assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-result.json")
+    parsed.database_url = "postgresql://example/atlas"
     parsed.base_url = "https://atlas.example.com"
     assert e2e_smoke._validate_args(parsed) == []
 
@@ -259,7 +260,7 @@ def test_saas_demo_route_case_runbook_preflight_command_matches_parser() -> None
 
     parsed = e2e_smoke._build_parser().parse_args(args)
 
-    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert "--database-url" not in args
     assert parsed.base_url == "$ATLAS_API_BASE_URL"
     assert parsed.token == "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}"
     assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
@@ -267,6 +268,7 @@ def test_saas_demo_route_case_runbook_preflight_command_matches_parser() -> None
     assert parsed.json is True
     assert parsed.artifact_dir is None
     assert parsed.output_result == Path("/tmp/faq-saas-demo-route-e2e-preflight.json")
+    parsed.database_url = "postgresql://example/atlas"
     parsed.base_url = "https://atlas.example.com"
     assert e2e_smoke._validate_args(parsed) == []
 
@@ -276,11 +278,12 @@ def test_saas_demo_route_case_runbook_seed_command_matches_parser() -> None:
 
     parsed = seeder._parse_args(args)
 
-    assert parsed.database_url == "${EXTRACTED_DATABASE_URL:-$DATABASE_URL}"
+    assert "--database-url" not in args
     assert parsed.account_id == "${ATLAS_FAQ_SEARCH_ACCOUNT_ID:-$ATLAS_ACCOUNT_ID}"
     assert parsed.route_case_file_output == Path("/tmp/faq-saas-demo-route-cases.json")
     assert parsed.output_result == Path("/tmp/faq-saas-demo-seed-result.json")
     assert parsed.cleanup_faq_id is None
+    parsed.database_url = "postgresql://example/atlas"
     assert seeder._validate_args(parsed) == []
 
 
@@ -372,6 +375,31 @@ def test_saas_demo_seed_default_database_url_ignores_implicit_atlas_db_defaults(
     assert seeder._default_database_url() == ""
 
 
+def test_saas_demo_seed_blank_database_url_uses_guarded_fallback(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("ATLAS_DB_HOST", "settings-host")
+    monkeypatch.setenv("ATLAS_DB_PORT", "6543")
+    monkeypatch.setenv("ATLAS_DB_DATABASE", "atlas_settings")
+    monkeypatch.setenv("ATLAS_DB_USER", "atlas_user")
+    monkeypatch.setenv("ATLAS_DB_PASSWORD", "atlas_pass")
+    monkeypatch.delenv("ATLAS_DB_SOCKET_PATH", raising=False)
+
+    args = seeder._parse_args(["--database-url", "", "--account-id", "acct-demo"])
+
+    assert args.database_url == "postgresql://atlas_user:atlas_pass@settings-host:6543/atlas_settings"
+
+
+def test_saas_demo_seed_blank_database_url_stays_missing_without_target(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
+
+    args = seeder._parse_args(["--database-url", "", "--account-id", "acct-demo"])
+
+    assert args.database_url == ""
+
+
 def test_saas_demo_cleanup_args_skip_seed_only_required_values() -> None:
     errors = seeder._validate_args(
         SimpleNamespace(
@@ -407,8 +435,11 @@ def test_saas_demo_route_case_output_is_seed_only() -> None:
     assert errors == ["--route-case-file-output is only available in seed mode"]
 
 
-def test_saas_demo_seed_preflight_writes_result_before_exit(tmp_path) -> None:
+def test_saas_demo_seed_preflight_writes_result_before_exit(tmp_path, monkeypatch) -> None:
     result_path = tmp_path / "seed-preflight.json"
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
 
     with pytest.raises(SystemExit) as exc:
         seeder.main([

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -202,6 +202,33 @@ def test_default_database_url_ignores_implicit_atlas_db_defaults(monkeypatch) ->
     assert smoke._default_database_url() == ""
 
 
+def test_blank_database_url_uses_guarded_fallback(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("ATLAS_DB_HOST", "settings-host")
+    monkeypatch.setenv("ATLAS_DB_PORT", "6543")
+    monkeypatch.setenv("ATLAS_DB_DATABASE", "atlas_settings")
+    monkeypatch.setenv("ATLAS_DB_USER", "atlas_user")
+    monkeypatch.setenv("ATLAS_DB_PASSWORD", "atlas_pass")
+    monkeypatch.delenv("ATLAS_DB_SOCKET_PATH", raising=False)
+    args = smoke._build_parser().parse_args(["--database-url", ""])
+
+    smoke._normalize_args(args)
+
+    assert args.database_url == "postgresql://atlas_user:atlas_pass@settings-host:6543/atlas_settings"
+
+
+def test_blank_database_url_stays_missing_without_target(monkeypatch) -> None:
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
+    args = smoke._build_parser().parse_args(["--database-url", ""])
+
+    smoke._normalize_args(args)
+
+    assert args.database_url == ""
+
+
 def test_script_preflight_uses_atlas_db_settings_fallback(tmp_path) -> None:
     result_path = tmp_path / "preflight.json"
     env = os.environ.copy()
@@ -368,8 +395,11 @@ def test_main_malformed_base_url_writes_preflight_result_before_exit(
     assert calls == []
 
 
-def test_main_writes_preflight_result_before_exit(tmp_path, capsys) -> None:
+def test_main_writes_preflight_result_before_exit(tmp_path, capsys, monkeypatch) -> None:
     result_path = tmp_path / "preflight.json"
+    monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _clear_atlas_db_env(monkeypatch)
 
     code = smoke.main([
         "--database-url",


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-DB-Blank-Fallback.md
Slice phase: Functional validation

The SaaS FAQ demo scripts had a guarded DB settings fallback, but runbook-shaped invocations could still pass `--database-url ""` and bypass that fallback. This normalizes blank DB URL CLI input through the same guarded discovery path and removes explicit empty DB URL arguments from the SaaS demo route docs.

## Intentional
- Blank `--database-url` behaves like an omitted DB URL; it still fails closed when no URL env or explicit Atlas DB target setting exists.
- Deployed API URL, token, and account id remain required hosted proof inputs.
- Historical hosted-proof records are left as records; the live runbook and preflight next-run examples are updated.

## Deferred
- Live seeded SaaS FAQ route E2E remains deferred until deployed API base URL, bearer token, and account id are configured.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/seed_content_ops_faq_saas_demo.py scripts/smoke_content_ops_faq_saas_demo_route_e2e.py tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
- `EXTRACTED_PIPELINE_STANDALONE=1 python -m pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` -> 56 passed
- `rg -n -- '--database-url "\$\{EXTRACTED_DATABASE_URL' docs/extraction/validation/content_ops_faq_saas_demo_route_case_runbook.md docs/extraction/validation/content_ops_faq_saas_demo_route_preflight_2026-05-29.md` -> no matches
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-db-blank-fallback-pr-body.md`

## Diff size
7 files, +167 / -13
