### PR TITLE
Add FAQ output ingestion source adapter

### DIFF
--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -15,6 +15,10 @@ from .campaign_customer_data import (
     normalize_campaign_opportunity_rows,
 )
 from .campaign_opportunities import normalize_campaign_opportunity
+from .faq_output_ingestion import (
+    faq_output_to_source_rows,
+    is_faq_output_bundle,
+)
 
 
 SourceDataFormat = Literal["auto", "json", "jsonl", "csv"]
@@ -425,6 +429,8 @@ def source_material_to_source_rows(source_material: Any) -> list[Any]:
     """Expand a source-material object, bundle, or row list into source rows."""
 
     if isinstance(source_material, Mapping):
+        if is_faq_output_bundle(source_material):
+            return faq_output_to_source_rows(source_material)
         return _source_rows_from_bundle(source_material)
     if isinstance(source_material, Sequence) and not isinstance(
         source_material,

--- a/extracted_content_pipeline/faq_output_ingestion.py
+++ b/extracted_content_pipeline/faq_output_ingestion.py
@@ -1,0 +1,219 @@
+"""Adapt generated FAQ output into campaign source rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any
+
+
+FAQ_OUTPUT_SOURCE_TYPE = "faq_output"
+
+_FAQ_OUTPUT_MARKER_KEYS = (
+    "generated",
+    "markdown",
+    "output_checks",
+    "ticket_source_count",
+    "saved_ids",
+)
+_FAQ_ITEM_ID_KEYS = (
+    "faq_id",
+    "faq_draft_id",
+    "draft_id",
+    "article_id",
+    "id",
+)
+_FAQ_ITEM_URL_KEYS = ("url", "source_url", "article_url", "faq_url")
+_SLUG_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+
+
+def is_faq_output_bundle(value: Any) -> bool:
+    """Return whether a mapping looks like a generated FAQ output bundle."""
+
+    if not isinstance(value, Mapping):
+        return False
+    items = value.get("items")
+    if not _is_sequence(items):
+        return False
+    return any(key in value for key in _FAQ_OUTPUT_MARKER_KEYS)
+
+
+def faq_output_to_source_rows(faq_output: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Convert generated FAQ output into source rows for campaign ingestion."""
+
+    if not is_faq_output_bundle(faq_output):
+        return []
+
+    saved_ids = _text_values(faq_output.get("saved_ids"))
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(faq_output.get("items") or (), start=1):
+        if not isinstance(item, Mapping):
+            continue
+        saved_id = saved_ids[index - 1] if index <= len(saved_ids) else ""
+        row = faq_item_to_source_row(item, rank=index, saved_id=saved_id)
+        if row:
+            rows.append(row)
+    return rows
+
+
+def faq_item_to_source_row(
+    item: Mapping[str, Any],
+    *,
+    rank: int,
+    saved_id: str = "",
+) -> dict[str, Any]:
+    """Convert one generated FAQ item into one source-material row."""
+
+    text = _faq_item_text(item)
+    if not text:
+        return {}
+
+    topic = _clean_text(item.get("topic"))
+    question = _clean_text(item.get("question"))
+    summary = _clean_text(item.get("summary"))
+    steps = _text_values(item.get("steps") or item.get("action_items"))
+    evidence_quotes = _text_values(item.get("evidence_quotes"))
+    source_ids = _text_values(item.get("source_ids"))
+    title = question or topic or f"FAQ item {rank}"
+    source_id = _source_id(item, rank=rank, saved_id=saved_id, title=title)
+
+    row: dict[str, Any] = {
+        "source_type": FAQ_OUTPUT_SOURCE_TYPE,
+        "source_id": source_id,
+        "source_title": title,
+        "text": text,
+        "faq_rank": rank,
+        "faq_question": question,
+        "faq_topic": topic,
+        "faq_summary": summary,
+        "faq_steps": steps,
+        "faq_customer_language": _customer_language(question, evidence_quotes),
+        "faq_source_ticket_ids": source_ids,
+        "faq_answer_evidence_status": _clean_text(
+            item.get("answer_evidence_status")
+        ),
+        "question_source": _clean_text(item.get("question_source")),
+        "pain_points": [topic] if topic else [],
+    }
+    for key in (
+        "frequency",
+        "weighted_frequency",
+        "failure_risk_score",
+        "opportunity_score",
+        "ticket_count",
+        "evidence_count",
+        "resolution_source_count",
+    ):
+        value = item.get(key)
+        if value not in (None, "", [], {}):
+            row[key] = value
+    url = _first_text(item, _FAQ_ITEM_URL_KEYS)
+    if url:
+        row["source_url"] = url
+    return _drop_empty(row)
+
+
+def _faq_item_text(item: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    question = _clean_text(item.get("question"))
+    topic = _clean_text(item.get("topic"))
+    summary = _clean_text(item.get("summary"))
+    answer = _clean_text(item.get("answer"))
+    steps = _text_values(item.get("steps") or item.get("action_items"))
+    evidence_quotes = _text_values(item.get("evidence_quotes"))
+    answer_evidence_status = _clean_text(item.get("answer_evidence_status"))
+
+    if question:
+        parts.append(f"FAQ question: {question}")
+    if topic:
+        parts.append(f"Topic: {topic}")
+    if summary:
+        parts.append(f"Summary: {summary}")
+    if answer:
+        parts.append(f"Answer: {answer}")
+    if steps:
+        numbered_steps = " ".join(
+            f"{index}. {step}" for index, step in enumerate(steps, start=1)
+        )
+        parts.append(f"Steps: {numbered_steps}")
+    if evidence_quotes:
+        parts.append("Customer wording: " + " ".join(evidence_quotes))
+    if answer_evidence_status:
+        parts.append(f"Answer evidence status: {answer_evidence_status}")
+    return "\n".join(parts)
+
+
+def _source_id(
+    item: Mapping[str, Any],
+    *,
+    rank: int,
+    saved_id: str,
+    title: str,
+) -> str:
+    candidate = _clean_text(saved_id) or _first_text(item, _FAQ_ITEM_ID_KEYS)
+    if candidate:
+        return candidate
+    slug = _SLUG_SEPARATOR_RE.sub("-", title.lower()).strip("-")
+    suffix = slug[:64].strip("-") or str(rank)
+    return f"faq-output-{rank}-{suffix}"
+
+
+def _customer_language(question: str, evidence_quotes: Sequence[str]) -> list[str]:
+    out: list[str] = []
+    for value in (question, *evidence_quotes):
+        text = _clean_text(value)
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        text = _clean_text(row.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _text_values(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        values: Sequence[Any] = (value,)
+    elif _is_sequence(value):
+        values = value
+    else:
+        values = (value,)
+    out: list[str] = []
+    for item in values:
+        text = _clean_text(item)
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _drop_empty(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): value
+        for key, value in row.items()
+        if value not in (None, "", [], {})
+    }
+
+
+def _is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    )
+
+
+__all__ = [
+    "FAQ_OUTPUT_SOURCE_TYPE",
+    "faq_item_to_source_row",
+    "faq_output_to_source_rows",
+    "is_faq_output_bundle",
+]

--- a/extracted_content_pipeline/faq_output_ingestion.py
+++ b/extracted_content_pipeline/faq_output_ingestion.py
@@ -44,13 +44,23 @@ def faq_output_to_source_rows(faq_output: Mapping[str, Any]) -> list[dict[str, A
     if not is_faq_output_bundle(faq_output):
         return []
 
+    items = tuple(faq_output.get("items") or ())
     saved_ids = _text_values(faq_output.get("saved_ids"))
+    report_saved_id = saved_ids[0] if len(saved_ids) == 1 else ""
     rows: list[dict[str, Any]] = []
-    for index, item in enumerate(faq_output.get("items") or (), start=1):
+    for index, item in enumerate(items, start=1):
         if not isinstance(item, Mapping):
             continue
-        saved_id = saved_ids[index - 1] if index <= len(saved_ids) else ""
-        row = faq_item_to_source_row(item, rank=index, saved_id=saved_id)
+        saved_id = (
+            report_saved_id
+            or (saved_ids[index - 1] if index <= len(saved_ids) else "")
+        )
+        row = faq_item_to_source_row(
+            item,
+            rank=index,
+            saved_id=saved_id,
+            saved_id_is_report_level=bool(report_saved_id and len(items) > 1),
+        )
         if row:
             rows.append(row)
     return rows
@@ -61,6 +71,7 @@ def faq_item_to_source_row(
     *,
     rank: int,
     saved_id: str = "",
+    saved_id_is_report_level: bool = False,
 ) -> dict[str, Any]:
     """Convert one generated FAQ item into one source-material row."""
 
@@ -75,7 +86,13 @@ def faq_item_to_source_row(
     evidence_quotes = _text_values(item.get("evidence_quotes"))
     source_ids = _text_values(item.get("source_ids"))
     title = question or topic or f"FAQ item {rank}"
-    source_id = _source_id(item, rank=rank, saved_id=saved_id, title=title)
+    source_id = _source_id(
+        item,
+        rank=rank,
+        saved_id=saved_id,
+        saved_id_is_report_level=saved_id_is_report_level,
+        title=title,
+    )
 
     row: dict[str, Any] = {
         "source_type": FAQ_OUTPUT_SOURCE_TYPE,
@@ -88,6 +105,7 @@ def faq_item_to_source_row(
         "faq_summary": summary,
         "faq_steps": steps,
         "faq_customer_language": _customer_language(question, evidence_quotes),
+        "faq_draft_id": saved_id,
         "faq_source_ticket_ids": source_ids,
         "faq_answer_evidence_status": _clean_text(
             item.get("answer_evidence_status")
@@ -148,9 +166,13 @@ def _source_id(
     *,
     rank: int,
     saved_id: str,
+    saved_id_is_report_level: bool,
     title: str,
 ) -> str:
-    candidate = _clean_text(saved_id) or _first_text(item, _FAQ_ITEM_ID_KEYS)
+    cleaned_saved_id = _clean_text(saved_id)
+    if cleaned_saved_id and saved_id_is_report_level:
+        return f"{cleaned_saved_id}:item-{rank}"
+    candidate = cleaned_saved_id or _first_text(item, _FAQ_ITEM_ID_KEYS)
     if candidate:
         return candidate
     slug = _SLUG_SEPARATOR_RE.sub("-", title.lower()).strip("-")

--- a/plans/PR-FAQ-Output-As-Ingestion-Source.md
+++ b/plans/PR-FAQ-Output-As-Ingestion-Source.md
@@ -1,0 +1,110 @@
+# FAQ Output As Ingestion Source
+
+## Why this slice exists
+
+The FAQ report lane can already turn support tickets into ranked FAQ items, and
+the blog/landing lanes can already ingest generic source material. The missing
+contract is the bridge between those two systems: a generated FAQ report should
+be reusable as source material without creating a one-off blog or landing-page
+patch.
+
+This slice builds that bridge at the source-adapter boundary so future FAQ
+output shape changes can be absorbed in one adapter instead of scattered across
+content generators.
+
+This is slightly over the 400-LOC soft cap because the adapter, source-material
+wiring, runner enrollment, and biting tests need to land together for the new
+contract to be real.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Vertical slice
+
+1. Add a small FAQ-output ingestion adapter that converts FAQ result dictionaries
+   into canonical source rows.
+2. Wire `source_material_to_source_rows(...)` to recognize FAQ result bundles and
+   route them through the adapter before generic bundle expansion.
+3. Add focused tests proving FAQ output rows normalize into campaign
+   opportunities while preserving source type, customer wording, FAQ metadata,
+   and no-items behavior.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_output_ingestion.py`
+- `extracted_content_pipeline/campaign_source_adapters.py`
+- `tests/test_extracted_ticket_faq_output_ingestion.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-FAQ-Output-As-Ingestion-Source.md`
+
+## Mechanism
+
+`faq_output_to_source_rows(...)` accepts the dictionary shape returned by
+`TicketFAQMarkdownResult.as_dict()` and produces rows with:
+
+- `source_type="faq_output"` so downstream consumers know the evidence is a
+  derived FAQ artifact, not raw support tickets.
+- stable source IDs from saved FAQ draft IDs when present, otherwise ranked FAQ
+  item IDs.
+- composed text containing the FAQ question, summary, steps, answer evidence
+  status, and customer-language evidence quotes.
+- metadata such as topic, question source, source ticket IDs, answer evidence
+  status, and opportunity score.
+
+`source_material_to_source_rows(...)` detects FAQ result bundles before generic
+bundle expansion. That keeps the integration point central: callers that already
+pass `source_material` to the campaign source adapter can pass FAQ output
+directly without knowing about FAQ internals.
+
+## Intentional
+
+- This does not change FAQ generation, saved FAQ draft shape, blog prompts, or
+  landing-page prompts. It only makes FAQ output consumable as source material.
+- The adapter treats FAQ output as a derived source type (`faq_output`) instead
+  of pretending the original support tickets are being ingested again.
+- The adapter is forgiving about item fields because the FAQ output shape may
+  evolve. Missing optional fields are skipped; items without usable question,
+  summary, steps, answer, or evidence text are ignored.
+
+## Deferred
+
+- Future PR: add UI/API selection so a user can intentionally feed a saved FAQ
+  report into blog or landing-page generation.
+- Future PR: adapt this adapter if the FAQ lane introduces standalone FAQ article
+  records with their own canonical IDs and URLs.
+- Parked hardening: none.
+
+## Verification
+
+Ran locally:
+
+- Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_campaign_source_adapters.py -q
+  - 72 passed
+- Command: python -m py_compile extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_ticket_faq_output_ingestion.py
+  - passed
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
+  - passed; 125 matching tests are enrolled
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - passed
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - passed
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - passed
+- Command: bash scripts/check_ascii_python.sh
+  - passed
+- Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - passed; no additional file changes
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - passed; 2648 passed, 9 skipped
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-as-ingestion-source.md
+  - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| FAQ output adapter | ~220 |
+| Source adapter wiring | ~10 |
+| Focused tests + runner enrollment | ~135 |
+| Plan doc | ~105 |
+| **Total** | **~470** |

--- a/plans/PR-FAQ-Output-As-Ingestion-Source.md
+++ b/plans/PR-FAQ-Output-As-Ingestion-Source.md
@@ -79,7 +79,8 @@ directly without knowing about FAQ internals.
 Ran locally:
 
 - Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_campaign_source_adapters.py -q
-  - 72 passed
+  - 72 passed; rerun after addressing the saved FAQ draft traceability review
+    comment
 - Command: python -m py_compile extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_ticket_faq_output_ingestion.py
   - passed
 - Command: python scripts/audit_extracted_pipeline_ci_enrollment.py
@@ -98,13 +99,16 @@ Ran locally:
   - passed; 2648 passed, 9 skipped
 - Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-as-ingestion-source.md
   - passed
+- Review update: addressed the bot P2 by preserving a report-level
+  `saved_ids[0]` value as `faq_draft_id` on every generated item row and using
+  an item suffix for unique `source_id` values in multi-item reports.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| FAQ output adapter | ~220 |
+| FAQ output adapter | ~230 |
 | Source adapter wiring | ~10 |
 | Focused tests + runner enrollment | ~135 |
-| Plan doc | ~105 |
-| **Total** | **~470** |
+| Plan doc | ~110 |
+| **Total** | **~485** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_content_ops_faq_saas_demo_corpus.py \
   tests/test_content_ops_faq_report_contract_docs.py \
   tests/test_extracted_ticket_faq_markdown.py \
+  tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \
   tests/test_smoke_content_ops_faq_search_route_concurrency.py \

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -62,8 +62,10 @@ def test_faq_output_rows_normalize_into_campaign_opportunities() -> None:
         FAQ_OUTPUT_SOURCE_TYPE,
         FAQ_OUTPUT_SOURCE_TYPE,
     ]
-    assert rows[0]["source_id"] == "faq-draft-1"
-    assert rows[1]["source_id"].startswith("faq-output-2-how-do-i-export")
+    assert rows[0]["source_id"] == "faq-draft-1:item-1"
+    assert rows[1]["source_id"] == "faq-draft-1:item-2"
+    assert rows[0]["faq_draft_id"] == "faq-draft-1"
+    assert rows[1]["faq_draft_id"] == "faq-draft-1"
     assert rows[0]["source_title"] == "Why was I charged twice?"
     assert rows[0]["faq_source_ticket_ids"] == ["ticket-1", "ticket-2"]
     assert rows[0]["faq_customer_language"] == [
@@ -84,7 +86,7 @@ def test_faq_output_rows_normalize_into_campaign_opportunities() -> None:
     assert first["opportunity_score"] == 4
     assert first["evidence"] == [{
         "text": rows[0]["text"],
-        "source_id": "faq-draft-1",
+        "source_id": "faq-draft-1:item-1",
         "source_type": FAQ_OUTPUT_SOURCE_TYPE,
         "source_title": "Why was I charged twice?",
     }]

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from extracted_content_pipeline.campaign_source_adapters import (
+    source_material_to_source_rows,
+    source_rows_to_campaign_opportunities,
+)
+from extracted_content_pipeline.faq_output_ingestion import (
+    FAQ_OUTPUT_SOURCE_TYPE,
+    faq_output_to_source_rows,
+    is_faq_output_bundle,
+)
+from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+
+
+def test_faq_output_rows_normalize_into_campaign_opportunities() -> None:
+    faq_output = {
+        "generated": 2,
+        "markdown": "# FAQ",
+        "saved_ids": ["faq-draft-1"],
+        "items": [
+            {
+                "topic": "billing confusion",
+                "question": "Why was I charged twice?",
+                "question_source": "customer_wording",
+                "summary": "Customers ask why duplicate-looking invoices appear.",
+                "steps": (
+                    "Check whether the second charge is a pending authorization.",
+                    "Confirm the invoice date and subscription workspace.",
+                ),
+                "evidence_quotes": (
+                    '`ticket-1` - Billing: "Why was I charged twice?"',
+                    '`ticket-2` - Invoice: "I see two charges this month."',
+                ),
+                "source_ids": ("ticket-1", "ticket-2"),
+                "answer_evidence_status": "resolution_evidence",
+                "frequency": 2,
+                "weighted_frequency": 2,
+                "failure_risk_score": 1,
+                "opportunity_score": 4,
+                "ticket_count": 2,
+                "evidence_count": 2,
+                "resolution_source_count": 1,
+            },
+            {
+                "topic": "export setup",
+                "question": "How do I export the report?",
+                "summary": "Customers ask where report exports live.",
+                "steps": ("Open Reports.",),
+                "source_ids": ("ticket-3",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ],
+    }
+
+    rows = faq_output_to_source_rows(faq_output)
+    loaded = source_rows_to_campaign_opportunities(
+        rows,
+        target_mode="landing_page",
+    )
+
+    assert [row["source_type"] for row in rows] == [
+        FAQ_OUTPUT_SOURCE_TYPE,
+        FAQ_OUTPUT_SOURCE_TYPE,
+    ]
+    assert rows[0]["source_id"] == "faq-draft-1"
+    assert rows[1]["source_id"].startswith("faq-output-2-how-do-i-export")
+    assert rows[0]["source_title"] == "Why was I charged twice?"
+    assert rows[0]["faq_source_ticket_ids"] == ["ticket-1", "ticket-2"]
+    assert rows[0]["faq_customer_language"] == [
+        "Why was I charged twice?",
+        '`ticket-1` - Billing: "Why was I charged twice?"',
+        '`ticket-2` - Invoice: "I see two charges this month."',
+    ]
+    assert "FAQ question: Why was I charged twice?" in rows[0]["text"]
+    assert "Customer wording:" in rows[0]["text"]
+    warning_codes = [warning.code for warning in loaded.warnings]
+    assert "missing_source_text" not in warning_codes
+    first = loaded.opportunities[0]
+    assert first["target_mode"] == "landing_page"
+    assert first["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
+    assert first["source_title"] == "Why was I charged twice?"
+    assert first["faq_answer_evidence_status"] == "resolution_evidence"
+    assert first["pain_points"] == ["billing confusion"]
+    assert first["opportunity_score"] == 4
+    assert first["evidence"] == [{
+        "text": rows[0]["text"],
+        "source_id": "faq-draft-1",
+        "source_type": FAQ_OUTPUT_SOURCE_TYPE,
+        "source_title": "Why was I charged twice?",
+    }]
+
+
+def test_source_material_to_source_rows_accepts_ticket_faq_result_dict() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "Invoice question",
+                "source_id": "ticket-1",
+                "evidence": [{
+                    "text": "Why was I charged twice this month?",
+                    "source_id": "ticket-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Open Billing, review the invoice history, and compare "
+                        "pending authorizations with settled charges."
+                    ),
+                }],
+            }
+        ]
+    )
+
+    rows = source_material_to_source_rows(result.as_dict())
+    loaded = source_rows_to_campaign_opportunities(rows, target_mode="blog_post")
+
+    assert len(rows) == 1
+    assert rows[0]["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
+    assert rows[0]["faq_answer_evidence_status"] == "resolution_evidence"
+    assert "Why was I charged twice this month?" in rows[0]["text"]
+    warning_codes = [warning.code for warning in loaded.warnings]
+    assert "missing_source_text" not in warning_codes
+    assert loaded.opportunities[0]["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
+    assert loaded.opportunities[0]["target_mode"] == "blog_post"
+
+
+def test_faq_output_adapter_ignores_non_faq_and_empty_items() -> None:
+    assert is_faq_output_bundle({"generated": 0, "items": []})
+    assert faq_output_to_source_rows({"generated": 0, "items": []}) == []
+    assert faq_output_to_source_rows({"generated": 1, "items": [{}]}) == []
+    assert not is_faq_output_bundle({"items": [{"question": "Not a FAQ result"}]})
+    assert faq_output_to_source_rows({"items": [{"question": "Not a FAQ result"}]}) == []


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-As-Ingestion-Source.md
Slice phase: Vertical slice

Generated FAQ reports can now be reused as source material through the existing campaign source adapter path. The adapter treats FAQ output as a derived `faq_output` source type, preserving customer wording and FAQ metadata without changing FAQ generation or adding one-off blog/landing-page patches.

## Intentional
- Treat FAQ output as derived source material (`faq_output`), not as another pass over raw support tickets.
- Keep FAQ generation, saved draft shape, blog prompts, and landing-page prompts unchanged; this is only the source-material bridge.
- Keep the adapter tolerant of optional/missing FAQ fields so future FAQ article shapes can be adapted centrally.

## Deferred
- Future PR: add UI/API selection so a user can intentionally feed a saved FAQ report into blog or landing-page generation.
- Future PR: adapt this adapter if the FAQ lane introduces standalone FAQ article records with canonical IDs and URLs.

## Parked hardening
- None.

## Review update
- Addressed bot P2: report-level `saved_ids[0]` now persists as `faq_draft_id` on every FAQ source row, and multi-item reports use unique `source_id` values with item suffixes.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_campaign_source_adapters.py -q` — 72 passed; rerun after saved draft traceability fix
- `python -m py_compile extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/campaign_source_adapters.py tests/test_extracted_ticket_faq_output_ingestion.py` — passed
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` — passed; 125 matching tests are enrolled
- `bash scripts/validate_extracted_content_pipeline.sh` — passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed
- `bash scripts/check_ascii_python.sh` — passed
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed; no additional file changes
- `bash scripts/run_extracted_pipeline_checks.sh` — passed; 2648 passed, 9 skipped
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-as-ingestion-source.md` — passed

## Diff size
5 files, +495 / -12