### PR TITLE
Document FAQ search contract handoff

### DIFF
--- a/docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md
+++ b/docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md
@@ -1,0 +1,139 @@
+# Content Ops FAQ Search Route Contract Handoff
+
+This document is the consumer-facing contract for the FAQ deflection search
+route used by the searchable demo and frontend mappers. The machine checker for
+this shape is `scripts/check_content_ops_faq_search_route_contract.py`.
+
+## Route
+
+Search:
+
+```http
+GET /api/v1/content-ops/faq-deflection-search?q=<query>&limit=5
+Authorization: Bearer <token>
+```
+
+Detail:
+
+```http
+GET /api/v1/content-ops/faq-deflection-search/{faq_id}
+Authorization: Bearer <token>
+```
+
+Optional search filters:
+
+- `corpus_id`: restricts matches to one seeded corpus.
+- `status`: defaults to approved results unless explicitly set blank.
+- `limit`: positive integer, capped by the route config.
+
+## Search Envelope
+
+Successful search responses use this envelope:
+
+```json
+{"query": "<query>", "results": [], "count": 0}
+```
+
+No-match is not an error. A no-match response is exactly:
+
+```json
+{"query": "<query>", "results": [], "count": 0}
+```
+
+When matches exist, `results[0]` is the lean card/list shape:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `faq_id` | string | ID to hydrate through the detail route. |
+| `question` | string | Customer-facing FAQ question. |
+| `answer_summary` | string | Short display summary only. Use detail for steps/body. |
+| `topic` | string | Deterministic FAQ topic label. |
+| `source_ids` | string list | Source row IDs behind the item. |
+| `ticket_count` | integer | Ticket/source volume represented by the FAQ item. |
+| `score` | integer | Deterministic text relevance score for this query. It is not a percentage and is not the FAQ opportunity score. |
+
+`count is the number of returned rows` in this response, not a total-result
+count across all pages.
+
+## Score Semantics
+
+`score` is query relevance from the search projection. It should drive match
+ordering or a generic relevance indicator only.
+
+Do not render `score` as:
+
+- a `0-100%` match bar,
+- customer impact,
+- cost savings,
+- opportunity score,
+- confidence that an answer is correct.
+
+Use `detail.items[].opportunity_score` when the UI needs the FAQ opportunity
+ranking that combines frequency and failure-risk signals.
+
+## Detail Payload
+
+Hydrate the full generated FAQ with `results[0].faq_id`. The detail route
+returns the persisted FAQ draft:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `account_id` | string | Authenticated account scope. |
+| `id` | string | FAQ draft ID; matches `results[0].faq_id`. |
+| `target_id` | string | Persisted target/corpus identifier. |
+| `target_mode` | string | Target type such as `support_account`. |
+| `title` | string | FAQ report title. |
+| `markdown` | string | Full generated FAQ Markdown. |
+| `items` | list | Full generated FAQ items. |
+| `source_count` | integer | Source rows considered. |
+| `ticket_source_count` | integer | Ticket-like sources represented. |
+| `output_checks` | object | Generator output-check status. |
+| `warnings` | list | Generator warnings. |
+| `metadata` | object | Persisted metadata such as corpus ID. |
+| `status` | string | Draft status, usually `approved` for search. |
+
+Each detail `items[]` entry carries the full generated FAQ shape:
+
+- strings: `topic`, `question`, `question_source`, `summary`, `answer`,
+  `answer_evidence_status`, `when_to_contact_support`
+- integers: `frequency`, `weighted_frequency`, `ticket_count`,
+  `opportunity_score`, `failure_risk_score`, `resolution_source_count`,
+  `evidence_count`, `displayed_evidence_count`
+- string lists: `failure_risk_signals`, `steps`, `action_items`,
+  `evidence_quotes`, `source_ids`, `source_labels`
+- count maps: `source_type_counts`, `weighted_source_volume_by_type`
+- term mappings: `term_mappings`, rendered as `term_mappings[]`
+
+Use detail `items[].steps` or `items[].action_items` for stepwise answer body
+rendering. Search `answer_summary` is intentionally not the full answer.
+
+## Term Mapping Shape
+
+Each `term_mappings[]` entry uses:
+
+- strings: `customer_term`, `documentation_term`, `suggestion`,
+  `first_source_id`
+- integers: `source_id_count`, `zero_result_source_count`,
+  `failure_risk_score`, `opportunity_score`
+- string list: `failure_risk_signals`
+
+## Go-Live Gate
+
+Before pointing a public demo at a host, run the checker with result and detail
+requirements enabled:
+
+```bash
+python scripts/check_content_ops_faq_search_route_contract.py \
+  --base-url "$ATLAS_API_BASE_URL" \
+  --token "${ATLAS_B2B_JWT:-$ATLAS_TOKEN}" \
+  --query "$ATLAS_FAQ_SEARCH_QUERY" \
+  --require-results \
+  --require-detail \
+  --max-search-ms 1500 \
+  --max-detail-ms 2500 \
+  --max-total-ms 3500 \
+  --output-result /tmp/faq-search-route-contract-result.json
+```
+
+The SaaS demo one-command smoke should remain the stronger proof because it
+seeds known data, checks search and detail, and cleans up afterward.

--- a/plans/PR-Content-Ops-FAQ-Search-Contract-Handoff.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Contract-Handoff.md
@@ -1,0 +1,85 @@
+# PR-Content-Ops-FAQ-Search-Contract-Handoff
+
+## Why this slice exists
+
+The FAQ search route exists and the seeded route checkers validate the response
+shape, but the landing-page/demo session still needs a stable handoff document
+that explains what to map from search results versus the hydrated FAQ detail
+route. Without that, callers can mislabel `score` as an opportunity percentage,
+try to render full answer steps from the lean search result, or treat no-match
+responses as errors.
+
+The live hosted SaaS FAQ route proof remains blocked on deployed API URL,
+bearer token, account id, and database target inputs. This slice is the
+smallest contract slice that can land while those secrets are unavailable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Functional validation
+
+1. Add a demo/consumer-facing FAQ search route contract handoff document.
+2. Explicitly document the search envelope, no-match envelope, `score`
+   semantics, lean result fields, and full generated FAQ detail payload.
+3. Add a focused regression test that keeps the handoff doc aligned with the
+   route checker constants.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md` | Stable route contract handoff for demo/frontend consumers. |
+| `tests/test_check_content_ops_faq_search_route_contract.py` | Pins the handoff doc to the checker-owned required fields and semantics. |
+| `plans/PR-Content-Ops-FAQ-Search-Contract-Handoff.md` | Slice contract. |
+
+## Mechanism
+
+The existing `check_content_ops_faq_search_route_contract.py` script already
+owns the machine-enforced field lists for search results and hydrated detail
+items. The new test reads the handoff doc and asserts it names those fields and
+the semantic caveats that are easy for the demo mapper to get wrong:
+
+```python
+for field in RESULT_FIELDS:
+    assert f"`{field}`" in doc
+assert "not a percentage" in doc
+assert '{"query": "<query>", "results": [], "count": 0}' in doc
+```
+
+That makes the document a maintained consumer contract instead of an unpinned
+note.
+
+## Intentional
+
+- No API response shape changes. This is a contract handoff for the shape that
+  already exists.
+- No hosted-route run is attempted because the required secret/runtime inputs
+  are not present in this checkout.
+- No generated FAQ detail fields are removed from the checker. The full detail
+  route remains the source for steps, term mappings, evidence, and Markdown.
+
+## Deferred
+
+- Live hosted SaaS FAQ route proof remains deferred until deployed API base URL,
+  bearer token, matching account id, and database target inputs are available.
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this doc/test handoff.
+
+## Verification
+
+- `python -m py_compile tests/test_check_content_ops_faq_search_route_contract.py`
+  - passed.
+- `python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q`
+  - 82 passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-search-contract-handoff-pr-body.md`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 85 |
+| Handoff doc | 139 |
+| Test | 36 |
+| **Total** | **260** |

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -15,6 +15,13 @@ _SCRIPT_PATH = (
     / "scripts"
     / "check_content_ops_faq_search_route_contract.py"
 )
+_HANDOFF_DOC_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "extraction"
+    / "validation"
+    / "content_ops_faq_search_route_contract_handoff.md"
+)
 _SPEC = importlib.util.spec_from_file_location(
     "check_content_ops_faq_search_route_contract",
     _SCRIPT_PATH,
@@ -202,6 +209,35 @@ def test_build_detail_url_allows_template_override():
     )
 
     assert url == "https://atlas.example.com/api/v2/faqs/id%20with%20space/full"
+
+
+def test_contract_handoff_doc_matches_checker_fields_and_semantics():
+    text = _HANDOFF_DOC_PATH.read_text(encoding="utf-8")
+
+    assert '{"query": "<query>", "results": [], "count": 0}' in text
+    assert "No-match is not an error." in text
+    assert "not a percentage" in text
+    assert "not the FAQ opportunity score" in text
+    assert "count is the number of returned rows" in text
+
+    for field in ("faq_id", *list(_MODULE.RESULT_FIELDS)):
+        assert f"`{field}`" in text
+    for field in _MODULE.DETAIL_FIELDS:
+        assert f"`{field}`" in text
+    for field in (
+        *_MODULE.DETAIL_ITEM_STRING_FIELDS,
+        *_MODULE.DETAIL_ITEM_INT_FIELDS,
+        *_MODULE.DETAIL_ITEM_STRING_LIST_FIELDS,
+        *_MODULE.DETAIL_ITEM_COUNT_MAP_FIELDS,
+        "term_mappings",
+    ):
+        assert f"`{field}`" in text
+    for field in (
+        *_MODULE.DETAIL_TERM_MAPPING_STRING_FIELDS,
+        *_MODULE.DETAIL_TERM_MAPPING_INT_FIELDS,
+        "failure_risk_signals",
+    ):
+        assert f"`{field}`" in text
 
 
 def test_validate_envelope_rejects_bool_count():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Contract-Handoff.md
Slice phase: Functional validation

The FAQ search route and checker already exist, but the demo/frontend session needs a stable consumer contract that explains what comes from search versus detail. This slice adds that handoff and pins it to the checker-owned required fields so `score`, no-match responses, lean search cards, and full generated FAQ detail do not drift.

## Intentional
- No API response shape changes. This documents and pins the existing contract.
- No hosted-route run is attempted because the required deployed API URL, bearer token, account id, and database target inputs are not present in this checkout.
- The search result stays lean; the detail route remains the source for steps, term mappings, evidence, and Markdown.

## Deferred
- Live hosted SaaS FAQ route proof remains deferred until deployed API base URL, bearer token, matching account id, and database target inputs are available.

## Parked hardening
- None. `HARDENING.md` has no active FAQ search entries touching this doc/test handoff.

## Verification
- `python -m py_compile tests/test_check_content_ops_faq_search_route_contract.py` - passed.
- `python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q` - 82 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-search-contract-handoff-pr-body.md` - passed.

## Diff size
3 files, +261 / -0
