### PR TITLE
Pin FAQ search handoff exact fields

### DIFF
--- a/plans/PR-Content-Ops-FAQ-Search-Contract-Exact-Fields.md
+++ b/plans/PR-Content-Ops-FAQ-Search-Contract-Exact-Fields.md
@@ -1,0 +1,84 @@
+# PR-Content-Ops-FAQ-Search-Contract-Exact-Fields
+
+## Why this slice exists
+
+PR-Content-Ops-FAQ-Search-Contract-Handoff pinned the FAQ search handoff doc so
+it cannot omit checker-owned fields, but review correctly noted that the pin was
+one-directional: the doc could still promise an extra lean search-card field the
+route does not return. That is the more dangerous frontend failure mode because
+a demo mapper may build UI against a non-existent field.
+
+This slice closes that consumer-contract gap while the live hosted SaaS FAQ
+route proof remains blocked on deployed API URL, bearer token, account id, and
+database target inputs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-search
+
+Slice phase: Functional validation
+
+1. Parse the handoff doc's `results[0]` search-card field table in the focused
+   route contract test.
+2. Assert that the documented lean search-card fields exactly match
+   `RESULT_FIELDS ∪ {faq_id}`.
+3. Leave the broader detail-section coverage as completeness-only because that
+   section includes prose lists and generated FAQ field groups.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `tests/test_check_content_ops_faq_search_route_contract.py` | Adds the exact lean search-card field assertion. |
+| `plans/PR-Content-Ops-FAQ-Search-Contract-Exact-Fields.md` | Slice contract. |
+
+## Mechanism
+
+The test extracts only the Markdown table immediately following:
+
+```md
+When matches exist, `results[0]` is the lean card/list shape:
+```
+
+It then reads the backticked first-column values and compares them to:
+
+```python
+{"faq_id", *RESULT_FIELDS}
+```
+
+This catches both omission and over-promising in the frontend-facing search
+card section.
+
+## Intentional
+
+- No route, checker, or handoff prose changes are needed; the current handoff
+  doc already lists the correct fields.
+- The exact-set assertion is scoped to the lean search-card table because that
+  table maps directly to `results[0]`. Detail prose stays completeness-pinned to
+  avoid brittle parsing of grouped generated FAQ lists.
+- No hosted-route run is attempted because the required runtime inputs remain
+  unavailable in this checkout.
+
+## Deferred
+
+- Live hosted SaaS FAQ route proof remains deferred until deployed API base URL,
+  bearer token, matching account id, and database target inputs are available.
+- Parked hardening: none. `HARDENING.md` was scanned and has no active FAQ
+  search entries touching this test-only handoff guard.
+
+## Verification
+
+- `python -m py_compile tests/test_check_content_ops_faq_search_route_contract.py`
+  - passed.
+- `python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q`
+  - 82 passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-search-contract-exact-fields-pr-body.md`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 84 |
+| Test | 19 |
+| **Total** | **103** |

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -1,6 +1,7 @@
 import importlib.util
 from io import BytesIO
 import json
+import re
 import sys
 import urllib.error
 from pathlib import Path
@@ -137,6 +138,20 @@ def _expected_checker_term_mapping_keys():
     )
 
 
+def _documented_search_card_fields(text: str) -> set[str]:
+    marker = "When matches exist, `results[0]` is the lean card/list shape:"
+    section = text.split(marker, maxsplit=1)[1].split(
+        "`count is the number of returned rows`",
+        maxsplit=1,
+    )[0]
+    fields: set[str] = set()
+    for line in section.splitlines():
+        match = re.match(r"^\| `([^`]+)` \|", line)
+        if match:
+            fields.add(match.group(1))
+    return fields
+
+
 def _producer_detail_item():
     result = build_ticket_faq_markdown(
         [
@@ -220,6 +235,10 @@ def test_contract_handoff_doc_matches_checker_fields_and_semantics():
     assert "not the FAQ opportunity score" in text
     assert "count is the number of returned rows" in text
 
+    assert _documented_search_card_fields(text) == {
+        "faq_id",
+        *list(_MODULE.RESULT_FIELDS),
+    }
     for field in ("faq_id", *list(_MODULE.RESULT_FIELDS)):
         assert f"`{field}`" in text
     for field in _MODULE.DETAIL_FIELDS:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-FAQ-Search-Contract-Exact-Fields.md
Slice phase: Functional validation

The FAQ search handoff doc now has a bidirectional guard for the lean `results[0]` search-card fields. The test still confirms every checker-owned field is documented, and now it also fails if the search-card table promises a field outside `RESULT_FIELDS ∪ {faq_id}`.

## Intentional
- No route, checker, or handoff prose changes. The current doc already lists the correct lean search fields.
- Exact-set parsing is scoped to the search-card table because it maps directly to `results[0]`; generated FAQ detail prose remains completeness-pinned.
- No hosted-route run is attempted because deployed URL/token/account/database inputs remain unavailable in this checkout.

## Deferred
- Live hosted SaaS FAQ route proof remains deferred until deployed API base URL, bearer token, matching account id, and database target inputs are available.

## Parked hardening
- None. `HARDENING.md` has no active FAQ search entries touching this test-only handoff guard.

## Verification
- `python -m py_compile tests/test_check_content_ops_faq_search_route_contract.py` - passed.
- `python -m pytest tests/test_check_content_ops_faq_search_route_contract.py -q` - 82 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-faq-search-contract-exact-fields-pr-body.md` - passed.

## Diff size
2 files, +103 / -0
