### PR TITLE
Bridge FAQ output resolution evidence

### DIFF
--- a/extracted_content_pipeline/faq_output_ingestion.py
+++ b/extracted_content_pipeline/faq_output_ingestion.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 FAQ_OUTPUT_SOURCE_TYPE = "faq_output"
+_RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
 
 _FAQ_OUTPUT_MARKER_KEYS = (
     "generated",
@@ -85,6 +86,7 @@ def faq_item_to_source_row(
     steps = _text_values(item.get("steps") or item.get("action_items"))
     evidence_quotes = _text_values(item.get("evidence_quotes"))
     source_ids = _text_values(item.get("source_ids"))
+    answer_evidence_status = _clean_text(item.get("answer_evidence_status"))
     title = question or topic or f"FAQ item {rank}"
     source_id = _source_id(
         item,
@@ -107,9 +109,8 @@ def faq_item_to_source_row(
         "faq_customer_language": _customer_language(question, evidence_quotes),
         "faq_draft_id": saved_id,
         "faq_source_ticket_ids": source_ids,
-        "faq_answer_evidence_status": _clean_text(
-            item.get("answer_evidence_status")
-        ),
+        "faq_answer_evidence_status": answer_evidence_status,
+        "resolution_text": _resolution_text(answer_evidence_status, steps),
         "question_source": _clean_text(item.get("question_source")),
         "pain_points": [topic] if topic else [],
     }
@@ -187,6 +188,12 @@ def _customer_language(question: str, evidence_quotes: Sequence[str]) -> list[st
         if text and text not in out:
             out.append(text)
     return out
+
+
+def _resolution_text(answer_evidence_status: str, steps: Sequence[str]) -> str:
+    if answer_evidence_status != _RESOLUTION_EVIDENCE_STATUS:
+        return ""
+    return " ".join(steps)
 
 
 def _first_text(row: Mapping[str, Any], keys: Sequence[str]) -> str:

--- a/plans/PR-FAQ-Output-Resolution-Evidence-Contract.md
+++ b/plans/PR-FAQ-Output-Resolution-Evidence-Contract.md
@@ -1,0 +1,100 @@
+# FAQ Output Resolution Evidence Contract
+
+## Why this slice exists
+
+#1109 made generated FAQ output reusable as source material, but the reviewer
+flagged the next real integration gap: the FAQ adapter preserves
+`faq_answer_evidence_status`, yet the support-ticket truthfulness gate reads the
+existing `resolution_text` contract. Without that bridge, grounded FAQ answers
+can be collected but not counted by the same gate that protects blog and landing
+generation from invented procedural steps.
+
+This slice keeps the fix at the ingestion boundary so blog, landing, and support
+ticket packaging all consume the same evidence shape.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Vertical slice
+
+1. Map FAQ items with `answer_evidence_status="resolution_evidence"` to the
+   existing `resolution_text` source-row field using their generated,
+   resolution-backed steps.
+2. Keep draft FAQ items (`draft_needs_review`) out of the resolution-evidence
+   contract even when they contain placeholder review steps.
+3. Add focused tests proving the adapter exposes resolution evidence and that
+   the support-ticket input package counts it through the existing
+   `support_ticket_resolution_evidence_*` fields.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_output_ingestion.py`
+- `tests/test_extracted_ticket_faq_output_ingestion.py`
+- `tests/test_extracted_support_ticket_input_package.py`
+- `plans/PR-FAQ-Output-Resolution-Evidence-Contract.md`
+
+## Mechanism
+
+The FAQ output adapter already emits `faq_answer_evidence_status`. This slice
+adds a narrow mapping:
+
+```python
+if answer_evidence_status == "resolution_evidence" and steps:
+    row["resolution_text"] = " ".join(steps)
+```
+
+That uses the existing support-ticket package path instead of adding a parallel
+FAQ-only gate. `build_support_ticket_input_package(...)` already treats
+`resolution_text` as the canonical signal for:
+
+- `support_ticket_resolution_evidence_present`
+- `support_ticket_resolution_evidence_count`
+- `support_ticket_resolution_examples`
+
+So FAQ output can unlock grounded procedural answers only when the FAQ lane has
+already marked the item as resolution-backed.
+
+## Intentional
+
+- This does not teach the generator a new FAQ-specific truthfulness concept. It
+  bridges FAQ output into the existing `resolution_text` evidence contract.
+- Draft/review-needed FAQ items keep their customer wording, topic, and
+  placeholder steps, but they do not set `resolution_text`.
+- This remains source-material plumbing. It does not fetch saved FAQ drafts from
+  a tenant store or add UI/API controls for selecting a FAQ report.
+
+## Deferred
+
+- Future PR: add UI/API selection so a user can intentionally feed a saved FAQ
+  report into blog or landing-page generation.
+- Parked hardening: none.
+
+## Verification
+
+Ran locally:
+
+- Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_support_ticket_input_package.py -q
+  - 28 passed
+- Command: python -m py_compile extracted_content_pipeline/faq_output_ingestion.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_support_ticket_input_package.py
+  - passed
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - passed
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - passed
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - passed
+- Command: bash scripts/check_ascii_python.sh
+  - passed
+- Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - passed; no additional file changes
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-resolution-evidence-contract.md
+  - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Adapter mapping | ~20 |
+| Focused tests | ~65 |
+| Plan doc | ~85 |
+| **Total** | **~170** |

--- a/tests/test_extracted_support_ticket_input_package.py
+++ b/tests/test_extracted_support_ticket_input_package.py
@@ -165,6 +165,57 @@ def test_support_ticket_input_package_surfaces_explicit_resolution_evidence() ->
     assert package.metadata["support_ticket_resolution_evidence_count"] == 1
 
 
+def test_support_ticket_input_package_counts_faq_output_resolution_evidence() -> None:
+    package = build_support_ticket_input_package({
+        "generated": 2,
+        "markdown": "# FAQ Report",
+        "saved_ids": ["faq-draft-1"],
+        "items": [
+            {
+                "topic": "billing confusion",
+                "question": "Why was I charged twice?",
+                "summary": "Customers ask why duplicate-looking invoices appear.",
+                "steps": [
+                    "Check whether the second charge is a pending authorization.",
+                    "Confirm the invoice date and subscription workspace.",
+                ],
+                "answer_evidence_status": "resolution_evidence",
+                "source_ids": ["ticket-1", "ticket-2"],
+            },
+            {
+                "topic": "export setup",
+                "question": "How do I export the report?",
+                "summary": "Customers ask where report exports live.",
+                "steps": ["Draft answer - support team should add the verified resolution."],
+                "answer_evidence_status": "draft_needs_review",
+                "source_ids": ["ticket-3"],
+            },
+        ],
+    })
+
+    assert package.inputs["source_material"][0]["source_type"] == "faq_output"
+    assert package.inputs["source_material"][0]["source_id"] == "faq-draft-1:item-1"
+    assert package.inputs["source_material"][0]["resolution_text"] == (
+        "Check whether the second charge is a pending authorization. "
+        "Confirm the invoice date and subscription workspace."
+    )
+    assert "resolution_text" not in package.inputs["source_material"][1]
+    assert package.inputs["support_ticket_resolution_evidence_present"] is True
+    assert package.inputs["support_ticket_resolution_evidence_count"] == 1
+    assert package.inputs["support_ticket_resolution_examples"] == [
+        {
+            "source_id": "faq-draft-1:item-1",
+            "source_title": "Why was I charged twice?",
+            "text": (
+                "Check whether the second charge is a pending authorization. "
+                "Confirm the invoice date and subscription workspace."
+            ),
+        }
+    ]
+    assert package.metadata["support_ticket_resolution_evidence_present"] is True
+    assert package.metadata["support_ticket_resolution_evidence_count"] == 1
+
+
 def test_support_ticket_input_package_surfaces_measured_outcome_evidence() -> None:
     package = build_support_ticket_input_package([
         {

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -67,6 +67,11 @@ def test_faq_output_rows_normalize_into_campaign_opportunities() -> None:
     assert rows[0]["faq_draft_id"] == "faq-draft-1"
     assert rows[1]["faq_draft_id"] == "faq-draft-1"
     assert rows[0]["source_title"] == "Why was I charged twice?"
+    assert rows[0]["resolution_text"] == (
+        "Check whether the second charge is a pending authorization. "
+        "Confirm the invoice date and subscription workspace."
+    )
+    assert "resolution_text" not in rows[1]
     assert rows[0]["faq_source_ticket_ids"] == ["ticket-1", "ticket-2"]
     assert rows[0]["faq_customer_language"] == [
         "Why was I charged twice?",
@@ -118,6 +123,9 @@ def test_source_material_to_source_rows_accepts_ticket_faq_result_dict() -> None
     assert len(rows) == 1
     assert rows[0]["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
     assert rows[0]["faq_answer_evidence_status"] == "resolution_evidence"
+    assert rows[0]["resolution_text"].startswith(
+        "Use the uploaded resolution evidence: Open Billing"
+    )
     assert "Why was I charged twice this month?" in rows[0]["text"]
     warning_codes = [warning.code for warning in loaded.warnings]
     assert "missing_source_text" not in warning_codes


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-Resolution-Evidence-Contract.md
Slice phase: Vertical slice

FAQ output now bridges its grounded-answer signal into the existing support-ticket resolution evidence contract. Items marked `resolution_evidence` emit `resolution_text` from their generated steps, while `draft_needs_review` items stay out of the resolution-evidence gate.

## Intentional
- Use the existing `resolution_text` contract instead of adding a FAQ-only truthfulness gate.
- Keep draft/review-needed FAQ items as customer-wording source material without treating placeholder steps as verified resolutions.
- Keep this as source-material plumbing; no UI/API saved-FAQ selection in this slice.

## Deferred
- Future PR: add UI/API selection so a user can intentionally feed a saved FAQ report into blog or landing-page generation.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_support_ticket_input_package.py -q` — 28 passed
- `python -m py_compile extracted_content_pipeline/faq_output_ingestion.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_extracted_support_ticket_input_package.py` — passed
- `bash scripts/validate_extracted_content_pipeline.sh` — passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed
- `bash scripts/check_ascii_python.sh` — passed
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed; no additional file changes
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-resolution-evidence-contract.md` — passed

## Diff size
4 files, +172 / -0