### PR TITLE
Wire selected FAQ output as source material

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -10,6 +10,10 @@ from extracted_content_pipeline.content_ops_input_provider import (
     ContentOpsInputPackage,
     RequestPayload,
 )
+from extracted_content_pipeline.faq_output_ingestion import (
+    FAQ_OUTPUT_SOURCE_TYPE,
+    is_faq_output_bundle,
+)
 from extracted_content_pipeline.support_ticket_input_provider import (
     SupportTicketInputProvider,
 )
@@ -112,7 +116,11 @@ def _is_empty_source_material(value: Any) -> bool:
 
 def _is_support_ticket_material(value: Any) -> bool:
     if isinstance(value, Mapping):
-        return _is_support_ticket_bundle(value) or _is_support_ticket_row(value)
+        return (
+            is_faq_output_bundle(value)
+            or _is_support_ticket_bundle(value)
+            or _is_support_ticket_row(value)
+        )
     if isinstance(value, (list, tuple)):
         return any(_is_support_ticket_material(item) for item in value)
     return False
@@ -137,6 +145,11 @@ def _is_support_ticket_bundle(value: Mapping[str, Any]) -> bool:
 def _is_support_ticket_row(value: Mapping[str, Any]) -> bool:
     keys = {_key(item) for item in value}
     source_type = _key(value.get("source_type") or value.get("type"))
+    if source_type == FAQ_OUTPUT_SOURCE_TYPE:
+        return _has_any_text(value, _SOURCE_TITLE_KEYS) or _has_any_text(
+            value,
+            _SOURCE_TEXT_KEYS,
+        )
     if source_type and source_type not in _SUPPORT_TICKET_SOURCE_TYPES:
         return False
     has_title = _has_any_text(value, _SOURCE_TITLE_KEYS)

--- a/extracted_content_pipeline/campaign_source_adapters.py
+++ b/extracted_content_pipeline/campaign_source_adapters.py
@@ -436,7 +436,13 @@ def source_material_to_source_rows(source_material: Any) -> list[Any]:
         source_material,
         (str, bytes, bytearray),
     ):
-        return list(source_material)
+        rows: list[Any] = []
+        for item in source_material:
+            if isinstance(item, Mapping) and is_faq_output_bundle(item):
+                rows.extend(faq_output_to_source_rows(item))
+            else:
+                rows.append(item)
+        return rows
     return []
 
 

--- a/extracted_content_pipeline/faq_output_ingestion.py
+++ b/extracted_content_pipeline/faq_output_ingestion.py
@@ -17,6 +17,7 @@ _FAQ_OUTPUT_MARKER_KEYS = (
     "ticket_source_count",
     "saved_ids",
 )
+_FAQ_OUTPUT_DRAFT_ID_KEYS = ("faq_id", "faq_draft_id", "draft_id", "id")
 _FAQ_ITEM_ID_KEYS = (
     "faq_id",
     "faq_draft_id",
@@ -47,6 +48,9 @@ def faq_output_to_source_rows(faq_output: Mapping[str, Any]) -> list[dict[str, A
 
     items = tuple(faq_output.get("items") or ())
     saved_ids = _text_values(faq_output.get("saved_ids"))
+    if not saved_ids:
+        draft_id = _first_text(faq_output, _FAQ_OUTPUT_DRAFT_ID_KEYS)
+        saved_ids = [draft_id] if draft_id else []
     report_saved_id = saved_ids[0] if len(saved_ids) == 1 else ""
     rows: list[dict[str, Any]] = []
     for index, item in enumerate(items, start=1):

--- a/extracted_content_pipeline/support_ticket_input_package.py
+++ b/extracted_content_pipeline/support_ticket_input_package.py
@@ -114,6 +114,17 @@ _MEASURED_OUTCOME_KEYS = (
     "impact_metric",
     "result_metric",
 )
+_PASSTHROUGH_KEYS = (
+    "faq_draft_id",
+    "faq_rank",
+    "faq_question",
+    "faq_topic",
+    "faq_summary",
+    "faq_steps",
+    "faq_customer_language",
+    "faq_source_ticket_ids",
+    "faq_answer_evidence_status",
+)
 _DATE_KEYS = (
     "created_at",
     "created_time",
@@ -314,6 +325,10 @@ def _normalize_ticket_row(row: Any, *, row_index: int) -> dict[str, Any]:
     measured_outcome = _evidence_text(_first_value(row, _MEASURED_OUTCOME_KEYS))
     if measured_outcome:
         normalized["measured_outcome"] = _clip_text(measured_outcome, max_chars=500)
+    for key in _PASSTHROUGH_KEYS:
+        value = row.get(key)
+        if value not in (None, "", [], {}):
+            normalized[key] = value
     for key, keys in (
         ("created_at", _DATE_KEYS),
         ("source_url", _URL_KEYS),

--- a/plans/PR-FAQ-Output-Selection-Wiring.md
+++ b/plans/PR-FAQ-Output-Selection-Wiring.md
@@ -21,14 +21,18 @@ Slice phase: Vertical slice
    `TicketFAQDraft.as_dict()`-shaped bundle without `saved_ids`.
 2. Teach the Atlas Content Ops input provider to accept FAQ output bundles and
    `faq_output` rows as support-ticket-derived source material.
-3. Preserve FAQ output provenance fields when the support-ticket input package
+3. Expand selected FAQ output bundles inside list-shaped `source_material` so
+   mixed selections such as `[ticket_row, saved_faq_output]` keep the selected
+   FAQ report.
+4. Preserve FAQ output provenance fields when the support-ticket input package
    normalizes selected FAQ source rows.
-4. Add focused tests proving a selected FAQ draft payload flows through the
+5. Add focused tests proving a selected FAQ draft payload flows through the
    provider with `faq_output` provenance, draft traceability, and resolution
    evidence intact.
 
 ### Files touched
 
+- `extracted_content_pipeline/campaign_source_adapters.py`
 - `extracted_content_pipeline/faq_output_ingestion.py`
 - `extracted_content_pipeline/support_ticket_input_package.py`
 - `atlas_brain/_content_ops_input_provider.py`
@@ -55,6 +59,10 @@ there the existing `SupportTicketInputProvider` and
 `build_support_ticket_input_package(...)` own normalization, output defaults,
 resolution evidence, and request merge behavior.
 
+The shared source-material adapter expands FAQ output bundles even when they
+appear inside list-shaped `source_material`, which keeps mixed selections from
+silently dropping selected FAQ reports.
+
 The support-ticket input package keeps FAQ provenance fields such as
 `faq_draft_id`, `faq_rank`, `faq_question`, and `faq_answer_evidence_status`
 while normalizing selected source rows so generation and later diagnostics can
@@ -79,9 +87,9 @@ trace the selected report.
 
 Ran locally:
 
-- Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_support_ticket_input_package.py -q
-  - 43 passed, 1 warning
-- Command: python -m py_compile extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/support_ticket_input_package.py atlas_brain/_content_ops_input_provider.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py
+- Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_support_ticket_input_package.py -q
+  - 114 passed, 1 warning
+- Command: python -m py_compile extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/support_ticket_input_package.py atlas_brain/_content_ops_input_provider.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py
   - passed
 - Command: bash scripts/validate_extracted_content_pipeline.sh
   - passed
@@ -101,8 +109,9 @@ Ran locally:
 | Area | Estimated LOC |
 |---|---:|
 | FAQ adapter draft-ID fallback | ~15 |
+| Source-material list expansion | ~15 |
 | Atlas provider detection | ~20 |
 | Support-ticket provenance passthrough | ~20 |
-| Focused tests | ~95 |
-| Plan doc | ~90 |
-| **Total** | **~240** |
+| Focused tests | ~125 |
+| Plan doc | ~95 |
+| **Total** | **~290** |

--- a/plans/PR-FAQ-Output-Selection-Wiring.md
+++ b/plans/PR-FAQ-Output-Selection-Wiring.md
@@ -1,0 +1,108 @@
+# FAQ Output Selection Wiring
+
+## Why this slice exists
+
+#1109 made FAQ output consumable as source rows and #1113 bridged grounded FAQ
+answers into the existing resolution-evidence contract. The next missing
+product seam is selection: when the UI/API already has a saved FAQ draft payload,
+the Atlas input provider should recognize that payload as valid Content Ops
+source material and route it through the same support-ticket package path.
+
+This keeps saved FAQ reuse at the ingestion boundary. The database fetch/UI
+picker can come later; the request contract can already carry the selected FAQ
+draft as `inputs.source_material`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Vertical slice
+
+1. Preserve a top-level saved FAQ draft ID when the input is a
+   `TicketFAQDraft.as_dict()`-shaped bundle without `saved_ids`.
+2. Teach the Atlas Content Ops input provider to accept FAQ output bundles and
+   `faq_output` rows as support-ticket-derived source material.
+3. Preserve FAQ output provenance fields when the support-ticket input package
+   normalizes selected FAQ source rows.
+4. Add focused tests proving a selected FAQ draft payload flows through the
+   provider with `faq_output` provenance, draft traceability, and resolution
+   evidence intact.
+
+### Files touched
+
+- `extracted_content_pipeline/faq_output_ingestion.py`
+- `extracted_content_pipeline/support_ticket_input_package.py`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_extracted_ticket_faq_output_ingestion.py`
+- `tests/test_atlas_content_ops_input_provider.py`
+- `plans/PR-FAQ-Output-Selection-Wiring.md`
+
+## Mechanism
+
+The FAQ adapter now treats a top-level `id`, `faq_id`, `faq_draft_id`, or
+`draft_id` as the report-level draft ID when `saved_ids` is absent. Multi-item
+reports still get unique source IDs via the existing `:item-{rank}` suffix while
+each row keeps `faq_draft_id`.
+
+The Atlas provider imports the FAQ-output detector and source type constant:
+
+```python
+if is_faq_output_bundle(source_material):
+    return SupportTicketInputProvider(...).build_content_ops_input_package(...)
+```
+
+It also accepts already-expanded rows where `source_type == "faq_output"`. From
+there the existing `SupportTicketInputProvider` and
+`build_support_ticket_input_package(...)` own normalization, output defaults,
+resolution evidence, and request merge behavior.
+
+The support-ticket input package keeps FAQ provenance fields such as
+`faq_draft_id`, `faq_rank`, `faq_question`, and `faq_answer_evidence_status`
+while normalizing selected source rows so generation and later diagnostics can
+trace the selected report.
+
+## Intentional
+
+- This does not fetch FAQ drafts from Postgres. The route still receives
+  selected source material from the caller; tenant-scoped fetching belongs in a
+  later API/UI slice.
+- This does not change generated content prompts or generation services.
+- `faq_output` remains a derived source type, not raw support-ticket evidence.
+
+## Deferred
+
+- Future PR: add tenant-scoped API/UI selection by saved FAQ draft ID.
+- Future PR: add an execute/preview smoke that selects a persisted FAQ draft
+  through the real API once the fetch layer exists.
+- Parked hardening: none.
+
+## Verification
+
+Ran locally:
+
+- Command: python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_support_ticket_input_package.py -q
+  - 43 passed, 1 warning
+- Command: python -m py_compile extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/support_ticket_input_package.py atlas_brain/_content_ops_input_provider.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py
+  - passed
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - passed
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - passed
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - passed
+- Command: bash scripts/check_ascii_python.sh
+  - passed
+- Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline
+  - passed; no additional file changes
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-selection-wiring.md
+  - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| FAQ adapter draft-ID fallback | ~15 |
+| Atlas provider detection | ~20 |
+| Support-ticket provenance passthrough | ~20 |
+| Focused tests | ~95 |
+| Plan doc | ~90 |
+| **Total** | **~240** |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -279,6 +279,50 @@ def test_atlas_content_ops_input_provider_expands_selected_faq_output() -> None:
     assert preview.can_run is True
 
 
+def test_atlas_content_ops_input_provider_expands_faq_output_inside_source_lists() -> None:
+    provider = build_content_ops_input_provider()
+
+    package = provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-1",
+                        "subject": "How do I update billing?",
+                        "description": "I cannot find the billing page.",
+                    },
+                    {
+                        "id": "faq-draft-42",
+                        "markdown": "# Saved FAQ report",
+                        "ticket_source_count": 2,
+                        "items": [
+                            {
+                                "topic": "billing confusion",
+                                "question": "Why was I charged twice?",
+                                "summary": (
+                                    "Customers ask why duplicate-looking invoices "
+                                    "appear."
+                                ),
+                                "steps": ("Check invoice history.",),
+                                "answer_evidence_status": "resolution_evidence",
+                            },
+                        ],
+                    },
+                ]
+            }
+        },
+    )
+
+    assert package.metadata["included_row_count"] == 2
+    assert package.inputs["source_material"][0]["source_type"] == "support_ticket"
+    assert package.inputs["source_material"][1]["source_type"] == "faq_output"
+    assert package.inputs["source_material"][1]["source_id"] == "faq-draft-42"
+    assert package.inputs["source_material"][1]["faq_draft_id"] == "faq-draft-42"
+    assert package.inputs["support_ticket_resolution_evidence_present"] is True
+    assert package.inputs["support_ticket_resolution_evidence_count"] == 1
+
+
 def test_atlas_content_ops_input_provider_expands_subject_body_ticket_rows() -> None:
     provider = build_content_ops_input_provider()
 

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -209,6 +209,76 @@ def test_atlas_content_ops_input_provider_expands_support_ticket_source_material
     assert preview.can_run is True
 
 
+def test_atlas_content_ops_input_provider_expands_selected_faq_output() -> None:
+    provider = build_content_ops_input_provider()
+
+    package = provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_material": {
+                    "id": "faq-draft-42",
+                    "title": "Saved FAQ report",
+                    "markdown": "# Saved FAQ report",
+                    "ticket_source_count": 3,
+                    "output_checks": {"has_action_items": True},
+                    "items": [
+                        {
+                            "topic": "billing confusion",
+                            "question": "Why was I charged twice?",
+                            "summary": (
+                                "Customers ask why duplicate-looking invoices "
+                                "appear."
+                            ),
+                            "steps": [
+                                "Check whether the second charge is pending.",
+                                "Confirm the invoice workspace.",
+                            ],
+                            "answer_evidence_status": "resolution_evidence",
+                            "source_ids": ["ticket-1", "ticket-2"],
+                        },
+                        {
+                            "topic": "export setup",
+                            "question": "How do I export the report?",
+                            "summary": "Customers ask where report exports live.",
+                            "steps": [
+                                "Draft answer - support team should add the "
+                                "verified resolution."
+                            ],
+                            "answer_evidence_status": "draft_needs_review",
+                            "source_ids": ["ticket-3"],
+                        },
+                    ],
+                }
+            }
+        },
+    )
+    payload = merge_content_ops_input_package({"inputs": {}}, package)
+    request = request_from_mapping(payload)
+    preview = preview_control_surface(request)
+
+    assert package.provider == "atlas_support_ticket_request"
+    assert request.outputs == ("faq_markdown", "landing_page", "blog_post")
+    assert request.inputs["source_material"][0]["source_type"] == "faq_output"
+    assert request.inputs["source_material"][0]["source_id"] == "faq-draft-42:item-1"
+    assert request.inputs["source_material"][0]["faq_draft_id"] == "faq-draft-42"
+    assert request.inputs["source_material"][0]["resolution_text"] == (
+        "Check whether the second charge is pending. Confirm the invoice workspace."
+    )
+    assert "resolution_text" not in request.inputs["source_material"][1]
+    assert request.inputs["support_ticket_resolution_evidence_present"] is True
+    assert request.inputs["support_ticket_resolution_evidence_count"] == 1
+    assert request.inputs["support_ticket_resolution_examples"][0] == {
+        "source_id": "faq-draft-42:item-1",
+        "source_title": "Why was I charged twice?",
+        "text": (
+            "Check whether the second charge is pending. Confirm the invoice "
+            "workspace."
+        ),
+    }
+    assert preview.can_run is True
+
+
 def test_atlas_content_ops_input_provider_expands_subject_body_ticket_rows() -> None:
     provider = build_content_ops_input_provider()
 

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -133,6 +133,43 @@ def test_source_material_to_source_rows_accepts_ticket_faq_result_dict() -> None
     assert loaded.opportunities[0]["target_mode"] == "blog_post"
 
 
+def test_faq_output_adapter_uses_top_level_draft_id_when_saved_ids_are_absent() -> None:
+    rows = source_material_to_source_rows({
+        "id": "faq-draft-42",
+        "title": "Saved FAQ report",
+        "markdown": "# Saved FAQ report",
+        "ticket_source_count": 3,
+        "output_checks": {"has_action_items": True},
+        "items": [
+            {
+                "topic": "billing confusion",
+                "question": "Why was I charged twice?",
+                "summary": "Customers ask why duplicate-looking invoices appear.",
+                "steps": ("Check invoice history.",),
+                "answer_evidence_status": "resolution_evidence",
+            },
+            {
+                "topic": "export setup",
+                "question": "How do I export the report?",
+                "summary": "Customers ask where report exports live.",
+                "steps": ("Draft answer - support team should add the verified resolution.",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ],
+    })
+
+    assert [row["source_id"] for row in rows] == [
+        "faq-draft-42:item-1",
+        "faq-draft-42:item-2",
+    ]
+    assert [row["faq_draft_id"] for row in rows] == [
+        "faq-draft-42",
+        "faq-draft-42",
+    ]
+    assert rows[0]["resolution_text"] == "Check invoice history."
+    assert "resolution_text" not in rows[1]
+
+
 def test_faq_output_adapter_ignores_non_faq_and_empty_items() -> None:
     assert is_faq_output_bundle({"generated": 0, "items": []})
     assert faq_output_to_source_rows({"generated": 0, "items": []}) == []

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -170,6 +170,36 @@ def test_faq_output_adapter_uses_top_level_draft_id_when_saved_ids_are_absent() 
     assert "resolution_text" not in rows[1]
 
 
+def test_source_material_to_source_rows_expands_faq_output_inside_lists() -> None:
+    rows = source_material_to_source_rows([
+        {
+            "ticket_id": "ticket-1",
+            "subject": "How do I update billing?",
+            "description": "I cannot find the billing page.",
+        },
+        {
+            "id": "faq-draft-42",
+            "markdown": "# Saved FAQ report",
+            "ticket_source_count": 2,
+            "items": [
+                {
+                    "topic": "billing confusion",
+                    "question": "Why was I charged twice?",
+                    "summary": "Customers ask why duplicate-looking invoices appear.",
+                    "steps": ("Check invoice history.",),
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            ],
+        },
+    ])
+
+    assert rows[0]["ticket_id"] == "ticket-1"
+    assert rows[1]["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
+    assert rows[1]["source_id"] == "faq-draft-42"
+    assert rows[1]["faq_draft_id"] == "faq-draft-42"
+    assert rows[1]["resolution_text"] == "Check invoice history."
+
+
 def test_faq_output_adapter_ignores_non_faq_and_empty_items() -> None:
     assert is_faq_output_bundle({"generated": 0, "items": []})
     assert faq_output_to_source_rows({"generated": 0, "items": []}) == []


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-Selection-Wiring.md
Slice phase: Vertical slice

Selected FAQ draft payloads can now be passed as `inputs.source_material` and routed through the Atlas Content Ops input provider. The provider recognizes FAQ output bundles/rows, the shared source-material adapter expands selected FAQ bundles even inside mixed source lists, the FAQ adapter preserves top-level draft IDs from saved draft payloads, and support-ticket package normalization keeps FAQ provenance plus resolution evidence intact.

## Intentional
- Accept selected FAQ draft payloads as request source material without adding database fetch or UI picker behavior yet.
- Preserve `faq_output` as a derived source type, not raw support-ticket evidence.
- Keep generation services and prompts unchanged; this is ingestion/provider wiring.

## Deferred
- Future PR: add tenant-scoped API/UI selection by saved FAQ draft ID.
- Future PR: add an execute/preview smoke that selects a persisted FAQ draft through the real API once the fetch layer exists.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_campaign_source_adapters.py tests/test_extracted_support_ticket_input_package.py -q` — 114 passed, 1 warning
- `python -m py_compile extracted_content_pipeline/campaign_source_adapters.py extracted_content_pipeline/faq_output_ingestion.py extracted_content_pipeline/support_ticket_input_package.py atlas_brain/_content_ops_input_provider.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_atlas_content_ops_input_provider.py` — passed
- `bash scripts/validate_extracted_content_pipeline.sh` — passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed
- `bash scripts/check_ascii_python.sh` — passed
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed; no additional file changes
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-selection-wiring.md` — passed

## Diff size
7 files, +338 / -2