### PR TITLE
Validate FAQ output ingestion bridge

### DIFF
--- a/plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md
+++ b/plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md
@@ -1,0 +1,96 @@
+# FAQ Output Proof Ingestion Bridge
+
+## Why this slice exists
+
+PR #1109 made generated FAQ output reusable as source material, and PR #1113
+bridged resolution-backed FAQ steps into the canonical `resolution_text`
+contract. The remaining gap is proof: the current FAQ output smoke demonstrates
+Markdown generation, but it does not exercise the real downstream bridge from
+generated FAQ output back into support-ticket source rows.
+
+This slice turns that smoke into a thin end-to-end validation of the bridge so a
+future drift in FAQ result shape, FAQ-output adapter behavior, or support-ticket
+resolution evidence packaging fails in one place.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Functional validation
+
+1. Add resolution-backed source rows to the existing FAQ output proof fixture.
+2. Extend the proof summary to adapt the generated FAQ result through
+   `faq_output_to_source_rows(...)`.
+3. Build a support-ticket input package from that adapted output and assert the
+   canonical `support_ticket_resolution_evidence_*` fields are present.
+4. Add focused tests for the success path and the new failure predicate.
+
+### Files touched
+
+- `plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md`
+- `scripts/smoke_content_ops_faq_output_proof.py`
+- `tests/test_smoke_content_ops_faq_output_proof.py`
+
+## Mechanism
+
+The smoke already invokes `scripts/build_extracted_ticket_faq_markdown.py` and
+reads the resulting compact diagnostic JSON. That CLI result intentionally omits
+full item bodies, so this slice also writes a small
+full FAQ result JSON artifact from the same source fixture using the library
+`TicketFAQMarkdownResult.as_dict()` shape that the FAQ-output adapter consumes.
+The proof then runs the generated full FAQ output through the downstream bridge:
+
+```python
+source_rows = faq_output_to_source_rows(result_payload)
+package = build_support_ticket_input_package(result_payload, outputs=("blog_post",))
+```
+
+The proof records adapted FAQ source-row count, whether any adapted row carries
+`resolution_text`, and whether the support-ticket package reports
+`support_ticket_resolution_evidence_present` with a nonzero count. The failure
+predicate fails closed if the generated output cannot be consumed through the
+adapter or if resolution-backed answers stop reaching the package contract.
+
+## Intentional
+
+- This is validation, not a new product path. It does not add UI/API controls
+  for selecting saved FAQ reports as input to other generators.
+- The fixture stays small because the goal is contract composition, not scale.
+  Existing FAQ scale and route stress docs cover large-row behavior separately.
+- The proof uses the existing support-ticket package contract instead of adding
+  a FAQ-specific resolution evidence check.
+
+## Deferred
+
+- UI/API selection for feeding saved FAQ reports into blog or landing generation
+  remains deferred until that workflow is picked as a vertical slice.
+- Hosted SaaS FAQ route proof remains blocked on deployed API URL, bearer token,
+  and account id.
+- Parked hardening: none.
+
+## Verification
+
+Ran locally:
+
+- `python -m pytest tests/test_smoke_content_ops_faq_output_proof.py -q` - 4
+  passed.
+- `python scripts/smoke_content_ops_faq_output_proof.py --artifact-dir
+  "$tmpdir"` - passed; summary reported 3 generated FAQ items, 3 adapted
+  `faq_output` source rows, and 1 support-ticket resolution evidence example.
+- `python -m py_compile scripts/smoke_content_ops_faq_output_proof.py
+  tests/test_smoke_content_ops_faq_output_proof.py` - passed.
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md`
+  - passed.
+- `python scripts/audit_plan_code_consistency.py
+  plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /home/juan-canfield/Desktop/atlas-pr-bodies/faq-output-proof-ingestion-bridge.md`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Smoke proof bridge | 116 |
+| Focused tests | 33 |
+| Plan doc | 96 |
+| **Total** | **244** |

--- a/scripts/smoke_content_ops_faq_output_proof.py
+++ b/scripts/smoke_content_ops_faq_output_proof.py
@@ -13,8 +13,23 @@ import sys
 import time
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.faq_output_ingestion import (
+    FAQ_OUTPUT_SOURCE_TYPE,
+    faq_output_to_source_rows,
+)
+from extracted_content_pipeline.campaign_source_adapters import (
+    load_source_campaign_opportunities_from_file,
+)
+from extracted_content_pipeline.support_ticket_input_package import (
+    build_support_ticket_input_package,
+)
+from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
+
+
 FAQ_CLI = ROOT / "scripts" / "build_extracted_ticket_faq_markdown.py"
 DEFAULT_SUPPORT_CONTACT = "support@example.com"
 DEFAULT_DOCUMENTATION_TERMS = (
@@ -32,6 +47,7 @@ DEFAULT_ROWS: tuple[dict[str, str], ...] = (
         "source_id": "ticket-export-1",
         "source_title": "Export attribution report",
         "text": "How do I export the attribution dashboard before renewal?",
+        "resolution_text": "Open Analytics, choose Attribution, then select Download report.",
         "pain_category": "reporting friction",
     },
     {
@@ -39,6 +55,7 @@ DEFAULT_ROWS: tuple[dict[str, str], ...] = (
         "source_id": "ticket-export-2",
         "source_title": "Reporting dashboard missing export",
         "text": "The reporting dashboard export is missing for my analyst role.",
+        "resolution_text": "Enable Report Downloads for the analyst role before exporting.",
         "pain_category": "reporting friction",
     },
     {
@@ -94,6 +111,7 @@ def run_output_proof(args: argparse.Namespace) -> dict[str, Any]:
 
     markdown_path = artifact_dir / "faq_output.md"
     result_path = artifact_dir / "faq_result.json"
+    full_result_path = artifact_dir / "faq_full_result.json"
     stdout_path = artifact_dir / "stdout.txt"
     stderr_path = artifact_dir / "stderr.txt"
     summary_path = artifact_dir / "proof_summary.json"
@@ -110,9 +128,18 @@ def run_output_proof(args: argparse.Namespace) -> dict[str, Any]:
     stderr_path.write_text(completed.stderr, encoding="utf-8")
 
     result_payload = _read_json(result_path)
+    full_result_payload = _full_faq_result_payload(
+        source_path=source_path,
+        support_contact=args.support_contact,
+    )
+    full_result_path.write_text(
+        json.dumps(full_result_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     markdown = markdown_path.read_text(encoding="utf-8") if markdown_path.exists() else ""
     proof = _proof_payload(
         result_payload=result_payload,
+        full_result_payload=full_result_payload,
         markdown=markdown,
         support_contact=args.support_contact,
     )
@@ -133,6 +160,7 @@ def run_output_proof(args: argparse.Namespace) -> dict[str, Any]:
             "source": str(source_path),
             "markdown": str(markdown_path) if markdown_path.exists() else None,
             "result": str(result_path) if result_path.exists() else None,
+            "full_result": str(full_result_path),
             "stdout": str(stdout_path),
             "stderr": str(stderr_path),
             "summary": str(summary_path),
@@ -179,9 +207,29 @@ def _faq_command(
     return command
 
 
+def _full_faq_result_payload(*, source_path: Path, support_contact: str) -> dict[str, Any]:
+    loaded = load_source_campaign_opportunities_from_file(
+        source_path,
+        file_format="csv",
+    )
+    result = build_ticket_faq_markdown(
+        loaded.opportunities,
+        title="Support Ticket FAQ Output Proof",
+        max_items=6,
+        support_contact=support_contact,
+        documentation_terms=DEFAULT_DOCUMENTATION_TERMS,
+        vocabulary_gap_rules=tuple(
+            tuple(part.strip() for part in rule.split(",") if part.strip())
+            for rule in DEFAULT_VOCABULARY_RULES
+        ),
+    )
+    return result.as_dict()
+
+
 def _proof_payload(
     *,
     result_payload: Mapping[str, Any] | None,
+    full_result_payload: Mapping[str, Any] | None,
     markdown: str,
     support_contact: str,
 ) -> dict[str, Any]:
@@ -199,6 +247,7 @@ def _proof_payload(
     ]
     step_counts = [_integer(item.get("step_count")) for item in items]
     output_checks = _mapping(result_payload.get("output_checks")) if result_payload else {}
+    bridge = _ingestion_bridge_proof(full_result_payload)
     return {
         "status": str(result_payload.get("status") or "") if result_payload else "",
         "generated": _integer(result_payload.get("generated")) if result_payload else 0,
@@ -222,7 +271,46 @@ def _proof_payload(
             for source_id in ("ticket-export-1", "search-export-1", "ticket-sso-1")
         ),
         "vocabulary_gaps": dict(vocabulary_gaps),
+        "ingestion_bridge": bridge,
         "markdown_bytes": len(markdown.encode("utf-8")),
+    }
+
+
+def _ingestion_bridge_proof(result_payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(result_payload, Mapping):
+        return {
+            "adapted_source_row_count": 0,
+            "resolution_text_row_count": 0,
+            "support_ticket_resolution_evidence_present": False,
+            "support_ticket_resolution_evidence_count": 0,
+            "support_ticket_resolution_example_count": 0,
+        }
+    source_rows = faq_output_to_source_rows(result_payload)
+    resolution_text_rows = [
+        row for row in source_rows
+        if isinstance(row, Mapping) and row.get("resolution_text")
+    ]
+    package = build_support_ticket_input_package(
+        result_payload,
+        outputs=("blog_post",),
+    )
+    return {
+        "adapted_source_row_count": len(source_rows),
+        "adapted_source_types": sorted({
+            str(row.get("source_type") or "")
+            for row in source_rows
+            if isinstance(row, Mapping) and row.get("source_type")
+        }),
+        "resolution_text_row_count": len(resolution_text_rows),
+        "support_ticket_resolution_evidence_present": (
+            package.inputs.get("support_ticket_resolution_evidence_present") is True
+        ),
+        "support_ticket_resolution_evidence_count": _integer(
+            package.inputs.get("support_ticket_resolution_evidence_count")
+        ),
+        "support_ticket_resolution_example_count": len(_sequence(
+            package.inputs.get("support_ticket_resolution_examples")
+        )),
     }
 
 
@@ -262,6 +350,32 @@ def _proof_failures(
         failures.append({"check": "source_id_coverage", "detail": proof.get("min_source_id_count")})
     if _integer(proof.get("min_step_count")) < 3:
         failures.append({"check": "action_step_coverage", "detail": proof.get("min_step_count")})
+    bridge = _mapping(proof.get("ingestion_bridge"))
+    if _integer(bridge.get("adapted_source_row_count")) < _integer(proof.get("generated")):
+        failures.append({
+            "check": "faq_output_adapter_row_coverage",
+            "detail": bridge.get("adapted_source_row_count"),
+        })
+    if FAQ_OUTPUT_SOURCE_TYPE not in set(_sequence(bridge.get("adapted_source_types"))):
+        failures.append({
+            "check": "faq_output_adapter_source_type",
+            "detail": bridge.get("adapted_source_types"),
+        })
+    if _integer(bridge.get("resolution_text_row_count")) < 1:
+        failures.append({
+            "check": "faq_output_resolution_text_bridge",
+            "detail": bridge.get("resolution_text_row_count"),
+        })
+    if bridge.get("support_ticket_resolution_evidence_present") is not True:
+        failures.append({
+            "check": "support_ticket_resolution_evidence_present",
+            "detail": bridge.get("support_ticket_resolution_evidence_present"),
+        })
+    if _integer(bridge.get("support_ticket_resolution_evidence_count")) < 1:
+        failures.append({
+            "check": "support_ticket_resolution_evidence_count",
+            "detail": bridge.get("support_ticket_resolution_evidence_count"),
+        })
     if proof.get("support_contact_present") is not True:
         failures.append({"check": "support_contact_present", "detail": support_contact})
     if proof.get("source_ids_present") is not True:

--- a/tests/test_smoke_content_ops_faq_output_proof.py
+++ b/tests/test_smoke_content_ops_faq_output_proof.py
@@ -27,11 +27,13 @@ def test_faq_output_proof_writes_artifacts_and_passes(tmp_path: Path) -> None:
     assert exit_code == 0
     summary = json.loads((artifact_dir / "proof_summary.json").read_text())
     result = json.loads((artifact_dir / "faq_result.json").read_text())
+    full_result = json.loads((artifact_dir / "faq_full_result.json").read_text())
     markdown = (artifact_dir / "faq_output.md").read_text()
     assert summary["ok"] is True
     assert summary["failures"] == []
     assert summary["proof"]["status"] == "ok"
     assert summary["proof"]["generated"] >= 3
+    assert len(full_result["items"]) == summary["proof"]["generated"]
     assert summary["proof"]["support_contact_present"] is True
     assert summary["proof"]["source_ids_present"] is True
     assert set(summary["proof"]["topics"]) >= {
@@ -41,6 +43,25 @@ def test_faq_output_proof_writes_artifacts_and_passes(tmp_path: Path) -> None:
     }
     assert summary["proof"]["min_source_id_count"] >= 1
     assert summary["proof"]["min_step_count"] >= 3
+    assert summary["proof"]["ingestion_bridge"]["adapted_source_row_count"] >= (
+        summary["proof"]["generated"]
+    )
+    assert summary["proof"]["ingestion_bridge"]["adapted_source_types"] == [
+        "faq_output"
+    ]
+    assert summary["proof"]["ingestion_bridge"]["resolution_text_row_count"] >= 1
+    assert (
+        summary["proof"]["ingestion_bridge"][
+            "support_ticket_resolution_evidence_present"
+        ]
+        is True
+    )
+    assert (
+        summary["proof"]["ingestion_bridge"][
+            "support_ticket_resolution_evidence_count"
+        ]
+        >= 1
+    )
     assert summary["proof"]["vocabulary_gaps"]["term_mapping_count"] >= 2
     assert {"export", "SSO"} <= set(
         summary["proof"]["vocabulary_gaps"]["top_customer_terms"]
@@ -100,6 +121,13 @@ def test_faq_output_proof_reports_failed_predicates() -> None:
             "topics": ["reporting friction"],
             "min_source_id_count": 0,
             "min_step_count": 1,
+            "ingestion_bridge": {
+                "adapted_source_row_count": 0,
+                "adapted_source_types": [],
+                "resolution_text_row_count": 0,
+                "support_ticket_resolution_evidence_present": False,
+                "support_ticket_resolution_evidence_count": 0,
+            },
             "support_contact_present": False,
             "source_ids_present": False,
             "vocabulary_gaps": {
@@ -122,6 +150,11 @@ def test_faq_output_proof_reports_failed_predicates() -> None:
         "generated_items",
         "source_id_coverage",
         "action_step_coverage",
+        "faq_output_adapter_row_coverage",
+        "faq_output_adapter_source_type",
+        "faq_output_resolution_text_bridge",
+        "support_ticket_resolution_evidence_present",
+        "support_ticket_resolution_evidence_count",
         "support_contact_present",
         "source_ids_rendered",
         "vocabulary_gap_mappings",


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md
Slice phase: Functional validation

This extends the FAQ output proof so it validates the real downstream bridge added by #1109 and #1113: generated FAQ output becomes `faq_output` source rows, and resolution-backed FAQ steps reach the canonical support-ticket `support_ticket_resolution_evidence_*` contract.

## Intentional
- This is validation only; no UI/API selection workflow is added.
- The fixture stays small because this checks contract composition, not scale.
- The compact CLI diagnostic result remains compact; the smoke writes a separate full service-result artifact for the adapter proof.

## Deferred
- UI/API selection for feeding saved FAQ reports into blog or landing generation remains deferred.
- Hosted SaaS FAQ route proof remains blocked on deployed API URL, bearer token, and account id.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_smoke_content_ops_faq_output_proof.py -q` - 4 passed.
- `python scripts/smoke_content_ops_faq_output_proof.py --artifact-dir "$tmpdir"` - passed; 3 generated FAQ items, 3 adapted `faq_output` rows, 1 resolution evidence example.
- `python -m py_compile scripts/smoke_content_ops_faq_output_proof.py tests/test_smoke_content_ops_faq_output_proof.py` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Output-Proof-Ingestion-Bridge.md` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-output-proof-ingestion-bridge.md` - passed.

## Diff size
3 files, +244 / -1
