### PR TITLE
Add FAQ output selection by ID

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -1,7 +1,7 @@
 """Atlas host input provider for Content Ops support-ticket requests."""
 
 from __future__ import annotations
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -17,7 +17,11 @@ from extracted_content_pipeline.faq_output_ingestion import (
 from extracted_content_pipeline.support_ticket_input_provider import (
     SupportTicketInputProvider,
 )
+from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
 
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+FAQRepositoryFactory = Callable[[Any], Any]
 
 _SUPPORT_TICKET_BUNDLE_KEYS = frozenset({
     "support_tickets",
@@ -59,6 +63,11 @@ _SUPPORT_TICKET_SOURCE_TYPES = frozenset({
     "conversation",
     "transcript",
 })
+_SOURCE_FAQ_ID_KEYS = (
+    "source_faq_ids",
+    "source_faq_draft_ids",
+    "selected_faq_draft_ids",
+)
 
 
 @dataclass(frozen=True)
@@ -66,14 +75,24 @@ class _AtlasSupportTicketInputProvider:
     """Request-aware provider used by the Atlas Content Ops router mount."""
 
     provider_name: str = "atlas_support_ticket_request"
+    pool_provider: PoolProvider | None = None
+    faq_repository_factory: FAQRepositoryFactory = PostgresTicketFAQRepository
 
     def build_content_ops_input_package(
         self,
         *,
         scope: TenantScope,
         request: RequestPayload | None = None,
-    ) -> ContentOpsInputPackage:
+    ) -> ContentOpsInputPackage | Awaitable[ContentOpsInputPackage]:
         source_material = _request_source_material(request)
+        source_faq_ids = _request_source_faq_ids(request)
+        if source_faq_ids:
+            return self._build_from_selected_faq_ids(
+                source_faq_ids,
+                source_material=source_material,
+                scope=scope,
+                request=request,
+            )
         if _is_empty_source_material(source_material) or not _is_support_ticket_material(
             source_material
         ):
@@ -86,11 +105,89 @@ class _AtlasSupportTicketInputProvider:
             request=request,
         )
 
+    async def _build_from_selected_faq_ids(
+        self,
+        source_faq_ids: Sequence[str],
+        *,
+        source_material: Any,
+        scope: TenantScope,
+        request: RequestPayload | None,
+    ) -> ContentOpsInputPackage:
+        loaded, missing = await self._load_selected_faq_drafts(source_faq_ids, scope=scope)
+        combined_source_material = _combine_source_material(source_material, loaded)
+        metadata = {
+            "selected_faq_id_count": len(source_faq_ids),
+            "selected_faq_loaded_count": len(loaded),
+            "selected_faq_missing_id_count": len(missing),
+        }
+        warnings = _selected_faq_warnings(
+            missing=missing,
+            repository_configured=self.pool_provider is not None,
+        )
+        if _is_empty_source_material(combined_source_material) or not _is_support_ticket_material(
+            combined_source_material
+        ):
+            return _noop_package(
+                self.provider_name,
+                metadata=metadata,
+                warnings=warnings,
+            )
+        package = SupportTicketInputProvider(
+            source_material=combined_source_material,
+            provider=self.provider_name,
+            metadata=metadata,
+        ).build_content_ops_input_package(
+            scope=scope,
+            request=request,
+        )
+        if hasattr(package, "__await__"):
+            package = await package
+        if not warnings:
+            return package
+        return ContentOpsInputPackage(
+            provider=package.provider,
+            inputs=package.inputs,
+            outputs=package.outputs,
+            target_mode=package.target_mode,
+            ingestion_profile=package.ingestion_profile,
+            metadata=package.metadata,
+            warnings=tuple(package.warnings) + tuple(warnings),
+        )
 
-def build_content_ops_input_provider() -> _AtlasSupportTicketInputProvider:
+    async def _load_selected_faq_drafts(
+        self,
+        source_faq_ids: Sequence[str],
+        *,
+        scope: TenantScope,
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        if self.pool_provider is None:
+            return [], list(source_faq_ids)
+        pool = self.pool_provider()
+        if hasattr(pool, "__await__"):
+            pool = await pool
+        repository = self.faq_repository_factory(pool)
+        loaded: list[dict[str, Any]] = []
+        missing: list[str] = []
+        for faq_id in source_faq_ids:
+            draft = await repository.get_draft(faq_id, scope=scope)
+            if draft is None:
+                missing.append(faq_id)
+                continue
+            loaded.append(draft.as_dict())
+        return loaded, missing
+
+
+def build_content_ops_input_provider(
+    *,
+    pool_provider: PoolProvider | None = None,
+    faq_repository_factory: FAQRepositoryFactory = PostgresTicketFAQRepository,
+) -> _AtlasSupportTicketInputProvider:
     """Return the host's request-aware Content Ops input provider."""
 
-    return _AtlasSupportTicketInputProvider()
+    return _AtlasSupportTicketInputProvider(
+        pool_provider=pool_provider,
+        faq_repository_factory=faq_repository_factory,
+    )
 
 
 def _request_source_material(request: RequestPayload | None) -> Any:
@@ -100,6 +197,46 @@ def _request_source_material(request: RequestPayload | None) -> Any:
     if not isinstance(inputs, Mapping):
         return None
     return inputs.get("source_material")
+
+
+def _request_source_faq_ids(request: RequestPayload | None) -> tuple[str, ...]:
+    if not isinstance(request, Mapping):
+        return ()
+    inputs = request.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return ()
+    for key in _SOURCE_FAQ_ID_KEYS:
+        values = _string_values(inputs.get(key))
+        if values:
+            return tuple(values)
+    return ()
+
+
+def _string_values(value: Any) -> tuple[str, ...]:
+    if value in (None, "", [], {}):
+        return ()
+    if isinstance(value, str):
+        values: Sequence[Any] = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = value
+    else:
+        values = (value,)
+    out: list[str] = []
+    for item in values:
+        text = _clean(item)
+        if text and text not in out:
+            out.append(text)
+    return tuple(out)
+
+
+def _combine_source_material(source_material: Any, selected_faq_outputs: Sequence[Any]) -> Any:
+    if not selected_faq_outputs:
+        return source_material
+    if _is_empty_source_material(source_material):
+        return list(selected_faq_outputs)
+    if isinstance(source_material, (list, tuple)):
+        return [*source_material, *selected_faq_outputs]
+    return [source_material, *selected_faq_outputs]
 
 
 def _is_empty_source_material(value: Any) -> bool:
@@ -176,14 +313,43 @@ def _clean(value: Any) -> str:
     return str(value or "").strip()
 
 
-def _noop_package(provider: str) -> ContentOpsInputPackage:
+def _selected_faq_warnings(
+    *,
+    missing: Sequence[str],
+    repository_configured: bool,
+) -> tuple[dict[str, Any], ...]:
+    if not repository_configured:
+        return ({
+            "code": "source_faq_repository_unconfigured",
+            "message": "Saved FAQ source selection is not configured for this route.",
+        },)
+    if not missing:
+        return ()
+    return ({
+        "code": "source_faq_drafts_not_found",
+        "message": "One or more selected FAQ reports were not found for this account.",
+        "missing_count": len(missing),
+    },)
+
+
+def _noop_package(
+    provider: str,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+    warnings: Sequence[Mapping[str, Any]] = (),
+) -> ContentOpsInputPackage:
     return ContentOpsInputPackage(
         provider=provider,
         inputs={},
         outputs=(),
         target_mode="",
         ingestion_profile="",
-        metadata={"source": "atlas_content_ops_input_provider", "mode": "noop"},
+        metadata={
+            "source": "atlas_content_ops_input_provider",
+            "mode": "noop",
+            **dict(metadata or {}),
+        },
+        warnings=tuple(dict(warning) for warning in warnings),
     )
 
 

--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_input_provider import (
@@ -113,14 +114,20 @@ class _AtlasSupportTicketInputProvider:
         scope: TenantScope,
         request: RequestPayload | None,
     ) -> ContentOpsInputPackage:
-        loaded, missing = await self._load_selected_faq_drafts(source_faq_ids, scope=scope)
+        valid_faq_ids, invalid_faq_ids = _partition_source_faq_ids(source_faq_ids)
+        loaded, missing = await self._load_selected_faq_drafts(
+            valid_faq_ids,
+            scope=scope,
+        )
         combined_source_material = _combine_source_material(source_material, loaded)
         metadata = {
             "selected_faq_id_count": len(source_faq_ids),
             "selected_faq_loaded_count": len(loaded),
             "selected_faq_missing_id_count": len(missing),
+            "selected_faq_invalid_id_count": len(invalid_faq_ids),
         }
         warnings = _selected_faq_warnings(
+            invalid=invalid_faq_ids,
             missing=missing,
             repository_configured=self.pool_provider is not None,
         )
@@ -229,6 +236,19 @@ def _string_values(value: Any) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _partition_source_faq_ids(values: Sequence[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    valid: list[str] = []
+    invalid: list[str] = []
+    for value in values:
+        try:
+            UUID(value)
+        except ValueError:
+            invalid.append(value)
+        else:
+            valid.append(value)
+    return tuple(valid), tuple(invalid)
+
+
 def _combine_source_material(source_material: Any, selected_faq_outputs: Sequence[Any]) -> Any:
     if not selected_faq_outputs:
         return source_material
@@ -315,21 +335,29 @@ def _clean(value: Any) -> str:
 
 def _selected_faq_warnings(
     *,
+    invalid: Sequence[str],
     missing: Sequence[str],
     repository_configured: bool,
 ) -> tuple[dict[str, Any], ...]:
+    warnings: list[dict[str, Any]] = []
+    if invalid:
+        warnings.append({
+            "code": "source_faq_ids_invalid",
+            "message": "One or more selected FAQ report IDs are invalid.",
+            "invalid_count": len(invalid),
+        })
     if not repository_configured:
-        return ({
+        warnings.append({
             "code": "source_faq_repository_unconfigured",
             "message": "Saved FAQ source selection is not configured for this route.",
-        },)
-    if not missing:
-        return ()
-    return ({
-        "code": "source_faq_drafts_not_found",
-        "message": "One or more selected FAQ reports were not found for this account.",
-        "missing_count": len(missing),
-    },)
+        })
+    elif missing:
+        warnings.append({
+            "code": "source_faq_drafts_not_found",
+            "message": "One or more selected FAQ reports were not found for this account.",
+            "missing_count": len(missing),
+        })
+    return tuple(warnings)
 
 
 def _noop_package(

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -230,7 +230,7 @@ try:
         scope_provider=build_content_ops_scope,
         reasoning_context_provider=select_content_ops_reasoning_context_provider,
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
-        input_provider=build_content_ops_input_provider(),
+        input_provider=build_content_ops_input_provider(pool_provider=get_db_pool),
         cache_policy_default_provider=_content_ops_cache_policy_default,
         opportunity_import_pool_provider=get_db_pool,
         usage_pool_provider=get_db_pool,

--- a/plans/PR-FAQ-Output-By-ID-Selection.md
+++ b/plans/PR-FAQ-Output-By-ID-Selection.md
@@ -13,6 +13,10 @@ same FAQ-output source adapter. This keeps the database and authorization
 concern at the host boundary instead of teaching blog or landing generators how
 to read FAQ storage.
 
+This is slightly over the 400-LOC soft cap after the review fix because
+repository wiring, UUID validation, warning behavior, and the biting provider
+tests need to ship together for the by-ID path to be safe.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/faq-output-ingestion
@@ -21,11 +25,13 @@ Slice phase: Vertical slice
 1. Add `inputs.source_faq_ids` support to the Atlas Content Ops input provider.
 2. Fetch selected FAQ drafts through `PostgresTicketFAQRepository.get_draft(...)`
    using the existing tenant `TenantScope`.
-3. Route loaded draft payloads through the existing support-ticket/FAQ-output
+3. Validate selected FAQ IDs before repository lookup so malformed IDs produce
+   provider warnings instead of Postgres UUID errors.
+4. Route loaded draft payloads through the existing support-ticket/FAQ-output
    package path.
-4. Wire the hosted API mount with the existing DB pool provider.
-5. Add focused tests for tenant-scoped repository lookup, missing IDs, and the
-   API preview route.
+5. Wire the hosted API mount with the existing DB pool provider.
+6. Add focused tests for tenant-scoped repository lookup, missing IDs, invalid
+   IDs, and the API preview route.
 
 ### Files touched
 
@@ -42,16 +48,18 @@ The host input provider gains optional repository wiring:
 build_content_ops_input_provider(pool_provider=get_db_pool)
 ```
 
-When `inputs.source_faq_ids` contains one or more IDs, the provider resolves the
-pool, builds a `PostgresTicketFAQRepository`, and calls `get_draft(faq_id,
-scope=scope)` for each ID. Drafts found under that tenant are converted with
-`TicketFAQDraft.as_dict()` and passed as source material to the existing
-`SupportTicketInputProvider`.
+When `inputs.source_faq_ids` contains one or more IDs, the provider partitions
+valid UUIDs from malformed values before touching the repository. Valid IDs
+resolve the pool, build a `PostgresTicketFAQRepository`, and call
+`get_draft(faq_id, scope=scope)` for each ID. Drafts found under that tenant are
+converted with `TicketFAQDraft.as_dict()` and passed as source material to the
+existing `SupportTicketInputProvider`.
 
-Missing IDs are reported as provider warnings and do not leak cross-tenant
-detail. If no selected draft is found and no other support-ticket material is
-present, the provider returns a warning-bearing noop package so preview/plan can
-surface the selection problem without silently running on unrelated inputs.
+Malformed or missing IDs are reported as provider warnings and do not leak
+cross-tenant detail. If no selected draft is found and no other support-ticket
+material is present, the provider returns a warning-bearing noop package so
+preview/plan can surface the selection problem without silently running on
+unrelated inputs.
 
 ## Intentional
 
@@ -78,7 +86,7 @@ surface the selection problem without silently running on unrelated inputs.
 Ran locally:
 
 - Command: python -m pytest tests/test_atlas_content_ops_input_provider.py -q
-  - 18 passed, 1 warning
+  - 19 passed, 1 warning
 - Command: python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_input_provider.py
   - passed
 - Command: git diff --check
@@ -90,8 +98,8 @@ Ran locally:
 
 | Area | Estimated LOC |
 |---|---:|
-| Host provider by-ID loader | ~120 |
+| Host provider by-ID loader | ~205 |
 | Hosted API wiring | ~5 |
-| Focused tests | ~120 |
-| Plan doc | ~90 |
-| **Total** | **~335** |
+| Focused tests | ~150 |
+| Plan doc | ~105 |
+| **Total** | **~465** |

--- a/plans/PR-FAQ-Output-By-ID-Selection.md
+++ b/plans/PR-FAQ-Output-By-ID-Selection.md
@@ -1,0 +1,97 @@
+# FAQ Output By ID Selection
+
+## Why this slice exists
+
+#1114 lets Content Ops reuse a saved FAQ report when the caller passes the full
+FAQ draft payload as `inputs.source_material`. That proves the ingestion path,
+but it still makes the caller carry the whole saved report around.
+
+The next thin product path is tenant-scoped selection by saved FAQ draft ID:
+when a request names saved FAQ IDs in `inputs`, the Atlas host provider should
+fetch those drafts for the authenticated account and hand their payloads to the
+same FAQ-output source adapter. This keeps the database and authorization
+concern at the host boundary instead of teaching blog or landing generators how
+to read FAQ storage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Vertical slice
+
+1. Add `inputs.source_faq_ids` support to the Atlas Content Ops input provider.
+2. Fetch selected FAQ drafts through `PostgresTicketFAQRepository.get_draft(...)`
+   using the existing tenant `TenantScope`.
+3. Route loaded draft payloads through the existing support-ticket/FAQ-output
+   package path.
+4. Wire the hosted API mount with the existing DB pool provider.
+5. Add focused tests for tenant-scoped repository lookup, missing IDs, and the
+   API preview route.
+
+### Files touched
+
+- `atlas_brain/_content_ops_input_provider.py`
+- `atlas_brain/api/__init__.py`
+- `tests/test_atlas_content_ops_input_provider.py`
+- `plans/PR-FAQ-Output-By-ID-Selection.md`
+
+## Mechanism
+
+The host input provider gains optional repository wiring:
+
+```python
+build_content_ops_input_provider(pool_provider=get_db_pool)
+```
+
+When `inputs.source_faq_ids` contains one or more IDs, the provider resolves the
+pool, builds a `PostgresTicketFAQRepository`, and calls `get_draft(faq_id,
+scope=scope)` for each ID. Drafts found under that tenant are converted with
+`TicketFAQDraft.as_dict()` and passed as source material to the existing
+`SupportTicketInputProvider`.
+
+Missing IDs are reported as provider warnings and do not leak cross-tenant
+detail. If no selected draft is found and no other support-ticket material is
+present, the provider returns a warning-bearing noop package so preview/plan can
+surface the selection problem without silently running on unrelated inputs.
+
+## Intentional
+
+- This does not add the UI picker. It only makes the hosted request contract
+  capable of selecting saved FAQ reports by ID.
+- This does not add a new top-level request field. IDs live under `inputs` so
+  the existing bounded request model can carry them.
+- This does not fetch by ID in the extracted package. Tenant-scoped database
+  reads remain host-owned; extracted code continues consuming already-loaded
+  source material.
+
+## Deferred
+
+- Future PR: add Intel UI controls that let a user pick saved FAQ reports and
+  send `inputs.source_faq_ids`.
+- Future PR: support deliberate mixed inline `source_material` plus
+  `source_faq_ids` composition if the UI needs both in one run.
+- Future PR: add execute-route smoke coverage once the UI/API picker is in
+  place and representative saved drafts exist in the test fixture layer.
+- Parked hardening: none.
+
+## Verification
+
+Ran locally:
+
+- Command: python -m pytest tests/test_atlas_content_ops_input_provider.py -q
+  - 18 passed, 1 warning
+- Command: python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_input_provider.py
+  - passed
+- Command: git diff --check
+  - passed
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-by-id-selection.md
+  - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider by-ID loader | ~120 |
+| Hosted API wiring | ~5 |
+| Focused tests | ~120 |
+| Plan doc | ~90 |
+| **Total** | **~335** |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -31,6 +31,8 @@ from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
 
 
 ROOT = Path(__file__).resolve().parents[1]
+FAQ_DRAFT_ID = "11111111-1111-4111-8111-111111111111"
+MISSING_FAQ_DRAFT_ID = "22222222-2222-4222-8222-222222222222"
 
 
 def _fresh_api_package():
@@ -78,7 +80,7 @@ def _support_ticket_csv_rows() -> list[dict[str, str]]:
         return list(csv.DictReader(handle))
 
 
-def _saved_faq_draft(faq_id: str = "faq-draft-42") -> TicketFAQDraft:
+def _saved_faq_draft(faq_id: str = FAQ_DRAFT_ID) -> TicketFAQDraft:
     return TicketFAQDraft(
         id=faq_id,
         target_id="ticket-faq-report",
@@ -359,7 +361,7 @@ def test_atlas_content_ops_input_provider_expands_faq_output_inside_source_lists
 @pytest.mark.asyncio
 async def test_atlas_content_ops_input_provider_fetches_selected_faq_ids_by_scope() -> None:
     pool = {
-        "drafts": {"faq-draft-42": _saved_faq_draft()},
+        "drafts": {FAQ_DRAFT_ID: _saved_faq_draft()},
         "calls": [],
     }
     provider = build_content_ops_input_provider(
@@ -369,18 +371,18 @@ async def test_atlas_content_ops_input_provider_fetches_selected_faq_ids_by_scop
 
     package = await provider.build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
-        request={"inputs": {"source_faq_ids": ["faq-draft-42"]}},
+        request={"inputs": {"source_faq_ids": [FAQ_DRAFT_ID]}},
     )
 
-    assert pool["calls"] == [("faq-draft-42", "acct-1")]
+    assert pool["calls"] == [(FAQ_DRAFT_ID, "acct-1")]
     assert package.provider == "atlas_support_ticket_request"
     assert package.metadata["selected_faq_id_count"] == 1
     assert package.metadata["selected_faq_loaded_count"] == 1
     assert package.metadata["selected_faq_missing_id_count"] == 0
     assert package.warnings == ()
     assert package.inputs["source_material"][0]["source_type"] == "faq_output"
-    assert package.inputs["source_material"][0]["source_id"] == "faq-draft-42"
-    assert package.inputs["source_material"][0]["faq_draft_id"] == "faq-draft-42"
+    assert package.inputs["source_material"][0]["source_id"] == FAQ_DRAFT_ID
+    assert package.inputs["source_material"][0]["faq_draft_id"] == FAQ_DRAFT_ID
     assert package.inputs["support_ticket_resolution_evidence_present"] is True
     assert package.inputs["support_ticket_resolution_evidence_count"] == 1
 
@@ -395,10 +397,10 @@ async def test_atlas_content_ops_input_provider_warns_for_missing_selected_faq_i
 
     package = await provider.build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
-        request={"inputs": {"source_faq_ids": ["missing-faq"]}},
+        request={"inputs": {"source_faq_ids": [MISSING_FAQ_DRAFT_ID]}},
     )
 
-    assert pool["calls"] == [("missing-faq", "acct-1")]
+    assert pool["calls"] == [(MISSING_FAQ_DRAFT_ID, "acct-1")]
     assert package.inputs == {}
     assert package.metadata["mode"] == "noop"
     assert package.metadata["selected_faq_id_count"] == 1
@@ -408,6 +410,33 @@ async def test_atlas_content_ops_input_provider_warns_for_missing_selected_faq_i
         "code": "source_faq_drafts_not_found",
         "message": "One or more selected FAQ reports were not found for this account.",
         "missing_count": 1,
+    },)
+
+
+@pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_warns_for_invalid_selected_faq_ids() -> None:
+    pool = {"drafts": {FAQ_DRAFT_ID: _saved_faq_draft()}, "calls": []}
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        faq_repository_factory=_FAQRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={"inputs": {"source_faq_ids": ["not-a-uuid"]}},
+    )
+
+    assert pool["calls"] == []
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["selected_faq_id_count"] == 1
+    assert package.metadata["selected_faq_loaded_count"] == 0
+    assert package.metadata["selected_faq_missing_id_count"] == 0
+    assert package.metadata["selected_faq_invalid_id_count"] == 1
+    assert package.warnings == ({
+        "code": "source_faq_ids_invalid",
+        "message": "One or more selected FAQ report IDs are invalid.",
+        "invalid_count": 1,
     },)
 
 
@@ -574,7 +603,7 @@ async def test_api_preview_route_applies_support_ticket_input_provider() -> None
 @pytest.mark.asyncio
 async def test_api_preview_route_fetches_selected_faq_ids() -> None:
     pool = {
-        "drafts": {"faq-draft-42": _saved_faq_draft()},
+        "drafts": {FAQ_DRAFT_ID: _saved_faq_draft()},
         "calls": [],
     }
     router = create_content_ops_control_surface_router(
@@ -589,10 +618,10 @@ async def test_api_preview_route_fetches_selected_faq_ids() -> None:
     route = _router_route(router, "/content-ops/preview", "POST")
     payload = await route.endpoint({
         "outputs": ["landing_page"],
-        "inputs": {"source_faq_ids": ["faq-draft-42"]},
+        "inputs": {"source_faq_ids": [FAQ_DRAFT_ID]},
     })
 
-    assert pool["calls"] == [("faq-draft-42", "acct-preview")]
+    assert pool["calls"] == [(FAQ_DRAFT_ID, "acct-preview")]
     assert payload["can_run"] is True
     assert payload["outputs"] == ["landing_page"]
     assert payload["input_provider"]["provider"] == "atlas_support_ticket_request"

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -27,6 +27,7 @@ from extracted_content_pipeline.support_ticket_input_provider import (
     SupportTicketInputProvider,
 )
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -75,6 +76,38 @@ def _support_ticket_csv_rows() -> list[dict[str, str]]:
     path = ROOT / "extracted_content_pipeline" / "examples" / "support_ticket_sources.csv"
     with path.open(newline="", encoding="utf-8") as handle:
         return list(csv.DictReader(handle))
+
+
+def _saved_faq_draft(faq_id: str = "faq-draft-42") -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=faq_id,
+        target_id="ticket-faq-report",
+        target_mode="support_ticket_faq",
+        title="Saved FAQ report",
+        markdown="# Saved FAQ report",
+        items=(
+            {
+                "topic": "billing confusion",
+                "question": "Why was I charged twice?",
+                "summary": "Customers ask why duplicate-looking invoices appear.",
+                "steps": ("Check invoice history.",),
+                "answer_evidence_status": "resolution_evidence",
+            },
+        ),
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"has_action_items": True},
+        status="draft",
+    )
+
+
+class _FAQRepo:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def get_draft(self, faq_id: str, *, scope: TenantScope):
+        self.pool["calls"].append((faq_id, scope.account_id))
+        return self.pool["drafts"].get(faq_id)
 
 
 def test_atlas_content_ops_input_provider_noops_without_source_material() -> None:
@@ -323,6 +356,61 @@ def test_atlas_content_ops_input_provider_expands_faq_output_inside_source_lists
     assert package.inputs["support_ticket_resolution_evidence_count"] == 1
 
 
+@pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_fetches_selected_faq_ids_by_scope() -> None:
+    pool = {
+        "drafts": {"faq-draft-42": _saved_faq_draft()},
+        "calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        faq_repository_factory=_FAQRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={"inputs": {"source_faq_ids": ["faq-draft-42"]}},
+    )
+
+    assert pool["calls"] == [("faq-draft-42", "acct-1")]
+    assert package.provider == "atlas_support_ticket_request"
+    assert package.metadata["selected_faq_id_count"] == 1
+    assert package.metadata["selected_faq_loaded_count"] == 1
+    assert package.metadata["selected_faq_missing_id_count"] == 0
+    assert package.warnings == ()
+    assert package.inputs["source_material"][0]["source_type"] == "faq_output"
+    assert package.inputs["source_material"][0]["source_id"] == "faq-draft-42"
+    assert package.inputs["source_material"][0]["faq_draft_id"] == "faq-draft-42"
+    assert package.inputs["support_ticket_resolution_evidence_present"] is True
+    assert package.inputs["support_ticket_resolution_evidence_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_warns_for_missing_selected_faq_ids() -> None:
+    pool = {"drafts": {}, "calls": []}
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        faq_repository_factory=_FAQRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={"inputs": {"source_faq_ids": ["missing-faq"]}},
+    )
+
+    assert pool["calls"] == [("missing-faq", "acct-1")]
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["selected_faq_id_count"] == 1
+    assert package.metadata["selected_faq_loaded_count"] == 0
+    assert package.metadata["selected_faq_missing_id_count"] == 1
+    assert package.warnings == ({
+        "code": "source_faq_drafts_not_found",
+        "message": "One or more selected FAQ reports were not found for this account.",
+        "missing_count": 1,
+    },)
+
+
 def test_atlas_content_ops_input_provider_expands_subject_body_ticket_rows() -> None:
     provider = build_content_ops_input_provider()
 
@@ -481,6 +569,35 @@ async def test_api_preview_route_applies_support_ticket_input_provider() -> None
     assert payload["can_run"] is True
     assert payload["outputs"] == ["faq_markdown", "landing_page", "blog_post"]
     assert payload["missing_inputs"] == []
+
+
+@pytest.mark.asyncio
+async def test_api_preview_route_fetches_selected_faq_ids() -> None:
+    pool = {
+        "drafts": {"faq-draft-42": _saved_faq_draft()},
+        "calls": [],
+    }
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=build_content_ops_input_provider(
+            pool_provider=lambda: pool,
+            faq_repository_factory=_FAQRepo,
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-preview"),
+    )
+
+    route = _router_route(router, "/content-ops/preview", "POST")
+    payload = await route.endpoint({
+        "outputs": ["landing_page"],
+        "inputs": {"source_faq_ids": ["faq-draft-42"]},
+    })
+
+    assert pool["calls"] == [("faq-draft-42", "acct-preview")]
+    assert payload["can_run"] is True
+    assert payload["outputs"] == ["landing_page"]
+    assert payload["input_provider"]["provider"] == "atlas_support_ticket_request"
+    assert payload["input_provider"]["metadata"]["included_row_count"] == 1
+    assert payload["input_provider"]["warnings"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-By-ID-Selection.md
Slice phase: Vertical slice

Saved FAQ reports can now be selected by ID through `inputs.source_faq_ids`. The Atlas host provider validates selected IDs, fetches each valid draft through the tenant-scoped FAQ repository, converts loaded drafts through the existing FAQ-output source-material path, and the hosted Content Ops API mount wires that provider to the existing DB pool.

## Intentional
- Keep database lookup host-owned instead of teaching extracted generators about FAQ storage.
- Use `inputs.source_faq_ids` instead of adding a new top-level request field.
- Defer the UI picker and mixed inline `source_material` plus `source_faq_ids` composition.

## Deferred
- Future PR: add Intel UI controls that let a user pick saved FAQ reports and send `inputs.source_faq_ids`.
- Future PR: support deliberate mixed inline `source_material` plus `source_faq_ids` composition if the UI needs both in one run.
- Future PR: add execute-route smoke coverage once the UI/API picker is in place and representative saved drafts exist in the test fixture layer.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_atlas_content_ops_input_provider.py -q` — 19 passed, 1 warning
- `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_input_provider.py` — passed
- `git diff --check` — passed
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-by-id-selection.md` — passed

## Diff size
4 files, +452 / -7