### PR TITLE
Add deflection report artifact

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -1,0 +1,300 @@
+"""Customer-facing support-ticket deflection report renderer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .ticket_faq_markdown import TicketFAQMarkdownResult
+
+
+_RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
+_DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
+
+
+@dataclass(frozen=True)
+class DeflectionReportArtifact:
+    """Rendered deflection report plus compact proof metadata."""
+
+    markdown: str
+    summary: dict[str, Any]
+    faq_result: TicketFAQMarkdownResult
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "markdown": self.markdown,
+            "summary": dict(self.summary),
+            "faq_result": self.faq_result.as_dict(),
+        }
+
+
+def build_deflection_report_artifact(
+    faq_result: TicketFAQMarkdownResult,
+    *,
+    title: str = "Support Ticket Deflection Report",
+    source_label: str | None = None,
+) -> DeflectionReportArtifact:
+    """Render a customer-facing report from a generated FAQ result."""
+
+    summary = deflection_report_summary(faq_result)
+    markdown = render_deflection_report(
+        faq_result,
+        title=title,
+        source_label=source_label,
+        summary=summary,
+    )
+    return DeflectionReportArtifact(
+        markdown=markdown,
+        summary=summary,
+        faq_result=faq_result,
+    )
+
+
+def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, Any]:
+    """Return compact counts used by the report and CLI summary JSON."""
+
+    items = tuple(_item(item) for item in faq_result.items)
+    proven = tuple(
+        item for item in items
+        if _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS
+    )
+    needs_review = tuple(
+        item for item in items
+        if _text(item.get("answer_evidence_status")) != _RESOLUTION_EVIDENCE_STATUS
+    )
+    return {
+        "generated": len(items),
+        "source_count": int(faq_result.source_count),
+        "ticket_source_count": int(faq_result.ticket_source_count),
+        "drafted_answer_count": len(proven),
+        "no_proven_answer_count": len(needs_review),
+        "output_checks": dict(faq_result.output_checks),
+        "top_question": _text(items[0].get("question")) if items else "",
+        "top_opportunity_score": _int(items[0].get("opportunity_score")) if items else 0,
+    }
+
+
+def render_deflection_report(
+    faq_result: TicketFAQMarkdownResult,
+    *,
+    title: str = "Support Ticket Deflection Report",
+    source_label: str | None = None,
+    summary: Mapping[str, Any] | None = None,
+) -> str:
+    """Render the customer-facing Markdown report."""
+
+    resolved_summary = dict(summary or deflection_report_summary(faq_result))
+    items = tuple(_item(item) for item in faq_result.items)
+    proven = tuple(
+        item for item in items
+        if _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS
+    )
+    needs_review = tuple(
+        item for item in items
+        if _text(item.get("answer_evidence_status")) != _RESOLUTION_EVIDENCE_STATUS
+    )
+
+    lines: list[str] = [
+        f"# {_md(title)}",
+        "",
+        "## Executive Summary",
+        "",
+        (
+            f"This report analyzed {resolved_summary.get('source_count', 0)} source rows "
+            f"and produced {resolved_summary.get('generated', 0)} ranked FAQ "
+            "opportunities from the supplied support data."
+        ),
+        "",
+        (
+            f"- Drafted answers with proven solutions: "
+            f"{resolved_summary.get('drafted_answer_count', 0)}"
+        ),
+        (
+            f"- No proven answer yet: "
+            f"{resolved_summary.get('no_proven_answer_count', 0)}"
+        ),
+        f"- Ticket sources represented: {resolved_summary.get('ticket_source_count', 0)}",
+        "",
+    ]
+    if source_label:
+        lines.extend(["**Source file:**", "", _md(source_label), ""])
+    lines.extend(_ranked_opportunity_section(items))
+    lines.extend(_drafted_answer_section(proven))
+    lines.extend(_no_proven_answer_section(needs_review))
+    lines.extend(_vocabulary_gap_section(items))
+    lines.extend(_evidence_appendix_section(items))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _ranked_opportunity_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = [
+        "## Ranked Question Opportunities",
+        "",
+        "| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |",
+        "|---:|---|---:|---:|---|---|",
+    ]
+    if not items:
+        return [*lines, "| - | No ranked FAQ opportunities were generated. | 0 | 0 | - | - |", ""]
+    for index, item in enumerate(items, start=1):
+        lines.append(
+            "| "
+            f"{index} | {_cell(item.get('question'))} | "
+            f"{_int(item.get('weighted_frequency') or item.get('frequency'))} | "
+            f"{_int(item.get('opportunity_score'))} | "
+            f"{_status_label(item)} | "
+            f"{_cell(', '.join(_texts(item.get('source_ids'))[:5]))} |"
+        )
+    return [*lines, ""]
+
+
+def _drafted_answer_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = ["## Drafted Answers With Proven Solutions", ""]
+    if not items:
+        return [
+            *lines,
+            "No FAQ gap in this run included uploaded resolution evidence. Keep every answer in review until support supplies a verified solution.",
+            "",
+        ]
+    for index, item in enumerate(items, start=1):
+        steps = _texts(item.get("steps"))
+        lines.extend([
+            f"### {index}. {_md(item.get('question'))}",
+            "",
+            "Uploaded resolution evidence supports this draft answer.",
+            "",
+            "**Draft answer steps:**",
+            "",
+            *[
+                f"{step_index}. {_md(step)}"
+                for step_index, step in enumerate(steps, start=1)
+            ],
+            "",
+            f"**Sources:** {_md(', '.join(_texts(item.get('source_ids'))))}",
+            "",
+        ])
+    return lines
+
+
+def _no_proven_answer_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = ["## No Proven Answer Yet", ""]
+    if not items:
+        return [*lines, "Every generated FAQ opportunity included uploaded resolution evidence.", ""]
+    for index, item in enumerate(items, start=1):
+        lines.extend([
+            f"### {index}. {_md(item.get('question'))}",
+            "",
+            (
+                "Customers repeatedly asked this question, but the uploaded data "
+                "did not include verified resolution evidence for a publishable answer."
+            ),
+            "",
+            (
+                "No verified support resolution was present in the uploaded data. "
+                "Support should add the approved answer before this FAQ is published."
+            ),
+            "",
+            f"**Sources:** {_md(', '.join(_texts(item.get('source_ids'))))}",
+            "",
+        ])
+    return lines
+
+
+def _vocabulary_gap_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
+    mappings: list[Mapping[str, Any]] = []
+    for item in items:
+        for mapping in item.get("term_mappings") or ():
+            if isinstance(mapping, Mapping):
+                mappings.append(mapping)
+    lines = [
+        "## Vocabulary Gaps",
+        "",
+        "| Customer wording | Documentation term | Suggested update | Source count |",
+        "|---|---|---|---:|",
+    ]
+    if not mappings:
+        return [*lines, "| - | - | No vocabulary-gap mappings were generated. | 0 |", ""]
+    for mapping in mappings:
+        lines.append(
+            "| "
+            f"{_cell(mapping.get('customer_term'))} | "
+            f"{_cell(mapping.get('documentation_term'))} | "
+            f"{_cell(mapping.get('suggestion'))} | "
+            f"{_int(mapping.get('source_id_count'))} |"
+        )
+    return [*lines, ""]
+
+
+def _evidence_appendix_section(items: Sequence[Mapping[str, Any]]) -> list[str]:
+    lines = ["## Evidence Appendix", ""]
+    for index, item in enumerate(items, start=1):
+        quotes = _texts(item.get("evidence_quotes"))
+        lines.extend([f"### {index}. {_md(item.get('question'))}", ""])
+        if not quotes:
+            lines.extend(["No source excerpts were rendered for this item.", ""])
+            continue
+        for quote in quotes:
+            lines.append(f"- {_md(quote)}")
+        lines.append("")
+    if len(lines) == 2:
+        lines.append("No evidence excerpts were rendered.")
+        lines.append("")
+    return lines
+
+
+def _status_label(item: Mapping[str, Any]) -> str:
+    status = _text(item.get("answer_evidence_status"))
+    if status == _RESOLUTION_EVIDENCE_STATUS:
+        return "drafted from resolution evidence"
+    if status == _DRAFT_NEEDS_REVIEW_STATUS:
+        return "no proven answer yet"
+    return status or "unknown"
+
+
+def _item(value: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _texts(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        values: Sequence[Any] = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = value
+    else:
+        values = (value,)
+    out: list[str] = []
+    for item in values:
+        text = _text(item)
+        if text:
+            out.append(text)
+    return out
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _cell(value: Any) -> str:
+    text = _md(value).replace("\n", " ")
+    return text.replace("|", "\\|")
+
+
+def _md(value: Any) -> str:
+    return _text(value).replace("\r", " ").strip()
+
+
+__all__ = [
+    "DeflectionReportArtifact",
+    "build_deflection_report_artifact",
+    "deflection_report_summary",
+    "render_deflection_report",
+]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -282,6 +282,9 @@
       "target": "extracted_content_pipeline/ticket_faq_markdown.py"
     },
     {
+      "target": "extracted_content_pipeline/faq_deflection_report.py"
+    },
+    {
       "target": "extracted_content_pipeline/ticket_faq_ports.py"
     },
     {

--- a/plans/PR-Content-Ops-Deflection-Report-Artifact.md
+++ b/plans/PR-Content-Ops-Deflection-Report-Artifact.md
@@ -1,0 +1,117 @@
+# Content Ops Deflection Report Artifact
+
+## Why this slice exists
+
+The hosted FAQ search route is parked on operator-side provisioning, but the
+$1,500 one-time deflection report does not depend on that route. The already
+validated generation pipeline can rank repeated support questions, distinguish
+resolution-backed answers from review-needed gaps, and emit source IDs.
+
+This slice turns that pipeline output into the first customer-facing report
+artifact shape: ranked question opportunities, drafted answers only when real
+resolution evidence exists, and a clear "no proven answer yet" list for gaps
+that still need a verified support answer.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Vertical slice
+
+1. Add a deterministic deflection-report renderer for
+   `TicketFAQMarkdownResult` objects.
+2. Add a CLI that loads a support-ticket CSV/JSON/JSONL file, runs the existing
+   FAQ generator, and writes the customer-facing report Markdown.
+3. Add focused tests proving resolution-backed items land in the drafted-answer
+   section, draft-needed items land in the no-proven-answer section, and the CLI
+   runs end to end against the checked SaaS support-ticket corpus.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Deflection-Report-Artifact.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `extracted_content_pipeline/manifest.json`
+- `scripts/build_content_ops_deflection_report.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+The renderer accepts the canonical FAQ result shape already produced by
+`build_ticket_faq_markdown(...)`. It partitions items by
+`answer_evidence_status`:
+
+```python
+resolution_evidence -> Drafted Answers With Proven Solutions
+draft_needs_review -> No Proven Answer Yet
+```
+
+The CLI uses the same source loader as the FAQ Markdown CLI, calls
+`build_ticket_faq_markdown(...)`, renders the report, and optionally writes a
+compact JSON summary. The report stays deterministic and does not call a model.
+
+## Intentional
+
+- This does not use the hosted FAQ search route or persisted search projection.
+  The report artifact is pipeline-only.
+- This does not add UI/API selection for saved FAQ reports; another open PR is
+  already working near that lane.
+- The checked SaaS corpus is labeled synthetic. It proves the artifact flow, not
+  a real customer acceptance run.
+
+## Deferred
+
+- Future PR: run this artifact against a real anonymized customer ticket export
+  once one is available.
+- Future PR: expose this report artifact through the hosted UI/API after the
+  CLI shape is accepted.
+- Future PR: add saved-FAQ selection only after the selection lane lands.
+- Parked hardening: none. `HARDENING.md` was scanned; no relevant active
+  `content-ops/deflection-report` item exists.
+
+## Verification
+
+Ran locally:
+
+- `python -m pytest tests/test_content_ops_deflection_report.py -q` - 4
+  passed.
+- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py`
+  - passed.
+- `python scripts/build_content_ops_deflection_report.py extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --source-format csv --output /tmp/content-ops-deflection-report.md --summary-output /tmp/content-ops-deflection-report-summary.json`
+  - passed; generated 7 ranked FAQ opportunities from 36 source rows, with 7
+    no-proven-answer gaps and no drafted answers because the checked corpus has
+    no resolution evidence. The focused pytest also covers a mixed
+    resolution-backed/no-proven corpus end to end through the CLI.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed; 126
+  matching tests are enrolled.
+- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_audit_extracted_pipeline_ci_enrollment.py -q`
+  - 12 passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline`
+  - passed; synced mapped files only.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed; 2662 passed, 9
+  skipped, 1 warning.
+- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-Deflection-Report-Artifact.md`
+  - passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-Deflection-Report-Artifact.md`
+  - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-deflection-report-artifact.md`
+  - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Renderer | 302 |
+| CLI | 141 |
+| Tests | 210 |
+| Manifest, runner, and plan | 119 |
+| **Total** | **772** |
+
+This is over the 400 LOC soft cap because the vertical slice needs a reusable
+renderer, a runnable operator command, and end-to-end proof in one PR. Splitting
+the CLI from the renderer would leave the artifact unable to demonstrate the
+real flow.

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build a customer-facing support-ticket deflection report."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
+    load_source_campaign_opportunities_from_file,
+    parse_default_fields_or_exit,
+)
+from extracted_content_pipeline.faq_deflection_report import (  # noqa: E402
+    build_deflection_report_artifact,
+)
+from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    DEFAULT_TITLE,
+    build_ticket_faq_markdown,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.max_items < 1:
+        raise SystemExit("--max-items must be positive")
+    if args.max_evidence_per_item < 1:
+        raise SystemExit("--max-evidence-per-item must be positive")
+    if args.max_text_chars < 1:
+        raise SystemExit("--max-text-chars must be positive")
+    if args.window_days is not None and args.window_days < 1:
+        raise SystemExit("--window-days must be positive")
+    if args.as_of_date and args.window_days is None:
+        raise SystemExit("--as-of-date requires --window-days")
+    if args.as_of_date:
+        try:
+            date.fromisoformat(args.as_of_date)
+        except ValueError:
+            raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
+
+    artifact = build_report(args)
+    if args.output:
+        args.output.write_text(artifact.markdown, encoding="utf-8")
+    else:
+        print(artifact.markdown, end="")
+    if args.summary_output:
+        args.summary_output.write_text(
+            json.dumps(artifact.summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.json:
+        print(json.dumps(artifact.summary, sort_keys=True))
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Source JSON, JSONL, or CSV file.")
+    parser.add_argument(
+        "--source-format",
+        choices=("auto", "json", "jsonl", "csv"),
+        default="auto",
+        help="Source file format. Defaults to suffix-based detection.",
+    )
+    parser.add_argument("--title", default="Support Ticket Deflection Report")
+    parser.add_argument("--faq-title", default=DEFAULT_TITLE)
+    parser.add_argument("--max-items", type=int, default=20)
+    parser.add_argument("--max-evidence-per-item", type=int, default=3)
+    parser.add_argument("--max-text-chars", type=int, default=1200)
+    parser.add_argument("--window-days", type=int)
+    parser.add_argument("--as-of-date")
+    parser.add_argument("--support-contact")
+    parser.add_argument(
+        "--default-field",
+        action="append",
+        default=[],
+        help="Fallback metadata applied to every source row. Repeat as key=value.",
+    )
+    parser.add_argument(
+        "--documentation-term",
+        action="append",
+        default=[],
+        help="Existing documentation term or heading. Repeat to provide multiple terms.",
+    )
+    parser.add_argument(
+        "--vocabulary-gap-rule",
+        action="append",
+        default=[],
+        help="Comma-separated customer/documentation aliases. Repeat for multiple rules.",
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--summary-output", type=Path)
+    parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
+    return parser.parse_args(argv)
+
+
+def build_report(args: argparse.Namespace):
+    loaded = load_source_campaign_opportunities_from_file(
+        args.path,
+        file_format=args.source_format,
+        max_text_chars=args.max_text_chars,
+        default_fields=parse_default_fields_or_exit(args.default_field),
+    )
+    faq_result = build_ticket_faq_markdown(
+        loaded.opportunities,
+        title=args.faq_title,
+        max_items=args.max_items,
+        max_evidence_per_item=args.max_evidence_per_item,
+        window_days=args.window_days,
+        as_of_date=args.as_of_date,
+        support_contact=args.support_contact,
+        documentation_terms=tuple(args.documentation_term or ()),
+        vocabulary_gap_rules=_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
+    )
+    return build_deflection_report_artifact(
+        faq_result,
+        title=args.title,
+        source_label=str(args.path),
+    )
+
+
+def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
+    rules: list[tuple[str, ...]] = []
+    for raw in values or ():
+        parts = tuple(part.strip() for part in str(raw).split(",") if part.strip())
+        if len(parts) < 2:
+            raise SystemExit("--vocabulary-gap-rule must contain at least two comma-separated terms")
+        rules.append(parts)
+    return tuple(rules)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -28,6 +28,7 @@ pytest \
   tests/test_extracted_campaign_source_adapters.py \
   tests/test_content_ops_faq_saas_demo_corpus.py \
   tests/test_content_ops_faq_report_contract_docs.py \
+  tests/test_content_ops_deflection_report.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from extracted_content_pipeline.faq_deflection_report import (
+    build_deflection_report_artifact,
+)
+from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownResult
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_content_ops_deflection_report.py"
+SAAS_DEMO = ROOT / "extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv"
+SPEC = importlib.util.spec_from_file_location(
+    "build_content_ops_deflection_report",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_deflection_report_partitions_proven_and_unproven_answers() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={
+            "uses_user_vocabulary": True,
+            "condensed": True,
+            "has_action_items": True,
+        },
+        items=(
+            {
+                "question": "How do I export attribution reports?",
+                "summary": "Customers ask how to export attribution reports.",
+                "weighted_frequency": 8,
+                "opportunity_score": 14,
+                "answer_evidence_status": "resolution_evidence",
+                "steps": [
+                    "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then select Download report.",
+                    "Confirm the answer matches the customer's support record before publishing it.",
+                ],
+                "source_ids": ("ticket-1", "ticket-2"),
+                "evidence_quotes": (
+                    "`ticket-1` - Export question: How do I export attribution reports?",
+                ),
+                "term_mappings": (
+                    {
+                        "customer_term": "export",
+                        "documentation_term": "Download report",
+                        "suggestion": "Add export as an alternate heading.",
+                        "source_id_count": 2,
+                    },
+                ),
+            },
+            {
+                "question": "Why is the dashboard stale?",
+                "summary": "Customers ask why dashboard totals are not refreshed.",
+                "frequency": 3,
+                "opportunity_score": 6,
+                "answer_evidence_status": "draft_needs_review",
+                "steps": [
+                    "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+                ],
+                "source_ids": ("ticket-3",),
+                "evidence_quotes": (
+                    "`ticket-3` - Stale dashboard: Why is the dashboard stale?",
+                ),
+            },
+        ),
+    )
+
+    artifact = build_deflection_report_artifact(result)
+
+    assert artifact.summary["drafted_answer_count"] == 1
+    assert artifact.summary["no_proven_answer_count"] == 1
+    assert "## Ranked Question Opportunities" in artifact.markdown
+    assert "## Drafted Answers With Proven Solutions" in artifact.markdown
+    assert "How do I export attribution reports?" in artifact.markdown
+    assert "Use the uploaded resolution evidence: Open Analytics" in artifact.markdown
+    assert "## No Proven Answer Yet" in artifact.markdown
+    assert "Why is the dashboard stale?" in artifact.markdown
+    assert "Customers repeatedly asked this question" in artifact.markdown
+    assert "No verified support resolution was present" in artifact.markdown
+    assert "export" in artifact.markdown
+    assert "Download report" in artifact.markdown
+
+
+def test_deflection_report_does_not_put_review_needed_steps_in_drafted_section() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=1,
+        ticket_source_count=1,
+        output_checks={
+            "uses_user_vocabulary": True,
+            "condensed": True,
+            "has_action_items": True,
+        },
+        items=(
+            {
+                "question": "Can I update permissions?",
+                "summary": "Customers ask about permissions.",
+                "frequency": 1,
+                "opportunity_score": 1,
+                "answer_evidence_status": "draft_needs_review",
+                "steps": [
+                    "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+                ],
+                "source_ids": ("ticket-1",),
+            },
+        ),
+    )
+
+    markdown = build_deflection_report_artifact(result).markdown
+    drafted_section = markdown.split("## No Proven Answer Yet", 1)[0]
+
+    assert "No FAQ gap in this run included uploaded resolution evidence." in drafted_section
+    assert "Review the cited ticket evidence" not in drafted_section
+    assert "Can I update permissions?" in markdown.split("## No Proven Answer Yet", 1)[1]
+
+
+def test_deflection_report_cli_builds_saas_demo_artifact(tmp_path: Path) -> None:
+    output = tmp_path / "deflection-report.md"
+    summary_output = tmp_path / "deflection-report-summary.json"
+
+    exit_code = MODULE.main([
+        str(SAAS_DEMO),
+        "--source-format",
+        "csv",
+        "--output",
+        str(output),
+        "--summary-output",
+        str(summary_output),
+    ])
+
+    assert exit_code == 0
+    markdown = output.read_text()
+    summary = json.loads(summary_output.read_text())
+    assert summary["generated"] >= 7
+    assert summary["source_count"] == 36
+    assert summary["no_proven_answer_count"] >= 1
+    assert "## Ranked Question Opportunities" in markdown
+    assert "## No Proven Answer Yet" in markdown
+    assert "support_ticket_saas_demo_sources.csv" in markdown
+    assert "tell users exactly what to try next" not in markdown
+
+
+def test_deflection_report_cli_splits_backed_and_unproven_answers(tmp_path: Path) -> None:
+    source = tmp_path / "mixed-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    summary_output = tmp_path / "deflection-report-summary.json"
+    rows = [
+        {
+            "ticket_id": f"ticket-export-{index}",
+            "source_type": "support_ticket",
+            "subject": "Export attribution report",
+            "message": "How do I export attribution reports?",
+            "pain_category": "exports",
+            "resolution_text": (
+                "Open Analytics then Attribution then click Download report."
+            ),
+        }
+        for index in range(4)
+    ]
+    rows.extend(
+        {
+            "ticket_id": f"ticket-sso-{index}",
+            "source_type": "support_ticket",
+            "subject": "SSO setup",
+            "message": "How do I enable SSO for my team?",
+            "pain_category": "authentication",
+        }
+        for index in range(3)
+    )
+    source.write_text(json.dumps(rows), encoding="utf-8")
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--output",
+        str(output),
+        "--summary-output",
+        str(summary_output),
+    ])
+
+    assert exit_code == 0
+    markdown = output.read_text()
+    summary = json.loads(summary_output.read_text())
+    drafted = markdown.split("## Drafted Answers With Proven Solutions", 1)[1].split(
+        "## No Proven Answer Yet",
+        1,
+    )[0]
+    no_proven = markdown.split("## No Proven Answer Yet", 1)[1].split(
+        "## Vocabulary Gaps",
+        1,
+    )[0]
+
+    assert summary["generated"] == 2
+    assert summary["source_count"] == 7
+    assert summary["drafted_answer_count"] == 1
+    assert summary["no_proven_answer_count"] == 1
+    assert "Open Analytics then Attribution then click Download report" in drafted
+    assert "How do I enable SSO for my team?" in no_proven
+    assert "Open Analytics then Attribution then click Download report" not in no_proven
+    assert "tell users exactly what to try next" not in drafted


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Deflection-Report-Artifact.md
Slice phase: Vertical slice

This ships the first pipeline-only $1,500 deflection report artifact: generated FAQ results become a customer-facing Markdown report with ranked question opportunities, resolution-backed answer drafts, and a no-proven-answer section for gaps without verified support resolutions.

## Intentional
- This does not use or depend on the hosted FAQ search route.
- This does not add UI/API selection for saved FAQ reports; that is a separate lane.
- The checked SaaS corpus is labeled synthetic and proves artifact flow, not real customer acceptance.

## Deferred
- Real anonymized customer export validation remains deferred until a sample exists.
- Hosted UI/API exposure remains deferred until the CLI artifact shape is accepted.
- Saved FAQ selection remains deferred to the selection lane.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py -q` - 4 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py` - passed.
- `python scripts/build_content_ops_deflection_report.py extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --source-format csv --output /tmp/content-ops-deflection-report.md --summary-output /tmp/content-ops-deflection-report-summary.json` - passed; 7 ranked opportunities from 36 rows, all no-proven-answer because the checked corpus has no resolution evidence.
- Focused pytest now also covers a mixed resolution-backed/no-proven corpus end to end through the CLI.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed; 126 matching tests enrolled.
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_audit_extracted_pipeline_ci_enrollment.py -q` - 12 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed; 2662 passed, 9 skipped, 1 warning.
- `python scripts/audit_plan_doc.py plans/PR-Content-Ops-Deflection-Report-Artifact.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-Content-Ops-Deflection-Report-Artifact.md` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/content-ops-deflection-report-artifact.md` - passed.

## Diff size
6 files, +772 / -0
