### PR TITLE
Add FAQ deflection report output

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -25,6 +25,9 @@ Currently wired:
   stays `None` when LLM or pool is absent.
 - `faq_markdown`: deterministic ticket FAQ builder. It runs without
   DB, and persists drafts when DB services are enabled.
+- `faq_deflection_report`: deterministic customer-facing report wrapper over
+  the FAQ builder. It runs without DB, and reuses the FAQ persistence path when
+  DB services are enabled.
 
 See `plans/PR-Content-Ops-Execution-Services-Wire-4.md`.
 """
@@ -56,6 +59,9 @@ from extracted_content_pipeline.campaign_postgres import (
 )
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
+)
+from extracted_content_pipeline.faq_deflection_report import (
+    FAQDeflectionReportService,
 )
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationService,
@@ -90,6 +96,9 @@ from extracted_content_pipeline.ticket_faq_postgres import (
 # re-creating it per request would just churn allocations.
 _SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
 _FAQ_MARKDOWN_SERVICE: TicketFAQMarkdownService = TicketFAQMarkdownService()
+_FAQ_DEFLECTION_REPORT_SERVICE: FAQDeflectionReportService = FAQDeflectionReportService(
+    faq_markdown=_FAQ_MARKDOWN_SERVICE
+)
 
 
 def _build_landing_page_service(
@@ -271,6 +280,7 @@ def build_content_ops_execution_services(
     sales_brief = None
     blog_post = None
     faq_markdown = _FAQ_MARKDOWN_SERVICE
+    faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
     if enable_db_services:
         llm = llm_factory()
         skills = skills_factory()
@@ -310,6 +320,7 @@ def build_content_ops_execution_services(
             pool=pool,
         )
         faq_markdown = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
+        faq_deflection_report = FAQDeflectionReportService(faq_markdown=faq_markdown)
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
@@ -319,6 +330,7 @@ def build_content_ops_execution_services(
         sales_brief=sales_brief,
         blog_post=blog_post,
         faq_markdown=faq_markdown,
+        faq_deflection_report=faq_deflection_report,
     )
 
 

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -64,6 +64,7 @@ class ContentOpsExecutionServices:
     sales_brief: Any | None = None
     signal_extraction: Any | None = None
     faq_markdown: Any | None = None
+    faq_deflection_report: Any | None = None
     reasoning_provider_configured: bool = False
     reasoning_provider_outputs: tuple[str, ...] = ()
 
@@ -88,6 +89,8 @@ class ContentOpsExecutionServices:
             return self.signal_extraction
         if output == "faq_markdown":
             return self.faq_markdown
+        if output == "faq_deflection_report":
+            return self.faq_deflection_report
         return None
 
     def configured_outputs(self) -> tuple[str, ...]:
@@ -100,6 +103,7 @@ class ContentOpsExecutionServices:
             "sales_brief",
             "signal_extraction",
             "faq_markdown",
+            "faq_deflection_report",
         ):
             if _has_generate_method(self.for_output(output)):
                 outputs.append(output)
@@ -170,6 +174,8 @@ class ContentOpsExecutionServices:
             signal_extraction=self.signal_extraction,
             # faq_markdown stays as-is; it does not consume reasoning.
             faq_markdown=self.faq_markdown,
+            # faq_deflection_report stays as-is; it does not consume reasoning.
+            faq_deflection_report=self.faq_deflection_report,
             reasoning_provider_configured=bool(active_outputs),
             reasoning_provider_outputs=active_tuple,
         )
@@ -631,6 +637,36 @@ async def _dispatch_faq_markdown(
     )
 
 
+async def _dispatch_faq_deflection_report(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del filters
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        source_material=request.inputs.get("source_material"),
+        report_title=_step_config_text(step.config, "report_title"),
+        faq_title=_step_config_text(step.config, "title"),
+        max_items=_step_config_int(step.config, "max_items"),
+        max_evidence_per_item=_step_config_int(step.config, "max_evidence_per_item"),
+        source_types=_step_config_sequence(step.config, "source_types"),
+        max_text_chars=_step_config_int(step.config, "max_text_chars"),
+        window_days=_step_config_int(step.config, "window_days"),
+        as_of_date=_step_config_text(step.config, "as_of_date"),
+        support_contact=_step_config_text(step.config, "support_contact"),
+        documentation_terms=_step_config_sequence(step.config, "documentation_terms"),
+        vocabulary_gap_rules=_step_config_nested_sequence(
+            step.config,
+            "vocabulary_gap_rules",
+        ),
+    )
+
+
 async def _dispatch_default(
     *,
     step: GenerationPlanStep,
@@ -661,6 +697,7 @@ _DISPATCH: Mapping[str, Any] = {
     "blog_post": _dispatch_blog_post,
     "signal_extraction": _dispatch_signal_extraction,
     "faq_markdown": _dispatch_faq_markdown,
+    "faq_deflection_report": _dispatch_faq_deflection_report,
 }
 
 _MAX_REASONING_VALIDATION_FAILURES = 50

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -207,6 +207,17 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         reasoning_requirement="absent",
         default_parse_retry_attempts=0,
     ),
+    "faq_deflection_report": OutputDefinition(
+        id="faq_deflection_report",
+        label="FAQ Deflection Report",
+        description="Customer-facing deflection report from support-ticket evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.0,
+        required_inputs=("source_material",),
+        default_max_items=20,
+        reasoning_requirement="absent",
+        default_parse_retry_attempts=0,
+    ),
 })
 
 

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -6,7 +6,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from .ticket_faq_markdown import TicketFAQMarkdownResult
+from .campaign_ports import TenantScope
+from .ticket_faq_markdown import TicketFAQMarkdownResult, TicketFAQMarkdownService
 
 
 _RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
@@ -27,6 +28,55 @@ class DeflectionReportArtifact:
             "summary": dict(self.summary),
             "faq_result": self.faq_result.as_dict(),
         }
+
+
+class FAQDeflectionReportService:
+    """Service-shaped generator for customer-facing FAQ deflection reports."""
+
+    def __init__(self, faq_markdown: TicketFAQMarkdownService | None = None) -> None:
+        self._faq_markdown = faq_markdown or TicketFAQMarkdownService()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        source_material: Any,
+        report_title: str | None = None,
+        faq_title: str | None = None,
+        max_items: int | None = None,
+        max_evidence_per_item: int | None = None,
+        source_types: Sequence[str] | None = None,
+        max_text_chars: int | None = None,
+        window_days: int | None = None,
+        as_of_date: Any = None,
+        support_contact: str | None = None,
+        intent_rules: Sequence[tuple[str, Sequence[str]]] | None = None,
+        documentation_terms: Sequence[str] | None = None,
+        vocabulary_gap_rules: Sequence[Sequence[str]] | None = None,
+        **kwargs: Any,
+    ) -> DeflectionReportArtifact:
+        del kwargs
+        faq_result = await self._faq_markdown.generate(
+            scope=scope,
+            target_mode=target_mode,
+            source_material=source_material,
+            title=faq_title,
+            max_items=max_items,
+            max_evidence_per_item=max_evidence_per_item,
+            source_types=source_types,
+            max_text_chars=max_text_chars,
+            window_days=window_days,
+            as_of_date=as_of_date,
+            support_contact=support_contact,
+            intent_rules=intent_rules,
+            documentation_terms=documentation_terms,
+            vocabulary_gap_rules=vocabulary_gap_rules,
+        )
+        return build_deflection_report_artifact(
+            faq_result,
+            title=report_title or "Support Ticket Deflection Report",
+        )
 
 
 def build_deflection_report_artifact(
@@ -294,6 +344,7 @@ def _md(value: Any) -> str:
 
 __all__ = [
     "DeflectionReportArtifact",
+    "FAQDeflectionReportService",
     "build_deflection_report_artifact",
     "deflection_report_summary",
     "render_deflection_report",

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -392,7 +392,7 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
                 "max_text_chars": config.max_text_chars,
             },
         )
-    if output == "faq_markdown":
+    if output in {"faq_markdown", "faq_deflection_report"}:
         config = _faq_markdown_config_for_request(request)
         step_config: dict[str, Any] = {
             "title": config.title,
@@ -413,9 +413,18 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             step_config["vocabulary_gap_rules"] = [
                 list(rule) for rule in config.vocabulary_gap_rules
             ]
+        if output == "faq_deflection_report":
+            step_config["report_title"] = (
+                _text_input(request.inputs, "deflection_report_title")
+                or "Support Ticket Deflection Report"
+            )
         return GenerationPlanStep(
             output=output,
-            runner="TicketFAQMarkdownService.generate",
+            runner=(
+                "FAQDeflectionReportService.generate"
+                if output == "faq_deflection_report"
+                else "TicketFAQMarkdownService.generate"
+            ),
             status="runnable",
             config=step_config,
         )

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -165,6 +165,11 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
         default_preset="none",
         supported_presets=("none",),
     ),
+    "faq_deflection_report": OutputReasoningPolicy(
+        output="faq_deflection_report",
+        default_preset="none",
+        supported_presets=("none",),
+    ),
     "email_campaign": OutputReasoningPolicy(
         output="email_campaign",
         default_preset="single_pass",

--- a/plans/PR-FAQ-Deflection-Report-Output.md
+++ b/plans/PR-FAQ-Deflection-Report-Output.md
@@ -1,0 +1,100 @@
+# PR-FAQ-Deflection-Report-Output
+
+## Why this slice exists
+
+PR-Content-Ops-Deflection-Report-Artifact added a deterministic renderer for
+the $1,500 support-ticket deflection report, but the real Content Ops execute
+surface still only exposes `faq_markdown`. That leaves the deliverable usable
+from the CLI but not from the normal `/content-ops/execute` product flow.
+
+This slice wires the report artifact as a first-class deterministic Content Ops
+output so a support-ticket upload can produce the customer-facing report through
+the same execution path as the FAQ generator.
+
+This exceeds the 400 LOC target because adding one real output must touch the
+catalog, plan, executor, host bundle, reasoning-policy parity, and focused tests
+at each integration point. Splitting those would leave a visible output without
+an executable product path, or an executable path without contract coverage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+
+Slice phase: Vertical slice
+
+1. Add a `faq_deflection_report` output definition and generation-plan mapping.
+2. Add a service-shaped deflection report generator that reuses the existing
+   `TicketFAQMarkdownService` and report renderer.
+3. Wire the host execution-services bundle so the output is available without an
+   LLM and persists FAQ drafts when DB services are enabled.
+4. Prove the output works through the executor and the hosted execute route.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `extracted_content_pipeline/control_surfaces.py` | Adds the output catalog entry. |
+| `extracted_content_pipeline/generation_plan.py` | Maps the output to its runner/config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Dispatches the output through the report service. |
+| `extracted_content_pipeline/faq_deflection_report.py` | Adds the service-shaped generator. |
+| `extracted_content_pipeline/reasoning_policy.py` | Marks the deterministic output as no-reasoning only. |
+| `atlas_brain/_content_ops_services.py` | Wires the host service bundle. |
+| `tests/test_extracted_content_ops_execution.py` | Covers executor behavior. |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | Covers hosted route behavior. |
+| `tests/test_atlas_content_ops_execution_services.py` | Covers host bundle availability. |
+| `tests/test_extracted_content_generation_plan.py` | Covers plan mapping/config. |
+| `tests/test_extracted_content_reasoning_policy.py` | Covers reasoning-policy parity. |
+| `plans/PR-FAQ-Deflection-Report-Output.md` | Documents the slice contract. |
+
+## Mechanism
+
+`FAQDeflectionReportService.generate(...)` takes the same support-ticket inputs
+as `faq_markdown`, delegates row normalization and FAQ generation to
+`TicketFAQMarkdownService.generate(...)`, and wraps the resulting
+`TicketFAQMarkdownResult` with `build_deflection_report_artifact(...)`.
+
+The new `faq_deflection_report` output shares the FAQ config knobs
+(`faq_title`, `faq_max_evidence_per_item`, documentation terms, vocabulary-gap
+rules) and adds `deflection_report_title` for the customer-facing report title.
+The executor returns the artifact dictionary shape, including `markdown`,
+`summary`, and the underlying `faq_result`.
+
+## Intentional
+
+- Keep `faq_markdown` unchanged so existing saved FAQ/search flows remain
+  stable.
+- Do not create a separate DB table for deflection reports in this vertical
+  slice; persistence stays with the underlying saved FAQ drafts.
+- Use `faq_deflection_report` instead of overloading the existing generic
+  `report` output, because that output is already a different intelligence
+  report generator.
+
+## Deferred
+
+- Future PR: persist/export named deflection report artifacts if customers need
+  report lifecycle separate from saved FAQ drafts.
+- Future PR: add UI controls for `faq_deflection_report` after the backend
+  execute contract is stable.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_reasoning_policy.py -q -- 142 passed.
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_reasoning_policy.py -- passed.
+- Command: git diff --check -- passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline -- passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- 2671 passed, 9 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-output.md -- pending.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Service, catalog, plan, executor, and host wiring | 148 |
+| Integration tests | 249 |
+| Plan doc | 100 |
+| **Total** | **497** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -14,7 +14,9 @@ the host has wired. Currently:
 - `blog_post` (E4): same shape as landing_page (no
   IntelligenceRepository); plugs the `PostgresBlogBlueprintRepository`
   (PR #458) + `PostgresBlogPostRepository`.
-- `faq_markdown` (this slice): always wired (stateless).
+- `faq_markdown`: always wired (stateless).
+- `faq_deflection_report` (this slice): always wired (stateless wrapper over
+  `faq_markdown`).
 
 Tests use the factory's dependency-injection kwargs (`llm_factory`
 / `skills_factory` / `pool_factory`) to stub host
@@ -22,7 +24,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (16 tests):
+Test inventory (17 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -41,15 +43,17 @@ Test inventory (16 tests):
 12. `blog_post` skips when no LLM (E4 fallback).
 13. `faq_markdown` runs through the full executor.
 14. `faq_markdown` persists when DB services are enabled.
-15. `configured_outputs()` with LLM + db enabled advertises
-    all 7 outputs: `(email_campaign, blog_post, report,
-    landing_page, sales_brief, signal_extraction, faq_markdown)` -- order
+15. `faq_deflection_report` runs through the full executor.
+16. `configured_outputs()` with LLM + db enabled advertises
+    all 8 outputs: `(email_campaign, blog_post, report,
+    landing_page, sales_brief, signal_extraction, faq_markdown,
+    faq_deflection_report)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-16. `configured_outputs()` without an active LLM (even with
+17. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
-    `signal_extraction` and `faq_markdown`.
+    deterministic outputs.
 """
 
 from __future__ import annotations
@@ -201,6 +205,39 @@ async def test_faq_markdown_persists_when_db_services_enabled() -> None:
     assert "INSERT INTO ticket_faq_markdown" in pool.fetchval_calls[0]["query"]
 
 
+@pytest.mark.asyncio
+async def test_faq_deflection_report_runs_through_host_bundle() -> None:
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "inputs": {
+                "deflection_report_title": "Acme Deflection Report",
+                "source_material": [{
+                    "ticket_id": "ticket-1",
+                    "source_type": "ticket",
+                    "message": "How do I fix failed exports?",
+                    "pain_category": "exports",
+                }]
+            },
+        },
+        services=services,
+    )
+
+    assert result["status"] == "completed", result
+    step = result["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["status"] == "completed"
+    assert step["result"]["summary"]["generated"] == 1
+    assert step["result"]["markdown"].startswith("# Acme Deflection Report")
+    assert "## Ranked Question Opportunities" in step["result"]["markdown"]
+
+
 def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
     """E2 canary: when the LLM factory returns a non-None client
     AND `enable_db_services=True`, the bundle's `landing_page`
@@ -223,6 +260,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
         "sales_brief",
         "signal_extraction",
         "faq_markdown",
+        "faq_deflection_report",
     )
 
 
@@ -240,7 +278,11 @@ def test_landing_page_slot_stays_none_when_no_active_llm() -> None:
     )
 
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
@@ -261,7 +303,11 @@ def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
         enable_db_services=True,
     )
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_landing_page_slot_stays_none_in_production_default() -> None:
@@ -280,7 +326,11 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
     )
 
     assert services.landing_page is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_campaign_wired_when_llm_active_and_db_enabled() -> None:
@@ -340,7 +390,11 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
     assert services.campaign is None
     assert services.report is None
     assert services.sales_brief is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_e3_services_skip_together_when_pool_is_none() -> None:
@@ -361,7 +415,11 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.report is None
     assert services.sales_brief is None
     assert services.blog_post is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_blog_post_wired_when_llm_active_and_db_enabled() -> None:
@@ -393,7 +451,11 @@ def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
         enable_db_services=True,
     )
     assert services.blog_post is None
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )
 
 
 def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
@@ -416,6 +478,7 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         "sales_brief",
         "signal_extraction",
         "faq_markdown",
+        "faq_deflection_report",
     )
 
 
@@ -429,4 +492,8 @@ def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
         pool_factory=_make_pool_stub,
         enable_db_services=True,
     )
-    assert services.configured_outputs() == ("signal_extraction", "faq_markdown")
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_markdown",
+        "faq_deflection_report",
+    )

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -505,6 +505,53 @@ def test_plan_maps_faq_markdown_to_ticket_faq_service():
     }
 
 
+def test_plan_maps_faq_deflection_report_to_report_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 4,
+            "inputs": {
+                "source_material": [
+                    {"source_type": "ticket", "text": "How do I export a report?"}
+                ],
+                "deflection_report_title": "Customer FAQ Deflection Report",
+                "faq_title": "Source FAQ",
+                "faq_documentation_terms": ["Download report"],
+                "faq_vocabulary_gap_rules": [["export", "download"]],
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "FAQDeflectionReportService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "title": "Source FAQ",
+        "max_items": 4,
+        "max_evidence_per_item": 3,
+        "source_types": [
+            "ticket",
+            "support_ticket",
+            "case",
+            "chat",
+            "chat_transcript",
+            "conversation",
+            "transcript",
+            "sales_call",
+            "meeting",
+            "sales_objection",
+            "objection",
+            "complaint",
+            "search_log",
+            "search_query",
+        ],
+        "max_text_chars": 1200,
+        "documentation_terms": ["Download report"],
+        "vocabulary_gap_rules": [["export", "download"]],
+        "report_title": "Customer FAQ Deflection Report",
+    }
+
+
 def test_plan_rejects_faq_as_of_date_without_window_days():
     with pytest.raises(ValueError, match="faq_as_of_date requires faq_window_days"):
         build_generation_plan_from_mapping(

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -18,6 +18,7 @@ from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
 )
+from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 from extracted_content_pipeline.signal_extraction import SignalExtractionService
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
 
@@ -628,6 +629,61 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
         == "Single sign-on setup"
     )
     assert "Billing export is confusing." not in step["result"]["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_faq_deflection_report_from_source_material() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 3,
+            "inputs": {
+                "deflection_report_title": "Acme Support Deflection Report",
+                "faq_title": "Acme Support FAQ",
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-1",
+                        "source_type": "support_ticket",
+                        "subject": "Export attribution",
+                        "message": "How do I export attribution reports?",
+                        "pain_category": "exports",
+                        "resolution_text": (
+                            "Open Analytics, choose Attribution, then select "
+                            "Download report."
+                        ),
+                    },
+                    {
+                        "ticket_id": "ticket-2",
+                        "source_type": "support_ticket",
+                        "subject": "Renewal invoice",
+                        "message": "How do I confirm my renewal invoice before payment?",
+                        "pain_category": "billing",
+                    },
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["runner"] == "FAQDeflectionReportService.generate"
+    assert step["status"] == "completed"
+    assert step["result"]["markdown"].startswith("# Acme Support Deflection Report")
+    assert "## Ranked Question Opportunities" in step["result"]["markdown"]
+    assert "## Drafted Answers With Proven Solutions" in step["result"]["markdown"]
+    assert "Open Analytics, choose Attribution" in step["result"]["markdown"]
+    assert "## No Proven Answer Yet" in step["result"]["markdown"]
+    assert step["result"]["summary"]["source_count"] == 2
+    assert step["result"]["summary"]["drafted_answer_count"] == 1
+    assert step["result"]["summary"]["no_proven_answer_count"] == 1
+    assert step["result"]["faq_result"]["markdown"].startswith("# Acme Support FAQ")
+    assert result["plan"]["steps"][0]["config"]["report_title"] == (
+        "Acme Support Deflection Report"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -23,6 +23,7 @@ from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationService,
 )
@@ -584,6 +585,66 @@ async def test_live_execute_route_accepts_faq_vocabulary_gap_inputs() -> None:
         item["term_mappings"][0]["documentation_term"]
         == "Single sign-on setup"
     )
+
+
+async def test_live_execute_route_returns_faq_deflection_report_artifact() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+    )
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "target_mode": "vendor_retention",
+        "outputs": ["faq_deflection_report"],
+        "limit": 3,
+        "require_quality_gates": False,
+        "inputs": {
+            "deflection_report_title": "Hosted FAQ Deflection Report",
+            "faq_title": "Hosted FAQ Source",
+            "source_material": {
+                "support_tickets": [
+                    {
+                        "ticket_id": "ticket-export-1",
+                        "source_type": "support_ticket",
+                        "subject": "Export report",
+                        "message": "How do I export attribution reports?",
+                        "pain_category": "exports",
+                        "resolution_text": (
+                            "Open Analytics, choose Attribution, then select "
+                            "Download report."
+                        ),
+                    },
+                    {
+                        "ticket_id": "ticket-billing-1",
+                        "source_type": "support_ticket",
+                        "subject": "Renewal invoice",
+                        "message": "How do I confirm my renewal invoice before payment?",
+                        "pain_category": "billing",
+                    },
+                ]
+            },
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert payload["plan"]["steps"][0]["config"]["report_title"] == (
+        "Hosted FAQ Deflection Report"
+    )
+
+    step = payload["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["status"] == "completed"
+    assert step["result"]["summary"]["source_count"] == 2
+    assert step["result"]["summary"]["drafted_answer_count"] == 1
+    assert step["result"]["summary"]["no_proven_answer_count"] == 1
+    assert step["result"]["markdown"].startswith("# Hosted FAQ Deflection Report")
+    assert "## Ranked Question Opportunities" in step["result"]["markdown"]
+    assert "## No Proven Answer Yet" in step["result"]["markdown"]
+    assert step["result"]["faq_result"]["markdown"].startswith("# Hosted FAQ Source")
 
 
 async def test_live_execute_route_handles_bulk_faq_source_material() -> None:

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -50,6 +50,7 @@ def test_output_policy_defaults_match_audit_recommendations() -> None:
     assert defaults == {
         "signal_extraction": "none",
         "faq_markdown": "none",
+        "faq_deflection_report": "none",
         "email_campaign": "single_pass",
         "landing_page": "single_pass",
         "blog_post": "multi_pass_structured",
@@ -102,6 +103,12 @@ def test_faq_markdown_only_supports_no_reasoning() -> None:
     assert supported_reasoning_presets("faq_markdown") == ("none",)
     with pytest.raises(ValueError, match="not supported"):
         resolve_reasoning_policy("faq_markdown", "single_pass")
+
+
+def test_faq_deflection_report_only_supports_no_reasoning() -> None:
+    assert supported_reasoning_presets("faq_deflection_report") == ("none",)
+    with pytest.raises(ValueError, match="not supported"):
+        resolve_reasoning_policy("faq_deflection_report", "single_pass")
 
 
 def test_email_campaign_supports_structured_but_not_strict_preset() -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Output.md
Slice phase: Vertical slice

Expose the $1,500 support-ticket deflection report as a real deterministic Content Ops output. The new `faq_deflection_report` path reuses the proven FAQ generator, wraps the result with the report artifact renderer, and returns it through the normal execute flow with `markdown`, `summary`, and the underlying `faq_result`.

## Intentional
- Keep `faq_markdown` unchanged so saved FAQ/search flows remain stable.
- Do not add a separate report persistence table in this vertical slice; the underlying FAQ draft persistence remains the source of saved customer evidence.
- Use `faq_deflection_report` instead of overloading the existing generic `report` output.

## Deferred
- Future PR: persist/export named deflection report artifacts if customers need report lifecycle separate from saved FAQ drafts.
- Future PR: add UI controls for `faq_deflection_report` after the backend execute contract is stable.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_reasoning_policy.py -q` -- 142 passed.
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_execution_services.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_reasoning_policy.py` -- passed.
- `git diff --check` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 2671 passed, 9 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-output.md` -- pending.

## Diff size
12 files, +480 / -17
