### PR TITLE
PR-FAQ-Deflection-Report-Contract

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -1,0 +1,157 @@
+{
+  "faq_result": {
+    "generated": 2,
+    "items": [
+      {
+        "action_items": [
+          "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report",
+          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "answer": "Customers mention: \"How do I export attribution reports?\" Evidence comes from 2 ticket source(s).",
+        "answer_evidence_status": "resolution_evidence",
+        "displayed_evidence_count": 1,
+        "evidence_count": 1,
+        "evidence_quotes": [
+          "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\""
+        ],
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "frequency": 2,
+        "opportunity_score": 2,
+        "question": "How do I export attribution reports?",
+        "question_source": "customer_wording",
+        "resolution_source_count": 2,
+        "source_ids": [
+          "ticket-export-1",
+          "ticket-export-2"
+        ],
+        "source_labels": [
+          "`ticket-export-1` - Export attribution"
+        ],
+        "source_type_counts": {
+          "support_ticket": 2
+        },
+        "steps": [
+          "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report",
+          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "summary": "Customers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "term_mappings": [
+          {
+            "customer_term": "export",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          },
+          {
+            "customer_term": "report download",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "reporting friction",
+        "weighted_frequency": 2,
+        "weighted_source_volume_by_type": {
+          "support_ticket": 2
+        },
+        "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
+      },
+      {
+        "action_items": [
+          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "answer": "Customers mention: \"Can I turn on SSO for all users?\" Evidence comes from 2 ticket source(s).",
+        "answer_evidence_status": "draft_needs_review",
+        "displayed_evidence_count": 1,
+        "evidence_count": 1,
+        "evidence_quotes": [
+          "`ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\""
+        ],
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "frequency": 2,
+        "opportunity_score": 2,
+        "question": "Can I turn on SSO for all users?",
+        "question_source": "customer_wording",
+        "resolution_source_count": 0,
+        "source_ids": [
+          "ticket-sso-2",
+          "ticket-sso-1"
+        ],
+        "source_labels": [
+          "`ticket-sso-2` - Team login"
+        ],
+        "source_type_counts": {
+          "support_ticket": 2
+        },
+        "steps": [
+          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "summary": "Customers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "term_mappings": [
+          {
+            "customer_term": "SSO",
+            "documentation_term": "Single sign-on setup",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-sso-2",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "other support issues",
+        "weighted_frequency": 2,
+        "weighted_source_volume_by_type": {
+          "support_ticket": 2
+        },
+        "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives."
+      }
+    ],
+    "markdown": "# Support Ticket FAQ Source\n\n_Source rows analyzed: 4. Ticket sources used: 4._\n\n## 1. How do I export attribution reports?\n\nCustomers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n- Customers say \"report download\"; documentation says \"Download report\". Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n## 2. Can I turn on SSO for all users?\n\nCustomers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"SSO\"; documentation says \"Single sign-on setup\". Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.\n\n**Sources:**\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
+    "output_checks": {
+      "condensed": true,
+      "has_action_items": true,
+      "uses_user_vocabulary": true
+    },
+    "saved_ids": [],
+    "source_count": 4,
+    "ticket_source_count": 4,
+    "warnings": []
+  },
+  "markdown": "# Support Ticket Deflection Report\n\n## Executive Summary\n\nThis report analyzed 4 source rows and produced 2 ranked FAQ opportunities from the supplied support data.\n\n- Drafted answers with proven solutions: 1\n- No proven answer yet: 1\n- Ticket sources represented: 4\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |\n|---:|---|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | 2 | drafted from resolution evidence | ticket-export-1, ticket-export-2 |\n| 2 | Can I turn on SSO for all users? | 2 | 2 | no proven answer yet | ticket-sso-2, ticket-sso-1 |\n\n## Drafted Answers With Proven Solutions\n\n### 1. How do I export attribution reports?\n\nUploaded resolution evidence supports this draft answer.\n\n**Draft answer steps:**\n\n1. Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Sources:** ticket-export-1, ticket-export-2\n\n## No Proven Answer Yet\n\n### 1. Can I turn on SSO for all users?\n\nCustomers repeatedly asked this question, but the uploaded data did not include verified resolution evidence for a publishable answer.\n\nNo verified support resolution was present in the uploaded data. Support should add the approved answer before this FAQ is published.\n\n**Sources:** ticket-sso-2, ticket-sso-1\n\n## Vocabulary Gaps\n\n| Customer wording | Documentation term | Suggested update | Source count |\n|---|---|---|---:|\n| export | Download report | Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| report download | Download report | Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| SSO | Single sign-on setup | Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. | 2 |\n\n## Evidence Appendix\n\n### 1. How do I export attribution reports?\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. Can I turn on SSO for all users?\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
+  "summary": {
+    "drafted_answer_count": 1,
+    "generated": 2,
+    "no_proven_answer_count": 1,
+    "output_checks": {
+      "condensed": true,
+      "has_action_items": true,
+      "uses_user_vocabulary": true
+    },
+    "source_count": 4,
+    "ticket_source_count": 4,
+    "top_opportunity_score": 2,
+    "top_question": "How do I export attribution reports?"
+  }
+}

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -1,11 +1,14 @@
 # Content Ops FAQ Report Contract
 
 This is the frontend/demo handoff for generated support-ticket FAQ reports.
-The canonical producer is
+The canonical FAQ producer is
 `extracted_content_pipeline.ticket_faq_markdown.TicketFAQMarkdownResult.as_dict()`.
+The canonical customer-facing deflection report producer is
+`extracted_content_pipeline.faq_deflection_report.DeflectionReportArtifact.as_dict()`.
 
 Use this contract for Content Ops `faq_markdown` execute results, persisted FAQ
-detail hydration, and landing-page demos that render the full generated FAQ
+detail hydration, Content Ops `faq_deflection_report` execute results, and
+landing-page demos that render the full generated FAQ or deflection report
 artifact.
 
 Do not use the compact search result row as the full report. Search returns a
@@ -29,6 +32,44 @@ type TicketFAQMarkdownResult = {
   saved_ids: string[];
 };
 ```
+
+## Deflection Report Artifact
+
+`faq_deflection_report` execute steps return this shape in
+`ContentOpsStepExecution.result`. The nested `faq_result` is the same generated
+FAQ artifact described above; `markdown` is the customer-facing $1,500 report.
+
+```ts
+type FAQDeflectionReportArtifact = {
+  markdown: string;
+  summary: FAQDeflectionReportSummary;
+  faq_result: TicketFAQMarkdownResult;
+};
+
+type FAQDeflectionReportSummary = {
+  generated: number;
+  source_count: number;
+  ticket_source_count: number;
+  drafted_answer_count: number;
+  no_proven_answer_count: number;
+  output_checks: {
+    uses_user_vocabulary: boolean;
+    condensed: boolean;
+    has_action_items: boolean;
+  };
+  top_question: string;
+  top_opportunity_score: number;
+};
+```
+
+The report Markdown always contains these customer-facing sections:
+
+- `Executive Summary`
+- `Ranked Question Opportunities`
+- `Drafted Answers With Proven Solutions`
+- `No Proven Answer Yet`
+- `Vocabulary Gaps`
+- `Evidence Appendix`
 
 ## FAQ Item
 
@@ -131,14 +172,22 @@ type TicketFAQSearchResponse = {
 ## Rendering Guidance
 
 - Use `items` for ranked cards or sections, and `markdown` for the full report.
+- For `faq_deflection_report`, render top-level `markdown` as the deliverable.
+  Use `summary` for proof badges and `faq_result` for drill-down cards.
 - Show `source_count`, `ticket_source_count`, and `output_checks` as proof badges.
 - Show `answer_evidence_status` near steps. `draft_needs_review` means the
   system found repeated customer wording but no uploaded resolution evidence, so
   the generated steps are review placeholders.
+- In deflection reports, `drafted_answer_count` counts only FAQ opportunities
+  backed by uploaded resolution evidence. `no_proven_answer_count` is not a
+  failure; it is the list of repeated questions where support has not supplied a
+  verified answer yet.
 - Show `term_mappings` as vocabulary-gap suggestions. These are grounded in the
   supplied documentation terms/rules and customer wording.
 - Treat `source_ids` and `evidence_quotes` as proof links/footnotes, not primary
   marketing copy.
 
 See [`content_ops_faq_report_example.json`](./content_ops_faq_report_example.json)
-for a current compact example.
+for a current compact FAQ example and
+[`content_ops_faq_deflection_report_example.json`](./content_ops_faq_deflection_report_example.json)
+for a current compact deflection report example.

--- a/plans/PR-FAQ-Deflection-Report-Contract.md
+++ b/plans/PR-FAQ-Deflection-Report-Contract.md
@@ -1,0 +1,85 @@
+# PR-FAQ-Deflection-Report-Contract
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Report-Output made `faq_deflection_report` a real Content Ops
+execute output, but the frontend/demo handoff doc still only describes
+`faq_markdown`. The next consumer needs a stable contract for the customer-facing
+deflection report artifact shape without reverse-engineering the Python result.
+
+This slice documents the new output shape and adds a checked example so the docs
+stay aligned with the producer.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+
+Slice phase: Product polish
+
+1. Extend the FAQ report frontend contract with the `faq_deflection_report`
+   execute result shape.
+2. Add a compact deflection report example JSON generated from the same support
+   ticket style as the existing FAQ example.
+3. Extend the contract-doc test to verify the example keys match the real
+   deflection report artifact dictionary shape.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `docs/frontend/content_ops_faq_report_contract.md` | Documents the deflection report execute result and rendering guidance. |
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | Adds a compact frontend/demo example artifact. |
+| `tests/test_content_ops_faq_report_contract_docs.py` | Verifies the new example matches producer shape and the doc links it. |
+| `plans/PR-FAQ-Deflection-Report-Contract.md` | Documents this slice contract. |
+
+## Mechanism
+
+The docs name the deflection report artifact dictionary output as the canonical
+producer contract for `faq_deflection_report`. The example carries the
+top-level `markdown`, `summary`, and `faq_result` keys that the execute route
+returns inside `steps[0].result`.
+
+The test builds a real FAQ result, wraps it with
+`build_deflection_report_artifact(...)`, and compares the checked-in example's
+top-level keys, summary keys, and nested FAQ result keys against the producer.
+
+## Intentional
+
+- This is docs/contract only; no runtime behavior changes.
+- The example is compact and synthetic, but labeled as an example artifact, not
+  customer proof.
+- Keep the existing `content_ops_faq_report_example.json` unchanged so current
+  `faq_markdown` consumers are not disrupted.
+
+## Deferred
+
+- Future PR: update Intel UI controls after the backend and handoff contract are
+  both landed.
+- Future PR: add a real anonymized customer example when a design-partner export
+  exists.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q
+  - Result: 3 passed.
+- Command: python -m py_compile tests/test_content_ops_faq_report_contract_docs.py
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Contract.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Contract.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-contract.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Contract doc | 55 |
+| Example JSON | 157 |
+| Tests | 77 |
+| Plan doc | 85 |
+| **Total** | **371** |

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -1,12 +1,18 @@
 import json
 from pathlib import Path
 
+from extracted_content_pipeline.faq_deflection_report import (
+    build_deflection_report_artifact,
+)
 from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DOC_PATH = ROOT / "docs/frontend/content_ops_faq_report_contract.md"
 EXAMPLE_PATH = ROOT / "docs/frontend/content_ops_faq_report_example.json"
+DEFLECTION_EXAMPLE_PATH = (
+    ROOT / "docs/frontend/content_ops_faq_deflection_report_example.json"
+)
 
 
 def _producer_report_shape() -> tuple[set[str], set[str]]:
@@ -40,6 +46,55 @@ def _producer_report_shape() -> tuple[set[str], set[str]]:
 
     assert result.items
     return set(result.as_dict()), set(result.items[0])
+
+
+def _producer_deflection_report_payload() -> dict[str, object]:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "source_title": "Export attribution",
+                "text": "How do I export attribution reports?",
+                "resolution_text": (
+                    "Open Analytics, choose Attribution, then click Download report"
+                ),
+            },
+            {
+                "source_id": "ticket-export-2",
+                "source_type": "support_ticket",
+                "source_title": "Report download",
+                "text": "Where is the report download for attribution exports?",
+                "resolution_text": (
+                    "Open Analytics, choose Attribution, then click Download report"
+                ),
+            },
+            {
+                "source_id": "ticket-sso-1",
+                "source_type": "support_ticket",
+                "source_title": "SSO setup",
+                "text": "How do I enable SSO for my team?",
+            },
+            {
+                "source_id": "ticket-sso-2",
+                "source_type": "support_ticket",
+                "source_title": "Team login",
+                "text": "Can I turn on SSO for all users?",
+            },
+        ],
+        title="Support Ticket FAQ Source",
+        max_items=2,
+        max_evidence_per_item=1,
+        support_contact="https://example.com/support",
+        documentation_terms=("Download report", "Single sign-on setup"),
+        vocabulary_gap_rules=(
+            ("export", "Download report"),
+            ("SSO", "Single sign-on setup"),
+            ("report download", "Download report"),
+        ),
+    )
+
+    return build_deflection_report_artifact(result).as_dict()
 
 
 def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
@@ -82,9 +137,31 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
         assert item["source_ids"]
 
 
+def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
+    payload = json.loads(DEFLECTION_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    producer_payload = _producer_deflection_report_payload()
+
+    assert set(payload) == set(producer_payload)
+    assert set(payload["summary"]) == set(producer_payload["summary"])
+    assert set(payload["faq_result"]) == set(producer_payload["faq_result"])
+    assert payload["summary"]["drafted_answer_count"] == 1
+    assert payload["summary"]["no_proven_answer_count"] == 1
+    assert payload["summary"]["generated"] == len(payload["faq_result"]["items"])
+    assert payload["summary"]["output_checks"] == {
+        "condensed": True,
+        "has_action_items": True,
+        "uses_user_vocabulary": True,
+    }
+    assert all(payload["faq_result"]["output_checks"].values())
+    assert "## Drafted Answers With Proven Solutions" in payload["markdown"]
+    assert "## No Proven Answer Yet" in payload["markdown"]
+
+
 def test_content_ops_faq_report_contract_links_example() -> None:
     doc = DOC_PATH.read_text(encoding="utf-8")
 
     assert "content_ops_faq_report_example.json" in doc
+    assert "content_ops_faq_deflection_report_example.json" in doc
     assert "account_id: string;" in doc
     assert EXAMPLE_PATH.exists()
+    assert DEFLECTION_EXAMPLE_PATH.exists()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Contract.md
Slice phase: Product polish

Documents the `faq_deflection_report` execute result contract now that the backend output is wired, and adds a checked frontend/demo example so downstream sessions do not have to reverse-engineer the Python artifact shape.

## Intentional
- This is docs/contract only; no runtime behavior changes.
- The example is compact and synthetic, but labeled as an example artifact, not customer proof.
- The existing `content_ops_faq_report_example.json` stays unchanged for current `faq_markdown` consumers.

## Deferred
- Future PR: update Intel UI controls after the backend and handoff contract are both landed.
- Future PR: add a real anonymized customer example when a design-partner export exists.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_faq_report_contract_docs.py -q` — 3 passed.
- `python -m py_compile tests/test_content_ops_faq_report_contract_docs.py` — passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Contract.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Contract.md` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-contract.md` — passed.

## Diff size
4 files, +371 / -3
