### PR TITLE
PR-FAQ-Deflection-Execute-Limit

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -36,6 +36,7 @@ else:
 
 from ..campaign_ports import TenantScope
 from ..campaign_postgres_import import import_campaign_opportunities
+from ..campaign_source_adapters import source_material_to_source_rows
 from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -121,6 +122,10 @@ _INPUT_PROVIDER_RESPONSE_METADATA_KEYS = frozenset({
     "skipped_row_count",
     "truncated_row_count",
 })
+_FAQ_SOURCE_MATERIAL_LIMITED_OUTPUTS = frozenset({
+    "faq_markdown",
+    "faq_deflection_report",
+})
 _SOURCE_MATERIAL_ROW_LIST_KEYS = {
     "sources",
     "opportunities",
@@ -133,8 +138,8 @@ _SOURCE_MATERIAL_ROW_LIST_KEYS = {
     "conversations",
     "feedback",
     "rows",
+    "items",
 }
-
 
 def _build_static_catalog_payload() -> Mapping[str, Any]:
     # PR-Describe-Control-Surfaces-Cache: the outputs/presets metadata
@@ -1267,7 +1272,7 @@ def _enforce_faq_execute_source_material_limit(
         outputs = resolve_outputs(request)
     except ValueError:
         return
-    if "faq_markdown" not in outputs:
+    if not _FAQ_SOURCE_MATERIAL_LIMITED_OUTPUTS.intersection(outputs):
         return
     inputs = payload.get("inputs")
     if not isinstance(inputs, Mapping):
@@ -1287,16 +1292,7 @@ def _enforce_faq_execute_source_material_limit(
 
 
 def _source_material_row_count(source_material: Any) -> int:
-    if isinstance(source_material, (list, tuple)):
-        return len(source_material)
-    if not isinstance(source_material, Mapping):
-        return 0
-    total = 0
-    for key in _SOURCE_MATERIAL_ROW_LIST_KEYS:
-        rows = source_material.get(key)
-        if isinstance(rows, (list, tuple)):
-            total += len(rows)
-    return total
+    return len(source_material_to_source_rows(source_material))
 
 
 async def _structured_reasoning_contexts(

--- a/plans/PR-FAQ-Deflection-Execute-Limit.md
+++ b/plans/PR-FAQ-Deflection-Execute-Limit.md
@@ -1,0 +1,82 @@
+# PR-FAQ-Deflection-Execute-Limit
+
+## Why this slice exists
+
+`faq_deflection_report` now runs through the same source-material FAQ generation
+path as `faq_markdown`, but the sync execute admission guard only recognizes
+`faq_markdown`. That leaves the new customer-facing report output able to bypass
+the configured inline source row cap.
+
+This slice closes that survivability gap at the shared route guard instead of
+adding per-service patchwork.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+
+Slice phase: Production hardening
+
+1. Apply the existing FAQ sync execute source-material row limit to both
+   `faq_markdown` and `faq_deflection_report`.
+2. Add a focused negative route test proving oversized `faq_deflection_report`
+   source material fails before service execution.
+3. Count the expanded source rows the execute path will consume, including FAQ
+   output bundle `items`.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `extracted_content_pipeline/api/control_surfaces.py` | Extends the FAQ execute row-limit guard to cover the deflection report output. |
+| `tests/test_extracted_content_control_surface_api.py` | Adds the regression test for the deflection report guard branch. |
+| `plans/PR-FAQ-Deflection-Execute-Limit.md` | Documents this slice contract. |
+
+## Mechanism
+
+The route-level helper that enforces `faq_execute_max_source_material_rows`
+now checks a single FAQ-limited output set. If the requested outputs include
+either FAQ Markdown or the deflection report, it counts rows in `inputs.source_material`
+through the same `source_material_to_source_rows(...)` adapter the execute path
+uses. That keeps generated FAQ output bundles from being counted as one top-level
+object when execution will expand their `items` into multiple rows.
+
+The guard returns the existing 413 envelope when the configured cap is exceeded.
+
+## Intentional
+
+- This reuses the existing 413 reason and payload so operators do not get a new
+  error contract for the same upload-size policy.
+- No runtime service behavior changes; the guard runs before service dispatch.
+- The row counter now reuses the shared source-row adapter instead of keeping a
+  second partial row-count implementation in the route.
+
+## Deferred
+
+- Parked hardening: none.
+- Future robust-testing slice: larger `faq_deflection_report` route generation
+  throughput and latency proof once the report output is exercised under the
+  same scale harness as `faq_markdown`.
+
+## Verification
+
+- Command: python -m pytest tests/test_extracted_content_control_surface_api.py -q -k "faq_source_material or source_material_bundle_1000 or non_source_material_arrays or nested_source_material"
+  - Result: 7 passed, 113 deselected.
+- Command: python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Execute-Limit.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Execute-Limit.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-execute-limit.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Route guard | 20 |
+| Tests | 80 |
+| Plan doc | 82 |
+| **Total** | **182** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2478,6 +2478,86 @@ async def test_execute_generation_route_rejects_faq_source_material_over_configu
 
 
 @pytest.mark.asyncio
+async def test_execute_generation_route_rejects_faq_source_material_deflection_report_over_configured_limit():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=service
+        ),
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_deflection_report"],
+                "inputs": {
+                    "source_material": [
+                        {
+                            "source_type": "ticket",
+                            "text": f"Ticket row {index}",
+                        }
+                        for index in range(3)
+                    ],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail["reason"] == "faq_source_material_too_large_for_sync_execute"
+    assert exc.value.detail["max_source_material_rows"] == 2
+    assert exc.value.detail["source_material_rows"] == 3
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_counts_faq_source_material_bundle_items():
+    service = _CampaignService()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            faq_execute_max_source_material_rows=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=service
+        ),
+    )
+    faq_output = {
+        "generated": 3,
+        "markdown": "# FAQ",
+        "output_checks": {"condensed": True},
+        "ticket_source_count": 3,
+        "items": [
+            {
+                "question": f"How do I handle FAQ item {index}?",
+                "summary": "Customer wording from the generated FAQ output.",
+                "answer_evidence_status": "draft_needs_review",
+            }
+            for index in range(3)
+        ],
+    }
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_deflection_report"],
+                "inputs": {"source_material": faq_output},
+            }
+        )
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail["source_material_rows"] == 3
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
 async def test_execute_generation_route_checks_input_provider_faq_rows_after_merge():
     service = _CampaignService()
     provider = _SyncInputProvider(


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Execute-Limit.md
Slice phase: Production hardening

Closes the sync execute admission gap where `faq_deflection_report` could bypass the FAQ source-material row cap even though it runs through the same FAQ generator path as `faq_markdown`.

## Intentional
- Reuses the existing 413 reason and payload for the same upload-size policy.
- No runtime service behavior changes; the guard runs before service dispatch.
- Reuses the shared `source_material_to_source_rows(...)` adapter for row counts so generated FAQ output bundle `items` are counted the same way execute consumes them.

## Deferred
- Future robust-testing slice: larger `faq_deflection_report` route generation throughput and latency proof once the report output is exercised under the same scale harness as `faq_markdown`.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_content_control_surface_api.py -q -k "faq_source_material or source_material_bundle_1000 or non_source_material_arrays or nested_source_material"` — 7 passed, 113 deselected.
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` — passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Execute-Limit.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Execute-Limit.md` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-execute-limit.md` — passed.

## Diff size
3 files, +170 / -12
