### PR TITLE
Prove FAQ get-draft tenant isolation

### DIFF
--- a/plans/PR-FAQ-Get-Draft-Postgres-Isolation.md
+++ b/plans/PR-FAQ-Get-Draft-Postgres-Isolation.md
@@ -1,0 +1,84 @@
+# FAQ Get Draft Postgres Isolation
+
+## Why this slice exists
+
+#1121 proved the execute route can load a selected FAQ draft ID through the
+Atlas input-provider repository seam and feed both landing/blog generators. The
+reviewer correctly called out the remaining completeness proof: the in-process
+smoke verifies scope-threading, but not the real Postgres fetch isolation.
+
+This slice adds the real-Postgres check that account B cannot load account A's
+saved FAQ draft by ID.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+Slice phase: Functional validation
+
+1. Add an env-gated Postgres integration test for
+   `PostgresTicketFAQRepository.get_draft(...)`.
+2. Save a FAQ draft under one generated account, fetch it successfully with
+   that account scope, and assert a different account scope returns `None` for
+   the same draft ID.
+3. Reuse the existing `EXTRACTED_DATABASE_URL` / `DATABASE_URL` integration-test
+   convention and clean up inserted rows by generated account ID.
+
+### Files touched
+
+- `tests/test_extracted_ticket_faq_postgres.py`
+- `plans/PR-FAQ-Get-Draft-Postgres-Isolation.md`
+
+## Mechanism
+
+The test imports `asyncpg` with `pytest.importorskip`, reads the same database
+URL environment variables used by existing FAQ search integration tests, applies
+the `325_ticket_faq_markdown.sql` migration, and uses the real
+`PostgresTicketFAQRepository` to save a draft.
+
+It then calls:
+
+```python
+await repo.get_draft(saved_id, scope=TenantScope(account_id=account_a))
+await repo.get_draft(saved_id, scope=TenantScope(account_id=account_b))
+```
+
+The first call must return the draft; the second must return `None`.
+
+## Intentional
+
+- This is repository-level, not another execute-route smoke. #1121 already
+  proved execute wiring; this slice proves the SQL-backed isolation boundary
+  that the execute route relies on.
+- The test is env-gated like the existing Postgres FAQ/search tests, so normal
+  CI without a database skips it instead of failing.
+- No production code changes are expected. If the test fails against a real DB,
+  the repository query would be fixed here.
+
+## Deferred
+
+- Future PR: hosted/live execute runbook artifact if operators need a recorded
+  environment proof that combines route execution and live Postgres in one
+  smoke.
+- Future PR: richer saved-FAQ picker with search/status filters if operators
+  need more than the recent list.
+- Parked hardening: none.
+
+## Verification
+
+Run locally:
+
+- Command: python -m pytest tests/test_extracted_ticket_faq_postgres.py::test_get_draft_is_tenant_scoped_against_postgres -q
+  - skipped locally: `EXTRACTED_DATABASE_URL` / `DATABASE_URL` not set
+- Command: python -m pytest tests/test_extracted_ticket_faq_postgres.py -q
+  - 18 passed, 1 skipped
+- Command: python -m py_compile tests/test_extracted_ticket_faq_postgres.py
+  - passed
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-get-draft-postgres-isolation.md
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Postgres isolation test | ~55 |
+| Plan doc | ~78 |
+| **Total** | **~133** |

--- a/tests/test_extracted_ticket_faq_postgres.py
+++ b/tests/test_extracted_ticket_faq_postgres.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -220,6 +223,51 @@ async def test_get_draft_returns_none_on_miss() -> None:
     )
 
     assert draft is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_draft_is_tenant_scoped_against_postgres() -> None:
+    asyncpg = pytest.importorskip("asyncpg")
+    database_url = os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not database_url:
+        pytest.skip("EXTRACTED_DATABASE_URL or DATABASE_URL is required")
+
+    root = Path(__file__).resolve().parents[1]
+    run_id = uuid4().hex
+    account_a = f"acct-faq-get-a-{run_id}"
+    account_b = f"acct-faq-get-b-{run_id}"
+    pool = await asyncpg.create_pool(database_url, min_size=1, max_size=2)
+    repo = PostgresTicketFAQRepository(pool)
+
+    try:
+        await pool.execute(
+            (root / "atlas_brain/storage/migrations/325_ticket_faq_markdown.sql").read_text()
+        )
+        saved_ids = await repo.save_drafts([
+            _draft(),
+        ], scope=TenantScope(account_id=account_a))
+        saved_id = saved_ids[0]
+
+        account_a_draft = await repo.get_draft(
+            saved_id,
+            scope=TenantScope(account_id=account_a),
+        )
+        account_b_draft = await repo.get_draft(
+            saved_id,
+            scope=TenantScope(account_id=account_b),
+        )
+
+        assert account_a_draft is not None
+        assert account_a_draft.id == saved_id
+        assert account_a_draft.title == "Support FAQ"
+        assert account_b_draft is None
+    finally:
+        await pool.execute(
+            "DELETE FROM ticket_faq_markdown WHERE account_id = ANY($1::text[])",
+            [account_a, account_b],
+        )
+        await pool.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Get-Draft-Postgres-Isolation.md
Slice phase: Functional validation

#1121 proved selected FAQ IDs reach landing/blog execute context through the input-provider repository seam. This slice adds the real Postgres completeness proof the review called out: a saved FAQ draft ID can be fetched by its owning account, but a different account scope returns `None` for the same ID.

## Intentional
- Repository-level Postgres integration, not another execute-route smoke. #1121 already proves execute wiring; this proves the SQL-backed isolation boundary it relies on.
- Env-gated with the existing `EXTRACTED_DATABASE_URL` / `DATABASE_URL` convention, so environments without a DB skip cleanly.
- No production code changes expected; if the integration fails against a real DB, the repository query would be fixed here.

## Deferred
- Future PR: hosted/live execute runbook artifact if operators need a recorded environment proof that combines route execution and live Postgres in one smoke.
- Future PR: richer saved-FAQ picker with search/status filters if operators need more than the recent list.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_postgres.py::test_get_draft_is_tenant_scoped_against_postgres -q` — skipped locally; no `EXTRACTED_DATABASE_URL` / `DATABASE_URL`
- `python -m pytest tests/test_extracted_ticket_faq_postgres.py -q` — 18 passed, 1 skipped
- `python -m py_compile tests/test_extracted_ticket_faq_postgres.py` — passed
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-get-draft-postgres-isolation.md` — passed

## Diff size
2 files, +132 / -0