### PR TITLE
Close out FAQ output ingestion backlog

### DIFF
--- a/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
+++ b/docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md
@@ -67,6 +67,11 @@ The following items appear in older plan docs but are no longer active backlog:
 - Landing-page SEO/AEO/GEO input contract, prompt consumption, save-time
   readiness, review UI, draft edit/repair, public rendering,
   sitemap/prerender, publish verification, and generation smoke coverage.
+- FAQ output as ingestion source for blog/landing generation, including
+  grounded resolution-evidence bridging, selected saved FAQ draft IDs, the New
+  Run saved-FAQ selector, execute-route context proof, Postgres tenant
+  isolation, and live execute-harness coverage with the real landing/blog
+  generation services.
 
 ## Active Backlog
 
@@ -250,6 +255,18 @@ needed financial complaint action policy before SaaS-style reporting/account
 rules. Those source-level fixes landed in the FAQ complaint/source-policy
 chain. Future FAQ/source work should be driven by a real customer help desk
 export, hosted UI need, or another real dataset exposing a generic policy gap.
+
+**FAQ output-as-ingestion closeout:** PRs #1109, #1113, #1114, #1116, #1118,
+#1121, #1123, and #1125 closed the current saved-FAQ reuse path. Generated FAQ
+output now adapts into canonical `faq_output` source rows, resolution-backed FAQ
+steps bridge into the existing support-ticket `resolution_text` contract, the
+host input provider can load selected saved FAQ drafts by `inputs.source_faq_ids`,
+the New Run UI can send those IDs, the execute route proves selected IDs reach
+landing/blog context, the SQL-backed `get_draft` lookup is tenant-scoped, and
+the live execute harness proves the real landing-page and blog-post generation
+services consume selected FAQ IDs. This does not create a new active
+implementation backlog. A hosted/live execute runbook artifact or richer
+saved-FAQ picker should be added only if operators need those surfaces.
 
 **Real CFPB output-quality update:** A follow-up run against three 150-row
 samples from the same local CFPB export (`Debt collection`, `Credit reporting,

--- a/plans/PR-FAQ-Output-Ingestion-Closeout.md
+++ b/plans/PR-FAQ-Output-Ingestion-Closeout.md
@@ -1,0 +1,79 @@
+# PR-FAQ-Output-Ingestion-Closeout
+
+## Why this slice exists
+
+The FAQ-output ingestion chain is now complete for the current product contract:
+FAQ output can become source material, grounded resolution evidence survives the
+bridge, saved FAQ reports can be selected by ID, the UI can send those IDs, the
+execute route proves selected IDs reach landing/blog context, real Postgres
+tenant isolation is covered, and the live execute harness proves the actual
+landing/blog services consume selected FAQ IDs.
+
+The deferred backlog still only records the older FAQ output-contract state.
+That stale note could steer another session into rebuilding closed work.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-output-ingestion
+
+Slice phase: Workflow/process
+
+1. Move the FAQ-output ingestion bridge and selected saved-FAQ ID reuse path
+   into the retired/closed backlog summary.
+2. Update the FAQ output-contract note with the merged chain through #1125.
+3. Keep remaining future work framed as trigger-based, not active backlog.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_deferred_backlog_2026-05-11.md`
+- `plans/PR-FAQ-Output-Ingestion-Closeout.md`
+
+## Mechanism
+
+The backlog update adds the completed FAQ-output ingestion path to the retired
+historical deferrals and extends the FAQ output-contract update with the actual
+merged chain:
+
+- FAQ output as source material
+- resolution-evidence bridge
+- selected saved FAQ by ID
+- UI selector
+- route/context smoke
+- Postgres tenant isolation proof
+- live execute harness proof with real landing/blog services
+
+The remaining hosted runbook artifact and richer picker are described as
+future work only if operators need them.
+
+## Intentional
+
+- Docs-only closeout. No runtime code, tests, or UI behavior changes.
+- This does not close FAQ generation itself as a product area; it closes this
+  lane's FAQ-output-as-ingestion-source path for the current contract.
+
+## Deferred
+
+- Future PR: hosted/live execute runbook artifact only if operators need an
+  environment-recorded proof beyond the test suite.
+- Future PR: richer saved-FAQ picker with search/status filters only if recent
+  saved reports are not enough for operators.
+- Parked hardening: none.
+
+## Verification
+
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Output-Ingestion-Closeout.md
+  - Result: passed.
+- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Output-Ingestion-Closeout.md
+  - Result: passed after staging the plan doc.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-ingestion-closeout.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backlog closeout | ~17 |
+| Plan doc | ~82 |
+| **Total** | **~99** |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Output-Ingestion-Closeout.md
Slice phase: Workflow/process

The FAQ-output ingestion path is closed for the current contract, but the deferred backlog still described only the older FAQ output lifecycle state. This docs-only slice records the completed chain through #1125 so future sessions do not rebuild closed work.

## Intentional
- Docs-only closeout. No runtime code, tests, or UI behavior changes.
- Closes this lane's FAQ-output-as-ingestion-source path for the current contract, not FAQ generation as a product area.

## Deferred
- Future PR: hosted/live execute runbook artifact only if operators need an environment-recorded proof beyond the test suite.
- Future PR: richer saved-FAQ picker with search/status filters only if recent saved reports are not enough for operators.

## Parked hardening
- None.

## Verification
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Output-Ingestion-Closeout.md` — passed
- `python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Output-Ingestion-Closeout.md` — passed
- `git diff --check` — passed
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-output-ingestion-closeout.md` — passed

## Diff size
2 files, +94 / -0