### PR TITLE
Add FAQ macro writeback preview

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -172,15 +172,15 @@ def build_macro_writeback_preview(
 
 
 def _macro_body(item: Mapping[str, Any]) -> str:
-    for key in ("resolution_text", "answer"):
-        value = _clean_text(item.get(key))
-        if value:
-            return value
+    resolution_text = _clean_text(item.get("resolution_text"))
+    if resolution_text:
+        return resolution_text
 
     steps = _string_tuple(item.get("steps"))
-    if not steps:
-        return ""
-    return "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
+    if steps:
+        return "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
+
+    return _clean_text(item.get("answer"))
 
 
 def _item_id(

--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -1,0 +1,230 @@
+"""Preview support-tool macro writeback from approved FAQ drafts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .ticket_faq_ports import TicketFAQDraft
+
+
+APPROVED_FAQ_STATUS = "approved"
+RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
+
+MacroPublishStatus = Literal["dry_run", "published", "updated", "skipped", "failed"]
+MacroSkipReason = Literal["draft_not_approved", "answer_not_verified", "missing_question", "missing_resolution_body"]
+
+
+@dataclass(frozen=True)
+class SupportMacroDraft:
+    """Platform-agnostic support macro / saved reply draft."""
+
+    title: str
+    body: str
+    category: str = ""
+    faq_draft_id: str = ""
+    faq_item_id: str = ""
+    source_ids: tuple[str, ...] = ()
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        data = asdict(self)
+        data["source_ids"] = list(self.source_ids)
+        return data
+
+
+@dataclass(frozen=True)
+class MacroWritebackSkippedItem:
+    """FAQ item that was not eligible for macro writeback."""
+
+    reason: MacroSkipReason
+    faq_draft_id: str = ""
+    faq_item_id: str = ""
+    question: str = ""
+    draft_status: str = ""
+    answer_evidence_status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MacroPublishResult:
+    """Per-item result returned by a macro writeback provider."""
+
+    macro: SupportMacroDraft
+    status: MacroPublishStatus
+    external_id: str = ""
+    error: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "macro": self.macro.as_dict(),
+            "status": self.status,
+            "external_id": self.external_id,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class MacroWritebackPreview:
+    """Dry-run preview of macros that would be written back."""
+
+    macros: tuple[SupportMacroDraft, ...] = ()
+    skipped: tuple[MacroWritebackSkippedItem, ...] = ()
+
+    @property
+    def publishable_count(self) -> int:
+        return len(self.macros)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "publishable_count": self.publishable_count,
+            "skipped_count": self.skipped_count,
+            "macros": [macro.as_dict() for macro in self.macros],
+            "skipped": [item.as_dict() for item in self.skipped],
+        }
+
+
+class MacroPublishProvider(Protocol):
+    async def publish(
+        self,
+        macros: Sequence[SupportMacroDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[MacroPublishResult]:
+        """Publish or preview support macros for one tenant scope."""
+
+
+class DryRunMacroPublishProvider:
+    async def publish(
+        self,
+        macros: Sequence[SupportMacroDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[MacroPublishResult]:
+        _ = scope
+        return tuple(MacroPublishResult(macro=macro, status="dry_run") for macro in macros)
+
+
+def build_macro_writeback_preview(
+    drafts: Sequence[TicketFAQDraft],
+) -> MacroWritebackPreview:
+    """Return publishable macro drafts and explicit skip reasons."""
+
+    macros: list[SupportMacroDraft] = []
+    skipped: list[MacroWritebackSkippedItem] = []
+
+    for draft in drafts:
+        for index, item in enumerate(draft.items, start=1):
+            item_id = _item_id(draft, item, index)
+            question = _clean_text(item.get("question"))
+            evidence_status = _clean_text(item.get("answer_evidence_status"))
+            draft_status = _clean_text(draft.status)
+
+            def skip(reason: MacroSkipReason) -> None:
+                skipped.append(
+                    MacroWritebackSkippedItem(
+                        reason=reason,
+                        faq_draft_id=_clean_text(draft.id),
+                        faq_item_id=item_id,
+                        question=question,
+                        draft_status=draft_status,
+                        answer_evidence_status=evidence_status,
+                    )
+                )
+
+            if draft_status != APPROVED_FAQ_STATUS:
+                skip("draft_not_approved")
+                continue
+            if evidence_status != RESOLUTION_EVIDENCE_STATUS:
+                skip("answer_not_verified")
+                continue
+            if not question:
+                skip("missing_question")
+                continue
+            body = _macro_body(item)
+            if not body:
+                skip("missing_resolution_body")
+                continue
+            macros.append(
+                SupportMacroDraft(
+                    title=question,
+                    body=body,
+                    category=_clean_text(item.get("topic")),
+                    faq_draft_id=_clean_text(draft.id),
+                    faq_item_id=item_id,
+                    source_ids=_string_tuple(item.get("source_ids")),
+                    metadata={
+                        "target_id": draft.target_id,
+                        "target_mode": draft.target_mode,
+                        "draft_title": draft.title,
+                    },
+                )
+            )
+
+    return MacroWritebackPreview(macros=tuple(macros), skipped=tuple(skipped))
+
+
+def _macro_body(item: Mapping[str, Any]) -> str:
+    for key in ("resolution_text", "answer"):
+        value = _clean_text(item.get(key))
+        if value:
+            return value
+
+    steps = _string_tuple(item.get("steps"))
+    if not steps:
+        return ""
+    return "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
+
+
+def _item_id(
+    draft: TicketFAQDraft,
+    item: Mapping[str, Any],
+    index: int,
+) -> str:
+    for key in ("faq_item_id", "id", "source_id"):
+        value = _clean_text(item.get(key))
+        if value:
+            return value
+    draft_id = _clean_text(draft.id)
+    if draft_id:
+        return f"{draft_id}:item-{index}"
+    return f"item-{index}"
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        cleaned = _clean_text(value)
+        return (cleaned,) if cleaned else ()
+    if isinstance(value, Sequence):
+        return tuple(cleaned for item in value if (cleaned := _clean_text(item)))
+    return ()
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).strip().split())
+
+
+__all__ = [
+    "APPROVED_FAQ_STATUS",
+    "RESOLUTION_EVIDENCE_STATUS",
+    "DryRunMacroPublishProvider",
+    "MacroPublishProvider",
+    "MacroPublishResult",
+    "MacroPublishStatus",
+    "MacroSkipReason",
+    "MacroWritebackPreview",
+    "MacroWritebackSkippedItem",
+    "SupportMacroDraft",
+    "build_macro_writeback_preview",
+]

--- a/plans/PR-FAQ-Macro-Writeback-Preview.md
+++ b/plans/PR-FAQ-Macro-Writeback-Preview.md
@@ -75,7 +75,7 @@ provider port but returns `dry_run` results only.
 ## Verification
 
 - `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py tests/test_extracted_ticket_faq_macro_writeback.py` -- passed.
-- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 5 passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 6 passed.
 - `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- passed, 127 matching tests enrolled.
 - `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
 - `bash scripts/check_ascii_python.sh` -- passed.
@@ -92,6 +92,6 @@ provider port but returns `dry_run` results only.
 |---|---:|
 | Plan | ~97 |
 | Macro writeback module | ~230 |
-| Tests | ~180 |
+| Tests | ~212 |
 | Runner enrollment | ~1 |
-| Total | ~508 |
+| Total | ~540 |

--- a/plans/PR-FAQ-Macro-Writeback-Preview.md
+++ b/plans/PR-FAQ-Macro-Writeback-Preview.md
@@ -1,0 +1,97 @@
+# PR: FAQ Macro Writeback Preview
+
+## Why this slice exists
+
+The FAQ pipeline can now ingest support tickets, generate verified FAQ items,
+and reuse those FAQ outputs as source material for blogs and landing pages.
+The next product unlock is closing the loop back into the support tool: turning
+approved, verified FAQ question/resolution pairs into support macros, saved
+replies, or canned responses. This first slice builds the safe core only: a
+provider-agnostic macro DTO, deterministic mapping, the verified-and-approved
+double gate, and a dry-run preview with no live help-desk API calls. The diff is
+over the 400-LOC soft cap because the product contract and its negative tests
+need to ship together; splitting the tests from the gate would weaken the slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add platform-agnostic macro writeback DTOs and a `MacroPublishProvider` port.
+2. Map `TicketFAQDraft.items` into macro drafts when the FAQ draft is approved
+   and the item has verified resolution evidence.
+3. Return skipped preview rows with explicit reasons for unapproved drafts,
+   unverified items, missing questions, and missing resolution bodies.
+4. Add a dry-run provider that returns per-item results without network calls.
+5. Enroll focused tests in the extracted pipeline check runner.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Preview.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback.py` — macro DTOs, mapping, gates, dry-run provider.
+- `tests/test_extracted_ticket_faq_macro_writeback.py` — focused mapping, gate, and dry-run tests.
+- `scripts/run_extracted_pipeline_checks.sh` — extracted check runner enrollment for the new test file.
+
+## Mechanism
+
+The new `faq_macro_writeback` module accepts persisted `TicketFAQDraft` rows and
+builds a `MacroWritebackPreview`. Each FAQ item is evaluated independently:
+
+```python
+draft.status == "approved"
+item["answer_evidence_status"] == "resolution_evidence"
+question is present
+resolution_text / answer / steps produce a body
+```
+
+Items that pass become `SupportMacroDraft` values with a title, body, category,
+FAQ draft id, FAQ item id, source ticket ids, and small metadata. Items that do
+not pass become `MacroWritebackSkippedItem` values with a machine-readable
+reason. `DryRunMacroPublishProvider.publish(...)` mirrors the future outbound
+provider port but returns `dry_run` results only.
+
+## Intentional
+
+- No live Zendesk, Intercom, or Freshdesk adapter is added in this slice. The
+  customer-facing safety contract must be proven before credentials, rate
+  limits, and platform-specific request shapes enter the system.
+- No idempotency table is added yet. The preview DTO carries `faq_draft_id` and
+  `faq_item_id` so the later mapping table has stable keys, but live upsert is a
+  separate slice.
+- Draft items marked `draft_needs_review` are skipped even when they contain
+  usable-looking steps. Macro writeback is customer-facing, so the gate is
+  stricter than blog/landing ingestion.
+
+## Deferred
+
+- Future PR `PR-FAQ-Macro-Writeback-Idempotency`: persist per-tenant platform
+  mapping from FAQ item ids to external macro ids.
+- Future PR `PR-FAQ-Macro-Writeback-Zendesk-Adapter`: add the first live
+  outbound provider adapter with scoped credentials and transport tests.
+- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approval workflow
+  and publish trigger around the provider port.
+- Parked hardening: none
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py tests/test_extracted_ticket_faq_macro_writeback.py` -- passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 5 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- passed, 127 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/check_extracted_imports.py` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/smoke_extracted_pipeline_imports.py` -- passed.
+- `python scripts/smoke_extracted_pipeline_standalone.py` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-preview.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~97 |
+| Macro writeback module | ~230 |
+| Tests | ~180 |
+| Runner enrollment | ~1 |
+| Total | ~508 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -30,6 +30,7 @@ pytest \
   tests/test_content_ops_faq_report_contract_docs.py \
   tests/test_content_ops_deflection_report.py \
   tests/test_extracted_ticket_faq_markdown.py \
+  tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback.py
@@ -7,6 +7,7 @@ from extracted_content_pipeline.faq_macro_writeback import (
     DryRunMacroPublishProvider,
     build_macro_writeback_preview,
 )
+from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
 from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
 
 
@@ -116,6 +117,7 @@ def test_macro_writeback_preview_falls_back_to_numbered_steps() -> None:
             items=(
                 {
                     "question": "How do I reset my password?",
+                    "answer": "Customers mention: reset access. Evidence comes from 1 ticket source(s).",
                     "steps": ("Open Settings.", "Choose Reset password."),
                     "answer_evidence_status": "resolution_evidence",
                 },
@@ -127,6 +129,36 @@ def test_macro_writeback_preview_falls_back_to_numbered_steps() -> None:
         "1. Open Settings.\n"
         "2. Choose Reset password."
     )
+
+
+def test_macro_writeback_preview_uses_real_faq_generator_resolution_steps() -> None:
+    generated = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Double charge",
+            "source_id": "ticket-1",
+            "evidence": [{
+                "text": "Why was I charged twice this month?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Open Billing, review the invoice history, and compare "
+                    "pending authorizations with settled charges."
+                ),
+            }],
+        }]
+    )
+    preview = build_macro_writeback_preview([
+        _draft(items=tuple(dict(item) for item in generated.items))
+    ])
+
+    macro = preview.macros[0]
+    assert "Customers mention:" in generated.items[0]["answer"]
+    assert "Customers mention:" not in macro.body
+    assert macro.body.startswith(
+        "1. Use the uploaded resolution evidence: Open Billing, review the invoice history"
+    )
+    assert "pending authorizations with settled charges" in macro.body
 
 
 def test_macro_writeback_preview_reports_missing_customer_facing_fields() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    DryRunMacroPublishProvider,
+    build_macro_writeback_preview,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+def _draft(
+    *,
+    status: str = "approved",
+    items: tuple[dict[str, object], ...],
+    draft_id: str = "faq-draft-1",
+) -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=draft_id,
+        target_id="ticket-faq-report",
+        target_mode="support_ticket_faq",
+        title="Saved FAQ report",
+        markdown="# Saved FAQ report",
+        items=items,
+        source_count=3,
+        ticket_source_count=3,
+        status=status,
+    )
+
+
+def test_macro_writeback_preview_maps_verified_approved_faq_item() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            items=(
+                {
+                    "faq_item_id": "faq-item-1",
+                    "topic": "billing confusion",
+                    "question": "Why was I charged twice?",
+                    "resolution_text": (
+                        "Open Billing, review the invoice history, and compare "
+                        "pending authorizations with settled charges."
+                    ),
+                    "answer_evidence_status": "resolution_evidence",
+                    "source_ids": ("ticket-1", "ticket-2"),
+                },
+            )
+        )
+    ])
+
+    assert preview.publishable_count == 1
+    assert preview.skipped_count == 0
+    macro = preview.macros[0]
+    assert macro.title == "Why was I charged twice?"
+    assert macro.body == (
+        "Open Billing, review the invoice history, and compare pending "
+        "authorizations with settled charges."
+    )
+    assert macro.category == "billing confusion"
+    assert macro.faq_draft_id == "faq-draft-1"
+    assert macro.faq_item_id == "faq-item-1"
+    assert macro.source_ids == ("ticket-1", "ticket-2")
+    assert macro.metadata == {
+        "target_id": "ticket-faq-report",
+        "target_mode": "support_ticket_faq",
+        "draft_title": "Saved FAQ report",
+    }
+    assert preview.as_dict()["publishable_count"] == 1
+
+
+def test_macro_writeback_preview_requires_verified_and_approved_double_gate() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            status="draft",
+            draft_id="faq-unapproved",
+            items=(
+                {
+                    "question": "How do I update billing?",
+                    "resolution_text": "Open Billing and update the payment method.",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            ),
+        ),
+        _draft(
+            draft_id="faq-unverified",
+            items=(
+                {
+                    "question": "How do I export a report?",
+                    "steps": ("Open Reports.", "Choose Export."),
+                    "answer_evidence_status": "draft_needs_review",
+                },
+            ),
+        ),
+        _draft(
+            draft_id="faq-approved",
+            items=(
+                {
+                    "question": "Where do I find invoices?",
+                    "answer": "Open Billing and choose Invoice history.",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            ),
+        ),
+    ])
+
+    assert [macro.title for macro in preview.macros] == ["Where do I find invoices?"]
+    assert [(item.faq_draft_id, item.reason) for item in preview.skipped] == [
+        ("faq-unapproved", "draft_not_approved"),
+        ("faq-unverified", "answer_not_verified"),
+    ]
+
+
+def test_macro_writeback_preview_falls_back_to_numbered_steps() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            items=(
+                {
+                    "question": "How do I reset my password?",
+                    "steps": ("Open Settings.", "Choose Reset password."),
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            )
+        )
+    ])
+
+    assert preview.macros[0].body == (
+        "1. Open Settings.\n"
+        "2. Choose Reset password."
+    )
+
+
+def test_macro_writeback_preview_reports_missing_customer_facing_fields() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            items=(
+                {
+                    "resolution_text": "Open Billing and review invoices.",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+                {
+                    "question": "How do I change seats?",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            )
+        )
+    ])
+
+    assert preview.macros == ()
+    assert [item.reason for item in preview.skipped] == [
+        "missing_question",
+        "missing_resolution_body",
+    ]
+    assert preview.skipped[1].question == "How do I change seats?"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_macro_provider_returns_per_item_preview_results() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            items=(
+                {
+                    "question": "Why was I charged twice?",
+                    "answer": "Open Billing and compare pending and settled charges.",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            )
+        )
+    ])
+
+    results = await DryRunMacroPublishProvider().publish(
+        preview.macros,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert len(results) == 1
+    assert results[0].status == "dry_run"
+    assert results[0].external_id == ""
+    assert results[0].error == ""
+    assert results[0].macro.title == "Why was I charged twice?"
+    assert results[0].as_dict()["macro"]["faq_item_id"] == "faq-draft-1:item-1"


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Preview.md
Slice phase: Vertical slice

This opens the safe core for FAQ-to-support-tool macro writeback: approved, verified FAQ question/resolution items now map into platform-agnostic macro drafts with explicit skipped-item reasons and a dry-run provider that performs no network calls.

## Intentional
- No live Zendesk, Intercom, or Freshdesk adapter in this slice.
- No idempotency table yet; the preview carries stable FAQ draft/item ids for that follow-up.
- `draft_needs_review` items are skipped even when they contain usable-looking text because macro writeback is customer-facing.

## Deferred
- Future PR `PR-FAQ-Macro-Writeback-Idempotency`: persist per-tenant external macro ids.
- Future PR `PR-FAQ-Macro-Writeback-Zendesk-Adapter`: add the first live outbound provider adapter.
- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approval workflow and publish trigger.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py tests/test_extracted_ticket_faq_macro_writeback.py`
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback.py -q`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `bash scripts/check_ascii_python.sh`
- `python scripts/check_extracted_imports.py`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/smoke_extracted_pipeline_imports.py`
- `python scripts/smoke_extracted_pipeline_standalone.py`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-preview.md`

## Diff size
4 files, +540 / -0