### PR TITLE
PR-FAQ-Deflection-Report-CLI-Gate

### DIFF
--- a/plans/PR-FAQ-Deflection-Report-CLI-Gate.md
+++ b/plans/PR-FAQ-Deflection-Report-CLI-Gate.md
@@ -1,0 +1,80 @@
+# FAQ Deflection Report CLI Gate
+
+## Why this slice exists
+
+The customer-facing deflection report CLI can build the $1,500 report artifact,
+but it does not yet expose the same fail-closed output-check gate as the
+underlying FAQ generator CLI. That leaves operator runs able to write a
+customer-facing report even when FAQ output checks fail.
+
+This is a production-hardening slice because the end-to-end report path already
+exists; the missing piece is making weak report output visible and blockable at
+the operator boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Production hardening
+
+1. Add a deflection-report CLI `--require-output-checks` flag.
+2. Add a compact `--result-output` JSON artifact that records status, failed
+   checks, report summary, and item-level proof metadata without duplicating the
+   full Markdown body.
+3. Prove the CLI still succeeds for the SaaS demo source rows.
+4. Prove weak output fails closed when the new gate is enabled and still writes
+   the JSON result artifact before exiting.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/build_content_ops_deflection_report.py` | Add the CLI gate and compact result artifact. |
+| `tests/test_content_ops_deflection_report.py` | Add success/failure coverage for the new CLI behavior. |
+| `plans/PR-FAQ-Deflection-Report-CLI-Gate.md` | Plan and verification contract. |
+
+## Mechanism
+
+`main()` builds the existing `DeflectionReportArtifact`, computes failed output
+checks from `artifact.faq_result.output_checks`, and writes `--result-output`
+before enforcing `--require-output-checks`.
+
+When required checks fail, the command raises `SystemExit` before writing the
+customer-facing Markdown output. The result artifact remains compact: it records
+the output status, summary counts, failed checks, and per-item counts/source ID
+proofs, but not the full Markdown body or full answer text.
+
+## Intentional
+
+- No change to the default CLI behavior. Existing operator commands still write
+  the report unless they opt into `--require-output-checks`.
+- The fail-closed path writes the JSON result artifact but does not write the
+  Markdown report. A failed gate should leave diagnostics, not a publishable
+  customer artifact.
+- The result artifact is smaller than the report body on purpose; the Markdown
+  file remains the report artifact on success.
+
+## Deferred
+
+- Parked hardening: none.
+- Future production-hardening slice: add a deployed-host report build runbook
+  once the operator-provisioned host from issue #1075 is available. This slice
+  stays on the local CLI boundary.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py -q
+- Command: python -m py_compile scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md
+- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md origin/main
+- Command: git diff --check
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-cli-gate.md
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| `scripts/build_content_ops_deflection_report.py` | 121 LOC |
+| `tests/test_content_ops_deflection_report.py` | 69 LOC |
+| `plans/PR-FAQ-Deflection-Report-CLI-Gate.md` | 80 LOC |
+| **Total** | **270 LOC** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from datetime import date
 import json
 from pathlib import Path
@@ -47,6 +48,21 @@ def main(argv: list[str] | None = None) -> int:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
 
     artifact = build_report(args)
+    failed_checks = _failed_output_checks(artifact.faq_result.output_checks)
+    if args.result_output:
+        args.result_output.write_text(
+            json.dumps(
+                _result_payload(args, artifact, failed_checks),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    if args.require_output_checks and failed_checks:
+        raise SystemExit(
+            f"Deflection report output checks failed: {', '.join(failed_checks)}"
+        )
     if args.output:
         args.output.write_text(artifact.markdown, encoding="utf-8")
     else:
@@ -98,6 +114,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--output", type=Path)
     parser.add_argument("--summary-output", type=Path)
+    parser.add_argument("--result-output", type=Path)
+    parser.add_argument(
+        "--require-output-checks",
+        action="store_true",
+        help="Exit non-zero when generated FAQ output checks fail.",
+    )
     parser.add_argument("--json", action="store_true", help="Print summary JSON to stdout.")
     return parser.parse_args(argv)
 
@@ -135,6 +157,105 @@ def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...
             raise SystemExit("--vocabulary-gap-rule must contain at least two comma-separated terms")
         rules.append(parts)
     return tuple(rules)
+
+
+def _failed_output_checks(output_checks: Mapping[str, Any]) -> list[str]:
+    return [name for name, passed in sorted(output_checks.items()) if passed is not True]
+
+
+def _result_payload(
+    args: argparse.Namespace,
+    artifact: Any,
+    failed_checks: list[str],
+) -> dict[str, Any]:
+    faq_result = artifact.faq_result
+    items = [dict(item) for item in faq_result.items]
+    return {
+        "status": "failed_output_checks" if failed_checks else "ok",
+        "input": {
+            "path": str(args.path),
+            "source_format": args.source_format,
+        },
+        "output": {
+            "markdown_path": str(args.output) if args.output else None,
+            "summary_path": str(args.summary_output) if args.summary_output else None,
+            "result_path": str(args.result_output) if args.result_output else None,
+        },
+        "config": {
+            "title": args.title,
+            "faq_title": args.faq_title,
+            "max_items": args.max_items,
+            "max_evidence_per_item": args.max_evidence_per_item,
+            "max_text_chars": args.max_text_chars,
+            "window_days": args.window_days,
+            "as_of_date": args.as_of_date,
+            "require_output_checks": bool(args.require_output_checks),
+            "support_contact": args.support_contact,
+            "documentation_terms": list(args.documentation_term or ()),
+            "vocabulary_gap_rules": [
+                list(rule) for rule in _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
+            ],
+        },
+        "summary": dict(artifact.summary),
+        "source_count": faq_result.source_count,
+        "ticket_source_count": faq_result.ticket_source_count,
+        "generated": len(items),
+        "output_checks": dict(faq_result.output_checks),
+        "failed_output_checks": list(failed_checks),
+        "diagnostics": {
+            "item_count": len(items),
+            "items": [
+                _item_summary(index, item)
+                for index, item in enumerate(items, start=1)
+            ],
+        },
+    }
+
+
+def _item_summary(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
+    source_ids = _texts(item.get("source_ids"))
+    return {
+        "rank": rank,
+        "topic": _text(item.get("topic")),
+        "question": _text(item.get("question")),
+        "answer_evidence_status": _text(item.get("answer_evidence_status")),
+        "ticket_count": _int(item.get("ticket_count")),
+        "opportunity_score": _int(item.get("opportunity_score")),
+        "source_id_count": len(source_ids),
+        "first_source_id": source_ids[0] if source_ids else "",
+        "step_count": len(_texts(item.get("steps"))),
+        "evidence_count": len(_texts(item.get("evidence_quotes"))),
+        "term_mapping_count": len(_mappings(item.get("term_mappings"))),
+    }
+
+
+def _mappings(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _texts(value: Any) -> list[str]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, str):
+        values = (value,)
+    elif isinstance(value, list | tuple):
+        values = value
+    else:
+        values = (value,)
+    return [text for raw in values if (text := _text(raw))]
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -4,6 +4,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 from extracted_content_pipeline.faq_deflection_report import (
     build_deflection_report_artifact,
 )
@@ -126,23 +128,33 @@ def test_deflection_report_does_not_put_review_needed_steps_in_drafted_section()
 def test_deflection_report_cli_builds_saas_demo_artifact(tmp_path: Path) -> None:
     output = tmp_path / "deflection-report.md"
     summary_output = tmp_path / "deflection-report-summary.json"
+    result_output = tmp_path / "deflection-report-result.json"
 
     exit_code = MODULE.main([
         str(SAAS_DEMO),
         "--source-format",
         "csv",
+        "--require-output-checks",
         "--output",
         str(output),
         "--summary-output",
         str(summary_output),
+        "--result-output",
+        str(result_output),
     ])
 
     assert exit_code == 0
     markdown = output.read_text()
     summary = json.loads(summary_output.read_text())
+    result = json.loads(result_output.read_text())
     assert summary["generated"] >= 7
     assert summary["source_count"] == 36
     assert summary["no_proven_answer_count"] >= 1
+    assert result["status"] == "ok"
+    assert result["failed_output_checks"] == []
+    assert result["summary"] == summary
+    assert result["config"]["require_output_checks"] is True
+    assert result["diagnostics"]["item_count"] == result["generated"]
     assert "## Ranked Question Opportunities" in markdown
     assert "## No Proven Answer Yet" in markdown
     assert "support_ticket_saas_demo_sources.csv" in markdown
@@ -208,3 +220,60 @@ def test_deflection_report_cli_splits_backed_and_unproven_answers(tmp_path: Path
     assert "How do I enable SSO for my team?" in no_proven
     assert "Open Analytics then Attribution then click Download report" not in no_proven
     assert "tell users exactly what to try next" not in drafted
+
+
+def test_deflection_report_cli_fails_required_output_checks_for_weak_rows(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "weak-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    summary_output = tmp_path / "deflection-report-summary.json"
+    result_output = tmp_path / "deflection-report-result.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-1",
+                "source_type": "support_ticket",
+                "subject": "Unique export issue",
+                "message": "The export button moved.",
+                "pain_category": "exports",
+            },
+            {
+                "ticket_id": "ticket-2",
+                "source_type": "support_ticket",
+                "subject": "Unique billing issue",
+                "message": "Billing receipt is missing.",
+                "pain_category": "billing",
+            },
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        MODULE.main([
+            str(source),
+            "--source-format",
+            "json",
+            "--require-output-checks",
+            "--output",
+            str(output),
+            "--summary-output",
+            str(summary_output),
+            "--result-output",
+            str(result_output),
+        ])
+
+    assert str(exc_info.value) == "Deflection report output checks failed: condensed"
+    assert not output.exists()
+    assert not summary_output.exists()
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["status"] == "failed_output_checks"
+    assert result["failed_output_checks"] == ["condensed"]
+    assert result["summary"]["source_count"] == 2
+    assert result["summary"]["ticket_source_count"] == 2
+    assert result["output"]["markdown_path"] == str(output)
+    assert result["output"]["summary_path"] == str(summary_output)
+    assert result["output"]["result_path"] == str(result_output)
+    assert result["diagnostics"]["item_count"] == 2
+    assert result["diagnostics"]["items"][0]["source_id_count"] == 1
+    assert "markdown" not in result


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-CLI-Gate.md
Slice phase: Production hardening

Adds a fail-closed operator gate to the customer-facing FAQ deflection report CLI so weak FAQ output can write diagnostics without writing a publishable report artifact.

## Intentional
- Default CLI behavior is unchanged; operators opt into the stricter gate with `--require-output-checks`.
- The fail-closed path writes `--result-output` before exiting but does not write Markdown or summary artifacts.
- The result artifact stays compact and does not duplicate the full Markdown body.

## Deferred
- Future production-hardening slice: deployed-host report build runbook once the operator-provisioned host from issue #1075 is available.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py -q` — 5 passed.
- `python -m py_compile scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py` — passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-CLI-Gate.md origin/main` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-cli-gate.md` — passed.

## Diff size
3 files, +270 / -0
