### PR TITLE
PR-FAQ-Deflection-Report-Intent-Rules

### DIFF
--- a/plans/PR-FAQ-Deflection-Report-Intent-Rules.md
+++ b/plans/PR-FAQ-Deflection-Report-Intent-Rules.md
@@ -1,0 +1,82 @@
+# FAQ Deflection Report Intent Rules
+
+## Why this slice exists
+
+The FAQ generator and hosted service support custom intent rules, but the
+customer-facing deflection report CLI cannot pass them through. That blocks the
+report workflow from using customer-specific symptom language to cluster repeat
+questions when the source rows do not already carry a useful taxonomy.
+
+This is a vertical slice because it adds one end-to-end operator control to the
+real report CLI and proves the generated report changes shape through the
+existing FAQ generator, report renderer, output-check gate, and result artifact.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Vertical slice
+
+1. Add repeatable `--intent-rule topic=keyword,keyword` support to
+   `scripts/build_content_ops_deflection_report.py`.
+2. Pass custom intent rules ahead of the default FAQ rules so operator-provided
+   customer language takes precedence.
+3. Record the custom intent rules in `--result-output` config metadata.
+4. Prove custom rules cluster weakly-taxonomized support rows into one FAQ
+   opportunity in the customer-facing report.
+5. Prove malformed intent rules fail before writing a report.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/build_content_ops_deflection_report.py` | Add CLI parsing, config metadata, and generator pass-through for custom intent rules. |
+| `tests/test_content_ops_deflection_report.py` | Add end-to-end CLI coverage for custom intent rules and malformed rule rejection. |
+| `plans/PR-FAQ-Deflection-Report-Intent-Rules.md` | Plan and verification contract. |
+
+## Mechanism
+
+The CLI accepts repeatable `--intent-rule` values shaped as
+`topic=keyword,keyword`. Parsing trims blanks and de-duplicates keywords
+case-insensitively within each rule. The report builder passes:
+
+```python
+intent_rules = (*custom_intent_rules, *DEFAULT_INTENT_RULES)
+```
+
+into `build_ticket_faq_markdown(...)`, matching the FAQ CLI precedence rule:
+custom customer language is evaluated before default taxonomy rules.
+
+## Intentional
+
+- No JSON `--rule-file` parity in this slice. The thinnest useful path is the
+  inline intent rule operator control; broader rules-file parity can follow if
+  operators need it.
+- No change to default report behavior. When no `--intent-rule` is provided,
+  the report still uses the generator defaults.
+- Custom rules prepend, not append, because customer-provided wording should win
+  over generic defaults for a paid report run.
+
+## Deferred
+
+- Parked hardening: none.
+- Future vertical slice: add deflection-report CLI `--rule-file` parity only if
+  operators need reusable customer rule bundles instead of inline command flags.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py -q
+- Command: python -m py_compile scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md
+- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md origin/main
+- Command: git diff --check
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-intent-rules.md
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| `scripts/build_content_ops_deflection_report.py` | 42 LOC |
+| `tests/test_content_ops_deflection_report.py` | 94 LOC |
+| `plans/PR-FAQ-Deflection-Report-Intent-Rules.md` | 82 LOC |
+| **Total** | **218 LOC** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -24,6 +24,7 @@ from extracted_content_pipeline.faq_deflection_report import (  # noqa: E402
     build_deflection_report_artifact,
 )
 from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
+    DEFAULT_INTENT_RULES,
     DEFAULT_TITLE,
     build_ticket_faq_markdown,
 )
@@ -112,6 +113,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=[],
         help="Comma-separated customer/documentation aliases. Repeat for multiple rules.",
     )
+    parser.add_argument(
+        "--intent-rule",
+        action="append",
+        default=[],
+        help="Custom intent mapping shaped as topic=keyword,keyword. Repeat for multiple rules.",
+    )
     parser.add_argument("--output", type=Path)
     parser.add_argument("--summary-output", type=Path)
     parser.add_argument("--result-output", type=Path)
@@ -125,6 +132,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def build_report(args: argparse.Namespace):
+    custom_intent_rules = _parse_intent_rules(args.intent_rule)
+    args.custom_intent_rules = custom_intent_rules
+    intent_rules = (*custom_intent_rules, *DEFAULT_INTENT_RULES)
     loaded = load_source_campaign_opportunities_from_file(
         args.path,
         file_format=args.source_format,
@@ -139,6 +149,7 @@ def build_report(args: argparse.Namespace):
         window_days=args.window_days,
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
+        intent_rules=intent_rules,
         documentation_terms=tuple(args.documentation_term or ()),
         vocabulary_gap_rules=_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
     )
@@ -157,6 +168,33 @@ def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...
             raise SystemExit("--vocabulary-gap-rule must contain at least two comma-separated terms")
         rules.append(parts)
     return tuple(rules)
+
+
+def _parse_intent_rules(values: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for value in values or ():
+        topic, separator, raw_keywords = str(value).partition("=")
+        topic = topic.strip()
+        keywords = _parse_intent_rule_keywords(raw_keywords)
+        if not separator or not topic or not keywords:
+            raise SystemExit(
+                "--intent-rule must use topic=keyword,keyword with at least one keyword"
+            )
+        rules.append((topic, keywords))
+    return tuple(rules)
+
+
+def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for part in value.split(","):
+        keyword = part.strip()
+        key = keyword.lower()
+        if not keyword or key in seen:
+            continue
+        seen.add(key)
+        keywords.append(keyword)
+    return tuple(keywords)
 
 
 def _failed_output_checks(output_checks: Mapping[str, Any]) -> list[str]:
@@ -194,6 +232,10 @@ def _result_payload(
             "documentation_terms": list(args.documentation_term or ()),
             "vocabulary_gap_rules": [
                 list(rule) for rule in _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
+            ],
+            "custom_intent_rules": [
+                {"topic": topic, "keywords": list(keywords)}
+                for topic, keywords in getattr(args, "custom_intent_rules", ())
             ],
         },
         "summary": dict(artifact.summary),

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -277,3 +277,97 @@ def test_deflection_report_cli_fails_required_output_checks_for_weak_rows(
     assert result["diagnostics"]["item_count"] == 2
     assert result["diagnostics"]["items"][0]["source_id_count"] == 1
     assert "markdown" not in result
+
+
+def test_deflection_report_cli_applies_custom_intent_rules(tmp_path: Path) -> None:
+    source = tmp_path / "intent-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    result_output = tmp_path / "deflection-report-result.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-access-1",
+                "source_type": "support_ticket",
+                "subject": "Invite links",
+                "message": "The invite link expired before a contractor could join.",
+            },
+            {
+                "ticket_id": "ticket-access-2",
+                "source_type": "support_ticket",
+                "subject": "Login email",
+                "message": "How do I change the login email for a new teammate?",
+            },
+        ]),
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--intent-rule",
+        "Account access=invite link,login email,LOGIN EMAIL",
+        "--require-output-checks",
+        "--output",
+        str(output),
+        "--result-output",
+        str(result_output),
+    ])
+
+    assert exit_code == 0
+    markdown = output.read_text(encoding="utf-8")
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["generated"] == 1
+    assert result["output_checks"]["condensed"] is True
+    assert result["failed_output_checks"] == []
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "Account access", "keywords": ["invite link", "login email"]}
+    ]
+    assert result["diagnostics"]["items"][0]["topic"] == "account access"
+    assert result["diagnostics"]["items"][0]["source_id_count"] == 2
+    assert "| 1 |" in markdown
+    assert "ticket-access-1, ticket-access-2" in markdown
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        "Account access",
+        "=invite link",
+        "Account access=",
+        "Account access=,",
+    ],
+)
+def test_deflection_report_cli_rejects_malformed_intent_rule(
+    rule: str,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "intent-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-access-1",
+                "source_type": "support_ticket",
+                "subject": "Invite links",
+                "message": "The invite link expired before a contractor could join.",
+            },
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        MODULE.main([
+            str(source),
+            "--source-format",
+            "json",
+            "--intent-rule",
+            rule,
+            "--output",
+            str(output),
+        ])
+
+    assert str(exc_info.value) == (
+        "--intent-rule must use topic=keyword,keyword with at least one keyword"
+    )
+    assert not output.exists()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Intent-Rules.md
Slice phase: Vertical slice

Adds inline custom intent rules to the customer-facing FAQ deflection report CLI so operators can cluster repeat questions by customer symptom language when the uploaded rows lack a useful taxonomy.

## Intentional
- No JSON `--rule-file` parity in this slice; the inline flag is the thinnest useful operator path.
- Default report behavior is unchanged when no `--intent-rule` is provided.
- Custom rules prepend the default FAQ rules so customer-provided language wins over generic taxonomy.

## Deferred
- Future vertical slice: add deflection-report CLI `--rule-file` parity only if operators need reusable customer rule bundles instead of inline command flags.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py -q` — 10 passed.
- `python -m py_compile scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py` — passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Intent-Rules.md origin/main` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-intent-rules.md` — passed.

## Diff size
3 files, +218 / -0
