### PR TITLE
Add FAQ macro writeback idempotency mapping

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -68,6 +68,21 @@ class MacroPublishResult:
 
 
 @dataclass(frozen=True)
+class MacroWritebackMapping:
+    """Tenant-scoped mapping from one FAQ item to one external macro."""
+
+    platform: str
+    faq_draft_id: str
+    faq_item_id: str
+    external_id: str
+    external_url: str = ""
+    metadata: JsonDict = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class MacroWritebackPreview:
     """Dry-run preview of macros that would be written back."""
 
@@ -99,6 +114,28 @@ class MacroPublishProvider(Protocol):
         scope: TenantScope,
     ) -> Sequence[MacroPublishResult]:
         """Publish or preview support macros for one tenant scope."""
+
+
+class MacroWritebackMappingRepository(Protocol):
+    """Persistence port for macro writeback idempotency mappings."""
+
+    async def get_mapping(
+        self,
+        *,
+        platform: str,
+        faq_draft_id: str,
+        faq_item_id: str,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping | None:
+        """Return the existing external macro mapping for one FAQ item."""
+
+    async def upsert_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        """Create or update the external macro mapping for one FAQ item."""
 
 
 class DryRunMacroPublishProvider:
@@ -223,6 +260,8 @@ __all__ = [
     "MacroPublishResult",
     "MacroPublishStatus",
     "MacroSkipReason",
+    "MacroWritebackMapping",
+    "MacroWritebackMappingRepository",
     "MacroWritebackPreview",
     "MacroWritebackSkippedItem",
     "SupportMacroDraft",

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -1,0 +1,105 @@
+"""Postgres storage for FAQ macro writeback idempotency mappings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .campaign_ports import TenantScope
+from .faq_macro_writeback import MacroWritebackMapping
+from .storage._jsonb_helpers import decode_jsonb_field, json_dump_jsonb, row_to_dict
+
+
+_MAPPING_COLUMNS = (
+    "platform, faq_draft_id, faq_item_id, external_id, external_url, metadata"
+)
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _metadata(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _row_to_mapping(row: Mapping[str, Any]) -> MacroWritebackMapping:
+    return MacroWritebackMapping(
+        platform=str(row.get("platform") or ""),
+        faq_draft_id=str(row.get("faq_draft_id") or ""),
+        faq_item_id=str(row.get("faq_item_id") or ""),
+        external_id=str(row.get("external_id") or ""),
+        external_url=str(row.get("external_url") or ""),
+        metadata=_metadata(row.get("metadata")),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresFAQMacroWritebackMappingRepository:
+    """Async Postgres adapter for FAQ macro writeback idempotency mappings."""
+
+    pool: Any
+
+    async def get_mapping(
+        self,
+        *,
+        platform: str,
+        faq_draft_id: str,
+        faq_item_id: str,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping | None:
+        rows = await self.pool.fetch(
+            f"""
+            SELECT {_MAPPING_COLUMNS}
+              FROM ticket_faq_macro_writebacks
+             WHERE account_id = $1
+               AND platform = $2
+               AND faq_draft_id = $3
+               AND faq_item_id = $4
+             LIMIT 1
+            """,
+            scope.account_id or "",
+            _clean(platform),
+            _clean(faq_draft_id),
+            _clean(faq_item_id),
+        )
+        if not rows:
+            return None
+        return _row_to_mapping(row_to_dict(rows[0]))
+
+    async def upsert_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        row = await self.pool.fetchrow(
+            f"""
+            INSERT INTO ticket_faq_macro_writebacks (
+                account_id, platform, faq_draft_id, faq_item_id,
+                external_id, external_url, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+            ON CONFLICT (account_id, platform, faq_draft_id, faq_item_id)
+            DO UPDATE SET
+                external_id = EXCLUDED.external_id,
+                external_url = EXCLUDED.external_url,
+                metadata = EXCLUDED.metadata,
+                updated_at = NOW()
+            RETURNING {_MAPPING_COLUMNS}
+            """,
+            scope.account_id or "",
+            _clean(mapping.platform),
+            _clean(mapping.faq_draft_id),
+            _clean(mapping.faq_item_id),
+            _clean(mapping.external_id),
+            _clean(mapping.external_url),
+            json_dump_jsonb(dict(mapping.metadata or {})),
+        )
+        return _row_to_mapping(row_to_dict(row))
+
+
+__all__ = [
+    "PostgresFAQMacroWritebackMappingRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/328_ticket_faq_macro_writebacks.sql
+++ b/extracted_content_pipeline/storage/migrations/328_ticket_faq_macro_writebacks.sql
@@ -1,0 +1,27 @@
+-- FAQ macro writeback idempotency: maps one approved FAQ item to the external
+-- macro / saved reply / canned response created in a customer's support tool.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_macro_writebacks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    platform TEXT NOT NULL,
+    faq_draft_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) ON DELETE CASCADE,
+    faq_item_id TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    external_url TEXT NOT NULL DEFAULT '',
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ticket_faq_macro_writebacks_account_id CHECK (btrim(account_id) <> ''),
+    CONSTRAINT chk_ticket_faq_macro_writebacks_platform CHECK (btrim(platform) <> ''),
+    CONSTRAINT chk_ticket_faq_macro_writebacks_faq_item_id CHECK (btrim(faq_item_id) <> ''),
+    CONSTRAINT chk_ticket_faq_macro_writebacks_external_id CHECK (btrim(external_id) <> ''),
+    UNIQUE (account_id, platform, faq_draft_id, faq_item_id),
+    UNIQUE (account_id, platform, external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_macro_writebacks_faq
+    ON ticket_faq_macro_writebacks (faq_draft_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_macro_writebacks_platform
+    ON ticket_faq_macro_writebacks (account_id, platform, updated_at DESC);

--- a/plans/PR-FAQ-Macro-Writeback-Idempotency.md
+++ b/plans/PR-FAQ-Macro-Writeback-Idempotency.md
@@ -1,0 +1,97 @@
+# PR: FAQ Macro Writeback Idempotency
+
+## Why this slice exists
+
+PR `FAQ-Macro-Writeback-Preview` proved that approved, verified FAQ items can
+be turned into platform-agnostic support macro drafts without network calls.
+The next safety requirement is idempotency: when a future Zendesk, Intercom, or
+Freshdesk adapter publishes the same FAQ item more than once, Atlas must update
+the existing external macro instead of creating duplicates in the customer's
+support tool. This slice adds the tenant-scoped mapping contract and Postgres
+storage needed before any live outbound adapter exists.
+The diff is over the 400-LOC soft cap because the storage contract, migration,
+and scoped upsert tests need to ship together; separating the tests from the
+idempotency table would leave the live-adapter prerequisite under-proven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add a `MacroWritebackMapping` DTO and repository port for storing the
+   external macro id that belongs to one FAQ item on one platform.
+2. Add a Postgres repository that upserts by account, platform, FAQ draft id,
+   and FAQ item id, with scoped lookup for later adapters.
+3. Add the `ticket_faq_macro_writebacks` migration with tenant, platform,
+   FAQ-item, and external-id uniqueness constraints.
+4. Add focused tests for scoped lookup, idempotent upsert SQL, JSON metadata
+   round-trip, and migration shape.
+5. Enroll the new tests in the extracted pipeline check runner.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Idempotency.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback.py` — mapping DTO and repository port.
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py` — Postgres mapping repository.
+- `extracted_content_pipeline/storage/migrations/328_ticket_faq_macro_writebacks.sql` — idempotency mapping table.
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` — repository and migration tests.
+- `scripts/run_extracted_pipeline_checks.sh` — extracted check runner enrollment for the new test file.
+
+## Mechanism
+
+The mapping key is:
+
+```text
+account_id + platform + faq_draft_id + faq_item_id
+```
+
+The value is the help-desk `external_id`, optional `external_url`, and JSONB
+metadata. `PostgresFAQMacroWritebackMappingRepository.upsert_mapping(...)`
+uses `ON CONFLICT (account_id, platform, faq_draft_id, faq_item_id) DO UPDATE`
+so repeated publishes update the existing mapping. Lookup always filters by
+`TenantScope.account_id`, which keeps tenant isolation at the source before the
+future live adapter reads credentials or external ids.
+
+## Intentional
+
+- No live outbound API adapter is added here. Idempotency must be a stable
+  storage contract before Zendesk/Freshdesk/Intercom request code depends on it.
+- The mapping uses `faq_item_id` instead of macro title because customer-facing
+  titles can be edited while the source FAQ item identity should remain stable.
+- The table also constrains `(account_id, platform, external_id)` so one
+  platform macro id cannot silently map to multiple FAQ items for the same
+  tenant.
+
+## Deferred
+
+- Future PR `PR-FAQ-Macro-Writeback-Zendesk-Adapter`: use this mapping repo to
+  choose create vs update in the first live adapter.
+- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approval workflow and
+  publish trigger around the provider plus mapping repository.
+- Parked hardening: none
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py` -- passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 11 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- passed, 128 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/check_extracted_imports.py` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `python scripts/smoke_extracted_pipeline_imports.py` -- passed.
+- `python scripts/smoke_extracted_pipeline_standalone.py` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-idempotency.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~97 |
+| Mapping DTO/port | ~39 |
+| Postgres repository | ~105 |
+| Migration | ~27 |
+| Tests | ~170 |
+| Runner enrollment | ~1 |
+| Total | ~439 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -31,6 +31,7 @@ pytest \
   tests/test_content_ops_deflection_report.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
+  tests/test_extracted_ticket_faq_macro_writeback_postgres.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping
+from extracted_content_pipeline.faq_macro_writeback_postgres import (
+    PostgresFAQMacroWritebackMappingRepository,
+)
+
+
+MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "extracted_content_pipeline"
+    / "storage"
+    / "migrations"
+    / "328_ticket_faq_macro_writebacks.sql"
+)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetch_rows: list[dict] = []
+        self.fetchrow_rows: list[dict] = []
+        self.fetch_calls: list[dict] = []
+        self.fetchrow_calls: list[dict] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": query, "args": args})
+        return self.fetchrow_rows.pop(0)
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "platform": "zendesk",
+        "faq_draft_id": "11111111-1111-1111-1111-111111111111",
+        "faq_item_id": "faq-draft-1:item-1",
+        "external_id": "macro-123",
+        "external_url": "https://example.zendesk.com/macros/123",
+        "metadata": json.dumps({"source": "dry_run"}),
+    }
+    row.update(overrides)
+    return row
+
+
+def test_ticket_faq_macro_writeback_migration_adds_scoped_unique_mapping() -> None:
+    sql = MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS ticket_faq_macro_writebacks" in sql
+    assert (
+        "faq_draft_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) "
+        "ON DELETE CASCADE"
+    ) in sql
+    assert "UNIQUE (account_id, platform, faq_draft_id, faq_item_id)" in sql
+    assert "UNIQUE (account_id, platform, external_id)" in sql
+    assert "chk_ticket_faq_macro_writebacks_account_id" in sql
+    assert "idx_ticket_faq_macro_writebacks_platform" in sql
+
+
+@pytest.mark.asyncio
+async def test_get_mapping_filters_by_tenant_platform_and_faq_item() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_row()]
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    mapping = await repo.get_mapping(
+        platform=" zendesk ",
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id=" faq-draft-1:item-1 ",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert mapping == MacroWritebackMapping(
+        platform="zendesk",
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="macro-123",
+        external_url="https://example.zendesk.com/macros/123",
+        metadata={"source": "dry_run"},
+    )
+    call = pool.fetch_calls[0]
+    assert "FROM ticket_faq_macro_writebacks" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert "platform = $2" in call["query"]
+    assert "faq_draft_id = $3" in call["query"]
+    assert "faq_item_id = $4" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "zendesk",
+        "11111111-1111-1111-1111-111111111111",
+        "faq-draft-1:item-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_mapping_returns_none_on_miss() -> None:
+    pool = _Pool()
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    mapping = await repo.get_mapping(
+        platform="zendesk",
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert mapping is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_mapping_uses_faq_item_idempotency_key_and_metadata_jsonb() -> None:
+    pool = _Pool()
+    pool.fetchrow_rows = [_row(external_id="macro-456", metadata={"updated": True})]
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    mapping = await repo.upsert_mapping(
+        MacroWritebackMapping(
+            platform=" zendesk ",
+            faq_draft_id="11111111-1111-1111-1111-111111111111",
+            faq_item_id=" faq-draft-1:item-1 ",
+            external_id=" macro-456 ",
+            external_url=" https://example.zendesk.com/macros/456 ",
+            metadata={"updated": True},
+        ),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    call = pool.fetchrow_calls[0]
+    assert "INSERT INTO ticket_faq_macro_writebacks" in call["query"]
+    assert "ON CONFLICT (account_id, platform, faq_draft_id, faq_item_id)" in call["query"]
+    assert "DO UPDATE SET" in call["query"]
+    assert "updated_at = NOW()" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "zendesk",
+        "11111111-1111-1111-1111-111111111111",
+        "faq-draft-1:item-1",
+        "macro-456",
+        "https://example.zendesk.com/macros/456",
+        '{"updated":true}',
+    )
+    assert mapping.external_id == "macro-456"
+    assert mapping.metadata == {"updated": True}
+
+
+@pytest.mark.asyncio
+async def test_upsert_mapping_keeps_account_scope_outside_client_payload() -> None:
+    pool = _Pool()
+    pool.fetchrow_rows = [_row()]
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    await repo.upsert_mapping(
+        MacroWritebackMapping(
+            platform="zendesk",
+            faq_draft_id="11111111-1111-1111-1111-111111111111",
+            faq_item_id="faq-draft-1:item-1",
+            external_id="macro-123",
+        ),
+        scope=TenantScope(account_id="acct-tenant-a"),
+    )
+
+    assert pool.fetchrow_calls[0]["args"][0] == "acct-tenant-a"
+    assert "account_id" not in pool.fetchrow_calls[0]["args"][-1]


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Idempotency.md
Slice phase: Vertical slice

This adds the tenant-scoped idempotency mapping required before live FAQ macro writeback adapters exist: one FAQ item on one platform maps to one external macro id, and repeated publishes update that mapping instead of creating duplicate support-tool macros.

## Intentional
- No live Zendesk, Intercom, or Freshdesk adapter in this slice.
- Idempotency is keyed by `account_id + platform + faq_draft_id + faq_item_id`, not by editable macro title.
- The table also constrains `account_id + platform + external_id` so one external macro cannot silently map to multiple FAQ items for the same tenant.

## Deferred
- Future PR `PR-FAQ-Macro-Writeback-Zendesk-Adapter`: use this mapping repo to choose create vs update in the first live adapter.
- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approval workflow and publish trigger around the provider plus mapping repository.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py`
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `bash scripts/check_ascii_python.sh`
- `python scripts/check_extracted_imports.py`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `python scripts/smoke_extracted_pipeline_imports.py`
- `python scripts/smoke_extracted_pipeline_standalone.py`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-idempotency.md`

## Diff size
6 files, +439 / -0