### PR TITLE
Add Zendesk FAQ macro writeback adapter

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -76,6 +76,7 @@ class MacroWritebackMapping:
     faq_item_id: str
     external_id: str
     external_url: str = ""
+    publish_status: str = "published"
     metadata: JsonDict = field(default_factory=dict)
 
     def as_dict(self) -> JsonDict:
@@ -136,6 +137,14 @@ class MacroWritebackMappingRepository(Protocol):
         scope: TenantScope,
     ) -> MacroWritebackMapping:
         """Create or update the external macro mapping for one FAQ item."""
+
+    async def reserve_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        """Reserve one FAQ item before creating an external macro."""
 
 
 class DryRunMacroPublishProvider:

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -11,7 +11,8 @@ from .storage._jsonb_helpers import decode_jsonb_field, json_dump_jsonb, row_to_
 
 
 _MAPPING_COLUMNS = (
-    "platform, faq_draft_id, faq_item_id, external_id, external_url, metadata"
+    "platform, faq_draft_id, faq_item_id, external_id, external_url, "
+    "publish_status, metadata"
 )
 
 
@@ -31,6 +32,7 @@ def _row_to_mapping(row: Mapping[str, Any]) -> MacroWritebackMapping:
         faq_item_id=str(row.get("faq_item_id") or ""),
         external_id=str(row.get("external_id") or ""),
         external_url=str(row.get("external_url") or ""),
+        publish_status=str(row.get("publish_status") or "published"),
         metadata=_metadata(row.get("metadata")),
     )
 
@@ -78,13 +80,14 @@ class PostgresFAQMacroWritebackMappingRepository:
             f"""
             INSERT INTO ticket_faq_macro_writebacks (
                 account_id, platform, faq_draft_id, faq_item_id,
-                external_id, external_url, metadata
+                external_id, external_url, publish_status, metadata
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
             ON CONFLICT (account_id, platform, faq_draft_id, faq_item_id)
             DO UPDATE SET
                 external_id = EXCLUDED.external_id,
                 external_url = EXCLUDED.external_url,
+                publish_status = EXCLUDED.publish_status,
                 metadata = EXCLUDED.metadata,
                 updated_at = NOW()
             RETURNING {_MAPPING_COLUMNS}
@@ -95,6 +98,43 @@ class PostgresFAQMacroWritebackMappingRepository:
             _clean(mapping.faq_item_id),
             _clean(mapping.external_id),
             _clean(mapping.external_url),
+            _clean(mapping.publish_status) or "published",
+            json_dump_jsonb(dict(mapping.metadata or {})),
+        )
+        return _row_to_mapping(row_to_dict(row))
+
+    async def reserve_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        row = await self.pool.fetchrow(
+            f"""
+            WITH inserted AS (
+                INSERT INTO ticket_faq_macro_writebacks (
+                    account_id, platform, faq_draft_id, faq_item_id,
+                    external_id, external_url, publish_status, metadata
+                )
+                VALUES ($1, $2, $3, $4, '', '', 'pending', $5::jsonb)
+                ON CONFLICT (account_id, platform, faq_draft_id, faq_item_id)
+                DO NOTHING
+                RETURNING {_MAPPING_COLUMNS}
+            )
+            SELECT {_MAPPING_COLUMNS} FROM inserted
+            UNION ALL
+            SELECT {_MAPPING_COLUMNS}
+              FROM ticket_faq_macro_writebacks
+             WHERE account_id = $1
+               AND platform = $2
+               AND faq_draft_id = $3
+               AND faq_item_id = $4
+            LIMIT 1
+            """,
+            scope.account_id or "",
+            _clean(mapping.platform),
+            _clean(mapping.faq_draft_id),
+            _clean(mapping.faq_item_id),
             json_dump_jsonb(dict(mapping.metadata or {})),
         )
         return _row_to_mapping(row_to_dict(row))

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -1,0 +1,281 @@
+"""Zendesk macro writeback adapter for approved FAQ macro drafts."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+import httpx
+
+from .campaign_ports import JsonDict, TenantScope
+from .faq_macro_writeback import (
+    MacroPublishResult,
+    MacroWritebackMapping,
+    MacroWritebackMappingRepository,
+    SupportMacroDraft,
+)
+
+
+ZENDESK_PLATFORM = "zendesk"
+
+
+@dataclass(frozen=True)
+class ZendeskMacroCredentials:
+    """Tenant Zendesk API credentials."""
+
+    email: str
+    api_token: str = field(repr=False)
+    subdomain: str = ""
+    base_url: str = ""
+
+    def normalized_base_url(self) -> str:
+        if cleaned := _clean(self.base_url).rstrip("/"):
+            return cleaned
+        subdomain = _clean(self.subdomain).removesuffix(".zendesk.com")
+        if not subdomain:
+            return ""
+        return f"https://{subdomain}.zendesk.com"
+
+    def is_complete(self) -> bool:
+        return bool(self.normalized_base_url() and _clean(self.email) and _clean(self.api_token))
+
+    def authorization_header(self) -> str:
+        token = f"{_clean(self.email)}/token:{_clean(self.api_token)}".encode("utf-8")
+        return "Basic " + base64.b64encode(token).decode("ascii")
+
+
+class ZendeskMacroCredentialsProvider(Protocol):
+    """Host-provided scoped Zendesk credential source."""
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        """Return Zendesk credentials for one tenant scope."""
+
+
+@dataclass(frozen=True)
+class StaticZendeskMacroCredentialsProvider:
+    """Simple credential provider for tests and single-tenant hosts."""
+
+    credentials: ZendeskMacroCredentials | None
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        _ = scope
+        return self.credentials
+
+
+@dataclass(frozen=True)
+class ZendeskMacroTransportError(Exception):
+    """Sanitized Zendesk transport failure."""
+
+    status_code: int
+    message: str = "zendesk_request_failed"
+
+    def __str__(self) -> str:
+        return f"{self.message}: status={self.status_code}"
+
+
+class ZendeskMacroTransport(Protocol):
+    """Transport boundary for Zendesk macro API calls."""
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Send one Zendesk macro request and return a JSON object."""
+
+
+class ZendeskHTTPMacroTransport:
+    """HTTP transport for Zendesk macro API calls."""
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=dict(headers),
+                json=dict(json),
+            )
+        if response.status_code >= 400:
+            raise ZendeskMacroTransportError(status_code=response.status_code)
+        payload = response.json()
+        return payload if isinstance(payload, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class ZendeskMacroPublishProvider:
+    """Zendesk implementation of macro writeback publishing."""
+
+    credentials_provider: ZendeskMacroCredentialsProvider
+    mapping_repository: MacroWritebackMappingRepository
+    transport: ZendeskMacroTransport = field(default_factory=ZendeskHTTPMacroTransport)
+
+    async def publish(
+        self,
+        macros: Sequence[SupportMacroDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[MacroPublishResult]:
+        credentials = await self.credentials_provider.credentials_for_scope(scope)
+        if credentials is None or not credentials.is_complete():
+            return tuple(
+                MacroPublishResult(
+                    macro=macro,
+                    status="failed",
+                    error="zendesk_credentials_missing",
+                )
+                for macro in macros
+            )
+        return tuple([
+            await self._publish_one(macro, credentials=credentials, scope=scope)
+            for macro in macros
+        ])
+
+    async def _publish_one(
+        self,
+        macro: SupportMacroDraft,
+        *,
+        credentials: ZendeskMacroCredentials,
+        scope: TenantScope,
+    ) -> MacroPublishResult:
+        if not macro.faq_draft_id or not macro.faq_item_id:
+            return MacroPublishResult(
+                macro=macro,
+                status="failed",
+                error="zendesk_macro_missing_faq_identity",
+            )
+        try:
+            existing = await self.mapping_repository.get_mapping(
+                platform=ZENDESK_PLATFORM,
+                faq_draft_id=macro.faq_draft_id,
+                faq_item_id=macro.faq_item_id,
+                scope=scope,
+            )
+            payload = _zendesk_macro_payload(macro)
+            if existing is None:
+                data = await self.transport.request(
+                    "POST",
+                    f"{credentials.normalized_base_url()}/api/v2/macros",
+                    headers=_headers(credentials),
+                    json=payload,
+                )
+                status = "published"
+            else:
+                data = await self.transport.request(
+                    "PUT",
+                    f"{credentials.normalized_base_url()}/api/v2/macros/{existing.external_id}",
+                    headers=_headers(credentials),
+                    json=payload,
+                )
+                status = "updated"
+            external_id = _external_id(data, fallback=existing.external_id if existing else "")
+            if not external_id:
+                return MacroPublishResult(
+                    macro=macro,
+                    status="failed",
+                    error="zendesk_macro_id_missing",
+                )
+            mapping = await self.mapping_repository.upsert_mapping(
+                MacroWritebackMapping(
+                    platform=ZENDESK_PLATFORM,
+                    faq_draft_id=macro.faq_draft_id,
+                    faq_item_id=macro.faq_item_id,
+                    external_id=external_id,
+                    external_url=_external_url(data),
+                    metadata={
+                        "title": macro.title,
+                        "category": macro.category,
+                    },
+                ),
+                scope=scope,
+            )
+            return MacroPublishResult(
+                macro=macro,
+                status=status,
+                external_id=mapping.external_id,
+            )
+        except Exception as exc:
+            return MacroPublishResult(
+                macro=macro,
+                status="failed",
+                error=_safe_error(exc),
+            )
+
+
+def _zendesk_macro_payload(macro: SupportMacroDraft) -> JsonDict:
+    return {
+        "macro": {
+            "title": macro.title,
+            "active": True,
+            "description": _description(macro),
+            "actions": [
+                {"field": "comment_value", "value": macro.body},
+                {"field": "comment_mode_is_public", "value": True},
+            ],
+        }
+    }
+
+
+def _description(macro: SupportMacroDraft) -> str:
+    if macro.category:
+        return f"FAQ macro generated from {macro.category} support tickets."
+    return "FAQ macro generated from support tickets."
+
+
+def _headers(credentials: ZendeskMacroCredentials) -> dict[str, str]:
+    return {
+        "Authorization": credentials.authorization_header(),
+        "Content-Type": "application/json",
+    }
+
+
+def _external_id(data: Mapping[str, Any], *, fallback: str = "") -> str:
+    macro = data.get("macro")
+    if isinstance(macro, Mapping):
+        return _clean(macro.get("id")) or _clean(fallback)
+    return _clean(fallback)
+
+
+def _external_url(data: Mapping[str, Any]) -> str:
+    macro = data.get("macro")
+    if isinstance(macro, Mapping):
+        return _clean(macro.get("url"))
+    return ""
+
+
+def _safe_error(exc: Exception) -> str:
+    if isinstance(exc, ZendeskMacroTransportError):
+        return str(exc)
+    return exc.__class__.__name__
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+__all__ = [
+    "StaticZendeskMacroCredentialsProvider",
+    "ZENDESK_PLATFORM",
+    "ZendeskHTTPMacroTransport",
+    "ZendeskMacroCredentials",
+    "ZendeskMacroCredentialsProvider",
+    "ZendeskMacroPublishProvider",
+    "ZendeskMacroTransport",
+    "ZendeskMacroTransportError",
+]

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -168,15 +168,38 @@ class ZendeskMacroPublishProvider:
                 scope=scope,
             )
             payload = _zendesk_macro_payload(macro)
-            if existing is None:
-                data = await self.transport.request(
-                    "POST",
-                    f"{credentials.normalized_base_url()}/api/v2/macros",
-                    headers=_headers(credentials),
-                    json=payload,
+            if existing is not None and not existing.external_id:
+                return MacroPublishResult(
+                    macro=macro,
+                    status="failed",
+                    error="zendesk_macro_mapping_pending_reconcile",
                 )
-                status = "published"
-            else:
+            if existing is None:
+                reservation = await self.mapping_repository.reserve_mapping(
+                    MacroWritebackMapping(
+                        platform=ZENDESK_PLATFORM,
+                        faq_draft_id=macro.faq_draft_id,
+                        faq_item_id=macro.faq_item_id,
+                        external_id="",
+                        publish_status="pending",
+                        metadata={
+                            "title": macro.title,
+                            "category": macro.category,
+                        },
+                    ),
+                    scope=scope,
+                )
+                if reservation.external_id:
+                    existing = reservation
+                else:
+                    data = await self.transport.request(
+                        "POST",
+                        f"{credentials.normalized_base_url()}/api/v2/macros",
+                        headers=_headers(credentials),
+                        json=payload,
+                    )
+                    status = "published"
+            if existing is not None:
                 data = await self.transport.request(
                     "PUT",
                     f"{credentials.normalized_base_url()}/api/v2/macros/{existing.external_id}",
@@ -189,22 +212,31 @@ class ZendeskMacroPublishProvider:
                 return MacroPublishResult(
                     macro=macro,
                     status="failed",
-                    error="zendesk_macro_id_missing",
+                    error="zendesk_macro_id_missing_after_create",
                 )
-            mapping = await self.mapping_repository.upsert_mapping(
-                MacroWritebackMapping(
-                    platform=ZENDESK_PLATFORM,
-                    faq_draft_id=macro.faq_draft_id,
-                    faq_item_id=macro.faq_item_id,
+            try:
+                mapping = await self.mapping_repository.upsert_mapping(
+                    MacroWritebackMapping(
+                        platform=ZENDESK_PLATFORM,
+                        faq_draft_id=macro.faq_draft_id,
+                        faq_item_id=macro.faq_item_id,
+                        external_id=external_id,
+                        external_url=_external_url(data),
+                        publish_status="published",
+                        metadata={
+                            "title": macro.title,
+                            "category": macro.category,
+                        },
+                    ),
+                    scope=scope,
+                )
+            except Exception:
+                return MacroPublishResult(
+                    macro=macro,
+                    status="failed",
                     external_id=external_id,
-                    external_url=_external_url(data),
-                    metadata={
-                        "title": macro.title,
-                        "category": macro.category,
-                    },
-                ),
-                scope=scope,
-            )
+                    error="zendesk_mapping_persist_failed",
+                )
             return MacroPublishResult(
                 macro=macro,
                 status=status,

--- a/extracted_content_pipeline/storage/migrations/329_ticket_faq_macro_writebacks_pending.sql
+++ b/extracted_content_pipeline/storage/migrations/329_ticket_faq_macro_writebacks_pending.sql
@@ -1,0 +1,24 @@
+-- Allow a pending idempotency reservation before the external Zendesk macro id
+-- exists. This closes the create-then-persist retry window: a retry that sees a
+-- pending row must reconcile instead of creating a duplicate macro.
+
+ALTER TABLE ticket_faq_macro_writebacks
+    ADD COLUMN IF NOT EXISTS publish_status TEXT NOT NULL DEFAULT 'published';
+
+ALTER TABLE ticket_faq_macro_writebacks
+    DROP CONSTRAINT IF EXISTS chk_ticket_faq_macro_writebacks_external_id;
+
+ALTER TABLE ticket_faq_macro_writebacks
+    ADD CONSTRAINT chk_ticket_faq_macro_writebacks_publish_status
+    CHECK (publish_status IN ('pending', 'published'));
+
+ALTER TABLE ticket_faq_macro_writebacks
+    ADD CONSTRAINT chk_ticket_faq_macro_writebacks_external_id_when_published
+    CHECK (publish_status <> 'published' OR btrim(external_id) <> '');
+
+ALTER TABLE ticket_faq_macro_writebacks
+    DROP CONSTRAINT IF EXISTS ticket_faq_macro_writebacks_account_id_platform_external_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ticket_faq_macro_writebacks_external_id_unique
+    ON ticket_faq_macro_writebacks (account_id, platform, external_id)
+    WHERE btrim(external_id) <> '';

--- a/plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md
+++ b/plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md
@@ -9,8 +9,8 @@ behind injectable credentials and transport so CI remains no-network while the
 production request shape, auth boundary, idempotency lookup, and per-item
 result handling are proven before any publish trigger is wired.
 The diff is over the 400-LOC soft cap because the live-adapter request shape,
-credential redaction, idempotency behavior, and failure isolation need to ship
-with tests in the same slice.
+credential redaction, idempotency behavior, pending-mapping retry safety, and
+failure isolation need to ship with tests in the same slice.
 
 ## Scope (this PR)
 
@@ -20,16 +20,22 @@ Slice phase: Vertical slice
 1. Add a Zendesk credentials DTO and scope-aware credentials provider protocol.
 2. Add a Zendesk macro transport protocol plus an HTTP transport implementation.
 3. Add `ZendeskMacroPublishProvider` that uses the idempotency mapping repo:
-   existing mapping -> update macro; missing mapping -> create macro.
+   existing mapping -> update macro; missing mapping -> reserve pending mapping
+   -> create macro -> complete mapping.
 4. Map a `SupportMacroDraft` to Zendesk's macro payload using `comment_value`
    plus public comment mode.
-5. Add focused no-network tests for create, update, missing credentials,
-   per-item failure isolation, auth header shape, and token redaction.
+5. Add focused no-network tests for create, update, pending-row retry refusal,
+   create-then-mapping failure, missing credentials, per-item failure isolation,
+   auth header shape, and token redaction.
 
 ### Files touched
 
 - `plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback.py` — mapping reservation port/status fields used by the adapter.
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py` — pending mapping reservation implementation.
 - `extracted_content_pipeline/faq_macro_writeback_zendesk.py` — Zendesk credentials, transport, and publish provider.
+- `extracted_content_pipeline/storage/migrations/329_ticket_faq_macro_writebacks_pending.sql` — migration allowing pending mapping rows before external ids exist.
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` — pending mapping storage and migration tests.
 - `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` — focused adapter tests with fake credentials, mapping repo, and transport.
 - `scripts/run_extracted_pipeline_checks.sh` — extracted check runner enrollment for the new test file.
 
@@ -39,16 +45,20 @@ Slice phase: Vertical slice
 for credentials, then handles each macro independently:
 
 ```text
-mapping exists -> PUT /api/v2/macros/{external_id}
-mapping missing -> POST /api/v2/macros
-successful response -> upsert mapping -> MacroPublishResult(status)
+mapping exists with external_id -> PUT /api/v2/macros/{external_id}
+mapping exists without external_id -> failed pending-reconcile, no POST
+mapping missing -> reserve pending mapping -> POST /api/v2/macros
+successful response -> complete mapping -> MacroPublishResult(status)
 failure -> MacroPublishResult(status="failed") and continue
 ```
 
 The payload follows Zendesk's macro API shape: `{"macro": {"title": ...,
 "actions": [...]}}`, with `comment_value` carrying the approved FAQ answer.
 The HTTP transport builds the Basic auth header from `email/token:api_token`
-but never stores the token in mapping metadata or error strings.
+but never stores the token in mapping metadata or error strings. A successful
+create whose mapping completion fails returns `zendesk_mapping_persist_failed`
+with the external id and leaves a pending mapping row; a retry sees that pending
+row and refuses to POST again until reconciliation clears or completes it.
 
 ## Intentional
 
@@ -57,21 +67,22 @@ but never stores the token in mapping metadata or error strings.
 - Credentials are provided through a protocol rather than read from global env.
   The host app can back this with encrypted tenant storage later without
   changing the adapter contract.
-- The adapter catches per-item failures and returns a failed result instead of
-  aborting the whole batch.
+- The adapter catches per-item boundary failures and returns a failed result
+  instead of aborting the whole batch.
 
 ## Deferred
 
 - Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approved FAQ drafts
-  to the provider and decide when a customer can run live publish.
+  to the provider and decide when a customer can run live publish, including
+  operator handling for pending rows that need reconciliation.
 - Future PR `PR-FAQ-Macro-Writeback-Credential-Storage`: provide encrypted
   tenant credential storage if the existing host secret pattern is not enough.
 - Parked hardening: none
 
 ## Verification
 
-- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` -- passed.
-- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 16 passed.
+- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py` -- passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 20 passed.
 - `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- passed, 129 matching tests enrolled.
 - `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
 - `bash scripts/check_ascii_python.sh` -- passed.
@@ -86,8 +97,12 @@ but never stores the token in mapping metadata or error strings.
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | ~93 |
-| Zendesk adapter | ~281 |
-| Tests | ~233 |
+| Plan | ~108 |
+| Mapping DTO/port | ~9 |
+| Mapping repository | ~46 |
+| Pending migration | ~24 |
+| Zendesk adapter | ~313 |
+| Postgres tests | ~54 |
+| Zendesk tests | ~304 |
 | Runner enrollment | ~1 |
-| Total | ~608 |
+| Total | ~859 |

--- a/plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md
+++ b/plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md
@@ -1,0 +1,93 @@
+# PR: FAQ Macro Writeback Zendesk Adapter
+
+## Why this slice exists
+
+The macro writeback preview and idempotency mapping now exist, but no outbound
+support-tool adapter can use them. The next vertical slice is the first real
+platform adapter: Zendesk macro create/update. This keeps the live API surface
+behind injectable credentials and transport so CI remains no-network while the
+production request shape, auth boundary, idempotency lookup, and per-item
+result handling are proven before any publish trigger is wired.
+The diff is over the 400-LOC soft cap because the live-adapter request shape,
+credential redaction, idempotency behavior, and failure isolation need to ship
+with tests in the same slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add a Zendesk credentials DTO and scope-aware credentials provider protocol.
+2. Add a Zendesk macro transport protocol plus an HTTP transport implementation.
+3. Add `ZendeskMacroPublishProvider` that uses the idempotency mapping repo:
+   existing mapping -> update macro; missing mapping -> create macro.
+4. Map a `SupportMacroDraft` to Zendesk's macro payload using `comment_value`
+   plus public comment mode.
+5. Add focused no-network tests for create, update, missing credentials,
+   per-item failure isolation, auth header shape, and token redaction.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback_zendesk.py` — Zendesk credentials, transport, and publish provider.
+- `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` — focused adapter tests with fake credentials, mapping repo, and transport.
+- `scripts/run_extracted_pipeline_checks.sh` — extracted check runner enrollment for the new test file.
+
+## Mechanism
+
+`ZendeskMacroPublishProvider.publish(...)` asks a scoped credentials provider
+for credentials, then handles each macro independently:
+
+```text
+mapping exists -> PUT /api/v2/macros/{external_id}
+mapping missing -> POST /api/v2/macros
+successful response -> upsert mapping -> MacroPublishResult(status)
+failure -> MacroPublishResult(status="failed") and continue
+```
+
+The payload follows Zendesk's macro API shape: `{"macro": {"title": ...,
+"actions": [...]}}`, with `comment_value` carrying the approved FAQ answer.
+The HTTP transport builds the Basic auth header from `email/token:api_token`
+but never stores the token in mapping metadata or error strings.
+
+## Intentional
+
+- No API route, UI, scheduler, or publish trigger is added here. The adapter is
+  callable but not product-wired until the approval/publish-trigger slice.
+- Credentials are provided through a protocol rather than read from global env.
+  The host app can back this with encrypted tenant storage later without
+  changing the adapter contract.
+- The adapter catches per-item failures and returns a failed result instead of
+  aborting the whole batch.
+
+## Deferred
+
+- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approved FAQ drafts
+  to the provider and decide when a customer can run live publish.
+- Future PR `PR-FAQ-Macro-Writeback-Credential-Storage`: provide encrypted
+  tenant credential storage if the existing host secret pattern is not enough.
+- Parked hardening: none
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` -- passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q` -- 16 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py` -- passed, 129 matching tests enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/check_extracted_imports.py` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `python scripts/smoke_extracted_pipeline_imports.py` -- passed.
+- `python scripts/smoke_extracted_pipeline_standalone.py` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-zendesk-adapter.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~93 |
+| Zendesk adapter | ~281 |
+| Tests | ~233 |
+| Runner enrollment | ~1 |
+| Total | ~608 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -32,6 +32,7 @@ pytest \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \
+  tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \
   tests/test_smoke_content_ops_faq_search_concurrency.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -19,6 +19,13 @@ MIGRATION = (
     / "migrations"
     / "328_ticket_faq_macro_writebacks.sql"
 )
+PENDING_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "extracted_content_pipeline"
+    / "storage"
+    / "migrations"
+    / "329_ticket_faq_macro_writebacks_pending.sql"
+)
 
 
 class _Pool:
@@ -44,6 +51,7 @@ def _row(**overrides) -> dict:
         "faq_item_id": "faq-draft-1:item-1",
         "external_id": "macro-123",
         "external_url": "https://example.zendesk.com/macros/123",
+        "publish_status": "published",
         "metadata": json.dumps({"source": "dry_run"}),
     }
     row.update(overrides)
@@ -62,6 +70,17 @@ def test_ticket_faq_macro_writeback_migration_adds_scoped_unique_mapping() -> No
     assert "UNIQUE (account_id, platform, external_id)" in sql
     assert "chk_ticket_faq_macro_writebacks_account_id" in sql
     assert "idx_ticket_faq_macro_writebacks_platform" in sql
+
+
+def test_ticket_faq_macro_writeback_pending_migration_prevents_retry_duplicates() -> None:
+    sql = PENDING_MIGRATION.read_text()
+
+    assert "ADD COLUMN IF NOT EXISTS publish_status" in sql
+    assert "DROP CONSTRAINT IF EXISTS chk_ticket_faq_macro_writebacks_external_id" in sql
+    assert "chk_ticket_faq_macro_writebacks_publish_status" in sql
+    assert "chk_ticket_faq_macro_writebacks_external_id_when_published" in sql
+    assert "DROP CONSTRAINT IF EXISTS ticket_faq_macro_writebacks_account_id_platform_external_id_key" in sql
+    assert "WHERE btrim(external_id) <> ''" in sql
 
 
 @pytest.mark.asyncio
@@ -83,6 +102,7 @@ async def test_get_mapping_filters_by_tenant_platform_and_faq_item() -> None:
         faq_item_id="faq-draft-1:item-1",
         external_id="macro-123",
         external_url="https://example.zendesk.com/macros/123",
+        publish_status="published",
         metadata={"source": "dry_run"},
     )
     call = pool.fetch_calls[0]
@@ -144,10 +164,44 @@ async def test_upsert_mapping_uses_faq_item_idempotency_key_and_metadata_jsonb()
         "faq-draft-1:item-1",
         "macro-456",
         "https://example.zendesk.com/macros/456",
+        "published",
         '{"updated":true}',
     )
     assert mapping.external_id == "macro-456"
+    assert mapping.publish_status == "published"
     assert mapping.metadata == {"updated": True}
+
+
+@pytest.mark.asyncio
+async def test_reserve_mapping_inserts_pending_row_without_external_id() -> None:
+    pool = _Pool()
+    pool.fetchrow_rows = [_row(external_id="", external_url="", publish_status="pending")]
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    mapping = await repo.reserve_mapping(
+        MacroWritebackMapping(
+            platform=" zendesk ",
+            faq_draft_id="11111111-1111-1111-1111-111111111111",
+            faq_item_id=" faq-draft-1:item-1 ",
+            external_id="will-not-be-used",
+            metadata={"title": "Question"},
+        ),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    call = pool.fetchrow_calls[0]
+    assert "WITH inserted AS" in call["query"]
+    assert "DO NOTHING" in call["query"]
+    assert "VALUES ($1, $2, $3, $4, '', '', 'pending', $5::jsonb)" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "zendesk",
+        "11111111-1111-1111-1111-111111111111",
+        "faq-draft-1:item-1",
+        '{"title":"Question"}',
+    )
+    assert mapping.external_id == ""
+    assert mapping.publish_status == "pending"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -20,9 +20,16 @@ from extracted_content_pipeline.faq_macro_writeback_zendesk import (
 
 
 class _MappingRepo:
-    def __init__(self, existing: MacroWritebackMapping | None = None) -> None:
+    def __init__(
+        self,
+        existing: MacroWritebackMapping | None = None,
+        *,
+        upsert_error: Exception | None = None,
+    ) -> None:
         self.existing = existing
+        self.upsert_error = upsert_error
         self.get_calls: list[dict[str, Any]] = []
+        self.reserve_calls: list[dict[str, Any]] = []
         self.upsert_calls: list[dict[str, Any]] = []
 
     async def get_mapping(
@@ -48,6 +55,17 @@ class _MappingRepo:
         scope: TenantScope,
     ) -> MacroWritebackMapping:
         self.upsert_calls.append({"mapping": mapping, "scope": scope})
+        if self.upsert_error is not None:
+            raise self.upsert_error
+        return mapping
+
+    async def reserve_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        self.reserve_calls.append({"mapping": mapping, "scope": scope})
         return mapping
 
 
@@ -137,11 +155,15 @@ async def test_zendesk_provider_creates_macro_and_persists_mapping() -> None:
     assert saved.platform == ZENDESK_PLATFORM
     assert saved.external_id == "123"
     assert saved.external_url == "https://example.zendesk.com/api/v2/macros/123"
+    assert saved.publish_status == "published"
     assert saved.metadata == {
         "title": "Why was I charged twice?",
         "category": "billing",
     }
     assert "secret-token" not in saved.as_dict()["metadata"].values()
+    reserved = repo.reserve_calls[0]["mapping"]
+    assert reserved.publish_status == "pending"
+    assert reserved.external_id == ""
 
 
 @pytest.mark.asyncio
@@ -166,6 +188,7 @@ async def test_zendesk_provider_updates_existing_macro_from_mapping() -> None:
     assert transport.calls[0]["method"] == "PUT"
     assert transport.calls[0]["url"] == "https://example.zendesk.com/api/v2/macros/123"
     assert repo.get_calls[0]["platform"] == ZENDESK_PLATFORM
+    assert repo.reserve_calls == []
 
 
 @pytest.mark.asyncio
@@ -184,6 +207,53 @@ async def test_zendesk_provider_fails_without_credentials_without_network_call()
     assert results[0].error == "zendesk_credentials_missing"
     assert transport.calls == []
     assert repo.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_refuses_to_repost_when_mapping_is_pending() -> None:
+    repo = _MappingRepo(existing=MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+    ))
+    transport = _Transport({"macro": {"id": 123}})
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "failed"
+    assert results[0].error == "zendesk_macro_mapping_pending_reconcile"
+    assert transport.calls == []
+    assert repo.reserve_calls == []
+    assert repo.upsert_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_marks_create_then_mapping_failure_without_reposting() -> None:
+    repo = _MappingRepo(upsert_error=RuntimeError("database down"))
+    transport = _Transport({"macro": {"id": 123}})
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    first = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+    repo.existing = repo.reserve_calls[0]["mapping"]
+    second = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert first[0].status == "failed"
+    assert first[0].external_id == "123"
+    assert first[0].error == "zendesk_mapping_persist_failed"
+    assert second[0].status == "failed"
+    assert second[0].error == "zendesk_macro_mapping_pending_reconcile"
+    assert [call["method"] for call in transport.calls] == ["POST"]
 
 
 @pytest.mark.asyncio
@@ -212,6 +282,7 @@ async def test_zendesk_provider_isolates_per_item_transport_failures() -> None:
     assert results[1].external_id == "456"
     assert len(transport.calls) == 2
     assert len(repo.upsert_calls) == 1
+    assert len(repo.reserve_calls) == 2
 
 
 def test_zendesk_credentials_repr_redacts_api_token_and_builds_base_url() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import base64
+from typing import Any, Mapping
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    MacroWritebackMapping,
+    SupportMacroDraft,
+)
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    StaticZendeskMacroCredentialsProvider,
+    ZENDESK_PLATFORM,
+    ZendeskMacroCredentials,
+    ZendeskMacroPublishProvider,
+    ZendeskMacroTransportError,
+)
+
+
+class _MappingRepo:
+    def __init__(self, existing: MacroWritebackMapping | None = None) -> None:
+        self.existing = existing
+        self.get_calls: list[dict[str, Any]] = []
+        self.upsert_calls: list[dict[str, Any]] = []
+
+    async def get_mapping(
+        self,
+        *,
+        platform: str,
+        faq_draft_id: str,
+        faq_item_id: str,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping | None:
+        self.get_calls.append({
+            "platform": platform,
+            "faq_draft_id": faq_draft_id,
+            "faq_item_id": faq_item_id,
+            "scope": scope,
+        })
+        return self.existing
+
+    async def upsert_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        self.upsert_calls.append({"mapping": mapping, "scope": scope})
+        return mapping
+
+
+class _Transport:
+    def __init__(self, *responses: Mapping[str, Any] | Exception) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers),
+            "json": dict(json),
+        })
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _credentials() -> ZendeskMacroCredentials:
+    return ZendeskMacroCredentials(
+        subdomain="example",
+        email="agent@example.com",
+        api_token="secret-token",
+    )
+
+
+def _macro(
+    *,
+    draft_id: str = "11111111-1111-1111-1111-111111111111",
+    item_id: str = "faq-draft-1:item-1",
+    title: str = "Why was I charged twice?",
+) -> SupportMacroDraft:
+    return SupportMacroDraft(
+        title=title,
+        body="1. Open Billing.\n2. Compare pending and settled charges.",
+        category="billing",
+        faq_draft_id=draft_id,
+        faq_item_id=item_id,
+        source_ids=("ticket-1",),
+    )
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_creates_macro_and_persists_mapping() -> None:
+    repo = _MappingRepo()
+    transport = _Transport({
+        "macro": {
+            "id": 123,
+            "url": "https://example.zendesk.com/api/v2/macros/123",
+        }
+    })
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "published"
+    assert results[0].external_id == "123"
+    call = transport.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"] == "https://example.zendesk.com/api/v2/macros"
+    assert call["json"]["macro"]["title"] == "Why was I charged twice?"
+    assert call["json"]["macro"]["actions"] == [
+        {
+            "field": "comment_value",
+            "value": "1. Open Billing.\n2. Compare pending and settled charges.",
+        },
+        {"field": "comment_mode_is_public", "value": True},
+    ]
+    assert _decoded_auth(call["headers"]["Authorization"]) == (
+        "agent@example.com/token:secret-token"
+    )
+    saved = repo.upsert_calls[0]["mapping"]
+    assert saved.platform == ZENDESK_PLATFORM
+    assert saved.external_id == "123"
+    assert saved.external_url == "https://example.zendesk.com/api/v2/macros/123"
+    assert saved.metadata == {
+        "title": "Why was I charged twice?",
+        "category": "billing",
+    }
+    assert "secret-token" not in saved.as_dict()["metadata"].values()
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_updates_existing_macro_from_mapping() -> None:
+    repo = _MappingRepo(existing=MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="123",
+    ))
+    transport = _Transport({"macro": {"id": 123}})
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "updated"
+    assert results[0].external_id == "123"
+    assert transport.calls[0]["method"] == "PUT"
+    assert transport.calls[0]["url"] == "https://example.zendesk.com/api/v2/macros/123"
+    assert repo.get_calls[0]["platform"] == ZENDESK_PLATFORM
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_fails_without_credentials_without_network_call() -> None:
+    repo = _MappingRepo()
+    transport = _Transport({"macro": {"id": 123}})
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(None),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "failed"
+    assert results[0].error == "zendesk_credentials_missing"
+    assert transport.calls == []
+    assert repo.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_isolates_per_item_transport_failures() -> None:
+    repo = _MappingRepo()
+    transport = _Transport(
+        ZendeskMacroTransportError(status_code=429),
+        {"macro": {"id": 456}},
+    )
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish(
+        [
+            _macro(item_id="faq-draft-1:item-1", title="First"),
+            _macro(item_id="faq-draft-1:item-2", title="Second"),
+        ],
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert [result.status for result in results] == ["failed", "published"]
+    assert results[0].error == "zendesk_request_failed: status=429"
+    assert results[1].external_id == "456"
+    assert len(transport.calls) == 2
+    assert len(repo.upsert_calls) == 1
+
+
+def test_zendesk_credentials_repr_redacts_api_token_and_builds_base_url() -> None:
+    credentials = ZendeskMacroCredentials(
+        subdomain="example.zendesk.com",
+        email="agent@example.com",
+        api_token="secret-token",
+    )
+
+    assert credentials.normalized_base_url() == "https://example.zendesk.com"
+    assert "secret-token" not in repr(credentials)
+    assert _decoded_auth(credentials.authorization_header()) == (
+        "agent@example.com/token:secret-token"
+    )
+
+
+def _decoded_auth(header: str) -> str:
+    assert header.startswith("Basic ")
+    return base64.b64decode(header.removeprefix("Basic ")).decode("utf-8")


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Zendesk-Adapter.md
Slice phase: Vertical slice

This adds the first live-platform macro writeback adapter boundary: Zendesk macro create/update with scoped credentials, injected transport, pending idempotency reservations, and per-item failure results. The adapter is callable but not wired to any product route or scheduler yet.

## Intentional
- No API route, UI, scheduler, or publish trigger in this slice.
- Credentials are supplied through a scoped provider protocol rather than global env.
- Tests use fake transport and credentials; CI makes no Zendesk network calls.
- Missing mappings are reserved as pending before POST, so a create whose mapping completion fails cannot silently re-POST on retry.

## Deferred
- Future PR `PR-FAQ-Macro-Writeback-Publish-Trigger`: wire approved FAQ drafts to the provider and surface pending rows for reconciliation.
- Future PR `PR-FAQ-Macro-Writeback-Credential-Storage`: add encrypted tenant credential storage if host secret patterns are not enough.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py`
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback.py -q`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `bash scripts/check_ascii_python.sh`
- `python scripts/check_extracted_imports.py`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `python scripts/smoke_extracted_pipeline_imports.py`
- `python scripts/smoke_extracted_pipeline_standalone.py`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-zendesk-adapter.md`

## Diff size
8 files, +856 / -3