### PR TITLE
PR-FAQ-Deflection-Report-Rule-File

### DIFF
--- a/plans/PR-FAQ-Deflection-Report-Rule-File.md
+++ b/plans/PR-FAQ-Deflection-Report-Rule-File.md
@@ -1,0 +1,97 @@
+# FAQ Deflection Report Rule File
+
+## Why this slice exists
+
+The FAQ Markdown CLI supports reusable JSON rule files for customer-specific
+intent and vocabulary mappings, but the customer-facing deflection report CLI
+only accepts inline `--intent-rule` and `--vocabulary-gap-rule` values. Paid
+report runs need the same reusable customer mapping path without asking
+operators to repeat long command lines.
+
+This slice extracts the existing FAQ CLI rule-file parser into one shared script
+helper before wiring the report CLI to it. That keeps rule parsing, validation,
+and precedence in one place instead of reimplementing the same contract in a
+second CLI.
+
+The estimated diff is over the 400 LOC target because the parser is being moved
+to one owner while preserving the existing FAQ CLI validation coverage and
+adding report-level proof. Keeping two independent parser copies would be
+smaller in this PR but would recreate the cross-layer drift pattern this lane
+has been tightening.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Vertical slice
+
+1. Move the existing JSON rule-file parser from the FAQ CLI into a shared script
+   helper.
+2. Keep the FAQ CLI behavior and tests on the shared parser.
+3. Add repeatable JSON rule-file support to the deflection report CLI.
+4. Combine explicit CLI rules before file-loaded rules so command-line values
+   still win when multiple mappings match.
+5. Record rule-file paths and resolved rule config in the report result JSON.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/content_ops_faq_cli_rules.py` | Shared JSON rule-file and inline-rule parser. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Import the shared parser instead of carrying a private copy. |
+| `scripts/build_content_ops_deflection_report.py` | Add JSON rule-file flag handling and shared parser routing. |
+| `tests/test_content_ops_deflection_report.py` | Prove report CLI rule files affect clustering/vocabulary and reject bad files. |
+| `plans/PR-FAQ-Deflection-Report-Rule-File.md` | Plan and verification contract. |
+
+## Mechanism
+
+The shared helper exposes:
+
+```python
+load_rule_files(paths)
+parse_intent_rules(values)
+parse_vocabulary_gap_rules(values)
+```
+
+Both CLIs use those functions. The deflection report CLI resolves:
+
+```python
+intent_rules = (*inline_intent, *file_intent, *DEFAULT_INTENT_RULES)
+vocabulary_gap_rules = (*inline_vocab, *file_vocab)
+```
+
+and passes the resolved rules to `build_ticket_faq_markdown(...)`.
+
+## Intentional
+
+- JSON rule files only. This matches the existing FAQ CLI rule-file contract.
+- This touches the FAQ CLI to remove duplicate parser ownership, but the
+  existing FAQ CLI tests continue to cover the parser's validation branches.
+- No docs update in this slice; the report CLI behavior is covered by `--help`
+  and focused tests. Operator docs can follow once the CLI surface settles.
+
+## Deferred
+
+- Parked hardening: none.
+- Future product-polish slice: add report CLI examples to the extracted README
+  and host runbook after this shared parser lands.
+
+## Verification
+
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py -q
+- Command: python -m py_compile scripts/content_ops_faq_cli_rules.py scripts/build_content_ops_deflection_report.py scripts/build_extracted_ticket_faq_markdown.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Rule-File.md
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Rule-File.md
+- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Rule-File.md origin/main
+- Command: git diff --check
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-rule-file.md
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| `scripts/content_ops_faq_cli_rules.py` | 193 LOC |
+| `scripts/build_extracted_ticket_faq_markdown.py` | 193 LOC |
+| `scripts/build_content_ops_deflection_report.py` | 68 LOC |
+| `tests/test_content_ops_deflection_report.py` | 118 LOC |
+| `plans/PR-FAQ-Deflection-Report-Rule-File.md` | 97 LOC |
+| **Total** | **669 LOC** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -15,6 +15,9 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
@@ -27,6 +30,11 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     DEFAULT_INTENT_RULES,
     DEFAULT_TITLE,
     build_ticket_faq_markdown,
+)
+from content_ops_faq_cli_rules import (  # noqa: E402
+    load_rule_files,
+    parse_intent_rules,
+    parse_vocabulary_gap_rules,
 )
 
 
@@ -114,6 +122,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Comma-separated customer/documentation aliases. Repeat for multiple rules.",
     )
     parser.add_argument(
+        "--rule-file",
+        action="append",
+        default=[],
+        type=Path,
+        help="JSON file with intent_rules and/or vocabulary_gap_rules. Repeat for multiple files.",
+    )
+    parser.add_argument(
         "--intent-rule",
         action="append",
         default=[],
@@ -132,7 +147,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def build_report(args: argparse.Namespace):
-    custom_intent_rules = _parse_intent_rules(args.intent_rule)
+    file_rules = load_rule_files(args.rule_file)
+    vocabulary_gap_rules = (
+        *parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
+        *file_rules["vocabulary_gap_rules"],
+    )
+    args.vocabulary_gap_rules = vocabulary_gap_rules
+    custom_intent_rules = (
+        *parse_intent_rules(args.intent_rule),
+        *file_rules["intent_rules"],
+    )
     args.custom_intent_rules = custom_intent_rules
     intent_rules = (*custom_intent_rules, *DEFAULT_INTENT_RULES)
     loaded = load_source_campaign_opportunities_from_file(
@@ -151,50 +175,13 @@ def build_report(args: argparse.Namespace):
         support_contact=args.support_contact,
         intent_rules=intent_rules,
         documentation_terms=tuple(args.documentation_term or ()),
-        vocabulary_gap_rules=_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
+        vocabulary_gap_rules=vocabulary_gap_rules,
     )
     return build_deflection_report_artifact(
         faq_result,
         title=args.title,
         source_label=str(args.path),
     )
-
-
-def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
-    rules: list[tuple[str, ...]] = []
-    for raw in values or ():
-        parts = tuple(part.strip() for part in str(raw).split(",") if part.strip())
-        if len(parts) < 2:
-            raise SystemExit("--vocabulary-gap-rule must contain at least two comma-separated terms")
-        rules.append(parts)
-    return tuple(rules)
-
-
-def _parse_intent_rules(values: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
-    rules: list[tuple[str, tuple[str, ...]]] = []
-    for value in values or ():
-        topic, separator, raw_keywords = str(value).partition("=")
-        topic = topic.strip()
-        keywords = _parse_intent_rule_keywords(raw_keywords)
-        if not separator or not topic or not keywords:
-            raise SystemExit(
-                "--intent-rule must use topic=keyword,keyword with at least one keyword"
-            )
-        rules.append((topic, keywords))
-    return tuple(rules)
-
-
-def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
-    keywords: list[str] = []
-    seen: set[str] = set()
-    for part in value.split(","):
-        keyword = part.strip()
-        key = keyword.lower()
-        if not keyword or key in seen:
-            continue
-        seen.add(key)
-        keywords.append(keyword)
-    return tuple(keywords)
 
 
 def _failed_output_checks(output_checks: Mapping[str, Any]) -> list[str]:
@@ -229,9 +216,10 @@ def _result_payload(
             "as_of_date": args.as_of_date,
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
+            "rule_files": [str(path) for path in args.rule_file],
             "documentation_terms": list(args.documentation_term or ()),
             "vocabulary_gap_rules": [
-                list(rule) for rule in _parse_vocabulary_gap_rules(args.vocabulary_gap_rule)
+                list(rule) for rule in getattr(args, "vocabulary_gap_rules", ())
             ],
             "custom_intent_rules": [
                 {"topic": topic, "keywords": list(keywords)}

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -16,6 +16,9 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
 
 _DOCUMENTATION_TERM_ROW_KEYS = (
     "documentation_term",
@@ -51,6 +54,11 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     is_zero_result_search_row,
     source_row_weight,
     weighted_source_volume_by_group,
+)
+from content_ops_faq_cli_rules import (  # noqa: E402
+    load_rule_files,
+    parse_intent_rules,
+    parse_vocabulary_gap_rules,
 )
 
 _SOURCE_CHANNELS = {
@@ -215,14 +223,14 @@ def main(argv: list[str] | None = None) -> int:
         args.documentation_term_format,
     )
     args.documentation_terms = documentation_terms
-    file_rules = _load_rule_files(args.rule_file)
+    file_rules = load_rule_files(args.rule_file)
     vocabulary_gap_rules = (
-        *_parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
+        *parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
         *file_rules["vocabulary_gap_rules"],
     )
     args.vocabulary_gap_rules = vocabulary_gap_rules
     custom_intent_rules = (
-        *_parse_intent_rules(args.intent_rule),
+        *parse_intent_rules(args.intent_rule),
         *file_rules["intent_rules"],
     )
     args.custom_intent_rules = custom_intent_rules
@@ -545,58 +553,6 @@ def _clean_diagnostic_text(value: Any) -> str:
     return " ".join(str(value or "").split())
 
 
-def _parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
-    rules: list[tuple[str, ...]] = []
-    for value in values:
-        terms = _parse_vocabulary_gap_rule_terms(value)
-        if len(terms) < 2:
-            raise SystemExit(
-                "--vocabulary-gap-rule must include at least two comma-separated terms"
-            )
-        rules.append(terms)
-    return tuple(rules)
-
-
-def _parse_vocabulary_gap_rule_terms(value: str) -> tuple[str, ...]:
-    terms: list[str] = []
-    seen: set[str] = set()
-    for part in value.split(","):
-        term = part.strip()
-        key = term.lower()
-        if not term or key in seen:
-            continue
-        seen.add(key)
-        terms.append(term)
-    return tuple(terms)
-
-
-def _parse_intent_rules(values: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
-    rules: list[tuple[str, tuple[str, ...]]] = []
-    for value in values:
-        topic, separator, raw_keywords = value.partition("=")
-        topic = topic.strip()
-        keywords = _parse_intent_rule_keywords(raw_keywords)
-        if not separator or not topic or not keywords:
-            raise SystemExit(
-                "--intent-rule must use topic=keyword,keyword with at least one keyword"
-            )
-        rules.append((topic, keywords))
-    return tuple(rules)
-
-
-def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
-    keywords: list[str] = []
-    seen: set[str] = set()
-    for part in value.split(","):
-        keyword = part.strip()
-        key = keyword.lower()
-        if not keyword or key in seen:
-            continue
-        seen.add(key)
-        keywords.append(keyword)
-    return tuple(keywords)
-
-
 def _cli_documentation_terms(
     inline_terms: list[str],
     files: list[Path],
@@ -787,133 +743,6 @@ def _clean_cli_documentation_terms(terms: list[str]) -> tuple[str, ...]:
         if text:
             out.setdefault(text.lower(), text)
     return tuple(out.values())
-
-
-def _load_rule_files(paths: list[Path]) -> dict[str, tuple[Any, ...]]:
-    intent_rules: list[tuple[str, tuple[str, ...]]] = []
-    vocabulary_gap_rules: list[tuple[str, ...]] = []
-    for path in paths:
-        payload = _load_rule_file(path)
-        intent_rules.extend(_parse_intent_rule_payloads(payload.get("intent_rules", []), path))
-        vocabulary_gap_rules.extend(
-            _parse_vocabulary_gap_rule_payloads(
-                payload.get("vocabulary_gap_rules", []),
-                path,
-            )
-        )
-    return {
-        "intent_rules": tuple(intent_rules),
-        "vocabulary_gap_rules": tuple(vocabulary_gap_rules),
-    }
-
-
-def _load_rule_file(path: Path) -> dict[str, Any]:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        raise SystemExit(f"--rule-file not found: {path}") from None
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"--rule-file must be valid JSON: {path}: {exc.msg}") from None
-    if not isinstance(payload, dict):
-        raise SystemExit(f"--rule-file must contain a JSON object: {path}")
-    allowed = {"intent_rules", "vocabulary_gap_rules"}
-    unknown = sorted(str(key) for key in payload if key not in allowed)
-    if unknown:
-        raise SystemExit(
-            f"--rule-file contains unsupported key(s): {', '.join(unknown)}"
-        )
-    return payload
-
-
-def _parse_intent_rule_payloads(
-    values: Any,
-    path: Path,
-) -> tuple[tuple[str, tuple[str, ...]], ...]:
-    if not isinstance(values, list):
-        raise SystemExit(f"--rule-file intent_rules must be an array: {path}")
-    rules: list[tuple[str, tuple[str, ...]]] = []
-    for index, value in enumerate(values, start=1):
-        if not isinstance(value, dict):
-            raise SystemExit(
-                f"--rule-file intent_rules[{index}] must be an object: {path}"
-            )
-        topic = _rule_file_text(
-            value.get("topic"),
-            path=path,
-            label=f"intent_rules[{index}].topic",
-            forbidden=("=", ","),
-        )
-        keywords = value.get("keywords")
-        if not isinstance(keywords, list):
-            raise SystemExit(
-                f"--rule-file intent_rules[{index}].keywords must be an array: {path}"
-            )
-        parsed_keywords = [
-            _rule_file_text(
-                keyword,
-                path=path,
-                label=f"intent_rules[{index}].keywords",
-                forbidden=(",",),
-            )
-            for keyword in keywords
-        ]
-        rule_text = f"{topic}={','.join(parsed_keywords)}"
-        try:
-            rules.extend(_parse_intent_rules([rule_text]))
-        except SystemExit as exc:
-            raise SystemExit(
-                f"--rule-file intent_rules[{index}] is invalid: {path}: {exc}"
-            ) from None
-    return tuple(rules)
-
-
-def _parse_vocabulary_gap_rule_payloads(
-    values: Any,
-    path: Path,
-) -> tuple[tuple[str, ...], ...]:
-    if not isinstance(values, list):
-        raise SystemExit(f"--rule-file vocabulary_gap_rules must be an array: {path}")
-    rules: list[tuple[str, ...]] = []
-    for index, value in enumerate(values, start=1):
-        if not isinstance(value, list):
-            raise SystemExit(
-                f"--rule-file vocabulary_gap_rules[{index}] must be an array: {path}"
-            )
-        aliases = [
-            _rule_file_text(
-                alias,
-                path=path,
-                label=f"vocabulary_gap_rules[{index}]",
-                forbidden=(",",),
-            )
-            for alias in value
-        ]
-        rule_text = ",".join(aliases)
-        try:
-            rules.extend(_parse_vocabulary_gap_rules([rule_text]))
-        except SystemExit as exc:
-            raise SystemExit(
-                f"--rule-file vocabulary_gap_rules[{index}] is invalid: {path}: {exc}"
-            ) from None
-    return tuple(rules)
-
-
-def _rule_file_text(
-    value: Any,
-    *,
-    path: Path,
-    label: str,
-    forbidden: tuple[str, ...],
-) -> str:
-    if not isinstance(value, str):
-        raise SystemExit(f"--rule-file {label} must contain string values: {path}")
-    text = value.strip()
-    for delimiter in forbidden:
-        if delimiter in text:
-            raise SystemExit(
-                f"--rule-file {label} cannot contain delimiter {delimiter!r}: {path}"
-            )
-    return text
 
 
 def _output_check_details(

--- a/scripts/content_ops_faq_cli_rules.py
+++ b/scripts/content_ops_faq_cli_rules.py
@@ -1,0 +1,193 @@
+"""Shared CLI parsing for support-ticket FAQ custom rules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
+    rules: list[tuple[str, ...]] = []
+    for raw in values or ():
+        parts = _parse_vocabulary_gap_rule_terms(str(raw))
+        if len(parts) < 2:
+            raise SystemExit(
+                "--vocabulary-gap-rule must include at least two comma-separated terms"
+            )
+        rules.append(parts)
+    return tuple(rules)
+
+
+def parse_intent_rules(values: list[str]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for value in values or ():
+        topic, separator, raw_keywords = str(value).partition("=")
+        topic = topic.strip()
+        keywords = _parse_intent_rule_keywords(raw_keywords)
+        if not separator or not topic or not keywords:
+            raise SystemExit(
+                "--intent-rule must use topic=keyword,keyword with at least one keyword"
+            )
+        rules.append((topic, keywords))
+    return tuple(rules)
+
+
+def load_rule_files(paths: list[Path]) -> dict[str, tuple[Any, ...]]:
+    intent_rules: list[tuple[str, tuple[str, ...]]] = []
+    vocabulary_gap_rules: list[tuple[str, ...]] = []
+    for path in paths:
+        payload = _load_rule_file(path)
+        intent_rules.extend(_parse_intent_rule_payloads(payload.get("intent_rules", []), path))
+        vocabulary_gap_rules.extend(
+            _parse_vocabulary_gap_rule_payloads(
+                payload.get("vocabulary_gap_rules", []),
+                path,
+            )
+        )
+    return {
+        "intent_rules": tuple(intent_rules),
+        "vocabulary_gap_rules": tuple(vocabulary_gap_rules),
+    }
+
+
+def _parse_vocabulary_gap_rule_terms(value: str) -> tuple[str, ...]:
+    terms: list[str] = []
+    seen: set[str] = set()
+    for part in value.split(","):
+        term = part.strip()
+        key = term.lower()
+        if not term or key in seen:
+            continue
+        seen.add(key)
+        terms.append(term)
+    return tuple(terms)
+
+
+def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
+    keywords: list[str] = []
+    seen: set[str] = set()
+    for part in value.split(","):
+        keyword = part.strip()
+        key = keyword.lower()
+        if not keyword or key in seen:
+            continue
+        seen.add(key)
+        keywords.append(keyword)
+    return tuple(keywords)
+
+
+def _load_rule_file(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"--rule-file not found: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"--rule-file must be valid JSON: {path}: {exc.msg}") from None
+    if not isinstance(payload, dict):
+        raise SystemExit(f"--rule-file must contain a JSON object: {path}")
+    allowed = {"intent_rules", "vocabulary_gap_rules"}
+    unknown = sorted(str(key) for key in payload if key not in allowed)
+    if unknown:
+        raise SystemExit(
+            f"--rule-file contains unsupported key(s): {', '.join(unknown)}"
+        )
+    return payload
+
+
+def _parse_intent_rule_payloads(
+    values: Any,
+    path: Path,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if not isinstance(values, list):
+        raise SystemExit(f"--rule-file intent_rules must be an array: {path}")
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for index, value in enumerate(values, start=1):
+        if not isinstance(value, dict):
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}] must be an object: {path}"
+            )
+        topic = _rule_file_text(
+            value.get("topic"),
+            path=path,
+            label=f"intent_rules[{index}].topic",
+            forbidden=("=", ","),
+        )
+        keywords = value.get("keywords")
+        if not isinstance(keywords, list):
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}].keywords must be an array: {path}"
+            )
+        parsed_keywords = [
+            _rule_file_text(
+                keyword,
+                path=path,
+                label=f"intent_rules[{index}].keywords",
+                forbidden=(",",),
+            )
+            for keyword in keywords
+        ]
+        rule_text = f"{topic}={','.join(parsed_keywords)}"
+        try:
+            rules.extend(parse_intent_rules([rule_text]))
+        except SystemExit as exc:
+            raise SystemExit(
+                f"--rule-file intent_rules[{index}] is invalid: {path}: {exc}"
+            ) from None
+    return tuple(rules)
+
+
+def _parse_vocabulary_gap_rule_payloads(
+    values: Any,
+    path: Path,
+) -> tuple[tuple[str, ...], ...]:
+    if not isinstance(values, list):
+        raise SystemExit(f"--rule-file vocabulary_gap_rules must be an array: {path}")
+    rules: list[tuple[str, ...]] = []
+    for index, value in enumerate(values, start=1):
+        if not isinstance(value, list):
+            raise SystemExit(
+                f"--rule-file vocabulary_gap_rules[{index}] must be an array: {path}"
+            )
+        aliases = [
+            _rule_file_text(
+                alias,
+                path=path,
+                label=f"vocabulary_gap_rules[{index}]",
+                forbidden=(",",),
+            )
+            for alias in value
+        ]
+        rule_text = ",".join(aliases)
+        try:
+            rules.extend(parse_vocabulary_gap_rules([rule_text]))
+        except SystemExit as exc:
+            raise SystemExit(
+                f"--rule-file vocabulary_gap_rules[{index}] is invalid: {path}: {exc}"
+            ) from None
+    return tuple(rules)
+
+
+def _rule_file_text(
+    value: Any,
+    *,
+    path: Path,
+    label: str,
+    forbidden: tuple[str, ...],
+) -> str:
+    if not isinstance(value, str):
+        raise SystemExit(f"--rule-file {label} must contain string values: {path}")
+    text = value.strip()
+    for delimiter in forbidden:
+        if delimiter in text:
+            raise SystemExit(
+                f"--rule-file {label} cannot contain delimiter {delimiter!r}: {path}"
+            )
+    return text
+
+
+__all__ = [
+    "load_rule_files",
+    "parse_intent_rules",
+    "parse_vocabulary_gap_rules",
+]

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -329,6 +329,124 @@ def test_deflection_report_cli_applies_custom_intent_rules(tmp_path: Path) -> No
     assert "ticket-access-1, ticket-access-2" in markdown
 
 
+def test_deflection_report_cli_accepts_json_rule_file(tmp_path: Path) -> None:
+    source = tmp_path / "rule-file-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    result_output = tmp_path / "deflection-report-result.json"
+    rule_file = tmp_path / "faq-rules.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-rule-1",
+                "source_type": "support_ticket",
+                "subject": "SSO sync",
+                "message": "How do I enable SSO after warehouse sync?",
+            },
+            {
+                "ticket_id": "ticket-rule-2",
+                "source_type": "support_ticket",
+                "subject": "Connector lag",
+                "message": "Can connector lag delay SSO provisioning?",
+            },
+        ]),
+        encoding="utf-8",
+    )
+    rule_file.write_text(
+        json.dumps({
+            "intent_rules": [
+                {"topic": "file topic", "keywords": ["warehouse sync", "connector lag"]}
+            ],
+            "vocabulary_gap_rules": [["SSO", "single sign-on"]],
+        }),
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--documentation-term",
+        "Single sign-on setup",
+        "--rule-file",
+        str(rule_file),
+        "--intent-rule",
+        "cli topic=warehouse sync,connector lag",
+        "--require-output-checks",
+        "--output",
+        str(output),
+        "--result-output",
+        str(result_output),
+    ])
+
+    assert exit_code == 0
+    markdown = output.read_text(encoding="utf-8")
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["rule_files"] == [str(rule_file)]
+    assert result["config"]["custom_intent_rules"] == [
+        {"topic": "cli topic", "keywords": ["warehouse sync", "connector lag"]},
+        {"topic": "file topic", "keywords": ["warehouse sync", "connector lag"]},
+    ]
+    assert result["config"]["vocabulary_gap_rules"] == [["SSO", "single sign-on"]]
+    assert result["generated"] == 1
+    assert result["diagnostics"]["items"][0]["topic"] == "cli topic"
+    assert result["diagnostics"]["items"][0]["source_id_count"] == 2
+    assert result["diagnostics"]["items"][0]["term_mapping_count"] >= 1
+    assert "SSO" in markdown
+    assert "Single sign-on setup" in markdown
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "--rule-file must contain a JSON object"),
+        ({"unknown": []}, "--rule-file contains unsupported key(s): unknown"),
+        ({"intent_rules": "bad"}, "--rule-file intent_rules must be an array"),
+        (
+            {"intent_rules": [{"topic": "data freshness", "keywords": []}]},
+            "--rule-file intent_rules[1] is invalid",
+        ),
+        (
+            {"vocabulary_gap_rules": [["SSO"]]},
+            "--rule-file vocabulary_gap_rules[1] is invalid",
+        ),
+    ],
+)
+def test_deflection_report_cli_rejects_invalid_rule_file(
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    source = tmp_path / "bad-rule-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    rule_file = tmp_path / "faq-rules.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-rule-1",
+                "source_type": "support_ticket",
+                "subject": "Sync lag",
+                "message": "The warehouse sync is delayed.",
+            },
+        ]),
+        encoding="utf-8",
+    )
+    rule_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        MODULE.main([
+            str(source),
+            "--source-format",
+            "json",
+            "--rule-file",
+            str(rule_file),
+            "--output",
+            str(output),
+        ])
+
+    assert message in str(exc_info.value)
+    assert not output.exists()
+
+
 @pytest.mark.parametrize(
     "rule",
     [


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Rule-File.md
Slice phase: Vertical slice

Adds reusable JSON rule-file support to the customer-facing FAQ deflection report CLI and moves the existing FAQ CLI rule parser into one shared script helper so the two CLIs do not drift.

## Intentional
- JSON rule files only, matching the existing FAQ CLI contract.
- The FAQ CLI is touched to remove duplicate parser ownership while preserving its existing validation tests.
- No docs update in this slice; operator docs can follow after the shared CLI surface lands.

## Deferred
- Future product-polish slice: add report CLI rule-file examples to the extracted README and host runbook.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py -q` — 157 passed.
- `python -m py_compile scripts/content_ops_faq_cli_rules.py scripts/build_content_ops_deflection_report.py scripts/build_extracted_ticket_faq_markdown.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py` — passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Rule-File.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Rule-File.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Rule-File.md origin/main` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-rule-file.md` — passed.

## Diff size
5 files, +447 / -222
