### PR TITLE
PR-FAQ-Deflection-Report-Rule-File-Docs

### DIFF
--- a/extracted_content_pipeline/README.md
+++ b/extracted_content_pipeline/README.md
@@ -242,6 +242,30 @@ overrides win when multiple rules match. Rule-file values use the same CLI
 delimiter guardrails: intent topics cannot contain `=` or `,`, and keywords or
 vocabulary aliases cannot contain `,`.
 
+To build the customer-facing Support Ticket Deflection Report deliverable from
+the same support-ticket rows, use the report CLI. It writes the full Markdown
+report, a compact summary JSON, and a result JSON with resolved rule config,
+output checks, and item-level proof metadata:
+
+```bash
+python scripts/build_content_ops_deflection_report.py \
+  extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --source-format csv \
+  --documentation-term "Single sign-on setup" \
+  --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
+  --require-output-checks \
+  --result-output deflection-report-result.json \
+  --summary-output deflection-report-summary.json \
+  --output deflection-report.md
+```
+
+The report CLI uses the same JSON rule-file contract and precedence as the FAQ
+CLI: explicit `--intent-rule` and `--vocabulary-gap-rule` values are evaluated
+before file-loaded rules, and default intent rules are evaluated last. When
+`--require-output-checks` is present and a check fails, the result JSON is still
+written for diagnostics, but the customer-facing Markdown and summary files are
+not written.
+
 For large-upload validation, compare the scale smoke `run_summary.json` against
 the checked-in failure profiles:
 

--- a/extracted_content_pipeline/docs/host_install_runbook.md
+++ b/extracted_content_pipeline/docs/host_install_runbook.md
@@ -302,6 +302,26 @@ Repeat `--rule-file` to combine files. Explicit `--intent-rule` and
 use the same CLI delimiter guardrails: intent topics cannot contain `=` or `,`,
 and keywords or vocabulary aliases cannot contain `,`.
 
+To build the customer-facing deflection report artifact for review or delivery,
+run the report CLI with the same support-ticket rows and rule-file contract:
+
+```bash
+python scripts/build_content_ops_deflection_report.py \
+  extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --source-format csv \
+  --documentation-term "Single sign-on setup" \
+  --rule-file extracted_content_pipeline/examples/faq_custom_rules.json \
+  --require-output-checks \
+  --result-output deflection-report-result.json \
+  --summary-output deflection-report-summary.json \
+  --output deflection-report.md
+```
+
+`deflection-report.md` is the customer-facing report. The result JSON records
+the resolved intent/vocabulary rules, output checks, and compact item proof
+metadata. If `--require-output-checks` fails, the result JSON is still written
+and the Markdown/summary artifacts are withheld.
+
 When `ticket_faq_markdown` migrations are installed, prove the persisted review
 loop with the FAQ lifecycle smoke:
 

--- a/plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md
+++ b/plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md
@@ -1,0 +1,75 @@
+# FAQ Deflection Report Rule File Docs
+
+## Why this slice exists
+
+The deflection report CLI now supports output-check gating, result JSON,
+custom intent rules, and reusable JSON rule files, but the operator docs still
+only show the lower-level FAQ Markdown CLI. Operators need a copy-pasteable
+report command for the $1,500 deliverable path, including the fail-closed
+behavior added before this slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+Slice phase: Product polish
+
+1. Add README guidance for generating the customer-facing deflection report
+   artifact from support-ticket rows.
+2. Add host-runbook guidance with the same command shape.
+3. Document rule-file reuse, result JSON, and output-check gating at the report
+   CLI boundary.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `extracted_content_pipeline/README.md` | Add operator-facing deflection report CLI example and behavior notes. |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | Add host runbook command for the report deliverable. |
+| `plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md` | Plan and verification contract. |
+
+## Mechanism
+
+The docs place the report CLI immediately after the existing reusable FAQ rule
+file section. Both examples use:
+
+```bash
+python scripts/build_content_ops_deflection_report.py ...
+```
+
+with `--rule-file`, `--result-output`, `--summary-output`,
+`--require-output-checks`, and `--output`. The prose names the fail-closed
+behavior: result JSON is written before the gate exits, while customer-facing
+Markdown is withheld when output checks fail.
+
+## Intentional
+
+- Docs only. The CLI behavior was implemented and tested in the prior code
+  slices.
+- The examples reuse the checked synthetic SaaS support-ticket rows and checked
+  JSON rule file so operators can run them locally without credentials.
+- No hosted-route runbook changes here; this is the local deliverable artifact
+  path, not the #1075 hosted search route.
+
+## Deferred
+
+- Parked hardening: none.
+- Future production-hardening slice: add deployed-host report build/runbook
+  proof only after the operator-provisioned host is available.
+
+## Verification
+
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md
+- Command: python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md origin/main
+- Command: rg -n "build_content_ops_deflection_report.py|deflection-report-result|Deflection report" extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md
+- Command: git diff --check
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-rule-file-docs.md
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| `extracted_content_pipeline/README.md` | 24 LOC |
+| `extracted_content_pipeline/docs/host_install_runbook.md` | 20 LOC |
+| `plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md` | 75 LOC |
+| **Total** | **119 LOC** |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md
Slice phase: Product polish

Documents the customer-facing deflection report CLI rule-file flow now that the report CLI supports JSON rule files, result JSON, and output-check gating.

## Intentional
- Docs only; the CLI behavior was implemented and tested in prior slices.
- Examples use checked synthetic SaaS support-ticket rows and the checked JSON rule file, so they are credential-free.
- No hosted-route runbook changes; this is the local report artifact path.

## Deferred
- Future production-hardening slice: add deployed-host report build/runbook proof only after the operator-provisioned host is available.

## Parked hardening
- None.

## Verification
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md` — passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md` — passed.
- `python scripts/audit_plan_doc_diff_size.py plans/PR-FAQ-Deflection-Report-Rule-File-Docs.md origin/main` — passed.
- `rg -n "build_content_ops_deflection_report.py|deflection-report-result|Deflection Report|deflection report artifact" extracted_content_pipeline/README.md extracted_content_pipeline/docs/host_install_runbook.md` — passed.
- `git diff --check` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-report-rule-file-docs.md` — passed.

## Diff size
3 files, +119 / -0
