### PR TITLE
Add FAQ macro writeback publish trigger

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -1,0 +1,164 @@
+"""Publish approved FAQ drafts to support macro providers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, replace
+from typing import Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .faq_macro_writeback import (
+    APPROVED_FAQ_STATUS,
+    MacroPublishProvider,
+    MacroPublishResult,
+    MacroWritebackPreview,
+    build_macro_writeback_preview,
+)
+from .ticket_faq_ports import TicketFAQRepository
+
+
+PUBLISHED_FAQ_STATUS = "published"
+SUCCESSFUL_MACRO_STATUSES = frozenset({"published", "updated"})
+
+
+@dataclass(frozen=True)
+class FAQMacroPublishSummary:
+    """Summary returned by the FAQ macro publish trigger."""
+
+    faq_id: str
+    found: bool
+    draft_status: str = ""
+    publishable_count: int = 0
+    skipped_count: int = 0
+    published_count: int = 0
+    updated_count: int = 0
+    failed_count: int = 0
+    pending_reconcile_count: int = 0
+    draft_status_updated: bool = False
+    skipped: Sequence[JsonDict] = field(default_factory=tuple)
+    results: Sequence[JsonDict] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.found
+            and self.publishable_count > 0
+            and self.skipped_count == 0
+            and self.failed_count == 0
+            and self.pending_reconcile_count == 0
+            and self.publishable_count == self.published_count + self.updated_count
+        )
+
+    def as_dict(self) -> JsonDict:
+        data = asdict(self)
+        data["ok"] = self.ok
+        data["skipped"] = [dict(item) for item in self.skipped]
+        data["results"] = [dict(item) for item in self.results]
+        return data
+
+
+@dataclass(frozen=True)
+class FAQMacroWritebackPublishService:
+    """Product-level trigger for approved FAQ macro writeback."""
+
+    faq_repository: TicketFAQRepository
+    provider: MacroPublishProvider
+    published_status: str = PUBLISHED_FAQ_STATUS
+
+    async def publish_faq_draft(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+    ) -> FAQMacroPublishSummary:
+        cleaned_id = _clean(faq_id)
+        if not cleaned_id:
+            return FAQMacroPublishSummary(faq_id="", found=False)
+
+        draft = await self.faq_repository.get_draft(cleaned_id, scope=scope)
+        if draft is None:
+            return FAQMacroPublishSummary(faq_id=cleaned_id, found=False)
+
+        preview = build_macro_writeback_preview([draft])
+        if not preview.macros:
+            return _summary(
+                faq_id=cleaned_id,
+                found=True,
+                draft_status=_clean(draft.status),
+                preview=preview,
+                results=(),
+            )
+
+        results = tuple(await self.provider.publish(preview.macros, scope=scope))
+        summary = _summary(
+            faq_id=cleaned_id,
+            found=True,
+            draft_status=_clean(draft.status),
+            preview=preview,
+            results=results,
+        )
+        if _should_mark_published(summary):
+            status_updated = await self.faq_repository.update_status(
+                cleaned_id,
+                self.published_status,
+                scope=scope,
+            )
+            return replace(summary, draft_status_updated=status_updated)
+        return summary
+
+
+def _summary(
+    *,
+    faq_id: str,
+    found: bool,
+    draft_status: str,
+    preview: MacroWritebackPreview,
+    results: Sequence[MacroPublishResult],
+) -> FAQMacroPublishSummary:
+    pending_reconcile_count = sum(1 for result in results if _is_pending_reconcile(result))
+    failed_count = sum(1 for result in results if result.status == "failed")
+    return FAQMacroPublishSummary(
+        faq_id=faq_id,
+        found=found,
+        draft_status=draft_status,
+        publishable_count=preview.publishable_count,
+        skipped_count=preview.skipped_count,
+        published_count=sum(1 for result in results if result.status == "published"),
+        updated_count=sum(1 for result in results if result.status == "updated"),
+        failed_count=failed_count,
+        pending_reconcile_count=pending_reconcile_count,
+        skipped=tuple(item.as_dict() for item in preview.skipped),
+        results=tuple(result.as_dict() for result in results),
+    )
+
+
+def _should_mark_published(summary: FAQMacroPublishSummary) -> bool:
+    result_count = len(summary.results)
+    return (
+        _clean(summary.draft_status) == APPROVED_FAQ_STATUS
+        and summary.publishable_count > 0
+        and result_count == summary.publishable_count
+        and summary.skipped_count == 0
+        and summary.failed_count == 0
+        and summary.pending_reconcile_count == 0
+        and all(
+            _clean(result.get("status")) in SUCCESSFUL_MACRO_STATUSES
+            for result in summary.results
+        )
+    )
+
+
+def _is_pending_reconcile(result: MacroPublishResult) -> bool:
+    error = _clean(result.error)
+    return result.status == "failed" and error.endswith("pending_reconcile")
+
+
+def _clean(value: object) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+__all__ = [
+    "FAQMacroPublishSummary",
+    "FAQMacroWritebackPublishService",
+    "PUBLISHED_FAQ_STATUS",
+    "SUCCESSFUL_MACRO_STATUSES",
+]

--- a/plans/PR-FAQ-Macro-Writeback-Publish-Trigger.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-Trigger.md
@@ -1,0 +1,106 @@
+# PR-FAQ-Macro-Writeback-Publish-Trigger
+
+## Why this slice exists
+
+The FAQ macro writeback lane can now preview approved FAQ items, persist
+idempotency mappings, and publish macros through the Zendesk adapter. What is
+still missing is the product-level trigger that ties those pieces together:
+fetch an approved FAQ draft for one tenant, publish only the verified macro
+items, and report any pending Zendesk reconciliation state instead of letting a
+retry duplicate external macros.
+
+This lands above the 400-LOC soft target because the service boundary and its
+approval/skipped/pending/dry-run tests need to ship together for the trigger to
+be reviewable as one real flow.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add a small FAQ macro publish service that fetches tenant-scoped FAQ drafts,
+   runs the existing preview double gate, calls an injected macro publish
+   provider, and returns a structured summary.
+2. Mark a FAQ draft `published` only when the whole draft cleanly publishes:
+   no skipped items, at least one publishable macro, and every provider result
+   is `published` or `updated`.
+3. Surface pending mapping reconciliation as first-class summary state so the
+   create-then-mapping-failure path from the Zendesk adapter does not disappear
+   behind a generic failure count.
+4. Add focused service tests proving approval gating, tenant-scoped repository
+   calls, clean publish status transition, skipped-item behavior, and pending
+   reconciliation reporting.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-Trigger.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback_publish.py` — publish trigger service.
+- `tests/test_extracted_ticket_faq_macro_writeback_publish.py` — service coverage.
+- `scripts/run_extracted_pipeline_checks.sh` — extracted-package CI enrollment for the new service test.
+
+## Mechanism
+
+The new `FAQMacroWritebackPublishService` accepts the existing
+`TicketFAQRepository` and `MacroPublishProvider` ports. Its `publish_faq_draft`
+method:
+
+1. Calls `faq_repository.get_draft(faq_id, scope=scope)`.
+2. Builds a `MacroWritebackPreview` from the returned draft.
+3. Calls `provider.publish(preview.macros, scope=scope)` only when the preview
+   has publishable macros.
+4. Counts successful, failed, skipped, and pending-reconcile outcomes.
+5. Calls `faq_repository.update_status(faq_id, "published", scope=scope)` only
+   when the draft had no skipped items and every provider result succeeded.
+
+Pending reconciliation is detected by provider result errors ending in
+`pending_reconcile`, including the Zendesk adapter's
+`zendesk_macro_mapping_pending_reconcile` result.
+
+## Intentional
+
+- No API route in this slice. The service is the narrow product trigger
+  boundary; routing, auth wiring, and UI controls belong in the next slice once
+  the orchestration contract is proven.
+- No live Zendesk lookup/reconcile yet. The adapter already prevents duplicate
+  POSTs on pending mappings, and this service surfaces that state so the next
+  publish-route slice can decide whether to run a reconcile command, show an
+  operator action, or both.
+- The draft status changes to `published` only on all-clean results. Partial
+  publish, skipped unverified items, missing drafts, and pending reconciliation
+  all leave the review status unchanged.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Publish-Route`: expose this service through a scoped
+  backend route / CLI entry point and wire the selected provider.
+- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: look up pending Zendesk macros by
+  their reserved title/category metadata and backfill `external_id` when a prior
+  create succeeded but mapping persistence failed.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: add the operator review action once the
+  route exists.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py — 6 passed.
+- python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_publish.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python scripts/check_extracted_imports.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- python scripts/smoke_extracted_pipeline_imports.py — passed.
+- python scripts/smoke_extracted_pipeline_standalone.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-trigger.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~105 |
+| Service | ~165 |
+| Tests | ~260 |
+| CI enrollment | ~5 |
+| Total | ~535 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -32,6 +32,7 @@ pytest \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \
+  tests/test_extracted_ticket_faq_macro_writeback_publish.py \
   tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from typing import Sequence, cast
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    MacroPublishResult,
+    MacroPublishStatus,
+    SupportMacroDraft,
+)
+from extracted_content_pipeline.faq_macro_writeback_publish import (
+    FAQMacroWritebackPublishService,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+class _FAQRepo:
+    def __init__(self, draft: TicketFAQDraft | None) -> None:
+        self.draft = draft
+        self.get_calls: list[dict[str, object]] = []
+        self.update_calls: list[dict[str, object]] = []
+
+    async def get_draft(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+    ) -> TicketFAQDraft | None:
+        self.get_calls.append({"faq_id": faq_id, "scope": scope})
+        return self.draft
+
+    async def update_status(
+        self,
+        faq_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        self.update_calls.append({
+            "faq_id": faq_id,
+            "status": status,
+            "scope": scope,
+        })
+        return True
+
+
+class _Provider:
+    def __init__(self, statuses: tuple[str, ...]) -> None:
+        self.statuses = statuses
+        self.calls: list[dict[str, object]] = []
+
+    async def publish(
+        self,
+        macros: Sequence[SupportMacroDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[MacroPublishResult]:
+        self.calls.append({"macros": tuple(macros), "scope": scope})
+        return tuple(
+            MacroPublishResult(
+                macro=macro,
+                status=cast(MacroPublishStatus, status),
+                external_id=f"external-{index}",
+            )
+            for index, (macro, status) in enumerate(zip(macros, self.statuses), start=1)
+        )
+
+
+class _PendingProvider:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def publish(
+        self,
+        macros: Sequence[SupportMacroDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[MacroPublishResult]:
+        self.calls.append({"macros": tuple(macros), "scope": scope})
+        return tuple(
+            MacroPublishResult(
+                macro=macro,
+                status="failed",
+                error="zendesk_macro_mapping_pending_reconcile",
+            )
+            for macro in macros
+        )
+
+
+def _draft(
+    *,
+    status: str = "approved",
+    items: tuple[dict[str, object], ...] | None = None,
+    draft_id: str = "faq-draft-1",
+) -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=draft_id,
+        target_id="ticket-faq-report",
+        target_mode="support_ticket_faq",
+        title="Saved FAQ report",
+        markdown="# Saved FAQ report",
+        items=items or (
+            {
+                "faq_item_id": "faq-item-1",
+                "topic": "billing",
+                "question": "Why was I charged twice?",
+                "resolution_text": "Open Billing and compare settled charges.",
+                "answer_evidence_status": "resolution_evidence",
+            },
+        ),
+        source_count=1,
+        ticket_source_count=1,
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_service_publishes_approved_verified_faq_and_marks_status() -> None:
+    scope = TenantScope(account_id="acct-1", user_id="user-1")
+    repo = _FAQRepo(_draft())
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(" faq-draft-1 ", scope=scope)
+
+    assert summary.ok is True
+    assert summary.as_dict()["ok"] is True
+    assert summary.publishable_count == 1
+    assert summary.skipped_count == 0
+    assert summary.published_count == 1
+    assert summary.draft_status_updated is True
+    assert provider.calls[0]["scope"] == scope
+    assert repo.get_calls == [{"faq_id": "faq-draft-1", "scope": scope}]
+    assert repo.update_calls == [{
+        "faq_id": "faq-draft-1",
+        "status": "published",
+        "scope": scope,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_publish_service_refuses_unapproved_draft_without_provider_call() -> None:
+    repo = _FAQRepo(_draft(status="draft"))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is False
+    assert summary.publishable_count == 0
+    assert summary.skipped_count == 1
+    assert summary.skipped[0]["reason"] == "draft_not_approved"
+    assert provider.calls == []
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_keeps_status_when_items_are_skipped() -> None:
+    repo = _FAQRepo(_draft(items=(
+        {
+            "faq_item_id": "faq-item-1",
+            "question": "Where do I find invoices?",
+            "resolution_text": "Open Billing and choose invoices.",
+            "answer_evidence_status": "resolution_evidence",
+        },
+        {
+            "faq_item_id": "faq-item-2",
+            "question": "How do I export a report?",
+            "answer": "Customers mention exports.",
+            "answer_evidence_status": "draft_needs_review",
+        },
+    )))
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is False
+    assert summary.publishable_count == 1
+    assert summary.skipped_count == 1
+    assert summary.published_count == 1
+    assert summary.skipped[0]["reason"] == "answer_not_verified"
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_surfaces_pending_reconcile_without_status_update() -> None:
+    repo = _FAQRepo(_draft())
+    provider = _PendingProvider()
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is False
+    assert summary.failed_count == 1
+    assert summary.pending_reconcile_count == 1
+    assert summary.results[0]["error"] == "zendesk_macro_mapping_pending_reconcile"
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_reports_missing_draft_without_provider_call() -> None:
+    repo = _FAQRepo(None)
+    provider = _Provider(("published",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "missing-faq",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.as_dict() == {
+        "faq_id": "missing-faq",
+        "found": False,
+        "draft_status": "",
+        "publishable_count": 0,
+        "skipped_count": 0,
+        "published_count": 0,
+        "updated_count": 0,
+        "failed_count": 0,
+        "pending_reconcile_count": 0,
+        "draft_status_updated": False,
+        "skipped": [],
+        "results": [],
+        "ok": False,
+    }
+    assert provider.calls == []
+    assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_does_not_mark_dry_run_results_published() -> None:
+    repo = _FAQRepo(_draft())
+    provider = _Provider(("dry_run",))
+    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is False
+    assert summary.publishable_count == 1
+    assert summary.published_count == 0
+    assert summary.updated_count == 0
+    assert repo.update_calls == []


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-Trigger.md
Slice phase: Vertical slice

Adds the FAQ macro writeback publish trigger service: it fetches one tenant-scoped FAQ draft, runs the existing approval + resolution-evidence preview gate, publishes eligible macros through an injected provider, reports skipped/pending outcomes, and marks the draft `published` only after a fully clean publish.

## Intentional
- No API route in this slice; the service contract is the next stable boundary for route/UI wiring.
- No live Zendesk reconcile yet; pending mapping rows are surfaced as `pending_reconcile` so the follow-up can backfill without duplicate POSTs.
- Partial publish, skipped items, dry-run results, missing drafts, and pending reconciliation do not update FAQ draft status.

## Deferred
- `PR-FAQ-Macro-Writeback-Publish-Route`: expose this service through a scoped backend route / CLI entry point and wire the selected provider.
- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: look up pending Zendesk macros by reserved title/category metadata and backfill `external_id`.
- `PR-FAQ-Macro-Writeback-Publish-UI`: add the operator review action once the route exists.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py` — 6 passed.
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_publish.py` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `python scripts/check_extracted_imports.py` — passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` — passed.
- `python scripts/smoke_extracted_pipeline_imports.py` — passed.
- `python scripts/smoke_extracted_pipeline_standalone.py` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-trigger.md` — passed.

## Diff size
4 files, +528 / -0