### PR TITLE
Add FAQ macro writeback publish route

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -38,6 +38,8 @@ from ..landing_page_postgres import (
     PostgresLandingPageRepository,
 )
 from ..landing_page_ports import LandingPageDraft, LandingPageSection
+from ..faq_macro_writeback import MacroPublishProvider
+from ..faq_macro_writeback_publish import FAQMacroWritebackPublishService
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
 from ..sales_brief_export import export_sales_brief_drafts
@@ -50,6 +52,10 @@ PoolProvider = Callable[[], Any | Awaitable[Any]]
 LLMProvider = Callable[[], LLMClient | Awaitable[LLMClient]]
 ScopeProvider = Callable[[], TenantScope | Mapping[str, Any] | None | Awaitable[Any]]
 SkillsProvider = Callable[[], SkillStore | Awaitable[SkillStore]]
+MacroPublishProviderFactory = Callable[
+    [],
+    MacroPublishProvider | Awaitable[MacroPublishProvider],
+]
 
 ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
 logger = logging.getLogger(__name__)
@@ -250,6 +256,7 @@ def create_generated_asset_router(
     scope_provider: ScopeProvider | None = None,
     llm_provider: LLMProvider | None = None,
     skills_provider: SkillsProvider | None = None,
+    macro_publish_provider: MacroPublishProviderFactory | None = None,
     config: GeneratedAssetApiConfig | None = None,
     dependencies: Sequence[Any] | None = None,
 ) -> APIRouter:
@@ -363,6 +370,40 @@ def create_generated_asset_router(
             "id": asset_id,
             "status": status,
             "updated": bool(updated),
+        }
+
+    @router.post("/{asset}/drafts/{draft_id}/publish-macros")
+    async def publish_faq_macros(
+        asset: str,
+        draft_id: str,
+    ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
+        if asset_name != "faq_markdown":
+            raise HTTPException(
+                status_code=400,
+                detail="only faq_markdown drafts can publish macros",
+            )
+        try:
+            faq_id = str(UUID(draft_id))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="FAQ draft not found") from None
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        provider = await _resolve_required_provider(
+            macro_publish_provider,
+            detail="FAQ macro publish provider unavailable",
+        )
+        summary = await FAQMacroWritebackPublishService(
+            faq_repository=PostgresTicketFAQRepository(pool),
+            provider=provider,
+        ).publish_faq_draft(faq_id, scope=tenant)
+        if not summary.found:
+            raise HTTPException(status_code=404, detail="FAQ draft not found")
+        return {
+            "account_id": tenant.account_id,
+            "asset": asset_name,
+            **summary.as_dict(),
         }
 
     @router.post("/{asset}/drafts/review-batch")

--- a/plans/PR-FAQ-Macro-Writeback-Publish-Route.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-Route.md
@@ -1,0 +1,88 @@
+# PR-FAQ-Macro-Writeback-Publish-Route
+
+## Why this slice exists
+
+The FAQ macro writeback core loop now exists behind
+`FAQMacroWritebackPublishService`: preview gate, provider publish, idempotent
+adapter behavior, and conservative FAQ draft status transition. The next
+missing product slice is a scoped entry point so the generated asset review API
+can trigger that service for one approved FAQ draft.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add an optional macro publish provider factory to the generated asset router.
+2. Add a FAQ-only `POST /content-assets/faq_markdown/drafts/{draft_id}/publish-macros`
+   route.
+3. Validate the route is FAQ-only, tenant-scoped, provider-backed, and returns
+   the service summary without hiding non-clean outcomes.
+4. Add focused API tests for clean publish, provider missing, wrong asset, and
+   pending-reconcile result handling.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-Route.md` — plan for this slice.
+- `extracted_content_pipeline/api/generated_assets.py` — publish-macros route and provider injection.
+- `tests/test_extracted_content_asset_api.py` — route coverage.
+
+## Mechanism
+
+The generated asset router gains a `macro_publish_provider` callable, resolved
+with the existing `_resolve_required_provider` helper. The new route:
+
+1. Accepts only `asset == "faq_markdown"`.
+2. Requires a UUID-shaped `draft_id` before touching Postgres.
+3. Resolves pool, tenant scope, and macro provider.
+4. Calls `FAQMacroWritebackPublishService(PostgresTicketFAQRepository(pool), provider)`.
+5. Returns `summary.as_dict()` plus `account_id` and `asset`.
+6. Returns 404 when the tenant-scoped FAQ draft is not found.
+
+The route does not create a provider itself. Host code decides whether the
+provider is Zendesk, dry-run, or another support platform adapter.
+
+## Intentional
+
+- No UI button in this slice. The route is the smallest real trigger that can
+  be tested end to end against the existing API boundary.
+- No live Zendesk credential wiring here. The router accepts a provider factory
+  so deployment code can inject the already-built adapter without the API module
+  owning secrets.
+- Pending reconciliation remains a non-clean 200 summary, not a duplicate POST
+  retry and not an HTTP 500. The provider completed its contract; the operator
+  needs the summary state surfaced.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Provider-Wiring`: instantiate the Zendesk provider
+  from host credentials / mapping repository in the deployed app.
+- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: backfill pending Zendesk mappings
+  by looking up reserved title/category metadata.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: add the review UI action once the route
+  is available.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_asset_api.py -k 'publish_macros or ticket_faq' — 7 passed, 56 deselected.
+- python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python scripts/check_extracted_imports.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- python scripts/smoke_extracted_pipeline_imports.py — passed.
+- python scripts/smoke_extracted_pipeline_standalone.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-route.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| API route | ~70 |
+| Tests | ~140 |
+| Total | ~300 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import cast
 
 import pytest
 
@@ -17,6 +18,10 @@ from extracted_content_pipeline.api.generated_assets import (
 )
 import extracted_content_pipeline.api.generated_assets as asset_api
 from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    MacroPublishResult,
+    MacroPublishStatus,
+)
 
 
 BATCH_REPORT_ID_1 = "11111111-1111-1111-1111-111111111111"
@@ -183,6 +188,26 @@ class _Skills:
     def get_prompt(self, name):
         self.calls.append(name)
         return self.prompt
+
+
+class _MacroProvider:
+    def __init__(self, *, status: str = "published", error: str = "") -> None:
+        self.status = status
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    async def publish(self, macros, *, scope: TenantScope):
+        captured = tuple(macros)
+        self.calls.append({"macros": captured, "scope": scope})
+        return tuple(
+            MacroPublishResult(
+                macro=macro,
+                status=cast(MacroPublishStatus, self.status),
+                external_id=f"external-{index}" if not self.error else "",
+                error=self.error,
+            )
+            for index, macro in enumerate(captured, start=1)
+        )
 
 
 def _report_row():
@@ -403,12 +428,31 @@ def _ticket_faq_row():
     }
 
 
+def _publishable_ticket_faq_row():
+    row = _ticket_faq_row()
+    row.update({
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "approved",
+        "items": [{
+            "faq_item_id": "faq-item-1",
+            "topic": "billing",
+            "question": "Why was I charged twice?",
+            "resolution_text": "Open Billing and compare settled charges.",
+            "answer_evidence_status": "resolution_evidence",
+            "source_ids": ["ticket-1"],
+        }],
+        "metadata": {"corpus_id": "corpus-1"},
+    })
+    return row
+
+
 def _client(
     pool,
     *,
     scope=None,
     llm=None,
     skills=None,
+    macro_provider=None,
     config: GeneratedAssetApiConfig | None = None,
     dependencies=None,
 ) -> TestClient:
@@ -426,12 +470,18 @@ def _client(
     async def skills_provider():
         return skills
 
+    async def macro_publish_provider():
+        return macro_provider
+
     app.include_router(
         create_generated_asset_router(
             pool_provider=pool_provider,
             scope_provider=scope_provider if scope is not None else None,
             llm_provider=llm_provider if llm is not None else None,
             skills_provider=skills_provider if skills is not None else None,
+            macro_publish_provider=(
+                macro_publish_provider if macro_provider is not None else None
+            ),
             config=config,
             dependencies=dependencies,
         )
@@ -1409,6 +1459,101 @@ def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() ->
         "support_account",
         "approved",
     )
+
+
+def test_generated_asset_router_publishes_ticket_faq_macros() -> None:
+    pool = _Pool(rows=[_publishable_ticket_faq_row()])
+    provider = _MacroProvider()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1", "user_id": "user_1"},
+        macro_provider=provider,
+    ).post(
+        "/content-assets/faq_markdown/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macros"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["account_id"] == "acct_1"
+    assert body["asset"] == "faq_markdown"
+    assert body["ok"] is True
+    assert body["publishable_count"] == 1
+    assert body["draft_status_updated"] is True
+    assert provider.calls[0]["scope"] == TenantScope(
+        account_id="acct_1",
+        user_id="user_1",
+    )
+    macro = provider.calls[0]["macros"][0]
+    assert macro.title == "Why was I charged twice?"
+    assert macro.body == "Open Billing and compare settled charges."
+    get_query, get_args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in get_query
+    assert get_args == ("11111111-1111-1111-1111-111111111111", "acct_1")
+    update_query, update_args = pool.fetch_calls[1]
+    assert "UPDATE ticket_faq_markdown" in update_query
+    assert update_args == ("11111111-1111-1111-1111-111111111111", "published", "acct_1")
+
+
+def test_generated_asset_router_publish_macros_requires_provider() -> None:
+    pool = _Pool(rows=[_publishable_ticket_faq_row()])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/faq_markdown/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macros"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "FAQ macro publish provider unavailable"
+
+
+def test_generated_asset_router_publish_macros_is_faq_only() -> None:
+    pool = _Pool()
+    provider = _MacroProvider()
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+        macro_provider=provider,
+    ).post(
+        "/content-assets/report/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macros"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "only faq_markdown drafts can publish macros"
+    assert provider.calls == []
+    assert pool.fetch_calls == []
+
+
+def test_generated_asset_router_publish_macros_surfaces_pending_reconcile() -> None:
+    pool = _Pool(rows=[_publishable_ticket_faq_row()])
+    provider = _MacroProvider(
+        status="failed",
+        error="zendesk_macro_mapping_pending_reconcile",
+    )
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+        macro_provider=provider,
+    ).post(
+        "/content-assets/faq_markdown/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macros"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert body["failed_count"] == 1
+    assert body["pending_reconcile_count"] == 1
+    assert body["draft_status_updated"] is False
+    assert body["results"][0]["error"] == "zendesk_macro_mapping_pending_reconcile"
+    assert len(pool.fetch_calls) == 1
 
 
 def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-Route.md
Slice phase: Vertical slice

Adds the scoped FAQ macro publish API route over the service from #1135. The generated asset router now accepts a host-provided macro publish provider factory and exposes `POST /content-assets/faq_markdown/drafts/{draft_id}/publish-macros` for one tenant-scoped FAQ draft.

## Intentional
- Provider construction stays host-owned through injection; this route does not own Zendesk credentials or secrets.
- Pending reconciliation returns as service summary state, not as a duplicate retry or route-level 500.
- No UI button yet; this proves the backend trigger first.

## Deferred
- `PR-FAQ-Macro-Writeback-Provider-Wiring`: instantiate the Zendesk provider from host credentials / mapping repository in the deployed app.
- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: backfill pending Zendesk mappings by looking up reserved title/category metadata.
- `PR-FAQ-Macro-Writeback-Publish-UI`: add the review UI action once the route is available.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_content_asset_api.py -k 'publish_macros or ticket_faq' — 7 passed, 56 deselected.
- python -m py_compile extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- python scripts/check_extracted_imports.py — passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
- python scripts/smoke_extracted_pipeline_imports.py — passed.
- python scripts/smoke_extracted_pipeline_standalone.py — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-route.md — passed.

## Diff size
3 files, +274 / -0