### PR TITLE
PR-FAQ-Deflection-Report-Term-File

### DIFF
--- a/plans/PR-FAQ-Deflection-Report-Term-File.md
+++ b/plans/PR-FAQ-Deflection-Report-Term-File.md
@@ -1,0 +1,106 @@
+# PR-FAQ-Deflection-Report-Term-File
+
+## Why this slice exists
+
+The customer-facing `faq_deflection_report` CLI now accepts custom intent and
+vocabulary rule files, but it still requires documentation terms to be repeated
+inline with `--documentation-term`. The underlying FAQ CLI already supports
+documentation-term files, and the deflection report docs describe the same
+glossary workflow around the report builder. That creates operator friction and
+one more place where the report deliverable can drift from the FAQ generator it
+wraps.
+
+This slice keeps the report product moving without touching the hosted-search
+blocker or the macro-writeback branch.
+
+The diff is over the 400 LOC soft cap because the indivisible part of the slice
+is moving the existing documentation-term-file parser into the shared CLI module
+instead of copying it into the report CLI. The large deletion from the FAQ CLI
+is the drift-reduction part of the change.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report
+
+Slice phase: Product polish
+
+1. Move the existing FAQ CLI documentation-term-file parser into the shared FAQ
+   CLI rules module.
+2. Keep the FAQ CLI behavior unchanged while importing the shared parser.
+3. Add `--documentation-term-file` and `--documentation-term-format` to the
+   deflection report CLI.
+4. Add focused deflection report CLI tests for a JSON documentation-term file
+   and an invalid documentation-term file.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `scripts/content_ops_faq_cli_rules.py` | Hosts the shared documentation-term-file parser. |
+| `scripts/build_extracted_ticket_faq_markdown.py` | Imports the shared parser and keeps existing CLI behavior. |
+| `scripts/build_content_ops_deflection_report.py` | Adds documentation-term-file flags and resolved config metadata. |
+| `tests/test_content_ops_deflection_report.py` | Proves deflection report term-file success and fail-closed parsing. |
+| `plans/PR-FAQ-Deflection-Report-Term-File.md` | Documents this slice contract. |
+
+## Mechanism
+
+`content_ops_faq_cli_rules.py` already owns shared FAQ CLI parsing for intent
+and vocabulary rules. This slice moves the existing documentation-term loader
+there too:
+
+```python
+documentation_terms = parse_documentation_terms(
+    args.documentation_term,
+    args.documentation_term_file,
+    args.documentation_term_format,
+)
+```
+
+Both CLIs then call the same parser. The deflection report CLI passes the
+resolved terms into `build_ticket_faq_markdown`, and the result JSON records the
+term files, requested format, and resolved terms for operator audit.
+
+## Intentional
+
+- This does not add a new rule-file schema for documentation terms. Rule files
+  stay limited to intent and vocabulary-gap rules so existing validation remains
+  strict.
+- This does not change report Markdown rendering or the hosted execute route.
+  The route already accepts resolved `faq_documentation_terms` through request
+  inputs; this slice is only offline report CLI ergonomics.
+- Existing parser behavior and error messages are preserved so the large FAQ
+  CLI test set remains the compatibility guard.
+
+## Deferred
+
+- Parked hardening: none.
+- Hosted/deployed deflection report validation remains deferred until the
+  operator-provisioned Atlas host and JWT tracked outside this PR are available.
+
+## Verification
+
+- Command: python -m py_compile scripts/content_ops_faq_cli_rules.py scripts/build_extracted_ticket_faq_markdown.py scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py
+  - Result: passed.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py -q -k "deflection_report_cli or documentation_term_file"
+  - Result: 26 passed, 133 deselected.
+- Command: python -m pytest tests/test_content_ops_deflection_report.py -q
+  - Result: 18 passed.
+- Command: python -m pytest tests/test_extracted_ticket_faq_markdown.py -q
+  - Result: 141 passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Term-File.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Term-File.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Shared parser extraction | 219 |
+| Deflection report CLI wiring | 29 |
+| FAQ CLI import cleanup | 223 |
+| Tests | 101 |
+| Plan doc | 106 |
+| **Total** | **678** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -32,7 +32,9 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     build_ticket_faq_markdown,
 )
 from content_ops_faq_cli_rules import (  # noqa: E402
+    DOCUMENTATION_TERM_FORMATS,
     load_rule_files,
+    parse_documentation_terms,
     parse_intent_rules,
     parse_vocabulary_gap_rules,
 )
@@ -116,6 +118,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Existing documentation term or heading. Repeat to provide multiple terms.",
     )
     parser.add_argument(
+        "--documentation-term-file",
+        action="append",
+        default=[],
+        type=Path,
+        help="UTF-8 text, JSON, JSONL, or CSV file with documentation terms.",
+    )
+    parser.add_argument(
+        "--documentation-term-format",
+        choices=DOCUMENTATION_TERM_FORMATS,
+        default="auto",
+        help="Format for documentation-term files. Defaults to suffix detection.",
+    )
+    parser.add_argument(
         "--vocabulary-gap-rule",
         action="append",
         default=[],
@@ -147,6 +162,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def build_report(args: argparse.Namespace):
+    documentation_terms = parse_documentation_terms(
+        args.documentation_term,
+        args.documentation_term_file,
+        args.documentation_term_format,
+    )
+    args.documentation_terms = documentation_terms
     file_rules = load_rule_files(args.rule_file)
     vocabulary_gap_rules = (
         *parse_vocabulary_gap_rules(args.vocabulary_gap_rule),
@@ -174,7 +195,7 @@ def build_report(args: argparse.Namespace):
         as_of_date=args.as_of_date,
         support_contact=args.support_contact,
         intent_rules=intent_rules,
-        documentation_terms=tuple(args.documentation_term or ()),
+        documentation_terms=documentation_terms,
         vocabulary_gap_rules=vocabulary_gap_rules,
     )
     return build_deflection_report_artifact(
@@ -217,7 +238,11 @@ def _result_payload(
             "require_output_checks": bool(args.require_output_checks),
             "support_contact": args.support_contact,
             "rule_files": [str(path) for path in args.rule_file],
-            "documentation_terms": list(args.documentation_term or ()),
+            "documentation_term_files": [
+                str(path) for path in args.documentation_term_file
+            ],
+            "documentation_term_format": args.documentation_term_format,
+            "documentation_terms": list(getattr(args, "documentation_terms", ())),
             "vocabulary_gap_rules": [
                 list(rule) for rule in getattr(args, "vocabulary_gap_rules", ())
             ],

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from datetime import date
-import io
 import json
 from pathlib import Path
 import sys
@@ -19,29 +17,6 @@ if str(ROOT) not in sys.path:
 SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
-
-_DOCUMENTATION_TERM_ROW_KEYS = (
-    "documentation_term",
-    "documentation_terms",
-    "term",
-    "heading",
-    "title",
-    "page_title",
-    "name",
-    "label",
-)
-_DOCUMENTATION_TERM_LIST_KEYS = (
-    "terms",
-    "headings",
-    "documents",
-    "pages",
-    "articles",
-    "rows",
-    "data",
-)
-_DOCUMENTATION_TERM_KEY_HINT = ", ".join(_DOCUMENTATION_TERM_ROW_KEYS)
-_DOCUMENTATION_TERM_FORMATS = ("auto", "text", "json", "jsonl", "csv")
-_EMPTY_JSONL_LINE = object()
 
 from extracted_content_pipeline.campaign_source_adapters import (  # noqa: E402
     load_source_campaign_opportunities_from_file,
@@ -56,7 +31,9 @@ from extracted_content_pipeline.ticket_faq_markdown import (  # noqa: E402
     weighted_source_volume_by_group,
 )
 from content_ops_faq_cli_rules import (  # noqa: E402
+    DOCUMENTATION_TERM_FORMATS,
     load_rule_files,
+    parse_documentation_terms,
     parse_intent_rules,
     parse_vocabulary_gap_rules,
 )
@@ -157,7 +134,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--documentation-term-format",
-        choices=_DOCUMENTATION_TERM_FORMATS,
+        choices=DOCUMENTATION_TERM_FORMATS,
         default="auto",
         help=(
             "Format for documentation-term files. Defaults to suffix-based "
@@ -217,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:
             date.fromisoformat(args.as_of_date)
         except ValueError:
             raise SystemExit("--as-of-date must use YYYY-MM-DD format") from None
-    documentation_terms = _cli_documentation_terms(
+    documentation_terms = parse_documentation_terms(
         args.documentation_term,
         args.documentation_term_file,
         args.documentation_term_format,
@@ -551,198 +528,6 @@ def _is_zero_result_search_source(
 
 def _clean_diagnostic_text(value: Any) -> str:
     return " ".join(str(value or "").split())
-
-
-def _cli_documentation_terms(
-    inline_terms: list[str],
-    files: list[Path],
-    file_format: str = "auto",
-) -> tuple[str, ...]:
-    terms: list[str] = []
-    terms.extend(inline_terms)
-    for path in files:
-        terms.extend(_load_cli_documentation_term_file(path, file_format=file_format))
-    return _clean_cli_documentation_terms(terms)
-
-
-def _load_cli_documentation_term_file(
-    path: Path,
-    *,
-    file_format: str = "auto",
-) -> tuple[str, ...]:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        raise SystemExit(f"--documentation-term-file not found: {path}") from None
-    suffix = path.suffix.lower()
-    resolved_format = file_format
-    if resolved_format == "auto":
-        if suffix == ".json":
-            resolved_format = "json"
-        elif suffix == ".jsonl":
-            resolved_format = "jsonl"
-        elif suffix == ".csv":
-            resolved_format = "csv"
-        else:
-            resolved_format = "text"
-    if resolved_format == "json":
-        terms = _load_cli_documentation_term_json(text, path)
-    elif resolved_format == "jsonl":
-        terms = _load_cli_documentation_term_jsonl(text, path)
-    elif resolved_format == "csv":
-        terms = _load_cli_documentation_term_csv(text, path)
-    else:
-        terms = _load_cli_documentation_term_text(text)
-    if not terms:
-        raise SystemExit(f"--documentation-term-file contains no terms: {path}")
-    return tuple(terms)
-
-
-def _load_cli_documentation_term_text(text: str) -> tuple[str, ...]:
-    return tuple(
-        line.strip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    )
-
-
-def _load_cli_documentation_term_json(text: str, path: Path) -> tuple[str, ...]:
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise SystemExit(
-            f"--documentation-term-file must be valid JSON: {path}: {exc.msg}"
-        ) from None
-    terms = tuple(_documentation_terms_from_payload(payload))
-    if not terms and _payload_has_unrecognized_term_fields(payload):
-        _raise_unrecognized_documentation_term_fields(path)
-    return terms
-
-
-def _load_cli_documentation_term_jsonl(text: str, path: Path) -> tuple[str, ...]:
-    saw_unrecognized_fields = False
-    terms: list[str] = []
-    for line_no, line in enumerate(text.splitlines(), start=1):
-        payload = _parse_documentation_term_jsonl_payload(line, path, line_no)
-        if payload is _EMPTY_JSONL_LINE:
-            continue
-        line_terms = tuple(_documentation_terms_from_payload(payload))
-        if not line_terms and _payload_has_unrecognized_term_fields(payload):
-            saw_unrecognized_fields = True
-        terms.extend(line_terms)
-    if not terms and saw_unrecognized_fields:
-        _raise_unrecognized_documentation_term_fields(path)
-    return tuple(terms)
-
-
-def _parse_documentation_term_jsonl_payload(
-    line: str,
-    path: Path,
-    line_no: int,
-) -> Any:
-    text = line.strip()
-    if not text:
-        return _EMPTY_JSONL_LINE
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise SystemExit(
-            "--documentation-term-file must be valid JSONL: "
-            f"{path}: line {line_no}: {exc.msg}"
-        ) from None
-
-
-def _load_cli_documentation_term_csv(text: str, path: Path) -> tuple[str, ...]:
-    rows = list(csv.DictReader(io.StringIO(text, newline="")))
-    if not rows:
-        return ()
-    terms = tuple(
-        term
-        for row in rows
-        for term in _documentation_terms_from_mapping(row)
-    )
-    if not terms:
-        _raise_unrecognized_documentation_term_fields(path)
-    return terms
-
-
-def _documentation_terms_from_payload(payload: Any) -> tuple[str, ...]:
-    if isinstance(payload, str):
-        return (payload,)
-    if isinstance(payload, dict):
-        terms = list(_documentation_terms_from_mapping(payload))
-        for key in _DOCUMENTATION_TERM_LIST_KEYS:
-            value = _case_insensitive_get(payload, key)
-            if value is not None:
-                terms.extend(_documentation_terms_from_payload(value))
-        return tuple(terms)
-    if isinstance(payload, list):
-        return tuple(
-            term
-            for item in payload
-            for term in _documentation_terms_from_payload(item)
-        )
-    return ()
-
-
-def _payload_has_unrecognized_term_fields(payload: Any) -> bool:
-    if isinstance(payload, dict):
-        has_row_key = any(
-            _case_insensitive_has_key(payload, key)
-            for key in _DOCUMENTATION_TERM_ROW_KEYS
-        )
-        list_values = [
-            value
-            for key in _DOCUMENTATION_TERM_LIST_KEYS
-            if (value := _case_insensitive_get(payload, key)) is not None
-        ]
-        if not has_row_key and not list_values:
-            return bool(payload)
-        return any(_payload_has_unrecognized_term_fields(value) for value in list_values)
-    if isinstance(payload, list):
-        return any(_payload_has_unrecognized_term_fields(item) for item in payload)
-    return False
-
-
-def _documentation_terms_from_mapping(
-    row: dict[str, Any],
-) -> tuple[str, ...]:
-    for key in _DOCUMENTATION_TERM_ROW_KEYS:
-        value = _case_insensitive_get(row, key)
-        if value not in (None, ""):
-            if isinstance(value, (dict, list)):
-                return _documentation_terms_from_payload(value)
-            return (str(value),)
-    return ()
-
-
-def _case_insensitive_get(row: dict[str, Any], key: str) -> Any:
-    target = key.lower()
-    for raw_key, value in row.items():
-        if str(raw_key).lstrip("\ufeff").lower() == target:
-            return value
-    return None
-
-
-def _case_insensitive_has_key(row: dict[str, Any], key: str) -> bool:
-    target = key.lower()
-    return any(str(raw_key).lstrip("\ufeff").lower() == target for raw_key in row)
-
-
-def _raise_unrecognized_documentation_term_fields(path: Path) -> None:
-    raise SystemExit(
-        "--documentation-term-file has no recognized term fields: "
-        f"{path}; expected one of: {_DOCUMENTATION_TERM_KEY_HINT}"
-    )
-
-
-def _clean_cli_documentation_terms(terms: list[str]) -> tuple[str, ...]:
-    out: dict[str, str] = {}
-    for term in terms:
-        text = " ".join(str(term).split())
-        if text:
-            out.setdefault(text.lower(), text)
-    return tuple(out.values())
 
 
 def _output_check_details(

--- a/scripts/content_ops_faq_cli_rules.py
+++ b/scripts/content_ops_faq_cli_rules.py
@@ -2,9 +2,46 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 from pathlib import Path
 from typing import Any
+
+DOCUMENTATION_TERM_FORMATS = ("auto", "text", "json", "jsonl", "csv")
+_DOCUMENTATION_TERM_ROW_KEYS = (
+    "documentation_term",
+    "documentation_terms",
+    "term",
+    "heading",
+    "title",
+    "page_title",
+    "name",
+    "label",
+)
+_DOCUMENTATION_TERM_LIST_KEYS = (
+    "terms",
+    "headings",
+    "documents",
+    "pages",
+    "articles",
+    "rows",
+    "data",
+)
+_DOCUMENTATION_TERM_KEY_HINT = ", ".join(_DOCUMENTATION_TERM_ROW_KEYS)
+_EMPTY_JSONL_LINE = object()
+
+
+def parse_documentation_terms(
+    inline_terms: list[str],
+    files: list[Path],
+    file_format: str = "auto",
+) -> tuple[str, ...]:
+    terms: list[str] = []
+    terms.extend(inline_terms)
+    for path in files:
+        terms.extend(_load_documentation_term_file(path, file_format=file_format))
+    return _clean_documentation_terms(terms)
 
 
 def parse_vocabulary_gap_rules(values: list[str]) -> tuple[tuple[str, ...], ...]:
@@ -75,6 +112,186 @@ def _parse_intent_rule_keywords(value: str) -> tuple[str, ...]:
         seen.add(key)
         keywords.append(keyword)
     return tuple(keywords)
+
+
+def _load_documentation_term_file(
+    path: Path,
+    *,
+    file_format: str = "auto",
+) -> tuple[str, ...]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise SystemExit(f"--documentation-term-file not found: {path}") from None
+    suffix = path.suffix.lower()
+    resolved_format = file_format
+    if resolved_format == "auto":
+        if suffix == ".json":
+            resolved_format = "json"
+        elif suffix == ".jsonl":
+            resolved_format = "jsonl"
+        elif suffix == ".csv":
+            resolved_format = "csv"
+        else:
+            resolved_format = "text"
+    if resolved_format == "json":
+        terms = _load_documentation_term_json(text, path)
+    elif resolved_format == "jsonl":
+        terms = _load_documentation_term_jsonl(text, path)
+    elif resolved_format == "csv":
+        terms = _load_documentation_term_csv(text, path)
+    else:
+        terms = _load_documentation_term_text(text)
+    if not terms:
+        raise SystemExit(f"--documentation-term-file contains no terms: {path}")
+    return tuple(terms)
+
+
+def _load_documentation_term_text(text: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def _load_documentation_term_json(text: str, path: Path) -> tuple[str, ...]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"--documentation-term-file must be valid JSON: {path}: {exc.msg}"
+        ) from None
+    terms = tuple(_documentation_terms_from_payload(payload))
+    if not terms and _payload_has_unrecognized_term_fields(payload):
+        _raise_unrecognized_documentation_term_fields(path)
+    return terms
+
+
+def _load_documentation_term_jsonl(text: str, path: Path) -> tuple[str, ...]:
+    saw_unrecognized_fields = False
+    terms: list[str] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        payload = _parse_documentation_term_jsonl_payload(line, path, line_no)
+        if payload is _EMPTY_JSONL_LINE:
+            continue
+        line_terms = tuple(_documentation_terms_from_payload(payload))
+        if not line_terms and _payload_has_unrecognized_term_fields(payload):
+            saw_unrecognized_fields = True
+        terms.extend(line_terms)
+    if not terms and saw_unrecognized_fields:
+        _raise_unrecognized_documentation_term_fields(path)
+    return tuple(terms)
+
+
+def _parse_documentation_term_jsonl_payload(
+    line: str,
+    path: Path,
+    line_no: int,
+) -> Any:
+    text = line.strip()
+    if not text:
+        return _EMPTY_JSONL_LINE
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            "--documentation-term-file must be valid JSONL: "
+            f"{path}: line {line_no}: {exc.msg}"
+        ) from None
+
+
+def _load_documentation_term_csv(text: str, path: Path) -> tuple[str, ...]:
+    rows = list(csv.DictReader(io.StringIO(text, newline="")))
+    if not rows:
+        return ()
+    terms = tuple(
+        term
+        for row in rows
+        for term in _documentation_terms_from_mapping(row)
+    )
+    if not terms:
+        _raise_unrecognized_documentation_term_fields(path)
+    return terms
+
+
+def _documentation_terms_from_payload(payload: Any) -> tuple[str, ...]:
+    if isinstance(payload, str):
+        return (payload,)
+    if isinstance(payload, dict):
+        terms = list(_documentation_terms_from_mapping(payload))
+        for key in _DOCUMENTATION_TERM_LIST_KEYS:
+            value = _case_insensitive_get(payload, key)
+            if value is not None:
+                terms.extend(_documentation_terms_from_payload(value))
+        return tuple(terms)
+    if isinstance(payload, list):
+        return tuple(
+            term
+            for item in payload
+            for term in _documentation_terms_from_payload(item)
+        )
+    return ()
+
+
+def _payload_has_unrecognized_term_fields(payload: Any) -> bool:
+    if isinstance(payload, dict):
+        has_row_key = any(
+            _case_insensitive_has_key(payload, key)
+            for key in _DOCUMENTATION_TERM_ROW_KEYS
+        )
+        list_values = [
+            value
+            for key in _DOCUMENTATION_TERM_LIST_KEYS
+            if (value := _case_insensitive_get(payload, key)) is not None
+        ]
+        if not has_row_key and not list_values:
+            return bool(payload)
+        return any(_payload_has_unrecognized_term_fields(value) for value in list_values)
+    if isinstance(payload, list):
+        return any(_payload_has_unrecognized_term_fields(item) for item in payload)
+    return False
+
+
+def _documentation_terms_from_mapping(
+    row: dict[str, Any],
+) -> tuple[str, ...]:
+    for key in _DOCUMENTATION_TERM_ROW_KEYS:
+        value = _case_insensitive_get(row, key)
+        if value not in (None, ""):
+            if isinstance(value, (dict, list)):
+                return _documentation_terms_from_payload(value)
+            return (str(value),)
+    return ()
+
+
+def _case_insensitive_get(row: dict[str, Any], key: str) -> Any:
+    target = key.lower()
+    for raw_key, value in row.items():
+        if str(raw_key).lstrip("\ufeff").lower() == target:
+            return value
+    return None
+
+
+def _case_insensitive_has_key(row: dict[str, Any], key: str) -> bool:
+    target = key.lower()
+    return any(str(raw_key).lstrip("\ufeff").lower() == target for raw_key in row)
+
+
+def _raise_unrecognized_documentation_term_fields(path: Path) -> None:
+    raise SystemExit(
+        "--documentation-term-file has no recognized term fields: "
+        f"{path}; expected one of: {_DOCUMENTATION_TERM_KEY_HINT}"
+    )
+
+
+def _clean_documentation_terms(terms: list[str]) -> tuple[str, ...]:
+    out: dict[str, str] = {}
+    for term in terms:
+        text = " ".join(str(term).split())
+        if text:
+            out.setdefault(text.lower(), text)
+    return tuple(out.values())
 
 
 def _load_rule_file(path: Path) -> dict[str, Any]:
@@ -187,7 +404,9 @@ def _rule_file_text(
 
 
 __all__ = [
+    "DOCUMENTATION_TERM_FORMATS",
     "load_rule_files",
+    "parse_documentation_terms",
     "parse_intent_rules",
     "parse_vocabulary_gap_rules",
 ]

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -395,6 +395,107 @@ def test_deflection_report_cli_accepts_json_rule_file(tmp_path: Path) -> None:
     assert "Single sign-on setup" in markdown
 
 
+def test_deflection_report_cli_accepts_documentation_term_file(tmp_path: Path) -> None:
+    source = tmp_path / "term-file-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    result_output = tmp_path / "deflection-report-result.json"
+    term_file = tmp_path / "documentation-terms.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "subject": "Export attribution report",
+                "message": "How do I export attribution reports?",
+                "pain_category": "exports",
+            },
+            {
+                "ticket_id": "ticket-export-2",
+                "source_type": "support_ticket",
+                "subject": "Export report",
+                "message": "Can I export the attribution report?",
+                "pain_category": "exports",
+            },
+        ]),
+        encoding="utf-8",
+    )
+    term_file.write_text(
+        json.dumps({
+            "documentation_terms": ["Single sign-on setup"],
+            "documents": [{"title": "Download report"}],
+        }),
+        encoding="utf-8",
+    )
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--documentation-term",
+        "Billing center",
+        "--documentation-term-file",
+        str(term_file),
+        "--require-output-checks",
+        "--output",
+        str(output),
+        "--result-output",
+        str(result_output),
+    ])
+
+    assert exit_code == 0
+    markdown = output.read_text(encoding="utf-8")
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["config"]["documentation_term_files"] == [str(term_file)]
+    assert result["config"]["documentation_term_format"] == "auto"
+    assert result["config"]["documentation_terms"] == [
+        "Billing center",
+        "Single sign-on setup",
+        "Download report",
+    ]
+    assert result["diagnostics"]["items"][0]["term_mapping_count"] >= 1
+    assert "Download report" in markdown
+    assert "export" in markdown
+
+
+def test_deflection_report_cli_rejects_bad_documentation_term_file(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "bad-term-file-support-tickets.json"
+    output = tmp_path / "deflection-report.md"
+    term_file = tmp_path / "documentation-terms.json"
+    source.write_text(
+        json.dumps([
+            {
+                "ticket_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "subject": "Export attribution report",
+                "message": "How do I export attribution reports?",
+            },
+        ]),
+        encoding="utf-8",
+    )
+    term_file.write_text(
+        json.dumps({"documents": [{"url": "https://help.example/export"}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        MODULE.main([
+            str(source),
+            "--source-format",
+            "json",
+            "--documentation-term-file",
+            str(term_file),
+            "--output",
+            str(output),
+        ])
+
+    assert "--documentation-term-file has no recognized term fields:" in str(
+        exc_info.value
+    )
+    assert not output.exists()
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Term-File.md
Slice phase: Product polish

The customer-facing `faq_deflection_report` CLI now accepts custom intent and vocabulary rule files, but documentation terms still had to be repeated inline with `--documentation-term`. This keeps the report deliverable aligned with the FAQ CLI by moving the existing documentation-term-file parser into the shared CLI rules module and wiring the report CLI to the same parser.

## Intentional
- No new rule-file schema for documentation terms; rule files stay limited to intent and vocabulary-gap rules.
- No report Markdown or hosted execute route changes; this is offline report CLI ergonomics.
- Existing FAQ CLI parser behavior and error messages are preserved by importing the shared parser.

## Deferred
- Hosted/deployed deflection report validation remains deferred until the operator-provisioned Atlas host and JWT are available.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/content_ops_faq_cli_rules.py scripts/build_extracted_ticket_faq_markdown.py scripts/build_content_ops_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py`
- `python -m pytest tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_markdown.py -q -k "deflection_report_cli or documentation_term_file"` — 26 passed, 133 deselected.
- `python -m pytest tests/test_content_ops_deflection_report.py -q` — 18 passed.
- `python -m pytest tests/test_extracted_ticket_faq_markdown.py -q` — 141 passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Term-File.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Term-File.md`
- `git diff --check`

## Diff size
5 files, +457 / -221
