### PR TITLE
Wire FAQ macro writeback provider

### DIFF
--- a/atlas_brain/_content_ops_macro_writeback.py
+++ b/atlas_brain/_content_ops_macro_writeback.py
@@ -1,0 +1,93 @@
+"""Host wiring for Content Ops FAQ macro writeback providers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import MacroPublishProvider
+from extracted_content_pipeline.faq_macro_writeback_postgres import (
+    PostgresFAQMacroWritebackMappingRepository,
+)
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
+    ZendeskMacroPublishProvider,
+)
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+ConfigProvider = Callable[[], Any | Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ConfigZendeskMacroCredentialsProvider:
+    """Zendesk credential source backed by centralized host config."""
+
+    config: Any
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        del scope
+        return zendesk_macro_credentials_from_config(self.config)
+
+
+async def build_content_ops_macro_publish_provider(
+    *,
+    pool_provider: PoolProvider,
+    config_provider: ConfigProvider | None = None,
+) -> MacroPublishProvider | None:
+    """Build the host-configured FAQ macro publish provider."""
+
+    pool = await _maybe_await(pool_provider())
+    if pool is None:
+        return None
+    if getattr(pool, "is_initialized", True) is False:
+        return None
+    config = await _resolve_config(config_provider)
+    return ZendeskMacroPublishProvider(
+        credentials_provider=ConfigZendeskMacroCredentialsProvider(config),
+        mapping_repository=PostgresFAQMacroWritebackMappingRepository(pool),
+    )
+
+
+def zendesk_macro_credentials_from_config(
+    config: Any,
+) -> ZendeskMacroCredentials | None:
+    """Return complete Zendesk macro credentials from centralized config."""
+
+    credentials = ZendeskMacroCredentials(
+        email=_config_value(config, "content_ops_zendesk_email"),
+        api_token=_config_value(config, "content_ops_zendesk_api_token"),
+        subdomain=_config_value(config, "content_ops_zendesk_subdomain"),
+        base_url=_config_value(config, "content_ops_zendesk_base_url"),
+    )
+    return credentials if credentials.is_complete() else None
+
+
+async def _resolve_config(config_provider: ConfigProvider | None) -> Any:
+    if config_provider is not None:
+        return await _maybe_await(config_provider())
+    from .config import settings
+
+    return settings.b2b_campaign
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+def _config_value(config: Any, name: str) -> str:
+    return str(getattr(config, name, "") or "").strip()
+
+
+__all__ = [
+    "ConfigZendeskMacroCredentialsProvider",
+    "build_content_ops_macro_publish_provider",
+    "zendesk_macro_credentials_from_config",
+]

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -172,6 +172,9 @@ try:
         build_content_ops_llm_client,
         build_content_ops_skill_store,
     )
+    from .._content_ops_macro_writeback import (
+        build_content_ops_macro_publish_provider,
+    )
     from .._content_ops_services import build_content_ops_execution_services
     from .._content_ops_scope import (
         build_content_ops_scope,
@@ -247,6 +250,9 @@ try:
         scope_provider=build_content_ops_scope,
         llm_provider=build_content_ops_llm_client,
         skills_provider=build_content_ops_skill_store,
+        macro_publish_provider=lambda: build_content_ops_macro_publish_provider(
+            pool_provider=get_db_pool,
+        ),
         dependencies=[Depends(_capture_content_ops_auth_user)],
     )
     router.include_router(content_assets_router)

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -7,7 +7,7 @@ Configuration is loaded from environment variables with sensible defaults.
 from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .config_defaults import DEFAULT_INVOICING_READONLY_PORT
@@ -4746,6 +4746,38 @@ class B2BCampaignConfig(BaseSettings):
             "per-run default; set ATLAS_B2B_CAMPAIGN_CONTENT_OPS_CACHE_POLICY_DEFAULT "
             "to exact-cache or no-store to default hosted runs."
         ),
+    )
+    content_ops_zendesk_email: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "ATLAS_CONTENT_OPS_ZENDESK_EMAIL",
+            "ZENDESK_EMAIL",
+        ),
+        description="Zendesk API user email for hosted Content Ops FAQ macro writeback.",
+    )
+    content_ops_zendesk_api_token: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "ATLAS_CONTENT_OPS_ZENDESK_API_TOKEN",
+            "ZENDESK_API_TOKEN",
+        ),
+        description="Zendesk API token for hosted Content Ops FAQ macro writeback.",
+    )
+    content_ops_zendesk_subdomain: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "ATLAS_CONTENT_OPS_ZENDESK_SUBDOMAIN",
+            "ZENDESK_SUBDOMAIN",
+        ),
+        description="Zendesk subdomain for hosted Content Ops FAQ macro writeback.",
+    )
+    content_ops_zendesk_base_url: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "ATLAS_CONTENT_OPS_ZENDESK_BASE_URL",
+            "ZENDESK_BASE_URL",
+        ),
+        description="Zendesk base URL override for hosted Content Ops FAQ macro writeback.",
     )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],

--- a/plans/PR-FAQ-Macro-Writeback-Provider-Wiring.md
+++ b/plans/PR-FAQ-Macro-Writeback-Provider-Wiring.md
@@ -1,0 +1,105 @@
+# PR-FAQ-Macro-Writeback-Provider-Wiring
+
+## Why this slice exists
+
+The FAQ macro publish route is mounted, but it only works when the host injects
+a `MacroPublishProvider`. The next missing production slice is Atlas host
+wiring: build the Zendesk provider with the existing database pool for
+idempotency mappings and env-backed Zendesk credentials, then pass that provider
+factory into the generated asset router.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add typed Zendesk macro writeback settings to `B2BCampaignConfig`.
+2. Add a host helper that builds `ZendeskMacroPublishProvider` with
+   `PostgresFAQMacroWritebackMappingRepository`.
+3. Read Zendesk credentials through centralized config without storing or
+   logging secrets.
+4. Wire the helper into `create_generated_asset_router` in the Atlas API
+   aggregator.
+5. Add focused tests for config credential parsing, missing credential behavior,
+   provider construction, and API aggregator wiring.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Provider-Wiring.md` — plan for this slice.
+- `atlas_brain/config.py` — typed Content Ops Zendesk credential settings.
+- `atlas_brain/_content_ops_macro_writeback.py` — host macro provider factory.
+- `atlas_brain/api/__init__.py` — generated asset router provider injection.
+- `tests/test_atlas_content_ops_macro_writeback.py` — host provider factory coverage.
+- `tests/test_atlas_content_ops_generated_assets_api.py` — API aggregator wiring assertion.
+- `scripts/run_extracted_pipeline_checks.sh` — extracted-package CI enrollment for the new host wiring test.
+
+## Mechanism
+
+`build_content_ops_macro_publish_provider` accepts the same `get_db_pool` style
+provider used by the rest of the Content Ops host wiring. It returns a
+`ZendeskMacroPublishProvider` composed from:
+
+- `EnvZendeskMacroCredentialsProvider`
+- `PostgresFAQMacroWritebackMappingRepository(pool)`
+
+Credentials are read through `B2BCampaignConfig` fields backed by these primary
+env vars:
+
+- `ATLAS_CONTENT_OPS_ZENDESK_EMAIL`
+- `ATLAS_CONTENT_OPS_ZENDESK_API_TOKEN`
+- `ATLAS_CONTENT_OPS_ZENDESK_SUBDOMAIN`
+- `ATLAS_CONTENT_OPS_ZENDESK_BASE_URL`
+
+The generic `ZENDESK_*` names are accepted as typed fallback aliases for local
+operator convenience. Incomplete credentials return `None` from the credential
+provider; the Zendesk adapter then produces per-macro
+`zendesk_credentials_missing` failures without exposing secrets.
+
+## Intentional
+
+- No tenant-specific credential table yet. This slice wires the deployed route
+  to one host-managed Zendesk credential source; multi-tenant credential storage
+  belongs in a later product/security slice.
+- No env logging and no token-bearing metadata. Credentials only enter the
+  Zendesk adapter.
+- The provider factory still returns a provider when credentials are missing, so
+  the route remains reachable and the publish summary can explain the credential
+  failure per macro.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: replace host env credentials with
+  tenant-scoped encrypted credential storage when more than one customer
+  support platform account needs live writeback.
+- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: backfill pending Zendesk mappings
+  by looking up reserved title/category metadata.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: add the review UI action now that the
+  route and host provider wiring exist.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_atlas_content_ops_generated_assets_api.py -q — 17 passed, 1 warning.
+- python -m py_compile atlas_brain/config.py atlas_brain/_content_ops_macro_writeback.py atlas_brain/api/__init__.py tests/test_atlas_content_ops_macro_writeback.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python scripts/check_extracted_imports.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- python scripts/smoke_extracted_pipeline_imports.py — passed.
+- python scripts/smoke_extracted_pipeline_standalone.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-provider-wiring.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~105 |
+| Config | ~40 |
+| Host helper | ~95 |
+| API mount | ~5 |
+| Tests | ~150 |
+| CI enrollment | ~5 |
+| Total | ~400 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -85,6 +85,7 @@ pytest \
   tests/test_atlas_content_ops_generated_assets_api.py \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \
+  tests/test_atlas_content_ops_macro_writeback.py \
   tests/test_atlas_content_ops_reasoning.py \
   tests/test_atlas_content_ops_scope.py \
   tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -8,6 +8,7 @@ routes through the hosted API surface.
 from __future__ import annotations
 
 import importlib
+import inspect
 import sys
 
 import pytest
@@ -62,6 +63,29 @@ def test_generated_asset_routes_use_shared_content_ops_auth_scope_and_pool() -> 
     assert closure["pool_provider"].__name__ == "get_db_pool"
     assert closure["scope_provider"].__name__ == "build_content_ops_scope"
     assert "_capture_content_ops_auth_user" in dependency_names
+
+
+def test_generated_asset_publish_macros_route_uses_host_provider_wiring() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(
+        api_pkg,
+        "/content-assets/{asset}/drafts/{draft_id}/publish-macros",
+    )
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    provider_factory = closure["macro_publish_provider"]
+
+    provider = provider_factory()
+
+    assert provider_factory.__name__ == "<lambda>"
+    assert inspect.iscoroutine(provider)
+    assert provider.cr_code.co_name == "build_content_ops_macro_publish_provider"
+    assert provider.cr_frame is not None
+    provider.close()
 
 
 def test_faq_deflection_search_route_uses_shared_content_ops_auth_scope_and_pool() -> None:

--- a/tests/test_atlas_content_ops_macro_writeback.py
+++ b/tests/test_atlas_content_ops_macro_writeback.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from atlas_brain.config import B2BCampaignConfig
+from atlas_brain._content_ops_macro_writeback import (
+    ConfigZendeskMacroCredentialsProvider,
+    build_content_ops_macro_publish_provider,
+    zendesk_macro_credentials_from_config,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback_postgres import (
+    PostgresFAQMacroWritebackMappingRepository,
+)
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroPublishProvider,
+)
+
+
+class _Pool:
+    is_initialized = True
+
+
+@dataclass(frozen=True)
+class _Config:
+    content_ops_zendesk_email: str = ""
+    content_ops_zendesk_api_token: str = ""
+    content_ops_zendesk_subdomain: str = ""
+    content_ops_zendesk_base_url: str = ""
+
+
+def test_zendesk_macro_credentials_from_config() -> None:
+    credentials = zendesk_macro_credentials_from_config(_Config(
+        content_ops_zendesk_email=" agent@example.com ",
+        content_ops_zendesk_api_token=" token ",
+        content_ops_zendesk_subdomain="acme",
+    ))
+
+    assert credentials is not None
+    assert credentials.email == "agent@example.com"
+    assert credentials.normalized_base_url() == "https://acme.zendesk.com"
+    assert "token" not in repr(credentials)
+
+
+def test_b2b_campaign_config_accepts_content_ops_zendesk_env_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "ATLAS_CONTENT_OPS_ZENDESK_EMAIL",
+        "ATLAS_CONTENT_OPS_ZENDESK_API_TOKEN",
+        "ATLAS_CONTENT_OPS_ZENDESK_SUBDOMAIN",
+        "ATLAS_CONTENT_OPS_ZENDESK_BASE_URL",
+        "ZENDESK_EMAIL",
+        "ZENDESK_API_TOKEN",
+        "ZENDESK_SUBDOMAIN",
+        "ZENDESK_BASE_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ZENDESK_EMAIL", "agent@example.com")
+    monkeypatch.setenv("ZENDESK_API_TOKEN", "token")
+    monkeypatch.setenv("ZENDESK_BASE_URL", "https://acme.zendesk.com/")
+
+    config = B2BCampaignConfig(_env_file=None)
+    credentials = zendesk_macro_credentials_from_config(config)
+
+    assert credentials is not None
+    assert credentials.normalized_base_url() == "https://acme.zendesk.com"
+
+
+@pytest.mark.asyncio
+async def test_config_zendesk_credentials_provider_returns_none_when_incomplete() -> None:
+    provider = ConfigZendeskMacroCredentialsProvider(_Config(
+        content_ops_zendesk_email="agent@example.com",
+    ))
+
+    assert await provider.credentials_for_scope(TenantScope(account_id="acct-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_build_content_ops_macro_publish_provider_uses_pool_mapping_repo() -> None:
+    pool = _Pool()
+
+    async def pool_provider():
+        return pool
+
+    provider = await build_content_ops_macro_publish_provider(
+        pool_provider=pool_provider,
+        config_provider=lambda: _Config(
+            content_ops_zendesk_email="agent@example.com",
+            content_ops_zendesk_api_token="token",
+            content_ops_zendesk_subdomain="acme",
+        ),
+    )
+
+    assert isinstance(provider, ZendeskMacroPublishProvider)
+    assert isinstance(
+        provider.mapping_repository,
+        PostgresFAQMacroWritebackMappingRepository,
+    )
+    assert provider.mapping_repository.pool is pool
+    credentials = await provider.credentials_provider.credentials_for_scope(
+        TenantScope(account_id="acct-1")
+    )
+    assert credentials is not None
+    assert credentials.email == "agent@example.com"
+
+
+@pytest.mark.asyncio
+async def test_build_content_ops_macro_publish_provider_returns_none_without_pool() -> None:
+    async def pool_provider():
+        return None
+
+    assert await build_content_ops_macro_publish_provider(
+        pool_provider=pool_provider,
+        config_provider=lambda: _Config(),
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_build_content_ops_macro_publish_provider_returns_none_for_uninitialized_pool() -> None:
+    class _UninitializedPool:
+        is_initialized = False
+
+    assert await build_content_ops_macro_publish_provider(
+        pool_provider=lambda: _UninitializedPool(),
+        config_provider=lambda: _Config(),
+    ) is None


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Provider-Wiring.md
Slice phase: Vertical slice

Wires the hosted Content Ops generated asset router to a real macro publish provider factory. Atlas now builds a Zendesk macro provider with env-backed credentials and the Postgres macro writeback mapping repository, then injects it into the FAQ macro publish route from #1136.

## Intentional
- Credentials are env-backed for this first host wiring slice; tenant-scoped encrypted credential storage is deferred.
- Missing/incomplete Zendesk credentials do not leak secrets and resolve as per-macro `zendesk_credentials_missing` through the existing adapter.
- Provider construction is isolated in `atlas_brain/_content_ops_macro_writeback.py` so the API mount stays small.

## Deferred
- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: replace host env credentials with tenant-scoped encrypted credential storage.
- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: backfill pending Zendesk mappings by looking up reserved title/category metadata.
- `PR-FAQ-Macro-Writeback-Publish-UI`: add the review UI action now that route and host provider wiring exist.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_atlas_content_ops_generated_assets_api.py -q — 17 passed, 1 warning.
- python -m py_compile atlas_brain/_content_ops_macro_writeback.py atlas_brain/api/__init__.py tests/test_atlas_content_ops_macro_writeback.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
- bash scripts/validate_extracted_content_pipeline.sh — passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
- bash scripts/check_ascii_python.sh — passed.
- python scripts/check_extracted_imports.py — passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
- python scripts/smoke_extracted_pipeline_imports.py — passed.
- python scripts/smoke_extracted_pipeline_standalone.py — passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-provider-wiring.md — passed.

## Diff size
6 files, +330 / -0