### PR TITLE
PR-FAQ-Deflection-Report-UI-Readonly

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -11,6 +11,7 @@ on:
       - "atlas-intel-ui/public/**"
       - "atlas-intel-ui/scripts/**"
       - "atlas-intel-ui/src/**"
+      - "docs/frontend/**"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - "atlas-intel-ui/public/**"
       - "atlas-intel-ui/scripts/**"
       - "atlas-intel-ui/src/**"
+      - "docs/frontend/**"
 
 jobs:
   atlas-intel-ui-checks:
@@ -49,6 +51,9 @@ jobs:
 
       - name: Test landing-page prerender verifier
         run: npm run test:landing-page-prerender
+
+      - name: Test Content Ops deflection report UI
+        run: npm run test:content-ops-deflection-report-ui
 
       - name: Build
         run: npm run build

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-29
+
+### atlas-intel-ui npm audit vulnerabilities
+- File/location: `atlas-intel-ui/package-lock.json`
+- Description: `npm ci` reports 6 dependency audit findings (2 moderate, 4 high).
+- Why it matters: Dependency vulnerabilities can become deploy-time security exposure, but resolving them may require package upgrades outside this UI rendering slice.
+- Effort: M
+- Category: security
+- Owner/session: Codex FAQ deflection report UI slice
+- Found during: PR-FAQ-Deflection-Report-UI-Readonly
+
 > **Atlas blog / deep-dive content pipeline** (`content-ops/blog-*` ownership
 > lanes): parked items live in [`ATLAS-HARDENING.md`](./ATLAS-HARDENING.md),
 > kept separate to avoid append-collisions with the concurrent

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -15,6 +15,7 @@
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",
+    "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/content-ops-deflection-report-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-deflection-report-ui.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function loadTsModule(path) {
+  const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  FAQ_DEFLECTION_REPORT_OUTPUT,
+  faqDeflectionReportAnswerSteps,
+  faqDeflectionReportView,
+} = await loadTsModule('../src/domain/contentOps/faqDeflectionReport.ts')
+
+const example = JSON.parse(
+  readFileSync(
+    new URL('../../docs/frontend/content_ops_faq_deflection_report_example.json', import.meta.url),
+    'utf8',
+  ),
+)
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+test('deflection report view splits proven and no-proven answers from contract example', () => {
+  const report = faqDeflectionReportView(example)
+
+  assert.ok(report)
+  assert.equal(report.summary.generated, 2)
+  assert.equal(report.provenItems.length, 1)
+  assert.equal(report.noProvenItems.length, 1)
+  assert.equal(report.provenItems[0].question, 'How do I export attribution reports?')
+  assert.equal(report.noProvenItems[0].question, 'Can I turn on SSO for all users?')
+  assert.equal(report.provenItems[0].answerEvidenceStatus, 'resolution_evidence')
+  assert.equal(report.noProvenItems[0].answerEvidenceStatus, 'draft_needs_review')
+  assert.ok(
+    !report.provenItems.some((item) => item.question.includes('SSO')),
+    'no-proven SSO gap must not render as a proven drafted answer',
+  )
+})
+
+test('deflection report UI suppresses unproven answer steps at render boundary', () => {
+  const report = faqDeflectionReportView(example)
+  assert.ok(report)
+  const [unproven] = report.noProvenItems
+  const [proven] = report.provenItems
+
+  assert.ok(unproven.steps.length > 0, 'fixture carries raw review-placeholder steps')
+  assert.deepEqual(faqDeflectionReportAnswerSteps(unproven, 'unproven'), [])
+  assert.deepEqual(faqDeflectionReportAnswerSteps(unproven, 'proven'), [])
+  assert.deepEqual(
+    faqDeflectionReportAnswerSteps(proven, 'proven'),
+    proven.steps,
+  )
+})
+
+test('new run page renders faq deflection report execute results distinctly', () => {
+  assert.equal(FAQ_DEFLECTION_REPORT_OUTPUT, 'faq_deflection_report')
+  assert.ok(newRunSource.includes('FAQDeflectionReportExecutionSummary'))
+  assert.ok(newRunSource.includes('output === FAQ_DEFLECTION_REPORT_OUTPUT'))
+  assert.ok(newRunSource.includes('faqDeflectionReportAnswerSteps(item, tone)'))
+  assert.ok(newRunSource.includes('Drafted Answers (proven solutions)'))
+  assert.ok(newRunSource.includes('No Proven Answer Yet'))
+  assert.ok(newRunSource.includes('FAQ_RESOLUTION_EVIDENCE_STATUS'))
+})

--- a/atlas-intel-ui/src/domain/contentOps/faqDeflectionReport.ts
+++ b/atlas-intel-ui/src/domain/contentOps/faqDeflectionReport.ts
@@ -1,0 +1,161 @@
+export const FAQ_DEFLECTION_REPORT_OUTPUT = 'faq_deflection_report'
+export const FAQ_RESOLUTION_EVIDENCE_STATUS = 'resolution_evidence'
+
+export interface FAQDeflectionReportView {
+  markdown: string
+  summary: FAQDeflectionReportSummaryView
+  items: FAQDeflectionReportItemView[]
+  provenItems: FAQDeflectionReportItemView[]
+  noProvenItems: FAQDeflectionReportItemView[]
+  outputChecks: Record<string, boolean>
+}
+
+export interface FAQDeflectionReportSummaryView {
+  generated: number | null
+  sourceCount: number | null
+  ticketSourceCount: number | null
+  draftedAnswerCount: number | null
+  noProvenAnswerCount: number | null
+  topQuestion: string
+  topOpportunityScore: number | null
+}
+
+export interface FAQDeflectionReportItemView {
+  question: string
+  topic: string
+  summary: string
+  answerEvidenceStatus: string
+  ticketCount: number | null
+  opportunityScore: number | null
+  weightedFrequency: number | null
+  steps: string[]
+  sourceIds: string[]
+  evidenceQuotes: string[]
+  termMappings: FAQTermMappingView[]
+}
+
+export interface FAQTermMappingView {
+  customerTerm: string
+  documentationTerm: string
+  suggestion: string
+  sourceIdCount: number | null
+}
+
+export type FAQDeflectionReportAnswerTone = 'proven' | 'unproven'
+
+export function faqDeflectionReportView(
+  result: Record<string, unknown>,
+): FAQDeflectionReportView | null {
+  const summary = recordValue(result.summary)
+  const faqResult = recordValue(result.faq_result)
+  if (!summary || !faqResult || typeof result.markdown !== 'string') {
+    return null
+  }
+
+  const items = recordArray(faqResult.items).map(faqDeflectionReportItem)
+  const provenItems = items.filter(isProvenFAQDeflectionReportItem)
+  const noProvenItems = items.filter((item) => !isProvenFAQDeflectionReportItem(item))
+
+  return {
+    markdown: result.markdown,
+    summary: {
+      generated: numberField(summary, 'generated'),
+      sourceCount: numberField(summary, 'source_count'),
+      ticketSourceCount: numberField(summary, 'ticket_source_count'),
+      draftedAnswerCount: numberField(summary, 'drafted_answer_count'),
+      noProvenAnswerCount: numberField(summary, 'no_proven_answer_count'),
+      topQuestion: stringField(summary, 'top_question') ?? '',
+      topOpportunityScore: numberField(summary, 'top_opportunity_score'),
+    },
+    items,
+    provenItems,
+    noProvenItems,
+    outputChecks: booleanRecord(summary.output_checks),
+  }
+}
+
+export function isProvenFAQDeflectionReportItem(
+  item: FAQDeflectionReportItemView,
+): boolean {
+  return item.answerEvidenceStatus === FAQ_RESOLUTION_EVIDENCE_STATUS
+}
+
+export function faqDeflectionReportAnswerSteps(
+  item: FAQDeflectionReportItemView,
+  tone: FAQDeflectionReportAnswerTone,
+): string[] {
+  if (tone !== 'proven' || !isProvenFAQDeflectionReportItem(item)) {
+    return []
+  }
+  return item.steps
+}
+
+function faqDeflectionReportItem(
+  item: Record<string, unknown>,
+): FAQDeflectionReportItemView {
+  return {
+    question: stringField(item, 'question') ?? 'Untitled FAQ opportunity',
+    topic: stringField(item, 'topic') ?? '',
+    summary: stringField(item, 'summary') ?? '',
+    answerEvidenceStatus: stringField(item, 'answer_evidence_status') ?? '',
+    ticketCount: numberField(item, 'ticket_count'),
+    opportunityScore: numberField(item, 'opportunity_score'),
+    weightedFrequency: numberField(item, 'weighted_frequency'),
+    steps: stringArray(item.steps),
+    sourceIds: stringArray(item.source_ids),
+    evidenceQuotes: stringArray(item.evidence_quotes),
+    termMappings: recordArray(item.term_mappings).map((mapping) => ({
+      customerTerm: stringField(mapping, 'customer_term') ?? '',
+      documentationTerm: stringField(mapping, 'documentation_term') ?? '',
+      suggestion: stringField(mapping, 'suggestion') ?? '',
+      sourceIdCount: numberField(mapping, 'source_id_count'),
+    })),
+  }
+}
+
+function booleanRecord(value: unknown): Record<string, boolean> {
+  const record = recordValue(value)
+  if (!record) return {}
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter((entry): entry is [string, boolean] => typeof entry[1] === 'boolean'),
+  )
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is string => typeof item === 'string' && item.trim() !== '',
+      )
+    : []
+}

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -69,3 +69,18 @@ export {
 
 export { inputContractDisplay } from './inputDisplay'
 export type { ContentOpsInputDisplayFallback } from './inputDisplay'
+
+export {
+  FAQ_DEFLECTION_REPORT_OUTPUT,
+  FAQ_RESOLUTION_EVIDENCE_STATUS,
+  faqDeflectionReportAnswerSteps,
+  faqDeflectionReportView,
+  isProvenFAQDeflectionReportItem,
+} from './faqDeflectionReport'
+export type {
+  FAQDeflectionReportAnswerTone,
+  FAQDeflectionReportItemView,
+  FAQDeflectionReportSummaryView,
+  FAQDeflectionReportView,
+  FAQTermMappingView,
+} from './faqDeflectionReport'

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -25,6 +25,7 @@ import {
   contentOpsIngestionFilePreflightError,
   contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
+  faqDeflectionReportAnswerSteps,
   fromWireCatalog,
   fromWireExecution,
   fromWireIngestionDiagnostics,
@@ -33,10 +34,13 @@ import {
   fromWirePreview,
   fromWireRequest,
   fromWireUsageSummary,
+  faqDeflectionReportView,
   inputContractDisplay,
   toWireIngestionInspectRequest,
   toWireIngestionImportRequest,
   toWireRequest,
+  FAQ_DEFLECTION_REPORT_OUTPUT,
+  FAQ_RESOLUTION_EVIDENCE_STATUS,
   type ContentOpsCatalog,
   type ContentOpsCachePolicy,
   type ContentOpsIngestionDiagnostics,
@@ -50,6 +54,9 @@ import {
   type CampaignReasoningContextView,
   type ContentOpsStepReasoningAudit,
   type ControlSurfacePreview,
+  type FAQDeflectionReportAnswerTone,
+  type FAQDeflectionReportItemView,
+  type FAQDeflectionReportView,
   type GenerationPlan,
   type GenerationPlanStep,
   type ContentOpsUsageBudgetEvaluation,
@@ -3037,7 +3044,285 @@ function ExecutionStepSummary({
   if (output === 'faq_markdown') {
     return <FAQMarkdownExecutionSummary result={result} />
   }
+  if (output === FAQ_DEFLECTION_REPORT_OUTPUT) {
+    return <FAQDeflectionReportExecutionSummary result={result} />
+  }
   return null
+}
+
+function FAQDeflectionReportExecutionSummary({
+  result,
+}: {
+  result: Record<string, unknown>
+}) {
+  const report = faqDeflectionReportView(result)
+  if (!report) return null
+
+  return (
+    <div className="mb-3 space-y-3 rounded-md border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-300">
+      <div className="flex flex-wrap items-center gap-3">
+        <DeflectionReportMetric
+          label="FAQ opportunities"
+          value={report.summary.generated}
+        />
+        <DeflectionReportMetric
+          label="Source rows"
+          value={report.summary.sourceCount}
+        />
+        <DeflectionReportMetric
+          label="Ticket sources"
+          value={report.summary.ticketSourceCount}
+        />
+        <DeflectionReportMetric
+          label="Proven answers"
+          value={report.summary.draftedAnswerCount ?? report.provenItems.length}
+        />
+        <DeflectionReportMetric
+          label="No proven answer"
+          value={report.summary.noProvenAnswerCount ?? report.noProvenItems.length}
+        />
+      </div>
+
+      <DeflectionOutputChecks checks={report.outputChecks} />
+      <DeflectionRankedOpportunities report={report} />
+      <DeflectionReportAnswerSection
+        title="Drafted Answers (proven solutions)"
+        tone="proven"
+        items={report.provenItems}
+      />
+      <DeflectionReportAnswerSection
+        title="No Proven Answer Yet"
+        tone="unproven"
+        items={report.noProvenItems}
+      />
+      <DeflectionVocabularyGaps report={report} />
+      <details className="text-xs text-slate-400">
+        <summary className="cursor-pointer text-slate-500 hover:text-slate-300">
+          Report Markdown
+        </summary>
+        <pre className="mt-2 max-h-96 overflow-auto rounded bg-slate-950/80 p-3 whitespace-pre-wrap font-mono text-[11px] text-slate-300">
+          {report.markdown}
+        </pre>
+      </details>
+    </div>
+  )
+}
+
+function DeflectionReportMetric({
+  label,
+  value,
+}: {
+  label: string
+  value: number | null
+}) {
+  return (
+    <span>
+      {label}: <span className="font-medium text-slate-100">{value ?? '--'}</span>
+    </span>
+  )
+}
+
+function DeflectionOutputChecks({
+  checks,
+}: {
+  checks: Record<string, boolean>
+}) {
+  const entries = Object.entries(checks)
+  if (entries.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {entries.map(([name, passed]) => (
+        <span
+          key={name}
+          className={clsx(
+            'rounded border px-2 py-0.5 text-[11px]',
+            passed
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+              : 'border-amber-500/40 bg-amber-500/10 text-amber-100',
+          )}
+        >
+          {name.replaceAll('_', ' ')}: {passed ? 'pass' : 'check'}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function DeflectionRankedOpportunities({
+  report,
+}: {
+  report: FAQDeflectionReportView
+}) {
+  if (report.items.length === 0) return null
+  return (
+    <Section label="Ranked opportunities">
+      <div className="grid gap-2">
+        {report.items.map((item, index) => (
+          <div
+            key={`${item.question}-${index}`}
+            className="rounded border border-slate-800 bg-slate-950/50 px-3 py-2"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-slate-100">
+                  {index + 1}. {item.question}
+                </div>
+                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-slate-500">
+                  {item.topic && <span>{item.topic}</span>}
+                  {item.ticketCount !== null && (
+                    <span>{formatCount(item.ticketCount)} tickets</span>
+                  )}
+                  {item.opportunityScore !== null && (
+                    <span>score {item.opportunityScore}</span>
+                  )}
+                </div>
+              </div>
+              <DeflectionStatusBadge item={item} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+function DeflectionReportAnswerSection({
+  title,
+  tone,
+  items,
+}: {
+  title: string
+  tone: FAQDeflectionReportAnswerTone
+  items: FAQDeflectionReportItemView[]
+}) {
+  return (
+    <Section label={title}>
+      {items.length === 0 ? (
+        <div className="rounded border border-slate-800 bg-slate-950/50 px-3 py-2 text-slate-500">
+          {tone === 'proven'
+            ? 'No proven drafted answers returned in this run.'
+            : 'No unproven FAQ gaps returned in this run.'}
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {items.map((item, index) => (
+            <div
+              key={`${tone}-${item.question}-${index}`}
+              className={clsx(
+                'rounded border px-3 py-2',
+                tone === 'proven'
+                  ? 'border-emerald-500/30 bg-emerald-500/10'
+                  : 'border-amber-500/40 bg-amber-500/10',
+              )}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="text-sm font-medium text-slate-100">
+                  {item.question}
+                </div>
+                <DeflectionStatusBadge item={item} />
+              </div>
+              {item.summary && (
+                <p className="mt-1 text-xs text-slate-300">{item.summary}</p>
+              )}
+              {tone === 'proven' ? (
+                <DeflectionStepList
+                  steps={faqDeflectionReportAnswerSteps(item, tone)}
+                />
+              ) : (
+                <p className="mt-2 text-xs text-amber-100">
+                  No verified support resolution was present in the uploaded data.
+                  Add an approved answer before publishing this FAQ.
+                </p>
+              )}
+              <DeflectionSourceIds ids={item.sourceIds} />
+            </div>
+          ))}
+        </div>
+      )}
+    </Section>
+  )
+}
+
+function DeflectionStatusBadge({
+  item,
+}: {
+  item: FAQDeflectionReportItemView
+}) {
+  const proven = item.answerEvidenceStatus === FAQ_RESOLUTION_EVIDENCE_STATUS
+  return (
+    <span
+      className={clsx(
+        'shrink-0 rounded px-2 py-0.5 text-[10px] uppercase tracking-wide',
+        proven
+          ? 'bg-emerald-500/20 text-emerald-200'
+          : 'bg-amber-500/20 text-amber-100',
+      )}
+    >
+      {proven ? 'proven solution' : 'no proven answer'}
+    </span>
+  )
+}
+
+function DeflectionStepList({ steps }: { steps: string[] }) {
+  if (steps.length === 0) return null
+  return (
+    <ol className="mt-2 ml-4 list-decimal space-y-1 text-xs text-slate-200">
+      {steps.map((step, index) => (
+        <li key={`${step}-${index}`}>{step}</li>
+      ))}
+    </ol>
+  )
+}
+
+function DeflectionSourceIds({ ids }: { ids: string[] }) {
+  if (ids.length === 0) return null
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      {ids.slice(0, 6).map((id) => (
+        <span
+          key={id}
+          className="max-w-full break-all rounded bg-slate-950/60 px-1.5 py-0.5 font-mono text-[11px] text-slate-200"
+        >
+          {id}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function DeflectionVocabularyGaps({
+  report,
+}: {
+  report: FAQDeflectionReportView
+}) {
+  const mappings = report.items.flatMap((item) => item.termMappings).slice(0, 5)
+  if (mappings.length === 0) return null
+  return (
+    <Section label="Vocabulary gaps">
+      <div className="grid gap-1.5">
+        {mappings.map((mapping, index) => (
+          <div
+            key={`${mapping.customerTerm}-${mapping.documentationTerm}-${index}`}
+            className="rounded border border-slate-800 bg-slate-950/50 px-2 py-1"
+          >
+            <span className="font-medium text-slate-100">
+              {mapping.customerTerm || 'Customer term'}
+            </span>
+            {' -> '}
+            <span className="text-cyan-200">
+              {mapping.documentationTerm || 'Documentation term'}
+            </span>
+            {mapping.sourceIdCount !== null && (
+              <span className="ml-2 text-slate-500">
+                {mapping.sourceIdCount} source
+                {mapping.sourceIdCount === 1 ? '' : 's'}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
 }
 
 function FAQMarkdownExecutionSummary({ result }: { result: Record<string, unknown> }) {

--- a/plans/PR-FAQ-Deflection-Report-UI-Readonly.md
+++ b/plans/PR-FAQ-Deflection-Report-UI-Readonly.md
@@ -1,0 +1,121 @@
+# PR-FAQ-Deflection-Report-UI-Readonly
+
+## Why this slice exists
+
+The `faq_deflection_report` backend is now complete as a pipeline-only product
+path: generation artifact, execute output, contract docs, bulk/concurrency
+proofs, and CLI ergonomics have all landed. The next product gap is the Intel
+UI: a user can execute the output only through the existing generic run form,
+but the result is not rendered as the $1,500 deflection report deliverable.
+
+This slice builds the thinnest end-to-end UI path: select/execute
+`faq_deflection_report` through the existing Content Ops execute route and
+render the returned report read-only from the verified frontend contract.
+The diff is over the 400 LOC soft cap because the vertical slice includes the
+typed contract parser, the read-only UI renderer, the focused fixture test, and
+CI enrollment for that test so the check is not left as unenrolled local-only
+coverage.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-ui
+
+Slice phase: Vertical slice
+
+1. Add typed UI/domain helpers for the `FAQDeflectionReportArtifact` contract
+   from `docs/frontend/content_ops_faq_report_contract.md`.
+2. Render completed `faq_deflection_report` execute results in
+   `ContentOpsNewRun` with ranked opportunities, proven drafted answers, and
+   no-proven-answer gaps as distinct sections.
+3. Add a focused UI contract test using
+   `docs/frontend/content_ops_faq_deflection_report_example.json`.
+4. Enroll that focused test in `.github/workflows/atlas_intel_ui_checks.yml`.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `atlas-intel-ui/src/domain/contentOps/faqDeflectionReport.ts` | Adds typed parsing/splitting helpers for the report artifact. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Exports the helper for screens/tests. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Renders the deflection report execute result read-only. |
+| `atlas-intel-ui/scripts/content-ops-deflection-report-ui.test.mjs` | Verifies the split against the canonical example and the screen branch. |
+| `atlas-intel-ui/package.json` | Adds the focused npm test script. |
+| `.github/workflows/atlas_intel_ui_checks.yml` | Runs the focused test in the UI CI lane. |
+| `HARDENING.md` | Parks pre-existing npm audit dependency findings observed during setup. |
+| `plans/PR-FAQ-Deflection-Report-UI-Readonly.md` | Documents this slice contract. |
+
+## Mechanism
+
+The generic execute flow already sends selected catalog output IDs through
+`executeContentOpsRun(toWireRequest(...))`. This PR keeps that path and adds a
+renderer branch for `faq_deflection_report`.
+
+The domain helper accepts a raw `Record<string, unknown>`, validates the minimum
+artifact shape, and splits `faq_result.items` with the same rule as the backend:
+
+```ts
+item.answer_evidence_status === 'resolution_evidence'
+```
+
+Only proven items render in "Drafted Answers (proven solutions)". All other
+items render in "No Proven Answer Yet", so the UI cannot style an unbacked gap
+as a publishable answer.
+
+## Intentional
+
+- No rule-file, intent-rule, or documentation-term controls are added here.
+  Operators can use the raw JSON input field until a follow-up control slice.
+- No persistence or review flow is added. This is execute-result rendering only.
+- The existing output selector remains catalog-driven; the UI does not hardcode
+  a fake output card when the backend catalog omits `faq_deflection_report`.
+
+## Deferred
+
+- Parked hardening: `atlas-intel-ui npm audit vulnerabilities` in
+  `HARDENING.md`; this was observed during `npm ci`, is not introduced by this
+  slice, and would require dependency upgrade work outside the read-only report
+  UI path.
+- Future product-polish slice: add first-class controls for documentation terms,
+  vocabulary-gap rules, and intent rules.
+- Future product-polish slice: add richer Markdown rendering/export affordances
+  after the read-only contract view is proven.
+
+## Verification
+
+- Command: npm ci
+  - Result: passed; reported 6 existing audit findings, parked in `HARDENING.md`.
+- Command: npm run test:content-ops-deflection-report-ui
+  - Result: 3 passed.
+- Command: npm run lint
+  - Result: passed.
+- Command: npm run build
+  - Result: passed.
+- Command: npm run test:landing-page-prerender
+  - Result: 4 passed.
+- Command: npm run verify:blog-geo
+  - Result: passed; verified 14 blog pages.
+- Command: npm run verify:landing-page-geo
+  - Result: passed; skipped because no generated landing-page sitemap entries were present.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-UI-Readonly.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-UI-Readonly.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Review fix verification: npm run test:content-ops-deflection-report-ui
+  - Result: 3 passed.
+- Review fix verification: npm run lint
+  - Result: passed.
+- Review fix verification: npm run build
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Domain helper | 161 |
+| UI renderer | 289 |
+| Test + CI enrollment | 84 |
+| Hardening entry | 11 |
+| Plan doc | 121 |
+| **Total** | **677** |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-UI-Readonly.md
Slice phase: Vertical slice

The `faq_deflection_report` backend is now pipeline-complete; this PR adds the thinnest Intel UI path that renders a completed execute result as the customer-facing report. It keeps execution on the existing Content Ops `/execute` flow, adds a typed contract helper for the verified report artifact, and renders ranked opportunities, proven drafted answers, and no-proven gaps as distinct read-only sections.

## Intentional
- No rule-file, intent-rule, or documentation-term controls are added here.
- No persistence or review flow is added; this is execute-result rendering only.
- The output selector stays catalog-driven and does not fake a `faq_deflection_report` card when the backend catalog omits it.

## Deferred
- First-class controls for documentation terms, vocabulary-gap rules, and intent rules.
- Richer Markdown rendering/export affordances after the read-only view is proven.

## Parked hardening
- `atlas-intel-ui npm audit vulnerabilities` in `HARDENING.md`; `npm ci` reported existing dependency audit findings that require dependency-upgrade work outside this UI slice.

## Verification
- `npm ci`
- `npm run test:content-ops-deflection-report-ui` — 3 passed.
- `npm run lint`
- `npm run build`
- `npm run test:landing-page-prerender` — 4 passed.
- `npm run verify:blog-geo` — verified 14 blog pages.
- `npm run verify:landing-page-geo` — skipped because no generated landing-page sitemap entries were present.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-UI-Readonly.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-UI-Readonly.md`
- `git diff --check`

## Diff size
8 files, +677 / -0
