### PR TITLE
Reconcile pending FAQ macro writebacks

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Protocol, Sequence
+from urllib.parse import urlencode
 
 import httpx
 
@@ -169,11 +170,18 @@ class ZendeskMacroPublishProvider:
             )
             payload = _zendesk_macro_payload(macro)
             if existing is not None and not existing.external_id:
-                return MacroPublishResult(
-                    macro=macro,
-                    status="failed",
-                    error="zendesk_macro_mapping_pending_reconcile",
+                existing = await self._reconcile_pending_mapping(
+                    existing,
+                    macro,
+                    credentials=credentials,
+                    scope=scope,
                 )
+                if existing is None:
+                    return MacroPublishResult(
+                        macro=macro,
+                        status="failed",
+                        error="zendesk_macro_mapping_pending_reconcile",
+                    )
             if existing is None:
                 reservation = await self.mapping_repository.reserve_mapping(
                     MacroWritebackMapping(
@@ -221,7 +229,10 @@ class ZendeskMacroPublishProvider:
                         faq_draft_id=macro.faq_draft_id,
                         faq_item_id=macro.faq_item_id,
                         external_id=external_id,
-                        external_url=_external_url(data),
+                        external_url=_external_url(
+                            data,
+                            fallback=existing.external_url if existing else "",
+                        ),
                         publish_status="published",
                         metadata={
                             "title": macro.title,
@@ -248,6 +259,43 @@ class ZendeskMacroPublishProvider:
                 status="failed",
                 error=_safe_error(exc),
             )
+
+    async def _reconcile_pending_mapping(
+        self,
+        existing: MacroWritebackMapping,
+        macro: SupportMacroDraft,
+        *,
+        credentials: ZendeskMacroCredentials,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping | None:
+        title = _pending_mapping_title(existing, macro)
+        if not title:
+            return None
+        data = await self.transport.request(
+            "GET",
+            _zendesk_macro_search_url(credentials, title),
+            headers=_headers(credentials),
+            json={},
+        )
+        match = _exact_title_macro(data, title=title)
+        external_id = _clean(match.get("id")) if match is not None else ""
+        if not external_id:
+            return None
+        return await self.mapping_repository.upsert_mapping(
+            MacroWritebackMapping(
+                platform=ZENDESK_PLATFORM,
+                faq_draft_id=macro.faq_draft_id,
+                faq_item_id=macro.faq_item_id,
+                external_id=external_id,
+                external_url=_clean(match.get("url")),
+                publish_status="published",
+                metadata={
+                    "title": macro.title,
+                    "category": macro.category,
+                },
+            ),
+            scope=scope,
+        )
 
 
 def _zendesk_macro_payload(macro: SupportMacroDraft) -> JsonDict:
@@ -284,11 +332,48 @@ def _external_id(data: Mapping[str, Any], *, fallback: str = "") -> str:
     return _clean(fallback)
 
 
-def _external_url(data: Mapping[str, Any]) -> str:
+def _external_url(data: Mapping[str, Any], *, fallback: str = "") -> str:
     macro = data.get("macro")
     if isinstance(macro, Mapping):
-        return _clean(macro.get("url"))
-    return ""
+        return _clean(macro.get("url")) or _clean(fallback)
+    return _clean(fallback)
+
+
+def _pending_mapping_title(
+    existing: MacroWritebackMapping,
+    macro: SupportMacroDraft,
+) -> str:
+    return _clean(existing.metadata.get("title")) or _clean(macro.title)
+
+
+def _zendesk_macro_search_url(
+    credentials: ZendeskMacroCredentials,
+    title: str,
+) -> str:
+    query = urlencode({"query": title})
+    return f"{credentials.normalized_base_url()}/api/v2/macros/search?{query}"
+
+
+def _exact_title_macro(
+    data: Mapping[str, Any],
+    *,
+    title: str,
+) -> Mapping[str, Any] | None:
+    macros = data.get("macros")
+    if not isinstance(macros, Sequence) or isinstance(macros, (str, bytes)):
+        return None
+    normalized_title = _normalized_title(title)
+    for macro in macros:
+        if (
+            isinstance(macro, Mapping)
+            and _normalized_title(macro.get("title")) == normalized_title
+        ):
+            return macro
+    return None
+
+
+def _normalized_title(value: Any) -> str:
+    return _clean(value).casefold()
 
 
 def _safe_error(exc: Exception) -> str:

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -363,13 +363,16 @@ def _exact_title_macro(
     if not isinstance(macros, Sequence) or isinstance(macros, (str, bytes)):
         return None
     normalized_title = _normalized_title(title)
+    matches: list[Mapping[str, Any]] = []
     for macro in macros:
         if (
             isinstance(macro, Mapping)
             and _normalized_title(macro.get("title")) == normalized_title
         ):
-            return macro
-    return None
+            matches.append(macro)
+    if len(matches) != 1:
+        return None
+    return matches[0]
 
 
 def _normalized_title(value: Any) -> str:

--- a/plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md
+++ b/plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md
@@ -18,11 +18,12 @@ Slice phase: Production hardening
 1. Add pending mapping reconciliation inside `ZendeskMacroPublishProvider`.
 2. Search Zendesk macros by the reserved title stored in pending mapping
    metadata, falling back to the current macro title.
-3. Require an exact normalized title match before accepting a search result.
+3. Require exactly one exact normalized title match before accepting a search
+   result.
 4. Backfill the mapping with the reconciled external macro id and continue the
    existing PUT update path.
-5. Add focused tests for successful reconciliation, no-match behavior, and safe
-   exact-match rejection.
+5. Add focused tests for successful reconciliation, no-match behavior, safe
+   exact-match rejection, and duplicate exact-title rejection.
 
 ### Files touched
 
@@ -40,20 +41,21 @@ The helper:
    `macro.title`.
 2. Calls Zendesk's official macro search endpoint:
    `/api/v2/macros/search?query=<title>`.
-3. Accepts only a result whose normalized `title` exactly matches the requested
-   title.
+3. Accepts only when exactly one result's normalized `title` matches the
+   requested title.
 4. Upserts the mapping with the found `external_id`, `external_url`, and the
    reserved metadata.
 5. Returns the reconciled mapping so the existing PUT path updates the macro
    body and returns `updated`.
 
-No match still returns the existing pending-reconcile failure, so retries remain
-duplicate-safe.
+No match or multiple exact-title matches still returns the existing
+pending-reconcile failure, so retries remain duplicate-safe and ambiguous
+results stay operator-visible.
 
 ## Intentional
 
-- Reconcile is title-exact, not fuzzy. A fuzzy match could attach one FAQ item
-  to the wrong Zendesk macro.
+- Reconcile is title-exact and uniqueness-gated, not fuzzy. Fuzzy or ambiguous
+  matching could attach one FAQ item to the wrong Zendesk macro.
 - Reconcile does not POST when a pending mapping exists. The pending row is the
   idempotency guard; reposting would reintroduce the duplicate-macro bug.
 - Category is retained in metadata but not required for matching, because the
@@ -73,7 +75,7 @@ Parked hardening: none
 
 ## Verification
 
-- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q — 9 passed.
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q — 10 passed.
 - python -m py_compile extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py — passed.
 - bash scripts/validate_extracted_content_pipeline.sh — passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
@@ -90,6 +92,6 @@ Parked hardening: none
 | Area | Estimated LOC |
 |---|---:|
 | Plan | ~95 |
-| Adapter | ~101 |
-| Tests | ~95 |
-| Total | ~291 |
+| Adapter | ~106 |
+| Tests | ~134 |
+| Total | ~335 |

--- a/plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md
+++ b/plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md
@@ -1,0 +1,95 @@
+# PR-FAQ-Macro-Writeback-Pending-Reconcile
+
+## Why this slice exists
+
+The Zendesk adapter now prevents duplicate macro creation by leaving an
+idempotency row in `pending` when Zendesk creates a macro but mapping
+persistence fails. The publish route surfaces that as
+`zendesk_macro_mapping_pending_reconcile`, but the row currently has no
+self-heal path. This slice adds the missing source-level fix: when a pending row
+exists, search Zendesk for the reserved macro title, backfill the mapping, and
+continue through the normal update path instead of staying stuck forever.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add pending mapping reconciliation inside `ZendeskMacroPublishProvider`.
+2. Search Zendesk macros by the reserved title stored in pending mapping
+   metadata, falling back to the current macro title.
+3. Require an exact normalized title match before accepting a search result.
+4. Backfill the mapping with the reconciled external macro id and continue the
+   existing PUT update path.
+5. Add focused tests for successful reconciliation, no-match behavior, and safe
+   exact-match rejection.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback_zendesk.py` — pending mapping reconciliation.
+- `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` — adapter coverage.
+
+## Mechanism
+
+When `_publish_one` finds an existing mapping with blank `external_id`, it calls
+a new reconcile helper before returning `zendesk_macro_mapping_pending_reconcile`.
+The helper:
+
+1. Reads `metadata["title"]` from the pending mapping, falling back to
+   `macro.title`.
+2. Calls Zendesk's official macro search endpoint:
+   `/api/v2/macros/search?query=<title>`.
+3. Accepts only a result whose normalized `title` exactly matches the requested
+   title.
+4. Upserts the mapping with the found `external_id`, `external_url`, and the
+   reserved metadata.
+5. Returns the reconciled mapping so the existing PUT path updates the macro
+   body and returns `updated`.
+
+No match still returns the existing pending-reconcile failure, so retries remain
+duplicate-safe.
+
+## Intentional
+
+- Reconcile is title-exact, not fuzzy. A fuzzy match could attach one FAQ item
+  to the wrong Zendesk macro.
+- Reconcile does not POST when a pending mapping exists. The pending row is the
+  idempotency guard; reposting would reintroduce the duplicate-macro bug.
+- Category is retained in metadata but not required for matching, because the
+  Zendesk search response shape does not reliably include the same local
+  category metadata we stored.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Pending-Reconcile-CLI`: optional operator command to
+  scan and reconcile all pending rows without waiting for a publish retry.
+- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: tenant-scoped encrypted
+  credential storage for multi-customer live writeback.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish
+  route.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q — 9 passed.
+- python -m py_compile extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python scripts/check_extracted_imports.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- python scripts/smoke_extracted_pipeline_imports.py — passed.
+- python scripts/smoke_extracted_pipeline_standalone.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-pending-reconcile.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~95 |
+| Adapter | ~101 |
+| Tests | ~95 |
+| Total | ~291 |

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -320,6 +320,45 @@ async def test_zendesk_provider_rejects_pending_mapping_title_near_miss() -> Non
 
 
 @pytest.mark.asyncio
+async def test_zendesk_provider_rejects_ambiguous_pending_mapping_title_matches() -> None:
+    repo = _MappingRepo(existing=MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+        metadata={"title": "Why was I charged twice?"},
+    ))
+    transport = _Transport({
+        "macros": [
+            {
+                "id": 123,
+                "url": "https://example.zendesk.com/api/v2/macros/123",
+                "title": "Why was I charged twice?",
+            },
+            {
+                "id": 456,
+                "url": "https://example.zendesk.com/api/v2/macros/456",
+                "title": " why  was I charged twice? ",
+            },
+        ]
+    })
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "failed"
+    assert results[0].error == "zendesk_macro_mapping_pending_reconcile"
+    assert [call["method"] for call in transport.calls] == ["GET"]
+    assert repo.reserve_calls == []
+    assert repo.upsert_calls == []
+
+
+@pytest.mark.asyncio
 async def test_zendesk_provider_marks_create_then_mapping_failure_without_reposting() -> None:
     repo = _MappingRepo(upsert_error=RuntimeError("database down"))
     transport = _Transport({"macro": {"id": 123}}, {"macros": []})

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -210,7 +210,58 @@ async def test_zendesk_provider_fails_without_credentials_without_network_call()
 
 
 @pytest.mark.asyncio
-async def test_zendesk_provider_refuses_to_repost_when_mapping_is_pending() -> None:
+async def test_zendesk_provider_reconciles_pending_mapping_before_update() -> None:
+    repo = _MappingRepo(existing=MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+        metadata={
+            "title": "Why was I charged twice?",
+            "category": "billing",
+        },
+    ))
+    transport = _Transport(
+        {
+            "macros": [
+                {
+                    "id": 123,
+                    "url": "https://example.zendesk.com/api/v2/macros/123",
+                    "title": " Why was I charged twice? ",
+                }
+            ]
+        },
+        {"macro": {"id": 123}},
+    )
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "updated"
+    assert results[0].external_id == "123"
+    assert [call["method"] for call in transport.calls] == ["GET", "PUT"]
+    assert transport.calls[0]["url"] == (
+        "https://example.zendesk.com/api/v2/macros/search?"
+        "query=Why+was+I+charged+twice%3F"
+    )
+    assert transport.calls[0]["json"] == {}
+    assert transport.calls[1]["url"] == "https://example.zendesk.com/api/v2/macros/123"
+    assert repo.reserve_calls == []
+    assert len(repo.upsert_calls) == 2
+    reconciled = repo.upsert_calls[0]["mapping"]
+    saved = repo.upsert_calls[1]["mapping"]
+    assert reconciled.external_id == "123"
+    assert reconciled.external_url == "https://example.zendesk.com/api/v2/macros/123"
+    assert saved.external_url == "https://example.zendesk.com/api/v2/macros/123"
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_refuses_to_repost_when_pending_mapping_has_no_match() -> None:
     repo = _MappingRepo(existing=MacroWritebackMapping(
         platform=ZENDESK_PLATFORM,
         faq_draft_id="11111111-1111-1111-1111-111111111111",
@@ -218,7 +269,7 @@ async def test_zendesk_provider_refuses_to_repost_when_mapping_is_pending() -> N
         external_id="",
         publish_status="pending",
     ))
-    transport = _Transport({"macro": {"id": 123}})
+    transport = _Transport({"macros": []})
     provider = ZendeskMacroPublishProvider(
         credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
         mapping_repository=repo,
@@ -229,7 +280,41 @@ async def test_zendesk_provider_refuses_to_repost_when_mapping_is_pending() -> N
 
     assert results[0].status == "failed"
     assert results[0].error == "zendesk_macro_mapping_pending_reconcile"
-    assert transport.calls == []
+    assert [call["method"] for call in transport.calls] == ["GET"]
+    assert repo.reserve_calls == []
+    assert repo.upsert_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_rejects_pending_mapping_title_near_miss() -> None:
+    repo = _MappingRepo(existing=MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+        metadata={"title": "Why was I charged twice?"},
+    ))
+    transport = _Transport({
+        "macros": [
+            {
+                "id": 999,
+                "url": "https://example.zendesk.com/api/v2/macros/999",
+                "title": "Why was I charged twice? old",
+            }
+        ]
+    })
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    results = await provider.publish([_macro()], scope=TenantScope(account_id="acct-1"))
+
+    assert results[0].status == "failed"
+    assert results[0].error == "zendesk_macro_mapping_pending_reconcile"
+    assert [call["method"] for call in transport.calls] == ["GET"]
     assert repo.reserve_calls == []
     assert repo.upsert_calls == []
 
@@ -237,7 +322,7 @@ async def test_zendesk_provider_refuses_to_repost_when_mapping_is_pending() -> N
 @pytest.mark.asyncio
 async def test_zendesk_provider_marks_create_then_mapping_failure_without_reposting() -> None:
     repo = _MappingRepo(upsert_error=RuntimeError("database down"))
-    transport = _Transport({"macro": {"id": 123}})
+    transport = _Transport({"macro": {"id": 123}}, {"macros": []})
     provider = ZendeskMacroPublishProvider(
         credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
         mapping_repository=repo,
@@ -253,7 +338,7 @@ async def test_zendesk_provider_marks_create_then_mapping_failure_without_repost
     assert first[0].error == "zendesk_mapping_persist_failed"
     assert second[0].status == "failed"
     assert second[0].error == "zendesk_macro_mapping_pending_reconcile"
-    assert [call["method"] for call in transport.calls] == ["POST"]
+    assert [call["method"] for call in transport.calls] == ["POST", "GET"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Pending-Reconcile.md
Slice phase: Production hardening

This closes the pending-mapping gap in Zendesk FAQ macro writeback. When a previous create succeeded but mapping persistence failed, the adapter now searches Zendesk by the reserved title, requires one unique exact-title match, backfills the mapping, and continues through the normal update path instead of staying stuck at pending reconcile.

## Intentional
- Reconcile is exact normalized title match plus uniqueness only; fuzzy or ambiguous matching could attach an FAQ item to the wrong Zendesk macro.
- Pending mappings still never POST, preserving the duplicate-macro guard.
- Category stays in mapping metadata but is not required for matching because Zendesk macro search does not reliably expose the local category shape.

## Deferred
- `PR-FAQ-Macro-Writeback-Pending-Reconcile-CLI`: optional operator command to scan and reconcile all pending rows without waiting for a publish retry.
- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: tenant-scoped encrypted credential storage for multi-customer live writeback.
- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish route.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_zendesk.py -q` — 10 passed.
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `python scripts/check_extracted_imports.py` — passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` — passed.
- `python scripts/smoke_extracted_pipeline_imports.py` — passed.
- `python scripts/smoke_extracted_pipeline_standalone.py` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-pending-reconcile.md` — passed.

## Diff size
3 files, +322 / -13.