### PR TITLE
PR-FAQ-Deflection-Report-UI-Controls

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Test Content Ops deflection report UI
         run: npm run test:content-ops-deflection-report-ui
 
+      - name: Test Content Ops FAQ configuration inputs
+        run: npm run test:content-ops-faq-configuration-inputs
+
       - name: Build
         run: npm run build
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -16,6 +16,7 @@
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
+    "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function loadTsModule(path) {
+  const source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
+  FAQ_MARKDOWN_OUTPUT,
+  faqConfigurationInputsSelected,
+} = await loadTsModule('../src/domain/contentOps/faqConfigurationInputs.ts')
+const { FAQ_DEFLECTION_REPORT_OUTPUT } = await loadTsModule(
+  '../src/domain/contentOps/faqDeflectionReport.ts',
+)
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+test('FAQ configuration controls apply to FAQ markdown and deflection report outputs', () => {
+  assert.equal(FAQ_MARKDOWN_OUTPUT, 'faq_markdown')
+  assert.equal(
+    FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
+    FAQ_DEFLECTION_REPORT_OUTPUT,
+  )
+  assert.equal(faqConfigurationInputsSelected([FAQ_MARKDOWN_OUTPUT]), true)
+  assert.equal(
+    faqConfigurationInputsSelected([FAQ_DEFLECTION_REPORT_OUTPUT]),
+    true,
+  )
+  assert.equal(faqConfigurationInputsSelected(['landing_page']), false)
+  assert.equal(faqConfigurationInputsSelected([]), false)
+})
+
+test('new run page uses the shared FAQ configuration output predicate', () => {
+  assert.ok(
+    newRunSource.includes(
+      'const faqConfigurationOutputSelected = faqConfigurationInputsSelected(',
+    ),
+  )
+  assert.ok(newRunSource.includes('{faqConfigurationOutputSelected && ('))
+  assert.ok(!newRunSource.includes('faqMarkdownOutputSelected'))
+  assert.ok(newRunSource.includes('FAQ vocabulary-gap inputs'))
+})

--- a/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
+++ b/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
@@ -1,0 +1,17 @@
+export const FAQ_MARKDOWN_OUTPUT = 'faq_markdown'
+export const FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT = 'faq_deflection_report'
+
+export const FAQ_CONFIGURATION_OUTPUTS = [
+  FAQ_MARKDOWN_OUTPUT,
+  FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
+] as const
+
+export function faqConfigurationInputsSelected(
+  outputs: readonly string[],
+): boolean {
+  return outputs.some((output) =>
+    FAQ_CONFIGURATION_OUTPUTS.includes(
+      output as (typeof FAQ_CONFIGURATION_OUTPUTS)[number],
+    ),
+  )
+}

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -71,6 +71,13 @@ export { inputContractDisplay } from './inputDisplay'
 export type { ContentOpsInputDisplayFallback } from './inputDisplay'
 
 export {
+  FAQ_CONFIGURATION_OUTPUTS,
+  FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
+  FAQ_MARKDOWN_OUTPUT,
+  faqConfigurationInputsSelected,
+} from './faqConfigurationInputs'
+
+export {
   FAQ_DEFLECTION_REPORT_OUTPUT,
   FAQ_RESOLUTION_EVIDENCE_STATUS,
   faqDeflectionReportAnswerSteps,

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -26,6 +26,7 @@ import {
   contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
   faqDeflectionReportAnswerSteps,
+  faqConfigurationInputsSelected,
   fromWireCatalog,
   fromWireExecution,
   fromWireIngestionDiagnostics,
@@ -120,7 +121,6 @@ const LANDING_PAGE_QUALITY_REPAIR_INPUT =
 const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
-const FAQ_MARKDOWN_OUTPUT = 'faq_markdown'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
 const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
 const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
@@ -261,11 +261,13 @@ export default function ContentOpsNewRun() {
   const blogPostOutputSelected = request.outputs.includes(BLOG_POST_OUTPUT)
   const faqSourceSelectionVisible =
     landingPageOutputSelected || blogPostOutputSelected
-  const faqMarkdownOutputSelected = request.outputs.includes(FAQ_MARKDOWN_OUTPUT)
-  const faqDocumentationTermsContract = faqMarkdownOutputSelected
+  const faqConfigurationOutputSelected = faqConfigurationInputsSelected(
+    request.outputs,
+  )
+  const faqDocumentationTermsContract = faqConfigurationOutputSelected
     ? catalog.inputContracts[FAQ_DOCUMENTATION_TERMS_INPUT]
     : undefined
-  const faqVocabularyGapRulesContract = faqMarkdownOutputSelected
+  const faqVocabularyGapRulesContract = faqConfigurationOutputSelected
     ? catalog.inputContracts[FAQ_VOCABULARY_GAP_RULES_INPUT]
     : undefined
   const faqDocumentationTermsDisplay = inputContractDisplay(
@@ -1090,7 +1092,7 @@ export default function ContentOpsNewRun() {
               </p>
             </div>
           )}
-          {faqMarkdownOutputSelected && (
+          {faqConfigurationOutputSelected && (
             <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-3">
               <div className="mb-3">
                 <h3 className="text-sm font-medium text-slate-200">

--- a/plans/PR-FAQ-Deflection-Report-UI-Controls.md
+++ b/plans/PR-FAQ-Deflection-Report-UI-Controls.md
@@ -1,0 +1,87 @@
+# PR-FAQ-Deflection-Report-UI-Controls
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Report-UI-Readonly made `faq_deflection_report` visible in the Intel UI, but its configuration controls still only appear for the older `faq_markdown` output. The backend generation plan uses the same `faq_documentation_terms` and `faq_vocabulary_gap_rules` inputs for both `faq_markdown` and `faq_deflection_report`, so a user running the $1,500 deflection report still has to hand-edit raw JSON for the vocabulary-gap part of the real flow.
+
+This slice keeps the first-class UI controls narrow: expose the existing FAQ vocabulary-gap controls when either FAQ output is selected, and lock that selection rule with a focused UI test. The slice intentionally does not add rule-file, custom intent-rule, or persistence controls.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-ui
+
+Slice phase: Product polish
+
+1. Add a small domain helper that treats `faq_markdown` and `faq_deflection_report` as FAQ-configuration outputs.
+2. Use that helper in `ContentOpsNewRun` so the existing documentation-terms and vocabulary-gap-rules fields render for `faq_deflection_report` runs.
+3. Add focused test coverage proving the controls are tied to both FAQ outputs and not unrelated outputs.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts` | Adds the FAQ output selection helper and constants. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Exports the helper/constants for the screen and focused test. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Uses the helper to show existing FAQ vocabulary-gap controls for deflection reports. |
+| `atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs` | Verifies the selection helper and screen wiring. |
+| `atlas-intel-ui/package.json` | Adds the focused npm test script. |
+| `.github/workflows/atlas_intel_ui_checks.yml` | Enrolls the focused test in the UI CI lane. |
+| `plans/PR-FAQ-Deflection-Report-UI-Controls.md` | Documents this slice contract. |
+
+## Mechanism
+
+The backend already maps both FAQ outputs through `_faq_markdown_config_for_request`, which reads these input keys:
+
+```ts
+faq_documentation_terms
+faq_vocabulary_gap_rules
+```
+
+This PR moves the UI's FAQ-output check from a single `faq_markdown` literal to a tested helper:
+
+```ts
+faqConfigurationInputsSelected(outputs)
+```
+
+The existing textareas, JSON update helpers, and catalog contract display stay unchanged. Only the visibility and contract lookup predicate changes from `faq_markdown` selected to any FAQ-configuration output selected.
+
+## Intentional
+
+- No custom intent-rule control is added because the hosted execute path does not currently expose an input contract for it.
+- No rule-file upload is added; that remains a CLI/report-operations surface until a dedicated UI slice defines the upload contract.
+- No new persistence or saved defaults are added. The controls continue writing directly into the existing inputs JSON.
+
+## Deferred
+
+- Parked hardening considered: `atlas-intel-ui npm audit vulnerabilities` remains parked in `HARDENING.md`; dependency upgrade work is outside this UI controls slice.
+- Future product-polish slice: add first-class custom intent-rule controls after the execute/catalog contract exposes the input.
+- Future product-polish slice: add rule-file upload or saved configuration presets if the report operations flow needs it.
+
+## Verification
+
+- Command: npm ci
+  - Result: passed; reported the same 6 existing audit findings already parked in `HARDENING.md`.
+- Command: npm run test:content-ops-faq-configuration-inputs
+  - Result: 2 passed.
+- Command: npm run test:content-ops-deflection-report-ui
+  - Result: 3 passed.
+- Command: npm run lint
+  - Result: passed.
+- Command: npm run build
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-UI-Controls.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-UI-Controls.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Domain helper + exports | 24 |
+| Screen wiring | 12 |
+| Test + CI enrollment | 62 |
+| Plan doc | 87 |
+| **Total** | **185** |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-UI-Controls.md
Slice phase: Product polish

`faq_deflection_report` now renders in the Intel UI, but the existing FAQ vocabulary-gap controls only appeared for `faq_markdown`. This PR shares the FAQ-output predicate so documentation terms and vocabulary-gap rules show for either FAQ output while continuing to write into the existing inputs JSON.

## Intentional
- No custom intent-rule control is added because the hosted execute path does not currently expose an input contract for it.
- No rule-file upload is added; that remains a CLI/report-operations surface until a dedicated UI slice defines the upload contract.
- No persistence or saved defaults are added; the controls keep writing directly into the existing inputs JSON.

## Deferred
- Custom intent-rule controls after the execute/catalog contract exposes the input.
- Rule-file upload or saved configuration presets if the report operations flow needs it.

## Parked hardening
- Existing `atlas-intel-ui npm audit vulnerabilities` remain parked in `HARDENING.md`; dependency upgrade work is outside this UI controls slice.

## Verification
- `npm ci` — same 6 existing audit findings already parked.
- `npm run test:content-ops-faq-configuration-inputs` — 2 passed.
- `npm run test:content-ops-deflection-report-ui` — 3 passed.
- `npm run lint`
- `npm run build`
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-UI-Controls.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-UI-Controls.md`
- `git diff --check`

## Diff size
7 files, +180 / -5
