### PR TITLE
PR-FAQ-Deflection-Report-Intent-Rule-Input

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
@@ -21,6 +21,8 @@ const {
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
   FAQ_MARKDOWN_OUTPUT,
   faqConfigurationInputsSelected,
+  faqIntentRulesDraftValue,
+  faqIntentRulesFromDraft,
 } = await loadTsModule('../src/domain/contentOps/faqConfigurationInputs.ts')
 const { FAQ_DEFLECTION_REPORT_OUTPUT } = await loadTsModule(
   '../src/domain/contentOps/faqDeflectionReport.ts',
@@ -55,4 +57,28 @@ test('new run page uses the shared FAQ configuration output predicate', () => {
   assert.ok(newRunSource.includes('{faqConfigurationOutputSelected && ('))
   assert.ok(!newRunSource.includes('faqMarkdownOutputSelected'))
   assert.ok(newRunSource.includes('FAQ vocabulary-gap inputs'))
+  assert.ok(newRunSource.includes('FAQ_INTENT_RULES_INPUT'))
+  assert.ok(newRunSource.includes('handleFaqIntentRulesChange'))
+})
+
+test('FAQ intent-rule draft helpers preserve line-based rules', () => {
+  assert.deepEqual(
+    faqIntentRulesFromDraft(
+      'data freshness=warehouse sync,connector lag\n\nDATA FRESHNESS=warehouse sync,connector lag\naccess setup=invite link',
+    ),
+    [
+      'data freshness=warehouse sync,connector lag',
+      'access setup=invite link',
+    ],
+  )
+  assert.equal(
+    faqIntentRulesDraftValue([
+      {
+        topic: 'data freshness',
+        keywords: ['warehouse sync', 'connector lag'],
+      },
+      'access setup=invite link',
+    ]),
+    'data freshness=warehouse sync,connector lag\naccess setup=invite link',
+  )
 })

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -323,6 +323,14 @@
       "asset": "faq_markdown",
       "group": "vocabulary_gap"
     },
+    "faq_intent_rules": {
+      "key": "faq_intent_rules",
+      "label": "Intent rules",
+      "type": "string_list",
+      "placeholder": "data freshness=warehouse sync,connector lag\naccess setup=invite link,new user",
+      "asset": "faq_markdown",
+      "group": "intent_mapping"
+    },
     "faq_vocabulary_gap_rules": {
       "key": "faq_vocabulary_gap_rules",
       "label": "Vocabulary-gap rules",

--- a/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
+++ b/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
@@ -15,3 +15,46 @@ export function faqConfigurationInputsSelected(
     ),
   )
 }
+
+export function faqIntentRulesDraftValue(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return typeof value === 'string' ? value : ''
+  }
+  return value
+    .filter((rule) => typeof rule !== 'undefined' && rule !== null)
+    .map((rule) => {
+      if (typeof rule === 'string') return rule
+      if (isIntentRuleObject(rule)) {
+        return `${rule.topic}=${rule.keywords.join(',')}`
+      }
+      return String(rule)
+    })
+    .join('\n')
+}
+
+export function faqIntentRulesFromDraft(value: string): string[] {
+  const seen = new Set<string>()
+  const rules: string[] = []
+  for (const line of value.split(/\r?\n/)) {
+    const rule = line.trim()
+    const key = rule.toLowerCase()
+    if (!rule || seen.has(key)) continue
+    seen.add(key)
+    rules.push(rule)
+  }
+  return rules
+}
+
+function isIntentRuleObject(
+  value: unknown,
+): value is { topic: string; keywords: string[] } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'topic' in value &&
+    typeof value.topic === 'string' &&
+    'keywords' in value &&
+    Array.isArray(value.keywords) &&
+    value.keywords.every((keyword) => typeof keyword === 'string')
+  )
+}

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -75,6 +75,8 @@ export {
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
   FAQ_MARKDOWN_OUTPUT,
   faqConfigurationInputsSelected,
+  faqIntentRulesDraftValue,
+  faqIntentRulesFromDraft,
 } from './faqConfigurationInputs'
 
 export {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -27,6 +27,8 @@ import {
   formatContentOpsBytes,
   faqDeflectionReportAnswerSteps,
   faqConfigurationInputsSelected,
+  faqIntentRulesDraftValue,
+  faqIntentRulesFromDraft,
   fromWireCatalog,
   fromWireExecution,
   fromWireIngestionDiagnostics,
@@ -122,8 +124,14 @@ const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
+const FAQ_INTENT_RULES_INPUT = 'faq_intent_rules'
 const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
 const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
+const FAQ_INTENT_RULES_DISPLAY_FALLBACK = {
+  label: 'Intent rules',
+  placeholder:
+    'data freshness=warehouse sync,connector lag\naccess setup=invite link,new user',
+}
 const FAQ_DOCUMENTATION_TERMS_DISPLAY_FALLBACK = {
   label: 'Documentation terms',
   placeholder: 'Single sign-on setup\nData export guide',
@@ -264,6 +272,9 @@ export default function ContentOpsNewRun() {
   const faqConfigurationOutputSelected = faqConfigurationInputsSelected(
     request.outputs,
   )
+  const faqIntentRulesContract = faqConfigurationOutputSelected
+    ? catalog.inputContracts[FAQ_INTENT_RULES_INPUT]
+    : undefined
   const faqDocumentationTermsContract = faqConfigurationOutputSelected
     ? catalog.inputContracts[FAQ_DOCUMENTATION_TERMS_INPUT]
     : undefined
@@ -277,6 +288,10 @@ export default function ContentOpsNewRun() {
   const faqVocabularyGapRulesDisplay = inputContractDisplay(
     faqVocabularyGapRulesContract,
     FAQ_VOCABULARY_GAP_RULES_DISPLAY_FALLBACK,
+  )
+  const faqIntentRulesDisplay = inputContractDisplay(
+    faqIntentRulesContract,
+    FAQ_INTENT_RULES_DISPLAY_FALLBACK,
   )
   const landingPageRepairAttemptContract = landingPageOutputSelected
     ? integerInputContract(catalog, LANDING_PAGE_QUALITY_REPAIR_INPUT)
@@ -353,6 +368,13 @@ export default function ContentOpsNewRun() {
 
   const handleFaqDocumentationTermsChange = (value: string) => {
     const updated = updateFaqDocumentationTermsInputJson(inputsJson, value)
+    if (!updated.ok) return
+    setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleFaqIntentRulesChange = (value: string) => {
+    const updated = updateFaqIntentRulesInputJson(inputsJson, value)
     if (!updated.ok) return
     setInputsJson(updated.value)
     markStale()
@@ -1100,6 +1122,25 @@ export default function ContentOpsNewRun() {
                 </h3>
               </div>
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                <label className="block text-sm lg:col-span-2">
+                  <span className="text-slate-300">
+                    {faqIntentRulesDisplay.label}
+                  </span>
+                  <textarea
+                    value={faqIntentRulesDraftValue(
+                      parsedInputsForControls.ok
+                        ? parsedInputsForControls.value[FAQ_INTENT_RULES_INPUT]
+                        : undefined,
+                    )}
+                    onChange={(e) =>
+                      handleFaqIntentRulesChange(e.target.value)
+                    }
+                    rows={3}
+                    disabled={faqInputsDisabled}
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    placeholder={faqIntentRulesDisplay.placeholder}
+                  />
+                </label>
                 <label className="block text-sm">
                   <span className="text-slate-300">
                     {faqDocumentationTermsDisplay.label}
@@ -2367,6 +2408,24 @@ function updateFaqDocumentationTermsInputJson(
     delete next[FAQ_DOCUMENTATION_TERMS_INPUT]
   } else {
     next[FAQ_DOCUMENTATION_TERMS_INPUT] = values
+  }
+
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function updateFaqIntentRulesInputJson(
+  current: string,
+  draftValue: string,
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+
+  const next = { ...parsed.value }
+  const rules = faqIntentRulesFromDraft(draftValue)
+  if (rules.length === 0) {
+    delete next[FAQ_INTENT_RULES_INPUT]
+  } else {
+    next[FAQ_INTENT_RULES_INPUT] = rules
   }
 
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -71,7 +71,7 @@ from ..reasoning_policy import (
     resolve_reasoning_policy,
 )
 from ..reasoning_signals import reasoning_validation_blocked_reason
-from ..ticket_faq_input_contract import ticket_faq_vocabulary_gap_input_contracts
+from ..ticket_faq_input_contract import ticket_faq_input_contracts
 
 ExecutionServicesProvider = Callable[
     [],
@@ -201,7 +201,7 @@ def _build_static_catalog_payload() -> Mapping[str, Any]:
         "input_contracts": {
             LANDING_PAGE_QUALITY_REPAIR_INPUT: landing_page_quality_repair_input_contract(),
             **landing_page_seo_geo_aeo_input_contracts(),
-            **ticket_faq_vocabulary_gap_input_contracts(),
+            **ticket_faq_input_contracts(),
         },
     }
 

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -30,7 +30,10 @@ from .support_ticket_context_contract import (
     is_support_ticket_context,
     is_support_ticket_topic_type,
 )
-from .ticket_faq_markdown import normalize_vocabulary_gap_rules
+from .ticket_faq_markdown import (
+    normalize_intent_rules,
+    normalize_vocabulary_gap_rules,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -629,6 +632,7 @@ async def _dispatch_faq_markdown(
         window_days=_step_config_int(step.config, "window_days"),
         as_of_date=_step_config_text(step.config, "as_of_date"),
         support_contact=_step_config_text(step.config, "support_contact"),
+        intent_rules=_step_config_intent_rules(step.config, "intent_rules"),
         documentation_terms=_step_config_sequence(step.config, "documentation_terms"),
         vocabulary_gap_rules=_step_config_nested_sequence(
             step.config,
@@ -659,6 +663,7 @@ async def _dispatch_faq_deflection_report(
         window_days=_step_config_int(step.config, "window_days"),
         as_of_date=_step_config_text(step.config, "as_of_date"),
         support_contact=_step_config_text(step.config, "support_contact"),
+        intent_rules=_step_config_intent_rules(step.config, "intent_rules"),
         documentation_terms=_step_config_sequence(step.config, "documentation_terms"),
         vocabulary_gap_rules=_step_config_nested_sequence(
             step.config,
@@ -799,6 +804,18 @@ def _step_config_nested_sequence(
     if raw is None:
         return None
     return normalize_vocabulary_gap_rules(raw, label=key) or None
+
+
+def _step_config_intent_rules(
+    config: Mapping[str, Any],
+    key: str,
+) -> tuple[tuple[str, tuple[str, ...]], ...] | None:
+    if not isinstance(config, Mapping):
+        return None
+    raw = config.get(key)
+    if raw is None:
+        return None
+    return normalize_intent_rules(raw, label=key) or None
 
 
 def _filters_from_inputs(inputs: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -34,7 +34,9 @@ from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
 from .ticket_faq_markdown import (
+    DEFAULT_INTENT_RULES,
     TicketFAQMarkdownConfig,
+    normalize_intent_rules,
     normalize_vocabulary_gap_rules,
 )
 
@@ -211,6 +213,7 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
     defaults = TicketFAQMarkdownConfig()
     window_days = _positive_int_input(request.inputs, "faq_window_days")
     as_of_date = _text_input(request.inputs, "faq_as_of_date")
+    custom_intent_rules = _intent_rules_input(request.inputs, "faq_intent_rules")
     if as_of_date is not None and window_days is None:
         raise ValueError("faq_as_of_date requires faq_window_days")
     if as_of_date is not None:
@@ -235,6 +238,11 @@ def _faq_markdown_config_for_request(request: ContentOpsRequest) -> TicketFAQMar
         as_of_date=as_of_date,
         support_contact=_text_input(request.inputs, "faq_support_contact")
         or defaults.support_contact,
+        intent_rules=(
+            (*custom_intent_rules, *DEFAULT_INTENT_RULES)
+            if custom_intent_rules
+            else defaults.intent_rules
+        ),
         documentation_terms=(
             _text_sequence_input(request.inputs, "faq_documentation_terms")
             or defaults.documentation_terms
@@ -287,6 +295,16 @@ def _nested_text_sequence_input(
     if raw is None:
         return None
     return normalize_vocabulary_gap_rules(raw, label=key) or None
+
+
+def _intent_rules_input(
+    inputs: Mapping[str, Any],
+    key: str,
+) -> tuple[tuple[str, tuple[str, ...]], ...] | None:
+    raw = inputs.get(key)
+    if raw is None:
+        return None
+    return normalize_intent_rules(raw, label=key) or None
 
 
 def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanStep:
@@ -407,6 +425,11 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
             step_config["as_of_date"] = config.as_of_date
         if config.support_contact:
             step_config["support_contact"] = config.support_contact
+        if config.intent_rules != DEFAULT_INTENT_RULES:
+            step_config["intent_rules"] = [
+                {"topic": topic, "keywords": list(keywords)}
+                for topic, keywords in config.intent_rules
+            ]
         if config.documentation_terms:
             step_config["documentation_terms"] = list(config.documentation_terms)
         if config.vocabulary_gap_rules:

--- a/extracted_content_pipeline/ticket_faq_input_contract.py
+++ b/extracted_content_pipeline/ticket_faq_input_contract.py
@@ -6,10 +6,24 @@ from typing import Any
 
 
 TICKET_FAQ_INPUT_ASSET = "faq_markdown"
+TICKET_FAQ_INTENT_MAPPING_INPUT_GROUP = "intent_mapping"
 TICKET_FAQ_VOCABULARY_GAP_INPUT_GROUP = "vocabulary_gap"
 
+FAQ_INTENT_RULES_INPUT = "faq_intent_rules"
 FAQ_DOCUMENTATION_TERMS_INPUT = "faq_documentation_terms"
 FAQ_VOCABULARY_GAP_RULES_INPUT = "faq_vocabulary_gap_rules"
+
+_TICKET_FAQ_INTENT_MAPPING_INPUT_CONTRACTS: tuple[dict[str, Any], ...] = (
+    {
+        "key": FAQ_INTENT_RULES_INPUT,
+        "label": "Intent rules",
+        "type": "string_list",
+        "placeholder": (
+            "data freshness=warehouse sync,connector lag\n"
+            "access setup=invite link,new user"
+        ),
+    },
+)
 
 _TICKET_FAQ_VOCABULARY_GAP_INPUT_CONTRACTS: tuple[dict[str, Any], ...] = (
     {
@@ -27,6 +41,22 @@ _TICKET_FAQ_VOCABULARY_GAP_INPUT_CONTRACTS: tuple[dict[str, Any], ...] = (
 )
 
 
+def ticket_faq_input_contracts() -> dict[str, dict[str, Any]]:
+    """Return wire contracts for hosted FAQ configuration inputs."""
+
+    return {
+        **{
+            item["key"]: {
+                **item,
+                "asset": TICKET_FAQ_INPUT_ASSET,
+                "group": TICKET_FAQ_INTENT_MAPPING_INPUT_GROUP,
+            }
+            for item in _TICKET_FAQ_INTENT_MAPPING_INPUT_CONTRACTS
+        },
+        **ticket_faq_vocabulary_gap_input_contracts(),
+    }
+
+
 def ticket_faq_vocabulary_gap_input_contracts() -> dict[str, dict[str, Any]]:
     """Return wire contracts for FAQ vocabulary-gap inputs."""
 
@@ -42,8 +72,11 @@ def ticket_faq_vocabulary_gap_input_contracts() -> dict[str, dict[str, Any]]:
 
 __all__ = [
     "FAQ_DOCUMENTATION_TERMS_INPUT",
+    "FAQ_INTENT_RULES_INPUT",
     "FAQ_VOCABULARY_GAP_RULES_INPUT",
     "TICKET_FAQ_INPUT_ASSET",
+    "TICKET_FAQ_INTENT_MAPPING_INPUT_GROUP",
     "TICKET_FAQ_VOCABULARY_GAP_INPUT_GROUP",
+    "ticket_faq_input_contracts",
     "ticket_faq_vocabulary_gap_input_contracts",
 ]

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -327,7 +327,7 @@ class TicketFAQMarkdownService:
             else self.config.source_types
         )
         resolved_intent_rules = (
-            tuple((topic, tuple(keywords)) for topic, keywords in intent_rules)
+            normalize_intent_rules(intent_rules)
             if intent_rules is not None
             else self.config.intent_rules
         )
@@ -861,6 +861,52 @@ def normalize_vocabulary_gap_rules(
 
 def _custom_vocabulary_gap_rules(custom_rules: Sequence[Sequence[str]]) -> tuple[tuple[str, ...], ...]:
     return normalize_vocabulary_gap_rules(custom_rules)
+
+
+def normalize_intent_rules(
+    custom_rules: Sequence[Any],
+    *,
+    label: str = "intent_rules",
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Normalize caller-supplied FAQ intent mapping rules."""
+
+    if not isinstance(custom_rules, Sequence) or isinstance(
+        custom_rules,
+        (str, bytes, bytearray),
+    ):
+        raise ValueError(f"{label} must be an array of intent rules")
+
+    rules: list[tuple[str, tuple[str, ...]]] = []
+    for index, raw_rule in enumerate(custom_rules, start=1):
+        topic: Any
+        keywords: Any
+        if isinstance(raw_rule, str):
+            topic, separator, raw_keywords = raw_rule.partition("=")
+            if not separator:
+                raise ValueError(f"{label}[{index}] must use topic=keyword,keyword")
+            keywords = raw_keywords.split(",")
+        elif isinstance(raw_rule, Mapping):
+            topic = raw_rule.get("topic")
+            keywords = raw_rule.get("keywords")
+        elif isinstance(raw_rule, Sequence) and not isinstance(
+            raw_rule,
+            (bytes, bytearray),
+        ):
+            values = tuple(raw_rule)
+            if len(values) != 2:
+                raise ValueError(f"{label}[{index}] must include topic and keywords")
+            topic, keywords = values
+        else:
+            raise ValueError(f"{label}[{index}] must be an intent rule")
+
+        cleaned_topic = _clean(topic)
+        cleaned_keywords = _clean_terms(_list(keywords))
+        if not cleaned_topic or not cleaned_keywords:
+            raise ValueError(
+                f"{label}[{index}] must include topic and at least one keyword"
+            )
+        rules.append((cleaned_topic, cleaned_keywords))
+    return tuple(rules)
 
 
 def _zero_result_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
@@ -1659,5 +1705,6 @@ __all__ = [
     "TicketFAQMarkdownResult",
     "TicketFAQMarkdownService",
     "build_ticket_faq_markdown",
+    "normalize_intent_rules",
     "normalize_vocabulary_gap_rules",
 ]

--- a/plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md
+++ b/plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md
@@ -1,0 +1,133 @@
+# PR-FAQ-Deflection-Report-Intent-Rule-Input
+
+## Why this slice exists
+
+The deflection report UI can now run the report and configure vocabulary-gap
+inputs, but custom intent rules remain CLI-only. That leaves a gap in the
+hosted flow: operators can tune the clustering language in the report CLI, but
+cannot send the same intent-to-FAQ mapping rules through the Content Ops execute
+route or Intel UI.
+
+This slice adds the thinnest end-to-end hosted path for custom FAQ intent rules:
+the control-surface catalog advertises the input, the execute plan threads it
+into both faq_markdown and faq_deflection_report, and the Intel UI writes it
+into the existing inputs JSON.
+The diff is over the 400 LOC soft cap because the input is only useful if the
+backend catalog, generation plan, execute dispatch, UI control, and regression
+tests land together; splitting those would create a visible control that is not
+yet honored or a backend capability that remains raw-JSON-only.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-ui
+
+Slice phase: Product polish
+
+1. Add a hosted FAQ intent-rule input contract shaped as one rule per line:
+   `topic=keyword,keyword`.
+2. Normalize faq_intent_rules in the generation plan and dispatch it to the
+   FAQ Markdown and deflection report services.
+3. Render an Intel UI textarea for the intent rules whenever FAQ configuration
+   outputs are selected.
+4. Add focused tests for backend plan/execute threading and UI JSON writing.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `extracted_content_pipeline/ticket_faq_input_contract.py` | Adds the intent-rule catalog input contract. |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | Adds shared intent-rule normalization for hosted callers. |
+| `extracted_content_pipeline/generation_plan.py` | Reads the hosted FAQ intent rules into FAQ step config. |
+| `extracted_content_pipeline/content_ops_execution.py` | Dispatches intent-rule config to FAQ services. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Adds the intent-rule contract to the hosted catalog payload. |
+| `tests/test_extracted_content_generation_plan.py` | Verifies deflection report plan config includes intent rules. |
+| `tests/test_extracted_content_ops_execution.py` | Verifies hosted execution applies intent rules to grouping. |
+| `tests/test_extracted_content_control_surface_api.py` | Verifies the catalog advertises the intent-rule input. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Adds the FAQ intent-rule textarea backed by inputs JSON. |
+| `atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs` | Verifies UI visibility and draft parsing helpers. |
+| `atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts` | Adds reusable FAQ intent-rule draft helpers. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Exports the FAQ intent-rule draft helpers. |
+| `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json` | Mirrors the backend catalog fixture for local UI runs. |
+| `tests/test_extracted_ticket_faq_markdown.py` | Verifies the shared intent-rule normalizer accepts and rejects the expected shapes. |
+| `plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md` | Documents this slice contract. |
+
+## Mechanism
+
+The hosted input key is faq_intent_rules.
+
+The UI textarea accepts one rule per line:
+
+```txt
+data freshness=warehouse sync,connector lag
+access setup=invite link,new user
+```
+
+The UI stores the draft as a JSON string list so partial textarea typing remains
+ergonomic:
+
+```json
+[
+  "data freshness=warehouse sync,connector lag"
+]
+```
+
+The backend normalizer accepts both that line-based shape and structured
+`{topic, keywords}` objects, then returns the same intent-rule tuple shape used
+by the FAQ service. The generation plan keeps the existing rule precedence:
+custom hosted rules are prepended before the default rules, so host-provided
+customer language wins over default taxonomy matches.
+
+## Intentional
+
+- No rule-file upload is added. File upload semantics need a separate UI/API
+  contract; this slice proves inline hosted intent rules first.
+- No saved presets/defaults are added. The controls continue writing directly
+  into the existing inputs JSON.
+- The UI stores line strings rather than objects because textarea controls need
+  to preserve partial typing without blocking on every intermediate invalid
+  character. The backend still accepts structured objects for API callers.
+
+## Deferred
+
+- Parked hardening considered: `atlas-intel-ui npm audit vulnerabilities`
+  remains parked in `HARDENING.md`; dependency upgrade work is outside this
+  intent-rule slice.
+- Future product-polish slice: add rule-file upload or saved configuration
+  presets after the hosted API contract for those workflows is defined.
+
+## Verification
+
+- Command: npm run test:content-ops-faq-configuration-inputs
+  - Result: 3 passed.
+- Command: npm run lint
+  - Result: passed.
+- Command: npm run build
+  - Result: passed.
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_accepts_line_and_object_shapes tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_rejects_invalid_shapes tests/test_extracted_content_generation_plan.py::test_plan_threads_custom_faq_intent_rules_to_deflection_report tests/test_extracted_content_ops_execution.py::test_execute_applies_hosted_faq_intent_rules tests/test_extracted_content_control_surface_api.py::test_describe_control_surfaces_route_returns_catalog_and_presets
+  - Result: 9 passed.
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surface_api.py
+  - Result: 365 passed, 1 skipped.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Result: passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Result: passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Result: passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Backend contract/threading | 145 |
+| Backend tests | 110 |
+| UI control + test | 117 |
+| Plan doc | 133 |
+| **Total** | **509** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -348,6 +348,17 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert input_contracts["secondary_keywords"]["type"] == "string_list"
     assert input_contracts["cta_url"]["asset"] == "landing_page"
     assert input_contracts["cta_url"]["placeholder"] == "/systems/ai-content-ops/intake"
+    assert input_contracts["faq_intent_rules"] == {
+        "key": "faq_intent_rules",
+        "label": "Intent rules",
+        "type": "string_list",
+        "placeholder": (
+            "data freshness=warehouse sync,connector lag\n"
+            "access setup=invite link,new user"
+        ),
+        "asset": "faq_markdown",
+        "group": "intent_mapping",
+    }
     assert input_contracts["faq_documentation_terms"] == {
         "key": "faq_documentation_terms",
         "label": "Documentation terms",

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -552,6 +552,33 @@ def test_plan_maps_faq_deflection_report_to_report_service():
     }
 
 
+def test_plan_threads_custom_faq_intent_rules_to_deflection_report():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 4,
+            "inputs": {
+                "source_material": [
+                    {
+                        "source_type": "ticket",
+                        "text": "The warehouse sync is delayed.",
+                    }
+                ],
+                "faq_intent_rules": [
+                    "data freshness=warehouse sync,connector lag"
+                ],
+            },
+        }
+    )
+
+    rules = plan["steps"][0]["config"]["intent_rules"]
+    assert rules[0] == {
+        "topic": "data freshness",
+        "keywords": ["warehouse sync", "connector lag"],
+    }
+    assert any(rule["topic"] == "integration setup" for rule in rules)
+
+
 def test_plan_rejects_faq_as_of_date_without_window_days():
     with pytest.raises(ValueError, match="faq_as_of_date requires faq_window_days"):
         build_generation_plan_from_mapping(

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -632,6 +632,45 @@ async def test_execute_runs_faq_markdown_service_from_source_material() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_applies_hosted_faq_intent_rules() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_markdown"],
+            "limit": 2,
+            "inputs": {
+                "faq_intent_rules": [
+                    {"topic": "data freshness", "keywords": ["warehouse sync"]}
+                ],
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-1",
+                        "source_type": "ticket",
+                        "subject": "Warehouse sync lag",
+                        "message": "The warehouse sync is delayed again.",
+                    },
+                    {
+                        "ticket_id": "ticket-2",
+                        "source_type": "ticket",
+                        "subject": "Warehouse sync stale",
+                        "message": "Warehouse sync data is stale this morning.",
+                    },
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(faq_markdown=TicketFAQMarkdownService()),
+    )
+
+    assert result["status"] == "completed"
+    assert result["plan"]["steps"][0]["config"]["intent_rules"][0] == {
+        "topic": "data freshness",
+        "keywords": ["warehouse sync"],
+    }
+    item = result["steps"][0]["result"]["items"][0]
+    assert item["topic"] == "data freshness"
+    assert item["ticket_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_execute_runs_faq_deflection_report_from_source_material() -> None:
     result = await execute_content_ops_from_mapping(
         {

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -18,6 +18,7 @@ from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
     build_ticket_faq_markdown,
+    normalize_intent_rules,
     weighted_source_volume_by_group,
 )
 
@@ -1171,6 +1172,38 @@ def test_build_ticket_faq_markdown_accepts_host_intent_rules() -> None:
 
     assert [item["topic"] for item in result.items] == ["data freshness"]
     assert result.items[0]["evidence_count"] == 2
+
+
+def test_normalize_intent_rules_accepts_line_and_object_shapes() -> None:
+    assert normalize_intent_rules(
+        [
+            "data freshness=warehouse sync,connector lag",
+            {"topic": "access setup", "keywords": ["invite link", "new user"]},
+        ],
+        label="faq_intent_rules",
+    ) == (
+        ("data freshness", ("warehouse sync", "connector lag")),
+        ("access setup", ("invite link", "new user")),
+    )
+
+
+@pytest.mark.parametrize(
+    ("rules", "message"),
+    [
+        ("bad", "faq_intent_rules must be an array"),
+        (["bad"], "faq_intent_rules[1] must use topic=keyword,keyword"),
+        ([{"topic": "data freshness", "keywords": []}], "faq_intent_rules[1]"),
+        ([{"topic": "data freshness", "keywords": "sync"}], "faq_intent_rules[1]"),
+        ([[None, ["sync"]]], "faq_intent_rules[1]"),
+    ],
+)
+def test_normalize_intent_rules_rejects_invalid_shapes(
+    rules: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        normalize_intent_rules(rules, label="faq_intent_rules")  # type: ignore[arg-type]
+    assert message in str(exc.value)
 
 
 def test_build_ticket_faq_markdown_keeps_total_volume_when_display_is_capped() -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md
Slice phase: Product polish

Custom FAQ intent rules were CLI-only. This PR adds the hosted path: the control-surface catalog advertises `faq_intent_rules`, the generation plan threads those rules into `faq_markdown` and `faq_deflection_report`, dispatch passes them to the services, and the Intel UI exposes a line-based textarea that writes into the existing inputs JSON.

## Intentional
- No rule-file upload is added; file upload semantics need a separate UI/API contract.
- No saved presets/defaults are added; the controls continue writing directly into inputs JSON.
- The UI stores line strings so the textarea can preserve partial typing; the backend also accepts structured objects for API callers.

## Deferred
- Rule-file upload or saved configuration presets after the hosted API contract for those workflows is defined.

## Parked hardening
- Existing `atlas-intel-ui npm audit vulnerabilities` remain parked in `HARDENING.md`; dependency upgrade work is outside this intent-rule slice.

## Verification
- `npm run test:content-ops-faq-configuration-inputs` — 3 passed.
- `npm run lint`
- `npm run build`
- `pytest tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_accepts_line_and_object_shapes tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_rejects_invalid_shapes tests/test_extracted_content_generation_plan.py::test_plan_threads_custom_faq_intent_rules_to_deflection_report tests/test_extracted_content_ops_execution.py::test_execute_applies_hosted_faq_intent_rules tests/test_extracted_content_control_surface_api.py::test_describe_control_surfaces_route_returns_catalog_and_presets` — 9 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surface_api.py` — 365 passed, 1 skipped.
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Report-Intent-Rule-Input.md`
- `git diff --check`

## Diff size
15 files, +505 / -4
