### PR TITLE
Add FAQ macro writeback reconcile CLI

### DIFF
--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -146,6 +146,15 @@ class MacroWritebackMappingRepository(Protocol):
     ) -> MacroWritebackMapping:
         """Reserve one FAQ item before creating an external macro."""
 
+    async def list_pending_mappings(
+        self,
+        *,
+        platform: str,
+        scope: TenantScope,
+        limit: int,
+    ) -> Sequence[MacroWritebackMapping]:
+        """Return pending external macro mappings for one tenant and platform."""
+
 
 class DryRunMacroPublishProvider:
     async def publish(

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -139,6 +139,30 @@ class PostgresFAQMacroWritebackMappingRepository:
         )
         return _row_to_mapping(row_to_dict(row))
 
+    async def list_pending_mappings(
+        self,
+        *,
+        platform: str,
+        scope: TenantScope,
+        limit: int,
+    ) -> tuple[MacroWritebackMapping, ...]:
+        rows = await self.pool.fetch(
+            f"""
+            SELECT {_MAPPING_COLUMNS}
+              FROM ticket_faq_macro_writebacks
+             WHERE account_id = $1
+               AND platform = $2
+               AND publish_status = 'pending'
+               AND btrim(external_id) = ''
+             ORDER BY updated_at ASC, faq_draft_id ASC, faq_item_id ASC
+             LIMIT $3
+            """,
+            scope.account_id or "",
+            _clean(platform),
+            max(1, int(limit)),
+        )
+        return tuple(_row_to_mapping(row_to_dict(row)) for row in rows)
+
 
 __all__ = [
     "PostgresFAQMacroWritebackMappingRepository",

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Any, Literal, Mapping, Protocol, Sequence
 from urllib.parse import urlencode
 
 import httpx
@@ -19,6 +19,7 @@ from .faq_macro_writeback import (
 
 
 ZENDESK_PLATFORM = "zendesk"
+MacroMappingReconcileStatus = Literal["reconciled", "pending", "skipped", "failed"]
 
 
 @dataclass(frozen=True)
@@ -93,6 +94,24 @@ class ZendeskMacroTransport(Protocol):
         json: Mapping[str, Any],
     ) -> Mapping[str, Any]:
         """Send one Zendesk macro request and return a JSON object."""
+
+
+@dataclass(frozen=True)
+class MacroMappingReconcileResult:
+    """Result for reconciling one pending external macro mapping."""
+
+    mapping: MacroWritebackMapping
+    status: MacroMappingReconcileStatus
+    external_id: str = ""
+    error: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "mapping": self.mapping.as_dict(),
+            "status": self.status,
+            "external_id": self.external_id,
+            "error": self.error,
+        }
 
 
 class ZendeskHTTPMacroTransport:
@@ -260,6 +279,91 @@ class ZendeskMacroPublishProvider:
                 error=_safe_error(exc),
             )
 
+    async def reconcile_pending_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroMappingReconcileResult:
+        """Backfill one pending mapping when Zendesk has a unique title match."""
+
+        if _clean(mapping.platform) != ZENDESK_PLATFORM:
+            return MacroMappingReconcileResult(
+                mapping=mapping,
+                status="skipped",
+                error="zendesk_macro_unsupported_platform",
+            )
+        if _clean(mapping.external_id):
+            return MacroMappingReconcileResult(
+                mapping=mapping,
+                status="skipped",
+                external_id=_clean(mapping.external_id),
+                error="zendesk_macro_mapping_already_has_external_id",
+            )
+        title = _pending_mapping_title(mapping, None)
+        if not title:
+            return MacroMappingReconcileResult(
+                mapping=mapping,
+                status="failed",
+                error="zendesk_macro_pending_title_missing",
+            )
+        credentials = await self.credentials_provider.credentials_for_scope(scope)
+        if credentials is None or not credentials.is_complete():
+            return MacroMappingReconcileResult(
+                mapping=mapping,
+                status="failed",
+                error="zendesk_credentials_missing",
+            )
+        try:
+            data = await self.transport.request(
+                "GET",
+                _zendesk_macro_search_url(credentials, title),
+                headers=_headers(credentials),
+                json={},
+            )
+            matches = _exact_title_macros(data, title=title)
+            if len(matches) != 1:
+                return MacroMappingReconcileResult(
+                    mapping=mapping,
+                    status="pending",
+                    error=(
+                        "zendesk_macro_mapping_ambiguous_reconcile"
+                        if matches
+                        else "zendesk_macro_mapping_pending_reconcile"
+                    ),
+                )
+            match = matches[0]
+            external_id = _clean(match.get("id"))
+            if not external_id:
+                return MacroMappingReconcileResult(
+                    mapping=mapping,
+                    status="failed",
+                    error="zendesk_macro_id_missing_after_reconcile",
+                )
+            reconciled = await self.mapping_repository.upsert_mapping(
+                MacroWritebackMapping(
+                    platform=ZENDESK_PLATFORM,
+                    faq_draft_id=mapping.faq_draft_id,
+                    faq_item_id=mapping.faq_item_id,
+                    external_id=external_id,
+                    external_url=_clean(match.get("url")),
+                    publish_status="published",
+                    metadata=dict(mapping.metadata or {}),
+                ),
+                scope=scope,
+            )
+            return MacroMappingReconcileResult(
+                mapping=reconciled,
+                status="reconciled",
+                external_id=reconciled.external_id,
+            )
+        except Exception as exc:
+            return MacroMappingReconcileResult(
+                mapping=mapping,
+                status="failed",
+                error=_safe_error(exc),
+            )
+
     async def _reconcile_pending_mapping(
         self,
         existing: MacroWritebackMapping,
@@ -277,7 +381,8 @@ class ZendeskMacroPublishProvider:
             headers=_headers(credentials),
             json={},
         )
-        match = _exact_title_macro(data, title=title)
+        matches = _exact_title_macros(data, title=title)
+        match = matches[0] if len(matches) == 1 else None
         external_id = _clean(match.get("id")) if match is not None else ""
         if not external_id:
             return None
@@ -341,9 +446,9 @@ def _external_url(data: Mapping[str, Any], *, fallback: str = "") -> str:
 
 def _pending_mapping_title(
     existing: MacroWritebackMapping,
-    macro: SupportMacroDraft,
+    macro: SupportMacroDraft | None,
 ) -> str:
-    return _clean(existing.metadata.get("title")) or _clean(macro.title)
+    return _clean(existing.metadata.get("title")) or _clean(macro.title if macro else "")
 
 
 def _zendesk_macro_search_url(
@@ -354,14 +459,14 @@ def _zendesk_macro_search_url(
     return f"{credentials.normalized_base_url()}/api/v2/macros/search?{query}"
 
 
-def _exact_title_macro(
+def _exact_title_macros(
     data: Mapping[str, Any],
     *,
     title: str,
-) -> Mapping[str, Any] | None:
+) -> tuple[Mapping[str, Any], ...]:
     macros = data.get("macros")
     if not isinstance(macros, Sequence) or isinstance(macros, (str, bytes)):
-        return None
+        return ()
     normalized_title = _normalized_title(title)
     matches: list[Mapping[str, Any]] = []
     for macro in macros:
@@ -370,9 +475,7 @@ def _exact_title_macro(
             and _normalized_title(macro.get("title")) == normalized_title
         ):
             matches.append(macro)
-    if len(matches) != 1:
-        return None
-    return matches[0]
+    return tuple(matches)
 
 
 def _normalized_title(value: Any) -> str:
@@ -390,6 +493,8 @@ def _clean(value: Any) -> str:
 
 
 __all__ = [
+    "MacroMappingReconcileResult",
+    "MacroMappingReconcileStatus",
     "StaticZendeskMacroCredentialsProvider",
     "ZENDESK_PLATFORM",
     "ZendeskHTTPMacroTransport",

--- a/plans/PR-FAQ-Macro-Writeback-Reconcile-CLI.md
+++ b/plans/PR-FAQ-Macro-Writeback-Reconcile-CLI.md
@@ -1,0 +1,101 @@
+# PR-FAQ-Macro-Writeback-Reconcile-CLI
+
+## Why this slice exists
+
+PR-FAQ-Macro-Writeback-Pending-Reconcile made pending Zendesk macro mappings
+fail safe: no match or ambiguous exact-title matches stay
+`zendesk_macro_mapping_pending_reconcile`. That protects customers from
+wrong-macro attachment, but operators still need a direct way to inspect and
+retry pending rows without waiting for another publish request. This slice adds
+that narrow operator path over the same repository and Zendesk reconciliation
+logic.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add a repository method for tenant-scoped pending macro writeback mappings.
+2. Add a public Zendesk pending-mapping reconcile method that reuses the
+   unique exact-title search behavior.
+3. Add a CLI that lists pending mappings, attempts reconciliation, and emits a
+   JSON summary.
+4. Add focused tests for pending-row listing, single-match reconciliation, and
+   ambiguous/no-match CLI output.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Reconcile-CLI.md` — plan for this slice.
+- `extracted_content_pipeline/faq_macro_writeback.py` — repository contract.
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py` — pending mapping query.
+- `extracted_content_pipeline/faq_macro_writeback_zendesk.py` — public pending reconcile result.
+- `scripts/reconcile_content_ops_faq_macro_writebacks.py` — operator CLI.
+- `scripts/run_extracted_pipeline_checks.sh` — CI enrollment for the new CLI test.
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` — pending query coverage.
+- `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py` — public reconcile coverage.
+- `tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py` — CLI summary coverage.
+
+## Mechanism
+
+The Postgres adapter exposes `list_pending_mappings(...)` for one
+`TenantScope`, one platform, and a bounded limit. It returns rows where the
+mapping is still pending and has no external id.
+
+`ZendeskMacroPublishProvider.reconcile_pending_mapping(...)` takes one pending
+mapping, reads the reserved title from mapping metadata, searches Zendesk by
+that title, and upserts only when exactly one normalized title match exists.
+Missing credentials, missing title, no match, ambiguous match, and persistence
+failures are returned as explicit result statuses/errors.
+
+The CLI wires those pieces with the existing `EXTRACTED_DATABASE_URL` /
+`DATABASE_URL` convention and centralized host config. By default it is a dry
+run that reports what would be attempted. `--execute` performs reconciliation.
+
+## Intentional
+
+- The CLI is tenant-scoped by required `--account-id`; there is no all-tenant
+  scan in this slice.
+- Dry run is the default because this is an operator recovery command touching
+  live support-tool mappings.
+- Reconcile still requires a unique exact-title match. Ambiguous rows remain
+  pending and visible in the summary.
+- The CLI backfills mappings only. It does not update macro body content; the
+  normal publish path still owns content updates once the mapping is recovered.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: tenant-scoped encrypted
+  credential storage for multi-customer live writeback.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish
+  route.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py -q — 23 passed.
+- python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/faq_macro_writeback_zendesk.py scripts/reconcile_content_ops_faq_macro_writebacks.py tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py — passed.
+- bash scripts/validate_extracted_content_pipeline.sh — passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline — passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt — passed.
+- bash scripts/check_ascii_python.sh — passed.
+- python scripts/check_extracted_imports.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- python scripts/smoke_extracted_pipeline_imports.py — passed.
+- python scripts/smoke_extracted_pipeline_standalone.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-reconcile-cli.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~101 |
+| Contract / adapters | ~158 |
+| CLI | ~172 |
+| CI enrollment | ~1 |
+| Tests | ~281 |
+| Total | ~713 |
+
+This is over the 400 LOC soft cap because the operator path needs a real
+contract method, a host CLI, and tests at all three integration points to avoid
+another under-enforced safety claim.

--- a/scripts/reconcile_content_ops_faq_macro_writebacks.py
+++ b/scripts/reconcile_content_ops_faq_macro_writebacks.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Reconcile pending Content Ops FAQ macro writeback mappings."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import Counter
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain._content_ops_macro_writeback import (  # noqa: E402
+    ConfigZendeskMacroCredentialsProvider,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope  # noqa: E402
+from extracted_content_pipeline.faq_macro_writeback import (  # noqa: E402
+    MacroWritebackMapping,
+)
+from extracted_content_pipeline.faq_macro_writeback_postgres import (  # noqa: E402
+    PostgresFAQMacroWritebackMappingRepository,
+)
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (  # noqa: E402
+    ZENDESK_PLATFORM,
+    ZendeskMacroPublishProvider,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("EXTRACTED_DATABASE_URL") or os.getenv("DATABASE_URL"),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument("--account-id", required=True, help="Tenant/account id.")
+    parser.add_argument("--limit", type=int, default=20, help="Maximum pending rows.")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Perform reconciliation. Without this flag the command only previews.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON output path. Defaults to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _create_pool(database_url: str):
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to reconcile macro writebacks; install it in the host app"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    pool = await _create_pool(args.database_url)
+    try:
+        payload = await reconcile_pending_macro_writebacks(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+    return 0
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not args.database_url:
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if not str(args.account_id or "").strip():
+        raise SystemExit("--account-id is required")
+    if args.limit < 1:
+        raise SystemExit("--limit must be positive")
+
+
+async def reconcile_pending_macro_writebacks(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    provider: Any | None = None,
+) -> dict[str, Any]:
+    scope = TenantScope(account_id=str(args.account_id).strip())
+    repository = PostgresFAQMacroWritebackMappingRepository(pool)
+    pending = await repository.list_pending_mappings(
+        platform=ZENDESK_PLATFORM,
+        scope=scope,
+        limit=args.limit,
+    )
+    if not args.execute:
+        results = [_dry_run_result(mapping) for mapping in pending]
+    else:
+        reconciler = provider or _build_provider(pool)
+        results = [
+            (
+                await reconciler.reconcile_pending_mapping(mapping, scope=scope)
+            ).as_dict()
+            for mapping in pending
+        ]
+    return _summary(
+        account_id=scope.account_id or "",
+        execute=bool(args.execute),
+        limit=args.limit,
+        pending=pending,
+        results=results,
+    )
+
+
+def _build_provider(pool: Any) -> ZendeskMacroPublishProvider:
+    return ZendeskMacroPublishProvider(
+        credentials_provider=ConfigZendeskMacroCredentialsProvider(_host_config()),
+        mapping_repository=PostgresFAQMacroWritebackMappingRepository(pool),
+    )
+
+
+def _host_config() -> Any:
+    from atlas_brain.config import settings
+
+    return settings.b2b_campaign
+
+
+def _dry_run_result(mapping: MacroWritebackMapping) -> dict[str, Any]:
+    return {
+        "mapping": mapping.as_dict(),
+        "status": "dry_run",
+        "external_id": "",
+        "error": "",
+    }
+
+
+def _summary(
+    *,
+    account_id: str,
+    execute: bool,
+    limit: int,
+    pending: Sequence[MacroWritebackMapping],
+    results: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    counts = Counter(str(result.get("status") or "") for result in results)
+    return {
+        "account_id": account_id,
+        "platform": ZENDESK_PLATFORM,
+        "execute": execute,
+        "limit": limit,
+        "pending_count": len(pending),
+        "result_counts": dict(sorted(counts.items())),
+        "results": list(results),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -33,6 +33,7 @@ pytest \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \
   tests/test_extracted_ticket_faq_macro_writeback_publish.py \
+  tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py \
   tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -205,6 +205,44 @@ async def test_reserve_mapping_inserts_pending_row_without_external_id() -> None
 
 
 @pytest.mark.asyncio
+async def test_list_pending_mappings_filters_pending_without_external_id() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [
+        _row(
+            external_id="",
+            external_url="",
+            publish_status="pending",
+            metadata={"title": "Question"},
+        )
+    ]
+    repo = PostgresFAQMacroWritebackMappingRepository(pool)
+
+    mappings = await repo.list_pending_mappings(
+        platform=" zendesk ",
+        scope=TenantScope(account_id="acct-1"),
+        limit=25,
+    )
+
+    call = pool.fetch_calls[0]
+    assert "publish_status = 'pending'" in call["query"]
+    assert "btrim(external_id) = ''" in call["query"]
+    assert "ORDER BY updated_at ASC, faq_draft_id ASC, faq_item_id ASC" in call["query"]
+    assert "LIMIT $3" in call["query"]
+    assert call["args"] == ("acct-1", "zendesk", 25)
+    assert mappings == (
+        MacroWritebackMapping(
+            platform="zendesk",
+            faq_draft_id="11111111-1111-1111-1111-111111111111",
+            faq_item_id="faq-draft-1:item-1",
+            external_id="",
+            external_url="",
+            publish_status="pending",
+            metadata={"title": "Question"},
+        ),
+    )
+
+
+@pytest.mark.asyncio
 async def test_upsert_mapping_keeps_account_scope_outside_client_payload() -> None:
     pool = _Pool()
     pool.fetchrow_rows = [_row()]

--- a/tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "reconcile_content_ops_faq_macro_writebacks.py"
+SPEC = importlib.util.spec_from_file_location(
+    "reconcile_content_ops_faq_macro_writebacks",
+    SCRIPT_PATH,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+cli = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = cli
+SPEC.loader.exec_module(cli)
+
+
+class _Pool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.fetch_calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.rows
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Result:
+    def __init__(self, mapping: MacroWritebackMapping, status: str, error: str = "") -> None:
+        self.mapping = mapping
+        self.status = status
+        self.error = error
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "mapping": self.mapping.as_dict(),
+            "status": self.status,
+            "external_id": self.mapping.external_id,
+            "error": self.error,
+        }
+
+
+class _Provider:
+    def __init__(self, status: str = "reconciled", error: str = "") -> None:
+        self.status = status
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def reconcile_pending_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> _Result:
+        self.calls.append({"mapping": mapping, "scope": scope})
+        return _Result(mapping, self.status, self.error)
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values = {
+        "account_id": "acct-1",
+        "limit": 10,
+        "execute": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "platform": "zendesk",
+        "faq_draft_id": "11111111-1111-1111-1111-111111111111",
+        "faq_item_id": "faq-draft-1:item-1",
+        "external_id": "",
+        "external_url": "",
+        "publish_status": "pending",
+        "metadata": json.dumps({"title": "Why was I charged twice?"}),
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_reconcile_cli_dry_run_lists_pending_rows_without_provider_call() -> None:
+    pool = _Pool([_row()])
+    provider = _Provider()
+
+    payload = await cli.reconcile_pending_macro_writebacks(
+        _args(execute=False),
+        pool,
+        provider=provider,
+    )
+
+    assert payload["execute"] is False
+    assert payload["pending_count"] == 1
+    assert payload["result_counts"] == {"dry_run": 1}
+    assert payload["results"][0]["status"] == "dry_run"
+    assert payload["results"][0]["mapping"]["metadata"] == {
+        "title": "Why was I charged twice?"
+    }
+    assert provider.calls == []
+    assert pool.fetch_calls[0]["args"] == ("acct-1", "zendesk", 10)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_cli_execute_surfaces_ambiguous_pending_rows() -> None:
+    pool = _Pool([_row(), _row(faq_item_id="faq-draft-1:item-2")])
+    provider = _Provider(
+        status="pending",
+        error="zendesk_macro_mapping_ambiguous_reconcile",
+    )
+
+    payload = await cli.reconcile_pending_macro_writebacks(
+        _args(execute=True, limit=2),
+        pool,
+        provider=provider,
+    )
+
+    assert payload["execute"] is True
+    assert payload["pending_count"] == 2
+    assert payload["result_counts"] == {"pending": 2}
+    assert [call["scope"].account_id for call in provider.calls] == ["acct-1", "acct-1"]
+    assert {
+        result["error"] for result in payload["results"]
+    } == {"zendesk_macro_mapping_ambiguous_reconcile"}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_cli_main_writes_output_and_closes_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pool = _Pool([_row()])
+    output = tmp_path / "reconcile.json"
+
+    async def create_pool(database_url: str) -> _Pool:
+        assert database_url == "postgres://example"
+        return pool
+
+    monkeypatch.setattr(cli, "_create_pool", create_pool)
+
+    code = await cli._main([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        "acct-1",
+        "--output",
+        str(output),
+    ])
+
+    assert code == 0
+    assert pool.closed is True
+    payload = json.loads(output.read_text())
+    assert payload["result_counts"] == {"dry_run": 1}

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -261,6 +261,80 @@ async def test_zendesk_provider_reconciles_pending_mapping_before_update() -> No
 
 
 @pytest.mark.asyncio
+async def test_zendesk_provider_public_reconcile_backfills_unique_pending_mapping() -> None:
+    repo = _MappingRepo()
+    mapping = MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+        metadata={"title": "Why was I charged twice?", "category": "billing"},
+    )
+    transport = _Transport({
+        "macros": [
+            {
+                "id": 123,
+                "url": "https://example.zendesk.com/api/v2/macros/123",
+                "title": "Why was I charged twice?",
+            }
+        ]
+    })
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    result = await provider.reconcile_pending_mapping(
+        mapping,
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert result.status == "reconciled"
+    assert result.external_id == "123"
+    assert [call["method"] for call in transport.calls] == ["GET"]
+    saved = repo.upsert_calls[0]["mapping"]
+    assert saved.external_id == "123"
+    assert saved.external_url == "https://example.zendesk.com/api/v2/macros/123"
+    assert saved.publish_status == "published"
+    assert saved.metadata == {"title": "Why was I charged twice?", "category": "billing"}
+
+
+@pytest.mark.asyncio
+async def test_zendesk_provider_public_reconcile_reports_ambiguous_title() -> None:
+    repo = _MappingRepo()
+    mapping = MacroWritebackMapping(
+        platform=ZENDESK_PLATFORM,
+        faq_draft_id="11111111-1111-1111-1111-111111111111",
+        faq_item_id="faq-draft-1:item-1",
+        external_id="",
+        publish_status="pending",
+        metadata={"title": "Why was I charged twice?"},
+    )
+    transport = _Transport({
+        "macros": [
+            {"id": 123, "title": "Why was I charged twice?"},
+            {"id": 456, "title": " why  was I charged twice? "},
+        ]
+    })
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StaticZendeskMacroCredentialsProvider(_credentials()),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    result = await provider.reconcile_pending_mapping(
+        mapping,
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert result.status == "pending"
+    assert result.error == "zendesk_macro_mapping_ambiguous_reconcile"
+    assert repo.upsert_calls == []
+
+
+@pytest.mark.asyncio
 async def test_zendesk_provider_refuses_to_repost_when_pending_mapping_has_no_match() -> None:
     repo = _MappingRepo(existing=MacroWritebackMapping(
         platform=ZENDESK_PLATFORM,


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Reconcile-CLI.md
Slice phase: Production hardening

This adds the operator recovery path deferred from pending Zendesk macro reconciliation. Pending mappings can now be listed tenant-by-tenant, previewed by default, and reconciled with `--execute` using the same unique exact-title Zendesk search contract.

## Intentional
- The CLI requires `--account-id`; there is no all-tenant scan in this slice.
- Dry run is the default because this command touches live support-tool mappings.
- Reconciliation still requires a unique exact-title match. No-match and ambiguous rows stay pending.
- The CLI backfills mappings only; the normal publish path still owns macro content updates.

## Deferred
- `PR-FAQ-Macro-Writeback-Tenant-Credentials`: tenant-scoped encrypted credential storage for multi-customer live writeback.
- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish route.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py -q` - 23 passed.
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/faq_macro_writeback_zendesk.py scripts/reconcile_content_ops_faq_macro_writebacks.py tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `python scripts/check_extracted_imports.py` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed.
- `python scripts/smoke_extracted_pipeline_imports.py` - passed.
- `python scripts/smoke_extracted_pipeline_standalone.py` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-reconcile-cli.md` - passed.

## Diff size
9 files, +703 / -10.