### PR TITLE
PR-FAQ-Intent-Rule-Regression-Net

### DIFF
--- a/plans/PR-FAQ-Intent-Rule-Regression-Net.md
+++ b/plans/PR-FAQ-Intent-Rule-Regression-Net.md
@@ -1,0 +1,83 @@
+# PR-FAQ-Intent-Rule-Regression-Net
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Report-Intent-Rule-Input shipped the hosted custom intent-rule
+path. The review was LGTM, but it identified two useful regression gaps: the
+double-normalize plan/dispatch path was manually verified but not pinned, and
+the deflection-report execute path was manually verified but only plan-tested.
+
+This slice adds the smallest regression net for those two behaviors without
+changing product code.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-ui
+
+Slice phase: Functional validation
+
+1. Add an idempotency test for `normalize_intent_rules`.
+2. Add an execute-level `faq_deflection_report` test proving hosted custom
+   intent rules affect report grouping.
+3. In that same report execute test, prove the fail-closed answer-evidence
+   promise remains intact when no resolution evidence is uploaded.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `tests/test_extracted_ticket_faq_markdown.py` | Adds the intent-rule idempotency regression test. |
+| `tests/test_extracted_content_ops_execution.py` | Adds the deflection-report execute regression test. |
+| `plans/PR-FAQ-Intent-Rule-Regression-Net.md` | Documents this slice contract. |
+
+## Mechanism
+
+The idempotency test normalizes mixed line/object rules, feeds the normalized
+tuple back through the same function, and asserts the result is unchanged.
+
+The report execute test runs `faq_deflection_report` through
+`execute_content_ops_from_mapping` with a hosted intent rule and no
+`resolution_text`. It asserts the generated report groups both tickets under
+the custom topic while summary counts and item statuses remain no-proven.
+
+## Intentional
+
+- No production code changes are included. The reviewed behavior was already
+  correct; this slice only locks it.
+- No UI changes are included because the UI input helper was covered in the
+  prior PR and the gap was backend execute coverage.
+
+## Deferred
+
+- Parked hardening considered: none. The slice addresses the two relevant
+  review follow-ups directly.
+
+## Verification
+
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_is_idempotent tests/test_extracted_content_ops_execution.py::test_execute_applies_hosted_faq_intent_rules_to_deflection_report_without_inventing_answers
+  - Result: 2 passed.
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution.py
+  - Result: 204 passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Result: passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Result: passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Result: passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Intent-Rule-Regression-Net.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Intent-Rule-Regression-Net.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| FAQ normalizer test | 15 |
+| Deflection report execute test | 55 |
+| Plan doc | 83 |
+| **Total** | **147** |

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -671,6 +671,58 @@ async def test_execute_applies_hosted_faq_intent_rules() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_applies_hosted_faq_intent_rules_to_deflection_report_without_inventing_answers() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 2,
+            "inputs": {
+                "faq_intent_rules": [
+                    "data freshness=warehouse sync,connector lag"
+                ],
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-1",
+                        "source_type": "support_ticket",
+                        "subject": "Warehouse sync lag",
+                        "message": "The warehouse sync is delayed again.",
+                    },
+                    {
+                        "ticket_id": "ticket-2",
+                        "source_type": "support_ticket",
+                        "subject": "Connector lag",
+                        "message": "CRM connector lag repeats every morning.",
+                    },
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    assert result["plan"]["steps"][0]["config"]["intent_rules"][0] == {
+        "topic": "data freshness",
+        "keywords": ["warehouse sync", "connector lag"],
+    }
+
+    step = result["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["status"] == "completed"
+    assert step["result"]["summary"]["drafted_answer_count"] == 0
+    assert step["result"]["summary"]["no_proven_answer_count"] == 1
+
+    item = step["result"]["faq_result"]["items"][0]
+    assert item["topic"] == "data freshness"
+    assert item["ticket_count"] == 2
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert "## Drafted Answers With Proven Solutions" in step["result"]["markdown"]
+    assert "## No Proven Answer Yet" in step["result"]["markdown"]
+    assert "No verified support resolution was present" in step["result"]["markdown"]
+
+
+@pytest.mark.asyncio
 async def test_execute_runs_faq_deflection_report_from_source_material() -> None:
     result = await execute_content_ops_from_mapping(
         {

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -1187,6 +1187,18 @@ def test_normalize_intent_rules_accepts_line_and_object_shapes() -> None:
     )
 
 
+def test_normalize_intent_rules_is_idempotent() -> None:
+    rules = normalize_intent_rules(
+        [
+            "data freshness=warehouse sync,connector lag",
+            {"topic": "access setup", "keywords": ["invite link", "new user"]},
+        ],
+        label="faq_intent_rules",
+    )
+
+    assert normalize_intent_rules(rules, label="intent_rules") == rules
+
+
 @pytest.mark.parametrize(
     ("rules", "message"),
     [


### PR DESCRIPTION
Plan: plans/PR-FAQ-Intent-Rule-Regression-Net.md
Slice phase: Functional validation

PR #1143 shipped hosted FAQ intent rules. This PR closes the two useful regression gaps from review: idempotency for the double-normalize path, and execute-level coverage for `faq_deflection_report` with custom intent rules while preserving the no-proven-answer fail-closed promise.

## Intentional
- No production code changes; the reviewed behavior was already correct.
- No UI changes; the gap was backend execute coverage.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py::test_normalize_intent_rules_is_idempotent tests/test_extracted_content_ops_execution.py::test_execute_applies_hosted_faq_intent_rules_to_deflection_report_without_inventing_answers` — 2 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_content_ops_execution.py` — 204 passed.
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Intent-Rule-Regression-Net.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Intent-Rule-Regression-Net.md`
- `git diff --check`

## Diff size
3 files, +147 / -0
