### PR TITLE
Add tenant Zendesk credentials for macro writeback

### DIFF
--- a/atlas_brain/_content_ops_macro_writeback.py
+++ b/atlas_brain/_content_ops_macro_writeback.py
@@ -48,16 +48,14 @@ class TenantZendeskMacroCredentialsProvider:
         scope: TenantScope,
     ) -> ZendeskMacroCredentials | None:
         if scope.account_id:
-            from .services.content_ops_zendesk_credentials import (
+            from ._content_ops_zendesk_credentials import (
                 lookup_zendesk_credentials,
             )
 
-            credentials = await lookup_zendesk_credentials(
+            return await lookup_zendesk_credentials(
                 self.pool,
                 account_id=scope.account_id,
             )
-            if credentials is not None:
-                return credentials
         return await self.fallback_provider.credentials_for_scope(scope)
 
 

--- a/atlas_brain/_content_ops_macro_writeback.py
+++ b/atlas_brain/_content_ops_macro_writeback.py
@@ -13,6 +13,7 @@ from extracted_content_pipeline.faq_macro_writeback_postgres import (
 )
 from extracted_content_pipeline.faq_macro_writeback_zendesk import (
     ZendeskMacroCredentials,
+    ZendeskMacroCredentialsProvider,
     ZendeskMacroPublishProvider,
 )
 
@@ -35,6 +36,31 @@ class ConfigZendeskMacroCredentialsProvider:
         return zendesk_macro_credentials_from_config(self.config)
 
 
+@dataclass(frozen=True)
+class TenantZendeskMacroCredentialsProvider:
+    """Zendesk credential source backed by tenant storage with config fallback."""
+
+    pool: Any
+    fallback_provider: ZendeskMacroCredentialsProvider
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        if scope.account_id:
+            from .services.content_ops_zendesk_credentials import (
+                lookup_zendesk_credentials,
+            )
+
+            credentials = await lookup_zendesk_credentials(
+                self.pool,
+                account_id=scope.account_id,
+            )
+            if credentials is not None:
+                return credentials
+        return await self.fallback_provider.credentials_for_scope(scope)
+
+
 async def build_content_ops_macro_publish_provider(
     *,
     pool_provider: PoolProvider,
@@ -48,8 +74,12 @@ async def build_content_ops_macro_publish_provider(
     if getattr(pool, "is_initialized", True) is False:
         return None
     config = await _resolve_config(config_provider)
+    config_provider_instance = ConfigZendeskMacroCredentialsProvider(config)
     return ZendeskMacroPublishProvider(
-        credentials_provider=ConfigZendeskMacroCredentialsProvider(config),
+        credentials_provider=TenantZendeskMacroCredentialsProvider(
+            pool=pool,
+            fallback_provider=config_provider_instance,
+        ),
         mapping_repository=PostgresFAQMacroWritebackMappingRepository(pool),
     )
 
@@ -88,6 +118,7 @@ def _config_value(config: Any, name: str) -> str:
 
 __all__ = [
     "ConfigZendeskMacroCredentialsProvider",
+    "TenantZendeskMacroCredentialsProvider",
     "build_content_ops_macro_publish_provider",
     "zendesk_macro_credentials_from_config",
 ]

--- a/atlas_brain/_content_ops_zendesk_credentials.py
+++ b/atlas_brain/_content_ops_zendesk_credentials.py
@@ -12,9 +12,6 @@ from extracted_content_pipeline.faq_macro_writeback_zendesk import (
     ZendeskMacroCredentials,
 )
 
-from .auth.encryption import decrypt_secret, encrypt_secret
-
-
 logger = logging.getLogger("atlas.content_ops_zendesk_credentials")
 
 TOKEN_PREFIX_LEN = 8
@@ -205,6 +202,22 @@ def _validated_credentials(
     if not credentials.is_complete():
         raise ValueError("Complete Zendesk email, API token, and endpoint are required")
     return credentials
+
+
+def encrypt_secret(raw: str) -> tuple[bytes, str]:
+    """Encrypt a secret through the host crypto boundary."""
+
+    from .auth.encryption import encrypt_secret as _encrypt_secret
+
+    return _encrypt_secret(raw)
+
+
+def decrypt_secret(ciphertext: bytes, kid: str) -> str | None:
+    """Decrypt a secret through the host crypto boundary."""
+
+    from .auth.encryption import decrypt_secret as _decrypt_secret
+
+    return _decrypt_secret(ciphertext, kid)
 
 
 def _display_record(row) -> ContentOpsZendeskCredentialRecord:

--- a/atlas_brain/_content_ops_zendesk_credentials.py
+++ b/atlas_brain/_content_ops_zendesk_credentials.py
@@ -12,10 +12,10 @@ from extracted_content_pipeline.faq_macro_writeback_zendesk import (
     ZendeskMacroCredentials,
 )
 
-from ..auth.encryption import decrypt_secret, encrypt_secret
+from .auth.encryption import decrypt_secret, encrypt_secret
 
 
-logger = logging.getLogger("atlas.services.content_ops_zendesk_credentials")
+logger = logging.getLogger("atlas.content_ops_zendesk_credentials")
 
 TOKEN_PREFIX_LEN = 8
 

--- a/atlas_brain/services/content_ops_zendesk_credentials.py
+++ b/atlas_brain/services/content_ops_zendesk_credentials.py
@@ -1,0 +1,249 @@
+"""Encrypted tenant Zendesk credentials for Content Ops macro writeback."""
+
+from __future__ import annotations
+
+import logging
+import uuid as _uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
+)
+
+from ..auth.encryption import decrypt_secret, encrypt_secret
+
+
+logger = logging.getLogger("atlas.services.content_ops_zendesk_credentials")
+
+TOKEN_PREFIX_LEN = 8
+
+
+@dataclass(frozen=True)
+class ContentOpsZendeskCredentialRecord:
+    """Display-safe active Zendesk credential row."""
+
+    id: _uuid.UUID
+    account_id: _uuid.UUID
+    email: str
+    api_token_prefix: str
+    subdomain: str
+    base_url: str
+    label: str
+    added_at: datetime
+    last_used_at: Optional[datetime]
+    revoked_at: Optional[datetime]
+
+
+async def upsert_zendesk_credentials(
+    pool,
+    *,
+    account_id: _uuid.UUID,
+    email: str,
+    api_token: str,
+    subdomain: str = "",
+    base_url: str = "",
+    label: str = "",
+) -> ContentOpsZendeskCredentialRecord:
+    """Encrypt and store one active Zendesk credential row for an account."""
+
+    credentials = _validated_credentials(
+        email=email,
+        api_token=api_token,
+        subdomain=subdomain,
+        base_url=base_url,
+    )
+    cleaned_token = str(api_token or "").strip()
+    ciphertext, kid = encrypt_secret(cleaned_token)
+    token_prefix = cleaned_token[:TOKEN_PREFIX_LEN]
+
+    async with pool.transaction() as conn:
+        await conn.execute(
+            "SELECT id FROM saas_accounts WHERE id = $1 FOR UPDATE",
+            account_id,
+        )
+        await conn.execute(
+            """
+            UPDATE content_ops_zendesk_credentials
+            SET revoked_at = NOW()
+            WHERE account_id = $1 AND revoked_at IS NULL
+            """,
+            account_id,
+        )
+        row = await conn.fetchrow(
+            """
+            INSERT INTO content_ops_zendesk_credentials (
+                account_id, email, encrypted_api_token, encryption_kid,
+                api_token_prefix, subdomain, base_url, label
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8
+            )
+            RETURNING id, account_id, email, api_token_prefix, subdomain,
+                      base_url, label, added_at, last_used_at, revoked_at
+            """,
+            account_id,
+            credentials.email,
+            ciphertext,
+            kid,
+            token_prefix,
+            credentials.subdomain,
+            credentials.base_url,
+            str(label or "").strip(),
+        )
+
+    return _display_record(row)
+
+
+async def list_zendesk_credentials(
+    pool,
+    *,
+    account_id: _uuid.UUID,
+) -> list[ContentOpsZendeskCredentialRecord]:
+    """Return display-safe active Zendesk credentials for one tenant."""
+
+    rows = await pool.fetch(
+        """
+        SELECT id, account_id, email, api_token_prefix, subdomain,
+               base_url, label, added_at, last_used_at, revoked_at
+        FROM content_ops_zendesk_credentials
+        WHERE account_id = $1 AND revoked_at IS NULL
+        ORDER BY added_at DESC
+        """,
+        account_id,
+    )
+    return [_display_record(row) for row in rows]
+
+
+async def revoke_zendesk_credentials(
+    pool,
+    *,
+    account_id: _uuid.UUID,
+    credential_id: _uuid.UUID,
+) -> bool:
+    """Soft-delete one tenant Zendesk credential row."""
+
+    row = await pool.fetchrow(
+        """
+        UPDATE content_ops_zendesk_credentials
+        SET revoked_at = NOW()
+        WHERE id = $1 AND account_id = $2 AND revoked_at IS NULL
+        RETURNING id
+        """,
+        credential_id,
+        account_id,
+    )
+    return row is not None
+
+
+async def lookup_zendesk_credentials(
+    pool,
+    *,
+    account_id: str | _uuid.UUID,
+) -> ZendeskMacroCredentials | None:
+    """Resolve decrypted Zendesk credentials for one tenant."""
+
+    try:
+        account_uuid = _uuid.UUID(str(account_id))
+    except (TypeError, ValueError):
+        logger.warning("zendesk credential lookup: invalid account_id=%r", account_id)
+        return None
+    try:
+        row = await pool.fetchrow(
+            """
+            SELECT id, email, encrypted_api_token, encryption_kid, subdomain, base_url
+            FROM content_ops_zendesk_credentials
+            WHERE account_id = $1 AND revoked_at IS NULL
+            ORDER BY added_at DESC
+            LIMIT 1
+            """,
+            account_uuid,
+        )
+    except Exception:
+        logger.exception("zendesk credential lookup failed account_id=%s", account_uuid)
+        return None
+    if row is None:
+        return None
+    token = decrypt_secret(bytes(row["encrypted_api_token"]), str(row["encryption_kid"]))
+    if not token:
+        logger.warning(
+            "zendesk credential decrypt failed account_id=%s credential_id=%s",
+            account_uuid,
+            row["id"],
+        )
+        return None
+    credentials = ZendeskMacroCredentials(
+        email=str(row["email"] or "").strip(),
+        api_token=token,
+        subdomain=str(row["subdomain"] or "").strip(),
+        base_url=str(row["base_url"] or "").strip(),
+    )
+    if not credentials.is_complete():
+        logger.warning(
+            "zendesk credential row incomplete account_id=%s credential_id=%s",
+            account_uuid,
+            row["id"],
+        )
+        return None
+    await _touch_credentials(pool, credential_id=row["id"])
+    return credentials
+
+
+def _validated_credentials(
+    *,
+    email: str,
+    api_token: str,
+    subdomain: str,
+    base_url: str,
+) -> ZendeskMacroCredentials:
+    credentials = ZendeskMacroCredentials(
+        email=str(email or "").strip(),
+        api_token=str(api_token or "").strip(),
+        subdomain=str(subdomain or "").strip(),
+        base_url=str(base_url or "").strip(),
+    )
+    if not credentials.is_complete():
+        raise ValueError("Complete Zendesk email, API token, and endpoint are required")
+    return credentials
+
+
+def _display_record(row) -> ContentOpsZendeskCredentialRecord:
+    return ContentOpsZendeskCredentialRecord(
+        id=row["id"],
+        account_id=row["account_id"],
+        email=str(row["email"] or ""),
+        api_token_prefix=str(row["api_token_prefix"] or ""),
+        subdomain=str(row["subdomain"] or ""),
+        base_url=str(row["base_url"] or ""),
+        label=str(row["label"] or ""),
+        added_at=row["added_at"],
+        last_used_at=row["last_used_at"],
+        revoked_at=row["revoked_at"],
+    )
+
+
+async def _touch_credentials(pool, *, credential_id: _uuid.UUID) -> None:
+    try:
+        await pool.execute(
+            """
+            UPDATE content_ops_zendesk_credentials
+            SET last_used_at = NOW()
+            WHERE id = $1
+            """,
+            credential_id,
+        )
+    except Exception:
+        logger.exception(
+            "zendesk credential touch failed credential_id=%s",
+            credential_id,
+        )
+
+
+__all__ = [
+    "ContentOpsZendeskCredentialRecord",
+    "TOKEN_PREFIX_LEN",
+    "list_zendesk_credentials",
+    "lookup_zendesk_credentials",
+    "revoke_zendesk_credentials",
+    "upsert_zendesk_credentials",
+]

--- a/atlas_brain/storage/migrations/330_content_ops_zendesk_credentials.sql
+++ b/atlas_brain/storage/migrations/330_content_ops_zendesk_credentials.sql
@@ -1,0 +1,34 @@
+-- Tenant-scoped Zendesk credentials for Content Ops FAQ macro writeback.
+--
+-- API tokens are encrypted at rest with the existing BYOK Fernet KEK
+-- (SaaSAuthConfig.byok_encryption_kek). Store only a token prefix for
+-- display; never expose encrypted_api_token through list/display DTOs.
+
+CREATE TABLE IF NOT EXISTS content_ops_zendesk_credentials (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id          UUID NOT NULL REFERENCES saas_accounts(id) ON DELETE CASCADE,
+    email               TEXT NOT NULL,
+    encrypted_api_token BYTEA NOT NULL,
+    encryption_kid      VARCHAR(64) NOT NULL,
+    api_token_prefix    VARCHAR(16) NOT NULL,
+    subdomain           TEXT NOT NULL DEFAULT '',
+    base_url            TEXT NOT NULL DEFAULT '',
+    label               VARCHAR(128) NOT NULL DEFAULT '',
+    added_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at        TIMESTAMPTZ,
+    revoked_at          TIMESTAMPTZ,
+    CONSTRAINT chk_content_ops_zendesk_credentials_email
+        CHECK (btrim(email) <> ''),
+    CONSTRAINT chk_content_ops_zendesk_credentials_token_prefix
+        CHECK (btrim(api_token_prefix) <> ''),
+    CONSTRAINT chk_content_ops_zendesk_credentials_endpoint
+        CHECK (btrim(subdomain) <> '' OR btrim(base_url) <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_zendesk_credentials_account_active
+    ON content_ops_zendesk_credentials (account_id, added_at DESC)
+    WHERE revoked_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_content_ops_zendesk_credentials_one_active
+    ON content_ops_zendesk_credentials (account_id)
+    WHERE revoked_at IS NULL;

--- a/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
+++ b/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
@@ -7,8 +7,8 @@ macro mappings, but hosted credentials are still process-level config. That is
 not enough for real multi-customer use: one tenant's macro publish path must
 resolve that tenant's Zendesk credentials, not a shared deployment credential.
 This slice adds encrypted, tenant-scoped Zendesk credential storage and wires
-macro writeback to prefer it while preserving the existing config fallback for
-local/single-tenant operation.
+macro writeback to prefer it while preserving the existing config fallback only
+for unscoped local/single-tenant operation.
 
 ## Scope (this PR)
 
@@ -19,8 +19,7 @@ Slice phase: Production hardening
 2. Add an Atlas service that encrypts Zendesk API tokens using the existing
    BYOK Fernet KEK helpers and decrypts them on tenant-scoped lookup.
 3. Add a host credentials provider that resolves tenant credentials from the
-   DB first, then falls back to existing centralized config when no tenant row
-   exists.
+   DB first, and fails closed for tenant-scoped publishes when no row exists.
 4. Wire the macro publish provider to use the tenant-aware credentials source.
 5. Add tests for migration shape, encrypted storage behavior, lookup
    scoping/decryption, and provider fallback order.
@@ -29,7 +28,7 @@ Slice phase: Production hardening
 
 - `plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md` — plan for this slice.
 - `atlas_brain/storage/migrations/330_content_ops_zendesk_credentials.sql` — credential storage.
-- `atlas_brain/services/content_ops_zendesk_credentials.py` — encrypted credential service.
+- `atlas_brain/_content_ops_zendesk_credentials.py` — encrypted credential service.
 - `atlas_brain/_content_ops_macro_writeback.py` — tenant-aware provider wiring.
 - `scripts/run_extracted_pipeline_checks.sh` — CI enrollment for the new credential test.
 - `tests/test_content_ops_zendesk_credentials.py` — service and migration coverage.
@@ -49,11 +48,11 @@ decrypts the API token with `decrypt_secret`, and returns
 but decrypt fails, it also returns `None` so the publish path does not use a
 broken credential.
 
-`TenantZendeskMacroCredentialsProvider` asks the tenant store first when a pool
-and account id are available. If no tenant credential exists, it uses the
-existing `ConfigZendeskMacroCredentialsProvider` as a local/single-tenant
-fallback. This keeps current deployments working while adding the production
-multi-tenant path.
+`TenantZendeskMacroCredentialsProvider` asks the tenant store when an account id
+is available. If no tenant credential exists, it returns `None` so tenant-scoped
+publish attempts fail closed instead of borrowing deployment-level Zendesk
+credentials. The existing `ConfigZendeskMacroCredentialsProvider` remains
+available only for unscoped local/single-tenant calls.
 
 ## Intentional
 
@@ -61,8 +60,9 @@ multi-tenant path.
   adds the storage and resolver foundation the API can call next.
 - API tokens never appear in display DTOs or logs; tests assert display rows do
   not carry plaintext or ciphertext.
-- Config fallback is only used when no tenant credential resolves. It preserves
-  existing single-tenant operation and keeps this slice backward compatible.
+- Config fallback is only used when the scope has no account id. Tenant-scoped
+  publishes fail closed without a tenant credential to avoid cross-tenant
+  writes.
 - The service uses the existing BYOK KEK instead of introducing a second
   encryption secret.
 
@@ -77,8 +77,8 @@ Parked hardening: none
 
 ## Verification
 
-- python -m pytest tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py -q — 13 passed.
-- python -m py_compile atlas_brain/services/content_ops_zendesk_credentials.py atlas_brain/_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py — passed.
+- python -m pytest tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py -q — 14 passed.
+- python -m py_compile atlas_brain/_content_ops_zendesk_credentials.py atlas_brain/_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py — passed.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
 - bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-tenant-credentials.md — passed.
 
@@ -88,9 +88,9 @@ Parked hardening: none
 |---|---:|
 | Plan | ~95 |
 | Migration | ~34 |
-| Service / wiring / CI | ~283 |
-| Tests | ~259 |
-| Total | ~673 |
+| Service / wiring / CI | ~284 |
+| Tests | ~280 |
+| Total | ~695 |
 
 This is over the 400 LOC soft cap because credential storage must ship with the
 encryption boundary, scoped lookup, provider wiring, and tests together. A

--- a/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
+++ b/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
@@ -38,9 +38,11 @@ Slice phase: Production hardening
 
 The new table stores one active Zendesk credential row per SaaS account. API
 tokens are encrypted via `atlas_brain.auth.encryption.encrypt_secret`, reusing
-the existing BYOK KEK rotation model. The table stores display-safe fields
-(`email`, `subdomain`, `base_url`, token prefix) plus `encrypted_api_token` and
-`encryption_kid`; active rows are soft-revoked with `revoked_at`.
+the existing BYOK KEK rotation model through lazy wrapper functions so the
+module remains importable in lean extracted CI. The table stores display-safe
+fields (`email`, `subdomain`, `base_url`, token prefix) plus
+`encrypted_api_token` and `encryption_kid`; active rows are soft-revoked with
+`revoked_at`.
 
 `lookup_zendesk_credentials(...)` filters by account id and active rows only,
 decrypts the API token with `decrypt_secret`, and returns
@@ -79,6 +81,7 @@ Parked hardening: none
 
 - python -m pytest tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py -q — 14 passed.
 - python -m py_compile atlas_brain/_content_ops_zendesk_credentials.py atlas_brain/_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py — passed.
+- python - <<'PY' ... import atlas_brain._content_ops_zendesk_credentials with cryptography blocked ... PY — passed.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
 - bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-tenant-credentials.md — passed.
 
@@ -88,9 +91,9 @@ Parked hardening: none
 |---|---:|
 | Plan | ~95 |
 | Migration | ~34 |
-| Service / wiring / CI | ~284 |
+| Service / wiring / CI | ~300 |
 | Tests | ~280 |
-| Total | ~695 |
+| Total | ~714 |
 
 This is over the 400 LOC soft cap because credential storage must ship with the
 encryption boundary, scoped lookup, provider wiring, and tests together. A

--- a/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
+++ b/plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
@@ -1,0 +1,97 @@
+# PR-FAQ-Macro-Writeback-Tenant-Credentials
+
+## Why this slice exists
+
+FAQ macro writeback can now publish, reconcile, and recover pending Zendesk
+macro mappings, but hosted credentials are still process-level config. That is
+not enough for real multi-customer use: one tenant's macro publish path must
+resolve that tenant's Zendesk credentials, not a shared deployment credential.
+This slice adds encrypted, tenant-scoped Zendesk credential storage and wires
+macro writeback to prefer it while preserving the existing config fallback for
+local/single-tenant operation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add a Postgres table for active/revoked Content Ops Zendesk credentials.
+2. Add an Atlas service that encrypts Zendesk API tokens using the existing
+   BYOK Fernet KEK helpers and decrypts them on tenant-scoped lookup.
+3. Add a host credentials provider that resolves tenant credentials from the
+   DB first, then falls back to existing centralized config when no tenant row
+   exists.
+4. Wire the macro publish provider to use the tenant-aware credentials source.
+5. Add tests for migration shape, encrypted storage behavior, lookup
+   scoping/decryption, and provider fallback order.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md` — plan for this slice.
+- `atlas_brain/storage/migrations/330_content_ops_zendesk_credentials.sql` — credential storage.
+- `atlas_brain/services/content_ops_zendesk_credentials.py` — encrypted credential service.
+- `atlas_brain/_content_ops_macro_writeback.py` — tenant-aware provider wiring.
+- `scripts/run_extracted_pipeline_checks.sh` — CI enrollment for the new credential test.
+- `tests/test_content_ops_zendesk_credentials.py` — service and migration coverage.
+- `tests/test_atlas_content_ops_macro_writeback.py` — host wiring coverage.
+
+## Mechanism
+
+The new table stores one active Zendesk credential row per SaaS account. API
+tokens are encrypted via `atlas_brain.auth.encryption.encrypt_secret`, reusing
+the existing BYOK KEK rotation model. The table stores display-safe fields
+(`email`, `subdomain`, `base_url`, token prefix) plus `encrypted_api_token` and
+`encryption_kid`; active rows are soft-revoked with `revoked_at`.
+
+`lookup_zendesk_credentials(...)` filters by account id and active rows only,
+decrypts the API token with `decrypt_secret`, and returns
+`ZendeskMacroCredentials`. If no row exists it returns `None`; if a row exists
+but decrypt fails, it also returns `None` so the publish path does not use a
+broken credential.
+
+`TenantZendeskMacroCredentialsProvider` asks the tenant store first when a pool
+and account id are available. If no tenant credential exists, it uses the
+existing `ConfigZendeskMacroCredentialsProvider` as a local/single-tenant
+fallback. This keeps current deployments working while adding the production
+multi-tenant path.
+
+## Intentional
+
+- This slice does not add dashboard/API endpoints to create credentials. It
+  adds the storage and resolver foundation the API can call next.
+- API tokens never appear in display DTOs or logs; tests assert display rows do
+  not carry plaintext or ciphertext.
+- Config fallback is only used when no tenant credential resolves. It preserves
+  existing single-tenant operation and keeps this slice backward compatible.
+- The service uses the existing BYOK KEK instead of introducing a second
+  encryption secret.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Credential-API`: tenant-authenticated endpoints or
+  admin CLI for adding/listing/revoking Zendesk credentials.
+- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish
+  route.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py -q — 13 passed.
+- python -m py_compile atlas_brain/services/content_ops_zendesk_credentials.py atlas_brain/_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-tenant-credentials.md — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~95 |
+| Migration | ~34 |
+| Service / wiring / CI | ~283 |
+| Tests | ~259 |
+| Total | ~673 |
+
+This is over the 400 LOC soft cap because credential storage must ship with the
+encryption boundary, scoped lookup, provider wiring, and tests together. A
+smaller slice would leave either unused storage or unproven credential routing.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -87,6 +87,7 @@ pytest \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \
   tests/test_atlas_content_ops_macro_writeback.py \
+  tests/test_content_ops_zendesk_credentials.py \
   tests/test_atlas_content_ops_reasoning.py \
   tests/test_atlas_content_ops_scope.py \
   tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/tests/test_atlas_content_ops_macro_writeback.py
+++ b/tests/test_atlas_content_ops_macro_writeback.py
@@ -7,6 +7,7 @@ import pytest
 from atlas_brain.config import B2BCampaignConfig
 from atlas_brain._content_ops_macro_writeback import (
     ConfigZendeskMacroCredentialsProvider,
+    TenantZendeskMacroCredentialsProvider,
     build_content_ops_macro_publish_provider,
     zendesk_macro_credentials_from_config,
 )
@@ -15,12 +16,19 @@ from extracted_content_pipeline.faq_macro_writeback_postgres import (
     PostgresFAQMacroWritebackMappingRepository,
 )
 from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZendeskMacroCredentials,
     ZendeskMacroPublishProvider,
 )
 
 
 class _Pool:
     is_initialized = True
+
+    async def fetchrow(self, query, *args):
+        return None
+
+    async def execute(self, query, *args):
+        return None
 
 
 @dataclass(frozen=True)
@@ -95,6 +103,7 @@ async def test_build_content_ops_macro_publish_provider_uses_pool_mapping_repo()
     )
 
     assert isinstance(provider, ZendeskMacroPublishProvider)
+    assert isinstance(provider.credentials_provider, TenantZendeskMacroCredentialsProvider)
     assert isinstance(
         provider.mapping_repository,
         PostgresFAQMacroWritebackMappingRepository,
@@ -127,3 +136,71 @@ async def test_build_content_ops_macro_publish_provider_returns_none_for_uniniti
         pool_provider=lambda: _UninitializedPool(),
         config_provider=lambda: _Config(),
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_tenant_zendesk_credentials_provider_prefers_tenant_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.services import content_ops_zendesk_credentials
+
+    tenant_credentials = ZendeskMacroCredentials(
+        email="tenant@example.com",
+        api_token="tenant-token",
+        subdomain="tenant",
+    )
+    calls: list[dict] = []
+
+    async def lookup(pool, *, account_id):
+        calls.append({"pool": pool, "account_id": account_id})
+        return tenant_credentials
+
+    monkeypatch.setattr(content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    pool = _Pool()
+    fallback = ConfigZendeskMacroCredentialsProvider(_Config(
+        content_ops_zendesk_email="fallback@example.com",
+        content_ops_zendesk_api_token="fallback-token",
+        content_ops_zendesk_subdomain="fallback",
+    ))
+    provider = TenantZendeskMacroCredentialsProvider(
+        pool=pool,
+        fallback_provider=fallback,
+    )
+
+    credentials = await provider.credentials_for_scope(
+        TenantScope(account_id="11111111-1111-1111-1111-111111111111")
+    )
+
+    assert credentials is tenant_credentials
+    assert calls == [{
+        "pool": pool,
+        "account_id": "11111111-1111-1111-1111-111111111111",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_tenant_zendesk_credentials_provider_falls_back_to_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain.services import content_ops_zendesk_credentials
+
+    async def lookup(pool, *, account_id):
+        return None
+
+    monkeypatch.setattr(content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    provider = TenantZendeskMacroCredentialsProvider(
+        pool=_Pool(),
+        fallback_provider=ConfigZendeskMacroCredentialsProvider(_Config(
+            content_ops_zendesk_email="fallback@example.com",
+            content_ops_zendesk_api_token="fallback-token",
+            content_ops_zendesk_subdomain="fallback",
+        )),
+    )
+
+    credentials = await provider.credentials_for_scope(
+        TenantScope(account_id="11111111-1111-1111-1111-111111111111")
+    )
+
+    assert credentials is not None
+    assert credentials.email == "fallback@example.com"
+    assert credentials.normalized_base_url() == "https://fallback.zendesk.com"

--- a/tests/test_atlas_content_ops_macro_writeback.py
+++ b/tests/test_atlas_content_ops_macro_writeback.py
@@ -109,9 +109,7 @@ async def test_build_content_ops_macro_publish_provider_uses_pool_mapping_repo()
         PostgresFAQMacroWritebackMappingRepository,
     )
     assert provider.mapping_repository.pool is pool
-    credentials = await provider.credentials_provider.credentials_for_scope(
-        TenantScope(account_id="acct-1")
-    )
+    credentials = await provider.credentials_provider.credentials_for_scope(TenantScope())
     assert credentials is not None
     assert credentials.email == "agent@example.com"
 
@@ -142,7 +140,7 @@ async def test_build_content_ops_macro_publish_provider_returns_none_for_uniniti
 async def test_tenant_zendesk_credentials_provider_prefers_tenant_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from atlas_brain.services import content_ops_zendesk_credentials
+    from atlas_brain import _content_ops_zendesk_credentials
 
     tenant_credentials = ZendeskMacroCredentials(
         email="tenant@example.com",
@@ -155,7 +153,7 @@ async def test_tenant_zendesk_credentials_provider_prefers_tenant_storage(
         calls.append({"pool": pool, "account_id": account_id})
         return tenant_credentials
 
-    monkeypatch.setattr(content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
     pool = _Pool()
     fallback = ConfigZendeskMacroCredentialsProvider(_Config(
         content_ops_zendesk_email="fallback@example.com",
@@ -179,15 +177,41 @@ async def test_tenant_zendesk_credentials_provider_prefers_tenant_storage(
 
 
 @pytest.mark.asyncio
-async def test_tenant_zendesk_credentials_provider_falls_back_to_config(
+async def test_tenant_zendesk_credentials_provider_falls_back_to_config_without_account_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from atlas_brain.services import content_ops_zendesk_credentials
+    from atlas_brain import _content_ops_zendesk_credentials
+
+    async def lookup(pool, *, account_id):
+        raise AssertionError("tenant lookup should not run without account_id")
+
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    provider = TenantZendeskMacroCredentialsProvider(
+        pool=_Pool(),
+        fallback_provider=ConfigZendeskMacroCredentialsProvider(_Config(
+            content_ops_zendesk_email="fallback@example.com",
+            content_ops_zendesk_api_token="fallback-token",
+            content_ops_zendesk_subdomain="fallback",
+        )),
+    )
+
+    credentials = await provider.credentials_for_scope(TenantScope())
+
+    assert credentials is not None
+    assert credentials.email == "fallback@example.com"
+    assert credentials.normalized_base_url() == "https://fallback.zendesk.com"
+
+
+@pytest.mark.asyncio
+async def test_tenant_zendesk_credentials_provider_fails_closed_for_unprovisioned_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain import _content_ops_zendesk_credentials
 
     async def lookup(pool, *, account_id):
         return None
 
-    monkeypatch.setattr(content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
     provider = TenantZendeskMacroCredentialsProvider(
         pool=_Pool(),
         fallback_provider=ConfigZendeskMacroCredentialsProvider(_Config(
@@ -201,6 +225,4 @@ async def test_tenant_zendesk_credentials_provider_falls_back_to_config(
         TenantScope(account_id="11111111-1111-1111-1111-111111111111")
     )
 
-    assert credentials is not None
-    assert credentials.email == "fallback@example.com"
-    assert credentials.normalized_base_url() == "https://fallback.zendesk.com"
+    assert credentials is None

--- a/tests/test_content_ops_zendesk_credentials.py
+++ b/tests/test_content_ops_zendesk_credentials.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from atlas_brain.services import content_ops_zendesk_credentials as service
+from atlas_brain import _content_ops_zendesk_credentials as service
 
 
 MIGRATION = (

--- a/tests/test_content_ops_zendesk_credentials.py
+++ b/tests/test_content_ops_zendesk_credentials.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import uuid
+
+import pytest
+
+from atlas_brain.services import content_ops_zendesk_credentials as service
+
+
+MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "storage"
+    / "migrations"
+    / "330_content_ops_zendesk_credentials.sql"
+)
+
+
+class _Pool:
+    def __init__(self, *, fetchrow_result=None, fetch_rows=None) -> None:
+        self.fetchrow_result = fetchrow_result
+        self.fetch_rows = list(fetch_rows or [])
+        self.execute_calls: list[dict] = []
+        self.fetchrow_calls: list[dict] = []
+        self.fetch_calls: list[dict] = []
+
+    def transaction(self):
+        return _Transaction(self)
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": query, "args": args})
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append({"query": query, "args": args})
+        return self.fetchrow_result
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": query, "args": args})
+        return self.fetch_rows
+
+
+class _Transaction:
+    def __init__(self, pool: _Pool) -> None:
+        self.pool = pool
+
+    async def __aenter__(self):
+        return self.pool
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _row(**overrides):
+    row = {
+        "id": uuid.uuid4(),
+        "account_id": uuid.uuid4(),
+        "email": "agent@example.com",
+        "encrypted_api_token": b"ciphertext",
+        "encryption_kid": "v1",
+        "api_token_prefix": "secret-t",
+        "subdomain": "acme",
+        "base_url": "",
+        "label": "Primary",
+        "added_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "last_used_at": None,
+        "revoked_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_content_ops_zendesk_credentials_migration_is_scoped_and_encrypted() -> None:
+    sql = MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS content_ops_zendesk_credentials" in sql
+    assert "account_id          UUID NOT NULL REFERENCES saas_accounts(id)" in sql
+    assert "encrypted_api_token BYTEA NOT NULL" in sql
+    assert "encryption_kid      VARCHAR(64) NOT NULL" in sql
+    assert "api_token_prefix    VARCHAR(16) NOT NULL" in sql
+    assert "uq_content_ops_zendesk_credentials_one_active" in sql
+    assert "WHERE revoked_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_zendesk_credentials_encrypts_token_and_returns_display_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetchrow_result=_row(account_id=account_id))
+    monkeypatch.setattr(
+        service,
+        "encrypt_secret",
+        lambda raw: (f"encrypted:{raw}".encode("utf-8"), "kid-1"),
+    )
+
+    record = await service.upsert_zendesk_credentials(
+        pool,
+        account_id=account_id,
+        email=" agent@example.com ",
+        api_token=" secret-token ",
+        subdomain="acme",
+        label=" Primary ",
+    )
+
+    insert_call = pool.fetchrow_calls[0]
+    assert "INSERT INTO content_ops_zendesk_credentials" in insert_call["query"]
+    assert insert_call["args"][0] == account_id
+    assert insert_call["args"][1] == "agent@example.com"
+    assert insert_call["args"][2] == b"encrypted:secret-token"
+    assert insert_call["args"][3] == "kid-1"
+    assert insert_call["args"][4] == "secret-t"
+    assert insert_call["args"][5] == "acme"
+    assert insert_call["args"][7] == "Primary"
+    assert record.api_token_prefix == "secret-t"
+    assert not hasattr(record, "api_token")
+    assert not hasattr(record, "encrypted_api_token")
+    assert not hasattr(record, "encryption_kid")
+
+
+@pytest.mark.asyncio
+async def test_lookup_zendesk_credentials_decrypts_tenant_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = uuid.uuid4()
+    row = _row(
+        id=uuid.uuid4(),
+        account_id=account_id,
+        encrypted_api_token=b"ciphertext",
+        encryption_kid="kid-1",
+    )
+    pool = _Pool(fetchrow_result=row)
+    monkeypatch.setattr(
+        service,
+        "decrypt_secret",
+        lambda ciphertext, kid: "secret-token"
+        if ciphertext == b"ciphertext" and kid == "kid-1"
+        else None,
+    )
+
+    credentials = await service.lookup_zendesk_credentials(
+        pool,
+        account_id=str(account_id),
+    )
+
+    assert credentials is not None
+    assert credentials.email == "agent@example.com"
+    assert credentials.api_token == "secret-token"
+    assert credentials.normalized_base_url() == "https://acme.zendesk.com"
+    assert pool.fetchrow_calls[0]["args"] == (account_id,)
+    assert "WHERE account_id = $1 AND revoked_at IS NULL" in pool.fetchrow_calls[0]["query"]
+    assert pool.execute_calls[0]["args"] == (row["id"],)
+
+
+@pytest.mark.asyncio
+async def test_lookup_zendesk_credentials_returns_none_on_decrypt_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = _Pool(fetchrow_result=_row())
+    monkeypatch.setattr(service, "decrypt_secret", lambda ciphertext, kid: None)
+
+    credentials = await service.lookup_zendesk_credentials(
+        pool,
+        account_id=str(uuid.uuid4()),
+    )
+
+    assert credentials is None
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_zendesk_credentials_is_display_safe() -> None:
+    account_id = uuid.uuid4()
+    pool = _Pool(fetch_rows=[_row(account_id=account_id)])
+
+    records = await service.list_zendesk_credentials(pool, account_id=account_id)
+
+    assert records[0].account_id == account_id
+    assert records[0].api_token_prefix == "secret-t"
+    assert "encrypted_api_token" not in records[0].__dict__
+    assert "encryption_kid" not in records[0].__dict__


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Tenant-Credentials.md
Slice phase: Production hardening

Encrypted tenant-scoped Zendesk credential storage with tenant-scoped macro publish resolution. The resolver now uses stored tenant credentials when `account_id` is present and fails closed when that tenant has no usable credential, while preserving centralized config credentials only for unscoped local/single-tenant calls.

## Intentional

- API tokens are encrypted with the existing BYOK Fernet KEK helpers and never appear in display DTOs or logs.
- The credential helper lives in a flat `atlas_brain._content_ops_*` module so extracted CI can import its tests without loading the torch-heavy `atlas_brain.services` package.
- The host crypto import is lazy, so lean extracted CI can collect mocked credential tests without requiring `cryptography`; runtime encryption/decryption still goes through `atlas_brain.auth.encryption`.
- Tenant-scoped publishes do not fall back to deployment-level Zendesk config. Missing, invalid, or undecryptable tenant credentials return no provider credential and let publish fail closed.
- Dashboard/API credential management is deferred; this slice only adds the storage and resolver foundation.

## Deferred

- `PR-FAQ-Macro-Writeback-Credential-API`: tenant-authenticated endpoints or admin CLI for adding/listing/revoking Zendesk credentials.
- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for the macro publish route.

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py -q` - 14 passed.
- `python -m py_compile atlas_brain/_content_ops_zendesk_credentials.py atlas_brain/_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_atlas_content_ops_macro_writeback.py` - passed.
- `python - <<'PY' ... import atlas_brain._content_ops_zendesk_credentials with cryptography blocked ... PY` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-tenant-credentials.md` - passed locally.

## Diff size

~714 LOC across credential storage, resolver wiring, CI enrollment, tests, and the plan. This stays over the 400 LOC soft cap because storage, encryption, scoped lookup, fail-closed provider wiring, and tests need to ship together for the security boundary to be meaningful.
