### PR TITLE
PR-FAQ-Config-Controls-Catalog-Gate

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs
@@ -20,6 +20,7 @@ async function loadTsModule(path) {
 const {
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
   FAQ_MARKDOWN_OUTPUT,
+  faqConfigurationControlsVisible,
   faqConfigurationInputsSelected,
   faqIntentRulesDraftValue,
   faqIntentRulesFromDraft,
@@ -54,11 +55,40 @@ test('new run page uses the shared FAQ configuration output predicate', () => {
       'const faqConfigurationOutputSelected = faqConfigurationInputsSelected(',
     ),
   )
-  assert.ok(newRunSource.includes('{faqConfigurationOutputSelected && ('))
+  assert.ok(
+    newRunSource.includes(
+      'const faqConfigurationControlsVisibleForCatalog =',
+    ),
+  )
+  assert.ok(newRunSource.includes('{faqConfigurationControlsVisibleForCatalog && ('))
+  assert.ok(newRunSource.includes('{faqIntentRulesContract && ('))
+  assert.ok(newRunSource.includes('{faqDocumentationTermsContract && ('))
+  assert.ok(newRunSource.includes('{faqVocabularyGapRulesContract && ('))
   assert.ok(!newRunSource.includes('faqMarkdownOutputSelected'))
   assert.ok(newRunSource.includes('FAQ vocabulary-gap inputs'))
   assert.ok(newRunSource.includes('FAQ_INTENT_RULES_INPUT'))
   assert.ok(newRunSource.includes('handleFaqIntentRulesChange'))
+})
+
+test('FAQ configuration controls require selected output and advertised catalog contract', () => {
+  assert.equal(
+    faqConfigurationControlsVisible([FAQ_DEFLECTION_REPORT_OUTPUT], {
+      intentRules: { key: 'faq_intent_rules' },
+    }),
+    true,
+  )
+  assert.equal(
+    faqConfigurationControlsVisible([FAQ_DEFLECTION_REPORT_OUTPUT], {}),
+    false,
+  )
+  assert.equal(
+    faqConfigurationControlsVisible(['landing_page'], {
+      intentRules: { key: 'faq_intent_rules' },
+      documentationTerms: { key: 'faq_documentation_terms' },
+      vocabularyGapRules: { key: 'faq_vocabulary_gap_rules' },
+    }),
+    false,
+  )
 })
 
 test('FAQ intent-rule draft helpers preserve line-based rules', () => {

--- a/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
+++ b/atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts
@@ -1,5 +1,8 @@
 export const FAQ_MARKDOWN_OUTPUT = 'faq_markdown'
 export const FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT = 'faq_deflection_report'
+export const FAQ_INTENT_RULES_INPUT = 'faq_intent_rules'
+export const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
+export const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
 
 export const FAQ_CONFIGURATION_OUTPUTS = [
   FAQ_MARKDOWN_OUTPUT,
@@ -13,6 +16,26 @@ export function faqConfigurationInputsSelected(
     FAQ_CONFIGURATION_OUTPUTS.includes(
       output as (typeof FAQ_CONFIGURATION_OUTPUTS)[number],
     ),
+  )
+}
+
+export interface FAQConfigurationInputContracts {
+  intentRules?: unknown
+  documentationTerms?: unknown
+  vocabularyGapRules?: unknown
+}
+
+export function faqConfigurationControlsVisible(
+  outputs: readonly string[],
+  contracts: FAQConfigurationInputContracts,
+): boolean {
+  return (
+    faqConfigurationInputsSelected(outputs) &&
+    Boolean(
+      contracts.intentRules ||
+        contracts.documentationTerms ||
+        contracts.vocabularyGapRules,
+    )
   )
 }
 

--- a/atlas-intel-ui/src/domain/contentOps/index.ts
+++ b/atlas-intel-ui/src/domain/contentOps/index.ts
@@ -73,11 +73,16 @@ export type { ContentOpsInputDisplayFallback } from './inputDisplay'
 export {
   FAQ_CONFIGURATION_OUTPUTS,
   FAQ_DEFLECTION_REPORT_CONFIGURATION_OUTPUT,
+  FAQ_DOCUMENTATION_TERMS_INPUT,
+  FAQ_INTENT_RULES_INPUT,
   FAQ_MARKDOWN_OUTPUT,
+  FAQ_VOCABULARY_GAP_RULES_INPUT,
+  faqConfigurationControlsVisible,
   faqConfigurationInputsSelected,
   faqIntentRulesDraftValue,
   faqIntentRulesFromDraft,
 } from './faqConfigurationInputs'
+export type { FAQConfigurationInputContracts } from './faqConfigurationInputs'
 
 export {
   FAQ_DEFLECTION_REPORT_OUTPUT,

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -26,6 +26,7 @@ import {
   contentOpsInlineRowsPreflightError,
   formatContentOpsBytes,
   faqDeflectionReportAnswerSteps,
+  faqConfigurationControlsVisible,
   faqConfigurationInputsSelected,
   faqIntentRulesDraftValue,
   faqIntentRulesFromDraft,
@@ -42,8 +43,11 @@ import {
   toWireIngestionInspectRequest,
   toWireIngestionImportRequest,
   toWireRequest,
+  FAQ_DOCUMENTATION_TERMS_INPUT,
   FAQ_DEFLECTION_REPORT_OUTPUT,
+  FAQ_INTENT_RULES_INPUT,
   FAQ_RESOLUTION_EVIDENCE_STATUS,
+  FAQ_VOCABULARY_GAP_RULES_INPUT,
   type ContentOpsCatalog,
   type ContentOpsCachePolicy,
   type ContentOpsIngestionDiagnostics,
@@ -124,9 +128,6 @@ const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
-const FAQ_INTENT_RULES_INPUT = 'faq_intent_rules'
-const FAQ_DOCUMENTATION_TERMS_INPUT = 'faq_documentation_terms'
-const FAQ_VOCABULARY_GAP_RULES_INPUT = 'faq_vocabulary_gap_rules'
 const FAQ_INTENT_RULES_DISPLAY_FALLBACK = {
   label: 'Intent rules',
   placeholder:
@@ -293,6 +294,12 @@ export default function ContentOpsNewRun() {
     faqIntentRulesContract,
     FAQ_INTENT_RULES_DISPLAY_FALLBACK,
   )
+  const faqConfigurationControlsVisibleForCatalog =
+    faqConfigurationControlsVisible(request.outputs, {
+      intentRules: faqIntentRulesContract,
+      documentationTerms: faqDocumentationTermsContract,
+      vocabularyGapRules: faqVocabularyGapRulesContract,
+    })
   const landingPageRepairAttemptContract = landingPageOutputSelected
     ? integerInputContract(catalog, LANDING_PAGE_QUALITY_REPAIR_INPUT)
     : null
@@ -1114,7 +1121,7 @@ export default function ContentOpsNewRun() {
               </p>
             </div>
           )}
-          {faqConfigurationOutputSelected && (
+          {faqConfigurationControlsVisibleForCatalog && (
             <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-3">
               <div className="mb-3">
                 <h3 className="text-sm font-medium text-slate-200">
@@ -1122,55 +1129,61 @@ export default function ContentOpsNewRun() {
                 </h3>
               </div>
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                <label className="block text-sm lg:col-span-2">
-                  <span className="text-slate-300">
-                    {faqIntentRulesDisplay.label}
-                  </span>
-                  <textarea
-                    value={faqIntentRulesDraftValue(
-                      parsedInputsForControls.ok
-                        ? parsedInputsForControls.value[FAQ_INTENT_RULES_INPUT]
-                        : undefined,
-                    )}
-                    onChange={(e) =>
-                      handleFaqIntentRulesChange(e.target.value)
-                    }
-                    rows={3}
-                    disabled={faqInputsDisabled}
-                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    placeholder={faqIntentRulesDisplay.placeholder}
-                  />
-                </label>
-                <label className="block text-sm">
-                  <span className="text-slate-300">
-                    {faqDocumentationTermsDisplay.label}
-                  </span>
-                  <textarea
-                    value={faqDocumentationTermsDraftValue(parsedInputsForControls)}
-                    onChange={(e) =>
-                      handleFaqDocumentationTermsChange(e.target.value)
-                    }
-                    rows={4}
-                    disabled={faqInputsDisabled}
-                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    placeholder={faqDocumentationTermsDisplay.placeholder}
-                  />
-                </label>
-                <label className="block text-sm">
-                  <span className="text-slate-300">
-                    {faqVocabularyGapRulesDisplay.label}
-                  </span>
-                  <textarea
-                    value={faqVocabularyRulesDraftValue(parsedInputsForControls)}
-                    onChange={(e) =>
-                      handleFaqVocabularyRulesChange(e.target.value)
-                    }
-                    rows={4}
-                    disabled={faqInputsDisabled}
-                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    placeholder={faqVocabularyGapRulesDisplay.placeholder}
-                  />
-                </label>
+                {faqIntentRulesContract && (
+                  <label className="block text-sm lg:col-span-2">
+                    <span className="text-slate-300">
+                      {faqIntentRulesDisplay.label}
+                    </span>
+                    <textarea
+                      value={faqIntentRulesDraftValue(
+                        parsedInputsForControls.ok
+                          ? parsedInputsForControls.value[FAQ_INTENT_RULES_INPUT]
+                          : undefined,
+                      )}
+                      onChange={(e) =>
+                        handleFaqIntentRulesChange(e.target.value)
+                      }
+                      rows={3}
+                      disabled={faqInputsDisabled}
+                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                      placeholder={faqIntentRulesDisplay.placeholder}
+                    />
+                  </label>
+                )}
+                {faqDocumentationTermsContract && (
+                  <label className="block text-sm">
+                    <span className="text-slate-300">
+                      {faqDocumentationTermsDisplay.label}
+                    </span>
+                    <textarea
+                      value={faqDocumentationTermsDraftValue(parsedInputsForControls)}
+                      onChange={(e) =>
+                        handleFaqDocumentationTermsChange(e.target.value)
+                      }
+                      rows={4}
+                      disabled={faqInputsDisabled}
+                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                      placeholder={faqDocumentationTermsDisplay.placeholder}
+                    />
+                  </label>
+                )}
+                {faqVocabularyGapRulesContract && (
+                  <label className="block text-sm">
+                    <span className="text-slate-300">
+                      {faqVocabularyGapRulesDisplay.label}
+                    </span>
+                    <textarea
+                      value={faqVocabularyRulesDraftValue(parsedInputsForControls)}
+                      onChange={(e) =>
+                        handleFaqVocabularyRulesChange(e.target.value)
+                      }
+                      rows={4}
+                      disabled={faqInputsDisabled}
+                      className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                      placeholder={faqVocabularyGapRulesDisplay.placeholder}
+                    />
+                  </label>
+                )}
               </div>
               {!parsedInputsForControls.ok && (
                 <p className="mt-2 text-xs text-amber-200">

--- a/plans/PR-FAQ-Config-Controls-Catalog-Gate.md
+++ b/plans/PR-FAQ-Config-Controls-Catalog-Gate.md
@@ -1,0 +1,90 @@
+# PR-FAQ-Config-Controls-Catalog-Gate
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Report-Intent-Rule-Input added the hosted intent-rule control.
+The review marked one remaining follow-up: the UI shows FAQ configuration
+controls based on selected outputs even if the backend catalog does not
+advertise the matching input contracts. That can produce version-skew controls
+that write inputs the current backend did not declare.
+
+This slice keeps the fix small: make the FAQ configuration panel and fields
+catalog-gated while preserving the existing controls when the catalog advertises
+them.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-ui
+
+Slice phase: Product polish
+
+1. Add a small domain helper for FAQ configuration-control visibility.
+2. Gate the FAQ configuration panel on both selected FAQ output and at least one
+   advertised FAQ input contract.
+3. Gate each FAQ textarea on its own advertised contract.
+4. Add focused UI helper/source tests for the version-skew case.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `atlas-intel-ui/src/domain/contentOps/faqConfigurationInputs.ts` | Adds reusable FAQ input keys and catalog-gated visibility helper. |
+| `atlas-intel-ui/src/domain/contentOps/index.ts` | Exports the new helper/constants. |
+| `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` | Uses catalog-gated visibility for FAQ config controls. |
+| `atlas-intel-ui/scripts/content-ops-faq-configuration-inputs.test.mjs` | Verifies the version-skew visibility behavior and screen wiring. |
+| `plans/PR-FAQ-Config-Controls-Catalog-Gate.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+The screen now asks the domain helper whether FAQ configuration controls are
+visible using the selected outputs plus the actual catalog contracts:
+
+```ts
+faqConfigurationControlsVisible(outputs, {
+  intentRules: faqIntentRulesContract,
+  documentationTerms: faqDocumentationTermsContract,
+  vocabularyGapRules: faqVocabularyGapRulesContract,
+})
+```
+
+The panel renders only when the helper returns true, and each textarea is wrapped
+by its corresponding contract check. If an older backend advertises only
+documentation terms and vocabulary-gap rules, the intent-rule field stays hidden
+instead of writing an undeclared input.
+
+## Intentional
+
+- No backend changes are included. This is a UI/catalog alignment fix.
+- The existing placeholder fallbacks remain for incomplete contract metadata,
+  but a missing contract no longer causes the field to render.
+
+## Deferred
+
+- Parked hardening considered: `atlas-intel-ui npm audit vulnerabilities`
+  remains parked in `HARDENING.md`; dependency upgrade work is outside this UI
+  catalog-gating slice.
+
+## Verification
+
+- Command: npm run test:content-ops-faq-configuration-inputs
+  - Result: 4 passed.
+- Command: npm run lint
+  - Result: passed.
+- Command: npm run build
+  - Result: passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Config-Controls-Catalog-Gate.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Config-Controls-Catalog-Gate.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Domain helper + exports | 28 |
+| Screen wiring | 119 |
+| Test updates | 32 |
+| Plan doc | 90 |
+| **Total** | **269** |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Config-Controls-Catalog-Gate.md
Slice phase: Product polish

The FAQ configuration panel was still output-gated only, so a version-skewed backend catalog could hide the corresponding input contracts while the UI still rendered textareas that write those undeclared inputs. This slice makes the panel and individual FAQ fields catalog-gated while preserving the existing controls when the catalog advertises them.

## Intentional
- No backend changes are included. This is a UI/catalog alignment fix.
- The existing placeholder fallbacks remain for incomplete contract metadata, but a missing contract no longer causes the field to render.

## Deferred
- No rule-file or persistence changes are included; this slice only closes the catalog-gating polish gap.

## Parked hardening
- `atlas-intel-ui npm audit vulnerabilities` remains parked in `HARDENING.md`; dependency upgrade work is outside this UI catalog-gating slice.

## Verification
- `npm run test:content-ops-faq-configuration-inputs` - 4 passed.
- `npm run lint` - passed.
- `npm run build` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Config-Controls-Catalog-Gate.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Config-Controls-Catalog-Gate.md` - passed.
- `git diff --check` - passed.

## Diff size
5 files, +215 / -54
