### PR TITLE
Add Content Ops Zendesk credential API

### DIFF
--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -184,6 +184,9 @@ try:
         describe_content_ops_reasoning_context_provider,
         select_content_ops_reasoning_context_provider,
     )
+    from .content_ops_zendesk_credentials import (
+        create_content_ops_zendesk_credentials_router,
+    )
     from ..auth.dependencies import AuthUser
     from ..config import settings
     from ..storage.database import get_db_pool
@@ -262,6 +265,11 @@ try:
         dependencies=[Depends(_capture_content_ops_auth_user)],
     )
     router.include_router(faq_search_router)
+    zendesk_credentials_router = create_content_ops_zendesk_credentials_router(
+        pool_provider=get_db_pool,
+        auth_dependency=_capture_content_ops_auth_user,
+    )
+    router.include_router(zendesk_credentials_router)
     public_landing_page_router = create_public_landing_page_router(
         pool_provider=get_db_pool,
     )

--- a/atlas_brain/api/content_ops_zendesk_credentials.py
+++ b/atlas_brain/api/content_ops_zendesk_credentials.py
@@ -16,7 +16,6 @@ from .._content_ops_zendesk_credentials import (
     upsert_zendesk_credentials,
 )
 from ..auth.dependencies import AuthUser
-from ..storage.database import get_db_pool
 
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
@@ -44,9 +43,15 @@ class ZendeskCredentialView(BaseModel):
     revoked_at: str | None = None
 
 
+def _default_pool_provider() -> Any:
+    from ..storage.database import get_db_pool
+
+    return get_db_pool()
+
+
 def create_content_ops_zendesk_credentials_router(
     *,
-    pool_provider: PoolProvider = get_db_pool,
+    pool_provider: PoolProvider = _default_pool_provider,
     auth_dependency: AuthDependency,
 ) -> APIRouter:
     """Create tenant-scoped Content Ops Zendesk credential routes."""

--- a/atlas_brain/api/content_ops_zendesk_credentials.py
+++ b/atlas_brain/api/content_ops_zendesk_credentials.py
@@ -75,6 +75,7 @@ def create_content_ops_zendesk_credentials_router(
         body: UpsertZendeskCredentialRequest,
         user: AuthUser = Depends(auth_dependency),
     ) -> ZendeskCredentialView:
+        _require_credential_admin(user)
         pool = await _resolve_ready_pool(pool_provider)
         account_id = _account_uuid(user)
         try:
@@ -103,6 +104,7 @@ def create_content_ops_zendesk_credentials_router(
         credential_id: str,
         user: AuthUser = Depends(auth_dependency),
     ) -> None:
+        _require_credential_admin(user)
         pool = await _resolve_ready_pool(pool_provider)
         account_id = _account_uuid(user)
         try:
@@ -135,6 +137,13 @@ def _account_uuid(user: AuthUser) -> _uuid.UUID:
         return _uuid.UUID(str(user.account_id))
     except (TypeError, ValueError):
         raise HTTPException(status_code=401, detail="Invalid tenant scope")
+
+
+def _require_credential_admin(user: AuthUser) -> None:
+    role = str(getattr(user, "role", "") or "").strip().lower()
+    if bool(getattr(user, "is_admin", False)) or role in {"owner", "admin"}:
+        return
+    raise HTTPException(status_code=403, detail="Admin access required")
 
 
 def _record_to_view(record: ContentOpsZendeskCredentialRecord) -> ZendeskCredentialView:

--- a/atlas_brain/api/content_ops_zendesk_credentials.py
+++ b/atlas_brain/api/content_ops_zendesk_credentials.py
@@ -1,0 +1,162 @@
+"""Content Ops Zendesk credential management routes."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import uuid as _uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .._content_ops_zendesk_credentials import (
+    ContentOpsZendeskCredentialRecord,
+    list_zendesk_credentials,
+    revoke_zendesk_credentials,
+    upsert_zendesk_credentials,
+)
+from ..auth.dependencies import AuthUser
+from ..storage.database import get_db_pool
+
+
+PoolProvider = Callable[[], Any | Awaitable[Any]]
+AuthDependency = Callable[..., AuthUser | Awaitable[AuthUser]]
+
+
+class UpsertZendeskCredentialRequest(BaseModel):
+    email: str = Field(..., min_length=3, max_length=320)
+    api_token: str = Field(..., min_length=1, max_length=4096)
+    subdomain: str = Field(default="", max_length=128)
+    base_url: str = Field(default="", max_length=512)
+    label: str = Field(default="", max_length=128)
+
+
+class ZendeskCredentialView(BaseModel):
+    id: str
+    account_id: str
+    email: str
+    api_token_prefix: str
+    subdomain: str
+    base_url: str
+    label: str
+    added_at: str
+    last_used_at: str | None = None
+    revoked_at: str | None = None
+
+
+def create_content_ops_zendesk_credentials_router(
+    *,
+    pool_provider: PoolProvider = get_db_pool,
+    auth_dependency: AuthDependency,
+) -> APIRouter:
+    """Create tenant-scoped Content Ops Zendesk credential routes."""
+
+    router = APIRouter(
+        prefix="/content-ops/zendesk-credentials",
+        tags=["content-ops"],
+    )
+
+    @router.get("", response_model=list[ZendeskCredentialView])
+    async def list_credentials(
+        user: AuthUser = Depends(auth_dependency),
+    ) -> list[ZendeskCredentialView]:
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        records = await list_zendesk_credentials(pool, account_id=account_id)
+        return [_record_to_view(record) for record in records]
+
+    @router.post("", response_model=ZendeskCredentialView, status_code=201)
+    async def add_or_rotate_credential(
+        body: UpsertZendeskCredentialRequest,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> ZendeskCredentialView:
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        try:
+            record = await upsert_zendesk_credentials(
+                pool,
+                account_id=account_id,
+                email=body.email,
+                api_token=body.api_token,
+                subdomain=body.subdomain,
+                base_url=body.base_url,
+                label=body.label,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            if exc.__class__.__name__ in ("UniqueViolationError", "IntegrityError"):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Concurrent Zendesk credential write lost the race. Retry the request.",
+                )
+            raise
+        return _record_to_view(record)
+
+    @router.delete("/{credential_id}", status_code=204)
+    async def revoke_credential(
+        credential_id: str,
+        user: AuthUser = Depends(auth_dependency),
+    ) -> None:
+        pool = await _resolve_ready_pool(pool_provider)
+        account_id = _account_uuid(user)
+        try:
+            parsed_credential_id = _uuid.UUID(str(credential_id))
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=404, detail="Credential not found")
+        revoked = await revoke_zendesk_credentials(
+            pool,
+            account_id=account_id,
+            credential_id=parsed_credential_id,
+        )
+        if not revoked:
+            raise HTTPException(status_code=404, detail="Credential not found")
+        return None
+
+    return router
+
+
+async def _resolve_ready_pool(pool_provider: PoolProvider) -> Any:
+    pool = pool_provider()
+    if hasattr(pool, "__await__"):
+        pool = await pool
+    if pool is None or getattr(pool, "is_initialized", True) is False:
+        raise HTTPException(status_code=503, detail="Database not ready")
+    return pool
+
+
+def _account_uuid(user: AuthUser) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(str(user.account_id))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid tenant scope")
+
+
+def _record_to_view(record: ContentOpsZendeskCredentialRecord) -> ZendeskCredentialView:
+    return ZendeskCredentialView(
+        id=str(record.id),
+        account_id=str(record.account_id),
+        email=record.email,
+        api_token_prefix=record.api_token_prefix,
+        subdomain=record.subdomain,
+        base_url=record.base_url,
+        label=record.label,
+        added_at=_fmt_time(record.added_at) or "",
+        last_used_at=_fmt_time(record.last_used_at),
+        revoked_at=_fmt_time(record.revoked_at),
+    )
+
+
+def _fmt_time(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+__all__ = [
+    "UpsertZendeskCredentialRequest",
+    "ZendeskCredentialView",
+    "create_content_ops_zendesk_credentials_router",
+]

--- a/plans/PR-FAQ-Macro-Writeback-Credential-API.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-API.md
@@ -14,7 +14,7 @@ Ownership lane: content-ops/faq-macro-writeback
 Slice phase: Vertical slice
 
 1. Add a host Content Ops Zendesk credential router with authenticated tenant
-   list, add/rotate, and revoke endpoints.
+   list plus admin-only add/rotate and revoke endpoints.
 2. Mount the router through the existing Content Ops auth capture path so all
    operations use the calling tenant's `account_id`.
 3. Return only display-safe credential views: token prefix, endpoint, label,
@@ -40,7 +40,8 @@ mount style. The default pool provider lazy-loads Atlas database access so the
 route module stays importable in the lean extracted CI environment. Each route
 resolves the authenticated `AuthUser`, parses `user.account_id` as a UUID,
 checks database readiness, and calls the credential service using that account
-id.
+id. Credential writes are additionally gated to tenant owner/admin users because
+the Zendesk credential is a tenant-wide integration secret.
 
 `POST /content-ops/zendesk-credentials` accepts Zendesk email, API token,
 subdomain or base URL, and an optional label. The service validates the endpoint,
@@ -58,6 +59,8 @@ the tenant.
   and encrypted storage are enough for the provisioning surface; live publish
   already reports credential failures through the macro writeback provider.
 - API tokens are accepted only on create/rotate and are never returned.
+- Listing is available to authenticated Content Ops users, while create/rotate
+  and revoke require tenant owner/admin rights.
 - The route fails closed when the database is not initialized.
 
 ## Deferred
@@ -70,7 +73,7 @@ Parked hardening: none
 
 ## Verification
 
-- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q — 19 passed, 1 warning.
+- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q — 21 passed, 1 warning.
 - python -m py_compile atlas_brain/api/content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
 
@@ -79,9 +82,9 @@ Parked hardening: none
 | Area | Estimated LOC |
 |---|---:|
 | Plan | ~70 |
-| API route / mount / CI | ~160 |
-| Tests | ~313 |
-| Total | ~535 |
+| API route / mount / CI | ~166 |
+| Tests | ~356 |
+| Total | ~584 |
 
 This is slightly over the 400 LOC soft cap because the API surface needs scoped
 create/list/revoke behavior and auth/mount coverage in the same vertical slice.

--- a/plans/PR-FAQ-Macro-Writeback-Credential-API.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-API.md
@@ -1,0 +1,85 @@
+# PR-FAQ-Macro-Writeback-Credential-API
+
+## Why this slice exists
+
+FAQ macro writeback now has encrypted tenant Zendesk credential storage and a
+fail-closed tenant resolver, but operators still have no product/API surface to
+provision those credentials. Without a scoped create/list/revoke path, the
+storage only works through manual database writes, which blocks real tenant
+setup.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add a host Content Ops Zendesk credential router with authenticated tenant
+   list, add/rotate, and revoke endpoints.
+2. Mount the router through the existing Content Ops auth capture path so all
+   operations use the calling tenant's `account_id`.
+3. Return only display-safe credential views: token prefix, endpoint, label,
+   timestamps, and ids; never plaintext or ciphertext.
+4. Add route tests for account scoping, display-safe responses, revoke behavior,
+   invalid ids, and API aggregator mounting.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Credential-API.md` — plan for this slice.
+- `atlas_brain/api/content_ops_zendesk_credentials.py` — credential management routes.
+- `atlas_brain/api/__init__.py` — host route mounting.
+- `scripts/run_extracted_pipeline_checks.sh` — CI enrollment for the new route test.
+- `tests/test_content_ops_zendesk_credentials_api.py` — route behavior tests.
+- `tests/test_atlas_content_ops_generated_assets_api.py` — API aggregator mount coverage.
+
+## Mechanism
+
+The new router is host-owned rather than extracted because it touches Atlas auth,
+Postgres pool access, and encrypted host credential storage. A factory accepts a
+`pool_provider` and `auth_dependency`, mirroring the existing Content Ops host
+mount style. Each route resolves the authenticated `AuthUser`, parses
+`user.account_id` as a UUID, checks database readiness, and calls the credential
+service using that account id.
+
+`POST /content-ops/zendesk-credentials` accepts Zendesk email, API token,
+subdomain or base URL, and an optional label. The service validates the endpoint,
+encrypts the API token, revokes any current active row for the tenant, and
+returns a display-safe DTO. `GET /content-ops/zendesk-credentials` lists active
+rows for the tenant. `DELETE /content-ops/zendesk-credentials/{credential_id}`
+soft-revokes a tenant-owned row and returns 404 for invalid ids or rows outside
+the tenant.
+
+## Intentional
+
+- This slice does not add dashboard UI. It creates the minimum authenticated
+  API surface the UI or admin tooling can call next.
+- This slice does not call Zendesk to validate credentials. Format validation
+  and encrypted storage are enough for the provisioning surface; live publish
+  already reports credential failures through the macro writeback provider.
+- API tokens are accepted only on create/rotate and are never returned.
+- The route fails closed when the database is not initialized.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for macro publish.
+- `PR-FAQ-Macro-Writeback-Credential-UI`: dashboard controls for adding,
+  listing, and revoking Zendesk credentials.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q — 18 passed, 1 warning.
+- python -m py_compile atlas_brain/api/content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~70 |
+| API route / mount / CI | ~156 |
+| Tests | ~220 |
+| Total | ~464 |
+
+This is slightly over the 400 LOC soft cap because the API surface needs scoped
+create/list/revoke behavior and auth/mount coverage in the same vertical slice.

--- a/plans/PR-FAQ-Macro-Writeback-Credential-API.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-API.md
@@ -36,9 +36,11 @@ Slice phase: Vertical slice
 The new router is host-owned rather than extracted because it touches Atlas auth,
 Postgres pool access, and encrypted host credential storage. A factory accepts a
 `pool_provider` and `auth_dependency`, mirroring the existing Content Ops host
-mount style. Each route resolves the authenticated `AuthUser`, parses
-`user.account_id` as a UUID, checks database readiness, and calls the credential
-service using that account id.
+mount style. The default pool provider lazy-loads Atlas database access so the
+route module stays importable in the lean extracted CI environment. Each route
+resolves the authenticated `AuthUser`, parses `user.account_id` as a UUID,
+checks database readiness, and calls the credential service using that account
+id.
 
 `POST /content-ops/zendesk-credentials` accepts Zendesk email, API token,
 subdomain or base URL, and an optional label. The service validates the endpoint,
@@ -68,7 +70,7 @@ Parked hardening: none
 
 ## Verification
 
-- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q — 18 passed, 1 warning.
+- python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q — 19 passed, 1 warning.
 - python -m py_compile atlas_brain/api/content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py — passed.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py — passed.
 
@@ -77,9 +79,9 @@ Parked hardening: none
 | Area | Estimated LOC |
 |---|---:|
 | Plan | ~70 |
-| API route / mount / CI | ~156 |
-| Tests | ~220 |
-| Total | ~464 |
+| API route / mount / CI | ~160 |
+| Tests | ~313 |
+| Total | ~535 |
 
 This is slightly over the 400 LOC soft cap because the API surface needs scoped
 create/list/revoke behavior and auth/mount coverage in the same vertical slice.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -88,6 +88,7 @@ pytest \
   tests/test_atlas_content_ops_input_provider.py \
   tests/test_atlas_content_ops_macro_writeback.py \
   tests/test_content_ops_zendesk_credentials.py \
+  tests/test_content_ops_zendesk_credentials_api.py \
   tests/test_atlas_content_ops_reasoning.py \
   tests/test_atlas_content_ops_scope.py \
   tests/test_support_ticket_provider_landing_blog_execute.py \

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -107,6 +107,24 @@ def test_faq_deflection_search_route_uses_shared_content_ops_auth_scope_and_pool
     assert "_capture_content_ops_auth_user" in dependency_names
 
 
+def test_content_ops_zendesk_credentials_route_uses_shared_auth_and_pool() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/zendesk-credentials")
+    closure = dict(
+        zip(
+            route.endpoint.__code__.co_freevars,
+            (cell.cell_contents for cell in route.endpoint.__closure__ or ()),
+        )
+    )
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert closure["pool_provider"].__name__ == "get_db_pool"
+    assert "_capture_content_ops_auth_user" in dependency_names
+
+
 def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
     api_pkg = _fresh_api_package()
     route = _route(api_pkg, "/content-ops/usage/summary")

--- a/tests/test_content_ops_zendesk_credentials_api.py
+++ b/tests/test_content_ops_zendesk_credentials_api.py
@@ -48,13 +48,13 @@ class _Pool:
     is_initialized = True
 
 
-def _user(account_id: uuid.UUID = ACCOUNT_ID) -> AuthUser:
+def _user(account_id: uuid.UUID = ACCOUNT_ID, *, role: str = "owner") -> AuthUser:
     return AuthUser(
         user_id="33333333-3333-3333-3333-333333333333",
         account_id=str(account_id),
         plan="b2b_growth",
         plan_status="active",
-        role="owner",
+        role=role,
         product="b2b_challenger",
     )
 
@@ -169,6 +169,28 @@ def test_add_zendesk_credential_maps_validation_error(
     assert "Complete Zendesk" in response.json()["detail"]
 
 
+def test_add_zendesk_credential_requires_admin_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def upsert(pool, **kwargs):
+        raise AssertionError("member should not be able to write credentials")
+
+    monkeypatch.setattr(api, "upsert_zendesk_credentials", upsert)
+    client = _client(user=_user(role="member"))
+
+    response = client.post(
+        "/content-ops/zendesk-credentials",
+        json={
+            "email": "agent@example.com",
+            "api_token": "secret-token",
+            "subdomain": "acme",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
+
+
 def test_revoke_zendesk_credential_is_account_scoped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -185,6 +207,21 @@ def test_revoke_zendesk_credential_is_account_scoped(
 
     assert response.status_code == 204
     assert calls == [{"account_id": ACCOUNT_ID, "credential_id": CREDENTIAL_ID}]
+
+
+def test_revoke_zendesk_credential_requires_admin_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def revoke(pool, *, account_id, credential_id):
+        raise AssertionError("member should not be able to revoke credentials")
+
+    monkeypatch.setattr(api, "revoke_zendesk_credentials", revoke)
+    client = _client(user=_user(role="member"))
+
+    response = client.delete(f"/content-ops/zendesk-credentials/{CREDENTIAL_ID}")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin access required"
 
 
 def test_revoke_zendesk_credential_returns_404_for_invalid_or_missing_id(

--- a/tests/test_content_ops_zendesk_credentials_api.py
+++ b/tests/test_content_ops_zendesk_credentials_api.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from atlas_brain._content_ops_zendesk_credentials import ContentOpsZendeskCredentialRecord
+from atlas_brain.api import content_ops_zendesk_credentials as api
+from atlas_brain.auth.dependencies import AuthUser
+
+
+ACCOUNT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+CREDENTIAL_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+class _Pool:
+    is_initialized = True
+
+
+def _user(account_id: uuid.UUID = ACCOUNT_ID) -> AuthUser:
+    return AuthUser(
+        user_id="33333333-3333-3333-3333-333333333333",
+        account_id=str(account_id),
+        plan="b2b_growth",
+        plan_status="active",
+        role="owner",
+        product="b2b_challenger",
+    )
+
+
+def _record(**overrides) -> ContentOpsZendeskCredentialRecord:
+    row = {
+        "id": CREDENTIAL_ID,
+        "account_id": ACCOUNT_ID,
+        "email": "agent@example.com",
+        "api_token_prefix": "secret-t",
+        "subdomain": "acme",
+        "base_url": "",
+        "label": "Primary",
+        "added_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "last_used_at": None,
+        "revoked_at": None,
+    }
+    row.update(overrides)
+    return ContentOpsZendeskCredentialRecord(**row)
+
+
+def _client(*, pool=None, user: AuthUser | None = None) -> TestClient:
+    app = fastapi.FastAPI()
+
+    def pool_provider():
+        return pool if pool is not None else _Pool()
+
+    def auth_dependency():
+        return user or _user()
+
+    app.include_router(api.create_content_ops_zendesk_credentials_router(
+        pool_provider=pool_provider,
+        auth_dependency=auth_dependency,
+    ))
+    return TestClient(app)
+
+
+def test_list_zendesk_credentials_returns_display_safe_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def list_credentials(pool, *, account_id):
+        calls.append({"pool": pool, "account_id": account_id})
+        return [_record()]
+
+    monkeypatch.setattr(api, "list_zendesk_credentials", list_credentials)
+    client = _client()
+
+    response = client.get("/content-ops/zendesk-credentials")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["id"] == str(CREDENTIAL_ID)
+    assert body[0]["account_id"] == str(ACCOUNT_ID)
+    assert body[0]["api_token_prefix"] == "secret-t"
+    assert "api_token" not in body[0]
+    assert "encrypted_api_token" not in body[0]
+    assert calls[0]["account_id"] == ACCOUNT_ID
+
+
+def test_add_zendesk_credential_uses_authenticated_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def upsert(pool, **kwargs):
+        calls.append({"pool": pool, **kwargs})
+        return _record(label=kwargs["label"], subdomain=kwargs["subdomain"])
+
+    monkeypatch.setattr(api, "upsert_zendesk_credentials", upsert)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/zendesk-credentials",
+        json={
+            "email": "agent@example.com",
+            "api_token": "secret-token",
+            "subdomain": "acme",
+            "label": "Primary",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["label"] == "Primary"
+    assert calls == [{
+        "pool": calls[0]["pool"],
+        "account_id": ACCOUNT_ID,
+        "email": "agent@example.com",
+        "api_token": "secret-token",
+        "subdomain": "acme",
+        "base_url": "",
+        "label": "Primary",
+    }]
+
+
+def test_add_zendesk_credential_maps_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def upsert(pool, **kwargs):
+        raise ValueError("Complete Zendesk email, API token, and endpoint are required")
+
+    monkeypatch.setattr(api, "upsert_zendesk_credentials", upsert)
+    client = _client()
+
+    response = client.post(
+        "/content-ops/zendesk-credentials",
+        json={"email": "agent@example.com", "api_token": "secret-token"},
+    )
+
+    assert response.status_code == 400
+    assert "Complete Zendesk" in response.json()["detail"]
+
+
+def test_revoke_zendesk_credential_is_account_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def revoke(pool, *, account_id, credential_id):
+        calls.append({"account_id": account_id, "credential_id": credential_id})
+        return True
+
+    monkeypatch.setattr(api, "revoke_zendesk_credentials", revoke)
+    client = _client()
+
+    response = client.delete(f"/content-ops/zendesk-credentials/{CREDENTIAL_ID}")
+
+    assert response.status_code == 204
+    assert calls == [{"account_id": ACCOUNT_ID, "credential_id": CREDENTIAL_ID}]
+
+
+def test_revoke_zendesk_credential_returns_404_for_invalid_or_missing_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    async def revoke(pool, *, account_id, credential_id):
+        calls.append({"account_id": account_id, "credential_id": credential_id})
+        return False
+
+    monkeypatch.setattr(api, "revoke_zendesk_credentials", revoke)
+    client = _client()
+
+    invalid = client.delete("/content-ops/zendesk-credentials/not-a-uuid")
+    missing = client.delete(f"/content-ops/zendesk-credentials/{CREDENTIAL_ID}")
+
+    assert invalid.status_code == 404
+    assert missing.status_code == 404
+    assert calls == [{"account_id": ACCOUNT_ID, "credential_id": CREDENTIAL_ID}]
+
+
+def test_zendesk_credential_routes_fail_when_database_unavailable() -> None:
+    class _UninitializedPool:
+        is_initialized = False
+
+    client = _client(pool=_UninitializedPool())
+
+    response = client.get("/content-ops/zendesk-credentials")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Database not ready"

--- a/tests/test_content_ops_zendesk_credentials_api.py
+++ b/tests/test_content_ops_zendesk_credentials_api.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 import uuid
 
 import pytest
@@ -9,12 +14,34 @@ fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from atlas_brain._content_ops_zendesk_credentials import ContentOpsZendeskCredentialRecord
-from atlas_brain.api import content_ops_zendesk_credentials as api
 from atlas_brain.auth.dependencies import AuthUser
 
 
+API_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "atlas_brain"
+    / "api"
+    / "content_ops_zendesk_credentials.py"
+)
 ACCOUNT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 CREDENTIAL_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+api = None
+
+
+def setup_module() -> None:
+    global api
+    api = _load_api_module()
+
+
+def _load_api_module():
+    spec = importlib.util.spec_from_file_location(
+        "atlas_brain.api.content_ops_zendesk_credentials_for_test",
+        API_MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 class _Pool:
@@ -190,3 +217,38 @@ def test_zendesk_credential_routes_fail_when_database_unavailable() -> None:
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Database not ready"
+
+
+def test_zendesk_credential_api_import_does_not_require_asyncpg() -> None:
+    script = textwrap.dedent("""
+import sys
+
+class BlockAsyncpg:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'asyncpg' or fullname.startswith('asyncpg.'):
+            raise ModuleNotFoundError(\"No module named 'asyncpg'\")
+        return None
+
+sys.meta_path.insert(0, BlockAsyncpg())
+import importlib.util
+from pathlib import Path
+
+path = Path('atlas_brain/api/content_ops_zendesk_credentials.py').resolve()
+spec = importlib.util.spec_from_file_location(
+    'atlas_brain.api.content_ops_zendesk_credentials_block_asyncpg_test',
+    path,
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+print(module.ZendeskCredentialView.__name__)
+""")
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ZendeskCredentialView" in result.stdout


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Credential-API.md
Slice phase: Vertical slice

Adds the authenticated host API surface needed to provision tenant Zendesk credentials for FAQ macro writeback. The route supports list, add/rotate, and revoke using the calling tenant's account id, returns only display-safe credential fields, and restricts credential writes to tenant owner/admin users.

## Intentional

- This is API-only; dashboard controls and publish UI remain separate slices.
- The create route stores the token through the encrypted credential service but never returns plaintext or ciphertext.
- The router is host-owned because it composes Atlas auth, database readiness, and encrypted credential storage.
- The default database pool provider is lazy-loaded so the route module and enrolled route tests stay importable in lean extracted CI without `asyncpg` installed.
- Listing is available to authenticated Content Ops users; create/rotate and revoke require owner/admin rights because the Zendesk credential is tenant-wide.
- Live Zendesk validation is deferred; publish/reconcile already reports provider failures when credentials are wrong.

## Deferred

- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action for macro publish.
- `PR-FAQ-Macro-Writeback-Credential-UI`: dashboard controls for adding, listing, and revoking Zendesk credentials.

## Parked hardening

None.

## Verification

- `python -m pytest tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py -q` - 21 passed, 1 warning.
- `python -m py_compile atlas_brain/api/content_ops_zendesk_credentials.py tests/test_content_ops_zendesk_credentials_api.py tests/test_atlas_content_ops_generated_assets_api.py` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-credential-api.md` - passed locally.

## Diff size

~584 LOC across API route/mount, CI enrollment, behavior tests, import regression test, write-authz tests, aggregator test, and the plan. This is over the 400 LOC soft cap because create/list/revoke, auth/mount coverage, extracted-CI import guard, and credential-write authorization need to land together for the provisioning path to be usable.
