### PR TITLE
PR-FAQ-Deflection-Paid-Gate

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -229,6 +229,7 @@ def build_content_ops_execution_services(
     skills_factory: Callable[[], SkillStore] | None = None,
     pool_factory: Callable[[], Any] | None = None,
     enable_db_services: bool = False,
+    expose_faq_markdown_output: bool = True,
 ) -> ContentOpsExecutionServices:
     """Return the host's Content Ops execution-services bundle.
 
@@ -279,7 +280,8 @@ def build_content_ops_execution_services(
     report = None
     sales_brief = None
     blog_post = None
-    faq_markdown = _FAQ_MARKDOWN_SERVICE
+    faq_markdown_service = _FAQ_MARKDOWN_SERVICE
+    faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
     faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
     if enable_db_services:
         llm = llm_factory()
@@ -319,8 +321,11 @@ def build_content_ops_execution_services(
             skills=skills,
             pool=pool,
         )
-        faq_markdown = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
-        faq_deflection_report = FAQDeflectionReportService(faq_markdown=faq_markdown)
+        faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
+        faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
+        faq_deflection_report = FAQDeflectionReportService(
+            faq_markdown=faq_markdown_service
+        )
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -167,6 +167,9 @@ try:
     from extracted_content_pipeline.api.faq_search import (
         create_faq_deflection_search_router,
     )
+    from extracted_content_pipeline.deflection_report_access import (
+        PostgresDeflectionReportArtifactStore,
+    )
     from .._content_ops_input_provider import build_content_ops_input_provider
     from .._content_ops_infrastructure import (
         build_content_ops_llm_client,
@@ -231,16 +234,25 @@ try:
         config=content_ops_config,
         dependencies=[Depends(_capture_content_ops_auth_user)],
         execution_services_provider=lambda: (
-            build_content_ops_execution_services(enable_db_services=True)
+            build_content_ops_execution_services(
+                enable_db_services=True,
+                expose_faq_markdown_output=False,
+            )
         ),
         scope_provider=build_content_ops_scope,
         reasoning_context_provider=select_content_ops_reasoning_context_provider,
         reasoning_status_provider=describe_content_ops_reasoning_context_provider,
         input_provider=build_content_ops_input_provider(pool_provider=get_db_pool),
+        deflection_report_store_provider=lambda: (
+            PostgresDeflectionReportArtifactStore(pool=get_db_pool())
+        ),
         cache_policy_default_provider=_content_ops_cache_policy_default,
         opportunity_import_pool_provider=get_db_pool,
         usage_pool_provider=get_db_pool,
         usage_dependencies=[Depends(_require_content_ops_usage_operator)],
+        deflection_report_paid_dependencies=[
+            Depends(_require_content_ops_usage_operator)
+        ],
         ingestion_import_admission_provider=lambda: (
             build_content_ops_import_admission_gate(
                 max_concurrency=content_ops_config.ingestion_import_max_concurrency

--- a/atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql
+++ b/atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql
@@ -1,0 +1,21 @@
+-- Store paid-gated FAQ deflection report artifacts by tenant/request.
+
+CREATE TABLE IF NOT EXISTS content_ops_deflection_reports (
+    account_id TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    snapshot JSONB NOT NULL,
+    artifact JSONB NOT NULL,
+    paid BOOLEAN NOT NULL DEFAULT FALSE,
+    payment_reference TEXT,
+    paid_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (account_id, request_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_deflection_reports_account_created
+    ON content_ops_deflection_reports (account_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_ops_deflection_reports_paid
+    ON content_ops_deflection_reports (account_id, paid)
+    WHERE paid = true;

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -15,7 +15,7 @@ from typing import Any
 from uuid import uuid4
 
 try:
-    from fastapi import APIRouter, Body, File, Form, HTTPException, Query, UploadFile
+    from fastapi import APIRouter, Body, File, Form, HTTPException, Path as PathParam, Query, UploadFile
     from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
     APIRouter = None
@@ -47,6 +47,7 @@ from ..content_ops_input_provider import (
     merge_content_ops_input_package,
 )
 from ..content_ops_cache_policy import normalize_content_ops_cache_policy
+from ..deflection_report_access import DeflectionReportArtifactStore
 from ..control_surfaces import (
     OUTPUT_CATALOG,
     PRESETS,
@@ -58,6 +59,10 @@ from ..control_surfaces import (
     resolve_outputs,
 )
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
+from ..faq_deflection_report import (
+    DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
+    build_deflection_snapshot,
+)
 from ..landing_page_input_contract import landing_page_seo_geo_aeo_input_contracts
 from ..ingestion_diagnostics import inspect_ingestion_file, inspect_ingestion_rows
 from ..landing_page_repair_contract import (
@@ -94,6 +99,10 @@ ReasoningStatusProvider = Callable[
 ]
 LLMProvider = Callable[[], Any | Awaitable[Any]]
 PoolProvider = Callable[[], Any | Awaitable[Any]]
+DeflectionReportStoreProvider = Callable[
+    [],
+    DeflectionReportArtifactStore | Awaitable[DeflectionReportArtifactStore],
+]
 ImportAdmissionProvider = Callable[[], Any | Awaitable[Any]]
 CachePolicyDefaultProvider = Callable[
     [TenantScope],
@@ -310,6 +319,7 @@ class ContentOpsControlSurfaceApiConfig:
     ingestion_opportunity_table: str = "campaign_opportunities"
     execute_max_concurrency: int = 8
     faq_execute_max_source_material_rows: int = _MAX_INGESTION_ROWS
+    deflection_snapshot_top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N
     ingestion_import_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
@@ -357,6 +367,8 @@ class ContentOpsControlSurfaceApiConfig:
                 "faq_execute_max_source_material_rows cannot exceed "
                 f"{_MAX_INGESTION_ROWS}"
             )
+        if self.deflection_snapshot_top_n <= 0:
+            raise ValueError("deflection_snapshot_top_n must be positive")
         if self.ingestion_import_max_concurrency <= 0:
             raise ValueError("ingestion_import_max_concurrency must be positive")
         if not isinstance(
@@ -551,10 +563,18 @@ if BaseModel is not None:
         replace_existing: bool = False
         dry_run: bool = False
 
+    class DeflectionReportPaidModel(BaseModel):
+        """Authenticated paid-release marker for a generated report."""
+
+        model_config = ConfigDict(extra="forbid")
+
+        payment_reference: str | None = Field(default=None, max_length=200)
+
 else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsRequestModel = Any
     ContentOpsIngestionInspectModel = Any
     ContentOpsIngestionImportModel = Any
+    DeflectionReportPaidModel = Any
 
 
 def create_content_ops_control_surface_router(
@@ -566,9 +586,11 @@ def create_content_ops_control_surface_router(
     reasoning_status_provider: ReasoningStatusProvider | None = None,
     llm_provider: LLMProvider | None = None,
     input_provider: InputProvider | None = None,
+    deflection_report_store_provider: DeflectionReportStoreProvider | None = None,
     opportunity_import_pool_provider: PoolProvider | None = None,
     usage_pool_provider: PoolProvider | None = None,
     usage_dependencies: Sequence[Any] | None = None,
+    deflection_report_paid_dependencies: Sequence[Any] | None = None,
     ingestion_import_admission_provider: ImportAdmissionProvider | None = None,
     cache_policy_default_provider: CachePolicyDefaultProvider | None = None,
     dependencies: Sequence[Any] | None = None,
@@ -655,6 +677,55 @@ def create_content_ops_control_surface_router(
             run_id=run_id,
             request_id=request_id,
         )
+
+    @router.get("/deflection-reports/{request_id}/snapshot")
+    async def deflection_report_snapshot(
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> dict[str, Any]:
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        snapshot = await store.get_snapshot(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+        )
+        if snapshot is None:
+            raise HTTPException(status_code=404, detail="Deflection report not found.")
+        return snapshot
+
+    @router.get("/deflection-reports/{request_id}/artifact")
+    async def deflection_report_artifact(
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> dict[str, Any]:
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        record = await store.get_artifact_record(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+        )
+        if record is None:
+            raise HTTPException(status_code=404, detail="Deflection report not found.")
+        if not record.paid:
+            raise HTTPException(status_code=403, detail="Deflection report is locked.")
+        return dict(record.artifact or {})
+
+    @router.post(
+        "/deflection-reports/{request_id}/paid",
+        dependencies=list(deflection_report_paid_dependencies or ()),
+    )
+    async def mark_deflection_report_paid(
+        payload: DeflectionReportPaidModel = Body(...),
+        request_id: str = PathParam(..., min_length=1, max_length=200),
+    ) -> dict[str, Any]:
+        store = await _resolve_deflection_report_store(deflection_report_store_provider)
+        scope = await _resolve_scope(scope_provider)
+        marked = await store.mark_paid(
+            account_id=_required_scope_account_id(scope),
+            request_id=request_id,
+            payment_reference=_clean(getattr(payload, "payment_reference", None)),
+        )
+        if not marked:
+            raise HTTPException(status_code=404, detail="Deflection report not found.")
+        return {"request_id": request_id, "paid": True}
 
     @router.post("/preview")
     async def preview_generation(
@@ -945,6 +1016,13 @@ def create_content_ops_control_surface_router(
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             result = _sanitize_execution_result(result)
+            result = await _gate_deflection_report_artifacts(
+                result,
+                store_provider=deflection_report_store_provider,
+                scope=scope,
+                request_id=request_id,
+                top_n=resolved_config.deflection_snapshot_top_n,
+            )
             result = _with_input_provider_diagnostics(result, payload_mapping)
             result["request_id"] = request_id
             usage_summary = await _execute_usage_summary(
@@ -1611,6 +1689,33 @@ async def _resolve_usage_pool(pool_provider: PoolProvider | None) -> Any:
     return pool
 
 
+async def _resolve_deflection_report_store(
+    provider: DeflectionReportStoreProvider | None,
+) -> DeflectionReportArtifactStore:
+    if provider is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops deflection report store is not configured.",
+        )
+    try:
+        store = await _resolve_provider(provider)
+    except Exception as exc:
+        logger.warning(
+            "Content Ops deflection report store provider failed",
+            extra={"error_type": type(exc).__name__},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops deflection report store is unavailable.",
+        ) from exc
+    if store is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Content Ops deflection report store is unavailable.",
+        )
+    return store
+
+
 async def _execute_usage_summary(
     *,
     usage_pool_provider: PoolProvider | None,
@@ -1637,6 +1742,74 @@ async def _execute_usage_summary(
             extra={"request_id": request_id},
         )
         return None
+
+
+async def _gate_deflection_report_artifacts(
+    result: Mapping[str, Any],
+    *,
+    store_provider: DeflectionReportStoreProvider | None,
+    scope: TenantScope | None,
+    request_id: str,
+    top_n: int,
+) -> dict[str, Any]:
+    gated = dict(result)
+    steps = list(gated.get("steps", ()) or ())
+    if not any(_is_completed_deflection_report_step(step) for step in steps):
+        return gated
+    store = await _resolve_deflection_report_store(store_provider)
+    account_id = _required_scope_account_id(scope)
+    gated_steps: list[dict[str, Any]] = []
+    for step in steps:
+        step_dict = dict(step)
+        if not _is_completed_deflection_report_step(step_dict):
+            gated_steps.append(step_dict)
+            continue
+        artifact = step_dict.get("result")
+        if not isinstance(artifact, Mapping):
+            raise HTTPException(
+                status_code=502,
+                detail="Deflection report artifact is malformed.",
+            )
+        try:
+            snapshot = build_deflection_snapshot(artifact, top_n=top_n).as_dict()
+            await store.save_report(
+                account_id=account_id,
+                request_id=request_id,
+                snapshot=snapshot,
+                artifact=dict(artifact),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.warning(
+                "Content Ops deflection report artifact storage failed",
+                exc_info=True,
+                extra={"request_id": request_id},
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Content Ops deflection report store is unavailable.",
+            ) from exc
+        step_dict["result"] = {
+            "request_id": request_id,
+            "snapshot": snapshot,
+            "full_report": {
+                "status": "locked",
+                "reason": "payment_required",
+            },
+        }
+        gated_steps.append(step_dict)
+    gated["steps"] = gated_steps
+    return gated
+
+
+def _is_completed_deflection_report_step(step: Any) -> bool:
+    if not isinstance(step, Mapping):
+        return False
+    return (
+        step.get("output") == "faq_deflection_report"
+        and step.get("status") == "completed"
+    )
 
 
 async def _evaluate_account_usage_budget(

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -1,0 +1,266 @@
+"""Storage boundary for paid-gated FAQ deflection reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+@dataclass(frozen=True)
+class DeflectionReportAccessRecord:
+    """Persisted report access state for one request."""
+
+    account_id: str
+    request_id: str
+    snapshot: dict[str, Any]
+    artifact: dict[str, Any] | None
+    paid: bool
+    payment_reference: str | None = None
+
+
+class DeflectionReportArtifactStore(Protocol):
+    """Host-owned persistence for snapshots, full artifacts, and paid flags."""
+
+    async def save_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        snapshot: Mapping[str, Any],
+        artifact: Mapping[str, Any],
+    ) -> None:
+        """Persist a generated report while keeping it locked by default."""
+
+    async def get_snapshot(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> dict[str, Any] | None:
+        """Return the free snapshot for a tenant/request pair."""
+
+    async def get_artifact_record(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> DeflectionReportAccessRecord | None:
+        """Return paid state and full artifact for a tenant/request pair."""
+
+    async def mark_paid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        """Mark a report paid. Returns False when no tenant/request row exists."""
+
+
+class InMemoryDeflectionReportArtifactStore:
+    """Test store with the same tenant/request semantics as the Postgres store."""
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], DeflectionReportAccessRecord] = {}
+
+    async def save_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        snapshot: Mapping[str, Any],
+        artifact: Mapping[str, Any],
+    ) -> None:
+        key = (_required_text(account_id, "account_id"), _required_text(request_id, "request_id"))
+        existing = self._rows.get(key)
+        self._rows[key] = DeflectionReportAccessRecord(
+            account_id=key[0],
+            request_id=key[1],
+            snapshot=dict(snapshot),
+            artifact=dict(artifact),
+            paid=bool(existing.paid) if existing else False,
+            payment_reference=existing.payment_reference if existing else None,
+        )
+
+    async def get_snapshot(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> dict[str, Any] | None:
+        row = self._rows.get((account_id, request_id))
+        return dict(row.snapshot) if row else None
+
+    async def get_artifact_record(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> DeflectionReportAccessRecord | None:
+        row = self._rows.get((account_id, request_id))
+        if row is None:
+            return None
+        return DeflectionReportAccessRecord(
+            account_id=row.account_id,
+            request_id=row.request_id,
+            snapshot=dict(row.snapshot),
+            artifact=dict(row.artifact or {}) if row.artifact is not None else None,
+            paid=row.paid,
+            payment_reference=row.payment_reference,
+        )
+
+    async def mark_paid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        key = (account_id, request_id)
+        row = self._rows.get(key)
+        if row is None:
+            return False
+        self._rows[key] = DeflectionReportAccessRecord(
+            account_id=row.account_id,
+            request_id=row.request_id,
+            snapshot=dict(row.snapshot),
+            artifact=dict(row.artifact or {}) if row.artifact is not None else None,
+            paid=True,
+            payment_reference=_clean(payment_reference) or row.payment_reference,
+        )
+        return True
+
+
+@dataclass(frozen=True)
+class PostgresDeflectionReportArtifactStore:
+    """Async Postgres adapter for paid-gated deflection reports."""
+
+    pool: Any
+
+    async def save_report(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        snapshot: Mapping[str, Any],
+        artifact: Mapping[str, Any],
+    ) -> None:
+        await self.pool.execute(
+            """
+            INSERT INTO content_ops_deflection_reports (
+                account_id, request_id, snapshot, artifact, paid, updated_at
+            )
+            VALUES ($1, $2, $3::jsonb, $4::jsonb, false, NOW())
+            ON CONFLICT (account_id, request_id) DO UPDATE
+            SET snapshot = EXCLUDED.snapshot,
+                artifact = EXCLUDED.artifact,
+                paid = content_ops_deflection_reports.paid,
+                payment_reference = content_ops_deflection_reports.payment_reference,
+                updated_at = NOW()
+            """,
+            _required_text(account_id, "account_id"),
+            _required_text(request_id, "request_id"),
+            json_dump_jsonb(dict(snapshot)),
+            json_dump_jsonb(dict(artifact)),
+        )
+
+    async def get_snapshot(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> dict[str, Any] | None:
+        row = await self.pool.fetchrow(
+            """
+            SELECT snapshot
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        if row is None:
+            return None
+        snapshot = decode_jsonb_field(row_to_dict(row).get("snapshot"), default={})
+        return dict(snapshot) if isinstance(snapshot, Mapping) else {}
+
+    async def get_artifact_record(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+    ) -> DeflectionReportAccessRecord | None:
+        row = await self.pool.fetchrow(
+            """
+            SELECT account_id, request_id, snapshot, artifact, paid, payment_reference
+            FROM content_ops_deflection_reports
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+        )
+        if row is None:
+            return None
+        return _record_from_row(row_to_dict(row))
+
+    async def mark_paid(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        payment_reference: str | None = None,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE content_ops_deflection_reports
+            SET paid = true,
+                paid_at = COALESCE(paid_at, NOW()),
+                payment_reference = COALESCE($3, payment_reference),
+                updated_at = NOW()
+            WHERE account_id = $1 AND request_id = $2
+            """,
+            account_id,
+            request_id,
+            _clean(payment_reference),
+        )
+        return parse_command_tag(result)
+
+
+def _record_from_row(row: Mapping[str, Any]) -> DeflectionReportAccessRecord:
+    snapshot = decode_jsonb_field(row.get("snapshot"), default={})
+    artifact = decode_jsonb_field(row.get("artifact"), default={})
+    return DeflectionReportAccessRecord(
+        account_id=str(row.get("account_id") or ""),
+        request_id=str(row.get("request_id") or ""),
+        snapshot=dict(snapshot) if isinstance(snapshot, Mapping) else {},
+        artifact=dict(artifact) if isinstance(artifact, Mapping) else None,
+        paid=bool(row.get("paid")),
+        payment_reference=_clean(row.get("payment_reference")),
+    )
+
+
+def _required_text(value: Any, field: str) -> str:
+    text = _clean(value)
+    if not text:
+        raise ValueError(f"{field} is required")
+    return text
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "DeflectionReportAccessRecord",
+    "DeflectionReportArtifactStore",
+    "InMemoryDeflectionReportArtifactStore",
+    "PostgresDeflectionReportArtifactStore",
+]

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -12,6 +12,21 @@ from .ticket_faq_markdown import TicketFAQMarkdownResult, TicketFAQMarkdownServi
 
 _RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
 _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
+DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
+
+
+@dataclass(frozen=True)
+class DeflectionSnapshot:
+    """Free preview projection that excludes paid answer/evidence fields."""
+
+    summary: dict[str, int]
+    top_questions: tuple[dict[str, Any], ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "summary": dict(self.summary),
+            "top_questions": [dict(question) for question in self.top_questions],
+        }
 
 
 @dataclass(frozen=True)
@@ -28,6 +43,9 @@ class DeflectionReportArtifact:
             "summary": dict(self.summary),
             "faq_result": self.faq_result.as_dict(),
         }
+
+    def snapshot(self, *, top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N) -> DeflectionSnapshot:
+        return build_deflection_snapshot(self, top_n=top_n)
 
 
 class FAQDeflectionReportService:
@@ -98,6 +116,43 @@ def build_deflection_report_artifact(
         markdown=markdown,
         summary=summary,
         faq_result=faq_result,
+    )
+
+
+def build_deflection_snapshot(
+    artifact: DeflectionReportArtifact | Mapping[str, Any],
+    *,
+    top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
+) -> DeflectionSnapshot:
+    """Project a report into the free snapshot shape.
+
+    The snapshot intentionally omits Markdown, answers, steps, evidence,
+    source IDs, term mappings, and nested FAQ item payloads.
+    """
+
+    if top_n <= 0:
+        raise ValueError("top_n must be positive")
+    summary = _artifact_summary(artifact)
+    items = _artifact_items(artifact)
+    snapshot_summary = {
+        "generated": _int(summary.get("generated")),
+        "drafted_answer_count": _int(summary.get("drafted_answer_count")),
+        "no_proven_answer_count": _int(summary.get("no_proven_answer_count")),
+    }
+    top_questions: list[dict[str, Any]] = []
+    for rank, item in enumerate(items[:top_n], start=1):
+        question = _text(item.get("question"))
+        top_questions.append({
+            "rank": rank,
+            "question": question,
+            "weighted_frequency": _int(
+                item.get("weighted_frequency") or item.get("frequency")
+            ),
+            "customer_wording": _snapshot_customer_wording(item, question),
+        })
+    return DeflectionSnapshot(
+        summary=snapshot_summary,
+        top_questions=tuple(top_questions),
     )
 
 
@@ -305,6 +360,38 @@ def _item(value: Mapping[str, Any]) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
 
 
+def _artifact_summary(
+    artifact: DeflectionReportArtifact | Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if isinstance(artifact, DeflectionReportArtifact):
+        return artifact.summary
+    value = artifact.get("summary")
+    return value if isinstance(value, Mapping) else {}
+
+
+def _artifact_items(
+    artifact: DeflectionReportArtifact | Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    if isinstance(artifact, DeflectionReportArtifact):
+        return tuple(_item(item) for item in artifact.faq_result.items)
+    faq_result = artifact.get("faq_result")
+    if not isinstance(faq_result, Mapping):
+        return ()
+    items = faq_result.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        return ()
+    return tuple(_item(item) for item in items if isinstance(item, Mapping))
+
+
+def _snapshot_customer_wording(item: Mapping[str, Any], question: str) -> str:
+    explicit = _text(item.get("customer_wording"))
+    if explicit:
+        return explicit
+    if _text(item.get("question_source")) == "customer_wording":
+        return question
+    return ""
+
+
 def _texts(value: Any) -> list[str]:
     if value in (None, "", [], {}):
         return []
@@ -343,8 +430,11 @@ def _md(value: Any) -> str:
 
 
 __all__ = [
+    "DEFAULT_DEFLECTION_SNAPSHOT_TOP_N",
+    "DeflectionSnapshot",
     "DeflectionReportArtifact",
     "FAQDeflectionReportService",
+    "build_deflection_snapshot",
     "build_deflection_report_artifact",
     "deflection_report_summary",
     "render_deflection_report",

--- a/plans/PR-FAQ-Deflection-Paid-Gate.md
+++ b/plans/PR-FAQ-Deflection-Paid-Gate.md
@@ -1,0 +1,142 @@
+# PR-FAQ-Deflection-Paid-Gate
+
+## Why this slice exists
+
+The portfolio results page is moving to a Free Snapshot -> $1,500 Backlog
+Report -> $500/mo ongoing model. The current hosted `faq_deflection_report`
+execute response returns the full `DeflectionReportArtifact` immediately:
+Markdown, drafted answers, evidence, and the nested FAQ result all leave ATLAS
+before payment. That breaks the product boundary because the free page would
+hold the paid deliverable.
+
+This slice builds the thinnest end-to-end ATLAS-owned gate: generate the real
+report, persist the full artifact server-side by `request_id`, return only a
+draft/evidence-free top-5 snapshot to the caller, and release the full artifact
+only after a privileged paid flag is set. The diff is expected to exceed the
+400 LOC soft cap because projection, storage, route gating, migration, host
+wiring, alternate-door closure, and negative tests must land together or the
+gate is not real.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+
+Slice phase: Vertical slice
+
+1. Add a `DeflectionSnapshot` projection with configurable top-N, default 5,
+   that includes only summary counts and ranked customer questions.
+2. Add a deflection report artifact store contract plus a Postgres
+   implementation that keeps the full artifact and paid flag in ATLAS.
+3. Gate the hosted `/content-ops/execute` response for `faq_deflection_report`
+   so the browser gets only the snapshot and `request_id`.
+4. Add snapshot, full-artifact, and mark-paid routes; keep snapshot/artifact
+   tenant-scoped, but put mark-paid behind a trusted dependency hook.
+5. Wire the host router to the Postgres store and add the migration.
+6. Hide the FAQ markdown output from the hosted buyer-executable output list while
+   keeping it available internally as the deflection report source generator.
+7. Add focused tests proving drafts/evidence are stripped before payment and
+   full release is fail-closed until paid.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `extracted_content_pipeline/faq_deflection_report.py` | Adds the snapshot projection contract and helpers. |
+| `extracted_content_pipeline/deflection_report_access.py` | Adds store contract, in-memory test store, and Postgres adapter. |
+| `extracted_content_pipeline/api/control_surfaces.py` | Persists full reports, returns snapshots, and exposes gated release routes. |
+| `atlas_brain/_content_ops_services.py` | Lets the host hide the FAQ markdown output as customer-executable while retaining it internally for deflection reports. |
+| `atlas_brain/api/__init__.py` | Wires the host Content Ops router to the Postgres deflection report store. |
+| `atlas_brain/storage/migrations/328_content_ops_deflection_reports.sql` | Adds the ATLAS-owned report artifact/paid-flag table. |
+| `tests/test_content_ops_deflection_report.py` | Proves snapshot projection strips paid content. |
+| `tests/test_atlas_content_ops_execution_services.py` | Proves hosted output hiding keeps the deflection report runnable. |
+| `tests/test_atlas_content_ops_generated_assets_api.py` | Proves the hosted mark-paid route uses the platform-admin gate. |
+| `tests/test_extracted_content_control_surface_api.py` | Proves execute redaction and paid-gated route behavior. |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | Updates hosted deflection route proofs to use the paid-gated release path. |
+| `plans/PR-FAQ-Deflection-Paid-Gate.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+`build_deflection_snapshot(artifact, top_n=5)` reads only
+`artifact.summary` and ranked `faq_result.items`. Each top question contains
+rank, question, weighted frequency, and customer wording. It intentionally does
+not carry answer text, steps, evidence quotes, source IDs, term mappings, or
+the full Markdown body.
+
+The hosted execute route keeps generating the full report internally. For each
+completed `faq_deflection_report` step it:
+
+1. builds the snapshot,
+2. saves `{account_id, request_id, snapshot, artifact, paid=false}` to the
+   configured store,
+3. replaces the step result with `{request_id, snapshot, full_report: locked}`.
+
+The same router exposes:
+
+- `GET /content-ops/deflection-reports/{request_id}/snapshot`
+- `GET /content-ops/deflection-reports/{request_id}/artifact`
+- `POST /content-ops/deflection-reports/{request_id}/paid`
+
+Snapshot reads are available to the authenticated tenant regardless of paid
+state. Full artifact reads return 403 until the paid flag is set. The paid
+marker route is mounted behind a trusted dependency; in the Atlas host that is
+the existing platform-admin usage gate, so a tenant buyer cannot self-unlock a
+report.
+
+The host execution bundle uses `expose_faq_markdown_output=False` for the
+browser-mounted Content Ops router. The FAQ markdown output remains available inside
+`FAQDeflectionReportService`, but it is no longer advertised or runnable as an
+alternate customer-facing output on that hosted boundary.
+
+## Intentional
+
+- This slice chooses a privileged mark-paid seam instead of a public buyer
+  route. Stripe checkout initiation remains portfolio-owned and Stripe webhook
+  mapping requires a dedicated requestId/payment mapping slice.
+- The library-level `execute_content_ops_from_mapping` still returns full
+  artifacts for tests and internal callers. The hosted route is the browser
+  boundary and applies the paid gate.
+- The extracted router still supports the FAQ markdown output for internal/test mounts.
+  The Atlas host hides it from the buyer-facing service bundle because it
+  carries the drafted answers and evidence this paywall protects.
+- If the hosted router has no deflection report store configured, it fails
+  closed for `faq_deflection_report` instead of returning the paid artifact.
+
+## Deferred
+
+- Future production-hardening slice: Stripe webhook -> ATLAS paid-flag flip
+  with requestId/payment mapping and webhook idempotency.
+- Future product-polish slice: portfolio/Intel UI copy and subscription
+  writeback messaging for the $500/mo ongoing offer.
+- Parked hardening considered: none.
+
+## Verification
+
+- Command: python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py atlas_brain/api/__init__.py atlas_brain/_content_ops_services.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_atlas_content_ops_execution_services.py
+  - Result: passed.
+- Command: pytest tests/test_extracted_content_control_surface_api.py::test_deflection_report_paid_route_uses_trusted_dependency tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_deflection_paid_route_uses_operator_gate tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_can_be_hidden_while_deflection_report_runs -q
+  - Result: 3 passed, 1 warning.
+- Command: pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_atlas_content_ops_execution_services.py tests/test_atlas_content_ops_generated_assets_api.py -q
+  - Result: 187 passed, 1 skipped, 1 warning.
+- Command: bash scripts/validate_extracted_content_pipeline.sh
+  - Result: passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+  - Result: passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt
+  - Result: passed.
+- Command: bash scripts/check_ascii_python.sh
+  - Result: passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Result: 2776 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-paid-gate.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Snapshot + store contract/adapters | 356 |
+| Hosted route gating | 175 |
+| Host wiring + migration + hosted output hiding | 46 |
+| Tests | 544 |
+| Plan doc | 142 |
+| **Total** | **1263** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -14,7 +14,9 @@ the host has wired. Currently:
 - `blog_post` (E4): same shape as landing_page (no
   IntelligenceRepository); plugs the `PostgresBlogBlueprintRepository`
   (PR #458) + `PostgresBlogPostRepository`.
-- `faq_markdown`: always wired (stateless).
+- `faq_markdown`: wired by default, but host callers can hide it from
+  customer-executable output lists while keeping it as the internal
+  deflection-report source.
 - `faq_deflection_report` (this slice): always wired (stateless wrapper over
   `faq_markdown`).
 
@@ -24,7 +26,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (17 tests):
+Test inventory (18 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -54,6 +56,8 @@ Test inventory (17 tests):
 17. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     deterministic outputs.
+18. The hosted paywall mode can hide `faq_markdown` while
+    retaining a runnable `faq_deflection_report`.
 """
 
 from __future__ import annotations
@@ -236,6 +240,48 @@ async def test_faq_deflection_report_runs_through_host_bundle() -> None:
     assert step["result"]["summary"]["generated"] == 1
     assert step["result"]["markdown"].startswith("# Acme Deflection Report")
     assert "## Ranked Question Opportunities" in step["result"]["markdown"]
+
+
+@pytest.mark.asyncio
+async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None:
+    pool = _FAQPoolStub()
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+        expose_faq_markdown_output=False,
+    )
+
+    assert services.faq_markdown is None
+    assert services.faq_deflection_report is not None
+    assert services.configured_outputs() == (
+        "signal_extraction",
+        "faq_deflection_report",
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["faq_deflection_report"],
+            "inputs": {
+                "deflection_report_title": "Hidden FAQ Source Report",
+                "source_material": [{
+                    "ticket_id": "ticket-1",
+                    "source_type": "ticket",
+                    "message": "How do I fix failed exports?",
+                    "pain_category": "exports",
+                }],
+            },
+        },
+        services=services,
+    )
+
+    assert result["status"] == "completed", result
+    step = result["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["status"] == "completed"
+    assert step["result"]["summary"]["generated"] == 1
+    assert step["result"]["markdown"].startswith("# Hidden FAQ Source Report")
 
 
 def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:

--- a/tests/test_atlas_content_ops_generated_assets_api.py
+++ b/tests/test_atlas_content_ops_generated_assets_api.py
@@ -144,6 +144,18 @@ def test_content_ops_usage_summary_route_uses_shared_auth_and_pool() -> None:
     assert "_require_content_ops_usage_operator" in dependency_names
 
 
+def test_content_ops_deflection_paid_route_uses_operator_gate() -> None:
+    api_pkg = _fresh_api_package()
+    route = _route(api_pkg, "/content-ops/deflection-reports/{request_id}/paid")
+    dependency_names = [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
+
+    assert "_capture_content_ops_auth_user" in dependency_names
+    assert "_require_content_ops_usage_operator" in dependency_names
+
+
 def test_content_ops_preview_route_uses_host_cache_policy_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from extracted_content_pipeline.faq_deflection_report import (
+    build_deflection_snapshot,
     build_deflection_report_artifact,
+)
+from extracted_content_pipeline.deflection_report_access import (
+    PostgresDeflectionReportArtifactStore,
 )
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownResult
 
@@ -123,6 +127,169 @@ def test_deflection_report_does_not_put_review_needed_steps_in_drafted_section()
     assert "No FAQ gap in this run included uploaded resolution evidence." in drafted_section
     assert "Review the cited ticket evidence" not in drafted_section
     assert "Can I update permissions?" in markdown.split("## No Proven Answer Yet", 1)[1]
+
+
+def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I export attribution reports?",
+                "question_source": "customer_wording",
+                "weighted_frequency": 8,
+                "answer": "Customers mention export trouble.",
+                "steps": ["Open Analytics and download the report."],
+                "evidence_quotes": ("ticket-export-1 said export failed",),
+                "source_ids": ("ticket-export-1",),
+                "answer_evidence_status": "resolution_evidence",
+            },
+            {
+                "question": "Can I enable SSO?",
+                "question_source": "customer_wording",
+                "weighted_frequency": 6,
+                "steps": ["Review before publishing."],
+                "evidence_quotes": ("ticket-sso-1 asked about SSO",),
+                "source_ids": ("ticket-sso-1",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    )
+    artifact = build_deflection_report_artifact(result)
+
+    snapshot = build_deflection_snapshot(artifact, top_n=1).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot == {
+        "summary": {
+            "generated": 2,
+            "drafted_answer_count": 1,
+            "no_proven_answer_count": 1,
+        },
+        "top_questions": [
+            {
+                "rank": 1,
+                "question": "How do I export attribution reports?",
+                "weighted_frequency": 8,
+                "customer_wording": "How do I export attribution reports?",
+            }
+        ],
+    }
+    assert "Open Analytics" not in encoded
+    assert "ticket-export-1" not in encoded
+    assert "evidence" not in encoded
+
+
+def test_deflection_snapshot_rejects_non_positive_top_n() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=0,
+        ticket_source_count=0,
+        output_checks={},
+        items=(),
+    )
+
+    with pytest.raises(ValueError, match="top_n must be positive"):
+        build_deflection_snapshot(build_deflection_report_artifact(result), top_n=0)
+
+
+@pytest.mark.asyncio
+async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
+    class _Pool:
+        def __init__(self) -> None:
+            self.rows: dict[tuple[str, str], dict[str, object]] = {}
+
+        async def execute(self, query: str, *args: object) -> str:
+            if "INSERT INTO content_ops_deflection_reports" in query:
+                account_id, request_id, snapshot, artifact = args
+                key = (str(account_id), str(request_id))
+                existing = self.rows.get(key, {})
+                self.rows[key] = {
+                    "account_id": account_id,
+                    "request_id": request_id,
+                    "snapshot": snapshot,
+                    "artifact": artifact,
+                    "paid": bool(existing.get("paid")),
+                    "payment_reference": existing.get("payment_reference"),
+                }
+                return "INSERT 0 1"
+            if "UPDATE content_ops_deflection_reports" in query:
+                account_id, request_id, payment_reference = args
+                key = (str(account_id), str(request_id))
+                if key not in self.rows:
+                    return "UPDATE 0"
+                self.rows[key]["paid"] = True
+                self.rows[key]["payment_reference"] = payment_reference
+                return "UPDATE 1"
+            raise AssertionError(query)
+
+        async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+            account_id, request_id = args
+            row = self.rows.get((str(account_id), str(request_id)))
+            if row is None:
+                return None
+            if "SELECT snapshot" in query:
+                return {"snapshot": row["snapshot"]}
+            return dict(row)
+
+    store = PostgresDeflectionReportArtifactStore(pool=_Pool())
+    snapshot = {
+        "summary": {
+            "generated": 1,
+            "drafted_answer_count": 1,
+            "no_proven_answer_count": 0,
+        },
+        "top_questions": [
+            {
+                "rank": 1,
+                "question": "How do I export reports?",
+                "weighted_frequency": 3,
+                "customer_wording": "How do I export reports?",
+            }
+        ],
+    }
+    artifact = {
+        "markdown": "# Full report\n\nOpen Analytics.",
+        "summary": {"generated": 1},
+        "faq_result": {"items": [{"source_ids": ["ticket-1"]}]},
+    }
+
+    await store.save_report(
+        account_id="acct-1",
+        request_id="request-1",
+        snapshot=snapshot,
+        artifact=artifact,
+    )
+
+    assert await store.get_snapshot(
+        account_id="acct-1",
+        request_id="request-1",
+    ) == snapshot
+    locked = await store.get_artifact_record(
+        account_id="acct-1",
+        request_id="request-1",
+    )
+    assert locked is not None
+    assert locked.paid is False
+    assert locked.artifact == artifact
+    assert await store.mark_paid(
+        account_id="acct-1",
+        request_id="request-1",
+        payment_reference="checkout-session:test",
+    ) is True
+    unlocked = await store.get_artifact_record(
+        account_id="acct-1",
+        request_id="request-1",
+    )
+    assert unlocked is not None
+    assert unlocked.paid is True
+    assert unlocked.payment_reference == "checkout-session:test"
+    assert await store.mark_paid(
+        account_id="acct-1",
+        request_id="missing",
+    ) is False
 
 
 def test_deflection_report_cli_builds_saas_demo_artifact(tmp_path: Path) -> None:

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -18,12 +18,17 @@ from extracted_content_pipeline.campaign_llm_client import (
 from extracted_content_pipeline.campaign_ports import CampaignReasoningContext
 from extracted_content_pipeline.content_ops_input_provider import ContentOpsInputPackage
 from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
+from extracted_content_pipeline.deflection_report_access import (
+    InMemoryDeflectionReportArtifactStore,
+)
+from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 
 
 pytestmark = pytest.mark.skipif(
     api_module.APIRouter is None,
     reason="fastapi is not installed in this test environment",
 )
+Depends = pytest.importorskip("fastapi").Depends
 
 _DEFAULT_EXECUTION_LIMITS = {
     "max_concurrency": 8,
@@ -38,6 +43,13 @@ def _route(router, path: str, method: str):
         if getattr(route, "path", None) == path and method.upper() in getattr(route, "methods", set()):
             return route
     raise AssertionError(f"route not found: {method} {path}")
+
+
+def _dependency_names(route) -> list[str]:
+    return [
+        getattr(dependency.call, "__name__", "")
+        for dependency in route.dependant.dependencies
+    ]
 
 
 class _UploadFile:
@@ -2406,6 +2418,192 @@ async def test_execute_generation_route_rejects_invalid_faq_vocabulary_rules_as_
     assert (
         exc.value.detail
         == "faq_vocabulary_gap_rules entries must include at least two terms"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report():
+    store = InMemoryDeflectionReportArtifactStore()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+        deflection_report_store_provider=lambda: store,
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    payload = await route.endpoint(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 3,
+            "require_quality_gates": False,
+            "inputs": {
+                "deflection_report_title": "Paid Gate Report",
+                "faq_title": "Paid Gate FAQ",
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-export-1",
+                        "source_type": "support_ticket",
+                        "subject": "Export report",
+                        "message": "How do I export attribution reports?",
+                        "pain_category": "exports",
+                        "resolution_text": "Open Analytics and download the report.",
+                    },
+                    {
+                        "ticket_id": "ticket-sso-1",
+                        "source_type": "support_ticket",
+                        "subject": "SSO setup",
+                        "message": "Can I enable SSO for my workspace?",
+                        "pain_category": "authentication",
+                    },
+                ],
+            },
+        }
+    )
+
+    assert payload["status"] == "completed"
+    request_id = payload["request_id"]
+    result = payload["steps"][0]["result"]
+    encoded = json.dumps(result, sort_keys=True)
+    assert result["request_id"] == request_id
+    assert result["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
+    assert result["snapshot"]["summary"]["generated"] == 2
+    assert result["snapshot"]["summary"]["drafted_answer_count"] == 1
+    assert result["snapshot"]["summary"]["no_proven_answer_count"] == 1
+    assert result["snapshot"]["top_questions"][0]["rank"] == 1
+    assert "markdown" not in result
+    assert "faq_result" not in result
+    assert "Open Analytics" not in encoded
+    assert "ticket-export-1" not in encoded
+
+    snapshot_route = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
+    assert await snapshot_route.endpoint(request_id=request_id) == result["snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_deflection_report_artifact_route_is_locked_until_marked_paid():
+    store = InMemoryDeflectionReportArtifactStore()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+        deflection_report_store_provider=lambda: store,
+    )
+
+    execute_route = _route(router, "/ops/execute", "POST")
+    payload = await execute_route.endpoint(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 2,
+            "require_quality_gates": False,
+            "inputs": {
+                "source_material": [
+                    {
+                        "ticket_id": "ticket-export-1",
+                        "source_type": "support_ticket",
+                        "subject": "Export report",
+                        "message": "How do I export attribution reports?",
+                        "pain_category": "exports",
+                        "resolution_text": "Open Analytics and download the report.",
+                    }
+                ],
+            },
+        }
+    )
+    request_id = payload["request_id"]
+    artifact_route = _route(router, "/ops/deflection-reports/{request_id}/artifact", "GET")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await artifact_route.endpoint(request_id=request_id)
+    assert exc.value.status_code == 403
+
+    paid_route = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
+    paid_payload = api_module.DeflectionReportPaidModel(
+        payment_reference="checkout-session:test"
+    )
+    assert await paid_route.endpoint(
+        payload=paid_payload,
+        request_id=request_id,
+    ) == {"request_id": request_id, "paid": True}
+
+    artifact = await artifact_route.endpoint(request_id=request_id)
+    assert artifact["markdown"].startswith("# Support Ticket Deflection Report")
+    assert "Open Analytics and download the report" in artifact["markdown"]
+    assert tuple(artifact["faq_result"]["items"][0]["source_ids"]) == (
+        "ticket-export-1",
+    )
+
+
+def test_deflection_report_paid_route_uses_trusted_dependency() -> None:
+    async def _tenant_user() -> None:
+        return None
+
+    async def _trusted_paid_release() -> None:
+        return None
+
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        dependencies=[Depends(_tenant_user)],
+        deflection_report_paid_dependencies=[Depends(_trusted_paid_release)],
+    )
+
+    paid_route = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
+    artifact_route = _route(
+        router,
+        "/ops/deflection-reports/{request_id}/artifact",
+        "GET",
+    )
+    snapshot_route = _route(
+        router,
+        "/ops/deflection-reports/{request_id}/snapshot",
+        "GET",
+    )
+
+    assert "_tenant_user" in _dependency_names(paid_route)
+    assert "_trusted_paid_release" in _dependency_names(paid_route)
+    assert "_trusted_paid_release" not in _dependency_names(artifact_route)
+    assert "_trusted_paid_release" not in _dependency_names(snapshot_route)
+
+
+@pytest.mark.asyncio
+async def test_execute_generation_route_fails_closed_without_deflection_report_store():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: {"account_id": "acct-gate", "user_id": "user-gate"},
+    )
+
+    route = _route(router, "/ops/execute", "POST")
+    with pytest.raises(api_module.HTTPException) as exc:
+        await route.endpoint(
+            {
+                "outputs": ["faq_deflection_report"],
+                "require_quality_gates": False,
+                "inputs": {
+                    "source_material": [
+                        {
+                            "ticket_id": "ticket-export-1",
+                            "source_type": "support_ticket",
+                            "message": "How do I export attribution reports?",
+                            "resolution_text": "Open Analytics.",
+                        }
+                    ],
+                },
+            }
+        )
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == (
+        "Content Ops deflection report store is not configured."
     )
 
 

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -24,6 +24,9 @@ from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.deflection_report_access import (
+    InMemoryDeflectionReportArtifactStore,
+)
 from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationService,
@@ -748,12 +751,14 @@ async def test_live_execute_route_accepts_faq_vocabulary_gap_inputs() -> None:
 
 
 async def test_live_execute_route_returns_faq_deflection_report_artifact() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(),
         execution_services_provider=lambda: ContentOpsExecutionServices(
             faq_deflection_report=FAQDeflectionReportService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+        deflection_report_store_provider=lambda: store,
     )
 
     route = _route(router, "/content-ops/execute", "POST")
@@ -798,22 +803,47 @@ async def test_live_execute_route_returns_faq_deflection_report_artifact() -> No
     step = payload["steps"][0]
     assert step["output"] == "faq_deflection_report"
     assert step["status"] == "completed"
-    assert step["result"]["summary"]["source_count"] == 2
-    assert step["result"]["summary"]["drafted_answer_count"] == 1
-    assert step["result"]["summary"]["no_proven_answer_count"] == 1
-    assert step["result"]["markdown"].startswith("# Hosted FAQ Deflection Report")
-    assert "## Ranked Question Opportunities" in step["result"]["markdown"]
-    assert "## No Proven Answer Yet" in step["result"]["markdown"]
-    assert step["result"]["faq_result"]["markdown"].startswith("# Hosted FAQ Source")
+    assert step["result"]["snapshot"]["summary"]["generated"] == 2
+    assert step["result"]["snapshot"]["summary"]["drafted_answer_count"] == 1
+    assert step["result"]["snapshot"]["summary"]["no_proven_answer_count"] == 1
+    assert step["result"]["full_report"]["status"] == "locked"
+    assert "markdown" not in step["result"]
+    assert "faq_result" not in step["result"]
+    assert "Open Analytics" not in json.dumps(step["result"], sort_keys=True)
+
+    request_id = payload["request_id"]
+    artifact_route = _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/artifact",
+        "GET",
+    )
+    paid_route = _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/paid",
+        "POST",
+    )
+    with pytest.raises(api_module.HTTPException) as exc:
+        await artifact_route.endpoint(request_id=request_id)
+    assert exc.value.status_code == 403
+    await paid_route.endpoint(
+        payload=api_module.DeflectionReportPaidModel(),
+        request_id=request_id,
+    )
+    artifact = await artifact_route.endpoint(request_id=request_id)
+    assert artifact["summary"]["source_count"] == 2
+    assert artifact["markdown"].startswith("# Hosted FAQ Deflection Report")
+    assert artifact["faq_result"]["markdown"].startswith("# Hosted FAQ Source")
 
 
 async def test_live_execute_route_handles_bulk_faq_deflection_report() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(),
         execution_services_provider=lambda: ContentOpsExecutionServices(
             faq_deflection_report=FAQDeflectionReportService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+        deflection_report_store_provider=lambda: store,
     )
     export_tickets = [
         {
@@ -860,19 +890,34 @@ async def test_live_execute_route_handles_bulk_faq_deflection_report() -> None:
     assert step["status"] == "completed"
 
     result = step["result"]
-    assert result["summary"]["source_count"] == 1000
-    assert result["summary"]["ticket_source_count"] == 1000
-    assert result["summary"]["drafted_answer_count"] >= 1
-    assert result["summary"]["no_proven_answer_count"] >= 1
-    assert "## Drafted Answers With Proven Solutions" in result["markdown"]
-    assert "## No Proven Answer Yet" in result["markdown"]
-    assert "ticket-export-bulk-0" in result["markdown"]
+    assert result["snapshot"]["summary"]["generated"] >= 2
+    assert result["snapshot"]["summary"]["drafted_answer_count"] >= 1
+    assert result["snapshot"]["summary"]["no_proven_answer_count"] >= 1
+    assert result["full_report"]["status"] == "locked"
+    assert "ticket-export-bulk-0" not in json.dumps(result, sort_keys=True)
 
-    faq_result = result["faq_result"]
+    await _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/paid",
+        "POST",
+    ).endpoint(
+        payload=api_module.DeflectionReportPaidModel(),
+        request_id=payload["request_id"],
+    )
+    artifact = await _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/artifact",
+        "GET",
+    ).endpoint(request_id=payload["request_id"])
+    assert artifact["summary"]["source_count"] == 1000
+    assert artifact["summary"]["ticket_source_count"] == 1000
+    assert "ticket-export-bulk-0" in artifact["markdown"]
+
+    faq_result = artifact["faq_result"]
     assert faq_result["source_count"] == 1000
     assert faq_result["ticket_source_count"] == 1000
     assert all(faq_result["output_checks"].values())
-    assert len(faq_result["items"]) == result["summary"]["generated"]
+    assert len(faq_result["items"]) == artifact["summary"]["generated"]
     assert any(
         item["answer_evidence_status"] == "resolution_evidence"
         for item in faq_result["items"]
@@ -904,12 +949,14 @@ async def test_live_execute_route_handles_concurrent_faq_deflection_reports() ->
             return await self._inner.generate(**kwargs)
 
     service = _BarrierFAQDeflectionReportService(expected=4)
+    store = InMemoryDeflectionReportArtifactStore()
     router = create_content_ops_control_surface_router(
         config=ContentOpsControlSurfaceApiConfig(execute_max_concurrency=4),
         execution_services_provider=lambda: ContentOpsExecutionServices(
             faq_deflection_report=service,
         ),
         scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+        deflection_report_store_provider=lambda: store,
     )
     route = _route(router, "/content-ops/execute", "POST")
 
@@ -962,15 +1009,33 @@ async def test_live_execute_route_handles_concurrent_faq_deflection_reports() ->
         assert step["status"] == "completed"
 
         result = step["result"]
-        assert result["summary"]["source_count"] == 250
-        assert result["summary"]["ticket_source_count"] == 250
-        assert result["summary"]["drafted_answer_count"] >= 1
-        assert result["summary"]["no_proven_answer_count"] >= 1
-        assert "## Drafted Answers With Proven Solutions" in result["markdown"]
-        assert "## No Proven Answer Yet" in result["markdown"]
-        assert f"ticket-export-concurrent-{case_index}-0" in result["markdown"]
+        assert result["snapshot"]["summary"]["generated"] >= 2
+        assert result["snapshot"]["summary"]["drafted_answer_count"] >= 1
+        assert result["snapshot"]["summary"]["no_proven_answer_count"] >= 1
+        assert result["full_report"]["status"] == "locked"
+        assert (
+            f"ticket-export-concurrent-{case_index}-0"
+            not in json.dumps(result, sort_keys=True)
+        )
 
-        faq_result = result["faq_result"]
+        await _route(
+            router,
+            "/content-ops/deflection-reports/{request_id}/paid",
+            "POST",
+        ).endpoint(
+            payload=api_module.DeflectionReportPaidModel(),
+            request_id=payload["request_id"],
+        )
+        artifact = await _route(
+            router,
+            "/content-ops/deflection-reports/{request_id}/artifact",
+            "GET",
+        ).endpoint(request_id=payload["request_id"])
+        assert artifact["summary"]["source_count"] == 250
+        assert artifact["summary"]["ticket_source_count"] == 250
+        assert f"ticket-export-concurrent-{case_index}-0" in artifact["markdown"]
+
+        faq_result = artifact["faq_result"]
         assert faq_result["source_count"] == 250
         assert faq_result["ticket_source_count"] == 250
         assert all(faq_result["output_checks"].values())


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Paid-Gate.md
Slice phase: Vertical slice

The free deflection results page must show real top questions without exposing the paid $1,500 report. The hosted `faq_deflection_report` route was returning the full artifact immediately, so this slice makes ATLAS persist the full report by request ID, return only a draft/evidence-free snapshot to the browser, and release the full artifact only after a privileged paid flag is set.

## Intentional
- This slice chooses a privileged mark-paid seam instead of a public buyer route. Stripe checkout initiation remains portfolio-owned and Stripe webhook mapping requires a dedicated requestId/payment mapping slice.
- The library-level `execute_content_ops_from_mapping` still returns full artifacts for tests and internal callers. The hosted route is the browser boundary and applies the paid gate.
- The extracted router still supports the FAQ markdown output for internal/test mounts. The Atlas host hides it from the buyer-facing service bundle because it carries the drafted answers and evidence this paywall protects.
- If the hosted router has no deflection report store configured, it fails closed for `faq_deflection_report` instead of returning the paid artifact.

## Deferred
- Future production-hardening slice: Stripe webhook -> ATLAS paid-flag flip with requestId/payment mapping and webhook idempotency.
- Future product-polish slice: portfolio/Intel UI copy and subscription writeback messaging for the $500/mo ongoing offer.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py atlas_brain/api/__init__.py atlas_brain/_content_ops_services.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_atlas_content_ops_generated_assets_api.py tests/test_atlas_content_ops_execution_services.py` - passed.
- `pytest tests/test_extracted_content_control_surface_api.py::test_deflection_report_paid_route_uses_trusted_dependency tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_deflection_paid_route_uses_operator_gate tests/test_atlas_content_ops_execution_services.py::test_faq_markdown_can_be_hidden_while_deflection_report_runs -q` - 3 passed, 1 warning.
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py tests/test_extracted_content_ops_live_execute_harness.py tests/test_atlas_content_ops_execution_services.py tests/test_atlas_content_ops_generated_assets_api.py -q` - 187 passed, 1 skipped, 1 warning.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2776 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-paid-gate.md` - passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Paid-Gate.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Paid-Gate.md` - passed.
- `git diff --check` - passed.

## Diff size
12 files, +1230 / -33
