### PR TITLE
Add Content Ops Zendesk credential UI

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -14,6 +14,7 @@
     "test:content-ops-cache-policy-ui": "node --test scripts/content-ops-cache-policy-ui.test.mjs",
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
+    "test:content-ops-zendesk-credentials": "node --test scripts/content-ops-zendesk-credentials-ui.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-zendesk-credentials-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-zendesk-credentials-ui.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fetchContentOpsZendeskCredentials,
+  saveContentOpsZendeskCredential,
+  revokeContentOpsZendeskCredential,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    const body = status === 204 ? null : JSON.stringify(payload)
+    return new Response(body, {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('credential list calls tenant Zendesk credential route', async () => {
+  const payload = [{
+    id: 'credential-1',
+    account_id: 'account-1',
+    email: 'agent@example.com',
+    api_token_prefix: 'tok',
+    subdomain: 'acme',
+    base_url: '',
+    label: 'Primary',
+    added_at: '2026-05-29T12:00:00+00:00',
+    last_used_at: null,
+    revoked_at: null,
+  }]
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchContentOpsZendeskCredentials()
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/zendesk-credentials`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('credential save posts write-only token payload', async () => {
+  const payload = {
+    id: 'credential-1',
+    account_id: 'account-1',
+    email: 'agent@example.com',
+    api_token_prefix: 'tok',
+    subdomain: 'acme',
+    base_url: '',
+    label: 'Primary',
+    added_at: '2026-05-29T12:00:00+00:00',
+    last_used_at: null,
+    revoked_at: null,
+  }
+  const calls = installFetchResponder(payload, 201)
+
+  await saveContentOpsZendeskCredential({
+    email: 'agent@example.com',
+    api_token: 'secret-token',
+    subdomain: 'acme',
+    base_url: '',
+    label: 'Primary',
+  })
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/zendesk-credentials`,
+  )
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), {
+    email: 'agent@example.com',
+    api_token: 'secret-token',
+    subdomain: 'acme',
+    base_url: '',
+    label: 'Primary',
+  })
+})
+
+test('credential revoke deletes encoded credential id', async () => {
+  const calls = installFetchResponder('', 204)
+
+  await revokeContentOpsZendeskCredential('credential/id')
+
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-ops/zendesk-credentials/credential%2Fid`,
+  )
+  assert.equal(init.method, 'DELETE')
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('new run page renders Zendesk credential controls', () => {
+  assert.ok(newRunSource.includes('function ZendeskCredentialCard'))
+  assert.ok(newRunSource.includes('fetchContentOpsZendeskCredentials'))
+  assert.ok(newRunSource.includes('saveContentOpsZendeskCredential'))
+  assert.ok(newRunSource.includes('revokeContentOpsZendeskCredential'))
+  assert.ok(newRunSource.includes('Zendesk macro connection'))
+  assert.ok(newRunSource.includes('Save connection'))
+  assert.ok(newRunSource.includes('Token prefix'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -5,6 +5,9 @@
  * `/content-ops/*` and `/content-assets/*` routes the backend exposes:
  *
  *   GET  /content-ops/control-surfaces
+ *   GET  /content-ops/zendesk-credentials
+ *   POST /content-ops/zendesk-credentials
+ *   DELETE /content-ops/zendesk-credentials/{credential_id}
  *   POST /content-ops/preview
  *   POST /content-ops/plan
  *   POST /content-ops/ingestion/files/inspect
@@ -174,6 +177,29 @@ export interface ContentOpsUsageSummaryResponse {
   by_model: ContentOpsUsageSummaryBreakdownResponse[]
   by_asset_type: ContentOpsUsageSummaryBreakdownResponse[]
   by_cache_status?: ContentOpsUsageSummaryBreakdownResponse[]
+}
+
+// GET/POST/DELETE /content-ops/zendesk-credentials
+
+export interface ContentOpsZendeskCredential {
+  id: string
+  account_id: string
+  email: string
+  api_token_prefix: string
+  subdomain: string
+  base_url: string
+  label: string
+  added_at: string
+  last_used_at?: string | null
+  revoked_at?: string | null
+}
+
+export interface UpsertContentOpsZendeskCredentialRequest {
+  email: string
+  api_token: string
+  subdomain?: string
+  base_url?: string
+  label?: string
 }
 
 // POST /content-ops/preview, /plan, /execute share this body shape.
@@ -613,6 +639,20 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return rawJson<T>(res)
 }
 
+async function deleteJson(path: string): Promise<void> {
+  const url = `${BASE}${path}`
+  const doFetch = () =>
+    fetchWithApiFallback(url, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const text = await rawText(res)
+    throw new Error(`API ${res.status}: ${text || res.statusText}`)
+  }
+}
+
 async function postMultipart<T>(path: string, body: FormData): Promise<T> {
   const url = `${BASE}${path}`
   const doFetch = () =>
@@ -784,6 +824,25 @@ export function fetchContentOpsTenantUsageSummary(
     '/usage/summary/tenant',
     params,
   )
+}
+
+/** GET /content-ops/zendesk-credentials -- display-safe tenant credential list. */
+export function fetchContentOpsZendeskCredentials(): Promise<
+  ContentOpsZendeskCredential[]
+> {
+  return getJson<ContentOpsZendeskCredential[]>('/zendesk-credentials')
+}
+
+/** POST /content-ops/zendesk-credentials -- add or rotate tenant Zendesk credential. */
+export function saveContentOpsZendeskCredential(
+  body: UpsertContentOpsZendeskCredentialRequest,
+): Promise<ContentOpsZendeskCredential> {
+  return postJson<ContentOpsZendeskCredential>('/zendesk-credentials', body)
+}
+
+/** DELETE /content-ops/zendesk-credentials/{id} -- revoke tenant Zendesk credential. */
+export function revokeContentOpsZendeskCredential(id: string): Promise<void> {
+  return deleteJson(`/zendesk-credentials/${encodeURIComponent(id)}`)
 }
 
 /** GET /content-assets/{asset}/drafts -- persisted generated assets. */

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -2,15 +2,18 @@ import { useMemo, useRef, useState, type ChangeEvent } from 'react'
 import {
   ChevronRight,
   FileUp,
+  KeyRound,
   Loader2,
   Play,
   RefreshCw,
   Search,
+  Trash2,
   Upload,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import {
   executeContentOpsRun,
+  fetchContentOpsZendeskCredentials,
   fetchGeneratedAssetDrafts,
   fetchContentOpsControlSurfaces,
   fetchContentOpsTenantUsageSummary,
@@ -20,6 +23,8 @@ import {
   inspectContentOpsIngestionFile,
   planContentOpsRun,
   previewContentOpsRun,
+  revokeContentOpsZendeskCredential,
+  saveContentOpsZendeskCredential,
 } from '../api/contentOps'
 import {
   contentOpsIngestionFilePreflightError,
@@ -64,7 +69,10 @@ import {
   type GenerationPlanStep,
   type ContentOpsUsageBudgetEvaluation,
 } from '../domain/contentOps'
-import type { GeneratedAssetDraft } from '../api/contentOps'
+import type {
+  ContentOpsZendeskCredential,
+  GeneratedAssetDraft,
+} from '../api/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
 
@@ -112,6 +120,13 @@ type IngestionFileLoadState =
   | { kind: 'loading' }
   | { kind: 'error'; message: string }
   | { kind: 'success'; filename: string; size: number }
+
+type ZendeskCredentialMutationState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'revoking'; id: string }
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
 
 const DEFAULT_INPUTS_JSON = '{\n  \n}'
 const DEFAULT_INGESTION_ROWS_JSON = '[\n  \n]'
@@ -180,6 +195,13 @@ export default function ContentOpsNewRun() {
     () => fetchContentOpsTenantUsageSummary({ days: 7 }),
     [],
   )
+  const {
+    data: zendeskCredentials,
+    loading: zendeskCredentialsLoading,
+    error: zendeskCredentialsError,
+    refresh: refreshZendeskCredentials,
+    refreshing: zendeskCredentialsRefreshing,
+  } = useApiData(() => fetchContentOpsZendeskCredentials(), [])
   const {
     data: faqDrafts,
     loading: faqDraftsLoading,
@@ -874,6 +896,13 @@ export default function ContentOpsNewRun() {
         loading={usageLoading}
         error={usageError}
         summary={usageSummary}
+      />
+      <ZendeskCredentialCard
+        credentials={zendeskCredentials ?? []}
+        loading={zendeskCredentialsLoading}
+        refreshing={zendeskCredentialsRefreshing}
+        error={zendeskCredentialsError}
+        onRefresh={refreshZendeskCredentials}
       />
 
       <form onSubmit={handleSubmit} className="space-y-8">
@@ -1669,6 +1698,234 @@ function UsageSummaryCard({
   )
 }
 
+function ZendeskCredentialCard({
+  credentials,
+  loading,
+  refreshing,
+  error,
+  onRefresh,
+}: {
+  credentials: ContentOpsZendeskCredential[]
+  loading: boolean
+  refreshing: boolean
+  error: Error | null
+  onRefresh: () => void
+}) {
+  const [email, setEmail] = useState('')
+  const [apiToken, setApiToken] = useState('')
+  const [subdomain, setSubdomain] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
+  const [label, setLabel] = useState('')
+  const [mutationState, setMutationState] =
+    useState<ZendeskCredentialMutationState>({ kind: 'idle' })
+  const canSave = canSaveZendeskCredential(email, apiToken, subdomain, baseUrl)
+  const mutating =
+    mutationState.kind === 'saving' || mutationState.kind === 'revoking'
+
+  const handleSave = async () => {
+    if (!canSave || mutationState.kind === 'saving') return
+    setMutationState({ kind: 'saving' })
+    try {
+      await saveContentOpsZendeskCredential({
+        email: email.trim(),
+        api_token: apiToken,
+        subdomain: subdomain.trim(),
+        base_url: baseUrl.trim(),
+        label: label.trim(),
+      })
+      setApiToken('')
+      setMutationState({ kind: 'success', message: 'Zendesk credential saved.' })
+      onRefresh()
+    } catch (err) {
+      setMutationState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleRevoke = async (credential: ContentOpsZendeskCredential) => {
+    if (mutationState.kind === 'revoking') return
+    setMutationState({ kind: 'revoking', id: credential.id })
+    try {
+      await revokeContentOpsZendeskCredential(credential.id)
+      setMutationState({
+        kind: 'success',
+        message: 'Zendesk credential revoked.',
+      })
+      onRefresh()
+    } catch (err) {
+      setMutationState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-medium text-slate-100">
+            <KeyRound className="h-4 w-4 text-cyan-300" />
+            Zendesk macro connection
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Add or rotate the tenant Zendesk API token used when FAQ entries are
+            published as macros.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading || refreshing || mutating}
+          className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+        >
+          <RefreshCw className={clsx('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+          Refresh
+        </button>
+      </div>
+
+      {error && !loading && (
+        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          Zendesk credentials unavailable: {error.message}
+        </div>
+      )}
+      {mutationState.kind === 'error' && (
+        <div className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+          {mutationState.message}
+        </div>
+      )}
+      {mutationState.kind === 'success' && (
+        <div className="mb-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
+          {mutationState.message}
+        </div>
+      )}
+
+      <div className="mb-4 grid grid-cols-1 gap-2 lg:grid-cols-2">
+        {loading ? (
+          <div className="flex items-center gap-2 rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Loading Zendesk credentials...
+          </div>
+        ) : credentials.length === 0 ? (
+          <div className="rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-400">
+            No Zendesk credential saved for this tenant yet.
+          </div>
+        ) : (
+          credentials.map((credential) => (
+            <div
+              key={credential.id}
+              className="rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-slate-200">
+                    {credential.label || credential.email}
+                  </div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {credential.email} - {formatZendeskCredentialEndpoint(credential)}
+                  </div>
+                  <div className="mt-1 text-[11px] text-slate-600">
+                    Token prefix {credential.api_token_prefix || 'n/a'} - Added{' '}
+                    {formatCredentialDate(credential.added_at)}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(credential)}
+                  disabled={mutating}
+                  className="flex items-center gap-1 rounded-md border border-rose-500/30 px-2 py-1 text-[11px] text-rose-200 hover:bg-rose-500/10 disabled:opacity-50"
+                >
+                  {mutationState.kind === 'revoking' &&
+                  mutationState.id === credential.id ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-3 w-3" />
+                  )}
+                  Revoke
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
+        <label className="block text-sm lg:col-span-2">
+          <span className="text-slate-300">Zendesk email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none"
+            placeholder="agent@example.com"
+          />
+        </label>
+        <label className="block text-sm lg:col-span-2">
+          <span className="text-slate-300">API token</span>
+          <input
+            type="password"
+            value={apiToken}
+            onChange={(e) => setApiToken(e.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none"
+            placeholder="Paste token to add or rotate"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-slate-300">Label</span>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none"
+            placeholder="Primary"
+          />
+        </label>
+        <label className="block text-sm lg:col-span-2">
+          <span className="text-slate-300">Subdomain</span>
+          <input
+            type="text"
+            value={subdomain}
+            onChange={(e) => setSubdomain(e.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none"
+            placeholder="acme"
+          />
+        </label>
+        <label className="block text-sm lg:col-span-2">
+          <span className="text-slate-300">Base URL</span>
+          <input
+            type="url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-sm text-slate-200 placeholder:text-slate-600 focus:border-cyan-500 focus:outline-none"
+            placeholder="https://acme.zendesk.com"
+          />
+        </label>
+        <div className="flex items-end">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave || mutating}
+            className="flex w-full items-center justify-center gap-2 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-sm font-medium text-cyan-100 hover:bg-cyan-500/20 disabled:opacity-50"
+          >
+            {mutationState.kind === 'saving' ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <KeyRound className="h-4 w-4" />
+            )}
+            Save connection
+          </button>
+        </div>
+      </div>
+      <p className="mt-2 text-xs text-slate-500">
+        Use either a Zendesk subdomain or full base URL. The token is write-only
+        and is not shown after save.
+      </p>
+    </section>
+  )
+}
+
 function FaqSourceSelector({
   drafts,
   selectedIds,
@@ -2184,6 +2441,35 @@ function formatUsageDate(value: string | null): string {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return date.toLocaleString()
+}
+
+function formatCredentialDate(value: string | null | undefined): string {
+  if (!value) return 'unknown'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString()
+}
+
+function formatZendeskCredentialEndpoint(
+  credential: ContentOpsZendeskCredential,
+): string {
+  const baseUrl = credential.base_url.trim()
+  if (baseUrl) return baseUrl
+  const subdomain = credential.subdomain.trim()
+  return subdomain ? `${subdomain}.zendesk.com` : 'endpoint not set'
+}
+
+function canSaveZendeskCredential(
+  email: string,
+  apiToken: string,
+  subdomain: string,
+  baseUrl: string,
+): boolean {
+  return Boolean(
+    email.trim() &&
+      apiToken.trim() &&
+      (subdomain.trim() || baseUrl.trim()),
+  )
 }
 
 function formatDuration(value: number): string {

--- a/plans/PR-FAQ-Macro-Writeback-Credential-UI.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-UI.md
@@ -1,0 +1,89 @@
+# PR-FAQ-Macro-Writeback-Credential-UI
+
+## Why this slice exists
+
+PR-FAQ-Macro-Writeback-Credential-API added authenticated, tenant-scoped
+Zendesk credential routes, but operators still have no dashboard control to
+provision those credentials. Without a UI, FAQ macro writeback remains blocked
+on direct API calls or manual database work even though the backend path exists.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add typed Content Ops frontend wrappers for listing, adding/rotating, and
+   revoking Zendesk credentials through the host API.
+2. Add a compact credential management card to the Content Ops new-run page.
+3. Keep token handling write-only in the UI: users can enter a new token, but
+   the saved list only shows display-safe fields returned by the API.
+4. Add a focused Node test for the route wrappers and UI wiring.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Credential-UI.md` - plan for this slice.
+- `atlas-intel-ui/package.json` - focused credential UI test script.
+- `atlas-intel-ui/scripts/content-ops-zendesk-credentials-ui.test.mjs` - API wrapper and UI source contract tests.
+- `atlas-intel-ui/src/api/contentOps.ts` - Zendesk credential DTOs and route wrappers.
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx` - credential management card on the new-run page.
+
+## Mechanism
+
+The frontend API adapter keeps the backend contract in snake case and calls the
+routes added by PR-FAQ-Macro-Writeback-Credential-API:
+
+- `GET /content-ops/zendesk-credentials`
+- `POST /content-ops/zendesk-credentials`
+- `DELETE /content-ops/zendesk-credentials/{credential_id}`
+
+`ContentOpsNewRun` loads the display-safe credential list with `useApiData`,
+renders any active credentials, and provides fields for Zendesk email, API
+token, subdomain, base URL, and optional label. Save calls the add/rotate route,
+clears the plaintext token field after success, and refreshes the credential
+list. Revoke calls the delete route for the selected credential and refreshes
+the list. Backend authorization remains load-bearing: list is available to
+authenticated Content Ops users, while write/revoke failures surface as API
+errors in the card.
+
+## Intentional
+
+- This slice does not add macro publish controls. It only provisions the tenant
+  credential needed before publish can be productized.
+- This slice does not try to validate Zendesk credentials client-side. Backend
+  storage validation and future publish/reconcile failures remain the source of
+  truth.
+- This slice does not show the API token after save. The UI only displays the
+  token prefix returned by the API.
+- This slice does not add client-side role gating. The backend already enforces
+  owner/admin writes, and showing the server error keeps the frontend simple
+  until a shared role-capability surface exists.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Publish-UI`: review UI action that publishes selected
+  FAQ entries to Zendesk macros using the saved credential.
+- Future PR: client-side capability/role hints if the dashboard gets a shared
+  tenant-permission surface.
+
+Parked hardening: none
+
+## Verification
+
+- npm --prefix atlas-intel-ui run test:content-ops-zendesk-credentials - 4 passed.
+- npm --prefix atlas-intel-ui run build - passed.
+- npm --prefix atlas-intel-ui run lint - passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-credential-ui.md - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| API wrapper types/functions | ~60 |
+| New-run credential card | ~290 |
+| Focused test script/package hook | ~175 |
+| **Total** | **~615** |
+
+This is over the 400 LOC soft cap because the first usable credential UI needs
+typed wrappers, visible list/add/revoke controls, and a test that proves the
+frontend is wired to the backend routes from the prior slice.


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Credential-UI.md
Slice phase: Vertical slice

Adds the first dashboard surface for the Zendesk credential API from #1148: Content Ops users can list display-safe tenant credentials, save or rotate the write-only API token, and revoke a saved credential before macro publish UI lands.

## Intentional

- This slice does not add macro publish controls. It only provisions the tenant credential needed before publish can be productized.
- This slice does not validate Zendesk credentials client-side. Backend storage validation and future publish/reconcile failures remain the source of truth.
- This slice does not show the API token after save; saved rows show only display-safe API fields.
- This slice does not add client-side role gating. Backend owner/admin enforcement remains load-bearing for write/revoke authorization.

## Deferred

- PR-FAQ-Macro-Writeback-Publish-UI: review UI action that publishes selected FAQ entries to Zendesk macros using the saved credential.
- Future PR: client-side capability/role hints if the dashboard gets a shared tenant-permission surface.

## Parked hardening

None.

## Verification

- npm --prefix atlas-intel-ui run test:content-ops-zendesk-credentials - 4 passed.
- npm --prefix atlas-intel-ui run build - passed.
- npm --prefix atlas-intel-ui run lint - passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-credential-ui.md - passed.

## Diff size

~608 LOC across plan, frontend API wrappers, new-run credential card, package script, and focused Node test. Over the 400 LOC soft cap because the first usable credential UI needs typed wrappers, visible list/add/revoke controls, and a test that proves the frontend is wired to the backend routes from the prior slice.
