### PR TITLE
PR-FAQ-Macro-Writeback-Publish-UI

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -15,6 +15,7 @@
     "test:content-ops-usage-budget-ui": "node --test scripts/content-ops-usage-budget-ui.test.mjs",
     "test:content-ops-usage-summary": "node --test scripts/content-ops-usage-summary.test.mjs",
     "test:content-ops-zendesk-credentials": "node --test scripts/content-ops-zendesk-credentials-ui.test.mjs",
+    "test:content-ops-faq-macro-publish": "node --test scripts/content-ops-faq-macro-publish-ui.test.mjs",
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  publishGeneratedFaqMacros,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('FAQ macro publish posts to encoded generated asset route', async () => {
+  const payload = {
+    account_id: 'account-1',
+    asset: 'faq_markdown',
+    faq_id: 'draft/id',
+    found: true,
+    ok: true,
+    draft_status: 'published',
+    publishable_count: 2,
+    skipped_count: 0,
+    published_count: 1,
+    updated_count: 1,
+    failed_count: 0,
+    pending_reconcile_count: 0,
+    draft_status_updated: true,
+    skipped: [],
+    results: [],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await publishGeneratedFaqMacros('draft/id')
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/faq_markdown/drafts/draft%2Fid/publish-macros`,
+  )
+  assert.equal(init.method, 'POST')
+  assert.deepEqual(init.headers, {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  })
+  assert.deepEqual(JSON.parse(init.body), {})
+})
+
+test('Generated Asset Review wires FAQ macro publish action and summary state', () => {
+  assert.ok(reviewSource.includes('publishGeneratedFaqMacros'))
+  assert.ok(reviewSource.includes('handlePublishFaqMacros'))
+  assert.ok(reviewSource.includes("asset === 'faq_markdown'"))
+  assert.ok(reviewSource.includes("status === 'approved'"))
+  assert.ok(reviewSource.includes('Publish macros'))
+  assert.ok(reviewSource.includes('MacroPublishResultBanner'))
+  assert.ok(reviewSource.includes('pending_reconcile_count'))
+  assert.ok(reviewSource.includes('draft_status_updated'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -19,6 +19,7 @@
  *   GET  /content-assets/{asset}/drafts/export
  *   PATCH /content-assets/landing_page/drafts/{id}
  *   POST /content-assets/landing_page/drafts/{id}/repair
+ *   POST /content-assets/faq_markdown/drafts/{id}/publish-macros
  *   POST /content-assets/{asset}/drafts/review
  *   POST /content-assets/{asset}/drafts/review-batch
  *
@@ -560,6 +561,37 @@ export interface GeneratedLandingPageDraftUpdate {
   reference_ids?: string[]
 }
 
+export interface GeneratedAssetMacroPublishSkippedItem {
+  question?: string
+  reason?: string
+  [key: string]: unknown
+}
+
+export interface GeneratedAssetMacroPublishResult {
+  status?: string
+  external_id?: string | null
+  error?: string | null
+  [key: string]: unknown
+}
+
+export interface GeneratedAssetMacroPublishSummary {
+  account_id?: string | null
+  asset: GeneratedAssetType
+  faq_id: string
+  found: boolean
+  ok: boolean
+  draft_status: string
+  publishable_count: number
+  skipped_count: number
+  published_count: number
+  updated_count: number
+  failed_count: number
+  pending_reconcile_count: number
+  draft_status_updated: boolean
+  skipped: GeneratedAssetMacroPublishSkippedItem[]
+  results: GeneratedAssetMacroPublishResult[]
+}
+
 // ---------------------------------------------------------------------------
 // Internal fetch plumbing
 // ---------------------------------------------------------------------------
@@ -915,6 +947,17 @@ export function repairGeneratedLandingPageDraft(
     }
     return rawJson<GeneratedAssetDraft>(res)
   })
+}
+
+/** POST /content-assets/faq_markdown/drafts/{id}/publish-macros -- publish approved FAQ macros. */
+export function publishGeneratedFaqMacros(
+  id: string,
+): Promise<GeneratedAssetMacroPublishSummary> {
+  return postAssetJson<GeneratedAssetMacroPublishSummary>(
+    'faq_markdown',
+    `/drafts/${encodeURIComponent(id)}/publish-macros`,
+    {},
+  )
 }
 
 async function repairErrorMessage(res: Response): Promise<string> {

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -20,6 +20,7 @@ import {
   Pencil,
   RefreshCw,
   Save,
+  UploadCloud,
   Wrench,
   X,
   XCircle,
@@ -28,12 +29,14 @@ import { clsx } from 'clsx'
 import {
   exportGeneratedAssetDraftsCsv,
   fetchGeneratedAssetDrafts,
+  publishGeneratedFaqMacros,
   repairGeneratedLandingPageDraft,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
   updateGeneratedLandingPageDraft,
   type GeneratedAssetDraft,
   type GeneratedLandingPageDraftUpdate,
+  type GeneratedAssetMacroPublishSummary,
   type GeneratedAssetListResponse,
   type GeneratedAssetType,
 } from '../api/contentOps'
@@ -121,6 +124,11 @@ type LandingPageEditState = {
   sections: LandingPageSectionEdit[]
 }
 
+type MacroPublishOutcome =
+  | { kind: 'idle' }
+  | { kind: 'success'; draftId: string; summary: GeneratedAssetMacroPublishSummary }
+  | { kind: 'error'; draftId: string; message: string }
+
 const ASSETS: Array<{
   id: GeneratedAssetType
   label: string
@@ -173,6 +181,8 @@ export default function ContentOpsAssetsReview() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
   const [exporting, setExporting] = useState(false)
   const [detailRow, setDetailRow] = useState<GeneratedAssetDraft | null>(null)
+  const [macroPublishOutcome, setMacroPublishOutcome] =
+    useState<MacroPublishOutcome>({ kind: 'idle' })
 
   const params = useMemo(
     () => ({
@@ -304,6 +314,27 @@ export default function ContentOpsAssetsReview() {
       const message = err instanceof Error ? err.message : String(err)
       setActionError(message)
       throw err
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const handlePublishFaqMacros = async (row: GeneratedAssetDraft) => {
+    const id = assetId(row)
+    if (!id) return
+    setBusyId(id)
+    setActionError(null)
+    setMacroPublishOutcome({ kind: 'idle' })
+    try {
+      const summary = await publishGeneratedFaqMacros(id)
+      setMacroPublishOutcome({ kind: 'success', draftId: id, summary })
+      await load(true)
+    } catch (err) {
+      setMacroPublishOutcome({
+        kind: 'error',
+        draftId: id,
+        message: err instanceof Error ? err.message : String(err),
+      })
     } finally {
       setBusyId(null)
     }
@@ -473,6 +504,7 @@ export default function ContentOpsAssetsReview() {
             {actionError}
           </div>
         )}
+        <MacroPublishResultBanner outcome={macroPublishOutcome} />
         {error && data && (
           <div className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
             Refresh failed: {error.message}
@@ -500,6 +532,7 @@ export default function ContentOpsAssetsReview() {
                   selected={selectedIds.has(assetId(row))}
                   onToggle={toggleRow}
                   onReview={handleReview}
+                  onPublishFaqMacros={handlePublishFaqMacros}
                   onOpenDetails={setDetailRow}
                 />
               ))}
@@ -529,6 +562,7 @@ function AssetRow({
   selected,
   onToggle,
   onReview,
+  onPublishFaqMacros,
   onOpenDetails,
 }: {
   row: GeneratedAssetDraft
@@ -537,6 +571,7 @@ function AssetRow({
   selected: boolean
   onToggle: (id: string) => void
   onReview: (row: GeneratedAssetDraft, status: 'approved' | 'rejected') => void
+  onPublishFaqMacros: (row: GeneratedAssetDraft) => void
   onOpenDetails: (row: GeneratedAssetDraft) => void
 }) {
   const id = assetId(row)
@@ -548,6 +583,7 @@ function AssetRow({
   const facts = assetFacts(row, asset)
   const repairHistory = assetRepairHistory(row)
   const repairSummary = repairHistorySummary(repairHistory)
+  const canPublishFaqMacros = asset === 'faq_markdown' && canReview && status === 'approved'
 
   return (
     <article className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
@@ -669,10 +705,93 @@ function AssetRow({
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <XCircle className="h-4 w-4" />}
             Reject
           </button>
+          {asset === 'faq_markdown' && (
+            <button
+              type="button"
+              onClick={() => onPublishFaqMacros(row)}
+              disabled={!canPublishFaqMacros || busy}
+              title={
+                canPublishFaqMacros
+                  ? 'Publish approved FAQ macros'
+                  : 'Approve this FAQ draft before publishing macros'
+              }
+              className="inline-flex items-center gap-2 rounded-md border border-cyan-500/40 px-3 py-2 text-sm text-cyan-200 hover:bg-cyan-500/10 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <UploadCloud className="h-4 w-4" />
+              )}
+              Publish macros
+            </button>
+          )}
         </div>
       </div>
     </article>
   )
+}
+
+function MacroPublishResultBanner({ outcome }: { outcome: MacroPublishOutcome }) {
+  if (outcome.kind === 'idle') return null
+  if (outcome.kind === 'error') {
+    return (
+      <div className="mt-4 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+        Macro publish failed for {outcome.draftId}: {outcome.message}
+      </div>
+    )
+  }
+
+  const { summary } = outcome
+  const hasPending = summary.pending_reconcile_count > 0
+  const hasFailures = summary.failed_count > 0
+  const hasSkipped = summary.skipped_count > 0
+  const tone = summary.ok
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100'
+    : hasPending || hasSkipped
+      ? 'border-amber-500/30 bg-amber-500/10 text-amber-100'
+      : 'border-rose-500/30 bg-rose-500/10 text-rose-100'
+  const title = summary.ok
+    ? 'FAQ macros published.'
+    : hasPending
+      ? 'FAQ macro publish needs reconciliation.'
+      : hasFailures
+        ? 'FAQ macro publish has failures.'
+        : 'FAQ macro publish needs review.'
+  const counts = macroPublishCountLabels(summary)
+
+  return (
+    <div className={clsx('mt-4 rounded-md border px-3 py-2 text-sm', tone)}>
+      <div className="font-medium">{title}</div>
+      <div className="mt-1 text-xs opacity-90">
+        Draft {outcome.draftId}
+        {summary.draft_status_updated ? ' moved to published.' : ' kept its current review status.'}
+      </div>
+      {counts.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          {counts.map((count) => (
+            <span
+              key={count}
+              className="rounded border border-current/20 bg-slate-950/30 px-2 py-0.5"
+            >
+              {count}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function macroPublishCountLabels(summary: GeneratedAssetMacroPublishSummary): string[] {
+  return [
+    { count: summary.published_count, label: 'published' },
+    { count: summary.updated_count, label: 'updated' },
+    { count: summary.skipped_count, label: 'skipped' },
+    { count: summary.failed_count, label: 'failed' },
+    { count: summary.pending_reconcile_count, label: 'pending reconcile' },
+  ]
+    .filter(({ count }) => count > 0)
+    .map(({ count, label }) => `${count} ${label}`)
 }
 
 function AssetDetailDrawer({

--- a/plans/PR-FAQ-Macro-Writeback-Publish-UI.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-UI.md
@@ -1,0 +1,85 @@
+# PR-FAQ-Macro-Writeback-Publish-UI
+
+## Why this slice exists
+
+The FAQ macro writeback lane now has tenant credentials, a publish service, and
+a scoped backend route:
+`POST /content-assets/faq_markdown/drafts/{draft_id}/publish-macros`. Operators
+can approve generated FAQ Markdown drafts in the review queue, but they still
+cannot trigger the Zendesk macro publish flow from the product UI. This slice
+adds the thinnest UI path from an approved FAQ draft to the existing publish
+route and surfaces the route summary without changing the backend contract.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add a typed frontend API wrapper for the FAQ macro publish route.
+2. Add a FAQ-only publish action to Generated Asset Review rows.
+3. Gate the button to approved FAQ drafts with a clear disabled hint for other
+   FAQ statuses.
+4. Surface success, skipped, failed, and pending-reconcile summary counts inline
+   after the publish call and refresh the review list so a clean publish can
+   show the updated draft status.
+5. Add a focused Node test for the wrapper route and source-level UI wiring.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-UI.md` -- plan for this slice.
+- `atlas-intel-ui/package.json` -- adds the focused test script.
+- `atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs` -- API wrapper and UI wiring checks.
+- `atlas-intel-ui/src/api/contentOps.ts` -- typed publish summary and wrapper.
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` -- FAQ row publish action and summary rendering.
+
+## Mechanism
+
+The frontend API adapter adds `publishGeneratedFaqMacros(id)`, which posts an
+empty JSON body to
+`/api/v1/content-assets/faq_markdown/drafts/{id}/publish-macros` using the same
+auth, fallback, and refresh plumbing as generated asset review actions.
+
+`ContentOpsAssetsReview` keeps one publish result state keyed by draft id. FAQ
+rows render a `Publish macros` button only on the FAQ Markdown tab. The button
+is enabled for approved drafts with an id, disabled for drafts that still need
+approval, and shows the existing busy spinner while the publish route is in
+flight. The returned summary is rendered inline as a compact outcome banner so
+operators can see whether macros published, updated, skipped, failed, or need
+pending reconciliation.
+
+## Intentional
+
+- No backend changes in this slice. The route already exists and owns tenant
+  scope, approval gating, provider wiring, and publish semantics.
+- No live Zendesk preview or credential picker in the review row. Credential
+  management landed separately; the publish route uses the tenant/provider
+  selected by backend wiring.
+- No broad drawer redesign. This is the narrow product trigger, not a full macro
+  operations console.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: add the backend reconcile command
+  for pending Zendesk mapping recovery.
+- `PR-FAQ-Macro-Writeback-Publish-History`: persist and display prior publish
+  attempts beyond the latest route response if operators need an audit trail.
+
+Parked hardening: none
+
+## Verification
+
+- npm --prefix atlas-intel-ui run test:content-ops-faq-macro-publish -- 2 passed.
+- npm --prefix atlas-intel-ui run build -- passed.
+- npm --prefix atlas-intel-ui run lint -- passed.
+- git diff --check -- passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-ui.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~82 |
+| API wrapper | ~43 |
+| Review UI | ~119 |
+| Focused test | ~121 |
+| Total | ~366 |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-UI.md
Slice phase: Vertical slice

This adds the thinnest product UI path from an approved FAQ Markdown draft to the existing FAQ macro publish route, so operators can publish generated FAQ items as Zendesk macros from Generated Asset Review and see the route summary without backend changes.

## Intentional
- Reuse the existing backend publish route instead of changing the backend contract.
- Gate the UI action to approved FAQ Markdown drafts and surface non-clean route summaries.
- Keep this out of the drawer redesign path; this is the narrow publish trigger.

## Deferred
- `PR-FAQ-Macro-Writeback-Pending-Reconcile`: add the backend reconcile command for pending Zendesk mapping recovery.
- `PR-FAQ-Macro-Writeback-Publish-History`: persist and display prior publish attempts beyond the latest route response if operators need an audit trail.

## Parked hardening
- None.

## Verification
- npm --prefix atlas-intel-ui run test:content-ops-faq-macro-publish -- 2 passed.
- npm --prefix atlas-intel-ui run build -- passed.
- npm --prefix atlas-intel-ui run lint -- passed.
- git diff --check -- passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-ui.md -- passed.

## Diff size
5 files, +369 / -0
