### PR TITLE
PR-FAQ-Macro-Writeback-Functional-Validation

### DIFF
--- a/plans/PR-FAQ-Macro-Writeback-Functional-Validation.md
+++ b/plans/PR-FAQ-Macro-Writeback-Functional-Validation.md
@@ -1,0 +1,86 @@
+# PR-FAQ-Macro-Writeback-Functional-Validation
+
+## Why this slice exists
+
+The FAQ macro writeback operator path is now reachable end to end from the
+dashboard: tenant credentials can be provisioned, approved FAQ Markdown drafts
+can be reviewed, and the review UI can call the hosted publish route. The lane
+has good unit coverage at each layer, but it still needs one focused functional
+validation that proves the core publish chain works as a chain: approved FAQ
+draft -> publish service -> tenant credential lookup -> Zendesk provider ->
+idempotency mapping -> Zendesk transport -> draft status update.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Functional validation
+
+1. Add a focused no-network functional test for the FAQ macro writeback publish
+   chain.
+2. Validate tenant-scoped credentials are used instead of config fallback when
+   the request has an account id.
+3. Validate the first publish creates one Zendesk macro and marks the FAQ draft
+   published.
+4. Validate a second publish reuses the saved mapping and updates the existing
+   macro instead of creating a duplicate.
+5. Enroll the new validation test in the extracted pipeline check runner.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Functional-Validation.md` -- plan for this slice.
+- `scripts/run_extracted_pipeline_checks.sh` -- CI enrollment for the validation test.
+- `tests/test_content_ops_faq_macro_writeback_flow.py` -- functional publish-chain validation.
+
+## Mechanism
+
+The new test builds the real `FAQMacroWritebackPublishService` with the real
+`ZendeskMacroPublishProvider` and `TenantZendeskMacroCredentialsProvider`.
+Only the outer dependencies are faked:
+
+1. A fake FAQ repository returns one approved, resolution-backed FAQ draft and
+   records status updates.
+2. A fake tenant credential lookup returns a Zendesk credential only for the
+   expected tenant account.
+3. An in-memory mapping repository records idempotency reservations and upserts.
+4. A fake Zendesk transport records POST/PUT calls and returns realistic macro
+   response envelopes.
+
+The first service call must POST one macro, persist the mapping, and mark the
+FAQ draft published. The second service call over the same mapping repository
+must PUT the existing macro id and avoid a second POST.
+
+## Intentional
+
+- No live Zendesk or database access. This is functional validation of our
+  integration contracts, not an external smoke test.
+- No UI/browser automation in this slice. PR #1152 already pinned the UI route
+  wrapper; this slice validates the publish chain behind that route.
+- No product behavior changes. If this test fails, the source chain is broken
+  and should be fixed in the failing layer.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Live-Smoke`: optional operator-only smoke against a
+  sandbox Zendesk account once live credentials and safe test data are available.
+- `PR-FAQ-Macro-Writeback-Publish-History`: persist prior publish attempts if
+  operators need an audit trail beyond the latest publish response.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_content_ops_faq_macro_writeback_flow.py -q -- 1 passed.
+- python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_content_ops_faq_macro_writeback_flow.py -q -- 15 passed.
+- python -m py_compile tests/test_content_ops_faq_macro_writeback_flow.py -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed; 135 matching tests enrolled.
+- git diff --check -- passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-functional-validation.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~82 |
+| Test | ~265 |
+| CI enrollment | ~1 |
+| Total | ~349 |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -87,6 +87,7 @@ pytest \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \
   tests/test_atlas_content_ops_macro_writeback.py \
+  tests/test_content_ops_faq_macro_writeback_flow.py \
   tests/test_content_ops_zendesk_credentials.py \
   tests/test_content_ops_zendesk_credentials_api.py \
   tests/test_atlas_content_ops_reasoning.py \

--- a/tests/test_content_ops_faq_macro_writeback_flow.py
+++ b/tests/test_content_ops_faq_macro_writeback_flow.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from atlas_brain._content_ops_macro_writeback import (
+    ConfigZendeskMacroCredentialsProvider,
+    TenantZendeskMacroCredentialsProvider,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    MacroWritebackMapping,
+)
+from extracted_content_pipeline.faq_macro_writeback_publish import (
+    FAQMacroWritebackPublishService,
+)
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZENDESK_PLATFORM,
+    ZendeskMacroCredentials,
+    ZendeskMacroPublishProvider,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+@dataclass(frozen=True)
+class _Config:
+    content_ops_zendesk_email: str = ""
+    content_ops_zendesk_api_token: str = ""
+    content_ops_zendesk_subdomain: str = ""
+    content_ops_zendesk_base_url: str = ""
+
+
+class _Pool:
+    pass
+
+
+class _FAQRepo:
+    def __init__(self, draft: TicketFAQDraft) -> None:
+        self.draft = draft
+        self.get_calls: list[dict[str, object]] = []
+        self.update_calls: list[dict[str, object]] = []
+
+    async def get_draft(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+    ) -> TicketFAQDraft | None:
+        self.get_calls.append({"faq_id": faq_id, "scope": scope})
+        return self.draft
+
+    async def update_status(
+        self,
+        faq_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        self.update_calls.append({
+            "faq_id": faq_id,
+            "status": status,
+            "scope": scope,
+        })
+        return True
+
+
+class _MappingRepo:
+    def __init__(self) -> None:
+        self.mappings: dict[tuple[str, str], MacroWritebackMapping] = {}
+        self.get_calls: list[dict[str, object]] = []
+        self.reserve_calls: list[dict[str, object]] = []
+        self.upsert_calls: list[dict[str, object]] = []
+
+    async def get_mapping(
+        self,
+        *,
+        platform: str,
+        faq_draft_id: str,
+        faq_item_id: str,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping | None:
+        self.get_calls.append({
+            "platform": platform,
+            "faq_draft_id": faq_draft_id,
+            "faq_item_id": faq_item_id,
+            "scope": scope,
+        })
+        return self.mappings.get((faq_draft_id, faq_item_id))
+
+    async def reserve_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        self.reserve_calls.append({"mapping": mapping, "scope": scope})
+        key = (mapping.faq_draft_id, mapping.faq_item_id)
+        existing = self.mappings.get(key)
+        if existing is not None:
+            return existing
+        self.mappings[key] = mapping
+        return mapping
+
+    async def upsert_mapping(
+        self,
+        mapping: MacroWritebackMapping,
+        *,
+        scope: TenantScope,
+    ) -> MacroWritebackMapping:
+        self.upsert_calls.append({"mapping": mapping, "scope": scope})
+        self.mappings[(mapping.faq_draft_id, mapping.faq_item_id)] = mapping
+        return mapping
+
+    async def list_pending_mappings(
+        self,
+        *,
+        platform: str,
+        scope: TenantScope,
+        limit: int,
+    ) -> Sequence[MacroWritebackMapping]:
+        del platform, scope, limit
+        return ()
+
+
+class _ZendeskTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers),
+            "json": dict(json),
+        })
+        if method == "POST":
+            return {
+                "macro": {
+                    "id": "macro-1",
+                    "url": "https://acme.zendesk.com/api/v2/macros/macro-1",
+                }
+            }
+        if method == "PUT":
+            return {
+                "macro": {
+                    "id": url.rsplit("/", 1)[-1],
+                    "url": url,
+                }
+            }
+        raise AssertionError(f"unexpected Zendesk method: {method}")
+
+
+@pytest.mark.asyncio
+async def test_faq_macro_writeback_publish_flow_uses_tenant_credentials_and_idempotency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain import _content_ops_zendesk_credentials
+
+    scope = TenantScope(
+        account_id="11111111-1111-1111-1111-111111111111",
+        user_id="user-1",
+    )
+    credentials = ZendeskMacroCredentials(
+        email="agent@example.com",
+        api_token="tenant-token",
+        subdomain="acme",
+    )
+    lookup_calls: list[dict[str, object]] = []
+
+    async def lookup(pool: object, *, account_id: str) -> ZendeskMacroCredentials | None:
+        lookup_calls.append({"pool": pool, "account_id": account_id})
+        return credentials if account_id == scope.account_id else None
+
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    pool = _Pool()
+    mapping_repo = _MappingRepo()
+    transport = _ZendeskTransport()
+    faq_repo = _FAQRepo(_approved_faq_draft())
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=TenantZendeskMacroCredentialsProvider(
+            pool=pool,
+            fallback_provider=ConfigZendeskMacroCredentialsProvider(_Config()),
+        ),
+        mapping_repository=mapping_repo,
+        transport=transport,
+    )
+    service = FAQMacroWritebackPublishService(
+        faq_repository=faq_repo,
+        provider=provider,
+    )
+
+    first = await service.publish_faq_draft("faq-draft-1", scope=scope)
+    second = await service.publish_faq_draft("faq-draft-1", scope=scope)
+
+    assert first.ok is True
+    assert first.published_count == 1
+    assert first.updated_count == 0
+    assert first.draft_status_updated is True
+    assert second.ok is True
+    assert second.published_count == 0
+    assert second.updated_count == 1
+    assert second.draft_status_updated is True
+    assert [call["method"] for call in transport.calls] == ["POST", "PUT"]
+    assert transport.calls[0]["url"] == "https://acme.zendesk.com/api/v2/macros"
+    assert transport.calls[1]["url"] == "https://acme.zendesk.com/api/v2/macros/macro-1"
+    assert transport.calls[0]["json"] == {
+        "macro": {
+            "title": "Why was I charged twice?",
+            "active": True,
+            "description": "FAQ macro generated from billing support tickets.",
+            "actions": [
+                {
+                    "field": "comment_value",
+                    "value": "Open Billing and compare settled charges.",
+                },
+                {"field": "comment_mode_is_public", "value": True},
+            ],
+        }
+    }
+    assert transport.calls[0]["headers"]["Authorization"] == credentials.authorization_header()
+    assert lookup_calls == [
+        {"pool": pool, "account_id": scope.account_id},
+        {"pool": pool, "account_id": scope.account_id},
+    ]
+    assert faq_repo.update_calls == [
+        {"faq_id": "faq-draft-1", "status": "published", "scope": scope},
+        {"faq_id": "faq-draft-1", "status": "published", "scope": scope},
+    ]
+    assert mapping_repo.reserve_calls[0]["scope"] == scope
+    assert mapping_repo.upsert_calls[0]["scope"] == scope
+    saved_mapping = mapping_repo.mappings[("faq-draft-1", "faq-item-1")]
+    assert saved_mapping.platform == ZENDESK_PLATFORM
+    assert saved_mapping.external_id == "macro-1"
+    assert saved_mapping.metadata["title"] == "Why was I charged twice?"
+
+
+def _approved_faq_draft() -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id="faq-draft-1",
+        target_id="ticket-faq-report",
+        target_mode="support_ticket_faq",
+        title="Saved FAQ report",
+        markdown="# Saved FAQ report",
+        items=(
+            {
+                "faq_item_id": "faq-item-1",
+                "topic": "billing",
+                "question": "Why was I charged twice?",
+                "resolution_text": "Open Billing and compare settled charges.",
+                "answer_evidence_status": "resolution_evidence",
+            },
+        ),
+        source_count=1,
+        ticket_source_count=1,
+        status="approved",
+    )


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Functional-Validation.md
Slice phase: Functional validation

This adds a focused no-network functional validation for the FAQ macro writeback publish chain: approved FAQ draft through the real publish service, tenant credential provider, Zendesk provider, idempotency mapping, fake Zendesk transport, and draft status update.

## Intentional
- Use fake database and Zendesk boundaries while exercising the real publish service and provider chain.
- Validate retry idempotency by proving the second publish updates the existing macro id instead of POSTing another macro.
- Avoid live Zendesk/database smoke testing until safe sandbox credentials and test data are available.

## Deferred
- `PR-FAQ-Macro-Writeback-Live-Smoke`: optional operator-only smoke against a sandbox Zendesk account once live credentials and safe test data are available.
- `PR-FAQ-Macro-Writeback-Publish-History`: persist prior publish attempts if operators need an audit trail beyond the latest publish response.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_content_ops_faq_macro_writeback_flow.py -q -- 1 passed.
- python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_zendesk_credentials.py tests/test_content_ops_faq_macro_writeback_flow.py -q -- 15 passed.
- python -m py_compile tests/test_content_ops_faq_macro_writeback_flow.py -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed; 135 matching tests enrolled.
- git diff --check -- passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-functional-validation.md -- passed.

## Diff size
3 files, +352 / -0
