### PR TITLE
PR-FAQ-Deflection-Stripe-Paid

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -1,0 +1,41 @@
+name: Atlas Content Ops Deflection Stripe Paid Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/api/billing.py"
+      - "atlas_brain/config.py"
+      - "extracted_content_pipeline/deflection_report_access.py"
+      - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/api/billing.py"
+      - "atlas_brain/config.py"
+      - "extracted_content_pipeline/deflection_report_access.py"
+      - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
+
+jobs:
+  atlas-content-ops-deflection-stripe-paid-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops deflection Stripe paid tests
+        run: python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -2,6 +2,8 @@
 
 import logging
 import uuid as _uuid
+from collections.abc import Mapping
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -9,6 +11,9 @@ from pydantic import BaseModel
 from ..auth.dependencies import AuthUser, require_auth
 from ..config import settings
 from ..storage.database import get_db_pool
+from extracted_content_pipeline.deflection_report_access import (
+    PostgresDeflectionReportArtifactStore,
+)
 
 logger = logging.getLogger("atlas.api.billing")
 
@@ -306,6 +311,12 @@ async def stripe_webhook(request: Request):
         meta = obj.metadata or {}
         if meta.get("source") == "vendor_briefing_report":
             await _handle_vendor_checkout_completed(pool, obj, meta)
+        elif meta.get("source") == "content_ops_deflection_report":
+            await _handle_content_ops_deflection_report_checkout_completed(
+                pool,
+                obj,
+                meta,
+            )
         else:
             account_id = await _handle_checkout_completed(pool, obj)
 
@@ -477,6 +488,108 @@ async def _handle_vendor_checkout_completed(pool, session, meta: dict) -> None:
         )
     except Exception:
         logger.exception("Failed to send vendor checkout confirmation email")
+
+
+async def _handle_content_ops_deflection_report_checkout_completed(
+    pool: Any,
+    session: Any,
+    meta: Mapping[str, Any],
+) -> None:
+    """Handle one-time deflection report checkout completion."""
+
+    session_id = _stripe_text(session, "id")
+    account_id_text = _clean_metadata(meta.get("account_id"))
+    request_id = _clean_metadata(meta.get("request_id"))
+    if _stripe_text(session, "mode") != "payment":
+        logger.warning(
+            "Deflection report checkout ignored: non-payment mode session=%s",
+            session_id,
+        )
+        return
+    if _stripe_text(session, "payment_status") != "paid":
+        logger.warning(
+            "Deflection report checkout ignored: unpaid session=%s",
+            session_id,
+        )
+        return
+    if not account_id_text or not request_id:
+        logger.warning(
+            "Deflection report checkout ignored: missing account_id/request_id session=%s",
+            session_id,
+        )
+        return
+    try:
+        _uuid.UUID(account_id_text)
+    except ValueError:
+        logger.warning(
+            "Deflection report checkout ignored: invalid account_id session=%s",
+            session_id,
+        )
+        return
+    if not _deflection_checkout_amount_is_valid(session):
+        logger.warning(
+            "Deflection report checkout ignored: amount/currency mismatch session=%s",
+            session_id,
+        )
+        return
+
+    marked = await PostgresDeflectionReportArtifactStore(pool=pool).mark_paid(
+        account_id=account_id_text,
+        request_id=request_id,
+        payment_reference=session_id or None,
+    )
+    if not marked:
+        logger.error(
+            "Deflection report checkout completed but report was not found: account=%s request=%s session=%s",
+            account_id_text,
+            request_id,
+            session_id,
+        )
+        raise HTTPException(status_code=409, detail="Deflection report not found")
+    return
+
+
+def _deflection_checkout_amount_is_valid(session: Any) -> bool:
+    cfg = settings.saas_auth
+    expected_cents = int(
+        getattr(cfg, "stripe_content_ops_deflection_report_amount_cents", 150000)
+        or 0
+    )
+    expected_currency = str(
+        getattr(cfg, "stripe_content_ops_deflection_report_currency", "usd") or ""
+    ).strip().lower()
+    amount_total = _stripe_object_value(session, "amount_total")
+    currency = _stripe_text(session, "currency").lower()
+    if expected_cents <= 0:
+        logger.error(
+            "Deflection report checkout price gate misconfigured: expected_cents=%s",
+            expected_cents,
+        )
+        return False
+    if not expected_currency:
+        logger.error("Deflection report checkout currency gate is misconfigured")
+        return False
+    if currency != expected_currency:
+        return False
+    try:
+        actual_cents = int(amount_total)
+    except (TypeError, ValueError):
+        return False
+    return actual_cents >= expected_cents
+
+
+def _stripe_text(obj: Any, key: str) -> str:
+    return str(_stripe_object_value(obj, key) or "").strip()
+
+
+def _stripe_object_value(obj: Any, key: str) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _clean_metadata(value: Any) -> str:
+    return str(value or "").strip()
 
 
 async def _handle_invoice_paid(pool, invoice) -> _uuid.UUID | None:

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -91,6 +91,15 @@ class SaaSAuthConfig(BaseSettings):
     stripe_b2b_pro_price_id: str = Field(default="", description="Stripe Price ID for B2B Pro plan")
     stripe_vendor_standard_price_id: str = Field(default="", description="Stripe Price ID for Vendor Standard ($499/mo)")
     stripe_vendor_pro_price_id: str = Field(default="", description="Stripe Price ID for Vendor Pro ($1,499/mo)")
+    stripe_content_ops_deflection_report_amount_cents: int = Field(
+        default=150000,
+        ge=0,
+        description="Minimum Stripe Checkout amount for the one-time Content Ops FAQ deflection report",
+    )
+    stripe_content_ops_deflection_report_currency: str = Field(
+        default="usd",
+        description="Stripe Checkout currency for the one-time Content Ops FAQ deflection report",
+    )
 
     # LLM Gateway plan tiers (PR-D2). Stripe products are created
     # operationally; the price IDs land here when ready, _init_price_map()

--- a/plans/PR-FAQ-Deflection-Stripe-Paid.md
+++ b/plans/PR-FAQ-Deflection-Stripe-Paid.md
@@ -1,0 +1,146 @@
+# PR-FAQ-Deflection-Stripe-Paid
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Paid-Gate shipped the ATLAS-owned free snapshot and paid full
+artifact gate, but the paid flag still requires a privileged operator call. The
+portfolio results page can start Stripe Checkout, but ATLAS needs to consume the
+verified Stripe completion event and flip the paid flag itself so the full
+report release does not depend on a manual unlock.
+
+This slice builds the thinnest production payment seam: a verified
+`checkout.session.completed` webhook with deflection-report metadata marks the
+matching ATLAS report paid. It keeps checkout creation portfolio-owned and does
+not add UI, subscriptions, or new report persistence.
+
+Review found three payment-delivery gaps while the PR was open: the Atlas test
+was enrolled in the extracted standalone CI lane, the deflection account
+namespace could collide with the `billing_events.account_id` FK, and a valid
+payment with no matching report row could be acknowledged permanently. Those
+are part of this production seam, so this slice fixes them before merge.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+
+Slice phase: Production hardening
+
+1. Teach the existing Stripe webhook to recognize
+   `metadata.source=content_ops_deflection_report`.
+2. Require the signed Stripe session to include `account_id` and `request_id`
+   metadata and a completed one-time paid Checkout session.
+3. Validate the session amount/currency against the configured deflection
+   report one-time price.
+4. Mark the matching `content_ops_deflection_reports` row paid with the Stripe
+   checkout session id as the payment reference.
+5. Keep deflection Stripe events out of the `billing_events.account_id`
+   `saas_accounts` FK field because deflection report accounts are stored in a
+   separate text namespace.
+6. Fail closed when a valid paid session cannot find a report row, so Stripe
+   retries instead of permanently stranding a paid-but-locked report.
+7. Add focused tests proving the happy path and detector failure branches.
+8. Move the Atlas webhook test into its own path-scoped CI workflow instead of
+   the extracted standalone lane.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `atlas_brain/config.py` | Adds the configured one-time deflection report amount/currency used by the Stripe webhook guard. |
+| `atlas_brain/api/billing.py` | Adds deflection-report Stripe completion handling to the existing webhook path. |
+| `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` | Proves the webhook helper marks paid only for valid deflection report payment sessions. |
+| `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml` | Runs the Atlas webhook test in a full-dependency path-scoped CI lane. |
+| `plans/PR-FAQ-Deflection-Stripe-Paid.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+The existing `/webhooks/stripe` handler already verifies the Stripe signature,
+deduplicates events through `billing_events`, and branches on
+`checkout.session.completed`. This slice adds a deflection-report branch before
+the existing subscription checkout handler:
+
+```python
+if meta.get("source") == "content_ops_deflection_report":
+    account_id = await _handle_content_ops_deflection_report_checkout_completed(...)
+```
+
+The helper fail-closes unless the session is a completed one-time payment with:
+
+- `mode == "payment"`
+- `payment_status == "paid"`
+- `amount_total >= ATLAS_SAAS_STRIPE_CONTENT_OPS_DEFLECTION_REPORT_AMOUNT_CENTS`
+- `currency == ATLAS_SAAS_STRIPE_CONTENT_OPS_DEFLECTION_REPORT_CURRENCY`
+- non-empty `metadata.account_id`
+- non-empty `metadata.request_id`
+
+When valid, it updates `content_ops_deflection_reports` with
+`paid=true`, `paid_at`, and `payment_reference=session.id` for the exact
+`(account_id, request_id)` pair. Deflection events still write the existing
+`billing_events` idempotency/audit row, but with `account_id=NULL`; the
+deflection report account namespace is intentionally not asserted to be a
+`saas_accounts(id)` foreign key.
+
+If the signed paid session is valid but no report row matches, the helper logs
+an error and raises a non-2xx webhook response before the idempotency row is
+written. That keeps the report locked and lets Stripe retry/reconcile instead
+of acknowledging a paid event that did not unlock anything.
+
+## Intentional
+
+- No checkout creation endpoint lands here. The portfolio owns Stripe Checkout
+  initiation and must set the metadata above.
+- No subscription handling lands here. The $500/mo ongoing product remains a
+  later slice with a different lifecycle than the one-time $1,500 report.
+- Missing or invalid metadata does not 4xx the Stripe webhook after signature
+  verification; it logs and leaves the report locked because retrying bad
+  metadata will not make it valid.
+- A valid paid session with no matching report row does return non-2xx. That
+  is different from bad metadata: it can represent a report-save/checkout race,
+  and acknowledging it would strand a paid customer with a locked report.
+- Deflection checkout events log to `billing_events` with `account_id=NULL`.
+  The event id remains the idempotency key, while the paid report state remains
+  keyed by `content_ops_deflection_reports(account_id, request_id)`.
+
+## Deferred
+
+- Future slice: portfolio/checkout contract docs with the exact required Stripe
+  metadata and success/cancel URL expectations.
+- Future slice: subscription/writeback payment flow for the $500/mo ongoing
+  offer.
+- Parked hardening considered: prior `mark_paid` non-asyncpg command-tag NIT is
+  not required for this Stripe webhook slice because production uses asyncpg and
+  this slice tests the SQL call at the helper boundary.
+
+## Verification
+
+- Command: python -m py_compile atlas_brain/api/billing.py atlas_brain/config.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+  - Result: passed.
+- Command: pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_content_ops_deflection_report.py::test_postgres_deflection_report_store_round_trips_paid_gate -q
+  - Result: 16 passed, 1 warning.
+- Command: pytest tests/test_llm_gateway_plan_tier.py tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_deflection_paid_route_uses_operator_gate tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q
+  - Result: 34 passed, 1 warning.
+- Command: pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q
+  - Result: 15 passed, 1 warning.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Stripe-Paid.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Stripe-Paid.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-stripe-paid.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Config + billing webhook helper | 122 |
+| CI workflow | 41 |
+| Tests | 260 |
+| Plan doc | 146 |
+| **Total** | **569** |
+
+The slice exceeds the soft 400 LOC budget because the review fix has to move
+the Atlas webhook test into a dedicated workflow and add negative fixtures for
+each payment-failure branch. Splitting that would leave either red CI or an
+unguarded paid-unlock seam.

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import sys
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from atlas_brain.api import billing
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.is_initialized = True
+        self.fetchval_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.update_result = "UPDATE 1"
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, args))
+        return None
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.execute_calls.append((query, args))
+        if "UPDATE content_ops_deflection_reports" in query:
+            return self.update_result
+        return "INSERT 0 1"
+
+
+def _session(
+    *,
+    account_id: str | None = None,
+    request_id: str | None = "req-123",
+    session_id: str = "cs_test_deflection",
+    mode: str = "payment",
+    payment_status: str = "paid",
+    amount_total: int | str | None = 150000,
+    currency: str = "usd",
+) -> SimpleNamespace:
+    metadata = {"source": "content_ops_deflection_report"}
+    if account_id is not None:
+        metadata["account_id"] = account_id
+    if request_id is not None:
+        metadata["request_id"] = request_id
+    return SimpleNamespace(
+        id=session_id,
+        mode=mode,
+        payment_status=payment_status,
+        amount_total=amount_total,
+        currency=currency,
+        metadata=metadata,
+        to_dict=lambda: {
+            "id": session_id,
+            "mode": mode,
+            "payment_status": payment_status,
+            "amount_total": amount_total,
+            "currency": currency,
+            "metadata": dict(metadata),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_deflection_checkout_completion_marks_report_paid() -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    pool = _Pool()
+
+    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+        pool,
+        session,
+        session.metadata,
+    )
+
+    assert returned is None
+    assert len(pool.execute_calls) == 1
+    query, args = pool.execute_calls[0]
+    assert "UPDATE content_ops_deflection_reports" in query
+    assert args == (account_id, "req-123", "cs_test_deflection")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("mode", "subscription"),
+        ("payment_status", "unpaid"),
+        ("account_id", None),
+        ("account_id", "not-a-uuid"),
+        ("request_id", None),
+        ("amount_total", 149999),
+        ("amount_total", None),
+        ("currency", "eur"),
+    ],
+)
+async def test_deflection_checkout_completion_fails_closed_for_invalid_sessions(
+    field: str,
+    value: Any,
+) -> None:
+    kwargs = {"account_id": str(uuid.uuid4())}
+    kwargs[field] = value
+    session = _session(**kwargs)
+    pool = _Pool()
+
+    returned = await billing._handle_content_ops_deflection_report_checkout_completed(
+        pool,
+        session,
+        session.metadata,
+    )
+
+    assert returned is None
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deflection_checkout_completion_fails_closed_when_report_missing() -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    pool = _Pool()
+    pool.update_result = "UPDATE 0"
+
+    with pytest.raises(billing.HTTPException) as exc:
+        await billing._handle_content_ops_deflection_report_checkout_completed(
+            pool,
+            session,
+            session.metadata,
+        )
+
+    assert exc.value.status_code == 409
+    assert len(pool.execute_calls) == 1
+    query, args = pool.execute_calls[0]
+    assert "UPDATE content_ops_deflection_reports" in query
+    assert args == (account_id, "req-123", "cs_test_deflection")
+
+
+@pytest.mark.parametrize(
+    ("amount_cents", "currency"),
+    [
+        (0, "usd"),
+        (-1, "usd"),
+        (150000, ""),
+    ],
+)
+def test_deflection_checkout_amount_rejects_misconfigured_price_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    amount_cents: int,
+    currency: str,
+) -> None:
+    session = _session(account_id=str(uuid.uuid4()))
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_report_amount_cents",
+        amount_cents,
+    )
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_content_ops_deflection_report_currency",
+        currency,
+    )
+
+    assert billing._deflection_checkout_amount_is_valid(session) is False
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_routes_deflection_checkout_to_paid_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    event = SimpleNamespace(
+        id="evt_deflection_paid",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
+    pool = _Pool()
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    response = await billing.stripe_webhook(request)
+
+    assert response == {"status": "ok"}
+    assert fake_stripe.api_key == "sk_test"
+    assert pool.fetchval_calls[0][1] == ("evt_deflection_paid",)
+    update_query, update_args = pool.execute_calls[0]
+    insert_query, insert_args = pool.execute_calls[1]
+    assert "UPDATE content_ops_deflection_reports" in update_query
+    assert update_args == (account_id, "req-123", "cs_test_deflection")
+    assert "INSERT INTO billing_events" in insert_query
+    assert insert_args[0] is None
+    assert insert_args[1] == "evt_deflection_paid"
+    assert insert_args[2] == "checkout.session.completed"
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_does_not_log_processed_event_when_report_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    event = SimpleNamespace(
+        id="evt_deflection_missing_report",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
+    pool = _Pool()
+    pool.update_result = "UPDATE 0"
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    with pytest.raises(billing.HTTPException) as exc:
+        await billing.stripe_webhook(request)
+
+    assert exc.value.status_code == 409
+    assert len(pool.execute_calls) == 1
+    update_query, update_args = pool.execute_calls[0]
+    assert "UPDATE content_ops_deflection_reports" in update_query
+    assert update_args == (account_id, "req-123", "cs_test_deflection")


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Stripe-Paid.md
Slice phase: Production hardening

The paid-gated deflection report now needs the production payment seam. This slice teaches the existing verified Stripe webhook to recognize one-time deflection report Checkout completions, validate the required metadata and configured amount/currency, and mark the matching ATLAS report paid through the shared deflection report store. Review fixes move the Atlas webhook test out of the extracted standalone lane, decouple deflection events from the `billing_events.account_id` FK, fail closed when a paid event has no matching report row, and reject broken price-gate configuration.

## Intentional
- No checkout creation endpoint lands here. The portfolio owns Stripe Checkout initiation and must set the required metadata.
- No subscription handling lands here. The $500/mo ongoing product remains a later slice with a different lifecycle than the one-time $1,500 report.
- Missing or invalid metadata does not 4xx the Stripe webhook after signature verification; it logs and leaves the report locked.
- A valid paid session with no matching report row does return non-2xx so Stripe can retry/reconcile instead of stranding a paid-but-locked report.
- Deflection checkout events log to `billing_events` with `account_id=NULL`; the report paid state is keyed by `content_ops_deflection_reports(account_id, request_id)`.

## Deferred
- Future slice: portfolio/checkout contract docs with the exact required Stripe metadata and success/cancel URL expectations.
- Future slice: subscription/writeback payment flow for the $500/mo ongoing offer.

## Parked hardening
- Prior `mark_paid` non-asyncpg command-tag NIT considered but not required here because production uses asyncpg and this slice tests the SQL call at the helper boundary.

## Verification
- `python -m py_compile atlas_brain/api/billing.py atlas_brain/config.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_content_ops_deflection_report.py::test_postgres_deflection_report_store_round_trips_paid_gate -q` - 16 passed, 1 warning.
- `pytest tests/test_llm_gateway_plan_tier.py tests/test_atlas_content_ops_generated_assets_api.py::test_content_ops_deflection_paid_route_uses_operator_gate tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 34 passed, 1 warning.
- `pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 15 passed, 1 warning.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Stripe-Paid.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Stripe-Paid.md` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-stripe-paid.md` - passed.

## Diff size
5 files, +569 / -0
