### PR TITLE
PR-FAQ-Macro-Writeback-Publish-History

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -39,6 +39,7 @@ from ..landing_page_postgres import (
 )
 from ..landing_page_ports import LandingPageDraft, LandingPageSection
 from ..faq_macro_writeback import MacroPublishProvider
+from ..faq_macro_writeback_postgres import PostgresFAQMacroPublishAttemptRepository
 from ..faq_macro_writeback_publish import FAQMacroWritebackPublishService
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
@@ -397,6 +398,7 @@ def create_generated_asset_router(
         summary = await FAQMacroWritebackPublishService(
             faq_repository=PostgresTicketFAQRepository(pool),
             provider=provider,
+            attempt_repository=PostgresFAQMacroPublishAttemptRepository(pool),
         ).publish_faq_draft(faq_id, scope=tenant)
         if not summary.found:
             raise HTTPException(status_code=404, detail="FAQ draft not found")

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 
 from .campaign_ports import TenantScope
 from .faq_macro_writeback import MacroWritebackMapping
+from .faq_macro_writeback_publish import FAQMacroPublishSummary
 from .storage._jsonb_helpers import decode_jsonb_field, json_dump_jsonb, row_to_dict
 
 
@@ -164,6 +165,50 @@ class PostgresFAQMacroWritebackMappingRepository:
         return tuple(_row_to_mapping(row_to_dict(row)) for row in rows)
 
 
+@dataclass(frozen=True)
+class PostgresFAQMacroPublishAttemptRepository:
+    """Async Postgres adapter for append-only FAQ macro publish attempts."""
+
+    pool: Any
+
+    async def record_attempt(
+        self,
+        summary: FAQMacroPublishSummary,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        await self.pool.execute(
+            """
+            INSERT INTO ticket_faq_macro_publish_attempts (
+                account_id, faq_draft_id, draft_status, ok,
+                publishable_count, skipped_count, published_count,
+                updated_count, failed_count, pending_reconcile_count,
+                draft_status_updated, skipped, results
+            )
+            VALUES (
+                $1, $2, $3, $4,
+                $5, $6, $7,
+                $8, $9, $10,
+                $11, $12::jsonb, $13::jsonb
+            )
+            """,
+            scope.account_id or "",
+            _clean(summary.faq_id),
+            _clean(summary.draft_status),
+            bool(summary.ok),
+            int(summary.publishable_count),
+            int(summary.skipped_count),
+            int(summary.published_count),
+            int(summary.updated_count),
+            int(summary.failed_count),
+            int(summary.pending_reconcile_count),
+            bool(summary.draft_status_updated),
+            json_dump_jsonb([dict(item) for item in summary.skipped]),
+            json_dump_jsonb([dict(item) for item in summary.results]),
+        )
+
+
 __all__ = [
+    "PostgresFAQMacroPublishAttemptRepository",
     "PostgresFAQMacroWritebackMappingRepository",
 ]

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, replace
+import logging
 from typing import Protocol, Sequence
 
 from .campaign_ports import JsonDict, TenantScope
@@ -18,6 +19,7 @@ from .ticket_faq_ports import TicketFAQRepository
 
 PUBLISHED_FAQ_STATUS = "published"
 SUCCESSFUL_MACRO_STATUSES = frozenset({"published", "updated"})
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -129,7 +131,19 @@ class FAQMacroWritebackPublishService:
     ) -> None:
         if self.attempt_repository is None or not summary.found:
             return
-        await self.attempt_repository.record_attempt(summary, scope=scope)
+        if not scope.account_id:
+            logger.info(
+                "skipping FAQ macro publish attempt history without account scope faq_id=%s",
+                summary.faq_id,
+            )
+            return
+        try:
+            await self.attempt_repository.record_attempt(summary, scope=scope)
+        except Exception:
+            logger.exception(
+                "failed to record FAQ macro publish attempt faq_id=%s",
+                summary.faq_id,
+            )
 
 
 def _summary(

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, replace
-from typing import Sequence
+from typing import Protocol, Sequence
 
 from .campaign_ports import JsonDict, TenantScope
 from .faq_macro_writeback import (
@@ -56,12 +56,25 @@ class FAQMacroPublishSummary:
         return data
 
 
+class FAQMacroPublishAttemptRepository(Protocol):
+    """Persistence port for append-only FAQ macro publish attempt history."""
+
+    async def record_attempt(
+        self,
+        summary: FAQMacroPublishSummary,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        """Persist one publish attempt summary for a tenant."""
+
+
 @dataclass(frozen=True)
 class FAQMacroWritebackPublishService:
     """Product-level trigger for approved FAQ macro writeback."""
 
     faq_repository: TicketFAQRepository
     provider: MacroPublishProvider
+    attempt_repository: FAQMacroPublishAttemptRepository | None = None
     published_status: str = PUBLISHED_FAQ_STATUS
 
     async def publish_faq_draft(
@@ -80,13 +93,15 @@ class FAQMacroWritebackPublishService:
 
         preview = build_macro_writeback_preview([draft])
         if not preview.macros:
-            return _summary(
+            summary = _summary(
                 faq_id=cleaned_id,
                 found=True,
                 draft_status=_clean(draft.status),
                 preview=preview,
                 results=(),
             )
+            await self._record_attempt(summary, scope=scope)
+            return summary
 
         results = tuple(await self.provider.publish(preview.macros, scope=scope))
         summary = _summary(
@@ -102,8 +117,19 @@ class FAQMacroWritebackPublishService:
                 self.published_status,
                 scope=scope,
             )
-            return replace(summary, draft_status_updated=status_updated)
+            summary = replace(summary, draft_status_updated=status_updated)
+        await self._record_attempt(summary, scope=scope)
         return summary
+
+    async def _record_attempt(
+        self,
+        summary: FAQMacroPublishSummary,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        if self.attempt_repository is None or not summary.found:
+            return
+        await self.attempt_repository.record_attempt(summary, scope=scope)
 
 
 def _summary(
@@ -157,6 +183,7 @@ def _clean(value: object) -> str:
 
 
 __all__ = [
+    "FAQMacroPublishAttemptRepository",
     "FAQMacroPublishSummary",
     "FAQMacroWritebackPublishService",
     "PUBLISHED_FAQ_STATUS",

--- a/extracted_content_pipeline/storage/migrations/330_ticket_faq_macro_publish_attempts.sql
+++ b/extracted_content_pipeline/storage/migrations/330_ticket_faq_macro_publish_attempts.sql
@@ -1,0 +1,36 @@
+-- Append-only audit trail for FAQ macro publish attempts.
+
+CREATE TABLE IF NOT EXISTS ticket_faq_macro_publish_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL,
+    faq_draft_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) ON DELETE CASCADE,
+    draft_status TEXT NOT NULL DEFAULT '',
+    ok BOOLEAN NOT NULL DEFAULT FALSE,
+    publishable_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,
+    published_count INTEGER NOT NULL DEFAULT 0,
+    updated_count INTEGER NOT NULL DEFAULT 0,
+    failed_count INTEGER NOT NULL DEFAULT 0,
+    pending_reconcile_count INTEGER NOT NULL DEFAULT 0,
+    draft_status_updated BOOLEAN NOT NULL DEFAULT FALSE,
+    skipped JSONB NOT NULL DEFAULT '[]'::jsonb,
+    results JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_ticket_faq_macro_publish_attempts_account_id
+        CHECK (btrim(account_id) <> ''),
+    CONSTRAINT chk_ticket_faq_macro_publish_attempts_counts
+        CHECK (
+            publishable_count >= 0
+            AND skipped_count >= 0
+            AND published_count >= 0
+            AND updated_count >= 0
+            AND failed_count >= 0
+            AND pending_reconcile_count >= 0
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_macro_publish_attempts_faq
+    ON ticket_faq_macro_publish_attempts (account_id, faq_draft_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_faq_macro_publish_attempts_created
+    ON ticket_faq_macro_publish_attempts (account_id, created_at DESC);

--- a/plans/PR-FAQ-Macro-Writeback-Publish-History.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-History.md
@@ -70,7 +70,8 @@ Parked hardening: none
 
 ## Verification
 
-- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'publish_macros or macro_writeback or publish_attempt or record_publish_attempt or ticket_faq_macro' -q -- 20 passed, 59 deselected.
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py -q -- 8 passed.
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'publish_macros or macro_writeback or publish_attempt or record_publish_attempt or ticket_faq_macro' -q -- 22 passed, 59 deselected.
 - python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -- passed.
 - python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed; 135 matching tests enrolled.
 - bash scripts/validate_extracted_content_pipeline.sh -- passed.
@@ -88,9 +89,13 @@ Parked hardening: none
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | ~96 |
+| Plan | ~97 |
 | Migration | ~36 |
 | Service/adapter | ~80 |
 | Route wiring | ~2 |
-| Tests | ~147 |
-| Total | ~361 |
+| Tests | ~199 |
+| Total | ~414 |
+
+This is above the 400 LOC soft cap after review because the fix adds
+source-level failure isolation and regression coverage for both audit-write
+exceptions and unscoped publish attempts.

--- a/plans/PR-FAQ-Macro-Writeback-Publish-History.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-History.md
@@ -1,0 +1,96 @@
+# PR-FAQ-Macro-Writeback-Publish-History
+
+## Why this slice exists
+
+The FAQ macro writeback path now works from the dashboard and has a functional
+validation proving tenant credentials, idempotency mapping, and Zendesk publish
+behavior. The remaining operational gap is that a publish response only exists
+in the current request. If an operator needs to understand what happened after
+the page refreshes, there is no durable record of whether a publish updated,
+failed, skipped, or needed pending reconciliation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add an append-only Postgres table for FAQ macro publish attempts.
+2. Add a small publish-attempt repository port and Postgres adapter.
+3. Have `FAQMacroWritebackPublishService` record the final publish summary when
+   an attempt reaches a real FAQ draft.
+4. Wire the generated asset publish route to the Postgres attempt repository.
+5. Add focused service, repository, and route tests proving clean and
+   non-clean summaries are persisted with tenant scope.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-History.md` -- plan for this slice.
+- `extracted_content_pipeline/api/generated_assets.py` -- route wiring for publish history.
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py` -- Postgres attempt persistence.
+- `extracted_content_pipeline/faq_macro_writeback_publish.py` -- attempt repository port and service hook.
+- `extracted_content_pipeline/storage/migrations/330_ticket_faq_macro_publish_attempts.sql` -- append-only attempt table.
+- `tests/test_extracted_content_asset_api.py` -- route wiring coverage.
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` -- attempt repository and migration coverage.
+- `tests/test_extracted_ticket_faq_macro_writeback_publish.py` -- service history hook coverage.
+
+## Mechanism
+
+The publish service gains an optional `attempt_repository`. After it builds the
+final summary for a found FAQ draft, and after any clean status transition, it
+calls `record_attempt(summary, scope=scope)`.
+
+The Postgres adapter inserts into `ticket_faq_macro_publish_attempts` with:
+
+- tenant scope and FAQ draft id
+- `ok`, draft status, counts, and status-transition flag
+- skipped items and provider results as JSONB
+
+The generated asset route constructs the service with both
+`PostgresTicketFAQRepository(pool)` and
+`PostgresFAQMacroPublishAttemptRepository(pool)`, so the hosted route persists
+the same summary it returns.
+
+## Intentional
+
+- No history read API or UI in this slice. This closes the write-side audit gap;
+  surfacing the attempts can be a separate product slice once the data exists.
+- Missing FAQ drafts are not recorded. The route returns 404, and there is no
+  resolved draft to audit.
+- The attempt record is written after the final summary is known, so the stored
+  row matches the response semantics exactly.
+
+## Deferred
+
+- `PR-FAQ-Macro-Writeback-Publish-History-Review-UI`: display recent attempts
+  in Generated Asset Review if operators need the audit trail in the drawer.
+- `PR-FAQ-Macro-Writeback-Live-Smoke`: optional sandbox Zendesk smoke once safe
+  credentials and test data are available.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'publish_macros or macro_writeback or publish_attempt or record_publish_attempt or ticket_faq_macro' -q -- 20 passed, 59 deselected.
+- python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -- passed.
+- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed; 135 matching tests enrolled.
+- bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- bash scripts/check_ascii_python.sh -- passed.
+- python scripts/check_extracted_imports.py -- passed.
+- python scripts/smoke_extracted_pipeline_imports.py -- passed.
+- python scripts/smoke_extracted_pipeline_standalone.py -- passed.
+- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline -- passed.
+- git diff --check -- passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~96 |
+| Migration | ~36 |
+| Service/adapter | ~80 |
+| Route wiring | ~2 |
+| Tests | ~147 |
+| Total | ~361 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1494,6 +1494,24 @@ def test_generated_asset_router_publishes_ticket_faq_macros() -> None:
     update_query, update_args = pool.fetch_calls[1]
     assert "UPDATE ticket_faq_markdown" in update_query
     assert update_args == ("11111111-1111-1111-1111-111111111111", "published", "acct_1")
+    attempt_query, attempt_args = next(
+        call for call in pool.execute_calls
+        if "ticket_faq_macro_publish_attempts" in call[0]
+    )
+    assert "INSERT INTO ticket_faq_macro_publish_attempts" in attempt_query
+    assert attempt_args[:11] == (
+        "acct_1",
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        True,
+        1,
+        0,
+        1,
+        0,
+        0,
+        0,
+        True,
+    )
 
 
 def test_generated_asset_router_publish_macros_requires_provider() -> None:
@@ -1554,6 +1572,24 @@ def test_generated_asset_router_publish_macros_surfaces_pending_reconcile() -> N
     assert body["draft_status_updated"] is False
     assert body["results"][0]["error"] == "zendesk_macro_mapping_pending_reconcile"
     assert len(pool.fetch_calls) == 1
+    attempt_query, attempt_args = next(
+        call for call in pool.execute_calls
+        if "ticket_faq_macro_publish_attempts" in call[0]
+    )
+    assert "INSERT INTO ticket_faq_macro_publish_attempts" in attempt_query
+    assert attempt_args[:11] == (
+        "acct_1",
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        False,
+        1,
+        0,
+        0,
+        0,
+        1,
+        1,
+        False,
+    )
 
 
 def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -8,7 +8,11 @@ import pytest
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping
 from extracted_content_pipeline.faq_macro_writeback_postgres import (
+    PostgresFAQMacroPublishAttemptRepository,
     PostgresFAQMacroWritebackMappingRepository,
+)
+from extracted_content_pipeline.faq_macro_writeback_publish import (
+    FAQMacroPublishSummary,
 )
 
 
@@ -26,6 +30,13 @@ PENDING_MIGRATION = (
     / "migrations"
     / "329_ticket_faq_macro_writebacks_pending.sql"
 )
+ATTEMPT_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "extracted_content_pipeline"
+    / "storage"
+    / "migrations"
+    / "330_ticket_faq_macro_publish_attempts.sql"
+)
 
 
 class _Pool:
@@ -34,6 +45,7 @@ class _Pool:
         self.fetchrow_rows: list[dict] = []
         self.fetch_calls: list[dict] = []
         self.fetchrow_calls: list[dict] = []
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
 
     async def fetch(self, query, *args):
         self.fetch_calls.append({"query": query, "args": args})
@@ -42,6 +54,10 @@ class _Pool:
     async def fetchrow(self, query, *args):
         self.fetchrow_calls.append({"query": query, "args": args})
         return self.fetchrow_rows.pop(0)
+
+    async def execute(self, query, *args):
+        self.execute_calls.append((str(query), args))
+        return "INSERT 0 1"
 
 
 def _row(**overrides) -> dict:
@@ -81,6 +97,19 @@ def test_ticket_faq_macro_writeback_pending_migration_prevents_retry_duplicates(
     assert "chk_ticket_faq_macro_writebacks_external_id_when_published" in sql
     assert "DROP CONSTRAINT IF EXISTS ticket_faq_macro_writebacks_account_id_platform_external_id_key" in sql
     assert "WHERE btrim(external_id) <> ''" in sql
+
+
+def test_ticket_faq_macro_publish_attempts_migration_adds_append_only_history() -> None:
+    sql = ATTEMPT_MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS ticket_faq_macro_publish_attempts" in sql
+    assert (
+        "faq_draft_id UUID NOT NULL REFERENCES ticket_faq_markdown(id) "
+        "ON DELETE CASCADE"
+    ) in sql
+    assert "skipped JSONB NOT NULL DEFAULT '[]'::jsonb" in sql
+    assert "results JSONB NOT NULL DEFAULT '[]'::jsonb" in sql
+    assert "idx_ticket_faq_macro_publish_attempts_faq" in sql
 
 
 @pytest.mark.asyncio
@@ -260,3 +289,48 @@ async def test_upsert_mapping_keeps_account_scope_outside_client_payload() -> No
 
     assert pool.fetchrow_calls[0]["args"][0] == "acct-tenant-a"
     assert "account_id" not in pool.fetchrow_calls[0]["args"][-1]
+
+
+@pytest.mark.asyncio
+async def test_record_publish_attempt_persists_summary_with_tenant_scope() -> None:
+    pool = _Pool()
+    repo = PostgresFAQMacroPublishAttemptRepository(pool)
+    summary = FAQMacroPublishSummary(
+        faq_id="11111111-1111-1111-1111-111111111111",
+        found=True,
+        draft_status="approved",
+        publishable_count=1,
+        skipped_count=0,
+        published_count=0,
+        updated_count=1,
+        failed_count=0,
+        pending_reconcile_count=0,
+        draft_status_updated=True,
+        skipped=(),
+        results=({
+            "status": "updated",
+            "external_id": "macro-123",
+            "error": "",
+        },),
+    )
+
+    await repo.record_attempt(summary, scope=TenantScope(account_id="acct-1"))
+
+    query, args = pool.execute_calls[0]
+    assert "INSERT INTO ticket_faq_macro_publish_attempts" in query
+    assert "account_id, faq_draft_id, draft_status, ok" in query
+    assert args == (
+        "acct-1",
+        "11111111-1111-1111-1111-111111111111",
+        "approved",
+        True,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        True,
+        "[]",
+        '[{"status":"updated","external_id":"macro-123","error":""}]',
+    )

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -46,6 +46,19 @@ class _FAQRepo:
         return True
 
 
+class _AttemptRepo:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def record_attempt(
+        self,
+        summary,
+        *,
+        scope: TenantScope,
+    ) -> None:
+        self.calls.append({"summary": summary, "scope": scope})
+
+
 class _Provider:
     def __init__(self, statuses: tuple[str, ...]) -> None:
         self.statuses = statuses
@@ -121,7 +134,12 @@ async def test_publish_service_publishes_approved_verified_faq_and_marks_status(
     scope = TenantScope(account_id="acct-1", user_id="user-1")
     repo = _FAQRepo(_draft())
     provider = _Provider(("published",))
-    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
 
     summary = await service.publish_faq_draft(" faq-draft-1 ", scope=scope)
 
@@ -138,6 +156,7 @@ async def test_publish_service_publishes_approved_verified_faq_and_marks_status(
         "status": "published",
         "scope": scope,
     }]
+    assert attempts.calls == [{"summary": summary, "scope": scope}]
 
 
 @pytest.mark.asyncio
@@ -195,7 +214,12 @@ async def test_publish_service_keeps_status_when_items_are_skipped() -> None:
 async def test_publish_service_surfaces_pending_reconcile_without_status_update() -> None:
     repo = _FAQRepo(_draft())
     provider = _PendingProvider()
-    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
 
     summary = await service.publish_faq_draft(
         "faq-draft-1",
@@ -207,13 +231,22 @@ async def test_publish_service_surfaces_pending_reconcile_without_status_update(
     assert summary.pending_reconcile_count == 1
     assert summary.results[0]["error"] == "zendesk_macro_mapping_pending_reconcile"
     assert repo.update_calls == []
+    assert attempts.calls == [{
+        "summary": summary,
+        "scope": TenantScope(account_id="acct-1"),
+    }]
 
 
 @pytest.mark.asyncio
 async def test_publish_service_reports_missing_draft_without_provider_call() -> None:
     repo = _FAQRepo(None)
     provider = _Provider(("published",))
-    service = FAQMacroWritebackPublishService(faq_repository=repo, provider=provider)
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
 
     summary = await service.publish_faq_draft(
         "missing-faq",
@@ -237,6 +270,7 @@ async def test_publish_service_reports_missing_draft_without_provider_call() -> 
     }
     assert provider.calls == []
     assert repo.update_calls == []
+    assert attempts.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ticket_faq_macro_writeback_publish.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_publish.py
@@ -47,7 +47,8 @@ class _FAQRepo:
 
 
 class _AttemptRepo:
-    def __init__(self) -> None:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
         self.calls: list[dict[str, object]] = []
 
     async def record_attempt(
@@ -56,6 +57,8 @@ class _AttemptRepo:
         *,
         scope: TenantScope,
     ) -> None:
+        if self.fail:
+            raise RuntimeError("attempt write failed")
         self.calls.append({"summary": summary, "scope": scope})
 
 
@@ -289,3 +292,51 @@ async def test_publish_service_does_not_mark_dry_run_results_published() -> None
     assert summary.published_count == 0
     assert summary.updated_count == 0
     assert repo.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_service_keeps_success_when_attempt_history_write_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    repo = _FAQRepo(_draft())
+    provider = _Provider(("published",))
+    attempts = _AttemptRepo(fail=True)
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert summary.ok is True
+    assert summary.published_count == 1
+    assert repo.update_calls == [{
+        "faq_id": "faq-draft-1",
+        "status": "published",
+        "scope": TenantScope(account_id="acct-1"),
+    }]
+    assert "failed to record FAQ macro publish attempt" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_publish_service_skips_attempt_history_without_account_scope() -> None:
+    repo = _FAQRepo(_draft())
+    provider = _Provider(("published",))
+    attempts = _AttemptRepo()
+    service = FAQMacroWritebackPublishService(
+        faq_repository=repo,
+        provider=provider,
+        attempt_repository=attempts,
+    )
+
+    summary = await service.publish_faq_draft(
+        "faq-draft-1",
+        scope=TenantScope(),
+    )
+
+    assert summary.ok is True
+    assert attempts.calls == []


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-History.md
Slice phase: Production hardening

This persists append-only FAQ macro publish attempt history from the existing publish service and hosted route, so operators are not limited to the latest in-browser response when a publish updates, skips, fails, or needs pending reconciliation. Review follow-up makes the audit write best-effort and skips unscoped attempt history.

## Intentional
- Add write-side attempt history only; read API and UI are deferred until operators need the trail surfaced.
- Record only attempts that resolve to a real FAQ draft and have tenant account scope.
- Store the final summary after publish/status handling so persisted rows match route response semantics.
- Treat audit-history write failures as best-effort so an already-completed Zendesk publish does not become a false 500.

## Deferred
- `PR-FAQ-Macro-Writeback-Publish-History-Review-UI`: display recent attempts in Generated Asset Review if operators need the audit trail in the drawer.
- `PR-FAQ-Macro-Writeback-Live-Smoke`: optional sandbox Zendesk smoke once safe credentials and test data are available.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py -q -- 8 passed.
- python -m pytest tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'publish_macros or macro_writeback or publish_attempt or record_publish_attempt or ticket_faq_macro' -q -- 22 passed, 59 deselected.
- python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_ticket_faq_macro_writeback_publish.py tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -- passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py -- passed; 135 matching tests enrolled.
- bash scripts/validate_extracted_content_pipeline.sh -- passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
- bash scripts/check_ascii_python.sh -- passed.
- python scripts/check_extracted_imports.py -- passed.
- python scripts/smoke_extracted_pipeline_imports.py -- passed.
- python scripts/smoke_extracted_pipeline_standalone.py -- passed.
- bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline -- passed.
- git diff --check -- passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history.md -- passed.

## Diff size
8 files, +426 / -6
