### PR TITLE
PR-FAQ-Deflection-Snapshot-Contract

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -1,0 +1,21 @@
+{
+  "summary": {
+    "drafted_answer_count": 1,
+    "generated": 2,
+    "no_proven_answer_count": 1
+  },
+  "top_questions": [
+    {
+      "customer_wording": "How do I export attribution reports?",
+      "question": "How do I export attribution reports?",
+      "rank": 1,
+      "weighted_frequency": 2
+    },
+    {
+      "customer_wording": "Can I turn on SSO for all users?",
+      "question": "Can I turn on SSO for all users?",
+      "rank": 2,
+      "weighted_frequency": 2
+    }
+  ]
+}

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -7,9 +7,9 @@ The canonical customer-facing deflection report producer is
 `extracted_content_pipeline.faq_deflection_report.DeflectionReportArtifact.as_dict()`.
 
 Use this contract for Content Ops `faq_markdown` execute results, persisted FAQ
-detail hydration, Content Ops `faq_deflection_report` execute results, and
-landing-page demos that render the full generated FAQ or deflection report
-artifact.
+detail hydration, Content Ops `faq_deflection_report` execute results, paid
+deflection report artifacts, free deflection snapshots, and landing-page demos
+that render the generated FAQ or deflection report artifact.
 
 Do not use the compact search result row as the full report. Search returns a
 ranked match preview; detail hydration returns the generated report.
@@ -70,6 +70,40 @@ The report Markdown always contains these customer-facing sections:
 - `No Proven Answer Yet`
 - `Vocabulary Gaps`
 - `Evidence Appendix`
+
+## Deflection Snapshot
+
+The hosted free results page receives this shape before payment. It is the
+canonical projection returned in `result.snapshot` from gated
+`faq_deflection_report` execute responses and from
+`GET /content-ops/deflection-reports/{request_id}/snapshot`.
+
+```ts
+type DeflectionSnapshot = {
+  summary: {
+    generated: number;
+    drafted_answer_count: number;
+    no_proven_answer_count: number;
+  };
+  top_questions: DeflectionSnapshotQuestion[];
+};
+
+type DeflectionSnapshotQuestion = {
+  rank: number;
+  question: string;
+  weighted_frequency: number;
+  customer_wording: string;
+};
+```
+
+This shape intentionally excludes paid deliverable fields:
+
+- no `markdown`
+- no `faq_result`
+- no answer text or `steps`
+- no `evidence_quotes`
+- no `source_ids`
+- no vocabulary term mappings
 
 ## FAQ Item
 
@@ -174,6 +208,9 @@ type TicketFAQSearchResponse = {
 - Use `items` for ranked cards or sections, and `markdown` for the full report.
 - For `faq_deflection_report`, render top-level `markdown` as the deliverable.
   Use `summary` for proof badges and `faq_result` for drill-down cards.
+- For unpaid deflection results, render only `DeflectionSnapshot.summary` and
+  `DeflectionSnapshot.top_questions`. Do not infer answer text, evidence, or
+  source IDs from the snapshot.
 - Show `source_count`, `ticket_source_count`, and `output_checks` as proof badges.
 - Show `answer_evidence_status` near steps. `draft_needs_review` means the
   system found repeated customer wording but no uploaded resolution evidence, so
@@ -190,4 +227,6 @@ type TicketFAQSearchResponse = {
 See [`content_ops_faq_report_example.json`](./content_ops_faq_report_example.json)
 for a current compact FAQ example and
 [`content_ops_faq_deflection_report_example.json`](./content_ops_faq_deflection_report_example.json)
-for a current compact deflection report example.
+for a current compact deflection report example. See
+[`content_ops_faq_deflection_snapshot_example.json`](./content_ops_faq_deflection_snapshot_example.json)
+for the free snapshot shape rendered before payment.

--- a/plans/PR-FAQ-Deflection-Snapshot-Contract.md
+++ b/plans/PR-FAQ-Deflection-Snapshot-Contract.md
@@ -1,0 +1,78 @@
+# PR-FAQ-Deflection-Snapshot-Contract
+
+## Why this slice exists
+
+The paid-gated deflection report now returns a free
+`DeflectionSnapshot` before payment, but `docs/frontend/` only documents the
+full paid report artifact. The results-page builder needs the same
+byte-faithful handoff for the free snapshot so it can render real top questions
+without accidentally typing against the paid `faq_result` shape.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+
+Slice phase: Product polish
+
+1. Document the `DeflectionSnapshot` TypeScript shape in the existing FAQ
+   frontend contract.
+2. Add a compact JSON example generated from the same producer fixture as the
+   full deflection report example.
+3. Extend the contract test so the example matches the producer shape and does
+   not expose paid answer/evidence fields.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `docs/frontend/content_ops_faq_report_contract.md` | Adds the free snapshot contract and rendering guidance. |
+| `docs/frontend/content_ops_faq_deflection_snapshot_example.json` | Adds a byte-faithful free snapshot example. |
+| `tests/test_content_ops_faq_report_contract_docs.py` | Locks the snapshot example against the producer helper. |
+| `plans/PR-FAQ-Deflection-Snapshot-Contract.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+The snapshot example is produced by:
+
+```python
+build_deflection_snapshot(_producer_deflection_report_payload(), top_n=2).as_dict()
+```
+
+That is the same projection used by the hosted free results route. The contract
+test compares keys against the producer payload and asserts that the JSON does
+not contain paid fields such as `markdown`, `faq_result`, `steps`,
+`evidence_quotes`, or `source_ids`.
+
+## Intentional
+
+- This slice only documents the free snapshot contract. It does not change the
+  hosted paid gate or frontend rendering code.
+- The example uses top 2 for compact docs, while the hosted default remains top
+  5 through `DEFAULT_DEFLECTION_SNAPSHOT_TOP_N`.
+
+## Deferred
+
+- Future slice: portfolio/Intel UI can type the free results page against this
+  snapshot example.
+- Parked hardening considered: none.
+
+## Verification
+
+- Command: pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources -q
+  - Result: 5 passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Snapshot-Contract.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Snapshot-Contract.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Contract doc | 47 |
+| Snapshot example | 21 |
+| Contract tests | 36 |
+| Plan doc | 78 |
+| **Total** | **182** |

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from extracted_content_pipeline.faq_deflection_report import (
+    build_deflection_snapshot,
     build_deflection_report_artifact,
 )
 from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
@@ -12,6 +13,9 @@ DOC_PATH = ROOT / "docs/frontend/content_ops_faq_report_contract.md"
 EXAMPLE_PATH = ROOT / "docs/frontend/content_ops_faq_report_example.json"
 DEFLECTION_EXAMPLE_PATH = (
     ROOT / "docs/frontend/content_ops_faq_deflection_report_example.json"
+)
+DEFLECTION_SNAPSHOT_EXAMPLE_PATH = (
+    ROOT / "docs/frontend/content_ops_faq_deflection_snapshot_example.json"
 )
 
 
@@ -157,11 +161,43 @@ def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
     assert "## No Proven Answer Yet" in payload["markdown"]
 
 
+def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() -> None:
+    payload = json.loads(DEFLECTION_SNAPSHOT_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    producer_payload = build_deflection_snapshot(
+        _producer_deflection_report_payload(),
+        top_n=2,
+    ).as_dict()
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload == producer_payload
+    assert set(payload) == {"summary", "top_questions"}
+    assert set(payload["summary"]) == {
+        "generated",
+        "drafted_answer_count",
+        "no_proven_answer_count",
+    }
+    for question in payload["top_questions"]:
+        assert set(question) == {
+            "rank",
+            "question",
+            "weighted_frequency",
+            "customer_wording",
+        }
+    assert "markdown" not in encoded
+    assert "faq_result" not in encoded
+    assert "steps" not in encoded
+    assert "evidence" not in encoded
+    assert "source_ids" not in encoded
+
+
 def test_content_ops_faq_report_contract_links_example() -> None:
     doc = DOC_PATH.read_text(encoding="utf-8")
 
     assert "content_ops_faq_report_example.json" in doc
     assert "content_ops_faq_deflection_report_example.json" in doc
+    assert "content_ops_faq_deflection_snapshot_example.json" in doc
+    assert "type DeflectionSnapshot" in doc
     assert "account_id: string;" in doc
     assert EXAMPLE_PATH.exists()
     assert DEFLECTION_EXAMPLE_PATH.exists()
+    assert DEFLECTION_SNAPSHOT_EXAMPLE_PATH.exists()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Snapshot-Contract.md
Slice phase: Product polish

The free deflection results page now has the same frontend handoff quality as the paid report: a documented `DeflectionSnapshot` shape plus a byte-faithful JSON example generated from the real producer projection.

## Intentional
- This slice only documents the free snapshot contract. It does not change the hosted paid gate or frontend rendering code.
- The example uses top 2 for compact docs, while the hosted default remains top 5 through `DEFAULT_DEFLECTION_SNAPSHOT_TOP_N`.

## Deferred
- Future slice: portfolio/Intel UI can type the free results page against this snapshot example.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources -q` - 5 passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Snapshot-Contract.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Snapshot-Contract.md` - passed.
- `git diff --check` - passed.

## Diff size
4 files, +178 / -4
