### PR TITLE
PR-FAQ-Deflection-Checkout-Contract

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -1,0 +1,124 @@
+# Content Ops FAQ Deflection Checkout Contract
+
+This is the frontend handoff for the one-time `$1,500` FAQ deflection report
+unlock flow.
+
+The portfolio owns Stripe Checkout creation and the results page UI. ATLAS owns
+the free snapshot, paid report storage, Stripe webhook verification, and the
+paid flag. The portfolio must not hold or synthesize the paid report before
+ATLAS releases it.
+
+## Flow
+
+1. Run `faq_deflection_report` through the Content Ops execute route.
+2. Render the returned free snapshot.
+3. Create Stripe Checkout with the required metadata below.
+4. Stripe sends `checkout.session.completed` to ATLAS.
+5. ATLAS verifies the signed Stripe event and marks the report paid.
+6. The portfolio hydrates the full report from ATLAS after the artifact route
+   returns `200`.
+
+## Execute Result
+
+For `faq_deflection_report`, the gated execute result replaces the full report
+step result with:
+
+```ts
+type GatedDeflectionExecuteResult = {
+  request_id: string;
+  snapshot: DeflectionSnapshot;
+  full_report: {
+    status: "locked";
+    reason: "payment_required";
+  };
+};
+```
+
+Render `snapshot` on the free page. Do not derive answer text, evidence, source
+IDs, or Markdown from this object.
+
+## Free Snapshot Endpoint
+
+```http
+GET /content-ops/deflection-reports/{request_id}/snapshot
+```
+
+Responses:
+
+- `200`: `DeflectionSnapshot`
+- `404`: no report exists for this `request_id` in the authenticated account
+
+The authenticated ATLAS scope supplies `account_id`; do not put `account_id` in
+the path or query string.
+
+## Paid Artifact Endpoint
+
+```http
+GET /content-ops/deflection-reports/{request_id}/artifact
+```
+
+Responses:
+
+- `200`: `FAQDeflectionReportArtifact`
+- `403`: report exists but `paid=false`; keep the unlock CTA visible
+- `404`: no report exists for this `request_id` in the authenticated account
+
+For now, this route is the paid-state read. Treat `200` as unlocked and `403` as
+locked. The portfolio should not request or cache the full artifact before
+payment.
+
+## Stripe Checkout Metadata
+
+The portfolio must create a one-time Stripe Checkout session with:
+
+```ts
+type DeflectionCheckoutMetadata = {
+  source: "content_ops_deflection_report";
+  account_id: string;
+  request_id: string;
+};
+```
+
+Required session properties:
+
+- `mode: "payment"`
+- `metadata.source: "content_ops_deflection_report"`
+- `metadata.account_id`: the same ATLAS account/tenant id that owns the report
+- `metadata.request_id`: the Content Ops request id returned by execute
+- `amount_total >= 150000`
+- `currency: "usd"`
+
+ATLAS stores the Stripe Checkout session id as the report `payment_reference`
+after the signed webhook marks the report paid.
+
+## Trust Boundary
+
+Use the Stripe webhook path:
+
+```text
+Stripe webhook -> ATLAS verifies -> ATLAS marks paid
+```
+
+The portfolio does not call an authed "mark paid" endpoint after Checkout. The
+operator route exists for privileged internal recovery:
+
+```http
+POST /content-ops/deflection-reports/{request_id}/paid
+```
+
+Do not wire customer checkout completion to that route. It is not the customer
+payment trust path.
+
+## Failure Handling
+
+- Missing or invalid metadata leaves the report locked.
+- Wrong amount or currency leaves the report locked.
+- A valid paid event with no matching report row returns non-2xx to Stripe so
+  the event can retry or be reconciled.
+- A repeated Stripe event is idempotent through the Stripe event id.
+
+## Related Contracts
+
+- [`content_ops_faq_report_contract.md`](./content_ops_faq_report_contract.md)
+- [`content_ops_faq_deflection_snapshot_example.json`](./content_ops_faq_deflection_snapshot_example.json)
+- [`content_ops_faq_deflection_report_example.json`](./content_ops_faq_deflection_report_example.json)

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -230,3 +230,8 @@ for a current compact FAQ example and
 for a current compact deflection report example. See
 [`content_ops_faq_deflection_snapshot_example.json`](./content_ops_faq_deflection_snapshot_example.json)
 for the free snapshot shape rendered before payment.
+
+See
+[`content_ops_faq_deflection_checkout_contract.md`](./content_ops_faq_deflection_checkout_contract.md)
+for the Stripe Checkout metadata, paid-gate endpoints, and portfolio/ATLAS trust
+boundary used to unlock the full report.

--- a/plans/PR-FAQ-Deflection-Checkout-Contract.md
+++ b/plans/PR-FAQ-Deflection-Checkout-Contract.md
@@ -1,0 +1,93 @@
+# PR-FAQ-Deflection-Checkout-Contract
+
+## Why this slice exists
+
+The free deflection snapshot, paid artifact route, and Stripe webhook paid flag
+now exist, but the portfolio/results-page session still needs a stable handoff
+for the Checkout seam. Without a written contract, the frontend can easily
+guess at metadata, paid-state, or trust boundaries and accidentally recreate the
+portfolio-owned mark-paid path we intentionally avoided.
+
+This slice closes the handoff requested in issue #1149: document the exact
+snapshot/artifact endpoints, required Stripe Checkout metadata, ATLAS-owned
+paid flag behavior, and paid-state interpretation for the frontend builder.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+
+Slice phase: Product polish
+
+1. Add a frontend contract doc for the one-time FAQ deflection Checkout flow.
+2. Link that contract from the existing FAQ report frontend contract.
+3. Add a doc test that pins the route names, metadata keys, Stripe source, and
+   trust-boundary language.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `docs/frontend/content_ops_faq_deflection_checkout_contract.md` | Documents the portfolio-to-ATLAS Checkout and paid-release contract. |
+| `docs/frontend/content_ops_faq_report_contract.md` | Links the Checkout contract from the existing report/snapshot contract. |
+| `tests/test_content_ops_faq_report_contract_docs.py` | Pins the contract link and required Checkout handoff terms. |
+| `plans/PR-FAQ-Deflection-Checkout-Contract.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+The new doc makes the paid funnel explicit:
+
+1. Portfolio renders the free `DeflectionSnapshot`.
+2. Portfolio creates Stripe Checkout with
+   `metadata.source=content_ops_deflection_report`, `metadata.account_id`, and
+   `metadata.request_id`.
+3. Stripe calls ATLAS' signed webhook.
+4. ATLAS verifies the event, validates amount/currency, and flips
+   `content_ops_deflection_reports.paid`.
+5. Portfolio hydrates the full report from
+   `GET /content-ops/deflection-reports/{request_id}/artifact` only after the
+   artifact route stops returning 403.
+
+The test is intentionally string-level. This is a frontend handoff contract, so
+the drift risk is missing or renamed contract terms rather than runtime logic.
+
+## Intentional
+
+- No runtime endpoint changes land here. The paid gate and Stripe webhook
+  already shipped; this slice documents how the portfolio should use them.
+- The contract tells the portfolio to treat the artifact route as the paid-state
+  read (`200` unlocked, `403` locked). A separate status endpoint is not required
+  for the current free snapshot -> paid report flow.
+- The operator `POST /content-ops/deflection-reports/{request_id}/paid` route is
+  named only as "not for portfolio use" because Stripe webhook is the source of
+  truth for customer payment.
+
+## Deferred
+
+- Future slice: add a dedicated paid-state endpoint only if the frontend needs a
+  lighter read than probing the artifact route.
+- Future slice: subscription/writeback contract for the $500/mo ongoing offer.
+- Parked hardening considered: none in `HARDENING.md` touch this docs-only
+  handoff slice.
+
+## Verification
+
+- Command: pytest tests/test_content_ops_faq_report_contract_docs.py -q
+  - Result: 5 passed.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Checkout-Contract.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Checkout-Contract.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-checkout-contract.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Checkout contract doc | 124 |
+| Existing contract link | 5 |
+| Doc test | 25 |
+| Plan doc | 93 |
+| **Total** | **247** |

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -17,6 +17,9 @@ DEFLECTION_EXAMPLE_PATH = (
 DEFLECTION_SNAPSHOT_EXAMPLE_PATH = (
     ROOT / "docs/frontend/content_ops_faq_deflection_snapshot_example.json"
 )
+DEFLECTION_CHECKOUT_CONTRACT_PATH = (
+    ROOT / "docs/frontend/content_ops_faq_deflection_checkout_contract.md"
+)
 
 
 def _producer_report_shape() -> tuple[set[str], set[str]]:
@@ -196,8 +199,30 @@ def test_content_ops_faq_report_contract_links_example() -> None:
     assert "content_ops_faq_report_example.json" in doc
     assert "content_ops_faq_deflection_report_example.json" in doc
     assert "content_ops_faq_deflection_snapshot_example.json" in doc
+    assert "content_ops_faq_deflection_checkout_contract.md" in doc
     assert "type DeflectionSnapshot" in doc
     assert "account_id: string;" in doc
     assert EXAMPLE_PATH.exists()
     assert DEFLECTION_EXAMPLE_PATH.exists()
     assert DEFLECTION_SNAPSHOT_EXAMPLE_PATH.exists()
+    assert DEFLECTION_CHECKOUT_CONTRACT_PATH.exists()
+
+
+def test_content_ops_faq_deflection_checkout_contract_pins_paid_handoff() -> None:
+    doc = DEFLECTION_CHECKOUT_CONTRACT_PATH.read_text(encoding="utf-8")
+
+    required_terms = {
+        'source: "content_ops_deflection_report"',
+        "account_id: string;",
+        "request_id: string;",
+        "GET /content-ops/deflection-reports/{request_id}/snapshot",
+        "GET /content-ops/deflection-reports/{request_id}/artifact",
+        "POST /content-ops/deflection-reports/{request_id}/paid",
+        "amount_total >= 150000",
+        'currency: "usd"',
+        "The portfolio does not call an authed \"mark paid\" endpoint",
+        "Stripe webhook -> ATLAS verifies -> ATLAS marks paid",
+    }
+
+    for term in required_terms:
+        assert term in doc


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Checkout-Contract.md
Slice phase: Product polish

The deflection report paid gate and Stripe webhook are now live, so this slice gives the portfolio/results-page builder a stable Checkout handoff: exact snapshot/artifact endpoints, required Stripe metadata, paid-state behavior, and the ATLAS-owned webhook trust boundary.

## Intentional
- No runtime endpoint changes land here. The paid gate and Stripe webhook already shipped; this slice documents how the portfolio should use them.
- The artifact route is the current paid-state read: `200` means unlocked, `403` means locked.
- The operator mark-paid route is documented only as not-for-portfolio-use; Stripe webhook remains the customer payment trust path.

## Deferred
- Future slice: add a dedicated paid-state endpoint only if the frontend needs a lighter read than probing the artifact route.
- Future slice: subscription/writeback contract for the $500/mo ongoing offer.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_faq_report_contract_docs.py -q` - 5 passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Checkout-Contract.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Checkout-Contract.md` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-checkout-contract.md` - passed.

## Diff size
4 files, +247 / -0
