### PR TITLE
PR-FAQ-Deflection-Paid-Flow-Validation

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -7,6 +7,7 @@ on:
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
+      - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
+      - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
 
 jobs:
@@ -38,4 +40,8 @@ jobs:
           python -m pip install pytest pytest-asyncio
 
       - name: Run Content Ops deflection Stripe paid tests
-        run: python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q
+        run: |
+          python -m pytest \
+            tests/test_atlas_billing_content_ops_deflection_stripe_paid.py \
+            tests/test_atlas_billing_content_ops_deflection_paid_flow.py \
+            -q

--- a/plans/PR-FAQ-Deflection-Paid-Flow-Validation.md
+++ b/plans/PR-FAQ-Deflection-Paid-Flow-Validation.md
@@ -1,0 +1,99 @@
+# PR-FAQ-Deflection-Paid-Flow-Validation
+
+## Why this slice exists
+
+The FAQ deflection funnel now has its runtime pieces merged: execute-time
+snapshot gating, paid artifact retrieval, Stripe webhook paid marking, and the
+frontend Checkout contract. What is still missing is one functional validation
+that proves those pieces work together as the user-facing flow we designed.
+
+This slice adds that proof without expanding the product surface: run the
+deflection report through the Content Ops execute route, confirm the free page
+only receives the snapshot, confirm the paid artifact is locked, process the
+Stripe webhook paid event, then confirm the paid artifact route releases the
+full report.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+
+Slice phase: Functional validation
+
+1. Add one focused in-process flow test for the free snapshot -> Stripe paid
+   webhook -> full artifact release path.
+2. Keep the test on the existing route/webhook/storage seams; do not add new
+   endpoint behavior.
+3. Prove the negative boundary that the locked response does not expose the paid
+   Markdown artifact before payment.
+4. Enroll the paid-flow test in the existing full-dependency billing CI lane.
+
+### Files touched
+
+| File | Purpose |
+|---|---|
+| `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml` | Runs the paid-flow validation in the existing Atlas billing CI lane. |
+| `tests/test_atlas_billing_content_ops_deflection_paid_flow.py` | Validates the integrated free snapshot, Stripe webhook, and paid artifact release flow. |
+| `plans/PR-FAQ-Deflection-Paid-Flow-Validation.md` | Documents the slice contract and verification. |
+
+## Mechanism
+
+The test wires the real Content Ops router with:
+
+- `FAQDeflectionReportService`
+- `InMemoryDeflectionReportArtifactStore`
+- a fixed tenant scope
+
+It calls the route endpoint directly for `/execute`, `/snapshot`, and
+`/artifact`, then sends `atlas_brain.api.billing.stripe_webhook` a fake Stripe
+module whose `Webhook.construct_event` returns a signed-event-equivalent
+Checkout session. The fake billing pool maps the webhook's
+`UPDATE content_ops_deflection_reports` call back to the same in-memory store
+used by the route, so the test proves the route and webhook agree on
+`(account_id, request_id)` and paid-state semantics.
+
+## Intentional
+
+- This is functional validation, not a new runtime feature.
+- The test uses an in-memory store adapter instead of live Postgres. The target
+  invariant is cross-seam control flow and contract shape; Postgres persistence
+  is already covered by the store round-trip test and can be re-run in a later
+  robust/live DB slice.
+- The Stripe event is fake but enters through `stripe_webhook`, so signature
+  verification placement, event routing, idempotency lookup, paid marking, and
+  audit insert ordering are still exercised.
+
+## Deferred
+
+- Future slice: live/ephemeral Postgres validation for the same paid flow.
+- Future slice: browser/UI validation once the portfolio results page consumes
+  the merged Checkout contract.
+- Parked hardening considered: none in `HARDENING.md` touch this functional
+  validation slice.
+
+## Verification
+
+- Command: pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q
+  - Result: 1 passed, 1 warning.
+- Command: pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_report.py::test_postgres_deflection_report_store_round_trips_paid_gate tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q
+  - Result: 17 passed, 1 warning.
+- Command: pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q
+  - Result: 16 passed, 1 warning.
+- Command: python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Paid-Flow-Validation.md
+  - Result: passed.
+- Command: python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Paid-Flow-Validation.md
+  - Result: passed.
+- Command: git diff --check
+  - Result: passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-paid-flow-validation.md
+  - Result: passed after enrolling the paid-flow test in the billing CI lane.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| CI workflow enrollment | 8 |
+| Flow validation test | 224 |
+| Plan doc | 99 |
+| **Total** | **331** |
+
+Actual diff is `+328 / -1`; the LOC budget counts total changed lines.

--- a/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
+++ b/tests/test_atlas_billing_content_ops_deflection_paid_flow.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from atlas_brain.api import billing
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
+from extracted_content_pipeline.deflection_report_access import (
+    InMemoryDeflectionReportArtifactStore,
+)
+from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
+
+
+def _route(router: Any, path: str, method: str) -> Any:
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
+            return route
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def _source_material() -> list[dict[str, str]]:
+    return [
+        {
+            "source_id": "ticket-export-1",
+            "source_type": "support_ticket",
+            "source_title": "Export attribution",
+            "text": "How do I export attribution reports?",
+            "resolution_text": (
+                "Open Analytics, choose Attribution, then click Download report"
+            ),
+        },
+        {
+            "source_id": "ticket-export-2",
+            "source_type": "support_ticket",
+            "source_title": "Report download",
+            "text": "Where is the report download for attribution exports?",
+            "resolution_text": (
+                "Open Analytics, choose Attribution, then click Download report"
+            ),
+        },
+        {
+            "source_id": "ticket-sso-1",
+            "source_type": "support_ticket",
+            "source_title": "SSO setup",
+            "text": "How do I enable SSO for my team?",
+        },
+        {
+            "source_id": "ticket-sso-2",
+            "source_type": "support_ticket",
+            "source_title": "Team login",
+            "text": "Can I turn on SSO for all users?",
+        },
+    ]
+
+
+def _session(
+    *,
+    account_id: str,
+    request_id: str,
+    session_id: str = "cs_test_paid_flow",
+) -> SimpleNamespace:
+    metadata = {
+        "source": "content_ops_deflection_report",
+        "account_id": account_id,
+        "request_id": request_id,
+    }
+    return SimpleNamespace(
+        id=session_id,
+        mode="payment",
+        payment_status="paid",
+        amount_total=150000,
+        currency="usd",
+        metadata=metadata,
+        to_dict=lambda: {
+            "id": session_id,
+            "mode": "payment",
+            "payment_status": "paid",
+            "amount_total": 150000,
+            "currency": "usd",
+            "metadata": dict(metadata),
+        },
+    )
+
+
+class _BillingPool:
+    def __init__(self, store: InMemoryDeflectionReportArtifactStore) -> None:
+        self.is_initialized = True
+        self.store = store
+        self.fetchval_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.fetchval_calls.append((query, args))
+        return None
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.execute_calls.append((query, args))
+        if "UPDATE content_ops_deflection_reports" in query:
+            account_id, request_id, payment_reference = args
+            marked = await self.store.mark_paid(
+                account_id=str(account_id),
+                request_id=str(request_id),
+                payment_reference=str(payment_reference or ""),
+            )
+            return "UPDATE 1" if marked else "UPDATE 0"
+        if "INSERT INTO billing_events" in query:
+            return "INSERT 0 1"
+        raise AssertionError(query)
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_flow_locks_snapshot_until_stripe_webhook_unlocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = "00000000-0000-0000-0000-000000000115"
+    store = InMemoryDeflectionReportArtifactStore()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            deflection_snapshot_top_n=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        deflection_report_store_provider=lambda: store,
+        scope_provider=lambda: {"account_id": account_id},
+    )
+
+    execute = _route(router, "/ops/execute", "POST")
+    executed = await execute.endpoint(
+        {
+            "outputs": ["faq_deflection_report"],
+            "limit": 2,
+            "inputs": {
+                "source_material": _source_material(),
+                "faq_documentation_terms": (
+                    "Download report",
+                    "Single sign-on setup",
+                ),
+                "faq_vocabulary_gap_rules": (
+                    ("export", "Download report"),
+                    ("SSO", "Single sign-on setup"),
+                ),
+            },
+        }
+    )
+
+    request_id = executed["request_id"]
+    gated_result = executed["steps"][0]["result"]
+    assert gated_result == {
+        "request_id": request_id,
+        "snapshot": gated_result["snapshot"],
+        "full_report": {
+            "status": "locked",
+            "reason": "payment_required",
+        },
+    }
+    assert gated_result["snapshot"]["summary"] == {
+        "generated": 2,
+        "drafted_answer_count": 1,
+        "no_proven_answer_count": 1,
+    }
+    encoded_gated_result = str(gated_result)
+    assert "markdown" not in encoded_gated_result
+    assert "faq_result" not in encoded_gated_result
+    assert "ticket-export-1" not in encoded_gated_result
+
+    snapshot_route = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
+    assert await snapshot_route.endpoint(request_id=request_id) == gated_result["snapshot"]
+
+    artifact_route = _route(router, "/ops/deflection-reports/{request_id}/artifact", "GET")
+    with pytest.raises(billing.HTTPException) as locked:
+        await artifact_route.endpoint(request_id=request_id)
+    assert locked.value.status_code == 403
+
+    event = SimpleNamespace(
+        id="evt_deflection_paid_flow",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=_session(account_id=account_id, request_id=request_id)),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    billing_pool = _BillingPool(store)
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", SimpleNamespace(Webhook=_Webhook, api_key=""))
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: billing_pool)
+
+    assert await billing.stripe_webhook(request) == {"status": "ok"}
+    assert billing_pool.fetchval_calls[0][1] == ("evt_deflection_paid_flow",)
+    assert "UPDATE content_ops_deflection_reports" in billing_pool.execute_calls[0][0]
+    assert "INSERT INTO billing_events" in billing_pool.execute_calls[1][0]
+
+    unlocked = await artifact_route.endpoint(request_id=request_id)
+    assert unlocked["summary"]["drafted_answer_count"] == 1
+    assert unlocked["summary"]["no_proven_answer_count"] == 1
+    assert "## Drafted Answers With Proven Solutions" in unlocked["markdown"]
+    assert "## No Proven Answer Yet" in unlocked["markdown"]
+    assert unlocked["faq_result"]["items"][0]["source_ids"]


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Paid-Flow-Validation.md
Slice phase: Functional validation

The free snapshot, paid artifact route, Stripe webhook, and Checkout contract are now merged. This slice adds the missing functional proof that those pieces work together: execute a deflection report, expose only the free snapshot while locked, process the Stripe paid event, and then release the full artifact.

## Intentional
- This is validation only; no runtime endpoint behavior changes land here.
- The test uses an in-memory store adapter to prove cross-seam control flow. Live/ephemeral Postgres validation is deferred to a later robust testing slice.
- The Stripe event is fake but enters through `stripe_webhook`, so event routing, idempotency lookup, paid marking, and audit insert ordering are exercised.

## Deferred
- Future slice: live/ephemeral Postgres validation for the same paid flow.
- Future slice: browser/UI validation once the portfolio results page consumes the merged Checkout contract.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` - 1 passed, 1 warning.
- `pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_content_ops_deflection_report.py::test_postgres_deflection_report_store_round_trips_paid_gate tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 17 passed, 1 warning.
- `pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` - 16 passed, 1 warning.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Paid-Flow-Validation.md` - passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Paid-Flow-Validation.md` - passed.
- `git diff --check` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-paid-flow-validation.md` - passed after enrolling the paid-flow test in the billing CI lane.

## Diff size
3 files, +330 / -1
