### PR TITLE
PR-FAQ-Macro-Writeback-Publish-History-Read-Route

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -408,6 +408,43 @@ def create_generated_asset_router(
             **summary.as_dict(),
         }
 
+    @router.get("/{asset}/drafts/{draft_id}/publish-macro-attempts")
+    async def list_faq_macro_publish_attempts(
+        asset: str,
+        draft_id: str,
+        limit: int = Query(20, ge=1, le=100),
+    ) -> dict[str, Any]:
+        asset_name = _asset_arg(asset)
+        if asset_name != "faq_markdown":
+            raise HTTPException(
+                status_code=400,
+                detail="only faq_markdown drafts can list macro publish attempts",
+            )
+        try:
+            faq_id = str(UUID(draft_id))
+        except ValueError:
+            raise HTTPException(status_code=404, detail="FAQ draft not found") from None
+        pool = await _resolve_pool(pool_provider)
+        scope = await _resolve_scope(scope_provider)
+        tenant = _tenant_scope(scope)
+        faq_repository = PostgresTicketFAQRepository(pool)
+        draft = await faq_repository.get_draft(faq_id, scope=tenant)
+        if draft is None:
+            raise HTTPException(status_code=404, detail="FAQ draft not found")
+        attempts = await PostgresFAQMacroPublishAttemptRepository(pool).list_attempts(
+            faq_id,
+            scope=tenant,
+            limit=limit,
+        )
+        return {
+            "account_id": tenant.account_id,
+            "asset": asset_name,
+            "faq_id": faq_id,
+            "count": len(attempts),
+            "limit": limit,
+            "attempts": [attempt.as_dict() for attempt in attempts],
+        }
+
     @router.post("/{asset}/drafts/review-batch")
     async def review_drafts_batch(
         asset: str,

--- a/extracted_content_pipeline/faq_macro_writeback_postgres.py
+++ b/extracted_content_pipeline/faq_macro_writeback_postgres.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 
 from .campaign_ports import TenantScope
 from .faq_macro_writeback import MacroWritebackMapping
-from .faq_macro_writeback_publish import FAQMacroPublishSummary
+from .faq_macro_writeback_publish import FAQMacroPublishAttempt, FAQMacroPublishSummary
 from .storage._jsonb_helpers import decode_jsonb_field, json_dump_jsonb, row_to_dict
 
 
@@ -26,6 +26,13 @@ def _metadata(value: Any) -> dict[str, Any]:
     return dict(decoded) if isinstance(decoded, Mapping) else {}
 
 
+def _json_list(value: Any) -> tuple[dict[str, Any], ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, list):
+        return ()
+    return tuple(dict(item) for item in decoded if isinstance(item, Mapping))
+
+
 def _row_to_mapping(row: Mapping[str, Any]) -> MacroWritebackMapping:
     return MacroWritebackMapping(
         platform=str(row.get("platform") or ""),
@@ -35,6 +42,25 @@ def _row_to_mapping(row: Mapping[str, Any]) -> MacroWritebackMapping:
         external_url=str(row.get("external_url") or ""),
         publish_status=str(row.get("publish_status") or "published"),
         metadata=_metadata(row.get("metadata")),
+    )
+
+
+def _row_to_attempt(row: Mapping[str, Any]) -> FAQMacroPublishAttempt:
+    return FAQMacroPublishAttempt(
+        id=str(row.get("id") or ""),
+        faq_id=str(row.get("faq_draft_id") or ""),
+        draft_status=str(row.get("draft_status") or ""),
+        ok=bool(row.get("ok")),
+        publishable_count=int(row.get("publishable_count") or 0),
+        skipped_count=int(row.get("skipped_count") or 0),
+        published_count=int(row.get("published_count") or 0),
+        updated_count=int(row.get("updated_count") or 0),
+        failed_count=int(row.get("failed_count") or 0),
+        pending_reconcile_count=int(row.get("pending_reconcile_count") or 0),
+        draft_status_updated=bool(row.get("draft_status_updated")),
+        skipped=_json_list(row.get("skipped")),
+        results=_json_list(row.get("results")),
+        created_at=str(row.get("created_at") or ""),
     )
 
 
@@ -206,6 +232,32 @@ class PostgresFAQMacroPublishAttemptRepository:
             json_dump_jsonb([dict(item) for item in summary.skipped]),
             json_dump_jsonb([dict(item) for item in summary.results]),
         )
+
+    async def list_attempts(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+        limit: int,
+    ) -> tuple[FAQMacroPublishAttempt, ...]:
+        rows = await self.pool.fetch(
+            """
+            SELECT
+                id, faq_draft_id, draft_status, ok,
+                publishable_count, skipped_count, published_count,
+                updated_count, failed_count, pending_reconcile_count,
+                draft_status_updated, skipped, results, created_at
+              FROM ticket_faq_macro_publish_attempts
+             WHERE account_id = $1
+               AND faq_draft_id = $2
+             ORDER BY created_at DESC, id DESC
+             LIMIT $3
+            """,
+            scope.account_id or "",
+            _clean(faq_id),
+            max(1, int(limit)),
+        )
+        return tuple(_row_to_attempt(row_to_dict(row)) for row in rows)
 
 
 __all__ = [

--- a/extracted_content_pipeline/faq_macro_writeback_publish.py
+++ b/extracted_content_pipeline/faq_macro_writeback_publish.py
@@ -58,6 +58,32 @@ class FAQMacroPublishSummary:
         return data
 
 
+@dataclass(frozen=True)
+class FAQMacroPublishAttempt:
+    """Persisted FAQ macro publish attempt summary."""
+
+    id: str
+    faq_id: str
+    draft_status: str
+    ok: bool
+    publishable_count: int = 0
+    skipped_count: int = 0
+    published_count: int = 0
+    updated_count: int = 0
+    failed_count: int = 0
+    pending_reconcile_count: int = 0
+    draft_status_updated: bool = False
+    skipped: Sequence[JsonDict] = field(default_factory=tuple)
+    results: Sequence[JsonDict] = field(default_factory=tuple)
+    created_at: str = ""
+
+    def as_dict(self) -> JsonDict:
+        data = asdict(self)
+        data["skipped"] = [dict(item) for item in self.skipped]
+        data["results"] = [dict(item) for item in self.results]
+        return data
+
+
 class FAQMacroPublishAttemptRepository(Protocol):
     """Persistence port for append-only FAQ macro publish attempt history."""
 
@@ -68,6 +94,15 @@ class FAQMacroPublishAttemptRepository(Protocol):
         scope: TenantScope,
     ) -> None:
         """Persist one publish attempt summary for a tenant."""
+
+    async def list_attempts(
+        self,
+        faq_id: str,
+        *,
+        scope: TenantScope,
+        limit: int,
+    ) -> Sequence[FAQMacroPublishAttempt]:
+        """Return recent publish attempt summaries for one tenant-scoped FAQ."""
 
 
 @dataclass(frozen=True)
@@ -197,6 +232,7 @@ def _clean(value: object) -> str:
 
 
 __all__ = [
+    "FAQMacroPublishAttempt",
     "FAQMacroPublishAttemptRepository",
     "FAQMacroPublishSummary",
     "FAQMacroWritebackPublishService",

--- a/plans/PR-FAQ-Macro-Writeback-Publish-History-Read-Route.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-History-Read-Route.md
@@ -1,0 +1,69 @@
+## Why this slice exists
+
+PR-FAQ-Macro-Writeback-Publish-History added append-only publish attempt writes for FAQ macro writeback. Operators still cannot read that history through the generated asset API, so the UI cannot show whether the last macro publish succeeded, failed, or needs reconcile.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Add a serializable publish-attempt DTO and repository contract for listing recent attempts.
+2. Implement the Postgres list query against the existing `ticket_faq_macro_publish_attempts` table, scoped by account and FAQ draft id.
+3. Add a generated asset API route for reading recent attempts for one FAQ draft.
+4. Cover the repository and route behavior with focused tests.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-History-Read-Route.md` — slice plan.
+- `extracted_content_pipeline/faq_macro_writeback_publish.py` — read DTO and repository contract.
+- `extracted_content_pipeline/faq_macro_writeback_postgres.py` — tenant-scoped attempt history query.
+- `extracted_content_pipeline/api/generated_assets.py` — FAQ-only publish attempt read route.
+- `tests/test_extracted_ticket_faq_macro_writeback_postgres.py` — Postgres adapter coverage.
+- `tests/test_extracted_content_asset_api.py` — API route coverage.
+
+## Mechanism
+
+The write-side table already stores normalized publish-attempt summaries. This slice adds `FAQMacroPublishAttempt` as the read DTO and extends the attempt repository port with `list_attempts(faq_id, scope, limit)`. The Postgres adapter filters by `account_id` and `faq_draft_id`, orders newest-first, and caps results with the requested limit.
+
+The API route is:
+
+```text
+GET /content-assets/faq_markdown/drafts/{draft_id}/publish-macro-attempts?limit=20
+```
+
+It rejects non-FAQ assets, validates the draft id as a UUID, confirms the FAQ draft exists under tenant scope, then returns recent attempts.
+
+## Intentional
+
+- No UI change in this slice. The route is the stable backend contract the review drawer can consume next.
+- No new migration. The table and indexes landed in the prior publish-history slice.
+- The route verifies the FAQ draft exists before listing history. An empty history for an existing FAQ returns `200` with no attempts; a missing FAQ returns `404`.
+
+## Deferred
+
+- PR-FAQ-Macro-Writeback-Publish-History-UI will surface this history in the Generated Asset Review drawer.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/api/generated_assets.py` — passed.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'macro_publish_attempt or publish_attempt or publish_macros' -q` — 9 passed, 68 deselected.
+- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -q` — 77 passed.
+- `git diff --check` — passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
+- `bash scripts/check_ascii_python.sh` — passed.
+- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history-read-route.md` — passed; cross-layer caller hints were advisory and covered by the focused route/repository tests above.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Plan | ~65 |
+| DTO / repository contract | ~40 |
+| Postgres adapter | ~60 |
+| API route | ~45 |
+| Tests | ~130 |
+| Total | ~340 |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -52,6 +52,21 @@ class _Pool:
         return self.execute_result
 
 
+class _FAQMacroPublishHistoryPool(_Pool):
+    def __init__(self, *, draft_row=None, attempt_rows=None) -> None:
+        super().__init__(rows=[])
+        self.draft_row = dict(draft_row) if draft_row is not None else None
+        self.attempt_rows = list(attempt_rows or [])
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((str(query), args))
+        if "FROM ticket_faq_markdown" in str(query):
+            return [self.draft_row] if self.draft_row is not None else []
+        if "FROM ticket_faq_macro_publish_attempts" in str(query):
+            return self.attempt_rows
+        return []
+
+
 class _PublicLandingPagePool(_Pool):
     async def fetch(self, query, *args):
         self.fetch_calls.append((str(query), args))
@@ -443,6 +458,31 @@ def _publishable_ticket_faq_row():
         }],
         "metadata": {"corpus_id": "corpus-1"},
     })
+    return row
+
+
+def _publish_attempt_row(**overrides):
+    row = {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "faq_draft_id": "11111111-1111-1111-1111-111111111111",
+        "draft_status": "approved",
+        "ok": True,
+        "publishable_count": 1,
+        "skipped_count": 0,
+        "published_count": 1,
+        "updated_count": 0,
+        "failed_count": 0,
+        "pending_reconcile_count": 0,
+        "draft_status_updated": True,
+        "skipped": [],
+        "results": [{
+            "status": "published",
+            "external_id": "external-1",
+            "external_url": "https://example.zendesk.com/macros/1",
+        }],
+        "created_at": "2026-05-30 12:00:00+00:00",
+    }
+    row.update(overrides)
     return row
 
 
@@ -1590,6 +1630,99 @@ def test_generated_asset_router_publish_macros_surfaces_pending_reconcile() -> N
         1,
         False,
     )
+
+
+def test_generated_asset_router_lists_faq_macro_publish_attempts() -> None:
+    pool = _FAQMacroPublishHistoryPool(
+        draft_row=_publishable_ticket_faq_row(),
+        attempt_rows=[_publish_attempt_row()],
+    )
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).get(
+        "/content-assets/faq_markdown/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macro-attempts?limit=3"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["account_id"] == "acct_1"
+    assert body["asset"] == "faq_markdown"
+    assert body["faq_id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["count"] == 1
+    assert body["limit"] == 3
+    assert body["attempts"][0] == {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "faq_id": "11111111-1111-1111-1111-111111111111",
+        "draft_status": "approved",
+        "ok": True,
+        "publishable_count": 1,
+        "skipped_count": 0,
+        "published_count": 1,
+        "updated_count": 0,
+        "failed_count": 0,
+        "pending_reconcile_count": 0,
+        "draft_status_updated": True,
+        "skipped": [],
+        "results": [{
+            "status": "published",
+            "external_id": "external-1",
+            "external_url": "https://example.zendesk.com/macros/1",
+        }],
+        "created_at": "2026-05-30 12:00:00+00:00",
+    }
+    get_query, get_args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in get_query
+    assert get_args == ("11111111-1111-1111-1111-111111111111", "acct_1")
+    attempts_query, attempts_args = pool.fetch_calls[1]
+    assert "FROM ticket_faq_macro_publish_attempts" in attempts_query
+    assert attempts_args == ("acct_1", "11111111-1111-1111-1111-111111111111", 3)
+
+
+def test_generated_asset_router_publish_attempts_is_faq_only() -> None:
+    pool = _FAQMacroPublishHistoryPool(
+        draft_row=_publishable_ticket_faq_row(),
+        attempt_rows=[_publish_attempt_row()],
+    )
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).get(
+        "/content-assets/report/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macro-attempts"
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "only faq_markdown drafts can list macro publish attempts"
+    )
+    assert pool.fetch_calls == []
+
+
+def test_generated_asset_router_publish_attempts_404s_missing_faq() -> None:
+    pool = _FAQMacroPublishHistoryPool(
+        draft_row=None,
+        attempt_rows=[_publish_attempt_row()],
+    )
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).get(
+        "/content-assets/faq_markdown/drafts/"
+        "11111111-1111-1111-1111-111111111111/publish-macro-attempts"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "FAQ draft not found"
+    assert len(pool.fetch_calls) == 1
+    get_query, get_args = pool.fetch_calls[0]
+    assert "FROM ticket_faq_markdown" in get_query
+    assert get_args == ("11111111-1111-1111-1111-111111111111", "acct_1")
 
 
 def test_generated_asset_router_reviews_blog_post_with_host_defined_status() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_postgres.py
@@ -74,6 +74,27 @@ def _row(**overrides) -> dict:
     return row
 
 
+def _attempt_row(**overrides) -> dict:
+    row = {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "faq_draft_id": "11111111-1111-1111-1111-111111111111",
+        "draft_status": "approved",
+        "ok": True,
+        "publishable_count": 1,
+        "skipped_count": 0,
+        "published_count": 0,
+        "updated_count": 1,
+        "failed_count": 0,
+        "pending_reconcile_count": 0,
+        "draft_status_updated": True,
+        "skipped": "[]",
+        "results": '[{"status":"updated","external_id":"macro-123"}]',
+        "created_at": "2026-05-30 12:00:00+00:00",
+    }
+    row.update(overrides)
+    return row
+
+
 def test_ticket_faq_macro_writeback_migration_adds_scoped_unique_mapping() -> None:
     sql = MIGRATION.read_text()
 
@@ -334,3 +355,45 @@ async def test_record_publish_attempt_persists_summary_with_tenant_scope() -> No
         "[]",
         '[{"status":"updated","external_id":"macro-123","error":""}]',
     )
+
+
+@pytest.mark.asyncio
+async def test_list_publish_attempts_filters_by_tenant_faq_and_limit() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [_attempt_row()]
+    repo = PostgresFAQMacroPublishAttemptRepository(pool)
+
+    attempts = await repo.list_attempts(
+        " 11111111-1111-1111-1111-111111111111 ",
+        scope=TenantScope(account_id="acct-1"),
+        limit=5,
+    )
+
+    call = pool.fetch_calls[0]
+    assert "FROM ticket_faq_macro_publish_attempts" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert "faq_draft_id = $2" in call["query"]
+    assert "ORDER BY created_at DESC, id DESC" in call["query"]
+    assert "LIMIT $3" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "11111111-1111-1111-1111-111111111111",
+        5,
+    )
+    assert len(attempts) == 1
+    assert attempts[0].as_dict() == {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "faq_id": "11111111-1111-1111-1111-111111111111",
+        "draft_status": "approved",
+        "ok": True,
+        "publishable_count": 1,
+        "skipped_count": 0,
+        "published_count": 0,
+        "updated_count": 1,
+        "failed_count": 0,
+        "pending_reconcile_count": 0,
+        "draft_status_updated": True,
+        "skipped": [],
+        "results": [{"status": "updated", "external_id": "macro-123"}],
+        "created_at": "2026-05-30 12:00:00+00:00",
+    }


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-History-Read-Route.md
Slice phase: Production hardening

PR-FAQ-Macro-Writeback-Publish-History added append-only publish attempt writes, but operators still need a tenant-scoped API read path before the review UI can show publish history. This slice adds the FAQ-only history route, backed by the existing Postgres table and scoped through the FAQ draft lookup.

## Intentional
- No UI change in this slice; the next slice can consume this route in the Generated Asset Review drawer.
- No new migration; the attempt history table and indexes already exist.
- The route checks the FAQ draft exists under tenant scope before returning history.

## Deferred
- PR-FAQ-Macro-Writeback-Publish-History-UI will surface this history in the review drawer.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_publish.py extracted_content_pipeline/faq_macro_writeback_postgres.py extracted_content_pipeline/api/generated_assets.py` — passed.
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -k 'macro_publish_attempt or publish_attempt or publish_macros' -q` — 9 passed, 68 deselected.
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_postgres.py tests/test_extracted_content_asset_api.py -q` — 77 passed.
- `git diff --check` — passed.
- `bash scripts/validate_extracted_content_pipeline.sh` — passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` — passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` — passed.
- `bash scripts/check_ascii_python.sh` — passed.
- `bash extracted/_shared/scripts/sync_extracted.sh extracted_content_pipeline` — passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history-read-route.md` — passed; cross-layer caller hints were advisory and covered by the focused route/repository tests above.

## Diff size
6 files, ~335 LOC estimated.