### PR TITLE
PR-FAQ-Macro-Writeback-Publish-History-UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs
@@ -23,6 +23,7 @@ async function loadTsModule(path, replacements = []) {
 }
 
 const {
+  fetchGeneratedFaqMacroPublishAttempts,
   publishGeneratedFaqMacros,
 } = await loadTsModule('../src/api/contentOps.ts', [
   [
@@ -109,6 +110,49 @@ test('FAQ macro publish posts to encoded generated asset route', async () => {
   assert.deepEqual(JSON.parse(init.body), {})
 })
 
+
+test('FAQ macro publish history fetches encoded generated asset route', async () => {
+  const payload = {
+    account_id: 'account-1',
+    asset: 'faq_markdown',
+    faq_id: 'draft/id',
+    count: 1,
+    limit: 5,
+    attempts: [
+      {
+        id: 'attempt-1',
+        faq_id: 'draft/id',
+        draft_status: 'published',
+        ok: true,
+        publishable_count: 2,
+        skipped_count: 0,
+        published_count: 1,
+        updated_count: 1,
+        failed_count: 0,
+        pending_reconcile_count: 0,
+        draft_status_updated: true,
+        skipped: [],
+        results: [{ status: 'published', external_id: 'macro-1' }],
+        created_at: '2026-05-30T17:40:00Z',
+      },
+    ],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchGeneratedFaqMacroPublishAttempts('draft/id', { limit: 5 })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/faq_markdown/drafts/draft%2Fid/publish-macro-attempts?limit=5`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+
 test('Generated Asset Review wires FAQ macro publish action and summary state', () => {
   assert.ok(reviewSource.includes('publishGeneratedFaqMacros'))
   assert.ok(reviewSource.includes('handlePublishFaqMacros'))
@@ -116,6 +160,9 @@ test('Generated Asset Review wires FAQ macro publish action and summary state', 
   assert.ok(reviewSource.includes("status === 'approved'"))
   assert.ok(reviewSource.includes('Publish macros'))
   assert.ok(reviewSource.includes('MacroPublishResultBanner'))
+  assert.ok(reviewSource.includes('fetchGeneratedFaqMacroPublishAttempts'))
+  assert.ok(reviewSource.includes('MacroPublishHistoryPanel'))
+  assert.ok(reviewSource.includes('Macro publish history'))
   assert.ok(reviewSource.includes('pending_reconcile_count'))
   assert.ok(reviewSource.includes('draft_status_updated'))
 })

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -592,6 +592,32 @@ export interface GeneratedAssetMacroPublishSummary {
   results: GeneratedAssetMacroPublishResult[]
 }
 
+export interface GeneratedAssetMacroPublishAttempt {
+  id: string
+  faq_id: string
+  draft_status: string
+  ok: boolean
+  publishable_count: number
+  skipped_count: number
+  published_count: number
+  updated_count: number
+  failed_count: number
+  pending_reconcile_count: number
+  draft_status_updated: boolean
+  skipped: GeneratedAssetMacroPublishSkippedItem[]
+  results: GeneratedAssetMacroPublishResult[]
+  created_at: string
+}
+
+export interface GeneratedAssetMacroPublishAttemptsResponse {
+  account_id?: string | null
+  asset: GeneratedAssetType
+  faq_id: string
+  count: number
+  limit: number
+  attempts: GeneratedAssetMacroPublishAttempt[]
+}
+
 // ---------------------------------------------------------------------------
 // Internal fetch plumbing
 // ---------------------------------------------------------------------------
@@ -957,6 +983,18 @@ export function publishGeneratedFaqMacros(
     'faq_markdown',
     `/drafts/${encodeURIComponent(id)}/publish-macros`,
     {},
+  )
+}
+
+/** GET /content-assets/faq_markdown/drafts/{id}/publish-macro-attempts -- recent publish history. */
+export function fetchGeneratedFaqMacroPublishAttempts(
+  id: string,
+  params: { limit?: number } = {},
+): Promise<GeneratedAssetMacroPublishAttemptsResponse> {
+  return getAssetJson<GeneratedAssetMacroPublishAttemptsResponse>(
+    'faq_markdown',
+    `/drafts/${encodeURIComponent(id)}/publish-macro-attempts`,
+    params,
   )
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -29,6 +29,7 @@ import { clsx } from 'clsx'
 import {
   exportGeneratedAssetDraftsCsv,
   fetchGeneratedAssetDrafts,
+  fetchGeneratedFaqMacroPublishAttempts,
   publishGeneratedFaqMacros,
   repairGeneratedLandingPageDraft,
   reviewGeneratedAssetDraft,
@@ -37,6 +38,8 @@ import {
   type GeneratedAssetDraft,
   type GeneratedLandingPageDraftUpdate,
   type GeneratedAssetMacroPublishSummary,
+  type GeneratedAssetMacroPublishAttempt,
+  type GeneratedAssetMacroPublishAttemptsResponse,
   type GeneratedAssetListResponse,
   type GeneratedAssetType,
 } from '../api/contentOps'
@@ -129,6 +132,21 @@ type MacroPublishOutcome =
   | { kind: 'success'; draftId: string; summary: GeneratedAssetMacroPublishSummary }
   | { kind: 'error'; draftId: string; message: string }
 
+type MacroPublishHistoryState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; draftId: string }
+  | { kind: 'loaded'; draftId: string; response: GeneratedAssetMacroPublishAttemptsResponse }
+  | { kind: 'error'; draftId: string; message: string }
+
+type MacroPublishCounts = Pick<
+  GeneratedAssetMacroPublishSummary,
+  | 'published_count'
+  | 'updated_count'
+  | 'skipped_count'
+  | 'failed_count'
+  | 'pending_reconcile_count'
+>
+
 const ASSETS: Array<{
   id: GeneratedAssetType
   label: string
@@ -183,6 +201,8 @@ export default function ContentOpsAssetsReview() {
   const [detailRow, setDetailRow] = useState<GeneratedAssetDraft | null>(null)
   const [macroPublishOutcome, setMacroPublishOutcome] =
     useState<MacroPublishOutcome>({ kind: 'idle' })
+  const [macroPublishHistory, setMacroPublishHistory] =
+    useState<MacroPublishHistoryState>({ kind: 'idle' })
 
   const params = useMemo(
     () => ({
@@ -202,6 +222,7 @@ export default function ContentOpsAssetsReview() {
       setData(result)
       setSelectedIds(new Set())
       setDetailRow(null)
+      setMacroPublishHistory({ kind: 'idle' })
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
@@ -213,6 +234,36 @@ export default function ContentOpsAssetsReview() {
   useEffect(() => {
     void load(false)
   }, [load])
+
+  useEffect(() => {
+    const id = detailRow && asset === 'faq_markdown' ? assetId(detailRow) : ''
+    if (!id) {
+      setMacroPublishHistory({ kind: 'idle' })
+      return
+    }
+
+    let active = true
+    setMacroPublishHistory({ kind: 'loading', draftId: id })
+    fetchGeneratedFaqMacroPublishAttempts(id, { limit: 5 })
+      .then((response) => {
+        if (active) {
+          setMacroPublishHistory({ kind: 'loaded', draftId: id, response })
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setMacroPublishHistory({
+            kind: 'error',
+            draftId: id,
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [asset, detailRow])
 
   const handleReview = async (row: GeneratedAssetDraft, nextStatus: 'approved' | 'rejected') => {
     const id = assetId(row)
@@ -546,6 +597,7 @@ export default function ContentOpsAssetsReview() {
           row={detailRow}
           asset={asset}
           saving={busyId === assetId(detailRow)}
+          publishHistory={macroPublishHistory}
           onSaveLandingPage={handleSaveLandingPageDraft}
           onRepairLandingPage={handleRepairLandingPageDraft}
           onClose={() => setDetailRow(null)}
@@ -782,7 +834,7 @@ function MacroPublishResultBanner({ outcome }: { outcome: MacroPublishOutcome })
   )
 }
 
-function macroPublishCountLabels(summary: GeneratedAssetMacroPublishSummary): string[] {
+function macroPublishCountLabels(summary: MacroPublishCounts): string[] {
   return [
     { count: summary.published_count, label: 'published' },
     { count: summary.updated_count, label: 'updated' },
@@ -794,10 +846,132 @@ function macroPublishCountLabels(summary: GeneratedAssetMacroPublishSummary): st
     .map(({ count, label }) => `${count} ${label}`)
 }
 
+
+function MacroPublishHistoryPanel({ history }: { history: MacroPublishHistoryState }) {
+  return (
+    <section className="mt-6">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-200">Macro publish history</h3>
+        {history.kind === "loaded" && (
+          <span className="text-xs text-slate-500">
+            {history.response.count} of {history.response.limit} recent
+          </span>
+        )}
+      </div>
+      <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-4">
+        {history.kind === "idle" && (
+          <p className="text-sm text-slate-400">Open an FAQ draft to load publish history.</p>
+        )}
+        {history.kind === "loading" && (
+          <div className="flex items-center text-sm text-slate-400">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading publish history...
+          </div>
+        )}
+        {history.kind === "error" && (
+          <p className="text-sm text-rose-200">
+            Could not load publish history for {history.draftId}: {history.message}
+          </p>
+        )}
+        {history.kind === "loaded" && history.response.attempts.length === 0 && (
+          <p className="text-sm text-slate-400">No macro publish attempts recorded yet.</p>
+        )}
+        {history.kind === "loaded" && history.response.attempts.length > 0 && (
+          <div className="space-y-3">
+            {history.response.attempts.map((attempt) => (
+              <MacroPublishAttemptRow key={attempt.id} attempt={attempt} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function MacroPublishAttemptRow({ attempt }: { attempt: GeneratedAssetMacroPublishAttempt }) {
+  const counts = macroPublishCountLabels(attempt)
+  const tone = attempt.ok
+    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-100"
+    : attempt.pending_reconcile_count > 0 || attempt.skipped_count > 0
+      ? "border-amber-500/30 bg-amber-500/10 text-amber-100"
+      : "border-rose-500/30 bg-rose-500/10 text-rose-100"
+  const title = attempt.ok
+    ? "Published"
+    : attempt.pending_reconcile_count > 0
+      ? "Needs reconcile"
+      : attempt.failed_count > 0
+        ? "Failed"
+        : "Needs review"
+
+  return (
+    <div className={clsx("rounded-md border p-3", tone)}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium">{title}</div>
+        <div className="font-mono text-xs opacity-80">{attempt.created_at || attempt.id}</div>
+      </div>
+      <div className="mt-1 text-xs opacity-90">
+        Draft status: {attempt.draft_status}
+        {attempt.draft_status_updated ? "; moved after publish." : "; status unchanged."}
+      </div>
+      {counts.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          {counts.map((count) => (
+            <span
+              key={count}
+              className="rounded border border-current/20 bg-slate-950/30 px-2 py-0.5"
+            >
+              {count}
+            </span>
+          ))}
+        </div>
+      )}
+      {attempt.skipped.length > 0 && (
+        <div className="mt-3 text-xs opacity-90">
+          Skipped: {attempt.skipped.map(macroPublishSkippedLabel).join("; ")}
+        </div>
+      )}
+      {attempt.results.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          {attempt.results.slice(0, 4).map((result, index) => (
+            <span
+              key={`${result.external_id || "result"}-${index}`}
+              className="rounded border border-current/20 bg-slate-950/30 px-2 py-0.5"
+            >
+              {macroPublishResultLabel(result)}
+            </span>
+          ))}
+          {attempt.results.length > 4 && (
+            <span className="rounded border border-current/20 bg-slate-950/30 px-2 py-0.5">
+              +{attempt.results.length - 4} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function macroPublishSkippedLabel(item: Record<string, unknown>): string {
+  const question = textValue(item.question) || "macro"
+  const reason = textValue(item.reason) || "skipped"
+  return `${question}: ${reason}`
+}
+
+function macroPublishResultLabel(result: Record<string, unknown>): string {
+  const status = textValue(result.status) || "unknown"
+  const externalId = textValue(result.external_id)
+  const error = textValue(result.error)
+  if (externalId) return `${status} ${externalId}`
+  if (error) return `${status}: ${error}`
+  return status
+}
+
+
 function AssetDetailDrawer({
   row,
   asset,
   saving,
+  publishHistory,
   onSaveLandingPage,
   onRepairLandingPage,
   onClose,
@@ -805,6 +979,7 @@ function AssetDetailDrawer({
   row: GeneratedAssetDraft
   asset: GeneratedAssetType
   saving: boolean
+  publishHistory: MacroPublishHistoryState
   onSaveLandingPage: (
     row: GeneratedAssetDraft,
     update: GeneratedLandingPageDraftUpdate,
@@ -1055,6 +1230,10 @@ function AssetDetailDrawer({
               ))}
             </div>
           </section>
+        )}
+
+        {asset === 'faq_markdown' && (
+          <MacroPublishHistoryPanel history={publishHistory} />
         )}
 
         {preview && (

--- a/plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md
+++ b/plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md
@@ -1,0 +1,88 @@
+# PR-FAQ-Macro-Writeback-Publish-History-UI
+
+## Why this slice exists
+
+PR-FAQ-Macro-Writeback-Publish-History-Read-Route added a tenant-scoped API
+route for recent FAQ macro publish attempts, but operators still cannot see
+that audit trail in the Generated Asset Review drawer. The publish button now
+returns a one-request summary, while a refreshed page has no visible record of
+prior skipped, failed, pending-reconcile, or successful attempts.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Product polish
+
+1. Add typed frontend DTOs and a wrapper for the FAQ macro publish-attempts
+   read route.
+2. Fetch recent publish attempts when an FAQ Markdown draft detail drawer opens.
+3. Render the attempt history in the drawer with status, counts, skipped items,
+   provider result status, and timestamps.
+4. Add focused Node coverage for the encoded route and source-level drawer
+   wiring.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md` -- slice plan.
+- `atlas-intel-ui/src/api/contentOps.ts` -- publish-attempt DTOs and wrapper.
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx` -- FAQ drawer history
+  fetch/render state.
+- `atlas-intel-ui/scripts/content-ops-faq-macro-publish-ui.test.mjs` --
+  focused route and source wiring checks.
+
+## Mechanism
+
+The frontend API adapter adds:
+
+```ts
+fetchGeneratedFaqMacroPublishAttempts(id, { limit })
+```
+
+which calls:
+
+```text
+GET /api/v1/content-assets/faq_markdown/drafts/{id}/publish-macro-attempts?limit=5
+```
+
+using the existing authenticated generated-asset fetch plumbing. The detail
+drawer receives a `publishHistory` state object from the page. When the drawer
+opens for a FAQ Markdown draft with an id, the page fetches recent attempts and
+passes loading/error/data state into the drawer. The drawer renders the history
+only for FAQ drafts, so other generated asset types keep their existing detail
+surface.
+
+## Intentional
+
+- No backend changes. The route already enforces tenant scope, FAQ-only access,
+  draft existence, and display-safe DTOs.
+- No polling or automatic refresh loop. Operators can close/reopen or use the
+  existing page refresh after a publish.
+- The drawer caps history at five attempts to keep the review surface compact.
+
+## Deferred
+
+- PR-FAQ-Macro-Writeback-Live-Smoke remains deferred until safe Zendesk sandbox
+  credentials and test macro data are available.
+- PR-FAQ-Macro-Writeback-Pending-Reconcile remains the future backend recovery
+  command for pending Zendesk mapping repairs.
+- Parked hardening: none.
+
+## Verification
+
+- `npm --prefix atlas-intel-ui run test:content-ops-faq-macro-publish` -- 3 passed.
+- `npm --prefix atlas-intel-ui run build` -- passed.
+- `npm --prefix atlas-intel-ui run lint` -- passed.
+- `git diff --check` -- passed.
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md` -- passed.
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md` -- passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history-ui.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Plan | ~70 |
+| API wrapper | ~45 |
+| Review drawer UI | ~145 |
+| Focused test | ~45 |
+| Total | ~305 |


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md
Slice phase: Product polish

The FAQ macro publish history read route is merged, but the Generated Asset Review drawer still does not show prior publish attempts. This slice adds the typed frontend wrapper and drawer panel so operators can inspect recent skipped, failed, pending-reconcile, and successful attempts for FAQ Markdown drafts.

## Intentional
- No backend changes; the read route already enforces tenant scope, FAQ-only access, draft existence, and display-safe DTOs.
- No polling or automatic refresh loop. Operators can close/reopen or use the existing page refresh after a publish.
- The drawer caps history at five attempts to keep the review surface compact.

## Deferred
- PR-FAQ-Macro-Writeback-Live-Smoke remains deferred until safe Zendesk sandbox credentials and test macro data are available.
- PR-FAQ-Macro-Writeback-Pending-Reconcile remains the future backend recovery command for pending Zendesk mapping repairs.

## Parked hardening
- None.

## Verification
- `npm --prefix atlas-intel-ui run test:content-ops-faq-macro-publish` -- 3 passed.
- `npm --prefix atlas-intel-ui run build` -- passed.
- `npm --prefix atlas-intel-ui run lint` -- passed.
- `git diff --check` -- passed.
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md` -- passed.
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Macro-Writeback-Publish-History-UI.md` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-macro-writeback-publish-history-ui.md` -- passed.

## Diff size
4 files, +353 / -1
