### PR TITLE
PR-Atlas-Brain-Test-CI-Enrollment-Audit

### DIFF
--- a/plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md
+++ b/plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md
@@ -1,0 +1,102 @@
+# PR-Atlas-Brain-Test-CI-Enrollment-Audit
+
+## Why this slice exists
+
+AI Content Ops / FAQ deflection work has repeatedly exposed the same CI shape
+failure: a test importing `atlas_brain.*` gets treated like extracted-lane
+coverage, then GitHub Actions fails because the extracted lane is not a host
+runtime lane. This recurred around #1097, #1154, and #1158, and the standing
+rule now needs a mechanical check instead of relying on session memory.
+
+The existing #957 extracted CI enrollment auditor verifies extracted-runner
+test enrollment. It does not verify the host-test counterpart: changed
+`atlas_brain.*` importing tests need a dedicated atlas area checks workflow
+that includes the file in both PR/push path filters and in the pytest run step.
+
+This slice exceeds the 400 LOC target after review feedback because the
+guardrail needs focused negative fixtures for the false-green split-workflow
+case and the inline `- run:` parser shape. Splitting that follow-up out would
+leave this PR with a known detector gap.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Workflow/process
+
+1. Extend `scripts/audit_extracted_pipeline_ci_enrollment.py` with an optional
+   changed-test scan for `atlas_brain.*` imports.
+2. Have local PR review pass the current base ref into that scan so the guard
+   only applies to tests changed by the current slice.
+3. Add fixture coverage for happy path and each missing-enrollment branch:
+   missing workflow, missing PR path filter, missing push path filter, and
+   missing pytest runner entry.
+4. Require one atlas workflow to carry all three enrollments for a changed
+   `atlas_brain.*` importing test instead of accepting coverage split across
+   multiple workflows.
+5. Leave existing extracted enrollment behavior unchanged.
+
+### Files touched
+
+- `plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md`
+- `scripts/audit_extracted_pipeline_ci_enrollment.py`
+- `tests/test_audit_extracted_pipeline_ci_enrollment.py`
+- `scripts/local_pr_review.sh`
+
+## Mechanism
+
+The auditor keeps its current all-repo extracted enrollment scan. A new CLI
+option asks git for changed Python test files under `tests/` versus the base ref.
+For those changed tests only, the auditor reads the test file, detects top-level
+`atlas_brain` imports, and checks dedicated atlas-prefixed workflow files
+for all three required enrollments:
+
+```text
+pull_request paths contains the test
+push paths contains the test
+workflow run text contains the exact pytest test path
+```
+
+The three checks must pass in the same atlas-prefixed workflow. If the PR path,
+push path, and run step are split across different workflows, the auditor emits
+a `DRIFT` failure naming the missing single-workflow enrollment. The workflow
+run parser accepts both named-step `run:` entries and inline `- run:` entries.
+
+## Intentional
+
+- This is changed-file scoped. A whole-repo scan would turn historical host test
+  coverage into unrelated debt for this workflow/process slice.
+- The dedicated workflow is intentionally identified by atlas-prefixed checks
+  workflow naming, matching the standing rule and avoiding accidental credit
+  from extracted or UI lanes.
+- The pytest runner check requires the exact test path in workflow text instead
+  of inferring from shell globs; that mirrors the "same PR add the file to the
+  pytest run-step" rule.
+- The workflow parser only reads `run:` step text for test paths. It is not a
+  YAML validator; malformed workflows still fail through the existing Actions
+  and local review gates.
+
+## Deferred
+
+- Parked hardening: none. This slice directly promotes the standing CI
+  enrollment rule into local review.
+- A future workflow/process slice can migrate historical host tests into
+  dedicated atlas workflows. This guard prevents new regressions without
+  rewriting old CI ownership in the same PR.
+
+## Verification
+
+- `python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q` - 17 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py .` - passed, 135 matching tests enrolled.
+- `python -m py_compile scripts/audit_extracted_pipeline_ci_enrollment.py tests/test_audit_extracted_pipeline_ci_enrollment.py` - passed.
+- `git diff --check -- scripts/audit_extracted_pipeline_ci_enrollment.py tests/test_audit_extracted_pipeline_ci_enrollment.py scripts/local_pr_review.sh plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-brain-ci-enrollment-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~102 |
+| Auditor | ~168 |
+| Tests | ~203 |
+| Local review hook | ~2 |
+| **Total** | **~475** |

--- a/scripts/audit_extracted_pipeline_ci_enrollment.py
+++ b/scripts/audit_extracted_pipeline_ci_enrollment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -33,6 +34,7 @@ class EnrollmentAudit:
     missing_from_runner: tuple[str, ...]
     missing_from_pull_request_filters: tuple[str, ...]
     missing_from_push_filters: tuple[str, ...]
+    atlas_brain_test_errors: tuple[str, ...] = ()
     workflow_errors: tuple[str, ...] = ()
 
     @property
@@ -59,6 +61,7 @@ class EnrollmentAudit:
                 "missing from push filters: "
                 + ", ".join(self.missing_from_push_filters)
             )
+        failures.extend(self.atlas_brain_test_errors)
         return tuple(failures)
 
 
@@ -80,6 +83,149 @@ def event_path_filters(workflow_text: str, event_name: str) -> tuple[str, ...]:
 
 def runner_test_paths(runner_text: str) -> set[str]:
     return set(re.findall(r"tests/[A-Za-z0-9_./-]+\.py", runner_text))
+
+
+def workflow_run_test_paths(workflow_text: str) -> set[str]:
+    paths: set[str] = set()
+    lines = workflow_text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        match = re.match(r"^(?P<indent>\s*)(?:-\s*)?run:\s*(?P<command>.*)$", line)
+        if match is None:
+            index += 1
+            continue
+
+        indent = len(match.group("indent"))
+        command_lines = [match.group("command")]
+        index += 1
+        while index < len(lines):
+            next_line = lines[index]
+            if next_line.strip() and len(next_line) - len(next_line.lstrip()) <= indent:
+                break
+            command_lines.append(next_line)
+            index += 1
+        paths.update(runner_test_paths("\n".join(command_lines)))
+    return paths
+
+
+def changed_test_paths(root: Path, base_ref: str) -> tuple[str, ...]:
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AM",
+            f"{base_ref}...HEAD",
+            "--",
+            "tests/test_*.py",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip().startswith("tests/test_") and line.strip().endswith(".py")
+    )
+
+
+def imports_atlas_brain(test_text: str) -> bool:
+    return bool(
+        re.search(
+            r"^\s*(?:from\s+atlas_brain(?:\.|\s+import)|import\s+atlas_brain(?:\.|\s|$))",
+            test_text,
+            re.MULTILINE,
+        )
+    )
+
+
+def atlas_brain_importing_tests(
+    root: Path,
+    test_paths: Iterable[str],
+) -> tuple[str, ...]:
+    matches: list[str] = []
+    for path in test_paths:
+        test_path = root / path
+        if test_path.is_file() and imports_atlas_brain(
+            test_path.read_text(encoding="utf-8")
+        ):
+            matches.append(path)
+    return tuple(sorted(matches))
+
+
+@dataclass(frozen=True)
+class AtlasWorkflowEnrollment:
+    pull_request_paths: tuple[str, ...]
+    push_paths: tuple[str, ...]
+    runner_paths: frozenset[str]
+
+
+def workflow_covers_atlas_test(workflow: AtlasWorkflowEnrollment, path: str) -> bool:
+    return (
+        covered_by_path_filter(path, workflow.pull_request_paths)
+        and covered_by_path_filter(path, workflow.push_paths)
+        and path in workflow.runner_paths
+    )
+
+
+def atlas_workflow_enrollments(root: Path) -> tuple[AtlasWorkflowEnrollment, ...]:
+    workflows: list[AtlasWorkflowEnrollment] = []
+    for workflow_path in sorted((root / ".github/workflows").glob("atlas_*_checks.yml")):
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        try:
+            pull_request_paths = event_path_filters(workflow_text, "pull_request")
+            push_paths = event_path_filters(workflow_text, "push")
+        except ValueError:
+            continue
+        workflows.append(
+            AtlasWorkflowEnrollment(
+                pull_request_paths=pull_request_paths,
+                push_paths=push_paths,
+                runner_paths=frozenset(workflow_run_test_paths(workflow_text)),
+            )
+        )
+    return tuple(workflows)
+
+
+def atlas_brain_test_workflow_errors(
+    root: Path,
+    test_paths: Iterable[str],
+) -> tuple[str, ...]:
+    workflows = atlas_workflow_enrollments(root)
+    errors: list[str] = []
+    for path in atlas_brain_importing_tests(root, test_paths):
+        if not workflows:
+            errors.append(
+                f"{path} imports atlas_brain.* but no atlas_*_checks.yml workflow exists"
+            )
+            continue
+        if any(workflow_covers_atlas_test(workflow, path) for workflow in workflows):
+            continue
+        missing: list[str] = []
+        if not any(
+            covered_by_path_filter(path, workflow.pull_request_paths)
+            for workflow in workflows
+        ):
+            missing.append("pull_request path filter")
+        if not any(
+            covered_by_path_filter(path, workflow.push_paths) for workflow in workflows
+        ):
+            missing.append("push path filter")
+        if not any(path in workflow.runner_paths for workflow in workflows):
+            missing.append("pytest run step")
+        if not missing:
+            missing.append(
+                "single atlas workflow with pull_request path filter, "
+                "push path filter, and pytest run step"
+            )
+        errors.append(
+            f"{path} imports atlas_brain.* but is missing dedicated atlas workflow enrollment: "
+            + ", ".join(missing)
+        )
+    return tuple(errors)
 
 
 def enrollment_candidate_tests(
@@ -104,6 +250,7 @@ def audit_ci_enrollment(
     workflow_path: Path | None = None,
     runner_path: Path | None = None,
     patterns: Iterable[str] = DEFAULT_ENROLLED_TEST_PATTERNS,
+    atlas_brain_test_paths: Iterable[str] = (),
 ) -> EnrollmentAudit:
     workflow = workflow_path or root / ".github/workflows/extracted_pipeline_checks.yml"
     runner = runner_path or root / "scripts/run_extracted_pipeline_checks.sh"
@@ -137,6 +284,10 @@ def audit_ci_enrollment(
             path for path in candidates
             if not covered_by_path_filter(path, push_filters)
         ),
+        atlas_brain_test_errors=atlas_brain_test_workflow_errors(
+            root,
+            atlas_brain_test_paths,
+        ),
         workflow_errors=tuple(workflow_errors),
     )
 
@@ -152,8 +303,24 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Repository root to audit.",
     )
+    parser.add_argument(
+        "--atlas-brain-tests-from",
+        metavar="BASE_REF",
+        help=(
+            "Also audit changed tests importing atlas_brain.* against dedicated "
+            "atlas_*_checks.yml workflow enrollment."
+        ),
+    )
     args = parser.parse_args(argv)
-    audit = audit_ci_enrollment(args.root)
+    atlas_brain_test_paths = (
+        changed_test_paths(args.root, args.atlas_brain_tests_from)
+        if args.atlas_brain_tests_from
+        else ()
+    )
+    audit = audit_ci_enrollment(
+        args.root,
+        atlas_brain_test_paths=atlas_brain_test_paths,
+    )
     if audit.ok:
         print(f"OK: {len(audit.candidates)} matching tests are enrolled.")
         return 0

--- a/scripts/local_pr_review.sh
+++ b/scripts/local_pr_review.sh
@@ -97,7 +97,7 @@ run_check "Pre-push audit wrapper" bash scripts/pre_push_audit.sh
 
 if [ -f scripts/audit_extracted_pipeline_ci_enrollment.py ]; then
     run_check "Extracted pipeline CI enrollment" \
-        python scripts/audit_extracted_pipeline_ci_enrollment.py
+        python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from "$base_ref"
 else
     echo
     echo "==> Extracted pipeline CI enrollment"

--- a/tests/test_audit_extracted_pipeline_ci_enrollment.py
+++ b/tests/test_audit_extracted_pipeline_ci_enrollment.py
@@ -216,3 +216,206 @@ def test_cli_returns_nonzero_for_incomplete_enrollment(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "missing from runner" in result.stdout
+
+
+def _write_atlas_workflow(
+    root: Path,
+    *,
+    workflow_name: str = "atlas_widget_checks.yml",
+    pull_request_filters: tuple[str, ...] = ("tests/test_atlas_widget.py",),
+    push_filters: tuple[str, ...] = ("tests/test_atlas_widget.py",),
+    runner_paths: tuple[str, ...] = ("tests/test_atlas_widget.py",),
+    inline_run: bool = False,
+) -> None:
+    lines = [
+        "name: Atlas Widget Checks",
+        "",
+        "on:",
+        "  pull_request:",
+        "    paths:",
+    ]
+    lines.extend(f'      - "{path}"' for path in pull_request_filters)
+    lines.extend(["  push:", "    paths:"])
+    lines.extend(f'      - "{path}"' for path in push_filters)
+    lines.extend(
+        [
+            "",
+            "jobs:",
+            "  atlas-widget-checks:",
+            "    runs-on: ubuntu-latest",
+            "    steps:",
+        ]
+    )
+    if inline_run:
+        lines.append("      - run: python -m pytest " + " ".join(runner_paths) + " -q")
+    else:
+        lines.extend(
+            [
+                "      - name: Run atlas widget tests",
+                "        run: python -m pytest " + " ".join(runner_paths) + " -q",
+            ]
+        )
+    lines.append("")
+    (root / f".github/workflows/{workflow_name}").write_text(
+        "\n".join(lines),
+        encoding="utf-8",
+    )
+
+
+def _write_atlas_importing_test(root: Path) -> str:
+    path = "tests/test_atlas_widget.py"
+    (root / path).write_text(
+        "from atlas_brain.widgets import build_widget\n\n"
+        "def test_widget():\n"
+        "    assert build_widget\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_atlas_brain_changed_test_accepts_dedicated_workflow(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(root)
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.ok
+    assert audit.atlas_brain_test_errors == ()
+
+
+def test_atlas_brain_changed_test_accepts_inline_run_step(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(root, inline_run=True)
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.ok
+    assert audit.atlas_brain_test_errors == ()
+
+
+def test_atlas_brain_changed_test_requires_atlas_workflow(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.atlas_brain_test_errors == (
+        "tests/test_atlas_widget.py imports atlas_brain.* but no "
+        "atlas_*_checks.yml workflow exists",
+    )
+    assert not audit.ok
+
+
+def test_atlas_brain_changed_test_reports_missing_pr_filter(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(root, pull_request_filters=("tests/test_other.py",))
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.atlas_brain_test_errors == (
+        "tests/test_atlas_widget.py imports atlas_brain.* but is missing "
+        "dedicated atlas workflow enrollment: pull_request path filter",
+    )
+    assert not audit.ok
+
+
+def test_atlas_brain_changed_test_reports_missing_push_filter(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(root, push_filters=("tests/test_other.py",))
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.atlas_brain_test_errors == (
+        "tests/test_atlas_widget.py imports atlas_brain.* but is missing "
+        "dedicated atlas workflow enrollment: push path filter",
+    )
+    assert not audit.ok
+
+
+def test_atlas_brain_changed_test_reports_missing_pytest_runner(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(root, runner_paths=("tests/test_other.py",))
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.atlas_brain_test_errors == (
+        "tests/test_atlas_widget.py imports atlas_brain.* but is missing "
+        "dedicated atlas workflow enrollment: pytest run step",
+    )
+    assert not audit.ok
+
+
+def test_atlas_brain_changed_test_rejects_split_workflow_enrollment(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    test_path = _write_atlas_importing_test(root)
+    _write_atlas_workflow(
+        root,
+        workflow_name="atlas_widget_pr_checks.yml",
+        push_filters=("tests/test_other.py",),
+        runner_paths=("tests/test_other.py",),
+    )
+    _write_atlas_workflow(
+        root,
+        workflow_name="atlas_widget_push_checks.yml",
+        pull_request_filters=("tests/test_other.py",),
+        runner_paths=("tests/test_other.py",),
+    )
+    _write_atlas_workflow(
+        root,
+        workflow_name="atlas_widget_run_checks.yml",
+        pull_request_filters=("tests/test_other.py",),
+        push_filters=("tests/test_other.py",),
+    )
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(test_path,),
+    )
+
+    assert audit.atlas_brain_test_errors == (
+        "tests/test_atlas_widget.py imports atlas_brain.* but is missing "
+        "dedicated atlas workflow enrollment: single atlas workflow with "
+        "pull_request path filter, push path filter, and pytest run step",
+    )
+    assert not audit.ok
+
+
+def test_non_atlas_brain_changed_test_does_not_need_atlas_workflow(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    path = "tests/test_plain_widget.py"
+    (root / path).write_text("def test_plain():\n    assert True\n", encoding="utf-8")
+
+    audit = _load_ci_enrollment_auditor().audit_ci_enrollment(
+        root,
+        atlas_brain_test_paths=(path,),
+    )
+
+    assert audit.ok
+    assert audit.atlas_brain_test_errors == ()


### PR DESCRIPTION
Plan: plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md
Slice phase: Workflow/process

This promotes the standing Atlas host-test CI enrollment rule into local review: changed Python tests that import atlas_brain.* now fail the CI enrollment audit unless they are covered by one dedicated atlas-prefixed checks workflow with pull_request paths, push paths, and a pytest run-step entry.

## Intentional
- Scope is changed-file only; historical host test workflow ownership is left untouched.
- Dedicated workflow credit is limited to atlas-prefixed checks workflows so extracted/UI lanes cannot accidentally satisfy host-test enrollment.
- The pytest runner check reads workflow run commands and requires the exact test path.
- The parser handles standard named `run:` steps and inline `- run:` steps, but does not try to become a YAML validator.

## Deferred
- Historical host test workflow migration can happen in a future workflow/process slice.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_audit_extracted_pipeline_ci_enrollment.py -q -> 17 passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py . -> OK: 135 matching tests are enrolled.
- python -m py_compile scripts/audit_extracted_pipeline_ci_enrollment.py tests/test_audit_extracted_pipeline_ci_enrollment.py -> passed.
- git diff --check -- scripts/audit_extracted_pipeline_ci_enrollment.py tests/test_audit_extracted_pipeline_ci_enrollment.py scripts/local_pr_review.sh plans/PR-Atlas-Brain-Test-CI-Enrollment-Audit.md -> passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-brain-ci-enrollment-pr-body.md -> passed.

## Diff size
4 files, +474 / -2
