### PR TITLE
PR-FAQ-Deflection-Paid-Postgres-Smoke

### DIFF
--- a/plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md
@@ -1,0 +1,97 @@
+# PR-FAQ-Deflection-Paid-Postgres-Smoke
+
+## Why this slice exists
+
+`PR-FAQ-Deflection-Paid-Flow-Validation` proved the free snapshot, Stripe
+completion helper, and paid artifact release flow with an in-memory store. Its
+deferred validation gap is a live/ephemeral Postgres smoke that uses the real
+`content_ops_deflection_reports` adapter and the billing paid-flag helper
+together. The smoke must be guarded because it writes paid-state rows, even when
+the row is an ephemeral smoke fixture.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Functional validation
+
+1. Add an operator smoke script that seeds one ephemeral deflection report row
+   in Postgres, verifies it is locked, routes a fake paid Checkout session
+   through the existing billing helper, and verifies the row unlocks.
+2. Require explicit `--database-url`, `--account-id`, and
+   `--confirm-postgres-write` before opening a pool or writing data.
+3. Fail closed when the request id is not an ephemeral `smoke-...` id or when
+   a generated smoke request id already exists.
+4. Cover the guarded branches and fake Postgres success path with focused
+   tests in the main suite.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md` -- slice plan.
+- `scripts/smoke_content_ops_deflection_paid_postgres.py` -- guarded operator
+  Postgres smoke.
+- `tests/test_faq_deflection_paid_postgres_smoke.py` -- preflight and fake
+  Postgres coverage.
+
+## Mechanism
+
+The script is invoked only with explicit operator inputs:
+
+```bash
+python scripts/smoke_content_ops_deflection_paid_postgres.py \
+  --database-url "$DATABASE_URL" \
+  --account-id "$ACCOUNT_ID" \
+  --confirm-postgres-write \
+  --json
+```
+
+It creates a generated `smoke-...` request id unless the operator supplies one,
+rejects non-smoke request ids, saves a small snapshot/artifact through
+`PostgresDeflectionReportArtifactStore`, confirms the artifact record is locked,
+then calls
+`billing._handle_content_ops_deflection_report_checkout_completed(...)` with a
+fake paid Checkout session carrying `metadata.source=content_ops_deflection_report`.
+The final read uses the same Postgres store to prove `paid=true` and the payment
+reference persisted.
+
+## Intentional
+
+- No real Stripe API call. This validates the Postgres paid-state flow behind
+  the webhook helper, not Stripe signature construction.
+- No environment reads for secrets. The database URL is an explicit argument.
+- The test file is kept out of extracted-check filename patterns because this
+  smoke imports host billing code and validates host Postgres wiring.
+- No cleanup step in this slice; the generated `smoke-...` request id is
+  returned in the JSON payload so operators can inspect or remove the row.
+
+## Deferred
+
+- Future robust-testing slice: hosted browser/API validation for the portfolio
+  result page once it consumes the merged Checkout contract.
+- Future hardening slice: optional cleanup mode for smoke rows if operators
+  want automatic deletion after successful inspection.
+- Parked hardening considered: none in `HARDENING.md` touch this gating slice.
+
+## Verification
+
+- `python -m pytest tests/test_faq_deflection_paid_postgres_smoke.py -q`
+  (5 passed, 1 warning from host torch import)
+- `python -m py_compile scripts/smoke_content_ops_deflection_paid_postgres.py tests/test_faq_deflection_paid_postgres_smoke.py`
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md`
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
+- `bash scripts/check_ascii_python.sh`
+- `git diff --check`
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-paid-postgres-smoke.md`
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Plan | ~90 |
+| Smoke script | ~335 |
+| Tests | ~195 |
+| Total | ~620 |
+
+The estimate exceeds the 400 LOC soft cap because the live-write guard and fake
+Postgres coverage need to ship together; otherwise the safety claim is only
+documented, not enforced.

--- a/scripts/smoke_content_ops_deflection_paid_postgres.py
+++ b/scripts/smoke_content_ops_deflection_paid_postgres.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Guarded Postgres smoke for the FAQ deflection paid gate."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+from typing import Any
+from uuid import UUID, uuid4
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.api import billing  # noqa: E402
+from extracted_content_pipeline.deflection_report_access import (  # noqa: E402
+    PostgresDeflectionReportArtifactStore,
+)
+
+
+SKIPPED_EXIT = 2
+SMOKE_REQUEST_PREFIX = "smoke-"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Postgres DSN. Required explicitly; this script does not read env vars.",
+    )
+    parser.add_argument(
+        "--account-id",
+        required=True,
+        help="UUID account id used for the ephemeral smoke row.",
+    )
+    parser.add_argument(
+        "--request-id",
+        default="",
+        help="Optional request id. Must start with smoke- when supplied.",
+    )
+    parser.add_argument(
+        "--payment-reference",
+        default="",
+        help="Optional fake Checkout session id/payment reference.",
+    )
+    parser.add_argument(
+        "--amount-cents",
+        type=int,
+        default=150000,
+        help="Fake Checkout amount_total in cents.",
+    )
+    parser.add_argument(
+        "--currency",
+        default="usd",
+        help="Fake Checkout currency.",
+    )
+    parser.add_argument(
+        "--confirm-postgres-write",
+        action="store_true",
+        help="Required before creating or updating the Postgres smoke row.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON output path. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Accepted for operator consistency; output is always JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _clean(args.database_url):
+        raise SystemExit("--database-url is required")
+    if not _clean(args.account_id):
+        raise SystemExit("--account-id is required")
+    if int(args.amount_cents) < 1:
+        raise SystemExit("--amount-cents must be positive")
+    if not _clean(args.currency):
+        raise SystemExit("--currency is required")
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required for the deflection paid Postgres smoke"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+async def run_deflection_paid_postgres_smoke(
+    args: argparse.Namespace,
+    pool: Any,
+    *,
+    store: PostgresDeflectionReportArtifactStore | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Run the guarded smoke, returning an exit code and JSON payload."""
+
+    preflight = _preflight(args)
+    if preflight is not None:
+        return preflight
+
+    account_id = _account_id(args)
+    request_id = _request_id(args)
+    payment_reference = _payment_reference(args)
+    artifact_store = store or PostgresDeflectionReportArtifactStore(pool=pool)
+
+    existing = await artifact_store.get_artifact_record(
+        account_id=account_id,
+        request_id=request_id,
+    )
+    if existing is not None:
+        return _not_run(
+            "ephemeral_request_already_exists",
+            account_id=account_id,
+            request_id=request_id,
+        )
+
+    snapshot, artifact = _smoke_payload(request_id)
+    await artifact_store.save_report(
+        account_id=account_id,
+        request_id=request_id,
+        snapshot=snapshot,
+        artifact=artifact,
+    )
+    locked = await artifact_store.get_artifact_record(
+        account_id=account_id,
+        request_id=request_id,
+    )
+    if locked is None:
+        return _failed(
+            "seeded_report_missing",
+            account_id=account_id,
+            request_id=request_id,
+        )
+    if locked.paid:
+        return _failed(
+            "seeded_report_unexpectedly_paid",
+            account_id=account_id,
+            request_id=request_id,
+        )
+
+    metadata = {
+        "source": "content_ops_deflection_report",
+        "account_id": account_id,
+        "request_id": request_id,
+    }
+    session = SimpleNamespace(
+        id=payment_reference,
+        mode="payment",
+        payment_status="paid",
+        amount_total=int(args.amount_cents),
+        currency=_clean(args.currency).lower(),
+        metadata=metadata,
+        to_dict=lambda: {
+            "id": payment_reference,
+            "mode": "payment",
+            "payment_status": "paid",
+            "amount_total": int(args.amount_cents),
+            "currency": _clean(args.currency).lower(),
+            "metadata": dict(metadata),
+        },
+    )
+    await billing._handle_content_ops_deflection_report_checkout_completed(
+        pool,
+        session,
+        metadata,
+    )
+    unlocked = await artifact_store.get_artifact_record(
+        account_id=account_id,
+        request_id=request_id,
+    )
+    if unlocked is None or not unlocked.paid:
+        return _failed(
+            "paid_gate_did_not_unlock",
+            account_id=account_id,
+            request_id=request_id,
+        )
+    return (
+        0,
+        {
+            "ok": True,
+            "skipped": False,
+            "account_id": account_id,
+            "request_id": request_id,
+            "payment_reference": unlocked.payment_reference,
+            "locked_before_paid": not locked.paid,
+            "paid_after_checkout": unlocked.paid,
+            "snapshot_summary": dict(unlocked.snapshot.get("summary") or {}),
+            "artifact_summary": dict((unlocked.artifact or {}).get("summary") or {}),
+        },
+    )
+
+
+def _preflight(args: argparse.Namespace) -> tuple[int, dict[str, Any]] | None:
+    account_id = _clean(args.account_id)
+    request_id = _clean(getattr(args, "request_id", ""))
+    if not getattr(args, "confirm_postgres_write", False):
+        return _not_run(
+            "missing_confirm_postgres_write",
+            account_id=account_id,
+            request_id=request_id,
+        )
+    try:
+        UUID(account_id)
+    except ValueError:
+        return _not_run(
+            "invalid_account_id",
+            account_id=account_id,
+            request_id=request_id,
+        )
+    if request_id and not request_id.startswith(SMOKE_REQUEST_PREFIX):
+        return _not_run(
+            "request_id_not_ephemeral",
+            account_id=account_id,
+            request_id=request_id,
+        )
+    return None
+
+
+def _smoke_payload(request_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    snapshot = {
+        "summary": {
+            "generated": 1,
+            "drafted_answer_count": 1,
+            "no_proven_answer_count": 0,
+        },
+        "top_questions": [
+            {
+                "rank": 1,
+                "question": "How do customers export attribution reports?",
+                "weighted_frequency": 2,
+                "customer_wording": "How do I export attribution reports?",
+            }
+        ],
+    }
+    artifact = {
+        "markdown": "# Smoke FAQ Deflection Report\n\nOpen Analytics and export.",
+        "summary": dict(snapshot["summary"]),
+        "faq_result": {
+            "items": [
+                {
+                    "question": "How do customers export attribution reports?",
+                    "answer": "Open Analytics and export the report.",
+                    "source_ids": [f"{request_id}:ticket-1"],
+                }
+            ]
+        },
+    }
+    return snapshot, artifact
+
+
+def _account_id(args: argparse.Namespace) -> str:
+    return str(UUID(_clean(args.account_id)))
+
+
+def _request_id(args: argparse.Namespace) -> str:
+    return _clean(getattr(args, "request_id", "")) or (
+        f"{SMOKE_REQUEST_PREFIX}deflection-paid-postgres-{uuid4().hex}"
+    )
+
+
+def _payment_reference(args: argparse.Namespace) -> str:
+    return _clean(getattr(args, "payment_reference", "")) or f"cs_{uuid4().hex}"
+
+
+def _not_run(reason: str, **extra: Any) -> tuple[int, dict[str, Any]]:
+    payload = {
+        "ok": False,
+        "skipped": True,
+        "not_run_reason": reason,
+    }
+    payload.update(extra)
+    return SKIPPED_EXIT, payload
+
+
+def _failed(reason: str, **extra: Any) -> tuple[int, dict[str, Any]]:
+    payload = {
+        "ok": False,
+        "skipped": False,
+        "error": reason,
+    }
+    payload.update(extra)
+    return 1, payload
+
+
+def _write_payload(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    preflight = _preflight(args)
+    if preflight is not None:
+        code, payload = preflight
+        _write_payload(payload, args)
+        return code
+
+    pool = await _create_pool(_clean(args.database_url))
+    try:
+        code, payload = await run_deflection_paid_postgres_smoke(args, pool)
+    finally:
+        close = getattr(pool, "close", None)
+        if close is not None:
+            maybe_awaitable = close()
+            if hasattr(maybe_awaitable, "__await__"):
+                await maybe_awaitable
+    _write_payload(payload, args)
+    return code
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_faq_deflection_paid_postgres_smoke.py
+++ b/tests/test_faq_deflection_paid_postgres_smoke.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/smoke_content_ops_deflection_paid_postgres.py"
+SPEC = importlib.util.spec_from_file_location(
+    "smoke_content_ops_deflection_paid_postgres",
+    SCRIPT,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+smoke = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(smoke)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str], dict[str, Any]] = {}
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.execute_calls.append((query, args))
+        if "INSERT INTO content_ops_deflection_reports" in query:
+            account_id, request_id, snapshot, artifact = args
+            key = (str(account_id), str(request_id))
+            existing = self.rows.get(key, {})
+            self.rows[key] = {
+                "account_id": str(account_id),
+                "request_id": str(request_id),
+                "snapshot": snapshot,
+                "artifact": artifact,
+                "paid": bool(existing.get("paid")),
+                "payment_reference": existing.get("payment_reference"),
+            }
+            return "INSERT 0 1"
+        if "UPDATE content_ops_deflection_reports" in query:
+            account_id, request_id, payment_reference = args
+            row = self.rows.get((str(account_id), str(request_id)))
+            if row is None:
+                return "UPDATE 0"
+            row["paid"] = True
+            row["payment_reference"] = payment_reference
+            return "UPDATE 1"
+        raise AssertionError(query)
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        self.fetchrow_calls.append((query, args))
+        account_id, request_id = args
+        row = self.rows.get((str(account_id), str(request_id)))
+        return dict(row) if row is not None else None
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_skips_before_pool_without_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fail_create_pool(database_url: str) -> object:
+        raise AssertionError(f"pool should not be opened for {database_url}")
+
+    output = tmp_path / "result.json"
+    monkeypatch.setattr(smoke, "_create_pool", fail_create_pool)
+
+    code = await smoke._main([
+        "--database-url",
+        "postgres://example",
+        "--account-id",
+        _ACCOUNT_ID,
+        "--output",
+        str(output),
+    ])
+
+    assert code == smoke.SKIPPED_EXIT
+    assert '"not_run_reason": "missing_confirm_postgres_write"' in output.read_text()
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_rejects_non_ephemeral_request_id() -> None:
+    pool = _Pool()
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(request_id="real-customer-request"),
+        pool,
+    )
+
+    assert code == smoke.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "request_id_not_ephemeral"
+    assert pool.execute_calls == []
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_rejects_invalid_account_id() -> None:
+    pool = _Pool()
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(account_id="not-a-uuid"),
+        pool,
+    )
+
+    assert code == smoke.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "invalid_account_id"
+    assert pool.execute_calls == []
+    assert pool.fetchrow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_refuses_existing_ephemeral_request() -> None:
+    pool = _Pool()
+    pool.rows[(_ACCOUNT_ID, "smoke-existing")] = {
+        "account_id": _ACCOUNT_ID,
+        "request_id": "smoke-existing",
+        "snapshot": "{}",
+        "artifact": "{}",
+        "paid": False,
+        "payment_reference": None,
+    }
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(request_id="smoke-existing"),
+        pool,
+    )
+
+    assert code == smoke.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "ephemeral_request_already_exists"
+    assert pool.execute_calls == []
+    assert len(pool.fetchrow_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_seeds_locks_marks_paid_and_rereads() -> None:
+    pool = _Pool()
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(
+            request_id="smoke-paid-flow",
+            payment_reference="cs_smoke_paid_flow",
+        ),
+        pool,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["skipped"] is False
+    assert payload["account_id"] == _ACCOUNT_ID
+    assert payload["request_id"] == "smoke-paid-flow"
+    assert payload["payment_reference"] == "cs_smoke_paid_flow"
+    assert payload["locked_before_paid"] is True
+    assert payload["paid_after_checkout"] is True
+    assert payload["snapshot_summary"] == {
+        "drafted_answer_count": 1,
+        "generated": 1,
+        "no_proven_answer_count": 0,
+    }
+    assert payload["artifact_summary"] == payload["snapshot_summary"]
+    assert len(pool.execute_calls) == 2
+    assert "INSERT INTO content_ops_deflection_reports" in pool.execute_calls[0][0]
+    assert "UPDATE content_ops_deflection_reports" in pool.execute_calls[1][0]
+    assert pool.execute_calls[1][1] == (
+        _ACCOUNT_ID,
+        "smoke-paid-flow",
+        "cs_smoke_paid_flow",
+    )
+    saved = pool.rows[(_ACCOUNT_ID, "smoke-paid-flow")]
+    assert saved["paid"] is True
+    assert saved["payment_reference"] == "cs_smoke_paid_flow"
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "database_url": "postgres://example",
+        "account_id": _ACCOUNT_ID,
+        "request_id": "",
+        "payment_reference": "",
+        "amount_cents": 150000,
+        "currency": "usd",
+        "confirm_postgres_write": True,
+        "output": None,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+_ACCOUNT_ID = "00000000-0000-0000-0000-000000000116"


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md
Slice phase: Functional validation

Adds a guarded Postgres smoke for the FAQ deflection paid gate. The smoke seeds one ephemeral report row, verifies it is locked, routes a fake paid Checkout session through the existing billing helper, and verifies the real Postgres store adapter rereads the row as paid.

## Intentional
- No real Stripe API call; this validates the Postgres paid-state path behind the webhook helper.
- No environment reads for secrets; `--database-url` is explicit.
- Tests stay out of extracted-check filename patterns because this imports host billing code.
- No cleanup mode yet; the generated `smoke-...` request id is returned for inspection/removal.

## Deferred
- Browser/API validation for the portfolio result page remains for a later slice.
- Optional cleanup mode for smoke rows remains deferred.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_faq_deflection_paid_postgres_smoke.py -q` (5 passed, 1 warning from host torch import)
- `python -m py_compile scripts/smoke_content_ops_deflection_paid_postgres.py tests/test_faq_deflection_paid_postgres_smoke.py`
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Paid-Postgres-Smoke.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
- `bash scripts/check_ascii_python.sh`
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-paid-postgres-smoke.md`

## Diff size
3 files, +623 / -0
