### PR TITLE
PR-FAQ-Deflection-Portfolio-Submit

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -37,6 +37,43 @@ type GatedDeflectionExecuteResult = {
 Render `snapshot` on the free page. Do not derive answer text, evidence, source
 IDs, or Markdown from this object.
 
+## Portfolio Blob Submit Endpoint
+
+The portfolio can hand ATLAS a support-ticket CSV blob and receive the same
+gated execute response:
+
+```http
+POST /content-ops/deflection-reports/submit
+```
+
+Request:
+
+```ts
+type DeflectionReportSubmitRequest = {
+  blob_url: string; // HTTPS Vercel Blob URL, public or signed
+  support_platform: "zendesk" | "intercom" | "help_scout" | "other";
+  company_name: string;
+  contact_email: string;
+  limit?: number; // default 1000, max 1000
+};
+```
+
+ATLAS fetches the blob server-side, parses it as CSV, normalizes rows through
+the support-ticket input package, and runs synchronous `faq_deflection_report`
+generation. A `200` response means the report row exists for the authenticated
+ATLAS account and `/snapshot` should be immediately readable.
+
+Caps and failures:
+
+- `blob_url` must be `https://`; private/signed URLs are preferred when the
+  portfolio makes them available.
+- ATLAS rejects localhost/private/link-local blob hosts after DNS resolution
+  and does not follow redirects.
+- Blob body cap: 50 MB. Larger responses return `413`.
+- Sync source-material cap: first 1,000 parsed rows, or `limit` when lower.
+- Empty CSVs or CSVs with no usable customer wording return `400`.
+- Fetch and CSV parse failures return `400`.
+
 ## Free Snapshot Endpoint
 
 ```http

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -7,6 +7,11 @@ import json
 import logging
 import math
 import tempfile
+import ipaddress
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,6 +42,7 @@ else:
 from ..campaign_ports import TenantScope
 from ..campaign_postgres_import import import_campaign_opportunities
 from ..campaign_source_adapters import source_material_to_source_rows
+from ..campaign_source_adapters import load_source_rows_from_file
 from ..content_ops_execution import (
     ContentOpsExecutionServices,
     execute_content_ops_from_mapping,
@@ -77,6 +83,7 @@ from ..reasoning_policy import (
 )
 from ..reasoning_signals import reasoning_validation_blocked_reason
 from ..ticket_faq_input_contract import ticket_faq_input_contracts
+from ..support_ticket_input_package import build_support_ticket_input_package
 
 ExecutionServicesProvider = Callable[
     [],
@@ -118,7 +125,16 @@ _MAX_INPUT_STRING_CHARS = 10000
 _MAX_INGESTION_ROWS = 1000
 _MAX_FILE_INGESTION_ROWS = 10000
 _MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
+_MAX_DEFLECTION_SUBMIT_BLOB_BYTES = 50 * 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
+_DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS = 15
+_DEFLECTION_SUBMIT_OUTPUTS = ("faq_deflection_report",)
+_DEFLECTION_SUBMIT_PLATFORMS = frozenset({
+    "zendesk",
+    "intercom",
+    "help_scout",
+    "other",
+})
 _UPLOAD_FILE_FORMATS = ("auto", "json", "jsonl", "csv")
 _MAX_REASONING_STATUS_LIST_ITEMS = 20
 _MAX_FALSIFICATION_RULES = 20
@@ -570,11 +586,54 @@ if BaseModel is not None:
 
         payment_reference: str | None = Field(default=None, max_length=200)
 
+    class DeflectionReportSubmitModel(BaseModel):
+        """Portfolio-owned upload handoff for a paid FAQ deflection report."""
+
+        model_config = ConfigDict(extra="forbid")
+
+        blob_url: str = Field(..., min_length=1, max_length=2048)
+        support_platform: str = Field(..., min_length=1, max_length=80)
+        company_name: str = Field(..., min_length=1, max_length=200)
+        contact_email: str = Field(..., min_length=3, max_length=320)
+        limit: int = Field(_MAX_INGESTION_ROWS, ge=1, le=_MAX_INGESTION_ROWS)
+
+        @field_validator("blob_url")
+        @classmethod
+        def _validate_blob_url(cls, value: Any) -> str:
+            return _validate_https_blob_url(value)
+
+        @field_validator("support_platform")
+        @classmethod
+        def _validate_support_platform(cls, value: Any) -> str:
+            text = (_clean(value) or "").lower().replace("-", "_")
+            if text not in _DEFLECTION_SUBMIT_PLATFORMS:
+                raise ValueError(
+                    "support_platform must be one of: zendesk, intercom, "
+                    "help_scout, other"
+                )
+            return text
+
+        @field_validator("company_name", "contact_email")
+        @classmethod
+        def _validate_required_text(cls, value: Any) -> str:
+            text = _clean(value)
+            if not text:
+                raise ValueError("field is required")
+            return str(text)
+
+        @field_validator("contact_email")
+        @classmethod
+        def _validate_contact_email(cls, value: str) -> str:
+            if "@" not in value or value.startswith("@") or value.endswith("@"):
+                raise ValueError("contact_email must be an email address")
+            return value
+
 else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsRequestModel = Any
     ContentOpsIngestionInspectModel = Any
     ContentOpsIngestionImportModel = Any
     DeflectionReportPaidModel = Any
+    DeflectionReportSubmitModel = Any
 
 
 def create_content_ops_control_surface_router(
@@ -1042,6 +1101,72 @@ def create_content_ops_control_surface_router(
         finally:
             await execute_gate.release()
 
+    @router.post("/deflection-reports/submit")
+    async def submit_deflection_report(
+        payload: DeflectionReportSubmitModel = Body(...),
+    ) -> dict[str, Any]:
+        data = _deflection_submit_payload_to_mapping(payload)
+        max_rows = min(
+            int(data.get("limit") or _MAX_INGESTION_ROWS),
+            resolved_config.faq_execute_max_source_material_rows,
+        )
+        rows, byte_count = await _load_deflection_submit_blob_rows(
+            data["blob_url"],
+            max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
+        )
+        if not rows:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason": "deflection_submit_empty_blob",
+                    "message": "Blob CSV did not contain support-ticket rows.",
+                },
+            )
+        raw_row_count = len(rows)
+        submitted_rows = _deflection_submit_rows_with_defaults(data, rows)[:max_rows]
+        title = _deflection_submit_title(data)
+        package = build_support_ticket_input_package(
+            submitted_rows,
+            provider="portfolio_deflection_submit",
+            outputs=_DEFLECTION_SUBMIT_OUTPUTS,
+            max_rows=max_rows,
+            campaign_name=title,
+        )
+        included_row_count = int(package.metadata.get("included_row_count") or 0)
+        if included_row_count <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason": "deflection_submit_no_usable_rows",
+                    "message": "Blob CSV did not include usable support-ticket wording.",
+                    "source_row_count": raw_row_count,
+                    "max_source_material_rows": max_rows,
+                },
+            )
+
+        execute_inputs = dict(package.inputs)
+        execute_inputs.update({
+            "deflection_report_title": title,
+            "company_name": data["company_name"],
+            "contact_email": data["contact_email"],
+            "support_platform": data["support_platform"],
+        })
+        result = await execute_generation({
+            "outputs": list(_DEFLECTION_SUBMIT_OUTPUTS),
+            "limit": max_rows,
+            "require_quality_gates": False,
+            "inputs": execute_inputs,
+        })
+        return _with_deflection_submit_diagnostics(
+            result,
+            byte_count=byte_count,
+            max_rows=max_rows,
+            source_row_count=raw_row_count,
+            submitted_row_count=len(submitted_rows),
+            package=package.as_dict(),
+            support_platform=data["support_platform"],
+        )
+
     return router
 
 
@@ -1103,6 +1228,246 @@ async def _inspect_uploaded_ingestion_file(
                     "Content Ops temporary ingestion upload cleanup failed",
                     extra={"source": _clean(source) or _clean(getattr(file, "filename", None))},
                 )
+
+
+async def _load_deflection_submit_blob_rows(
+    blob_url: str,
+    *,
+    max_bytes: int,
+) -> tuple[list[Any], int]:
+    return await asyncio.to_thread(
+        _load_deflection_submit_blob_rows_sync,
+        blob_url,
+        max_bytes,
+    )
+
+
+def _load_deflection_submit_blob_rows_sync(
+    blob_url: str,
+    max_bytes: int,
+) -> tuple[list[Any], int]:
+    data = _read_bounded_https_blob(blob_url, max_bytes=max_bytes)
+    if not data:
+        raise HTTPException(
+            status_code=400,
+            detail="Blob CSV is empty.",
+        )
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="content-ops-deflection-submit-",
+            suffix=".csv",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            handle.write(data)
+        try:
+            rows = load_source_rows_from_file(temp_path, file_format="csv")
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Blob CSV could not be parsed.",
+            ) from exc
+        return rows, len(data)
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Content Ops deflection submit temp cleanup failed")
+
+
+def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
+    url = _validate_https_blob_fetch_target(blob_url)
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Atlas-Content-Ops/1.0"},
+    )
+    try:
+        with _open_https_blob_request(
+            request,
+            timeout=_DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
+        ) as response:
+            data = response.read(max_bytes + 1)
+    except urllib.error.HTTPError as exc:
+        if 300 <= int(getattr(exc, "code", 0) or 0) < 400:
+            raise HTTPException(
+                status_code=400,
+                detail="Blob URL redirects are not allowed.",
+            ) from exc
+        raise HTTPException(
+            status_code=400,
+            detail="Blob URL could not be fetched.",
+        ) from exc
+    except (OSError, urllib.error.URLError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Blob URL could not be fetched.",
+        ) from exc
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "deflection_submit_blob_too_large",
+                "max_file_bytes": max_bytes,
+            },
+        )
+    return data
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+
+def _open_https_blob_request(
+    request: urllib.request.Request,
+    *,
+    timeout: int,
+) -> Any:
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    return opener.open(request, timeout=timeout)
+
+
+def _validate_https_blob_url(value: Any) -> str:
+    text = _clean(value) or ""
+    parsed = urllib.parse.urlparse(text)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("blob_url must be an https URL")
+    host = parsed.hostname or ""
+    if not host or _is_blocked_blob_host(host):
+        raise ValueError("blob_url host is not allowed")
+    if parsed.username or parsed.password:
+        raise ValueError("blob_url must not include credentials")
+    return text
+
+
+def _validate_https_blob_fetch_target(value: Any) -> str:
+    url = _validate_https_blob_url(value)
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    try:
+        _validate_blob_host_resolution(host)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return url
+
+
+def _validate_blob_host_resolution(host: str) -> None:
+    # This preflight closes common hostname-to-private SSRF cases. urllib still
+    # resolves again at connect time, so a full DNS-rebinding defense would pin
+    # the validated IP at connection construction.
+    try:
+        resolved = socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise ValueError("blob_url host could not be resolved") from exc
+    if not resolved:
+        raise ValueError("blob_url host could not be resolved")
+    for item in resolved:
+        sockaddr = item[4]
+        if not sockaddr:
+            raise ValueError("blob_url host could not be resolved")
+        if _is_blocked_blob_host(str(sockaddr[0])):
+            raise ValueError("blob_url host is not allowed")
+
+
+def _is_blocked_blob_host(host: str) -> bool:
+    lowered = host.strip().lower().rstrip(".")
+    if lowered in {"localhost", "0.0.0.0"} or lowered.endswith(".local"):
+        return True
+    try:
+        address = ipaddress.ip_address(lowered)
+    except ValueError:
+        return False
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _deflection_submit_rows_with_defaults(
+    data: Mapping[str, Any],
+    rows: Sequence[Any],
+) -> list[Any]:
+    defaults = {
+        "source_type": "support_ticket",
+        "company_name": data["company_name"],
+        "contact_email": data["contact_email"],
+        "support_platform": data["support_platform"],
+    }
+    return [
+        {**defaults, **dict(row)}
+        if isinstance(row, Mapping)
+        else row
+        for row in rows
+    ]
+
+
+def _deflection_submit_title(data: Mapping[str, Any]) -> str:
+    return f"{data['company_name']} Support Deflection Report"
+
+
+def _with_deflection_submit_diagnostics(
+    response: Mapping[str, Any],
+    *,
+    byte_count: int,
+    max_rows: int,
+    source_row_count: int,
+    submitted_row_count: int,
+    package: Mapping[str, Any],
+    support_platform: str,
+) -> dict[str, Any]:
+    out = dict(response)
+    existing = out.get("input_provider")
+    diagnostics = dict(existing) if isinstance(existing, Mapping) else {}
+    metadata = dict(diagnostics.get("metadata") or {})
+    package_metadata = package.get("metadata") if isinstance(package, Mapping) else {}
+    if isinstance(package_metadata, Mapping):
+        metadata.update({
+            key: package_metadata[key]
+            for key in (
+                "included_row_count",
+                "skipped_row_count",
+                "source_period",
+            )
+            if key in package_metadata
+        })
+    truncated_row_count = max(0, source_row_count - submitted_row_count)
+    metadata.update({
+        "source": "portfolio_deflection_submit",
+        "source_row_count": source_row_count,
+        "submitted_row_count": submitted_row_count,
+        "truncated_row_count": truncated_row_count,
+        "max_source_material_rows": max_rows,
+        "blob_bytes": byte_count,
+        "support_platform": support_platform,
+    })
+    warnings = [
+        dict(warning)
+        for warning in diagnostics.get("warnings") or ()
+        if isinstance(warning, Mapping)
+    ]
+    if truncated_row_count:
+        warnings.append({
+            "code": "deflection_submit_rows_truncated",
+            "message": (
+                f"Used first {submitted_row_count} support-ticket rows "
+                f"out of {source_row_count}."
+            ),
+            "row_count": source_row_count,
+            "max_rows": max_rows,
+            "truncated_row_count": truncated_row_count,
+        })
+    out["input_provider"] = {
+        "provider": "portfolio_deflection_submit",
+        "metadata": metadata,
+        "warnings": warnings,
+    }
+    return out
 
 
 async def _read_bounded_upload(file: UploadFile) -> bytes:
@@ -2203,6 +2568,15 @@ def _ingestion_import_payload_to_mapping(payload: Any) -> dict[str, Any]:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 
 
+def _deflection_submit_payload_to_mapping(payload: Any) -> dict[str, Any]:
+    if BaseModel is not None and isinstance(payload, DeflectionReportSubmitModel):
+        return payload.model_dump()
+    try:
+        return DeflectionReportSubmitModel.model_validate(payload).model_dump()
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
+
+
 def _validate_input_shape(
     value: Any,
     *,
@@ -2290,5 +2664,6 @@ __all__ = [
     "ContentOpsControlSurfaceApiConfig",
     "ContentOpsIngestionImportModel",
     "ContentOpsRequestModel",
+    "DeflectionReportSubmitModel",
     "create_content_ops_control_surface_router",
 ]

--- a/plans/PR-FAQ-Deflection-Portfolio-Submit.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Submit.md
@@ -1,0 +1,117 @@
+# PR-FAQ-Deflection-Portfolio-Submit
+
+## Why this slice exists
+
+Issue #1161 closed the portfolio integration questions and made one product
+decision explicit: the portfolio should hand ATLAS a support-ticket CSV blob
+reference, and ATLAS should fetch, normalize, execute, persist, and return the
+locked deflection report response. Without this seam the portfolio must either
+duplicate ATLAS support-ticket CSV normalization or cannot route a buyer to a
+real `{request_id}` results page.
+
+This slice exceeds the 400 LOC target because the endpoint is not useful
+without the contract doc, bounded server-side blob fetch, SSRF guard fixtures,
+URL/size/input failure fixtures, and extracted-runner enrollment. Splitting
+those out would leave a public integration endpoint without its safety and
+contract proof.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Vertical slice
+
+1. Add `POST /content-ops/deflection-reports/submit` to the existing Content
+   Ops router.
+2. Accept the portfolio handoff body from #1161: `blob_url`,
+   `support_platform`, `company_name`, and `contact_email`, with optional
+   `limit`.
+3. Fetch only HTTPS blob URLs through a bounded server-side read that rejects
+   private DNS targets and redirects, parse CSV rows through the existing
+   source-row loader, and run the existing synchronous `faq_deflection_report`
+   execute path.
+4. Return the same gated execute shape as `/execute`: `request_id`, snapshot,
+   and locked `full_report`; no paid artifact leaks.
+5. Document the endpoint contract and caps for the portfolio.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Submit.md`
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+
+## Mechanism
+
+The new route lives in `create_content_ops_control_surface_router`, so it
+inherits the same host auth dependency, tenant scope, execution-services
+provider, deflection store, usage summary, and paid-gate behavior as `/execute`.
+The route validates the URL shape, rejects localhost/private/link-local DNS
+targets before fetch, blocks redirects instead of following them, downloads the
+referenced CSV into a temporary file with a byte cap, loads rows with
+`load_source_rows_from_file(file_format="csv")`, rejects empty or wholly
+un-normalizable inputs, then builds an internal execute payload:
+
+```json
+{
+  "outputs": ["faq_deflection_report"],
+  "limit": 1000,
+  "require_quality_gates": false,
+  "inputs": {
+    "source_material": [...],
+    "company_name": "...",
+    "contact_email": "...",
+    "support_platform": "zendesk"
+  }
+}
+```
+
+The route delegates execution to the same internal flow that already persists
+deflection artifacts and replaces the full artifact with the locked paid-gate
+result.
+
+## Intentional
+
+- This is sync, matching the currently shipped execute seam. A `200` means the
+  report was persisted and the returned `request_id` can hydrate `/snapshot`
+  immediately for the same authenticated account.
+- The endpoint accepts HTTPS blob URLs only. Public Vercel Blob works now;
+  signed/private URLs can use the same field without changing the ATLAS API.
+- DNS is preflighted before `urllib` connects and redirects are blocked. A
+  full DNS-rebinding defense would require pinning the validated IP during
+  connection construction; that is beyond this vertical slice.
+- The route caps parsed rows at the same FAQ sync execute cap. It does not add
+  a background ingestion path in this vertical slice.
+- The route does not create Stripe Checkout or mark reports paid. The existing
+  webhook remains the only customer payment trust boundary.
+
+## Deferred
+
+- Parked hardening: none.
+- Async/background blob execution for exports beyond the sync row cap remains a
+  future robust-testing / production-hardening slice.
+- Private Vercel Blob signing is a portfolio-side follow-up from issue #1161;
+  this endpoint can consume those URLs once the portfolio sends them.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` - 8 passed.
+- `python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_extracted_content_deflection_submit.py -q` - 9 passed, 1 warning.
+- `python -m pytest tests/test_extracted_content_control_surface_api.py -q` - 123 passed, 1 skipped.
+- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-submit-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~117 |
+| Contract doc | ~37 |
+| Router implementation | ~375 |
+| Tests | ~343 |
+| CI runner enrollment | ~1 |
+| **Total** | **~873** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -29,6 +29,7 @@ pytest \
   tests/test_content_ops_faq_saas_demo_corpus.py \
   tests/test_content_ops_faq_report_contract_docs.py \
   tests/test_content_ops_deflection_report.py \
+  tests/test_extracted_content_deflection_submit.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import socket
+import urllib.error
+from typing import Any
+
+import pytest
+
+import extracted_content_pipeline.api.control_surfaces as api_module
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
+from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
+from extracted_content_pipeline.deflection_report_access import (
+    InMemoryDeflectionReportArtifactStore,
+)
+from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
+
+
+def _route(router: Any, path: str, method: str) -> Any:
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
+            return route
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+class _BlobResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self, _size: int) -> bytes:
+        return self._data
+
+    def __enter__(self) -> "_BlobResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def _csv_bytes(rows: list[str]) -> bytes:
+    return ("\n".join(rows) + "\n").encode("utf-8")
+
+
+def _install_blob(
+    monkeypatch: pytest.MonkeyPatch,
+    data: bytes,
+) -> list[tuple[str, int]]:
+    calls: list[tuple[str, int]] = []
+
+    def _open(request: Any, *, timeout: int) -> _BlobResponse:
+        calls.append((request.full_url, timeout))
+        return _BlobResponse(data)
+
+    monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
+    return calls
+
+
+def _install_public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _getaddrinfo(host: str, port: int, *, type: int):
+        return [(
+            socket.AF_INET,
+            type,
+            6,
+            "",
+            ("93.184.216.34", port),
+        )]
+
+    monkeypatch.setattr(api_module.socket, "getaddrinfo", _getaddrinfo)
+
+
+def _router(
+    store: InMemoryDeflectionReportArtifactStore,
+):
+    return create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(
+            prefix="/ops",
+            tags=("ops",),
+            deflection_snapshot_top_n=2,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        deflection_report_store_provider=lambda: store,
+        scope_provider=lambda: {"account_id": "acct-portfolio-submit"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_fetches_blob_and_returns_locked_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message,resolution_text,pain_category",
+        (
+            "ticket-export-1,Export attribution,"
+            "How do I export attribution reports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        (
+            "ticket-export-2,Report download,"
+            "Where is the report download for attribution exports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        "ticket-sso-1,SSO setup,How do I enable SSO for my team?,,auth",
+    ])
+    calls = _install_blob(monkeypatch, csv_data)
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    payload = await submit.endpoint({
+        "blob_url": "https://portfolio.example/blob/tickets.csv",
+        "support_platform": "zendesk",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "limit": 2,
+    })
+
+    assert calls == [(
+        "https://portfolio.example/blob/tickets.csv",
+        api_module._DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
+    )]
+    assert payload["status"] == "completed"
+    assert payload["request_id"].startswith("content-ops-")
+    gated_result = payload["steps"][0]["result"]
+    assert gated_result == {
+        "request_id": payload["request_id"],
+        "snapshot": gated_result["snapshot"],
+        "full_report": {
+            "status": "locked",
+            "reason": "payment_required",
+        },
+    }
+    assert "markdown" not in str(gated_result)
+    assert "ticket-export-1" not in str(gated_result)
+    assert payload["input_provider"]["metadata"] == {
+        "blob_bytes": len(csv_data),
+        "included_row_count": 2,
+        "max_source_material_rows": 2,
+        "skipped_row_count": 0,
+        "source": "portfolio_deflection_submit",
+        "source_period": "Uploaded support tickets",
+        "source_row_count": 3,
+        "submitted_row_count": 2,
+        "support_platform": "zendesk",
+        "truncated_row_count": 1,
+    }
+    assert payload["input_provider"]["warnings"] == [{
+        "code": "deflection_submit_rows_truncated",
+        "message": "Used first 2 support-ticket rows out of 3.",
+        "row_count": 3,
+        "max_rows": 2,
+        "truncated_row_count": 1,
+    }]
+
+    snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
+    assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+
+    artifact = _route(router, "/ops/deflection-reports/{request_id}/artifact", "GET")
+    with pytest.raises(api_module.HTTPException) as locked:
+        await artifact.endpoint(request_id=payload["request_id"])
+    assert locked.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_non_https_blob_url() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "http://portfolio.example/blob/tickets.csv",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 422
+    assert "blob_url must be an https URL" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_oversize_blob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    monkeypatch.setattr(api_module, "_MAX_DEFLECTION_SUBMIT_BLOB_BYTES", 10)
+    _install_blob(monkeypatch, b"01234567890")
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example/blob/tickets.csv",
+            "support_platform": "intercom",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == {
+        "reason": "deflection_submit_blob_too_large",
+        "max_file_bytes": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_csv_without_usable_ticket_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    _install_blob(
+        monkeypatch,
+        _csv_bytes([
+            "ticket_id,created_at",
+            "ticket-empty,2026-05-01",
+        ]),
+    )
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example/blob/tickets.csv",
+            "support_platform": "help_scout",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == {
+        "reason": "deflection_submit_no_usable_rows",
+        "message": "Blob CSV did not include usable support-ticket wording.",
+        "source_row_count": 1,
+        "max_source_material_rows": 1000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_hostname_resolving_to_private_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _getaddrinfo(host: str, port: int, *, type: int):
+        assert host == "blob.attacker.example"
+        return [(
+            socket.AF_INET,
+            type,
+            6,
+            "",
+            ("169.254.169.254", port),
+        )]
+
+    def _open(_request: Any, *, timeout: int) -> _BlobResponse:
+        raise AssertionError("private DNS target must be rejected before fetch")
+
+    monkeypatch.setattr(api_module.socket, "getaddrinfo", _getaddrinfo)
+    monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://blob.attacker.example/tickets.csv",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "blob_url host is not allowed"
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_non_ip_literal_internal_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _getaddrinfo(host: str, port: int, *, type: int):
+        assert host == "metadata.google.internal"
+        return [(
+            socket.AF_INET,
+            type,
+            6,
+            "",
+            ("169.254.169.254", port),
+        )]
+
+    monkeypatch.setattr(api_module.socket, "getaddrinfo", _getaddrinfo)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://metadata.google.internal/computeMetadata/v1/",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "blob_url host is not allowed"
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_blob_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    calls: list[str] = []
+
+    def _open(request: Any, *, timeout: int) -> _BlobResponse:
+        calls.append(request.full_url)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            302,
+            "Found",
+            {"Location": "http://169.254.169.254/latest/meta-data"},
+            None,
+        )
+
+    monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example/blob/tickets.csv",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert calls == ["https://portfolio.example/blob/tickets.csv"]
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL redirects are not allowed."
+
+
+def test_deflection_submit_opener_disables_redirects() -> None:
+    handler = api_module._NoRedirectHandler()
+
+    assert handler.redirect_request(None, None, 302, "Found", {}, "https://x") is None


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Submit.md
Slice phase: Vertical slice

This adds the ATLAS-owned portfolio blob submit seam from issue #1161: the portfolio posts an HTTPS support-ticket CSV blob reference, ATLAS fetches it server-side, normalizes rows through the existing support-ticket package, runs `faq_deflection_report`, persists the full artifact behind the paid gate, and returns the locked snapshot response with a `request_id`.

## Intentional
- The endpoint is synchronous because current `/execute` is synchronous; `200` means `/snapshot` is immediately readable for the same authenticated account.
- Blob submit accepts HTTPS URLs only, rejects private DNS targets and redirects, and keeps customer payment unlocks on the existing Stripe webhook trust path.
- Rows past the sync cap are truncated with response diagnostics; async/background execution is deferred.

## Deferred
- Async/background blob execution for exports beyond the sync cap remains a future hardening slice.
- Private/signed Vercel Blob URLs are a portfolio-side follow-up; this endpoint can consume them through the same `blob_url` field.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_extracted_content_deflection_submit.py -q -> 8 passed.
- python -m pytest tests/test_atlas_billing_content_ops_deflection_paid_flow.py tests/test_extracted_content_deflection_submit.py -q -> 9 passed, 1 warning.
- python -m pytest tests/test_extracted_content_control_surface_api.py -q -> 123 passed, 1 skipped.
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py -> passed.
- bash scripts/validate_extracted_content_pipeline.sh -> passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -> passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt -> passed.
- bash scripts/check_ascii_python.sh -> passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-submit-pr-body.md -> passed.

## Diff size
5 files, +873 / -0
