### PR TITLE
PR-FAQ-Deflection-Postgres-Smoke-Cleanup

### DIFF
--- a/plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md
+++ b/plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md
@@ -1,0 +1,82 @@
+# PR-FAQ-Deflection-Postgres-Smoke-Cleanup
+
+## Why this slice exists
+
+`PR-FAQ-Deflection-Paid-Postgres-Smoke` added a guarded live/ephemeral Postgres
+smoke for the FAQ deflection paid gate and deferred an optional cleanup mode.
+Operators can already inspect or manually remove the returned `smoke-...` row,
+but repeated smoke runs should not require manual database cleanup when the
+paid-gate proof succeeds.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Production hardening
+
+1. Add `--cleanup-on-success` to the existing Postgres smoke.
+2. Delete only the exact tenant/request row created by the smoke, and only when
+   the request id is still an ephemeral `smoke-...` id.
+3. Report cleanup intent and result in the JSON payload.
+4. Cover cleanup success and cleanup miss/failure behavior with focused tests.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md` -- slice plan.
+- `scripts/smoke_content_ops_deflection_paid_postgres.py` -- optional cleanup
+  mode for successful smoke rows.
+- `tests/test_faq_deflection_paid_postgres_smoke.py` -- cleanup regression
+  coverage.
+
+## Mechanism
+
+When `--cleanup-on-success` is present, the smoke runs the same guarded paid
+flow first. After the final reread proves the row is paid, the script executes a
+targeted delete:
+
+```sql
+DELETE FROM content_ops_deflection_reports
+WHERE account_id = $1
+  AND request_id = $2
+  AND request_id LIKE 'smoke-%'
+```
+
+The `smoke-` predicate is duplicated in SQL so a later bug in Python request-id
+handling cannot delete non-ephemeral rows. Cleanup runs only after the smoke
+has succeeded; preflight skips and failed paid-gate checks do not delete
+anything.
+
+## Intentional
+
+- No general cleanup command. This only cleans up the row created by a
+  successful smoke invocation.
+- Cleanup miss is reported as a failed smoke result because the operator asked
+  for cleanup and the row remained or could not be confirmed deleted.
+- The script keeps direct SQL for cleanup rather than widening the shared
+  deflection report store port for an operator-only maintenance behavior.
+
+## Deferred
+
+- Future robust-testing slice: hosted browser/API validation for the portfolio
+  result page once it consumes the merged Checkout contract.
+- Parked hardening considered: none in `HARDENING.md` touch this cleanup slice.
+
+## Verification
+
+- `python -m pytest tests/test_faq_deflection_paid_postgres_smoke.py -q`
+  (7 passed, 1 warning from host torch import)
+- `python -m py_compile scripts/smoke_content_ops_deflection_paid_postgres.py tests/test_faq_deflection_paid_postgres_smoke.py`
+- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md`
+- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md`
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
+- `bash scripts/check_ascii_python.sh`
+- `git diff --check`
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-postgres-smoke-cleanup.md`
+
+## Estimated diff size
+
+| Area | Estimate |
+|---|---:|
+| Plan | ~85 |
+| Smoke script | ~50 |
+| Tests | ~55 |
+| Total | ~190 |

--- a/scripts/smoke_content_ops_deflection_paid_postgres.py
+++ b/scripts/smoke_content_ops_deflection_paid_postgres.py
@@ -21,6 +21,9 @@ from atlas_brain.api import billing  # noqa: E402
 from extracted_content_pipeline.deflection_report_access import (  # noqa: E402
     PostgresDeflectionReportArtifactStore,
 )
+from extracted_content_pipeline.storage._jsonb_helpers import (  # noqa: E402
+    parse_command_tag,
+)
 
 
 SKIPPED_EXIT = 2
@@ -64,6 +67,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--confirm-postgres-write",
         action="store_true",
         help="Required before creating or updating the Postgres smoke row.",
+    )
+    parser.add_argument(
+        "--cleanup-on-success",
+        action="store_true",
+        help="Delete the ephemeral smoke row after the paid-gate proof succeeds.",
     )
     parser.add_argument(
         "--output",
@@ -187,6 +195,24 @@ async def run_deflection_paid_postgres_smoke(
             account_id=account_id,
             request_id=request_id,
         )
+    cleanup_requested = bool(getattr(args, "cleanup_on_success", False))
+    cleanup_deleted = False
+    if cleanup_requested:
+        cleanup_deleted = await _cleanup_ephemeral_report(
+            pool,
+            account_id=account_id,
+            request_id=request_id,
+        )
+        if not cleanup_deleted:
+            return _failed(
+                "cleanup_failed",
+                account_id=account_id,
+                request_id=request_id,
+                payment_reference=unlocked.payment_reference,
+                cleanup_requested=True,
+                cleanup_deleted=False,
+                paid_after_checkout=True,
+            )
     return (
         0,
         {
@@ -197,6 +223,8 @@ async def run_deflection_paid_postgres_smoke(
             "payment_reference": unlocked.payment_reference,
             "locked_before_paid": not locked.paid,
             "paid_after_checkout": unlocked.paid,
+            "cleanup_requested": cleanup_requested,
+            "cleanup_deleted": cleanup_deleted,
             "snapshot_summary": dict(unlocked.snapshot.get("summary") or {}),
             "artifact_summary": dict((unlocked.artifact or {}).get("summary") or {}),
         },
@@ -273,6 +301,27 @@ def _request_id(args: argparse.Namespace) -> str:
 
 def _payment_reference(args: argparse.Namespace) -> str:
     return _clean(getattr(args, "payment_reference", "")) or f"cs_{uuid4().hex}"
+
+
+async def _cleanup_ephemeral_report(
+    pool: Any,
+    *,
+    account_id: str,
+    request_id: str,
+) -> bool:
+    if not request_id.startswith(SMOKE_REQUEST_PREFIX):
+        return False
+    result = await pool.execute(
+        """
+        DELETE FROM content_ops_deflection_reports
+        WHERE account_id = $1
+          AND request_id = $2
+          AND request_id LIKE 'smoke-%'
+        """,
+        account_id,
+        request_id,
+    )
+    return parse_command_tag(result)
 
 
 def _not_run(reason: str, **extra: Any) -> tuple[int, dict[str, Any]]:

--- a/tests/test_faq_deflection_paid_postgres_smoke.py
+++ b/tests/test_faq_deflection_paid_postgres_smoke.py
@@ -25,6 +25,7 @@ class _Pool:
         self.rows: dict[tuple[str, str], dict[str, Any]] = {}
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
         self.fetchrow_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.delete_result = "DELETE 1"
 
     async def execute(self, query: str, *args: Any) -> str:
         self.execute_calls.append((query, args))
@@ -49,6 +50,11 @@ class _Pool:
             row["paid"] = True
             row["payment_reference"] = payment_reference
             return "UPDATE 1"
+        if "DELETE FROM content_ops_deflection_reports" in query:
+            account_id, request_id = args
+            if self.delete_result == "DELETE 1":
+                self.rows.pop((str(account_id), str(request_id)), None)
+            return self.delete_result
         raise AssertionError(query)
 
     async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
@@ -174,6 +180,52 @@ async def test_deflection_paid_postgres_smoke_seeds_locks_marks_paid_and_rereads
     assert saved["payment_reference"] == "cs_smoke_paid_flow"
 
 
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_can_cleanup_successful_smoke_row() -> None:
+    pool = _Pool()
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(
+            request_id="smoke-cleanup",
+            payment_reference="cs_smoke_cleanup",
+            cleanup_on_success=True,
+        ),
+        pool,
+    )
+
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["cleanup_requested"] is True
+    assert payload["cleanup_deleted"] is True
+    assert (_ACCOUNT_ID, "smoke-cleanup") not in pool.rows
+    assert len(pool.execute_calls) == 3
+    assert "DELETE FROM content_ops_deflection_reports" in pool.execute_calls[2][0]
+    assert pool.execute_calls[2][1] == (_ACCOUNT_ID, "smoke-cleanup")
+
+
+@pytest.mark.asyncio
+async def test_deflection_paid_postgres_smoke_reports_cleanup_miss() -> None:
+    pool = _Pool()
+    pool.delete_result = "DELETE 0"
+
+    code, payload = await smoke.run_deflection_paid_postgres_smoke(
+        _args(
+            request_id="smoke-cleanup-miss",
+            payment_reference="cs_smoke_cleanup_miss",
+            cleanup_on_success=True,
+        ),
+        pool,
+    )
+
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["error"] == "cleanup_failed"
+    assert payload["cleanup_requested"] is True
+    assert payload["cleanup_deleted"] is False
+    assert payload["paid_after_checkout"] is True
+    assert pool.rows[(_ACCOUNT_ID, "smoke-cleanup-miss")]["paid"] is True
+
+
 def _args(**overrides: Any) -> argparse.Namespace:
     values: dict[str, Any] = {
         "database_url": "postgres://example",
@@ -183,6 +235,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "amount_cents": 150000,
         "currency": "usd",
         "confirm_postgres_write": True,
+        "cleanup_on_success": False,
         "output": None,
         "json": True,
     }


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md
Slice phase: Production hardening

Adds `--cleanup-on-success` to the guarded FAQ deflection paid Postgres smoke. Cleanup runs only after the paid-gate proof succeeds and deletes only the exact tenant/request row whose request id still matches the `smoke-...` guard.

## Intentional
- No general cleanup command; this only removes a successful smoke row.
- Cleanup miss is reported as a failed smoke because the operator explicitly requested cleanup.
- Direct SQL keeps the shared deflection report store port focused on product access behavior.

## Deferred
- Hosted browser/API validation for the portfolio result page remains deferred.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_faq_deflection_paid_postgres_smoke.py -q` (7 passed, 1 warning from host torch import)
- `python -m py_compile scripts/smoke_content_ops_deflection_paid_postgres.py tests/test_faq_deflection_paid_postgres_smoke.py`
- `python scripts/audit_plan_doc.py plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md`
- `python scripts/audit_plan_code_consistency.py plans/PR-FAQ-Deflection-Postgres-Smoke-Cleanup.md`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py`
- `bash scripts/check_ascii_python.sh`
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-postgres-smoke-cleanup.md`

## Diff size
3 files, +184 / -0
