### PR TITLE
PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed

### DIFF
--- a/atlas_brain/_content_ops_macro_writeback.py
+++ b/atlas_brain/_content_ops_macro_writeback.py
@@ -38,7 +38,7 @@ class ConfigZendeskMacroCredentialsProvider:
 
 @dataclass(frozen=True)
 class TenantZendeskMacroCredentialsProvider:
-    """Zendesk credential source backed by tenant storage with config fallback."""
+    """Zendesk credential source backed by tenant storage with unscoped fallback."""
 
     pool: Any
     fallback_provider: ZendeskMacroCredentialsProvider
@@ -47,15 +47,18 @@ class TenantZendeskMacroCredentialsProvider:
         self,
         scope: TenantScope,
     ) -> ZendeskMacroCredentials | None:
-        if scope.account_id:
+        account_id = _scope_text(scope.account_id)
+        if account_id:
             from ._content_ops_zendesk_credentials import (
                 lookup_zendesk_credentials,
             )
 
             return await lookup_zendesk_credentials(
                 self.pool,
-                account_id=scope.account_id,
+                account_id=account_id,
             )
+        if _has_tenant_markers(scope):
+            return None
         return await self.fallback_provider.credentials_for_scope(scope)
 
 
@@ -112,6 +115,20 @@ async def _maybe_await(value: Any) -> Any:
 
 def _config_value(config: Any, name: str) -> str:
     return str(getattr(config, name, "") or "").strip()
+
+
+def _scope_text(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _has_tenant_markers(scope: TenantScope) -> bool:
+    if _scope_text(scope.user_id):
+        return True
+    return any(
+        _scope_text(value)
+        for values in (scope.allowed_vendors or (), scope.roles or ())
+        for value in values
+    )
 
 
 __all__ = [

--- a/plans/PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed.md
+++ b/plans/PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed.md
@@ -1,0 +1,80 @@
+# PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed
+
+## Why this slice exists
+
+PR #1146 added tenant Zendesk credential lookup for FAQ macro writeback and
+intended config credentials to remain available only for unscoped
+local/single-tenant operation. The remaining gap is the boundary between
+"unscoped" and "tenant-scoped but missing an account id": a scope that carries
+tenant/user markers without a usable `account_id` can still reach the config
+fallback. That can let a mis-scoped hosted publish borrow shared Zendesk
+credentials, so this production-hardening slice closes that fallback path.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+
+1. Tighten FAQ macro writeback credential resolution so config fallback is
+   available only for an empty `TenantScope`.
+2. Fail closed when a scope contains authenticated tenant markers but no
+   usable account id.
+3. Add focused regression coverage proving user, role, and vendor-scoped
+   requests do not call the config fallback.
+4. Add a caller-layer smoke regression proving config credentials do not let a
+   user-scoped live smoke proceed without an account id.
+
+### Files touched
+
+- `plans/PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed.md` - plan for
+  this slice.
+- `atlas_brain/_content_ops_macro_writeback.py` - fallback boundary for
+  tenant Zendesk credentials.
+- `tests/test_atlas_content_ops_macro_writeback.py` - regression tests for
+  tenant-marker fail-closed behavior.
+- `tests/test_faq_macro_writeback_live_zendesk_smoke.py` - caller-layer
+  regression for the default live smoke credential provider.
+
+## Mechanism
+
+`TenantZendeskMacroCredentialsProvider.credentials_for_scope(...)` keeps the
+existing tenant-row lookup when `scope.account_id` is non-empty after trimming.
+If the account id is missing or blank but the scope still carries hosted tenant
+markers (`user_id`, `allowed_vendors`, or `roles`), it returns `None` instead
+of calling the fallback provider. A completely empty `TenantScope()` remains
+eligible for `ConfigZendeskMacroCredentialsProvider`, preserving local
+single-tenant usage and existing tests.
+
+## Intentional
+
+- This slice does not remove config-based Zendesk credentials. They still
+  support unscoped local/single-tenant runs where no tenant context exists.
+- The fail-closed predicate stays local to the host credential adapter because
+  package-level macro publishing only knows whether credentials resolved, not
+  whether the host scope was safely scoped.
+- No config fields are added; the existing typed `B2BCampaignConfig` Zendesk
+  fields remain the only config-backed source.
+- Cross-layer caller hints were inspected. The package publisher already maps
+  missing credentials to `zendesk_credentials_missing`; this slice adds a
+  live-smoke caller regression for the default host provider path.
+
+## Deferred
+
+- None.
+
+Parked hardening: none
+
+## Verification
+
+- python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py tests/test_content_ops_zendesk_credentials.py tests/test_faq_macro_writeback_live_zendesk_smoke.py -q - 28 passed.
+- python -m py_compile atlas_brain/_content_ops_macro_writeback.py tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py tests/test_content_ops_zendesk_credentials.py tests/test_faq_macro_writeback_live_zendesk_smoke.py - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - passed; extracted reasoning core 295 passed, extracted content pipeline 2792 passed / 10 skipped.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Provider guard | ~25 |
+| Tests | ~110 |
+| Total | ~210 |

--- a/tests/test_atlas_content_ops_macro_writeback.py
+++ b/tests/test_atlas_content_ops_macro_writeback.py
@@ -39,6 +39,18 @@ class _Config:
     content_ops_zendesk_base_url: str = ""
 
 
+class _FailingFallbackCredentialsProvider:
+    def __init__(self) -> None:
+        self.calls: list[TenantScope] = []
+
+    async def credentials_for_scope(
+        self,
+        scope: TenantScope,
+    ) -> ZendeskMacroCredentials | None:
+        self.calls.append(scope)
+        raise AssertionError("config fallback should not run for tenant scopes")
+
+
 def test_zendesk_macro_credentials_from_config() -> None:
     credentials = zendesk_macro_credentials_from_config(_Config(
         content_ops_zendesk_email=" agent@example.com ",
@@ -200,6 +212,72 @@ async def test_tenant_zendesk_credentials_provider_falls_back_to_config_without_
     assert credentials is not None
     assert credentials.email == "fallback@example.com"
     assert credentials.normalized_base_url() == "https://fallback.zendesk.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope",
+    (
+        TenantScope(user_id="user-1"),
+        TenantScope(allowed_vendors=("Acme",)),
+        TenantScope(roles=("content-admin",)),
+        TenantScope(account_id=" ", user_id="user-1"),
+    ),
+)
+async def test_tenant_zendesk_credentials_provider_fails_closed_for_tenant_markers_without_account_id(
+    scope: TenantScope,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain import _content_ops_zendesk_credentials
+
+    async def lookup(pool, *, account_id):
+        raise AssertionError("tenant lookup should not run without account_id")
+
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    fallback = _FailingFallbackCredentialsProvider()
+    provider = TenantZendeskMacroCredentialsProvider(
+        pool=_Pool(),
+        fallback_provider=fallback,
+    )
+
+    credentials = await provider.credentials_for_scope(scope)
+
+    assert credentials is None
+    assert fallback.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tenant_zendesk_credentials_provider_trims_account_id_for_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from atlas_brain import _content_ops_zendesk_credentials
+
+    tenant_credentials = ZendeskMacroCredentials(
+        email="tenant@example.com",
+        api_token="tenant-token",
+        subdomain="tenant",
+    )
+    calls: list[str] = []
+
+    async def lookup(pool, *, account_id):
+        del pool
+        calls.append(account_id)
+        return tenant_credentials
+
+    monkeypatch.setattr(_content_ops_zendesk_credentials, "lookup_zendesk_credentials", lookup)
+    fallback = _FailingFallbackCredentialsProvider()
+    provider = TenantZendeskMacroCredentialsProvider(
+        pool=_Pool(),
+        fallback_provider=fallback,
+    )
+
+    credentials = await provider.credentials_for_scope(
+        TenantScope(account_id=" 11111111-1111-1111-1111-111111111111 ")
+    )
+
+    assert credentials is tenant_credentials
+    assert calls == ["11111111-1111-1111-1111-111111111111"]
+    assert fallback.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_faq_macro_writeback_live_zendesk_smoke.py
+++ b/tests/test_faq_macro_writeback_live_zendesk_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Sequence
 
 import pytest
@@ -144,6 +145,36 @@ async def test_live_zendesk_smoke_requires_tenant_credentials_before_provider_ca
 
     assert code == smoke.SKIPPED_EXIT
     assert payload["not_run_reason"] == "zendesk_credentials_missing"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_live_zendesk_smoke_fails_closed_for_user_scope_without_account_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _PublishProvider()
+    monkeypatch.setattr(
+        smoke,
+        "_host_config",
+        lambda: SimpleNamespace(
+            content_ops_zendesk_email="fallback@example.com",
+            content_ops_zendesk_api_token="fallback-token",
+            content_ops_zendesk_subdomain="fallback",
+            content_ops_zendesk_base_url="",
+        ),
+    )
+
+    code, payload = await smoke.run_live_zendesk_smoke(
+        _args(account_id="", user_id="operator-1"),
+        pool=object(),
+        faq_repository=_FAQRepo(_approved_draft()),
+        provider=provider,
+        attempt_repository=_AttemptRepo(),
+    )
+
+    assert code == smoke.SKIPPED_EXIT
+    assert payload["not_run_reason"] == "zendesk_credentials_missing"
+    assert payload["account_id"] == ""
     assert provider.calls == []
 
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Credential-Fallback-Fail-Closed.md
Slice phase: Production hardening

PR #1146 intended deployment-level Zendesk config credentials to remain available only for unscoped local/single-tenant macro writeback. This slice closes the remaining hosted-scope gap: if a scope carries tenant markers but no usable `account_id`, the tenant credential adapter now fails closed instead of borrowing the config fallback.

## Intentional
- Config-based Zendesk credentials remain available for a completely empty `TenantScope()` so unscoped local/single-tenant runs still work.
- The fail-closed predicate lives in the host credential adapter because the extracted macro publisher only receives resolved credentials, not host authentication context.
- No config fields are added; the existing typed `B2BCampaignConfig` Zendesk fields remain the config-backed source.
- Cross-layer caller hints were inspected. The package publisher already maps missing credentials to `zendesk_credentials_missing`; this slice adds a live-smoke caller regression for the default host provider path.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py tests/test_content_ops_zendesk_credentials.py tests/test_faq_macro_writeback_live_zendesk_smoke.py -q` - 28 passed.
- `python -m py_compile atlas_brain/_content_ops_macro_writeback.py tests/test_atlas_content_ops_macro_writeback.py tests/test_content_ops_faq_macro_writeback_flow.py tests/test_content_ops_zendesk_credentials.py tests/test_faq_macro_writeback_live_zendesk_smoke.py` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed; extracted reasoning core 295 passed, extracted content pipeline 2792 passed / 10 skipped.

## Diff size
4 files, +209 / -3