### PR TITLE
PR-FAQ-Deflection-Blob-Redirect-Hardening

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-05-30
+
+### FAQ deflection blob submit DNS-rebinding TOCTOU
+- File/location: `extracted_content_pipeline/api/control_surfaces.py` `_validate_blob_host_resolution` / `_read_bounded_https_blob`
+- Description: Blob submit validates resolved host IPs before fetch, but urllib re-resolves during connect, leaving a DNS-rebinding time-of-check/time-of-use gap.
+- Why it matters: The endpoint is customer-reachable for paid deflection report submits, so broad GA should pin the validated IP at connection construction or restrict fetches to trusted blob hosts.
+- Effort: M
+- Category: security
+- Owner/session: Codex FAQ deflection blob redirect hardening
+- Found during: PR-FAQ-Deflection-Blob-Redirect-Hardening
+
 ## 2026-05-29
 
 ### atlas-intel-ui npm audit vulnerabilities

--- a/plans/PR-FAQ-Deflection-Blob-Redirect-Hardening.md
+++ b/plans/PR-FAQ-Deflection-Blob-Redirect-Hardening.md
@@ -1,0 +1,68 @@
+# PR-FAQ-Deflection-Blob-Redirect-Hardening
+
+## Why this slice exists
+
+PR #1166 added the portfolio blob submit route and fixed the blocking SSRF
+review by resolving blob hostnames before fetch and disabling redirects. The
+review left one skip-worthy but useful robustness gap: the route-level redirect
+test stubs the fetch helper, so the actual `_open_https_blob_request` wiring is
+not pinned by a regression. This slice locks in that opener-level behavior and
+parks the larger DNS-rebinding TOCTOU follow-up outside this small test slice.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-submit
+Slice phase: Robust testing
+
+1. Add a focused test that exercises `_read_bounded_https_blob` through the
+   real `_open_https_blob_request` boundary.
+2. Assert the opener is built with `_NoRedirectHandler` and maps a 3xx
+   `HTTPError` to the customer-safe redirect rejection.
+3. Park the DNS-rebinding pinned-connection follow-up in `HARDENING.md`.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Blob-Redirect-Hardening.md` - plan for this slice.
+- `tests/test_extracted_content_deflection_submit.py` - opener-level redirect
+  regression.
+- `HARDENING.md` - parked DNS-rebinding hardening follow-up.
+
+## Mechanism
+
+The new test calls `_read_bounded_https_blob(...)` directly after mocking public
+DNS resolution and `urllib.request.build_opener`. The mock opener records the
+request and raises an HTTP 302. Because the test does not replace
+`_open_https_blob_request`, it verifies the production helper constructs the
+opener with `_NoRedirectHandler`, passes the expected URL/timeout, and returns
+the same 400 "redirects are not allowed" error that the route surfaces.
+
+## Intentional
+
+- This slice does not implement full DNS-rebinding protection. The current
+  preflight DNS check closes common hostname-to-private cases, but urllib can
+  still re-resolve at connect time; pinning the validated IP belongs in a
+  larger networking-hardening slice.
+- No route behavior changes are expected. This is a regression-test slice for
+  behavior already merged in #1166.
+
+## Deferred
+
+- `PR-FAQ-Deflection-Blob-DNS-Pinning`: connect to the validated IP with an
+  explicit `Host` header, or restrict submit blobs to a trusted blob host set,
+  so DNS rebinding cannot swap the target after preflight validation.
+
+Parked hardening: `FAQ deflection blob submit DNS-rebinding TOCTOU`.
+
+## Verification
+
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q - 9 passed.
+- python -m py_compile tests/test_extracted_content_deflection_submit.py - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~65 |
+| Test | ~45 |
+| Hardening | ~10 |
+| Total | ~120 |

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -341,3 +341,46 @@ def test_deflection_submit_opener_disables_redirects() -> None:
     handler = api_module._NoRedirectHandler()
 
     assert handler.redirect_request(None, None, 302, "Found", {}, "https://x") is None
+
+
+def test_read_bounded_https_blob_rejects_redirects_through_no_redirect_opener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_public_dns(monkeypatch)
+    handlers: list[Any] = []
+    calls: list[tuple[str, int]] = []
+
+    class _RedirectingOpener:
+        def open(self, request: Any, *, timeout: int) -> Any:
+            calls.append((request.full_url, timeout))
+            raise urllib.error.HTTPError(
+                request.full_url,
+                302,
+                "Found",
+                {"Location": "http://169.254.169.254/latest/meta-data"},
+                None,
+            )
+
+    def _build_opener(*opener_handlers: Any) -> _RedirectingOpener:
+        handlers.extend(opener_handlers)
+        return _RedirectingOpener()
+
+    monkeypatch.setattr(api_module.urllib.request, "build_opener", _build_opener)
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        api_module._read_bounded_https_blob(
+            "https://portfolio.example/blob/tickets.csv",
+            max_bytes=100,
+        )
+
+    assert any(
+        handler is api_module._NoRedirectHandler
+        or isinstance(handler, api_module._NoRedirectHandler)
+        for handler in handlers
+    )
+    assert calls == [(
+        "https://portfolio.example/blob/tickets.csv",
+        api_module._DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
+    )]
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL redirects are not allowed."


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Blob-Redirect-Hardening.md
Slice phase: Robust testing

PR #1166 fixed the blocking SSRF redirect issue for portfolio blob submit. This slice pins the no-redirect opener wiring with a focused regression that exercises `_read_bounded_https_blob` through the real `_open_https_blob_request` boundary, and parks the larger DNS-rebinding TOCTOU follow-up for a dedicated hardening slice.

## Intentional
- No route behavior changes are expected; this is a regression-test slice for behavior already merged in #1166.
- Full DNS-rebinding protection is deferred because pinning the validated IP at connection time is a larger networking-hardening change.

## Deferred
- `PR-FAQ-Deflection-Blob-DNS-Pinning`: connect to the validated IP with an explicit `Host` header, or restrict submit blobs to trusted blob hosts.

## Parked hardening
- `FAQ deflection blob submit DNS-rebinding TOCTOU` in `HARDENING.md`.

## Verification
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` - 9 passed.
- `python -m py_compile tests/test_extracted_content_deflection_submit.py` - passed.

## Diff size
3 files, +122 / -0