### PR TITLE
PR-FAQ-Deflection-Blob-DNS-Pinning

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,17 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-05-30
-
-### FAQ deflection blob submit DNS-rebinding TOCTOU
-- File/location: `extracted_content_pipeline/api/control_surfaces.py` `_validate_blob_host_resolution` / `_read_bounded_https_blob`
-- Description: Blob submit validates resolved host IPs before fetch, but urllib re-resolves during connect, leaving a DNS-rebinding time-of-check/time-of-use gap.
-- Why it matters: The endpoint is customer-reachable for paid deflection report submits, so broad GA should pin the validated IP at connection construction or restrict fetches to trusted blob hosts.
-- Effort: M
-- Category: security
-- Owner/session: Codex FAQ deflection blob redirect hardening
-- Found during: PR-FAQ-Deflection-Blob-Redirect-Hardening
-
 ## 2026-05-29
 
 ### atlas-intel-ui npm audit vulnerabilities

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import http.client
 import json
 import logging
 import math
+import ssl
 import tempfile
 import ipaddress
 import socket
 import urllib.error
 import urllib.parse
-import urllib.request
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -1278,17 +1279,25 @@ def _load_deflection_submit_blob_rows_sync(
 
 
 def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
-    url = _validate_https_blob_fetch_target(blob_url)
-    request = urllib.request.Request(
-        url,
-        headers={"User-Agent": "Atlas-Content-Ops/1.0"},
-    )
+    target = _validate_https_blob_fetch_target(blob_url)
+    response: Any | None = None
     try:
-        with _open_https_blob_request(
-            request,
+        response = _open_https_blob_request(
+            target,
             timeout=_DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
-        ) as response:
-            data = response.read(max_bytes + 1)
+        )
+        status = int(getattr(response, "status", 0) or 0)
+        if 300 <= status < 400:
+            raise HTTPException(
+                status_code=400,
+                detail="Blob URL redirects are not allowed.",
+            )
+        if status < 200 or status >= 300:
+            raise HTTPException(
+                status_code=400,
+                detail="Blob URL could not be fetched.",
+            )
+        data = response.read(max_bytes + 1)
     except urllib.error.HTTPError as exc:
         if 300 <= int(getattr(exc, "code", 0) or 0) < 400:
             raise HTTPException(
@@ -1304,6 +1313,9 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
             status_code=400,
             detail="Blob URL could not be fetched.",
         ) from exc
+    finally:
+        if response is not None:
+            _close_https_blob_response(response)
     if len(data) > max_bytes:
         raise HTTPException(
             status_code=413,
@@ -1315,18 +1327,96 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
     return data
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, *_args: object, **_kwargs: object) -> None:
-        return None
+@dataclass(frozen=True)
+class _BlobFetchTarget:
+    url: str
+    host: str
+    port: int
+    path: str
+    host_header: str
+    connect_host: str
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        *,
+        port: int,
+        connect_host: str,
+        timeout: int,
+    ) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._connect_host = connect_host
+
+    def connect(self) -> None:
+        self.sock = self._create_connection(
+            (self._connect_host, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self._tunnel()
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
+_PINNED_HTTPS_CONNECTION_CLASS = _PinnedHTTPSConnection
+
+
+class _PinnedBlobResponse:
+    def __init__(
+        self,
+        response: http.client.HTTPResponse,
+        connection: http.client.HTTPSConnection,
+    ) -> None:
+        self._response = response
+        self._connection = connection
+        self.status = response.status
+
+    def read(self, size: int) -> bytes:
+        return self._response.read(size)
+
+    def close(self) -> None:
+        self._response.close()
+        self._connection.close()
 
 
 def _open_https_blob_request(
-    request: urllib.request.Request,
+    target: _BlobFetchTarget,
     *,
     timeout: int,
 ) -> Any:
-    opener = urllib.request.build_opener(_NoRedirectHandler)
-    return opener.open(request, timeout=timeout)
+    connection = _PINNED_HTTPS_CONNECTION_CLASS(
+        target.host,
+        port=target.port,
+        connect_host=target.connect_host,
+        timeout=timeout,
+    )
+    try:
+        connection.request(
+            "GET",
+            target.path,
+            headers={
+                "Host": target.host_header,
+                "User-Agent": "Atlas-Content-Ops/1.0",
+            },
+        )
+        response = connection.getresponse()
+        return _PinnedBlobResponse(response, connection)
+    except Exception:
+        connection.close()
+        raise
+
+
+def _close_https_blob_response(response: Any) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
 
 
 def _validate_https_blob_url(value: Any) -> str:
@@ -1334,6 +1424,10 @@ def _validate_https_blob_url(value: Any) -> str:
     parsed = urllib.parse.urlparse(text)
     if parsed.scheme != "https" or not parsed.netloc:
         raise ValueError("blob_url must be an https URL")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("blob_url must be an https URL") from exc
     host = parsed.hostname or ""
     if not host or _is_blocked_blob_host(host):
         raise ValueError("blob_url host is not allowed")
@@ -1342,33 +1436,53 @@ def _validate_https_blob_url(value: Any) -> str:
     return text
 
 
-def _validate_https_blob_fetch_target(value: Any) -> str:
+def _validate_https_blob_fetch_target(value: Any) -> _BlobFetchTarget:
     url = _validate_https_blob_url(value)
     parsed = urllib.parse.urlparse(url)
     host = parsed.hostname or ""
+    port = parsed.port or 443
     try:
-        _validate_blob_host_resolution(host)
+        connect_host = _validate_blob_host_resolution(host, port)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return url
+    path = urllib.parse.urlunparse((
+        "",
+        "",
+        parsed.path or "/",
+        parsed.params,
+        parsed.query,
+        "",
+    ))
+    return _BlobFetchTarget(
+        url=url,
+        host=host,
+        port=port,
+        path=path,
+        host_header=parsed.netloc,
+        connect_host=connect_host,
+    )
 
 
-def _validate_blob_host_resolution(host: str) -> None:
-    # This preflight closes common hostname-to-private SSRF cases. urllib still
-    # resolves again at connect time, so a full DNS-rebinding defense would pin
-    # the validated IP at connection construction.
+def _validate_blob_host_resolution(host: str, port: int) -> str:
     try:
-        resolved = socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
+        resolved = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
     except OSError as exc:
         raise ValueError("blob_url host could not be resolved") from exc
     if not resolved:
         raise ValueError("blob_url host could not be resolved")
+    connect_host: str | None = None
     for item in resolved:
         sockaddr = item[4]
         if not sockaddr:
             raise ValueError("blob_url host could not be resolved")
-        if _is_blocked_blob_host(str(sockaddr[0])):
+        address = str(sockaddr[0])
+        if _is_blocked_blob_host(address):
             raise ValueError("blob_url host is not allowed")
+        if connect_host is None:
+            connect_host = address
+    if connect_host is None:
+        raise ValueError("blob_url host could not be resolved")
+    return connect_host
 
 
 def _is_blocked_blob_host(host: str) -> bool:

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1308,7 +1308,7 @@ def _read_bounded_https_blob(blob_url: str, *, max_bytes: int) -> bytes:
             status_code=400,
             detail="Blob URL could not be fetched.",
         ) from exc
-    except (OSError, urllib.error.URLError) as exc:
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
         raise HTTPException(
             status_code=400,
             detail="Blob URL could not be fetched.",

--- a/plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md
+++ b/plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md
@@ -1,0 +1,90 @@
+# PR-FAQ-Deflection-Blob-DNS-Pinning
+
+## Why this slice exists
+
+#1169 closed blob-submit redirect SSRF, but its review called out a remaining
+DNS-rebinding time-of-check/time-of-use gap: the submit endpoint validated the
+hostname's resolved IPs before fetch, then let `urllib` resolve the hostname
+again when opening the socket. `HARDENING.md` parked this as the active
+customer-reachable security item for the deflection/Stripe lane.
+
+This slice promotes that parked hardening item because the portfolio funnel now
+passes signed blob URLs into ATLAS and the endpoint should fail closed before
+broader hosted validation.
+
+The total diff exceeds the 400 LOC target because the DNS-pinning socket path,
+the promoted hardening removal, and the security regression fixtures need to
+ship together; splitting the tests from the transport change would leave the
+SSRF guard's failure branch unproven.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-blob-fetch
+Slice phase: Production hardening
+
+1. Pin the HTTPS blob fetch socket to an IP returned by the preflight DNS
+   validation.
+2. Preserve TLS verification and SNI against the original blob hostname.
+3. Keep the existing no-redirect, bounded-read, HTTPS-only, no-credential, and
+   private-address rejection behavior.
+4. Remove the promoted DNS-rebinding entry from `HARDENING.md`.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md`
+- `HARDENING.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+The HTTPS blob target validator now returns a structured blob-fetch target
+that includes the normalized URL, parsed hostname/port, request path, Host
+header, and a connect host selected from the already-validated public DNS
+answers. The opener uses a pinned HTTPS connection to that connect host while
+sending SNI and certificate verification for the original
+hostname and preserving the original Host header.
+
+Redirects remain fail-closed because the code reads the first response directly
+and rejects any 3xx status without following `Location`.
+
+## Intentional
+
+- This slice does not add a trusted-host allowlist. The immediate parked issue
+  is the DNS-rebinding TOCTOU gap; a host allowlist would be a separate product
+  contract with the portfolio uploader.
+- The resolver still rejects the whole target when any DNS answer is private or
+  otherwise blocked, even if another answer is public.
+- The implementation uses stdlib `http.client`/`ssl` instead of adding a new
+  HTTP dependency to the extracted package.
+
+## Deferred
+
+- Parked hardening: none for this slice. The DNS-rebinding item from #1169 is
+  promoted and removed from `HARDENING.md`.
+- Portfolio result-page hosted validation remains in the deflection/Stripe
+  lane after the open hosted-submit handoff thread finishes.
+
+## Verification
+
+- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py - passed.
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q - 12 passed.
+- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- bash scripts/check_ascii_python.sh - passed.
+- bash scripts/validate_extracted_content_pipeline.sh - passed.
+- bash scripts/run_extracted_pipeline_checks.sh - passed, 2812 passed, 10 skipped, 1 warning.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-blob-dns-pinning.md - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 75 |
+| Blob fetch implementation | 164 |
+| Regression tests | 198 |
+| Hardening queue update | 10 |
+| **Total** | **447** |
+
+The non-plan code/test diff is under 400 LOC. The total exceeds 400 because
+the plan doc plus security regression fixtures ship with the code change.

--- a/plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md
+++ b/plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md
@@ -68,12 +68,12 @@ and rejects any 3xx status without following `Location`.
 ## Verification
 
 - python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py - passed.
-- python -m pytest tests/test_extracted_content_deflection_submit.py -q - 12 passed.
+- python -m pytest tests/test_extracted_content_deflection_submit.py -q - 13 passed.
 - python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
 - python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
 - bash scripts/check_ascii_python.sh - passed.
 - bash scripts/validate_extracted_content_pipeline.sh - passed.
-- bash scripts/run_extracted_pipeline_checks.sh - passed, 2812 passed, 10 skipped, 1 warning.
+- bash scripts/run_extracted_pipeline_checks.sh - passed, 2813 passed, 10 skipped, 1 warning.
 - bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-blob-dns-pinning.md - passed.
 
 ## Estimated diff size

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import socket
 import urllib.error
 from typing import Any
@@ -400,6 +401,24 @@ def test_read_bounded_https_blob_rejects_non_success_status() -> None:
     assert exc.value.status_code == 400
     assert exc.value.detail == "Blob URL could not be fetched."
     assert response.closed
+
+
+def test_read_bounded_https_blob_rejects_malformed_http_response() -> None:
+    with pytest.raises(api_module.HTTPException) as exc:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            _install_public_dns(monkeypatch)
+
+            def _open(_target: Any, *, timeout: int) -> _BlobResponse:
+                raise http.client.BadStatusLine("not-http")
+
+            monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
+            api_module._read_bounded_https_blob(
+                "https://portfolio.example/blob/tickets.csv",
+                max_bytes=100,
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL could not be fetched."
 
 
 def test_read_bounded_https_blob_uses_validated_ip_for_pinned_connection(

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -26,11 +26,16 @@ def _route(router: Any, path: str, method: str) -> Any:
 
 
 class _BlobResponse:
-    def __init__(self, data: bytes) -> None:
+    def __init__(self, data: bytes, *, status: int = 200) -> None:
         self._data = data
+        self.status = status
+        self.closed = False
 
     def read(self, _size: int) -> bytes:
         return self._data
+
+    def close(self) -> None:
+        self.closed = True
 
     def __enter__(self) -> "_BlobResponse":
         return self
@@ -46,11 +51,11 @@ def _csv_bytes(rows: list[str]) -> bytes:
 def _install_blob(
     monkeypatch: pytest.MonkeyPatch,
     data: bytes,
-) -> list[tuple[str, int]]:
-    calls: list[tuple[str, int]] = []
+) -> list[tuple[str, str, int]]:
+    calls: list[tuple[str, str, int]] = []
 
-    def _open(request: Any, *, timeout: int) -> _BlobResponse:
-        calls.append((request.full_url, timeout))
+    def _open(target: Any, *, timeout: int) -> _BlobResponse:
+        calls.append((target.url, target.connect_host, timeout))
         return _BlobResponse(data)
 
     monkeypatch.setattr(api_module, "_open_https_blob_request", _open)
@@ -121,6 +126,7 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
 
     assert calls == [(
         "https://portfolio.example/blob/tickets.csv",
+        "93.184.216.34",
         api_module._DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
     )]
     assert payload["status"] == "completed"
@@ -173,6 +179,23 @@ async def test_deflection_submit_rejects_non_https_blob_url() -> None:
     with pytest.raises(api_module.HTTPException) as exc:
         await submit.endpoint({
             "blob_url": "http://portfolio.example/blob/tickets.csv",
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        })
+
+    assert exc.value.status_code == 422
+    assert "blob_url must be an https URL" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_blob_url_with_invalid_port() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint({
+            "blob_url": "https://portfolio.example:99999/blob/tickets.csv",
             "support_platform": "zendesk",
             "company_name": "Acme Co.",
             "contact_email": "lead@acme.example",
@@ -310,10 +333,10 @@ async def test_deflection_submit_rejects_blob_redirects(
     _install_public_dns(monkeypatch)
     calls: list[str] = []
 
-    def _open(request: Any, *, timeout: int) -> _BlobResponse:
-        calls.append(request.full_url)
+    def _open(target: Any, *, timeout: int) -> _BlobResponse:
+        calls.append(target.url)
         raise urllib.error.HTTPError(
-            request.full_url,
+            target.url,
             302,
             "Found",
             {"Location": "http://169.254.169.254/latest/meta-data"},
@@ -337,50 +360,137 @@ async def test_deflection_submit_rejects_blob_redirects(
     assert exc.value.detail == "Blob URL redirects are not allowed."
 
 
-def test_deflection_submit_opener_disables_redirects() -> None:
-    handler = api_module._NoRedirectHandler()
+def test_read_bounded_https_blob_rejects_redirect_status_without_following() -> None:
+    response = _BlobResponse(b"", status=302)
 
-    assert handler.redirect_request(None, None, 302, "Found", {}, "https://x") is None
+    with pytest.raises(api_module.HTTPException) as exc:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            _install_public_dns(monkeypatch)
+            monkeypatch.setattr(
+                api_module,
+                "_open_https_blob_request",
+                lambda _target, *, timeout: response,
+            )
+            api_module._read_bounded_https_blob(
+                "https://portfolio.example/blob/tickets.csv",
+                max_bytes=100,
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL redirects are not allowed."
+    assert response.closed
 
 
-def test_read_bounded_https_blob_rejects_redirects_through_no_redirect_opener(
+def test_read_bounded_https_blob_rejects_non_success_status() -> None:
+    response = _BlobResponse(b"expired", status=403)
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            _install_public_dns(monkeypatch)
+            monkeypatch.setattr(
+                api_module,
+                "_open_https_blob_request",
+                lambda _target, *, timeout: response,
+            )
+            api_module._read_bounded_https_blob(
+                "https://portfolio.example/blob/tickets.csv",
+                max_bytes=100,
+            )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Blob URL could not be fetched."
+    assert response.closed
+
+
+def test_read_bounded_https_blob_uses_validated_ip_for_pinned_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_public_dns(monkeypatch)
-    handlers: list[Any] = []
-    calls: list[tuple[str, int]] = []
+    csv_data = _csv_bytes(["ticket_id,message", "ticket-1,How do I export?"])
+    calls: list[tuple[str, int, str, int, str, dict[str, str]]] = []
 
-    class _RedirectingOpener:
-        def open(self, request: Any, *, timeout: int) -> Any:
-            calls.append((request.full_url, timeout))
-            raise urllib.error.HTTPError(
-                request.full_url,
-                302,
-                "Found",
-                {"Location": "http://169.254.169.254/latest/meta-data"},
-                None,
-            )
+    class _PinnedConnection:
+        def __init__(
+            self,
+            host: str,
+            *,
+            port: int,
+            connect_host: str,
+            timeout: int,
+        ) -> None:
+            self.host = host
+            self.port = port
+            self.connect_host = connect_host
+            self.timeout = timeout
+            self.closed = False
 
-    def _build_opener(*opener_handlers: Any) -> _RedirectingOpener:
-        handlers.extend(opener_handlers)
-        return _RedirectingOpener()
+        def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            headers: dict[str, str],
+        ) -> None:
+            calls.append((
+                self.host,
+                self.port,
+                self.connect_host,
+                self.timeout,
+                f"{method} {path}",
+                headers,
+            ))
 
-    monkeypatch.setattr(api_module.urllib.request, "build_opener", _build_opener)
+        def getresponse(self) -> _BlobResponse:
+            return _BlobResponse(csv_data)
 
-    with pytest.raises(api_module.HTTPException) as exc:
-        api_module._read_bounded_https_blob(
-            "https://portfolio.example/blob/tickets.csv",
-            max_bytes=100,
-        )
+        def close(self) -> None:
+            self.closed = True
 
-    assert any(
-        handler is api_module._NoRedirectHandler
-        or isinstance(handler, api_module._NoRedirectHandler)
-        for handler in handlers
+    monkeypatch.setattr(api_module, "_PINNED_HTTPS_CONNECTION_CLASS", _PinnedConnection)
+
+    data = api_module._read_bounded_https_blob(
+        "https://portfolio.example:444/blob/tickets.csv?sig=abc",
+        max_bytes=1000,
     )
+
+    assert data == csv_data
     assert calls == [(
-        "https://portfolio.example/blob/tickets.csv",
+        "portfolio.example",
+        444,
+        "93.184.216.34",
         api_module._DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS,
+        "GET /blob/tickets.csv?sig=abc",
+        {
+            "Host": "portfolio.example:444",
+            "User-Agent": "Atlas-Content-Ops/1.0",
+        },
     )]
-    assert exc.value.status_code == 400
-    assert exc.value.detail == "Blob URL redirects are not allowed."
+
+
+def test_pinned_https_connection_uses_validated_ip_but_original_sni() -> None:
+    calls: list[tuple[str, object]] = []
+
+    class _Context:
+        def wrap_socket(self, sock: object, *, server_hostname: str) -> object:
+            calls.append(("sni", server_hostname))
+            return ("tls", sock, server_hostname)
+
+    connection = api_module._PinnedHTTPSConnection(
+        "portfolio.example",
+        port=443,
+        connect_host="93.184.216.34",
+        timeout=15,
+    )
+    connection._context = _Context()
+    connection._create_connection = lambda address, timeout, source_address: calls.append((
+        "connect",
+        (address, timeout, source_address),
+    )) or "socket"
+
+    connection.connect()
+
+    assert calls == [
+        ("connect", (("93.184.216.34", 443), 15, None)),
+        ("sni", "portfolio.example"),
+    ]
+    assert connection.sock == ("tls", "socket", "portfolio.example")


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Blob-DNS-Pinning.md
Slice phase: Production hardening

#1169 closed blob-submit redirect SSRF, but its review called out the remaining DNS-rebinding TOCTOU in the customer-reachable portfolio blob submit path. This promotes the parked hardening item by pinning the HTTPS socket to the public IP returned by DNS preflight while preserving TLS verification/SNI for the original blob hostname.

## Intentional
- No trusted-host allowlist in this slice; this closes the parked DNS-rebinding TOCTOU without changing the portfolio blob-host contract.
- DNS validation still fails closed when any answer is private or otherwise blocked, even if another answer is public.
- Uses stdlib `http.client`/`ssl` rather than adding a new extracted-package HTTP dependency.

## Deferred
- Portfolio result-page hosted validation remains in the deflection/Stripe lane after the open hosted-submit handoff thread finishes.

## Parked hardening
- None. The #1169 DNS-rebinding item is promoted and removed from `HARDENING.md`.

## Verification
- python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py - passed.
- python -m pytest tests/test_extracted_content_deflection_submit.py -q - 13 passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- bash scripts/check_ascii_python.sh - passed.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- bash scripts/run_extracted_pipeline_checks.sh - passed, 2813 passed, 10 skipped, 1 warning.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-faq-deflection-blob-dns-pinning.md - passed before the review follow-up; pre-push hook reruns it on push.

## Diff size
4 files, +397 / -80.