### PR TITLE
PR-Agents-No-Wait-After-Open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,13 @@ but silently ignoring them recreates the diff-only review gap.
 GitHub Actions still runs the same wrapper after the PR opens. Treat CI
 as the final enforcement layer, not the first reviewer.
 
+After opening or updating a PR, the builder does **not** wait for CI,
+automated review, or human review comments. Report the PR URL, the
+local verification already run, and any immediately visible PR status,
+then stop. The operator will tell the builder when checks are green or
+when review comments are ready to inspect. Only resume PR inspection,
+comment handling, or merge decisions after that operator signal.
+
 ### 3d. Thin-slice and hardening triage
 
 Every plan names a slice phase in `Scope (this PR)`, and the PR body

--- a/plans/PR-Agents-No-Wait-After-Open.md
+++ b/plans/PR-Agents-No-Wait-After-Open.md
@@ -1,0 +1,52 @@
+# PR-Agents-No-Wait-After-Open
+
+## Why this slice exists
+
+The builder workflow needs to match the operator handoff contract: once the PR
+is open, the builder should not keep polling checks or waiting for review
+comments. The operator will tell the builder when review comments are up or
+when checks are ready to inspect.
+
+## Scope (this PR)
+
+Ownership lane: workflow/agents-contract
+Slice phase: Workflow/process
+
+1. Add the no-wait post-open handoff rule to `AGENTS.md`.
+2. Keep reviewer-side CI/LGTM requirements unchanged.
+
+### Files touched
+
+- `plans/PR-Agents-No-Wait-After-Open.md`
+- `AGENTS.md`
+
+## Mechanism
+
+The builder workflow section now states that after opening or updating a PR,
+the builder stops active polling and returns the PR URL/status. Follow-up
+inspection happens only after the operator says comments/checks are ready.
+
+## Intentional
+
+- This does not weaken the reviewer CI gate. Reviewers still require green CI
+  before LGTM.
+- This does not change the local pre-push validation requirement before a PR is
+  opened.
+
+## Deferred
+
+- Parked hardening: none.
+
+## Verification
+
+- python scripts/audit_plan_doc.py plans/PR-Agents-No-Wait-After-Open.md - passed.
+- python scripts/audit_plan_code_consistency.py plans/PR-Agents-No-Wait-After-Open.md - passed.
+- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-agents-no-wait-open-pr.md - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 45 |
+| AGENTS.md contract text | 15 |
+| **Total** | **60** |


### PR DESCRIPTION
Plan: plans/PR-Agents-No-Wait-After-Open.md
Slice phase: Workflow/process

Document the builder handoff rule that once a PR is open or updated, the builder stops instead of polling CI or waiting for review comments. The operator will signal when checks are green or comments are ready to inspect.

## Intentional
- Reviewer CI/LGTM requirements remain unchanged.
- Local pre-push validation before opening a PR remains unchanged.

## Deferred
- None.

## Parked hardening
- None.

## Verification
- python scripts/audit_plan_doc.py plans/PR-Agents-No-Wait-After-Open.md - passed.
- python scripts/audit_plan_code_consistency.py plans/PR-Agents-No-Wait-After-Open.md - passed.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/pr-agents-no-wait-open-pr.md - passed.

## Diff size
2 files, +57 / -0.