### PR TITLE
PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding

### DIFF
--- a/plans/PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding.md
+++ b/plans/PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding.md
@@ -1,0 +1,65 @@
+# PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding
+
+## Why this slice exists
+
+PR #1176 shipped the hosted portfolio result-page smoke, but review caught a
+false-green gap before the follow-up fix could be pushed: the page check proved
+the expected `request_id` and `account_id` appeared somewhere in the HTML, not
+that the unlock CTA itself carried those values in its Stripe Checkout metadata.
+
+This slice closes that exact review finding on top of the merged result-page
+smoke so stale or missing unlock CTA metadata cannot pass the hosted validation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Functional validation
+
+1. Parse the hosted result-page HTML with a stdlib HTML parser to find the
+   `data-atlas-deflection-unlock` element.
+2. Require that element to carry the exact expected Checkout metadata values:
+   `data-checkout-source`, `data-checkout-request_id`, and
+   `data-checkout-account_id`.
+3. Add a regression where the correct values exist elsewhere on the page but
+   stale values live on the unlock CTA.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding.md`
+- `scripts/smoke_content_ops_deflection_portfolio_result_page.py`
+- `tests/test_smoke_content_ops_deflection_portfolio_result_page.py`
+
+## Mechanism
+
+`UnlockCtaParser` subclasses `html.parser.HTMLParser` and captures the first
+start tag with `data-atlas-deflection-unlock`. `_page_errors` keeps the existing
+page-level marker checks, then validates the Checkout metadata directly on that
+captured element.
+
+## Intentional
+
+- The parser remains stdlib-only so the smoke stays lightweight and does not
+  add a runtime dependency to operator machines.
+- This PR does not change the runbook or CI enrollment; #1176 already enrolled
+  the same smoke and test file.
+
+## Deferred
+
+- Parked hardening: none.
+- Stripe webhook paid-unlock hosted E2E remains the next validation step after
+  the pre-payment result-page smoke passes against the hosted portfolio page.
+
+## Verification
+
+- py_compile for the touched smoke script and test file - passed.
+- Focused pytest for `tests/test_smoke_content_ops_deflection_portfolio_result_page.py` - 8 passed.
+- Full extracted pipeline check wrapper - passed; `extracted_reasoning_core` 295 passed, and `extracted_content_pipeline` 2846 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 65 |
+| Smoke script | 30 |
+| Tests | 25 |
+| **Total** | **120** |

--- a/scripts/smoke_content_ops_deflection_portfolio_result_page.py
+++ b/scripts/smoke_content_ops_deflection_portfolio_result_page.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from html.parser import HTMLParser
 import json
 import math
 import os
@@ -53,6 +54,17 @@ class HttpResult:
     text: str
     payload: Any = None
     errors: tuple[str, ...] = ()
+
+
+class UnlockCtaParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attrs: dict[str, str] | None = None
+
+    def handle_starttag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key: value or "" for key, value in attrs}
+        if "data-atlas-deflection-unlock" in attr_map and self.attrs is None:
+            self.attrs = attr_map
 
 
 def _load_dotenv_files() -> None:
@@ -229,10 +241,28 @@ def _page_errors(html: str, *, request_id: str, account_id: str) -> list[str]:
     for marker in REQUIRED_PAGE_MARKERS:
         if marker not in html:
             errors.append(f"portfolio result page missing marker: {marker}")
+    unlock_attrs = _unlock_cta_attrs(html)
+    if unlock_attrs is None:
+        errors.append("portfolio result page missing unlock CTA element")
+    else:
+        for attr, expected in (
+            ("data-checkout-source", "content_ops_deflection_report"),
+            ("data-checkout-request_id", request_id),
+            ("data-checkout-account_id", account_id),
+        ):
+            actual = unlock_attrs.get(attr)
+            if actual != expected:
+                errors.append(f"portfolio result page unlock CTA {attr} must be {expected}")
     for value, label in ((request_id, "request_id"), (account_id, "account_id")):
         if value not in html:
             errors.append(f"portfolio result page missing {label} value")
     return errors
+
+
+def _unlock_cta_attrs(html: str) -> dict[str, str] | None:
+    parser = UnlockCtaParser()
+    parser.feed(html)
+    return parser.attrs
 
 
 def _result_payload(

--- a/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
+++ b/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
@@ -164,6 +164,31 @@ def test_page_errors_require_portfolio_hooks_and_metadata_values() -> None:
     assert "portfolio result page missing account_id value" in errors
 
 
+def test_page_errors_bind_checkout_metadata_to_unlock_cta() -> None:
+    html = """
+    <main data-atlas-deflection-result>
+      <section data-atlas-deflection-request-id="content-ops-123">
+        content-ops-123 acct-123 content_ops_deflection_report request_id account_id
+      </section>
+      <a data-atlas-deflection-unlock
+         data-checkout-source="content_ops_deflection_report"
+         data-checkout-request_id="stale-request"
+         data-checkout-account_id="stale-account">Unlock full report</a>
+    </main>
+    """
+
+    errors = smoke._page_errors(
+        html,
+        request_id="content-ops-123",
+        account_id="acct-123",
+    )
+
+    assert errors == [
+        "portfolio result page unlock CTA data-checkout-request_id must be content-ops-123",
+        "portfolio result page unlock CTA data-checkout-account_id must be acct-123",
+    ]
+
+
 def test_snapshot_errors_reject_paid_report_leaks() -> None:
     snapshot = {
         **SNAPSHOT,


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Result-Page-CTA-Metadata-Binding.md
Slice phase: Functional validation

PR #1176 shipped the hosted portfolio result-page smoke, and review found the remaining false-green path: request/account ids could appear elsewhere in the page while stale values lived on the unlock CTA. This follow-up binds the smoke to the actual CTA Checkout metadata attributes.

## Intentional
- The parser stays stdlib-only so the smoke remains portable on operator machines.
- Runbook and CI enrollment are unchanged because #1176 already enrolled this smoke and test file.

## Deferred
- Stripe webhook paid-unlock hosted E2E remains the next validation step after pre-payment result-page validation.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_portfolio_result_page.py tests/test_smoke_content_ops_deflection_portfolio_result_page.py`
- `python -m pytest tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` - 8 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - `extracted_reasoning_core` 295 passed; `extracted_content_pipeline` 2846 passed, 10 skipped, 1 warning.

## Diff size
3 files, +120 / -0