### PR TITLE
PR-FAQ-Deflection-Portfolio-Result-Page-UI

### DIFF
--- a/.github/workflows/portfolio_ui_checks.yml
+++ b/.github/workflows/portfolio_ui_checks.yml
@@ -1,0 +1,41 @@
+name: Portfolio UI Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/portfolio_ui_checks.yml"
+      - "portfolio-ui/api/**"
+      - "portfolio-ui/package.json"
+      - "portfolio-ui/package-lock.json"
+      - "portfolio-ui/scripts/**"
+      - "portfolio-ui/src/**"
+      - "portfolio-ui/vercel.json"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/portfolio_ui_checks.yml"
+      - "portfolio-ui/api/**"
+      - "portfolio-ui/package.json"
+      - "portfolio-ui/package-lock.json"
+      - "portfolio-ui/scripts/**"
+      - "portfolio-ui/src/**"
+      - "portfolio-ui/vercel.json"
+
+jobs:
+  portfolio-ui-checks:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: portfolio-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Test FAQ deflection result page
+        run: npm run test:deflection-result

--- a/plans/PR-FAQ-Deflection-Portfolio-Result-Page-UI.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Result-Page-UI.md
@@ -1,0 +1,133 @@
+# PR-FAQ-Deflection-Portfolio-Result-Page-UI
+
+## Why this slice exists
+
+The FAQ deflection backend now returns a locked report snapshot and the
+portfolio result-page validation harness is on `main`, but the portfolio app
+does not yet have a customer-facing result route that emits the required
+Checkout metadata or unlock controls. Without that route, the hosted validation
+smoke has no real portfolio page to exercise and the Stripe handoff remains a
+documented contract instead of a product surface.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Add a hosted portfolio route for FAQ deflection report results keyed by
+   `{request_id}` and `account_id`.
+2. Render the free snapshot only when it is already available from the submit
+   flow, and strip/fail closed on paid-report fields.
+3. Add a server-side portfolio Checkout endpoint that creates Stripe Checkout
+   sessions with the required deflection metadata.
+4. Wire the result page unlock action to that server endpoint without exposing
+   ATLAS service credentials in browser code.
+5. Add focused portfolio tests for the route markers, trust boundary, and
+   Checkout request contract.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Result-Page-UI.md`
+- `.github/workflows/portfolio_ui_checks.yml`
+- `portfolio-ui/package.json`
+- `portfolio-ui/vercel.json`
+- `portfolio-ui/src/App.tsx`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+- `portfolio-ui/api/content-ops/deflection/checkout.js`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+
+## Mechanism
+
+The hosted route `/services/faq-deflection/results/:requestId` rewrites to a
+Vercel function that returns HTML containing the stable
+`data-atlas-deflection-*` hooks, `request_id`, `account_id`, and
+`content_ops_deflection_report` markers required by the hosted validation
+harness. The SPA route uses the same URL locally and looks for the free snapshot
+in `sessionStorage` under
+`atlas:deflection:snapshot:{request_id}`. Snapshot rendering is limited to
+`summary` and `top_questions`; any forbidden paid-report key such as `markdown`,
+`faq_result`, `answer`, `evidence`, or `source_ids` causes the page to hide the
+snapshot and show a review state instead.
+
+The unlock button posts `{ request_id, account_id }` to
+`/api/content-ops/deflection/checkout`. That Vercel function validates the
+fields, builds a one-time Stripe Checkout Session with:
+
+```json
+{
+  "mode": "payment",
+  "metadata": {
+    "source": "content_ops_deflection_report",
+    "account_id": "...",
+    "request_id": "..."
+  }
+}
+```
+
+and redirects the browser only to Stripe's returned Checkout URL. The function
+does not call the privileged ATLAS `/paid` route; ATLAS still unlocks only from
+the signed Stripe webhook.
+
+## Intentional
+
+- This slice does not place `ATLAS_B2B_JWT`, `ATLAS_API_BASE_URL`, or any
+  service credential in Vite/browser code. The current portfolio app is static
+  Vite plus Vercel functions, so customer-visible ATLAS reads need a separate
+  server proxy before the browser can hydrate `/snapshot` or `/artifact`
+  directly.
+- The server-rendered HTML route validates `account_id` before rendering and
+  escapes script-serialized values defensively so the hosted customer route
+  cannot reflect script terminators from query strings.
+- The page does not synthesize estimates when no snapshot is available. It
+  displays only real snapshot numbers already provided by the submit flow.
+- Checkout uses Stripe's direct API through `fetch` instead of adding the
+  Stripe SDK dependency in this vertical slice.
+- If operators configure `STRIPE_DEFLECTION_REPORT_PRICE_ID`, the checkout
+  handler validates that Stripe Price object is active, USD, and at least
+  150000 cents before creating a Checkout session. This prevents a dashboard
+  price misconfiguration from taking payment that ATLAS would later refuse to
+  unlock.
+- The paid artifact view is not implemented here. The unlock success return
+  route keeps the page visible while ATLAS waits for the verified Stripe
+  webhook to mark the report paid.
+
+## Deferred
+
+- Add a secure portfolio server proxy for ATLAS snapshot/artifact hydration
+  after the result route is live.
+- Add the paid artifact renderer after the proxy can fetch
+  `/content-ops/deflection-reports/{request_id}/artifact` server-side.
+- Add private Vercel Blob upload/submit UX before the result route if the
+  portfolio needs a fully self-serve upload funnel.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
+- `npm run build --prefix portfolio-ui` - passed using the existing ignored
+  root `portfolio-ui/node_modules` install for local verification; `npm ci` in
+  this worktree is blocked by pre-existing portfolio lockfile drift.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-result-page-ui-pr-body.md` -
+  passed after the review fixes.
+- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core
+  295 passed; extracted_content_pipeline 2845 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~132 |
+| Portfolio UI workflow | ~38 |
+| Route wiring | ~12 |
+| Result page | ~330 |
+| Checkout API | ~215 |
+| Hosted result HTML function | ~175 |
+| Focused test script | ~265 |
+| Package script | ~1 |
+| **Total** | **~1168** |
+
+The slice is over the 400 LOC target because the usable route, server-side
+Checkout creation, hosted raw-HTML validation surface, paid-field guard, and
+focused contract tests are the minimum vertical customer path that validates the
+trust boundary without leaking credentials.

--- a/portfolio-ui/api/content-ops/deflection/checkout.js
+++ b/portfolio-ui/api/content-ops/deflection/checkout.js
@@ -1,0 +1,231 @@
+const CHECKOUT_SOURCE = "content_ops_deflection_report";
+const DEFAULT_AMOUNT_CENTS = 150000;
+const DEFAULT_CURRENCY = "usd";
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(payload));
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseAmount(value) {
+  const parsed = Number.parseInt(clean(value), 10);
+  return Number.isFinite(parsed) && parsed >= DEFAULT_AMOUNT_CENTS
+    ? parsed
+    : DEFAULT_AMOUNT_CENTS;
+}
+
+function normalizeCurrency(value) {
+  const normalized = clean(value).toLowerCase();
+  return /^[a-z]{3}$/.test(normalized) ? normalized : DEFAULT_CURRENCY;
+}
+
+function stripeAuthHeaders(stripeSecretKey) {
+  return {
+    "Authorization": `Basic ${Buffer.from(`${stripeSecretKey}:`).toString("base64")}`,
+  };
+}
+
+function publicBaseUrl(req) {
+  const configured = clean(process.env.DEFLECTION_CHECKOUT_PUBLIC_BASE_URL);
+  if (configured) return configured.replace(/\/+$/, "");
+  const host = clean(req.headers?.["x-forwarded-host"]) || clean(req.headers?.host);
+  if (host) {
+    const proto = clean(req.headers?.["x-forwarded-proto"]) || "https";
+    return `${proto}://${host}`.replace(/\/+$/, "");
+  }
+  const vercelUrl = clean(process.env.VERCEL_URL);
+  return vercelUrl ? `https://${vercelUrl}`.replace(/\/+$/, "") : "";
+}
+
+async function readBody(req) {
+  if (req.body && typeof req.body === "object") return req.body;
+  if (typeof req.body === "string") return JSON.parse(req.body);
+
+  const chunks = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function validatePayload(payload) {
+  const requestId = clean(payload?.request_id);
+  const accountId = clean(payload?.account_id);
+  const errors = [];
+  if (!requestId || !REQUEST_ID_RE.test(requestId)) {
+    errors.push("request_id must be a valid Content Ops request id");
+  }
+  if (!accountId || !UUID_RE.test(accountId)) {
+    errors.push("account_id must be a valid ATLAS account UUID");
+  }
+  return { requestId, accountId, errors };
+}
+
+function resultPath(requestId, accountId, checkout) {
+  const path = `/services/faq-deflection/results/${encodeURIComponent(requestId)}`;
+  const params = new URLSearchParams({ account_id: accountId });
+  if (checkout) params.set("checkout", checkout);
+  return `${path}?${params.toString()}`;
+}
+
+function checkoutUrls(req, requestId, accountId) {
+  const baseUrl = publicBaseUrl(req);
+  if (!baseUrl) return { errors: ["public base URL could not be resolved"] };
+  const successUrl =
+    clean(process.env.DEFLECTION_CHECKOUT_SUCCESS_URL) ||
+    `${baseUrl}${resultPath(requestId, accountId, "success")}`;
+  const cancelUrl =
+    clean(process.env.DEFLECTION_CHECKOUT_CANCEL_URL) ||
+    `${baseUrl}${resultPath(requestId, accountId, "cancel")}`;
+  return { successUrl, cancelUrl, errors: [] };
+}
+
+function buildStripeCheckoutBody({ requestId, accountId, successUrl, cancelUrl }) {
+  const params = new URLSearchParams();
+  params.set("mode", "payment");
+  params.set("success_url", successUrl);
+  params.set("cancel_url", cancelUrl);
+  params.set("metadata[source]", CHECKOUT_SOURCE);
+  params.set("metadata[account_id]", accountId);
+  params.set("metadata[request_id]", requestId);
+  params.set("payment_intent_data[metadata][source]", CHECKOUT_SOURCE);
+  params.set("payment_intent_data[metadata][account_id]", accountId);
+  params.set("payment_intent_data[metadata][request_id]", requestId);
+  params.set("client_reference_id", requestId);
+  params.set("line_items[0][quantity]", "1");
+
+  const priceId = clean(process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID);
+  if (priceId) {
+    params.set("line_items[0][price]", priceId);
+    return params;
+  }
+
+  const amount = parseAmount(process.env.DEFLECTION_REPORT_AMOUNT_CENTS);
+  const currency = normalizeCurrency(process.env.DEFLECTION_REPORT_CURRENCY);
+  params.set("line_items[0][price_data][currency]", currency);
+  params.set("line_items[0][price_data][unit_amount]", String(amount));
+  params.set("line_items[0][price_data][product_data][name]", "FAQ Deflection Report");
+  params.set(
+    "line_items[0][price_data][product_data][description]",
+    "One-time unlock for the full support-ticket FAQ deflection report.",
+  );
+  return params;
+}
+
+async function validateConfiguredPrice(stripeSecretKey) {
+  const priceId = clean(process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID);
+  if (!priceId) return { ok: true };
+
+  const response = await fetch(
+    `https://api.stripe.com/v1/prices/${encodeURIComponent(priceId)}`,
+    {
+      headers: stripeAuthHeaders(stripeSecretKey),
+    },
+  );
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || !payload || typeof payload !== "object") {
+    return {
+      ok: false,
+      message: "configured Stripe Price could not be validated",
+    };
+  }
+  if (
+    payload.active === false ||
+    payload.currency !== DEFAULT_CURRENCY ||
+    payload.unit_amount < DEFAULT_AMOUNT_CENTS
+  ) {
+    return {
+      ok: false,
+      message: "configured Stripe Price must be active, usd, and at least 150000 cents",
+    };
+  }
+  return { ok: true };
+}
+
+async function createCheckoutSession(params, stripeSecretKey) {
+  const response = await fetch("https://api.stripe.com/v1/checkout/sessions", {
+    method: "POST",
+    headers: {
+      ...stripeAuthHeaders(stripeSecretKey),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params,
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || !payload || typeof payload.url !== "string") {
+    const message =
+      payload && typeof payload.error?.message === "string"
+        ? payload.error.message
+        : "Stripe Checkout session could not be created";
+    return { ok: false, status: response.status, message };
+  }
+  return { ok: true, url: payload.url };
+}
+
+export {
+  CHECKOUT_SOURCE,
+  buildStripeCheckoutBody,
+  checkoutUrls,
+  resultPath,
+  validateConfiguredPrice,
+  validatePayload,
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    json(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+
+  const stripeSecretKey = clean(process.env.STRIPE_SECRET_KEY);
+  if (!stripeSecretKey) {
+    json(res, 503, { error: "checkout_not_configured" });
+    return;
+  }
+
+  let payload;
+  try {
+    payload = await readBody(req);
+  } catch {
+    json(res, 400, { error: "invalid_json" });
+    return;
+  }
+
+  const { requestId, accountId, errors } = validatePayload(payload);
+  if (errors.length > 0) {
+    json(res, 400, { error: "invalid_checkout_request", details: errors });
+    return;
+  }
+
+  const urls = checkoutUrls(req, requestId, accountId);
+  if (urls.errors.length > 0) {
+    json(res, 503, { error: "checkout_url_not_configured", details: urls.errors });
+    return;
+  }
+  const priceValidation = await validateConfiguredPrice(stripeSecretKey);
+  if (!priceValidation.ok) {
+    json(res, 503, { error: "checkout_price_not_configured", details: priceValidation.message });
+    return;
+  }
+
+  const body = buildStripeCheckoutBody({
+    requestId,
+    accountId,
+    successUrl: urls.successUrl,
+    cancelUrl: urls.cancelUrl,
+  });
+  const session = await createCheckoutSession(body, stripeSecretKey);
+  if (!session.ok) {
+    json(res, 502, { error: "stripe_checkout_failed", details: session.message });
+    return;
+  }
+
+  json(res, 200, { url: session.url });
+}

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -1,0 +1,172 @@
+import { CHECKOUT_SOURCE, resultPath } from "./checkout.js";
+
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function clean(value) {
+  if (Array.isArray(value)) return clean(value[0]);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function escapeHtml(value) {
+  return clean(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function scriptJson(value) {
+  return JSON.stringify(clean(value))
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function requestUrl(req) {
+  const proto = clean(req.headers?.["x-forwarded-proto"]) || "https";
+  const host = clean(req.headers?.["x-forwarded-host"]) || clean(req.headers?.host) || "localhost";
+  return new URL(req.url || "/", `${proto}://${host}`);
+}
+
+function requestIdFrom(req, url) {
+  const queryId = clean(req.query?.request_id) || clean(url.searchParams.get("request_id"));
+  if (queryId) return queryId;
+  const match = url.pathname.match(/\/services\/faq-deflection\/results\/([^/?#]+)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
+  const safeRequestId = escapeHtml(requestId);
+  const safeAccountId = escapeHtml(accountId);
+  const safeCheckoutStatus = escapeHtml(checkoutStatus);
+  const resultHref = resultPath(requestId || "missing-request", accountId, "");
+  const buttonDisabled = requestId && accountId ? "" : "disabled";
+  const statusBanner =
+    checkoutStatus === "success"
+      ? `<div class="notice success">Checkout returned successfully. ATLAS unlocks the paid report only after Stripe sends the verified webhook.</div>`
+      : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>FAQ Deflection Report | Juan Canfield</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #020617; color: #f8fafc; }
+    a { color: #86efac; }
+    .shell { max-width: 1120px; margin: 0 auto; padding: 48px 24px; }
+    .grid { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 32px; align-items: start; }
+    .eyebrow { display: inline-flex; margin-bottom: 20px; border: 1px solid rgba(34, 197, 94, .35); border-radius: 999px; padding: 6px 10px; color: #86efac; font-size: 12px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    h1 { max-width: 760px; margin: 0; font-size: clamp(36px, 6vw, 56px); line-height: 1; letter-spacing: 0; }
+    .lede { max-width: 760px; margin-top: 20px; color: rgba(226, 232, 240, .84); font-size: 18px; line-height: 1.7; }
+    .panel { border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(15, 23, 42, .72); padding: 24px; }
+    .meta { display: grid; gap: 14px; margin: 24px 0; }
+    dt { color: rgba(226, 232, 240, .62); font-size: 13px; }
+    dd { margin: 4px 0 0; color: #f8fafc; font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    button { width: 100%; border: 0; border-radius: 8px; background: #22c55e; color: #020617; padding: 13px 16px; font-weight: 800; cursor: pointer; }
+    button:disabled { background: #1e293b; color: rgba(226, 232, 240, .55); cursor: not-allowed; }
+    .snapshot { margin-top: 32px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(15, 23, 42, .42); padding: 24px; }
+    .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
+    .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
+    .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
+    @media (max-width: 820px) { .grid { grid-template-columns: 1fr; } .shell { padding-top: 32px; } }
+  </style>
+</head>
+<body>
+  <main
+    class="shell"
+    data-atlas-deflection-result
+    data-atlas-deflection-request-id="${safeRequestId}"
+    data-atlas-deflection-account-id="${safeAccountId}"
+    data-atlas-deflection-report-source="${CHECKOUT_SOURCE}"
+  >
+    <a href="/services">Services</a>
+    <div class="grid">
+      <section>
+        <div class="eyebrow">Locked report</div>
+        <h1>FAQ deflection report is ready for review</h1>
+        <p class="lede">The free snapshot and paid artifact stay separated. The full report unlocks only after Stripe confirms payment and ATLAS releases the artifact from its signed webhook path.</p>
+        ${statusBanner}
+        <section class="snapshot" aria-labelledby="snapshot-title">
+          <h2 id="snapshot-title">Free snapshot</h2>
+          <p class="muted">The hosted result page exposes the report identifiers for Checkout. It does not synthesize estimates or render answer, evidence, source_ids, markdown, or faq_result fields before payment.</p>
+        </section>
+      </section>
+      <aside class="panel">
+        <h2>Unlock full report</h2>
+        <p class="muted">$1,500 one-time Stripe Checkout session.</p>
+        <dl class="meta">
+          <div><dt>Checkout metadata source</dt><dd>${CHECKOUT_SOURCE}</dd></div>
+          <div><dt>request_id</dt><dd>${safeRequestId || "Missing request id"}</dd></div>
+          <div><dt>account_id</dt><dd>${safeAccountId || "Missing account id"}</dd></div>
+          <div><dt>canonical result path</dt><dd>${escapeHtml(resultHref)}</dd></div>
+          <div><dt>checkout</dt><dd>${safeCheckoutStatus || "locked"}</dd></div>
+        </dl>
+        <button type="button" data-atlas-deflection-unlock ${buttonDisabled}>Continue to Checkout</button>
+        <p id="checkout-message" class="muted" role="status"></p>
+      </aside>
+    </div>
+  </main>
+  <script>
+    const button = document.querySelector("[data-atlas-deflection-unlock]");
+    const message = document.getElementById("checkout-message");
+    const requestId = ${scriptJson(requestId)};
+    const accountId = ${scriptJson(accountId)};
+    if (button && requestId && accountId) {
+      button.addEventListener("click", async () => {
+        button.disabled = true;
+        message.textContent = "Opening Checkout...";
+        try {
+          const response = await fetch("/api/content-ops/deflection/checkout", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ request_id: requestId, account_id: accountId })
+          });
+          const payload = await response.json();
+          if (!response.ok || !payload.url) throw new Error(payload.error || "checkout_failed");
+          window.location.assign(payload.url);
+        } catch {
+          button.disabled = false;
+          message.textContent = "Checkout could not be started.";
+        }
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+export { renderResultPage };
+
+export default function handler(req, res) {
+  const url = requestUrl(req);
+  const requestId = requestIdFrom(req, url);
+  const accountId = clean(req.query?.account_id) || clean(url.searchParams.get("account_id"));
+  if (requestId && !REQUEST_ID_RE.test(requestId)) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Invalid request_id");
+    return;
+  }
+  if (accountId && !UUID_RE.test(accountId)) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Invalid account_id");
+    return;
+  }
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(
+    renderResultPage({
+      requestId,
+      accountId,
+      checkoutStatus: clean(url.searchParams.get("checkout")),
+    }),
+  );
+}

--- a/portfolio-ui/package.json
+++ b/portfolio-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test:deflection-result": "node scripts/faq-deflection-result-page.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import handler, {
+  CHECKOUT_SOURCE,
+  buildStripeCheckoutBody,
+  resultPath,
+  validateConfiguredPrice,
+  validatePayload,
+} from "../api/content-ops/deflection/checkout.js";
+import resultPageHandler, { renderResultPage } from "../api/content-ops/deflection/result-page.js";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
+const pageSource = await readFile(resolve(root, "src/pages/FaqDeflectionResult.tsx"), "utf8");
+const vercelConfig = JSON.parse(await readFile(resolve(root, "vercel.json"), "utf8"));
+const checkoutSource = await readFile(
+  resolve(root, "api/content-ops/deflection/checkout.js"),
+  "utf8",
+);
+const resultPageSource = await readFile(
+  resolve(root, "api/content-ops/deflection/result-page.js"),
+  "utf8",
+);
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+function mockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(value) {
+      this.body = value;
+    },
+  };
+}
+
+await test("route is wired at the hosted FAQ deflection result path", () => {
+  assert.match(appSource, /FaqDeflectionResult/);
+  assert.match(appSource, /\/services\/faq-deflection\/results\/:requestId/);
+  assert.deepEqual(vercelConfig.rewrites[0], {
+    source: "/services/faq-deflection/results/:requestId",
+    destination: "/api/content-ops/deflection/result-page?request_id=:requestId",
+  });
+});
+
+await test("result page exposes validation markers and checkout metadata", () => {
+  const html = renderResultPage({
+    requestId: "content-ops-abc123",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+  });
+  for (const marker of [
+    "data-atlas-deflection-result",
+    "data-atlas-deflection-request-id",
+    "data-atlas-deflection-unlock",
+    "request_id",
+    "account_id",
+  ]) {
+    assert.match(pageSource, new RegExp(marker));
+    assert.match(resultPageSource, new RegExp(marker));
+    assert.match(html, new RegExp(marker));
+  }
+  assert.match(pageSource, /content_ops_deflection_report/);
+  assert.match(html, /content_ops_deflection_report/);
+  assert.match(html, /content-ops-abc123/);
+  assert.match(html, /2b2b950d-f64b-4852-bc30-f92a34cdf169/);
+});
+
+await test("result pages never embed ATLAS service credentials or paid-route calls", () => {
+  for (const source of [pageSource, resultPageSource]) {
+    assert.doesNotMatch(source, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
+    assert.doesNotMatch(source, /\/paid\b/);
+  }
+});
+
+await test("snapshot guard names paid report fields that must not render pre-payment", () => {
+  for (const forbidden of ["markdown", "faq_result", "answer", "evidence_quotes", "source_ids"]) {
+    assert.match(pageSource, new RegExp(`"${forbidden}"`));
+  }
+  assert.match(pageSource, /collectForbiddenKeys/);
+});
+
+await test("checkout endpoint validates request and account identifiers", () => {
+  const valid = validatePayload({
+    request_id: "content-ops-abc123",
+    account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+  });
+  assert.deepEqual(valid.errors, []);
+
+  const invalid = validatePayload({
+    request_id: "../bad",
+    account_id: "not-a-uuid",
+  });
+  assert.deepEqual(invalid.errors, [
+    "request_id must be a valid Content Ops request id",
+    "account_id must be a valid ATLAS account UUID",
+  ]);
+});
+
+await test("hosted result page rejects script-breaking account_id input", () => {
+  const res = mockResponse();
+  resultPageHandler(
+    {
+      url: "/services/faq-deflection/results/content-ops-abc123?account_id=%3C%2Fscript%3E%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E",
+      headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
+      query: {
+        request_id: "content-ops-abc123",
+        account_id: "</script><img src=x onerror=alert(1)>",
+      },
+    },
+    res,
+  );
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body, "Invalid account_id");
+});
+
+await test("rendered inline script escapes script terminators defensively", () => {
+  const html = renderResultPage({
+    requestId: "content-ops-abc123",
+    accountId: "</script><img src=x onerror=alert(1)>",
+  });
+  assert.doesNotMatch(html, /const accountId = "<\/script>/);
+  assert.match(html, /const accountId = "\\u003c\/script>/);
+});
+
+await test("checkout body carries the Stripe metadata contract and one-time price", () => {
+  delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  process.env.DEFLECTION_REPORT_AMOUNT_CENTS = "10";
+  process.env.DEFLECTION_REPORT_CURRENCY = "USD";
+  const body = buildStripeCheckoutBody({
+    requestId: "content-ops-abc123",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    successUrl: "https://example.com/success",
+    cancelUrl: "https://example.com/cancel",
+  });
+
+  assert.equal(body.get("mode"), "payment");
+  assert.equal(body.get("metadata[source]"), CHECKOUT_SOURCE);
+  assert.equal(body.get("metadata[account_id]"), "2b2b950d-f64b-4852-bc30-f92a34cdf169");
+  assert.equal(body.get("metadata[request_id]"), "content-ops-abc123");
+  assert.equal(body.get("payment_intent_data[metadata][source]"), CHECKOUT_SOURCE);
+  assert.equal(body.get("line_items[0][quantity]"), "1");
+  assert.equal(body.get("line_items[0][price_data][currency]"), "usd");
+  assert.equal(body.get("line_items[0][price_data][unit_amount]"), "150000");
+});
+
+await test("configured Stripe Price must validate against webhook floor before Checkout", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_deflection_low";
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { active: true, currency: "usd", unit_amount: 149999 };
+      },
+    };
+  };
+
+  try {
+    const result = await validateConfiguredPrice("sk_test_123");
+    assert.deepEqual(result, {
+      ok: false,
+      message: "configured Stripe Price must be active, usd, and at least 150000 cents",
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+  }
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.stripe.com/v1/prices/price_deflection_low");
+});
+
+await test("checkout return path preserves result identifiers", () => {
+  const path = resultPath(
+    "content-ops-abc123",
+    "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    "success",
+  );
+  assert.equal(
+    path,
+    "/services/faq-deflection/results/content-ops-abc123?account_id=2b2b950d-f64b-4852-bc30-f92a34cdf169&checkout=success",
+  );
+});
+
+await test("handler creates Stripe Checkout without calling privileged ATLAS paid route", async () => {
+  assert.doesNotMatch(checkoutSource, /\/content-ops\/deflection-reports\/.+\/paid/);
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_123";
+  delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { url: "https://checkout.stripe.com/c/session" };
+      },
+    };
+  };
+
+  const req = {
+    method: "POST",
+    headers: {
+      host: "portfolio.example.com",
+      "x-forwarded-proto": "https",
+    },
+    body: {
+      request_id: "content-ops-abc123",
+      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    },
+  };
+  const res = mockResponse();
+
+  try {
+    await handler(req, res);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), { url: "https://checkout.stripe.com/c/session" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(calls[0].options.body.get("metadata[source]"), CHECKOUT_SOURCE);
+  assert.equal(calls[0].options.body.get("metadata[request_id]"), "content-ops-abc123");
+});

--- a/portfolio-ui/src/App.tsx
+++ b/portfolio-ui/src/App.tsx
@@ -6,6 +6,7 @@ const Home = lazy(() => import("@/pages/Home"));
 const Projects = lazy(() => import("@/pages/Projects"));
 const ProjectDetail = lazy(() => import("@/pages/ProjectDetail"));
 const Services = lazy(() => import("@/pages/Services"));
+const FaqDeflectionResult = lazy(() => import("@/pages/FaqDeflectionResult"));
 const Systems = lazy(() => import("@/pages/Systems"));
 const Insights = lazy(() => import("@/pages/Insights"));
 const InsightDetail = lazy(() => import("@/pages/InsightDetail"));
@@ -30,6 +31,10 @@ export default function App() {
           <Route path="/projects" element={<Projects />} />
           <Route path="/projects/:slug" element={<ProjectDetail />} />
           <Route path="/services" element={<Services />} />
+          <Route
+            path="/services/faq-deflection/results/:requestId"
+            element={<FaqDeflectionResult />}
+          />
           <Route path="/systems" element={<Systems />} />
           <Route path="/insights" element={<Insights />} />
           <Route path="/insights/:slug" element={<InsightDetail />} />

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  CreditCard,
+  FileLock2,
+  Loader2,
+} from "lucide-react";
+import { SeoHead } from "@/components/seo/SeoHead";
+
+const SNAPSHOT_STORAGE_PREFIX = "atlas:deflection:snapshot:";
+const CHECKOUT_ENDPOINT = "/api/content-ops/deflection/checkout";
+const CHECKOUT_SOURCE = "content_ops_deflection_report";
+const FORBIDDEN_SNAPSHOT_KEYS = new Set([
+  "answer",
+  "answers",
+  "evidence",
+  "evidence_quotes",
+  "faq_result",
+  "full_report",
+  "markdown",
+  "source_id",
+  "source_ids",
+  "steps",
+  "term_mappings",
+]);
+
+type DeflectionSnapshot = {
+  summary: {
+    generated: number;
+    drafted_answer_count: number;
+    no_proven_answer_count: number;
+  };
+  top_questions: Array<{
+    rank: number;
+    question: string;
+    weighted_frequency: number;
+    customer_wording: string;
+  }>;
+};
+
+type SnapshotState =
+  | { status: "available"; snapshot: DeflectionSnapshot }
+  | { status: "missing" }
+  | { status: "invalid"; reason: string };
+
+type CheckoutState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "error"; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectForbiddenKeys(value: unknown, leaked = new Set<string>()) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectForbiddenKeys(item, leaked);
+    return leaked;
+  }
+  if (!isRecord(value)) return leaked;
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_SNAPSHOT_KEYS.has(key)) leaked.add(key);
+    collectForbiddenKeys(child, leaked);
+  }
+  return leaked;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseSnapshot(value: unknown): SnapshotState {
+  const leaked = [...collectForbiddenKeys(value)].sort();
+  if (leaked.length > 0) {
+    return {
+      status: "invalid",
+      reason: `Snapshot included paid-report fields: ${leaked.join(", ")}`,
+    };
+  }
+  if (!isRecord(value) || !isRecord(value.summary) || !Array.isArray(value.top_questions)) {
+    return { status: "invalid", reason: "Snapshot shape did not match the deflection contract." };
+  }
+
+  const generated = finiteNumber(value.summary.generated);
+  const draftedAnswerCount = finiteNumber(value.summary.drafted_answer_count);
+  const noProvenAnswerCount = finiteNumber(value.summary.no_proven_answer_count);
+  if (
+    generated === null ||
+    draftedAnswerCount === null ||
+    noProvenAnswerCount === null
+  ) {
+    return { status: "invalid", reason: "Snapshot summary metrics were incomplete." };
+  }
+
+  const topQuestions = value.top_questions.map((item) => {
+    if (!isRecord(item)) return null;
+    const rank = finiteNumber(item.rank);
+    const weightedFrequency = finiteNumber(item.weighted_frequency);
+    const question = typeof item.question === "string" ? item.question.trim() : "";
+    const customerWording =
+      typeof item.customer_wording === "string" ? item.customer_wording.trim() : "";
+    if (rank === null || weightedFrequency === null || !question || !customerWording) {
+      return null;
+    }
+    return {
+      rank,
+      question,
+      weighted_frequency: weightedFrequency,
+      customer_wording: customerWording,
+    };
+  });
+
+  if (topQuestions.some((item) => item === null)) {
+    return { status: "invalid", reason: "Snapshot questions were incomplete." };
+  }
+
+  return {
+    status: "available",
+    snapshot: {
+      summary: {
+        generated,
+        drafted_answer_count: draftedAnswerCount,
+        no_proven_answer_count: noProvenAnswerCount,
+      },
+      top_questions: topQuestions as DeflectionSnapshot["top_questions"],
+    },
+  };
+}
+
+function readStoredSnapshot(requestId: string | undefined): SnapshotState {
+  if (!requestId || typeof window === "undefined") return { status: "missing" };
+  const raw = window.sessionStorage.getItem(`${SNAPSHOT_STORAGE_PREFIX}${requestId}`);
+  if (!raw) return { status: "missing" };
+  try {
+    return parseSnapshot(JSON.parse(raw));
+  } catch {
+    return { status: "invalid", reason: "Snapshot JSON could not be parsed." };
+  }
+}
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+export default function FaqDeflectionResult() {
+  const { requestId } = useParams();
+  const [searchParams] = useSearchParams();
+  const accountId = searchParams.get("account_id")?.trim() ?? "";
+  const checkoutStatus = searchParams.get("checkout")?.trim() ?? "";
+  const [snapshotState, setSnapshotState] = useState<SnapshotState>({ status: "missing" });
+  const [checkout, setCheckout] = useState<CheckoutState>({ status: "idle" });
+  const canCheckout = Boolean(requestId && accountId && checkout.status !== "submitting");
+
+  useEffect(() => {
+    setSnapshotState(readStoredSnapshot(requestId));
+  }, [requestId]);
+
+  const metricCards = useMemo(() => {
+    if (snapshotState.status !== "available") return [];
+    const { summary } = snapshotState.snapshot;
+    return [
+      { label: "Questions found", value: summary.generated },
+      { label: "Evidence-backed answers", value: summary.drafted_answer_count },
+      { label: "Needs support proof", value: summary.no_proven_answer_count },
+    ];
+  }, [snapshotState]);
+
+  const startCheckout = async () => {
+    if (!requestId || !accountId) return;
+    setCheckout({ status: "submitting" });
+    try {
+      const response = await fetch(CHECKOUT_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ request_id: requestId, account_id: accountId }),
+      });
+      const payload = (await response.json().catch(() => null)) as { url?: unknown; error?: unknown } | null;
+      if (!response.ok || !payload || typeof payload.url !== "string") {
+        const message =
+          payload && typeof payload.error === "string"
+            ? payload.error
+            : "Checkout could not be started.";
+        setCheckout({ status: "error", message });
+        return;
+      }
+      window.location.assign(payload.url);
+    } catch {
+      setCheckout({ status: "error", message: "Checkout could not be reached." });
+    }
+  };
+
+  return (
+    <>
+      <SeoHead
+        meta={{
+          title: "FAQ Deflection Report",
+          description:
+            "Review the locked FAQ deflection report snapshot and unlock the full customer-support opportunity report.",
+          canonicalPath: requestId
+            ? `/services/faq-deflection/results/${encodeURIComponent(requestId)}`
+            : "/services/faq-deflection/results",
+          noindex: true,
+        }}
+      />
+
+      <section
+        className="mx-auto max-w-6xl px-6 py-10 md:py-14"
+        data-atlas-deflection-result
+        data-atlas-deflection-request-id={requestId ?? ""}
+        data-atlas-deflection-account-id={accountId}
+        data-atlas-deflection-report-source={CHECKOUT_SOURCE}
+      >
+        <Link
+          to="/services"
+          className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-surface-200 transition-colors hover:text-white"
+        >
+          <ArrowLeft size={16} />
+          Services
+        </Link>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div>
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-primary-500/30 bg-primary-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary-300">
+              <FileLock2 size={14} />
+              Locked report
+            </div>
+            <h1 className="max-w-3xl text-4xl font-bold tracking-normal text-white md:text-5xl">
+              FAQ deflection report is ready for review
+            </h1>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-surface-200/85">
+              The free snapshot shows only repeated customer questions and
+              summary counts. The full report unlocks after Stripe confirms the
+              one-time payment and ATLAS releases the artifact from the signed
+              webhook path.
+            </p>
+
+            {checkoutStatus === "success" && (
+              <div className="mt-6 flex items-start gap-3 rounded-lg border border-primary-500/30 bg-primary-500/10 p-4 text-sm text-primary-100">
+                <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary-300" />
+                <p>
+                  Checkout returned successfully. ATLAS unlocks the paid report
+                  only after Stripe sends the verified webhook.
+                </p>
+              </div>
+            )}
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-3">
+              {metricCards.length > 0 ? (
+                metricCards.map((metric) => (
+                  <div
+                    key={metric.label}
+                    className="rounded-lg border border-surface-700/60 bg-surface-800/40 p-5"
+                  >
+                    <dt className="text-sm text-surface-200/70">{metric.label}</dt>
+                    <dd className="mt-3 text-3xl font-semibold text-white">
+                      {formatCount(metric.value)}
+                    </dd>
+                  </div>
+                ))
+              ) : (
+                <div className="sm:col-span-3 rounded-lg border border-surface-700/60 bg-surface-800/40 p-5">
+                  <p className="text-sm font-semibold text-white">Snapshot not loaded</p>
+                  <p className="mt-2 text-sm leading-6 text-surface-200/75">
+                    This page has not received the free snapshot from the submit
+                    flow yet. No estimates are displayed until real snapshot
+                    values are present.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {snapshotState.status === "invalid" && (
+              <div className="mt-6 flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
+                <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-amber-300" />
+                <p>{snapshotState.reason}</p>
+              </div>
+            )}
+
+            {snapshotState.status === "available" && (
+              <div className="mt-10">
+                <h2 className="text-xl font-semibold text-white">Top repeated questions</h2>
+                <div className="mt-4 divide-y divide-surface-700/60 rounded-lg border border-surface-700/60 bg-surface-800/30">
+                  {snapshotState.snapshot.top_questions.map((item) => (
+                    <article key={`${item.rank}-${item.question}`} className="p-5">
+                      <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.16em] text-primary-300">
+                        <span>Rank {item.rank}</span>
+                        <span>{formatCount(item.weighted_frequency)} weighted mentions</span>
+                      </div>
+                      <h3 className="mt-3 text-lg font-semibold text-white">{item.question}</h3>
+                      <p className="mt-2 text-sm leading-6 text-surface-200/75">
+                        {item.customer_wording}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <aside className="h-fit rounded-lg border border-surface-700/60 bg-surface-800/45 p-6">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-500/15 text-primary-300">
+                <CreditCard size={20} />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-white">Unlock full report</p>
+                <p className="text-sm text-surface-200/70">$1,500 one-time payment</p>
+              </div>
+            </div>
+
+            <dl className="mt-6 space-y-4 text-sm">
+              <div>
+                <dt className="text-surface-200/60">Checkout metadata source</dt>
+                <dd className="mt-1 break-all font-mono text-xs text-surface-100">
+                  {CHECKOUT_SOURCE}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-surface-200/60">request_id</dt>
+                <dd className="mt-1 break-all font-mono text-xs text-surface-100">
+                  {requestId || "Missing request id"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-surface-200/60">account_id</dt>
+                <dd className="mt-1 break-all font-mono text-xs text-surface-100">
+                  {accountId || "Missing account id"}
+                </dd>
+              </div>
+            </dl>
+
+            <button
+              type="button"
+              className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-3 text-sm font-semibold text-surface-900 transition hover:brightness-110 disabled:cursor-not-allowed disabled:bg-surface-700 disabled:text-surface-200/60"
+              data-atlas-deflection-unlock
+              disabled={!canCheckout}
+              onClick={startCheckout}
+            >
+              {checkout.status === "submitting" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Opening Checkout
+                </>
+              ) : (
+                <>
+                  <CreditCard size={16} />
+                  Continue to Checkout
+                </>
+              )}
+            </button>
+
+            {!accountId && (
+              <p className="mt-3 text-xs leading-5 text-amber-200">
+                Missing account_id. Return to the submit flow to create a
+                Checkout session for the right ATLAS tenant.
+              </p>
+            )}
+            {checkout.status === "error" && (
+              <p className="mt-3 text-xs leading-5 text-amber-200">{checkout.message}</p>
+            )}
+            <p className="mt-4 text-xs leading-5 text-surface-200/60">
+              The portfolio creates Checkout. ATLAS unlocks the artifact only
+              after the verified Stripe webhook.
+            </p>
+          </aside>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/portfolio-ui/vercel.json
+++ b/portfolio-ui/vercel.json
@@ -3,6 +3,10 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
+    {
+      "source": "/services/faq-deflection/results/:requestId",
+      "destination": "/api/content-ops/deflection/result-page?request_id=:requestId"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Result-Page-UI.md
Slice phase: Vertical slice

Add the portfolio FAQ deflection result page surface that #1176 can validate: a hosted raw-HTML result route with stable request/account/Checkout markers, a local SPA route that can render only free snapshot fields, and a server-side Stripe Checkout endpoint that carries the required `content_ops_deflection_report` metadata without exposing ATLAS service credentials.

## Intentional
- No `ATLAS_B2B_JWT`, `ATLAS_API_BASE_URL`, or service credential is placed in browser code. Customer-visible ATLAS snapshot/artifact hydration needs a later server proxy.
- The server-rendered HTML route validates `account_id` before rendering and escapes script-serialized values defensively so query strings cannot reflect script terminators.
- The page does not synthesize estimates when no snapshot is available; it displays only real snapshot values already provided by the submit flow.
- Checkout uses Stripe's direct API through `fetch` instead of adding the Stripe SDK dependency in this vertical slice.
- If operators configure `STRIPE_DEFLECTION_REPORT_PRICE_ID`, the checkout handler validates that Stripe Price object is active, USD, and at least 150000 cents before creating a Checkout session.
- The paid artifact view is deferred. The page never calls the privileged ATLAS `/paid` route; ATLAS still unlocks from the signed Stripe webhook.

## Deferred
- Add a secure portfolio server proxy for ATLAS snapshot/artifact hydration.
- Add the paid artifact renderer after the proxy can fetch `/content-ops/deflection-reports/{request_id}/artifact` server-side.
- Add private Vercel Blob upload/submit UX before the result route if the portfolio needs a fully self-serve upload funnel.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2845 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-result-page-ui-pr-body.md` - passed after review fixes.

## Diff size
9 files, +1220 / -0
