### PR TITLE
PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -335,17 +335,23 @@ async def stripe_webhook(request: Request):
     # Log event -- pass dict for JSONB column, add ::jsonb cast for asyncpg
     import json
     payload_str = json.dumps(event.data.object.to_dict() if hasattr(event.data.object, 'to_dict') else {})
-    await pool.execute(
-        """
-        INSERT INTO billing_events (account_id, stripe_event_id, event_type, payload)
-        VALUES ($1, $2, $3, $4::jsonb)
-        ON CONFLICT (stripe_event_id) DO NOTHING
-        """,
-        account_id,
-        event.id,
-        event_type,
-        payload_str,
-    )
+    try:
+        await pool.execute(
+            """
+            INSERT INTO billing_events (account_id, stripe_event_id, event_type, payload)
+            VALUES ($1, $2, $3, $4::jsonb)
+            ON CONFLICT (stripe_event_id) DO NOTHING
+            """,
+            account_id,
+            event.id,
+            event_type,
+            payload_str,
+        )
+    except Exception:
+        logger.exception(
+            "Stripe webhook side effect completed but billing_events audit insert failed: event=%s",
+            event.id,
+        )
 
     return {"status": "ok"}
 

--- a/plans/PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort.md
+++ b/plans/PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort.md
@@ -1,0 +1,66 @@
+# PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort
+
+## Why this slice exists
+
+The deflection/Stripe paid-unlock path now has a hosted smoke. The webhook marks
+the deflection report paid before writing the generic `billing_events` audit row.
+That audit insert is a secondary write after the side-effectful unlock; if it
+fails, Stripe currently sees an error even though the report was already marked
+paid.
+
+This slice applies the repo's secondary-write rule to the deflection paid-unlock
+path: audit logging failures are logged and do not fail an already-successful
+unlock.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Production hardening
+
+1. Wrap the post-webhook `billing_events` insert in best-effort error handling.
+2. Preserve fail-closed behavior for the actual Stripe signature, event
+   validation, report lookup, and paid update.
+3. Add a regression proving a deflection checkout still returns `{"status":
+   "ok"}` when the audit insert fails after the paid update succeeds.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort.md`
+- `atlas_brain/api/billing.py`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+`stripe_webhook` keeps the existing idempotency check and event-specific
+handlers unchanged. Only the final generic `billing_events` insert moves behind
+a `try`/`except Exception` block with `logger.exception(...)`.
+
+## Intentional
+
+- This does not make paid updates best-effort. If the deflection report row is
+  missing, the webhook still returns a non-2xx response for Stripe retry.
+- This applies to the shared webhook audit insert after every successfully
+  handled event, not just deflection events, because the insert is always
+  secondary to the event-specific side effect.
+
+## Deferred
+
+- Parked hardening: none.
+- Dedicated reconciliation for missing audit rows remains outside this slice;
+  this slice only prevents secondary audit failures from reversing a completed
+  webhook side effect.
+
+## Verification
+
+- py_compile for `atlas_brain/api/billing.py` and the deflection Stripe paid test file - passed.
+- Focused pytest for `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - 16 passed, 1 warning.
+- Path-scoped workflow pytest pair for deflection Stripe paid checks - 17 passed, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 66 |
+| Billing route | 28 |
+| Tests | 53 |
+| **Total** | **148** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -16,6 +16,7 @@ class _Pool:
         self.fetchval_calls: list[tuple[str, tuple[Any, ...]]] = []
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
         self.update_result = "UPDATE 1"
+        self.fail_billing_event_insert = False
 
     async def fetchval(self, query: str, *args: Any) -> Any:
         self.fetchval_calls.append((query, args))
@@ -25,6 +26,8 @@ class _Pool:
         self.execute_calls.append((query, args))
         if "UPDATE content_ops_deflection_reports" in query:
             return self.update_result
+        if self.fail_billing_event_insert and "INSERT INTO billing_events" in query:
+            raise RuntimeError("billing event insert failed")
         return "INSERT 0 1"
 
 
@@ -211,6 +214,56 @@ async def test_stripe_webhook_routes_deflection_checkout_to_paid_gate(
     assert insert_args[0] is None
     assert insert_args[1] == "evt_deflection_paid"
     assert insert_args[2] == "checkout.session.completed"
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    event = SimpleNamespace(
+        id="evt_deflection_paid_audit_failure",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
+    pool = _Pool()
+    pool.fail_billing_event_insert = True
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    response = await billing.stripe_webhook(request)
+
+    assert response == {"status": "ok"}
+    update_query, update_args = pool.execute_calls[0]
+    insert_query, insert_args = pool.execute_calls[1]
+    assert "UPDATE content_ops_deflection_reports" in update_query
+    assert update_args == (account_id, "req-123", "cs_test_deflection")
+    assert "INSERT INTO billing_events" in insert_query
+    assert insert_args[1] == "evt_deflection_paid_audit_failure"
+    assert "billing_events audit insert failed" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort.md
Slice phase: Production hardening

The deflection paid-unlock webhook marks the report paid before writing the generic `billing_events` audit row. This makes that secondary audit write best-effort so an already-successful paid unlock does not return an error to Stripe if the audit insert fails.

## Intentional
- The actual paid update remains fail-closed; missing deflection report rows still return non-2xx for Stripe retry.
- The best-effort wrapper applies to the shared post-handler audit insert because it is secondary after every successful webhook side effect.

## Deferred
- Dedicated reconciliation for missing audit rows is outside this slice.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/api/billing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 16 passed, 1 warning.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` - 17 passed, 1 warning.

## Diff size
3 files, +136 / -11