### PR TITLE
PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency

### DIFF
--- a/plans/PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency.md
+++ b/plans/PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency.md
@@ -1,0 +1,78 @@
+# PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Stripe-Event-Log-Best-Effort made the final
+`billing_events` insert best-effort after the Stripe paid-unlock side effect.
+That is the right secondary-write behavior, but the regression coverage only
+proved the first webhook response stays `ok` when the audit insert fails.
+
+This slice locks down the retry/idempotency contract around that behavior: a
+successful audit insert must make duplicate Stripe events short-circuit, while a
+retry after an audit-insert failure may re-run the paid update but must converge
+by inserting the idempotency row on the successful retry.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Robust testing
+
+1. Make the deflection Stripe paid webhook test double model processed
+   `billing_events` ids instead of always returning no match.
+2. Add duplicate-event coverage proving an already-recorded Stripe event returns
+   `{"status": "already_processed"}` before any paid update.
+3. Add retry-after-audit-failure coverage proving the paid update is safe to
+   repeat once and the next successful audit insert restores the idempotency
+   guard.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency.md`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+
+## Mechanism
+
+The existing `_Pool` test double grows a `processed_event_ids` set. Its
+`fetchval` method returns a sentinel id for `billing_events` lookups when the
+event id is already recorded, and its `execute` method records the event id
+when the `INSERT INTO billing_events` succeeds.
+
+The new tests exercise `stripe_webhook` through the same fake Stripe module and
+request shape as the existing paid-unlock tests, so the assertions cover the
+real idempotency branch instead of a helper-level shortcut.
+
+## Intentional
+
+- No production code changes land here. The current webhook behavior already
+  does the right thing: report unlock is idempotent, and the audit row is the
+  duplicate-event guard when available.
+- This slice stays in the host API billing test suite. It must not be enrolled
+  in extracted-checks because the test imports `atlas_brain.api.billing`.
+- A retry after an audit insert failure is allowed to perform the paid update a
+  second time. The update is keyed by `(account_id, request_id)` and writes the
+  same Stripe session reference, so the important contract is convergence after
+  the successful retry.
+
+## Deferred
+
+- Parked hardening: none.
+- A separate reconciliation job for audit rows missing after a completed unlock
+  remains outside this slice. The Stripe 2xx response means Stripe normally
+  will not retry automatically after the best-effort audit failure.
+
+## Verification
+
+- Command: python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+  - Result: passed.
+- Command: python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q
+  - Result: 18 passed, 1 warning.
+- Command: python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q
+  - Result: 19 passed, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 78 |
+| Tests | 119 |
+| **Total** | **197** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -17,9 +17,16 @@ class _Pool:
         self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
         self.update_result = "UPDATE 1"
         self.fail_billing_event_insert = False
+        self.processed_event_ids: set[str] = set()
 
     async def fetchval(self, query: str, *args: Any) -> Any:
         self.fetchval_calls.append((query, args))
+        if (
+            "FROM billing_events" in query
+            and args
+            and args[0] in self.processed_event_ids
+        ):
+            return "billing-event-id"
         return None
 
     async def execute(self, query: str, *args: Any) -> str:
@@ -28,6 +35,8 @@ class _Pool:
             return self.update_result
         if self.fail_billing_event_insert and "INSERT INTO billing_events" in query:
             raise RuntimeError("billing event insert failed")
+        if "INSERT INTO billing_events" in query:
+            self.processed_event_ids.add(str(args[1]))
         return "INSERT 0 1"
 
 
@@ -214,6 +223,51 @@ async def test_stripe_webhook_routes_deflection_checkout_to_paid_gate(
     assert insert_args[0] is None
     assert insert_args[1] == "evt_deflection_paid"
     assert insert_args[2] == "checkout.session.completed"
+    assert pool.processed_event_ids == {"evt_deflection_paid"}
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_skips_processed_deflection_checkout_before_paid_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    event = SimpleNamespace(
+        id="evt_deflection_paid_duplicate",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
+    pool = _Pool()
+    pool.processed_event_ids.add("evt_deflection_paid_duplicate")
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    response = await billing.stripe_webhook(request)
+
+    assert response == {"status": "already_processed"}
+    assert pool.fetchval_calls[0][1] == ("evt_deflection_paid_duplicate",)
+    assert pool.execute_calls == []
 
 
 @pytest.mark.asyncio
@@ -264,6 +318,71 @@ async def test_stripe_webhook_keeps_paid_unlock_when_audit_insert_fails(
     assert "INSERT INTO billing_events" in insert_query
     assert insert_args[1] == "evt_deflection_paid_audit_failure"
     assert "billing_events audit insert failed" in caplog.text
+    assert pool.processed_event_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_retry_after_audit_failure_restores_idempotency(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    account_id = str(uuid.uuid4())
+    session = _session(account_id=account_id)
+    event = SimpleNamespace(
+        id="evt_deflection_paid_retry",
+        type="checkout.session.completed",
+        data=SimpleNamespace(object=session),
+    )
+
+    class _Webhook:
+        @staticmethod
+        def construct_event(_body: bytes, _sig: str, _secret: str) -> Any:
+            return event
+
+    fake_stripe = SimpleNamespace(Webhook=_Webhook, api_key="")
+    pool = _Pool()
+    pool.fail_billing_event_insert = True
+    request = SimpleNamespace(
+        headers={"stripe-signature": "valid"},
+        body=lambda: _body(),
+    )
+
+    async def _body() -> bytes:
+        return b"{}"
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "sk_test")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_webhook_secret",
+        "whsec_test",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    assert await billing.stripe_webhook(request) == {"status": "ok"}
+    assert pool.processed_event_ids == set()
+    assert "billing_events audit insert failed" in caplog.text
+
+    pool.fail_billing_event_insert = False
+    assert await billing.stripe_webhook(request) == {"status": "ok"}
+    assert pool.processed_event_ids == {"evt_deflection_paid_retry"}
+
+    assert await billing.stripe_webhook(request) == {"status": "already_processed"}
+
+    update_calls = [
+        call
+        for call in pool.execute_calls
+        if "UPDATE content_ops_deflection_reports" in call[0]
+    ]
+    insert_calls = [
+        call for call in pool.execute_calls if "INSERT INTO billing_events" in call[0]
+    ]
+    assert len(update_calls) == 2
+    assert all(
+        call[1] == (account_id, "req-123", "cs_test_deflection")
+        for call in update_calls
+    )
+    assert len(insert_calls) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency.md
Slice phase: Robust testing

Lock down the deflection Stripe paid-unlock retry/idempotency contract after the audit row became best-effort: duplicate Stripe events short-circuit when the `billing_events` row exists, and a retry after an audit-insert failure can repeat the idempotent paid update once before restoring the duplicate-event guard.

## Intentional
- No production code changes land here. The current webhook behavior already does the right thing: report unlock is idempotent, and the audit row is the duplicate-event guard when available.
- This stays in the host API billing test suite, not extracted-checks, because it imports `atlas_brain.api.billing`.
- A retry after an audit insert failure is allowed to perform the paid update a second time because the update is keyed by `(account_id, request_id)` and writes the same Stripe session reference.

## Deferred
- A separate reconciliation job for audit rows missing after a completed unlock remains outside this slice.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_atlas_billing_content_ops_deflection_stripe_paid.py` - passed.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` - 18 passed, 1 warning.
- `python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` - 19 passed, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-stripe-paid-retry-idempotency-pr-body.md` - passed after rebasing onto #1178.

## Diff size
2 files, +197 / -0
