### PR TITLE
PR-FAQ-Deflection-Portfolio-Atlas-Proxy

### DIFF
--- a/.github/workflows/portfolio_ui_checks.yml
+++ b/.github/workflows/portfolio_ui_checks.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Test FAQ deflection result page
         run: npm run test:deflection-result
+
+      - name: Test FAQ deflection ATLAS proxy
+        run: npm run test:deflection-atlas-proxy

--- a/plans/PR-FAQ-Deflection-Portfolio-Atlas-Proxy.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Atlas-Proxy.md
@@ -1,0 +1,112 @@
+# PR-FAQ-Deflection-Portfolio-Atlas-Proxy
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Portfolio-Result-Page-UI added the hosted result page and
+server-side Checkout creation, but it intentionally did not let browser code
+call ATLAS because that would expose the B2B service JWT. The next product step
+is a portfolio-owned server proxy that can read ATLAS snapshot/artifact state
+with secret server env vars and render real free snapshot numbers on the hosted
+result page.
+
+This keeps the paywall trust boundary intact: the portfolio can display the
+free snapshot and read paid/unpaid artifact state, but ATLAS still releases the
+full artifact only after Stripe's verified webhook marks the report paid.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Add a server-only portfolio ATLAS proxy helper for deflection report
+   snapshot/artifact hydration.
+2. Add a public portfolio API route that validates `request_id` and
+   `account_id`, checks that the account matches the configured portfolio
+   service account, and returns a locked/unlocked report envelope.
+3. Render real free snapshot metrics and top questions in the hosted result
+   page when ATLAS returns a snapshot.
+4. Keep full paid artifact rendering deferred; this slice only reports
+   `artifact_status` and never derives paid copy from the snapshot.
+5. Enroll the proxy tests in the existing portfolio UI CI lane.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Atlas-Proxy.md`
+- `portfolio-ui/api/content-ops/deflection/atlas-report.js`
+- `portfolio-ui/api/content-ops/deflection/report.js`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/package.json`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `.github/workflows/portfolio_ui_checks.yml`
+
+## Mechanism
+
+`atlas-report.js` owns the server-only ATLAS integration. It reads
+`ATLAS_API_BASE_URL`, `ATLAS_B2B_JWT`, and `ATLAS_ACCOUNT_ID` from server env,
+rejects missing config, rejects account mismatches, then calls:
+
+```text
+GET /api/v1/content-ops/deflection-reports/{request_id}/snapshot
+GET /api/v1/content-ops/deflection-reports/{request_id}/artifact
+```
+
+with `Authorization: Bearer <ATLAS_B2B_JWT>` and per-fetch abort timeouts.
+Snapshot responses are whitelist-projected into only the known free fields:
+`summary.{generated,drafted_answer_count,no_proven_answer_count}` and
+`top_questions[].{rank,question,weighted_frequency,customer_wording}`. Extra
+fields from ATLAS are dropped before the browser-visible envelope is returned.
+Artifact `403` becomes `artifact_status: "locked"`, `200` becomes
+`"unlocked"`, and `404` becomes `"missing"`.
+
+The hosted result page calls the helper server-side and renders only snapshot
+summary/top-question fields. The browser-visible API route returns the same
+sanitized envelope without the token.
+
+## Intentional
+
+- The proxy is bound to the configured `ATLAS_ACCOUNT_ID`. The public
+  `account_id` query is validation and Checkout metadata continuity, not a
+  tenant selector for arbitrary ATLAS accounts.
+- The full paid artifact renderer remains out of scope. Returning
+  `artifact_status` proves paid-state hydration without adding Markdown/FAQ
+  rendering in this slice.
+- The server result page still renders without a snapshot when ATLAS is
+  unavailable or times out; it does not synthesize counts or fallback estimates.
+- The route uses server env vars only; no `VITE_` env or browser code receives
+  the ATLAS JWT.
+- Public config failures omit env-var detail strings from the browser response.
+
+## Deferred
+
+- Render the paid `FAQDeflectionReportArtifact` after the proxy is deployed and
+  live artifact hydration is verified.
+- Add a customer-facing upload/submit form ahead of this result page once the
+  private Blob upload path is chosen.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 9 checks.
+- `npm run build --prefix portfolio-ui` - passed using the existing ignored
+  root `portfolio-ui/node_modules` install for local verification; `npm ci` in
+  this worktree is blocked by pre-existing portfolio lockfile drift.
+- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core
+  295 passed; extracted_content_pipeline 2853 passed, 10 skipped, 1 warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-atlas-proxy-pr-body.md` -
+  passed after the review fixes.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~113 |
+| Proxy helper/API | ~370 |
+| Hosted result page hydration | ~120 |
+| Tests and package/workflow wiring | ~320 |
+| **Total** | **~923** |
+
+The slice is above 400 LOC because the secure proxy, fail-closed snapshot
+sanitizer, hosted page hydration, API envelope, and CI-enrolled negative
+fixtures are the minimum safe vertical path.

--- a/portfolio-ui/api/content-ops/deflection/atlas-report.js
+++ b/portfolio-ui/api/content-ops/deflection/atlas-report.js
@@ -1,0 +1,283 @@
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULT_ATLAS_TIMEOUT_MS = 5000;
+
+function clean(value) {
+  if (Array.isArray(value)) return clean(value[0]);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function configFromEnv(env = process.env) {
+  const timeoutMs = Number.parseInt(clean(env.ATLAS_PROXY_TIMEOUT_MS), 10);
+  return {
+    baseUrl: clean(env.ATLAS_API_BASE_URL),
+    token: clean(env.ATLAS_B2B_JWT || env.ATLAS_TOKEN),
+    accountId: clean(env.ATLAS_ACCOUNT_ID),
+    timeoutMs:
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_ATLAS_TIMEOUT_MS,
+  };
+}
+
+function reportRequestErrors({ requestId, accountId }, config) {
+  const errors = [];
+  if (!requestId || !REQUEST_ID_RE.test(requestId)) {
+    errors.push("request_id must be a valid Content Ops request id");
+  }
+  if (!accountId || !UUID_RE.test(accountId)) {
+    errors.push("account_id must be a valid ATLAS account UUID");
+  }
+  if (!config.baseUrl) errors.push("ATLAS_API_BASE_URL is not configured");
+  if (!config.token) errors.push("ATLAS_B2B_JWT is not configured");
+  if (!config.accountId || !UUID_RE.test(config.accountId)) {
+    errors.push("ATLAS_ACCOUNT_ID is not configured");
+  } else if (accountId && accountId !== config.accountId) {
+    errors.push("account_id does not match the configured ATLAS account");
+  }
+  return errors;
+}
+
+function atlasUrl(baseUrl, path) {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function atlasPath(requestId, suffix) {
+  return `/api/v1/content-ops/deflection-reports/${encodeURIComponent(requestId)}/${suffix}`;
+}
+
+async function fetchAtlasJson({ config, path, fetchImpl = fetch }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  try {
+    const response = await fetchImpl(atlasUrl(config.baseUrl, path), {
+      headers: {
+        "Accept": "application/json",
+        "Authorization": `Bearer ${config.token}`,
+      },
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload = null;
+    if (text) {
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        return { status: response.status, payload: null, parseError: true };
+      }
+    }
+    return { status: response.status, payload, parseError: false };
+  } catch (error) {
+    return {
+      status: null,
+      payload: null,
+      parseError: false,
+      networkError: error && typeof error === "object" ? error.name || "fetch_error" : "fetch_error",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function cleanString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function projectSnapshot(snapshot) {
+  const errors = [];
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return { ok: false, errors: ["snapshot response must be an object"] };
+  }
+  if (!snapshot.summary || typeof snapshot.summary !== "object") {
+    errors.push("snapshot.summary must be an object");
+  }
+  if (!Array.isArray(snapshot.top_questions)) {
+    errors.push("snapshot.top_questions must be an array");
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  const generated = finiteNumber(snapshot.summary.generated);
+  const draftedAnswerCount = finiteNumber(snapshot.summary.drafted_answer_count);
+  const noProvenAnswerCount = finiteNumber(snapshot.summary.no_proven_answer_count);
+  if (
+    generated === null ||
+    draftedAnswerCount === null ||
+    noProvenAnswerCount === null
+  ) {
+    errors.push("snapshot.summary metrics must be finite numbers");
+  }
+
+  const topQuestions = snapshot.top_questions.map((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      errors.push("snapshot.top_questions entries must be objects");
+      return null;
+    }
+    const rank = finiteNumber(item.rank);
+    const weightedFrequency = finiteNumber(item.weighted_frequency);
+    const question = cleanString(item.question);
+    const customerWording = cleanString(item.customer_wording);
+    if (rank === null || weightedFrequency === null || !question || !customerWording) {
+      errors.push("snapshot.top_questions entries must include safe projected fields");
+      return null;
+    }
+    return {
+      rank,
+      question,
+      weighted_frequency: weightedFrequency,
+      customer_wording: customerWording,
+    };
+  });
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    snapshot: {
+      summary: {
+        generated,
+        drafted_answer_count: draftedAnswerCount,
+        no_proven_answer_count: noProvenAnswerCount,
+      },
+      top_questions: topQuestions,
+    },
+  };
+}
+
+function snapshotErrors(snapshot) {
+  const projection = projectSnapshot(snapshot);
+  return projection.ok ? [] : projection.errors;
+}
+
+function snapshotFailed(snapshot) {
+  return snapshot.status !== 200 || snapshot.parseError || snapshot.networkError;
+}
+
+function artifactFailed(artifact) {
+  return artifact.parseError || artifact.networkError;
+}
+
+function proxyErrorPublicPayload(report) {
+  if (report.error === "atlas_proxy_not_configured") {
+    return {
+      ok: false,
+      statusCode: report.statusCode,
+      error: report.error,
+    };
+  }
+  return report;
+}
+
+async function loadDeflectionReport({
+  requestId,
+  accountId,
+  env = process.env,
+  fetchImpl = fetch,
+}) {
+  const config = configFromEnv(env);
+  const cleanedRequestId = clean(requestId);
+  const cleanedAccountId = clean(accountId);
+  const errors = reportRequestErrors(
+    { requestId: cleanedRequestId, accountId: cleanedAccountId },
+    config,
+  );
+  if (errors.length > 0) {
+    const configError = errors.some((error) => error.endsWith("is not configured"));
+    return {
+      ok: false,
+      statusCode: configError ? 503 : 400,
+      error: configError ? "atlas_proxy_not_configured" : "invalid_report_request",
+      details: errors,
+    };
+  }
+
+  const snapshot = await fetchAtlasJson({
+    config,
+    path: atlasPath(cleanedRequestId, "snapshot"),
+    fetchImpl,
+  });
+  if (snapshot.status === 404) {
+    return {
+      ok: false,
+      statusCode: 404,
+      error: "report_not_found",
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+    };
+  }
+  if (snapshotFailed(snapshot)) {
+    return {
+      ok: false,
+      statusCode: 502,
+      error: "atlas_snapshot_failed",
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+    };
+  }
+
+  const projectedSnapshot = projectSnapshot(snapshot.payload);
+  if (!projectedSnapshot.ok) {
+    return {
+      ok: false,
+      statusCode: 502,
+      error: "atlas_snapshot_contract_violation",
+      details: projectedSnapshot.errors,
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+    };
+  }
+
+  const artifact = await fetchAtlasJson({
+    config,
+    path: atlasPath(cleanedRequestId, "artifact"),
+    fetchImpl,
+  });
+  if (artifact.status === 200 && !artifactFailed(artifact)) {
+    return {
+      ok: true,
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+      snapshot: projectedSnapshot.snapshot,
+      artifact_status: "unlocked",
+      artifact: artifact.payload,
+    };
+  }
+  if (artifact.status === 403) {
+    return {
+      ok: true,
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+      snapshot: projectedSnapshot.snapshot,
+      artifact_status: "locked",
+    };
+  }
+  if (artifact.status === 404) {
+    return {
+      ok: true,
+      request_id: cleanedRequestId,
+      account_id: cleanedAccountId,
+      snapshot: projectedSnapshot.snapshot,
+      artifact_status: "missing",
+    };
+  }
+  return {
+    ok: false,
+    statusCode: 502,
+    error: "atlas_artifact_failed",
+    request_id: cleanedRequestId,
+    account_id: cleanedAccountId,
+  };
+}
+
+export {
+  atlasPath,
+  atlasUrl,
+  clean,
+  configFromEnv,
+  fetchAtlasJson,
+  loadDeflectionReport,
+  projectSnapshot,
+  proxyErrorPublicPayload,
+  reportRequestErrors,
+  snapshotErrors,
+};

--- a/portfolio-ui/api/content-ops/deflection/report.js
+++ b/portfolio-ui/api/content-ops/deflection/report.js
@@ -1,0 +1,33 @@
+import { clean, loadDeflectionReport, proxyErrorPublicPayload } from "./atlas-report.js";
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(payload));
+}
+
+function requestUrl(req) {
+  const proto = clean(req.headers?.["x-forwarded-proto"]) || "https";
+  const host = clean(req.headers?.["x-forwarded-host"]) || clean(req.headers?.host) || "localhost";
+  return new URL(req.url || "/", `${proto}://${host}`);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    json(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+
+  const url = requestUrl(req);
+  const report = await loadDeflectionReport({
+    requestId: clean(req.query?.request_id) || clean(url.searchParams.get("request_id")),
+    accountId: clean(req.query?.account_id) || clean(url.searchParams.get("account_id")),
+  });
+  if (!report.ok) {
+    json(res, report.statusCode || 502, proxyErrorPublicPayload(report));
+    return;
+  }
+  json(res, 200, report);
+}

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -1,3 +1,4 @@
+import { loadDeflectionReport } from "./atlas-report.js";
 import { CHECKOUT_SOURCE, resultPath } from "./checkout.js";
 
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
@@ -37,12 +38,49 @@ function requestIdFrom(req, url) {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
-function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
+function formatNumber(value) {
+  return Number.isFinite(value) ? String(value) : "0";
+}
+
+function renderSnapshot(report) {
+  if (!report || !report.ok || !report.snapshot) {
+    return `<section class="snapshot" aria-labelledby="snapshot-title">
+          <h2 id="snapshot-title">Free snapshot</h2>
+          <p class="muted">The hosted result page could not load the ATLAS snapshot yet. No estimates are shown until ATLAS returns real snapshot values.</p>
+        </section>`;
+  }
+  const summary = report.snapshot.summary || {};
+  const questions = Array.isArray(report.snapshot.top_questions)
+    ? report.snapshot.top_questions
+    : [];
+  return `<section class="snapshot" aria-labelledby="snapshot-title">
+          <h2 id="snapshot-title">Free snapshot</h2>
+          <div class="metrics">
+            <div><span>Questions found</span><strong>${escapeHtml(formatNumber(summary.generated))}</strong></div>
+            <div><span>Evidence-backed answers</span><strong>${escapeHtml(formatNumber(summary.drafted_answer_count))}</strong></div>
+            <div><span>Needs support proof</span><strong>${escapeHtml(formatNumber(summary.no_proven_answer_count))}</strong></div>
+          </div>
+          <div class="questions">
+            ${questions
+              .map(
+                (item) => `<article>
+              <p class="rank">Rank ${escapeHtml(formatNumber(item.rank))} - ${escapeHtml(formatNumber(item.weighted_frequency))} weighted mentions</p>
+              <h3>${escapeHtml(item.question)}</h3>
+              <p class="muted">${escapeHtml(item.customer_wording)}</p>
+            </article>`,
+              )
+              .join("")}
+          </div>
+        </section>`;
+}
+
+function renderResultPage({ requestId, accountId, checkoutStatus = "", report = null }) {
   const safeRequestId = escapeHtml(requestId);
   const safeAccountId = escapeHtml(accountId);
   const safeCheckoutStatus = escapeHtml(checkoutStatus);
   const resultHref = resultPath(requestId || "missing-request", accountId, "");
   const buttonDisabled = requestId && accountId ? "" : "disabled";
+  const artifactStatus = report && report.ok ? report.artifact_status : "snapshot_unavailable";
   const statusBanner =
     checkoutStatus === "success"
       ? `<div class="notice success">Checkout returned successfully. ATLAS unlocks the paid report only after Stripe sends the verified webhook.</div>`
@@ -71,10 +109,18 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
     button { width: 100%; border: 0; border-radius: 8px; background: #22c55e; color: #020617; padding: 13px 16px; font-weight: 800; cursor: pointer; }
     button:disabled { background: #1e293b; color: rgba(226, 232, 240, .55); cursor: not-allowed; }
     .snapshot { margin-top: 32px; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(15, 23, 42, .42); padding: 24px; }
+    .metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 18px 0 24px; }
+    .metrics div { border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; padding: 14px; background: rgba(2, 6, 23, .35); }
+    .metrics span { display: block; color: rgba(226, 232, 240, .66); font-size: 13px; }
+    .metrics strong { display: block; margin-top: 8px; font-size: 28px; }
+    .questions { display: grid; gap: 14px; }
+    .questions article { border-top: 1px solid rgba(30, 41, 59, .9); padding-top: 14px; }
+    .questions h3 { margin: 6px 0; font-size: 17px; }
+    .rank { color: #86efac; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
     .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
     .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
-    @media (max-width: 820px) { .grid { grid-template-columns: 1fr; } .shell { padding-top: 32px; } }
+    @media (max-width: 820px) { .grid, .metrics { grid-template-columns: 1fr; } .shell { padding-top: 32px; } }
   </style>
 </head>
 <body>
@@ -92,10 +138,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
         <h1>FAQ deflection report is ready for review</h1>
         <p class="lede">The free snapshot and paid artifact stay separated. The full report unlocks only after Stripe confirms payment and ATLAS releases the artifact from its signed webhook path.</p>
         ${statusBanner}
-        <section class="snapshot" aria-labelledby="snapshot-title">
-          <h2 id="snapshot-title">Free snapshot</h2>
-          <p class="muted">The hosted result page exposes the report identifiers for Checkout. It does not synthesize estimates or render answer, evidence, source_ids, markdown, or faq_result fields before payment.</p>
-        </section>
+        ${renderSnapshot(report)}
       </section>
       <aside class="panel">
         <h2>Unlock full report</h2>
@@ -105,6 +148,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
           <div><dt>request_id</dt><dd>${safeRequestId || "Missing request id"}</dd></div>
           <div><dt>account_id</dt><dd>${safeAccountId || "Missing account id"}</dd></div>
           <div><dt>canonical result path</dt><dd>${escapeHtml(resultHref)}</dd></div>
+          <div><dt>artifact_status</dt><dd>${escapeHtml(artifactStatus)}</dd></div>
           <div><dt>checkout</dt><dd>${safeCheckoutStatus || "locked"}</dd></div>
         </dl>
         <button type="button" data-atlas-deflection-unlock ${buttonDisabled}>Continue to Checkout</button>
@@ -143,7 +187,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "" }) {
 
 export { renderResultPage };
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   const url = requestUrl(req);
   const requestId = requestIdFrom(req, url);
   const accountId = clean(req.query?.account_id) || clean(url.searchParams.get("account_id"));
@@ -162,11 +206,16 @@ export default function handler(req, res) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-store");
+  const report =
+    requestId && accountId
+      ? await loadDeflectionReport({ requestId, accountId })
+      : null;
   res.end(
     renderResultPage({
       requestId,
       accountId,
       checkoutStatus: clean(url.searchParams.get("checkout")),
+      report,
     }),
   );
 }

--- a/portfolio-ui/package.json
+++ b/portfolio-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test:deflection-atlas-proxy": "node scripts/faq-deflection-atlas-proxy.test.mjs",
     "test:deflection-result": "node scripts/faq-deflection-result-page.test.mjs",
     "preview": "vite preview"
   },

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import reportHandler from "../api/content-ops/deflection/report.js";
+import {
+  atlasPath,
+  fetchAtlasJson,
+  loadDeflectionReport,
+  projectSnapshot,
+  snapshotErrors,
+} from "../api/content-ops/deflection/atlas-report.js";
+import { renderResultPage } from "../api/content-ops/deflection/result-page.js";
+
+const ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+const REQUEST_ID = "content-ops-abc123";
+const ENV = {
+  ATLAS_API_BASE_URL: "https://atlas.example.com",
+  ATLAS_B2B_JWT: "secret-service-token",
+  ATLAS_ACCOUNT_ID: ACCOUNT_ID,
+};
+
+const SNAPSHOT = {
+  summary: {
+    generated: 3,
+    drafted_answer_count: 2,
+    no_proven_answer_count: 1,
+  },
+  top_questions: [
+    {
+      rank: 1,
+      question: "How do I reset billing access?",
+      weighted_frequency: 12,
+      customer_wording: "billing reset access",
+    },
+  ],
+};
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+function response(payload, status = 200) {
+  return {
+    status,
+    async text() {
+      return JSON.stringify(payload);
+    },
+  };
+}
+
+function mockFetch(results) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url, options });
+    const next = results.shift();
+    if (!next) throw new Error(`unexpected fetch: ${url}`);
+    return next;
+  };
+  return { calls, fetchImpl };
+}
+
+function mockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(value) {
+      this.body = value;
+    },
+  };
+}
+
+function withEnv(nextEnv, fn) {
+  const previous = {};
+  for (const key of Object.keys(nextEnv)) {
+    previous[key] = process.env[key];
+    process.env[key] = nextEnv[key];
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const key of Object.keys(nextEnv)) {
+        if (previous[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous[key];
+        }
+      }
+    });
+}
+
+await test("proxy rejects account mismatch before calling ATLAS", async () => {
+  const { calls, fetchImpl } = mockFetch([]);
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+    env: ENV,
+    fetchImpl,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 400);
+  assert.deepEqual(result.details, ["account_id does not match the configured ATLAS account"]);
+  assert.equal(calls.length, 0);
+});
+
+await test("proxy returns locked snapshot envelope without artifact payload", async () => {
+  const leakySnapshot = {
+    ...SNAPSHOT,
+    answer_steps: ["paid step"],
+    faq_markdown: "# paid",
+    top_questions: [{ ...SNAPSHOT.top_questions[0], source_ids: ["ticket-1"] }],
+  };
+  const { calls, fetchImpl } = mockFetch([
+    response(leakySnapshot, 200),
+    response({ detail: "payment required" }, 403),
+  ]);
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    env: ENV,
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.artifact_status, "locked");
+  assert.deepEqual(result.snapshot, SNAPSHOT);
+  assert.equal(JSON.stringify(result).includes("answer_steps"), false);
+  assert.equal(JSON.stringify(result).includes("faq_markdown"), false);
+  assert.equal(JSON.stringify(result).includes("source_ids"), false);
+  assert.equal("artifact" in result, false);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${atlasPath(REQUEST_ID, "snapshot")}`);
+  assert.equal(calls[1].url, `${ENV.ATLAS_API_BASE_URL}${atlasPath(REQUEST_ID, "artifact")}`);
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+});
+
+await test("proxy returns unlocked artifact only after ATLAS returns 200", async () => {
+  const artifact = { markdown: "# Paid report", summary: { generated: 3 } };
+  const { fetchImpl } = mockFetch([response(SNAPSHOT, 200), response(artifact, 200)]);
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    env: ENV,
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.artifact_status, "unlocked");
+  assert.deepEqual(result.artifact, artifact);
+});
+
+await test("snapshot projection only returns known safe fields", async () => {
+  const result = projectSnapshot({
+    ...SNAPSHOT,
+    markdown: "# paid",
+    answer_steps: ["paid step"],
+    top_questions: [{ ...SNAPSHOT.top_questions[0], faq_markdown: "# paid" }],
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.snapshot, SNAPSHOT);
+  assert.equal(JSON.stringify(result).includes("markdown"), false);
+  assert.equal(JSON.stringify(result).includes("answer_steps"), false);
+  assert.deepEqual(snapshotErrors({ summary: {}, top_questions: [] }), [
+    "snapshot.summary metrics must be finite numbers",
+  ]);
+});
+
+await test("ATLAS fetches carry abort signals and timeout failures return errors", async () => {
+  const fetchImpl = (url, options = {}) =>
+    new Promise((resolve) => {
+      assert.equal(url, `${ENV.ATLAS_API_BASE_URL}${atlasPath(REQUEST_ID, "snapshot")}`);
+      assert.equal(options.signal instanceof AbortSignal, true);
+      options.signal.addEventListener("abort", () => {
+        resolve({
+          status: 599,
+          async text() {
+            throw Object.assign(new Error("aborted"), { name: "AbortError" });
+          },
+        });
+      });
+    });
+  const result = await fetchAtlasJson({
+    config: { ...ENV, baseUrl: ENV.ATLAS_API_BASE_URL, token: ENV.ATLAS_B2B_JWT, timeoutMs: 1 },
+    path: atlasPath(REQUEST_ID, "snapshot"),
+    fetchImpl,
+  });
+  assert.equal(result.networkError, "AbortError");
+});
+
+await test("unresponsive ATLAS returns graceful snapshot failure", async () => {
+  const fetchImpl = async (url, options = {}) => {
+    assert.equal(options.signal instanceof AbortSignal, true);
+    throw Object.assign(new Error(`timeout ${url}`), { name: "AbortError" });
+  };
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    env: { ...ENV, ATLAS_PROXY_TIMEOUT_MS: "1" },
+    fetchImpl,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.statusCode, 502);
+  assert.equal(result.error, "atlas_snapshot_failed");
+});
+
+await test("public report API hides config details from browser responses", async () => {
+  await withEnv({ ATLAS_API_BASE_URL: "", ATLAS_B2B_JWT: "", ATLAS_ACCOUNT_ID: "" }, async () => {
+    const req = {
+      method: "GET",
+      headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
+      query: { request_id: REQUEST_ID, account_id: ACCOUNT_ID },
+      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}&account_id=${ACCOUNT_ID}`,
+    };
+    const res = mockResponse();
+    await reportHandler(req, res);
+    assert.equal(res.statusCode, 503);
+    const payload = JSON.parse(res.body);
+    assert.deepEqual(payload, {
+      ok: false,
+      statusCode: 503,
+      error: "atlas_proxy_not_configured",
+    });
+    assert.equal(JSON.stringify(payload).includes("ATLAS_B2B_JWT"), false);
+  });
+});
+
+await test("public report API returns sanitized locked envelope and never the token", async () => {
+  const previousFetch = globalThis.fetch;
+  const { fetchImpl } = mockFetch([response(SNAPSHOT, 200), response({}, 403)]);
+  globalThis.fetch = fetchImpl;
+  await withEnv(ENV, async () => {
+    const req = {
+      method: "GET",
+      headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
+      query: { request_id: REQUEST_ID, account_id: ACCOUNT_ID },
+      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}&account_id=${ACCOUNT_ID}`,
+    };
+    const res = mockResponse();
+    try {
+      await reportHandler(req, res);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["Cache-Control"], "no-store");
+    const payload = JSON.parse(res.body);
+    assert.equal(payload.artifact_status, "locked");
+    assert.equal(JSON.stringify(payload).includes(ENV.ATLAS_B2B_JWT), false);
+  });
+});
+
+await test("hosted result page renders real snapshot metrics from the proxy envelope", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    report: {
+      ok: true,
+      snapshot: SNAPSHOT,
+      artifact_status: "locked",
+    },
+  });
+  assert.match(html, /Questions found/);
+  assert.match(html, />3</);
+  assert.match(html, /How do I reset billing access\?/);
+  assert.match(html, /artifact_status/);
+  assert.match(html, /locked/);
+  assert.doesNotMatch(html, /# Paid report/);
+});

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -110,9 +110,9 @@ await test("checkout endpoint validates request and account identifiers", () => 
   ]);
 });
 
-await test("hosted result page rejects script-breaking account_id input", () => {
+await test("hosted result page rejects script-breaking account_id input", async () => {
   const res = mockResponse();
-  resultPageHandler(
+  await resultPageHandler(
     {
       url: "/services/faq-deflection/results/content-ops-abc123?account_id=%3C%2Fscript%3E%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E",
       headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Atlas-Proxy.md
Slice phase: Vertical slice

Add a server-only portfolio ATLAS proxy for FAQ deflection result hydration. The proxy validates `request_id`/`account_id`, binds requests to the configured `ATLAS_ACCOUNT_ID`, fetches snapshot/artifact state with the server-side ATLAS JWT, whitelist-projects snapshot fields, and lets the hosted result page render real free snapshot metrics without exposing secrets to browser code.

## Intentional
- The proxy is bound to the configured `ATLAS_ACCOUNT_ID`; the public `account_id` is validation and Checkout metadata continuity, not a tenant selector.
- Full paid artifact rendering remains deferred. The proxy returns `artifact_status` and the artifact only after ATLAS returns `200`, but this PR does not add the paid report UI.
- The hosted result page still renders without fabricated counts when ATLAS is unavailable or times out.
- Public config failures omit env-var detail strings from the browser response.
- No `VITE_` env or browser code receives the ATLAS JWT.

## Deferred
- Render the paid `FAQDeflectionReportArtifact` after live proxy hydration is verified.
- Add a customer-facing upload/submit form once the private Blob upload path is chosen.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 9 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2853 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-atlas-proxy-pr-body.md` - passed after review fixes.

## Diff size
8 files, +762 / -9
