### PR TITLE
PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
@@ -136,6 +136,11 @@ deflection metadata, and then confirms the artifact route returns the full paid
 report. The event id and Checkout session id are generated when omitted, so a
 fresh run does not reuse Stripe webhook idempotency keys.
 
+To also prove the deployed duplicate-event guard, add `--replay-webhook`. That
+posts the same signed event a second time and requires the webhook response to
+return `{"status": "already_processed"}` before the final paid artifact fetch.
+Use this only after the first paid-unlock smoke path is expected to succeed.
+
 ## Interpreting Results
 
 The result artifact records HTTP statuses, the returned `request_id`, compact

--- a/plans/PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke.md
@@ -1,0 +1,76 @@
+# PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Stripe-Paid-Retry-Idempotency locked the Stripe paid-unlock
+retry contract in the host billing tests. The hosted smoke still proves only
+the first signed webhook unlocks the artifact. Operators need an optional
+deployed-host replay probe that posts the same Stripe event again and confirms
+the webhook reports the already-processed state without relocking the paid
+artifact.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Robust testing
+
+1. Add an opt-in `--replay-webhook` mode to the hosted deflection Stripe
+   paid-unlock smoke.
+2. Require the replay response to be HTTP 200 with
+   `{"status": "already_processed"}`.
+3. Keep the post-webhook artifact check in place after replay so the smoke
+   still proves the paid report remains accessible.
+4. Document the replay flag in the deflection submit handoff runbook.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke.md`
+- `scripts/smoke_content_ops_deflection_stripe_paid_unlock.py`
+- `tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py`
+- `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md`
+
+## Mechanism
+
+The smoke already builds one deterministic Stripe event body and signature.
+When `--replay-webhook` is present, it posts that same signed event a second
+time after the first webhook returns `{"status": "ok"}` and before fetching the
+paid artifact. The result JSON gains a `replay_webhook` status field so operator
+artifacts show whether the duplicate-event guard was exercised.
+
+## Intentional
+
+- Replay stays opt-in because the normal smoke is a paid-unlock proof; operators
+  may not want every run to post duplicate webhook traffic.
+- The replay expectation is strict: `already_processed`, not either `ok` or
+  `already_processed`. If the audit row is absent after the first successful
+  webhook, the deployed idempotency guard did not prove the contract this smoke
+  is meant to validate.
+- The smoke remains stdlib-only and keeps using the configured hosted URL and
+  signed webhook secret. No Stripe CLI dependency is introduced.
+
+## Deferred
+
+- Parked hardening: none.
+- Full browser Checkout replay is still outside this slice; this probes the
+  deployed ATLAS webhook idempotency boundary with a locally signed
+  Stripe-compatible event.
+
+## Verification
+
+- Command: python -m py_compile scripts/smoke_content_ops_deflection_stripe_paid_unlock.py tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+  - Result: passed.
+- Command: python -m pytest tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py -q
+  - Result: 9 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Result: extracted_reasoning_core 295 passed; extracted_content_pipeline
+    2855 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Smoke script | 40 |
+| Tests | 67 |
+| Runbook | 6 |
+| **Total** | **189** |

--- a/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/scripts/smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -75,6 +75,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--artifact-path-template", default=ARTIFACT_PATH_TEMPLATE)
     parser.add_argument("--output-result", type=Path)
     parser.add_argument("--preflight-only", action="store_true")
+    parser.add_argument("--replay-webhook", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -252,6 +253,7 @@ def _result_payload(
     session_id: str = "",
     before_artifact: HttpResult | None = None,
     webhook: HttpResult | None = None,
+    replay_webhook: HttpResult | None = None,
     after_artifact: HttpResult | None = None,
     errors: Sequence[str] = (),
 ) -> dict[str, Any]:
@@ -270,6 +272,14 @@ def _result_payload(
         },
         "before_artifact": {"status": before_artifact.status if before_artifact else None},
         "webhook": {"status": webhook.status if webhook else None},
+        "replay_webhook": {
+            "status": replay_webhook.status if replay_webhook else None,
+            "payload_status": (
+                replay_webhook.payload.get("status")
+                if replay_webhook and isinstance(replay_webhook.payload, Mapping)
+                else None
+            ),
+        },
         "after_artifact": {"status": after_artifact.status if after_artifact else None},
     }
 
@@ -354,6 +364,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     elif not isinstance(webhook.payload, Mapping) or webhook.payload.get("status") != "ok":
         errors.append("stripe webhook response status must be ok")
 
+    replay_webhook = None
+    if not errors and args.replay_webhook:
+        replay_webhook = _json_request(
+            "POST",
+            _join_url(_clean(args.base_url), _clean(args.webhook_path)),
+            body=body,
+            stripe_signature=signature,
+            timeout=float(args.timeout),
+        )
+        if replay_webhook.status != 200:
+            errors.append(
+                f"stripe webhook replay status must be 200, got {replay_webhook.status}"
+            )
+        elif (
+            not isinstance(replay_webhook.payload, Mapping)
+            or replay_webhook.payload.get("status") != "already_processed"
+        ):
+            errors.append("stripe webhook replay status must be already_processed")
+
     after_artifact = None
     if not errors:
         after_artifact = _json_request(
@@ -374,6 +403,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         session_id=session_id,
         before_artifact=before_artifact,
         webhook=webhook,
+        replay_webhook=replay_webhook,
         after_artifact=after_artifact,
         errors=errors,
     )

--- a/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
+++ b/tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py
@@ -197,6 +197,84 @@ def test_main_posts_signed_webhook_and_unlocks_artifact(monkeypatch, tmp_path, c
     }
 
 
+def test_main_replays_signed_webhook_and_requires_idempotent_response(
+    monkeypatch,
+    tmp_path,
+    capsys,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _open(request, *, timeout):
+        body = request.data or b""
+        calls.append({
+            "url": request.full_url,
+            "method": request.get_method(),
+            "headers": dict(request.header_items()),
+            "body": body.decode("utf-8"),
+            "timeout": timeout,
+        })
+        get_count = len([c for c in calls if c["method"] == "GET"])
+        post_count = len([c for c in calls if c["method"] == "POST"])
+        if request.get_method() == "GET" and get_count == 1:
+            raise _http_error(request.full_url, 403, {"detail": "payment_required"})
+        if request.get_method() == "POST" and post_count == 1:
+            return FakeResponse(200, {"status": "ok"})
+        if request.get_method() == "POST":
+            return FakeResponse(200, {"status": "already_processed"})
+        return FakeResponse(200, ARTIFACT)
+
+    monkeypatch.setattr(smoke, "_open_http_request", _open)
+    monkeypatch.setattr(smoke.time, "time", lambda: 1700000000)
+
+    code = smoke.main([*_base_args(tmp_path), "--replay-webhook", "--json"])
+
+    assert code == 0
+    printed = json.loads(capsys.readouterr().out)
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert printed == payload
+    assert payload["ok"] is True
+    assert payload["webhook"] == {"status": 200}
+    assert payload["replay_webhook"] == {
+        "status": 200,
+        "payload_status": "already_processed",
+    }
+    assert payload["after_artifact"]["status"] == 200
+
+    assert [call["method"] for call in calls] == ["GET", "POST", "POST", "GET"]
+    first_webhook = calls[1]
+    replay_webhook = calls[2]
+    assert replay_webhook["url"] == first_webhook["url"]
+    assert replay_webhook["body"] == first_webhook["body"]
+    assert (
+        replay_webhook["headers"]["Stripe-signature"]
+        == first_webhook["headers"]["Stripe-signature"]
+    )
+
+
+def test_main_rejects_replay_webhook_without_already_processed(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    calls: list[str] = []
+
+    def _open(request, *, timeout):
+        calls.append(request.get_method())
+        if request.get_method() == "GET":
+            raise _http_error(request.full_url, 403, {"detail": "payment_required"})
+        return FakeResponse(200, {"status": "ok"})
+
+    monkeypatch.setattr(smoke, "_open_http_request", _open)
+
+    code = smoke.main([*_base_args(tmp_path), "--replay-webhook"])
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+
+    assert code == 1
+    assert calls == ["GET", "POST", "POST"]
+    assert payload["replay_webhook"] == {"status": 200, "payload_status": "ok"}
+    assert payload["after_artifact"]["status"] is None
+    assert payload["errors"] == ["stripe webhook replay status must be already_processed"]
+
+
 def test_main_stops_before_webhook_when_artifact_is_not_locked(monkeypatch, tmp_path) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Stripe-Paid-Replay-Smoke.md
Slice phase: Robust testing

Extend the hosted deflection Stripe paid-unlock smoke with an opt-in duplicate-webhook replay probe. When `--replay-webhook` is set, the smoke posts the same signed Checkout event a second time, requires `{"status": "already_processed"}`, then confirms the paid artifact remains accessible.

## Intentional
- Replay is opt-in so the normal paid-unlock smoke stays focused on the first unlock.
- The replay expectation is strict: `already_processed`, not `ok`, because this slice proves the deployed duplicate-event guard.
- The smoke remains stdlib-only and does not add Stripe CLI or live Checkout dependencies.

## Deferred
- Full browser Checkout replay remains outside this slice.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_stripe_paid_unlock.py tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py -q` - 9 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2855 passed, 10 skipped, 1 warning.

## Diff size
4 files, +189 / -0
