### PR TITLE
PR-FAQ-Deflection-Submit-Multipart-CSV

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -37,20 +37,23 @@ type GatedDeflectionExecuteResult = {
 Render `snapshot` on the free page. Do not derive answer text, evidence, source
 IDs, or Markdown from this object.
 
-## Portfolio Blob Submit Endpoint
+## Portfolio Submit Endpoint
 
-The portfolio can hand ATLAS a support-ticket CSV blob and receive the same
-gated execute response:
+The production PII-safe submit path is an authenticated server-to-server
+multipart upload. The portfolio should read its private Blob server-side, then
+POST the CSV bytes to ATLAS; do not expose raw support-ticket CSVs through a
+public signed proxy.
 
 ```http
 POST /content-ops/deflection-reports/submit
+Content-Type: multipart/form-data
 ```
 
 Request:
 
 ```ts
-type DeflectionReportSubmitRequest = {
-  blob_url: string; // HTTPS Vercel Blob URL, public or signed
+type DeflectionReportSubmitMultipart = {
+  csv_file: File; // raw support-ticket CSV bytes
   support_platform: "zendesk" | "intercom" | "help_scout" | "other";
   company_name: string;
   contact_email: string;
@@ -58,21 +61,22 @@ type DeflectionReportSubmitRequest = {
 };
 ```
 
-ATLAS fetches the blob server-side, parses it as CSV, normalizes rows through
-the support-ticket input package, and runs synchronous `faq_deflection_report`
-generation. A `200` response means the report row exists for the authenticated
-ATLAS account and `/snapshot` should be immediately readable.
+ATLAS parses the CSV bytes, normalizes rows through the support-ticket input
+package, and runs synchronous `faq_deflection_report` generation. A `200`
+response means the report row exists for the authenticated ATLAS account and
+`/snapshot` should be immediately readable.
 
 Caps and failures:
 
-- `blob_url` must be `https://`; private/signed URLs are preferred when the
-  portfolio makes them available.
-- ATLAS rejects localhost/private/link-local blob hosts after DNS resolution
-  and does not follow redirects.
-- Blob body cap: 50 MB. Larger responses return `413`.
+- CSV upload body cap: 50 MB. Larger uploads return `413`.
 - Sync source-material cap: first 1,000 parsed rows, or `limit` when lower.
 - Empty CSVs or CSVs with no usable customer wording return `400`.
-- Fetch and CSV parse failures return `400`.
+- CSV parse failures return `400`.
+
+Legacy compatibility: ATLAS still accepts JSON with `blob_url` at the same
+route. That path is not the recommended production PII posture; if used, the
+URL must be `https://`, must not contain URL credentials, must resolve to a
+public host, and redirects are rejected.
 
 ## Free Snapshot Endpoint
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -21,7 +21,7 @@ from typing import Any
 from uuid import uuid4
 
 try:
-    from fastapi import APIRouter, Body, File, Form, HTTPException, Path as PathParam, Query, UploadFile
+    from fastapi import APIRouter, Body, File, Form, HTTPException, Path as PathParam, Query, Request, UploadFile
     from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 except ImportError as exc:  # pragma: no cover - exercised in dependency-light CI.
     APIRouter = None
@@ -30,6 +30,7 @@ except ImportError as exc:  # pragma: no cover - exercised in dependency-light C
     File = None
     Form = None
     Query = None
+    Request = None
     UploadFile = None
     BaseModel = None
     ConfigDict = None
@@ -127,6 +128,7 @@ _MAX_INGESTION_ROWS = 1000
 _MAX_FILE_INGESTION_ROWS = 10000
 _MAX_INGESTION_FILE_BYTES = 25 * 1024 * 1024
 _MAX_DEFLECTION_SUBMIT_BLOB_BYTES = 50 * 1024 * 1024
+_MAX_DEFLECTION_SUBMIT_MULTIPART_OVERHEAD_BYTES = 1024 * 1024
 _MAX_INGESTION_SAMPLE_LIMIT = 25
 _DEFLECTION_SUBMIT_FETCH_TIMEOUT_SECONDS = 15
 _DEFLECTION_SUBMIT_OUTPUTS = ("faq_deflection_report",)
@@ -587,21 +589,15 @@ if BaseModel is not None:
 
         payment_reference: str | None = Field(default=None, max_length=200)
 
-    class DeflectionReportSubmitModel(BaseModel):
-        """Portfolio-owned upload handoff for a paid FAQ deflection report."""
+    class _DeflectionReportSubmitFieldsModel(BaseModel):
+        """Shared portfolio submit metadata fields."""
 
         model_config = ConfigDict(extra="forbid")
 
-        blob_url: str = Field(..., min_length=1, max_length=2048)
         support_platform: str = Field(..., min_length=1, max_length=80)
         company_name: str = Field(..., min_length=1, max_length=200)
         contact_email: str = Field(..., min_length=3, max_length=320)
         limit: int = Field(_MAX_INGESTION_ROWS, ge=1, le=_MAX_INGESTION_ROWS)
-
-        @field_validator("blob_url")
-        @classmethod
-        def _validate_blob_url(cls, value: Any) -> str:
-            return _validate_https_blob_url(value)
 
         @field_validator("support_platform")
         @classmethod
@@ -629,12 +625,28 @@ if BaseModel is not None:
                 raise ValueError("contact_email must be an email address")
             return value
 
+    class DeflectionReportSubmitModel(_DeflectionReportSubmitFieldsModel):
+        """Portfolio-owned URL handoff for a paid FAQ deflection report."""
+
+        blob_url: str = Field(..., min_length=1, max_length=2048)
+
+        @field_validator("blob_url")
+        @classmethod
+        def _validate_blob_url(cls, value: Any) -> str:
+            return _validate_https_blob_url(value)
+
+    class DeflectionReportSubmitFieldsModel(_DeflectionReportSubmitFieldsModel):
+        """Portfolio-owned multipart handoff fields for a paid FAQ deflection report."""
+
+        pass
+
 else:  # pragma: no cover - module import fallback when FastAPI is unavailable.
     ContentOpsRequestModel = Any
     ContentOpsIngestionInspectModel = Any
     ContentOpsIngestionImportModel = Any
     DeflectionReportPaidModel = Any
     DeflectionReportSubmitModel = Any
+    DeflectionReportSubmitFieldsModel = Any
 
 
 def create_content_ops_control_surface_router(
@@ -1104,23 +1116,22 @@ def create_content_ops_control_surface_router(
 
     @router.post("/deflection-reports/submit")
     async def submit_deflection_report(
-        payload: DeflectionReportSubmitModel = Body(...),
+        request: Request,
     ) -> dict[str, Any]:
-        data = _deflection_submit_payload_to_mapping(payload)
+        data, rows, byte_count, byte_count_key = await _load_deflection_submit_rows_from_request(
+            request,
+            max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
+        )
         max_rows = min(
             int(data.get("limit") or _MAX_INGESTION_ROWS),
             resolved_config.faq_execute_max_source_material_rows,
-        )
-        rows, byte_count = await _load_deflection_submit_blob_rows(
-            data["blob_url"],
-            max_bytes=_MAX_DEFLECTION_SUBMIT_BLOB_BYTES,
         )
         if not rows:
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "reason": "deflection_submit_empty_blob",
-                    "message": "Blob CSV did not contain support-ticket rows.",
+                    "reason": "deflection_submit_empty_csv",
+                    "message": "Submitted CSV did not contain support-ticket rows.",
                 },
             )
         raw_row_count = len(rows)
@@ -1166,9 +1177,103 @@ def create_content_ops_control_surface_router(
             submitted_row_count=len(submitted_rows),
             package=package.as_dict(),
             support_platform=data["support_platform"],
+            byte_count_key=byte_count_key,
         )
 
     return router
+
+
+async def _load_deflection_submit_rows_from_request(
+    request: Any,
+    *,
+    max_bytes: int,
+) -> tuple[dict[str, Any], list[Any], int, str]:
+    if isinstance(request, Mapping):
+        data = _deflection_submit_payload_to_mapping(request)
+        rows, byte_count = await _load_deflection_submit_blob_rows(
+            data["blob_url"],
+            max_bytes=max_bytes,
+        )
+        return data, rows, byte_count, "blob_bytes"
+
+    content_type = _request_content_type(request)
+    if "multipart/form-data" in content_type:
+        _reject_oversize_deflection_submit_multipart(request, max_bytes=max_bytes)
+        try:
+            form = await request.form(max_part_size=max_bytes)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Multipart deflection submit body could not be parsed.",
+            ) from exc
+        csv_file = form.get("csv_file") if hasattr(form, "get") else None
+        if csv_file is None:
+            raise HTTPException(status_code=422, detail="csv_file is required")
+        data = _deflection_submit_form_to_mapping(form)
+        rows, byte_count = await _load_deflection_submit_upload_rows(
+            csv_file,
+            max_bytes=max_bytes,
+        )
+        return data, rows, byte_count, "uploaded_bytes"
+
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="JSON deflection submit body could not be parsed.",
+        ) from exc
+    data = _deflection_submit_payload_to_mapping(payload)
+    rows, byte_count = await _load_deflection_submit_blob_rows(
+        data["blob_url"],
+        max_bytes=max_bytes,
+    )
+    return data, rows, byte_count, "blob_bytes"
+
+
+def _request_content_type(request: Any) -> str:
+    headers = getattr(request, "headers", {}) or {}
+    value = ""
+    if hasattr(headers, "get"):
+        value = headers.get("content-type") or headers.get("Content-Type") or ""
+    return str(value).lower()
+
+
+def _reject_oversize_deflection_submit_multipart(
+    request: Any,
+    *,
+    max_bytes: int,
+) -> None:
+    headers = getattr(request, "headers", {}) or {}
+    value = ""
+    if hasattr(headers, "get"):
+        value = headers.get("content-length") or headers.get("Content-Length") or ""
+    if not _clean(value):
+        return
+    try:
+        content_length = int(str(value))
+    except ValueError:
+        return
+    if content_length > max_bytes + _MAX_DEFLECTION_SUBMIT_MULTIPART_OVERHEAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "deflection_submit_csv_too_large",
+                "max_file_bytes": max_bytes,
+            },
+        )
+
+
+def _deflection_submit_form_to_mapping(form: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "support_platform": form.get("support_platform") if hasattr(form, "get") else None,
+        "company_name": form.get("company_name") if hasattr(form, "get") else None,
+        "contact_email": form.get("contact_email") if hasattr(form, "get") else None,
+    }
+    limit = form.get("limit") if hasattr(form, "get") else None
+    if _clean(limit):
+        data["limit"] = limit
+    return _deflection_submit_fields_to_mapping(data)
 
 
 async def _inspect_uploaded_ingestion_file(
@@ -1243,6 +1348,37 @@ async def _load_deflection_submit_blob_rows(
     )
 
 
+async def _load_deflection_submit_upload_rows(
+    csv_file: Any,
+    *,
+    max_bytes: int,
+) -> tuple[list[Any], int]:
+    try:
+        data = await csv_file.read(max_bytes + 1)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded CSV could not be read.",
+        ) from exc
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "reason": "deflection_submit_csv_too_large",
+                "max_file_bytes": max_bytes,
+            },
+        )
+    if not data:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded CSV is empty.",
+        )
+    return _parse_deflection_submit_csv_bytes(
+        data,
+        parse_error_detail="Uploaded CSV could not be parsed.",
+    )
+
+
 def _load_deflection_submit_blob_rows_sync(
     blob_url: str,
     max_bytes: int,
@@ -1253,6 +1389,17 @@ def _load_deflection_submit_blob_rows_sync(
             status_code=400,
             detail="Blob CSV is empty.",
         )
+    return _parse_deflection_submit_csv_bytes(
+        data,
+        parse_error_detail="Blob CSV could not be parsed.",
+    )
+
+
+def _parse_deflection_submit_csv_bytes(
+    data: bytes,
+    *,
+    parse_error_detail: str,
+) -> tuple[list[Any], int]:
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -1267,7 +1414,7 @@ def _load_deflection_submit_blob_rows_sync(
         except (OSError, UnicodeDecodeError, ValueError) as exc:
             raise HTTPException(
                 status_code=400,
-                detail="Blob CSV could not be parsed.",
+                detail=parse_error_detail,
             ) from exc
         return rows, len(data)
     finally:
@@ -1534,6 +1681,7 @@ def _with_deflection_submit_diagnostics(
     submitted_row_count: int,
     package: Mapping[str, Any],
     support_platform: str,
+    byte_count_key: str = "blob_bytes",
 ) -> dict[str, Any]:
     out = dict(response)
     existing = out.get("input_provider")
@@ -1557,7 +1705,7 @@ def _with_deflection_submit_diagnostics(
         "submitted_row_count": submitted_row_count,
         "truncated_row_count": truncated_row_count,
         "max_source_material_rows": max_rows,
-        "blob_bytes": byte_count,
+        byte_count_key: byte_count,
         "support_platform": support_platform,
     })
     warnings = [
@@ -2691,6 +2839,15 @@ def _deflection_submit_payload_to_mapping(payload: Any) -> dict[str, Any]:
         raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
 
 
+def _deflection_submit_fields_to_mapping(payload: Any) -> dict[str, Any]:
+    if BaseModel is not None and isinstance(payload, DeflectionReportSubmitFieldsModel):
+        return payload.model_dump()
+    try:
+        return DeflectionReportSubmitFieldsModel.model_validate(payload).model_dump()
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=_validation_detail(exc)) from exc
+
+
 def _validate_input_shape(
     value: Any,
     *,
@@ -2778,6 +2935,7 @@ __all__ = [
     "ContentOpsControlSurfaceApiConfig",
     "ContentOpsIngestionImportModel",
     "ContentOpsRequestModel",
+    "DeflectionReportSubmitFieldsModel",
     "DeflectionReportSubmitModel",
     "create_content_ops_control_surface_router",
 ]

--- a/plans/PR-FAQ-Deflection-Submit-Multipart-CSV.md
+++ b/plans/PR-FAQ-Deflection-Submit-Multipart-CSV.md
@@ -1,0 +1,104 @@
+# PR-FAQ-Deflection-Submit-Multipart-CSV
+
+## Why this slice exists
+
+Issue #1161 surfaced a production PII problem with the current
+portfolio-to-ATLAS submit seam: private Vercel Blob objects do not provide a
+native signed fetch URL, so keeping the `blob_url` contract would force the
+portfolio to build a new public signed-proxy route for raw support-ticket CSVs.
+
+This slice adds the safer production shape: portfolio reads its own private blob
+server-side, then POSTs the CSV bytes to ATLAS over the existing authenticated
+Bearer submit call.
+
+The review pass found one production-critical parser edge: Starlette's default
+multipart part limit can reject files above 1 MiB before the route's own 50 MB
+bounded read runs. This PR now sets the parser part limit to the same CSV cap
+and adds an early `Content-Length` guard before parsing the multipart body,
+which pushes the final diff over the nominal 400 LOC budget.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Production hardening
+
+1. Extend `POST /content-ops/deflection-reports/submit` to accept
+   `multipart/form-data` with `csv_file`, `support_platform`, `company_name`,
+   `contact_email`, and optional `limit`.
+2. Keep the existing JSON `blob_url` submit contract for compatibility while
+   making multipart the documented production path.
+3. Reuse the existing CSV normalization, 50 MB cap, 1000-row limit, truncation
+   diagnostics, and synchronous execute envelope.
+4. Match Starlette's multipart parser part limit to the advertised CSV cap and
+   reject clearly oversize multipart bodies before form parsing.
+5. Update frontend contract docs to steer production wiring away from a public
+   signed proxy.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Multipart-CSV.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+
+## Mechanism
+
+The submit route now inspects the request content type. Multipart requests read
+`csv_file` with a bounded `max_bytes + 1` read and parse those bytes through the
+same temp-file CSV loader used by the URL-fetching path. JSON requests continue
+to validate `blob_url` and fetch through the existing DNS-pinned HTTPS loader.
+
+Before reading multipart form data, the route rejects a `Content-Length` above
+the CSV cap plus a small multipart overhead allowance. It then calls
+`request.form(max_part_size=max_bytes)` so Starlette's parser accepts the same
+file range the route advertises and the bounded upload reader enforces.
+
+Both input shapes then feed the same support-ticket input package and
+`faq_deflection_report` execution path. Diagnostics report `uploaded_bytes` for
+multipart and keep `blob_bytes` for legacy JSON submits.
+
+## Intentional
+
+- The legacy `blob_url` path remains for compatibility and local rollback, but
+  docs mark multipart as the production PII-safe path.
+- This does not add browser upload or portfolio UI. Portfolio must still read
+  its private Blob server-side and call ATLAS with the service JWT.
+- The response shape remains the Content Ops execute envelope. No one-off
+  flattened submit response is introduced.
+- The `Content-Length` pre-check allows 1 MiB of multipart overhead above the
+  CSV cap. That keeps normal boundary/header overhead from false-blocking while
+  still bounding the disk-spool path before `request.form(...)`.
+
+## Deferred
+
+- Parked hardening: none.
+- Removing the legacy `blob_url` path can be a later cleanup after portfolio
+  production traffic has moved to multipart.
+
+## Verification
+
+- Command: python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py tests/test_content_ops_faq_report_contract_docs.py
+  - Result: passed.
+- Command: python -m pytest tests/test_extracted_content_deflection_submit.py tests/test_content_ops_faq_report_contract_docs.py -q
+  - Result: 22 passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Result: extracted_reasoning_core 295 passed; extracted_content_pipeline
+    2859 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-multipart-csv.md
+  - Result: passed after review fix.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 104 |
+| Submit route/helper | 196 |
+| Tests | 157 |
+| Docs | 34 |
+| **Total** | **491** |
+
+The slice exceeds 400 LOC because the review fix is part of the production
+contract: without the explicit parser limit, the advertised 50 MB multipart path
+can reject files above Starlette's default part cap before the route's own
+bounded read runs.

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -217,6 +217,8 @@ def test_content_ops_faq_deflection_checkout_contract_pins_paid_handoff() -> Non
         "request_id: string;",
         "GET /content-ops/deflection-reports/{request_id}/snapshot",
         "GET /content-ops/deflection-reports/{request_id}/artifact",
+        "csv_file: File;",
+        "do not expose raw support-ticket CSVs through a",
         "POST /content-ops/deflection-reports/{request_id}/paid",
         "amount_total >= 150000",
         'currency: "usd"',

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -45,6 +45,31 @@ class _BlobResponse:
         return None
 
 
+class _Upload:
+    def __init__(self, data: bytes, *, filename: str = "tickets.csv") -> None:
+        self._data = data
+        self.filename = filename
+
+    async def read(self, _size: int) -> bytes:
+        return self._data
+
+
+class _FormRequest:
+    def __init__(
+        self,
+        form: dict[str, Any],
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._form = form
+        self.headers = headers or {"content-type": "multipart/form-data; boundary=test"}
+        self.form_kwargs: dict[str, Any] | None = None
+
+    async def form(self, **kwargs: Any) -> dict[str, Any]:
+        self.form_kwargs = dict(kwargs)
+        return self._form
+
+
 def _csv_bytes(rows: list[str]) -> bytes:
     return ("\n".join(rows) + "\n").encode("utf-8")
 
@@ -170,6 +195,136 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     with pytest.raises(api_module.HTTPException) as locked:
         await artifact.endpoint(request_id=payload["request_id"])
     assert locked.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message,resolution_text,pain_category",
+        (
+            "ticket-export-1,Export attribution,"
+            "How do I export attribution reports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        (
+            "ticket-export-2,Report download,"
+            "Where is the report download for attribution exports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        "ticket-sso-1,SSO setup,How do I enable SSO for my team?,,auth",
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    router = _router(store)
+
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest({
+        "csv_file": _Upload(csv_data),
+        "support_platform": "help-scout",
+        "company_name": "Acme Co.",
+        "contact_email": "lead@acme.example",
+        "limit": "2",
+    })
+    payload = await submit.endpoint(request)
+
+    assert request.form_kwargs == {
+        "max_part_size": api_module._MAX_DEFLECTION_SUBMIT_BLOB_BYTES
+    }
+    assert payload["status"] == "completed"
+    assert payload["request_id"].startswith("content-ops-")
+    gated_result = payload["steps"][0]["result"]
+    assert gated_result["request_id"] == payload["request_id"]
+    assert gated_result["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
+    assert "markdown" not in str(gated_result)
+    assert "ticket-export-1" not in str(gated_result)
+    assert payload["input_provider"]["metadata"] == {
+        "included_row_count": 2,
+        "max_source_material_rows": 2,
+        "skipped_row_count": 0,
+        "source": "portfolio_deflection_submit",
+        "source_period": "Uploaded support tickets",
+        "source_row_count": 3,
+        "submitted_row_count": 2,
+        "support_platform": "help_scout",
+        "truncated_row_count": 1,
+        "uploaded_bytes": len(csv_data),
+    }
+
+    snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
+    assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_multipart_without_csv_file() -> None:
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        }))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "csv_file is required"
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_oversize_uploaded_csv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_module, "_MAX_DEFLECTION_SUBMIT_BLOB_BYTES", 10)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(_FormRequest({
+            "csv_file": _Upload(b"01234567890"),
+            "support_platform": "intercom",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        }))
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == {
+        "reason": "deflection_submit_csv_too_large",
+        "max_file_bytes": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_deflection_submit_rejects_oversize_multipart_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_module, "_MAX_DEFLECTION_SUBMIT_BLOB_BYTES", 10)
+    monkeypatch.setattr(api_module, "_MAX_DEFLECTION_SUBMIT_MULTIPART_OVERHEAD_BYTES", 3)
+    router = _router(InMemoryDeflectionReportArtifactStore())
+    submit = _route(router, "/ops/deflection-reports/submit", "POST")
+    request = _FormRequest(
+        {
+            "csv_file": _Upload(b"small"),
+            "support_platform": "zendesk",
+            "company_name": "Acme Co.",
+            "contact_email": "lead@acme.example",
+        },
+        headers={
+            "content-type": "multipart/form-data; boundary=test",
+            "content-length": "14",
+        },
+    )
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await submit.endpoint(request)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == {
+        "reason": "deflection_submit_csv_too_large",
+        "max_file_bytes": 10,
+    }
+    assert request.form_kwargs is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Multipart-CSV.md
Slice phase: Production hardening

Add multipart CSV submit support for the FAQ deflection portfolio handoff so private Vercel Blob exports can stay private: portfolio reads the blob server-side, then posts raw CSV bytes to ATLAS over the existing authenticated `/deflection-reports/submit` call.

## Intentional
- The legacy JSON `blob_url` path remains for compatibility, but docs now mark multipart as the production PII-safe path.
- Starlette's multipart parser part limit is explicitly raised to the same 50 MB CSV cap, and oversized multipart requests are rejected before form parsing.
- The response shape remains the existing Content Ops execute envelope; no flattened submit response is introduced.
- This does not add browser upload or portfolio UI. Portfolio still owns reading its private Blob and calling ATLAS with the service JWT.

## Deferred
- Removing the legacy `blob_url` path can happen after portfolio production traffic moves to multipart.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py tests/test_content_ops_faq_report_contract_docs.py` - passed.
- `python -m pytest tests/test_extracted_content_deflection_submit.py tests/test_content_ops_faq_report_contract_docs.py -q` - 22 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2859 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-multipart-csv.md` - passed.

## Diff size
5 files, +457 / -34
