### PR TITLE
PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer.md
@@ -1,0 +1,95 @@
+# PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Portfolio-Atlas-Proxy gave the hosted portfolio result page a
+server-only ATLAS proxy and real snapshot hydration, then intentionally deferred
+paid artifact rendering. The next customer-visible step is to let the hosted
+result page display the full `FAQDeflectionReportArtifact` after ATLAS returns
+an unlocked artifact envelope.
+
+This slice keeps the paywall trust boundary intact: locked reports remain
+snapshot-only, and the hosted page never derives paid copy from free snapshot
+fields. The paid report appears only when the portfolio server receives
+`artifact_status: "unlocked"` with artifact Markdown from ATLAS.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Render the paid artifact Markdown on the hosted result page only for an
+   unlocked ATLAS artifact envelope.
+2. Escape the Markdown/HTML as text instead of injecting rendered HTML.
+3. Keep locked, missing, invalid, or unavailable artifact states on the
+   snapshot-only path with no paid-report body.
+4. Add focused Node tests for locked, unlocked, and hostile artifact Markdown.
+5. Leave ATLAS proxy routes, Stripe Checkout, and browser SPA behavior
+   unchanged.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+
+## Mechanism
+
+`renderResultPage(...)` continues to receive the sanitized server-side proxy
+envelope. A new paid-artifact renderer checks all of these conditions before
+emitting the full report section:
+
+```text
+report.ok === true
+report.artifact_status === "unlocked"
+typeof report.artifact.markdown === "string"
+report.artifact.markdown.trim() is non-empty
+```
+
+When the conditions pass, the Markdown is escaped and placed inside a `<pre>`
+element marked with `data-atlas-deflection-paid-report`. When they fail, no paid
+report marker or artifact body is rendered. The unlock panel switches to an
+unlocked state after ATLAS reports the artifact unlocked, which avoids offering
+a second Checkout session for an already unlocked report.
+
+## Intentional
+
+- This slice does not add a Markdown parser. Rendering artifact Markdown as
+  escaped text proves the paid unlock path without introducing an HTML
+  sanitization surface.
+- The renderer trusts only the ATLAS artifact envelope, not the snapshot. Free
+  snapshot fields cannot create paid report copy.
+- Missing or malformed artifact Markdown stays out of the DOM even when the
+  envelope says `unlocked`; a future rich renderer can add more structured
+  artifact validation.
+- The browser SPA remains a validation shell. The hosted server-rendered page is
+  the product path that has access to the server-only proxy.
+
+## Deferred
+
+- Rich Markdown styling, section navigation, and downloadable report exports
+  after live paid artifact validation proves the shape customers should see.
+- Browser SPA paid-state polish after the server-rendered hosted page is
+  verified in production.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 11 checks.
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
+- `npm run build --prefix portfolio-ui` - passed using the existing ignored root
+  `portfolio-ui/node_modules` install for local verification; `npm ci` in this
+  worktree is blocked by pre-existing portfolio lockfile drift.
+- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core
+  295 passed; extracted_content_pipeline 2855 passed, 10 skipped, 1 warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-paid-report-renderer-pr-body.md` -
+  passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~80 |
+| Hosted paid renderer | ~80 |
+| Tests | ~50 |
+| **Total** | **~210** |

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -74,13 +74,38 @@ function renderSnapshot(report) {
         </section>`;
 }
 
+function renderPaidArtifact(report) {
+  const markdown =
+    report &&
+    report.ok &&
+    report.artifact_status === "unlocked" &&
+    report.artifact &&
+    typeof report.artifact.markdown === "string"
+      ? report.artifact.markdown.trim()
+      : "";
+
+  if (!markdown) return "";
+
+  return `<section class="paid-report" aria-labelledby="paid-report-title" data-atlas-deflection-paid-report>
+          <h2 id="paid-report-title">Full report</h2>
+          <p class="muted">Unlocked from the ATLAS paid artifact after Stripe webhook verification.</p>
+          <pre class="report-markdown">${escapeHtml(markdown)}</pre>
+        </section>`;
+}
+
 function renderResultPage({ requestId, accountId, checkoutStatus = "", report = null }) {
   const safeRequestId = escapeHtml(requestId);
   const safeAccountId = escapeHtml(accountId);
   const safeCheckoutStatus = escapeHtml(checkoutStatus);
   const resultHref = resultPath(requestId || "missing-request", accountId, "");
-  const buttonDisabled = requestId && accountId ? "" : "disabled";
   const artifactStatus = report && report.ok ? report.artifact_status : "snapshot_unavailable";
+  const isUnlocked = artifactStatus === "unlocked";
+  const buttonDisabled = requestId && accountId && !isUnlocked ? "" : "disabled";
+  const unlockHeading = isUnlocked ? "Full report unlocked" : "Unlock full report";
+  const unlockCopy = isUnlocked
+    ? "ATLAS has released the paid artifact for this request."
+    : "$1,500 one-time Stripe Checkout session.";
+  const unlockButtonLabel = isUnlocked ? "Report unlocked" : "Continue to Checkout";
   const statusBanner =
     checkoutStatus === "success"
       ? `<div class="notice success">Checkout returned successfully. ATLAS unlocks the paid report only after Stripe sends the verified webhook.</div>`
@@ -117,6 +142,8 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     .questions article { border-top: 1px solid rgba(30, 41, 59, .9); padding-top: 14px; }
     .questions h3 { margin: 6px 0; font-size: 17px; }
     .rank { color: #86efac; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    .paid-report { margin-top: 24px; border: 1px solid rgba(134, 239, 172, .28); border-radius: 8px; background: rgba(20, 83, 45, .16); padding: 24px; }
+    .report-markdown { margin: 18px 0 0; max-height: 720px; overflow: auto; border: 1px solid rgba(30, 41, 59, .9); border-radius: 8px; background: rgba(2, 6, 23, .55); padding: 18px; color: #e2e8f0; font: 13px/1.65 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
     .notice { margin-top: 20px; border-radius: 8px; padding: 14px 16px; color: #fde68a; background: rgba(251, 191, 36, .1); border: 1px solid rgba(251, 191, 36, .28); }
     .success { color: #bbf7d0; background: rgba(34, 197, 94, .1); border-color: rgba(34, 197, 94, .28); }
     .muted { color: rgba(226, 232, 240, .68); line-height: 1.65; }
@@ -139,10 +166,11 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
         <p class="lede">The free snapshot and paid artifact stay separated. The full report unlocks only after Stripe confirms payment and ATLAS releases the artifact from its signed webhook path.</p>
         ${statusBanner}
         ${renderSnapshot(report)}
+        ${renderPaidArtifact(report)}
       </section>
       <aside class="panel">
-        <h2>Unlock full report</h2>
-        <p class="muted">$1,500 one-time Stripe Checkout session.</p>
+        <h2>${unlockHeading}</h2>
+        <p class="muted">${unlockCopy}</p>
         <dl class="meta">
           <div><dt>Checkout metadata source</dt><dd>${CHECKOUT_SOURCE}</dd></div>
           <div><dt>request_id</dt><dd>${safeRequestId || "Missing request id"}</dd></div>
@@ -151,7 +179,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
           <div><dt>artifact_status</dt><dd>${escapeHtml(artifactStatus)}</dd></div>
           <div><dt>checkout</dt><dd>${safeCheckoutStatus || "locked"}</dd></div>
         </dl>
-        <button type="button" data-atlas-deflection-unlock ${buttonDisabled}>Continue to Checkout</button>
+        <button type="button" data-atlas-deflection-unlock ${buttonDisabled}>${unlockButtonLabel}</button>
         <p id="checkout-message" class="muted" role="status"></p>
       </aside>
     </div>

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -33,6 +33,11 @@ const SNAPSHOT = {
   ],
 };
 
+const PAID_ARTIFACT = {
+  markdown: '# Paid report\n\n<script>alert("xss")</script>',
+  summary: { generated: 3 },
+};
+
 async function test(name, fn) {
   try {
     await fn();
@@ -269,4 +274,40 @@ await test("hosted result page renders real snapshot metrics from the proxy enve
   assert.match(html, /artifact_status/);
   assert.match(html, /locked/);
   assert.doesNotMatch(html, /# Paid report/);
+  assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
+});
+
+await test("hosted result page renders escaped paid artifact only after unlock", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    report: {
+      ok: true,
+      snapshot: SNAPSHOT,
+      artifact_status: "unlocked",
+      artifact: PAID_ARTIFACT,
+    },
+  });
+  assert.match(html, /data-atlas-deflection-paid-report/);
+  assert.match(html, /# Paid report/);
+  assert.match(html, /&lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt;/);
+  assert.doesNotMatch(html, /<script>alert\("xss"\)<\/script>/);
+  assert.match(html, /Full report unlocked/);
+  assert.match(html, /Report unlocked/);
+});
+
+await test("hosted result page with malformed unlocked artifact does not invent paid copy", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    report: {
+      ok: true,
+      snapshot: SNAPSHOT,
+      artifact_status: "unlocked",
+      artifact: { summary: { generated: 3 } },
+    },
+  });
+  assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
+  assert.doesNotMatch(html, /# Paid report/);
+  assert.match(html, /Full report unlocked/);
 });


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Paid-Report-Renderer.md
Slice phase: Vertical slice

This slice renders the paid FAQ deflection artifact on the hosted portfolio result page only after the server-side ATLAS proxy reports `artifact_status: "unlocked"`. Locked, missing, malformed, or unavailable artifact states remain snapshot-only, and artifact Markdown is escaped as text rather than injected as HTML.

## Intentional
- The renderer uses escaped Markdown in a `<pre>` instead of a Markdown parser so this slice proves the paid unlock path without adding an HTML sanitization surface.
- The paid report body is sourced only from the unlocked ATLAS artifact envelope; free snapshot fields cannot create paid copy.
- Malformed unlocked artifacts do not render paid-report content.
- The browser SPA remains unchanged; the hosted server-rendered page is the server-only proxy product path.

## Deferred
- Rich Markdown styling, section navigation, and downloadable report exports after live paid artifact validation.
- Browser SPA paid-state polish after the server-rendered hosted page is verified in production.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 11 checks.
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2855 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-paid-report-renderer-pr-body.md` - passed.

## Diff size
3 files, +167 / -4
