### PR TITLE
PR-FAQ-Deflection-Submit-Multipart-Smoke

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
@@ -1,7 +1,8 @@
 # Content Ops FAQ Deflection Submit Handoff Runbook
 
 Use this runbook to prove the deployed ATLAS API can consume the portfolio's
-signed support-ticket CSV blob and return the gated deflection report response.
+support-ticket CSV over the authenticated submit handoff and return the gated
+deflection report response.
 
 ## Required Inputs
 
@@ -12,9 +13,12 @@ signed support-ticket CSV blob and return the gated deflection report response.
 - `ATLAS_ACCOUNT_ID` or `ATLAS_FAQ_SEARCH_ACCOUNT_ID`: the account id that
   maps to the bearer token. The submit route derives account scope from auth;
   the portfolio needs this value for Stripe Checkout metadata.
-- `ATLAS_DEFLECTION_SUBMIT_BLOB_URL`: HTTPS support-ticket CSV blob URL. A
-  private signed URL is preferred; the URL must live long enough for the sync
-  submit call.
+- `ATLAS_DEFLECTION_SUBMIT_CSV_FILE`: local support-ticket CSV fixture for the
+  preferred multipart hosted smoke. Use a representative private-Blob export
+  downloaded by the operator or portfolio server-side code path.
+- `ATLAS_DEFLECTION_SUBMIT_BLOB_URL`: optional legacy HTTPS support-ticket CSV
+  blob URL. This fallback remains available for rollback coverage but is not
+  the preferred production PII posture.
 - `ATLAS_DEFLECTION_COMPANY_NAME`: company name to include in the report title.
 - `ATLAS_DEFLECTION_CONTACT_EMAIL`: buyer/contact email.
 - `ATLAS_DEFLECTION_SUPPORT_PLATFORM`: `zendesk`, `intercom`, `help_scout`, or
@@ -68,7 +72,28 @@ python scripts/smoke_content_ops_deflection_submit_handoff.py \
   --json
 ```
 
-The smoke sends:
+With `ATLAS_DEFLECTION_SUBMIT_CSV_FILE` or `--csv-file`, the smoke sends:
+
+```http
+POST /api/v1/content-ops/deflection-reports/submit
+Content-Type: multipart/form-data
+```
+
+Form fields:
+
+```text
+csv_file=@tickets.csv
+support_platform=zendesk
+company_name=Acme Co.
+contact_email=lead@example.com
+limit=1000
+```
+
+This matches the production handoff: the portfolio reads its private Blob
+server-side, then posts raw CSV bytes to ATLAS with the existing bearer token.
+Do not expose raw support-ticket CSVs through a public signed proxy.
+
+If no CSV file is provided, the smoke falls back to the legacy JSON contract:
 
 ```json
 {
@@ -80,7 +105,7 @@ The smoke sends:
 }
 ```
 
-to `/api/v1/content-ops/deflection-reports/submit`, then verifies:
+Both submit modes then verify:
 
 - Submit returns `200` with `status: "completed"`.
 - The top-level `request_id` is non-empty.
@@ -88,7 +113,9 @@ to `/api/v1/content-ops/deflection-reports/submit`, then verifies:
 - The free snapshot has `summary` and `top_questions` and does not contain
   answer, evidence, source id, Markdown, or full FAQ result fields.
 - `full_report` is `{ "status": "locked", "reason": "payment_required" }`.
-- Submit diagnostics identify `portfolio_deflection_submit`.
+- Submit diagnostics identify `portfolio_deflection_submit` and include the
+  expected byte counter (`uploaded_bytes` for multipart, `blob_bytes` for the
+  legacy JSON path).
 - `GET /api/v1/content-ops/deflection-reports/{request_id}/snapshot` returns
   `200` with the same snapshot.
 - `GET /api/v1/content-ops/deflection-reports/{request_id}/artifact` returns
@@ -143,9 +170,11 @@ Use this only after the first paid-unlock smoke path is expected to succeed.
 
 ## Interpreting Results
 
-The result artifact records HTTP statuses, the returned `request_id`, compact
-submit diagnostics, and deterministic errors. It intentionally redacts the
-bearer token and signed blob query string; only the blob host is recorded.
+The result artifact records HTTP statuses, submit mode, CSV file size when
+multipart is used, the returned `request_id`, compact submit diagnostics, and
+deterministic errors. It intentionally redacts the bearer token, signed blob
+query string, and CSV contents; only the blob host is recorded for the legacy
+JSON path.
 
 Exit codes:
 

--- a/plans/PR-FAQ-Deflection-Submit-Multipart-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Submit-Multipart-Smoke.md
@@ -1,0 +1,97 @@
+# PR-FAQ-Deflection-Submit-Multipart-Smoke
+
+## Why this slice exists
+
+#1184 moved the production-safe portfolio submit contract from JSON `blob_url`
+fetching to authenticated server-to-server multipart CSV upload. The hosted
+handoff smoke still only exercises the legacy JSON shape, so operators cannot
+prove the deployed production path without hand-rolling a multipart call.
+
+This slice updates the existing hosted smoke and runbook to make a local CSV
+file the preferred submit input while keeping the JSON `blob_url` path as a
+compatibility fallback.
+
+The diff is slightly over the 400 LOC target because the smoke is a checker
+surface. The multipart encoder, input validation, mode-specific diagnostics,
+diagnostics redaction, legacy fallback, and negative fixtures need to ship
+together so the hosted proof cannot false-green the wrong submit mode.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Functional validation
+
+1. Add `--csv-file` / `ATLAS_DEFLECTION_SUBMIT_CSV_FILE` support to
+   `scripts/smoke_content_ops_deflection_submit_handoff.py`.
+2. Send multipart form data when a CSV file is provided, including
+   `csv_file`, `support_platform`, `company_name`, `contact_email`, and
+   `limit`.
+3. Keep the existing JSON `blob_url` mode for legacy hosted proof and rollback.
+4. Extend smoke validation/tests so the multipart path fails closed on missing
+   or unsafe file inputs, sends no JSON `blob_url`, redacts secrets, and
+   requires multipart `uploaded_bytes` diagnostics.
+5. Update the submit handoff runbook to document multipart as the preferred
+   production smoke path.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Multipart-Smoke.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+- `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md`
+
+## Mechanism
+
+The smoke chooses submit mode from inputs:
+
+```text
+--csv-file present -> multipart submit
+otherwise          -> legacy JSON blob_url submit
+```
+
+Multipart mode reads the local CSV bytes, builds a bounded multipart request
+with a generated boundary, posts it with the existing bearer token, and then
+reuses the current execute-envelope, snapshot, and unpaid-artifact validation.
+The execute-envelope validator requires `uploaded_bytes` in multipart mode and
+`blob_bytes` in legacy JSON mode so an incomplete diagnostics envelope cannot
+false-green the hosted proof.
+The result artifact records only non-sensitive mode/size metadata. It does not
+write the bearer token, signed blob query string, or CSV contents.
+
+## Intentional
+
+- The smoke still rejects localhost API hosts because this remains a hosted
+  handoff proof, not a local route test.
+- `blob_url` support remains because #1184 kept that backend contract for
+  compatibility. The runbook will steer production validation to `--csv-file`.
+- This slice does not add a live artifact. The operator still supplies deployed
+  ATLAS auth plus a real support-ticket CSV when running the smoke.
+- The script hand-builds multipart with the Python standard library so the
+  extracted CI environment does not need `requests`.
+
+## Deferred
+
+- Parked hardening: none. `HARDENING.md` has no active entries touching this
+  smoke or submit route lane.
+- Removing the legacy JSON `blob_url` smoke mode remains deferred until the
+  portfolio production path no longer needs rollback coverage.
+
+## Verification
+
+- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py`
+- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q`
+- `bash scripts/run_extracted_pipeline_checks.sh`
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-multipart-smoke.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 97 |
+| Smoke script | 195 |
+| Tests | 212 |
+| Runbook | 49 |
+| **Total** | **553** |
+
+This is over the soft cap for the checker-surface reason named in **Why this
+slice exists**.

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -15,12 +15,14 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
 LOCAL_BASE_URL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
 SUPPORT_PLATFORMS = frozenset({"zendesk", "intercom", "help_scout", "other"})
+CSV_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
 SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit"
 SNAPSHOT_PATH_TEMPLATE = "/api/v1/content-ops/deflection-reports/{request_id}/snapshot"
 ARTIFACT_PATH_TEMPLATE = "/api/v1/content-ops/deflection-reports/{request_id}/artifact"
@@ -73,6 +75,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-url", default=_env("ATLAS_API_BASE_URL"))
     parser.add_argument("--token", default=_env("ATLAS_B2B_JWT", "ATLAS_TOKEN"))
     parser.add_argument("--account-id", default=_env("ATLAS_ACCOUNT_ID", "ATLAS_FAQ_SEARCH_ACCOUNT_ID"))
+    parser.add_argument("--csv-file", type=Path, default=_env("ATLAS_DEFLECTION_SUBMIT_CSV_FILE") or None)
     parser.add_argument("--blob-url", default=_env("ATLAS_DEFLECTION_SUBMIT_BLOB_URL"))
     parser.add_argument("--support-platform", default=_env("ATLAS_DEFLECTION_SUPPORT_PLATFORM") or "zendesk")
     parser.add_argument("--company-name", default=_env("ATLAS_DEFLECTION_COMPANY_NAME"))
@@ -104,8 +107,13 @@ def _validate_args(args: argparse.Namespace) -> list[str]:
         errors.append("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required")
     if not _clean(args.account_id):
         errors.append("ATLAS_ACCOUNT_ID, ATLAS_FAQ_SEARCH_ACCOUNT_ID, or --account-id is required")
-    if not _clean(args.blob_url):
-        errors.append("ATLAS_DEFLECTION_SUBMIT_BLOB_URL or --blob-url is required")
+    if _clean(args.csv_file):
+        errors.extend(_csv_file_errors(Path(args.csv_file)))
+    elif not _clean(args.blob_url):
+        errors.append(
+            "ATLAS_DEFLECTION_SUBMIT_CSV_FILE/--csv-file or "
+            "ATLAS_DEFLECTION_SUBMIT_BLOB_URL/--blob-url is required"
+        )
     else:
         errors.extend(_blob_url_errors(_clean(args.blob_url)))
     if _clean(args.support_platform) not in SUPPORT_PLATFORMS:
@@ -162,11 +170,40 @@ def _blob_url_errors(blob_url: str) -> list[str]:
     return []
 
 
+def _csv_file_errors(csv_file: Path) -> list[str]:
+    try:
+        path = csv_file.expanduser()
+        stat = path.stat()
+    except OSError:
+        return ["--csv-file must point to a readable support-ticket CSV file"]
+    if not path.is_file():
+        return ["--csv-file must point to a file"]
+    if stat.st_size <= 0:
+        return ["--csv-file must not be empty"]
+    if stat.st_size > CSV_UPLOAD_MAX_BYTES:
+        return ["--csv-file must be 50 MB or smaller"]
+    return []
+
+
+def _submit_mode(args: argparse.Namespace) -> str:
+    return "multipart" if _clean(args.csv_file) else "json_blob_url"
+
+
+def _csv_file_size(args: argparse.Namespace) -> int | None:
+    if not _clean(args.csv_file):
+        return None
+    try:
+        return Path(args.csv_file).expanduser().stat().st_size
+    except OSError:
+        return None
+
+
 def _required_input_status(args: argparse.Namespace) -> dict[str, dict[str, bool]]:
     return {
         "base_url": {"present": bool(_clean(args.base_url))},
         "token": {"present": bool(_clean(args.token))},
         "account_id": {"present": bool(_clean(args.account_id))},
+        "csv_file": {"present": bool(_clean(args.csv_file))},
         "blob_url": {"present": bool(_clean(args.blob_url))},
         "company_name": {"present": bool(_clean(args.company_name))},
         "contact_email": {"present": bool(_clean(args.contact_email))},
@@ -195,27 +232,26 @@ def _submit_body(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def _submit_fields(args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "support_platform": _clean(args.support_platform),
+        "company_name": _clean(args.company_name),
+        "contact_email": _clean(args.contact_email),
+        "limit": str(int(args.limit)),
+    }
+
+
 def _open_http_request(request: urllib.request.Request, *, timeout: float) -> Any:
     return urllib.request.urlopen(request, timeout=timeout)
 
 
-def _json_request(
+def _parse_http_json_response(
     method: str,
     url: str,
     *,
-    token: str,
+    request: urllib.request.Request,
     timeout: float,
-    body: Mapping[str, Any] | None = None,
 ) -> HttpJsonResponse:
-    encoded_body = None
-    headers = {
-        "Accept": "application/json",
-        "Authorization": f"Bearer {token}",
-    }
-    if body is not None:
-        encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    request = urllib.request.Request(url, data=encoded_body, headers=headers, method=method)
     try:
         with _open_http_request(request, timeout=timeout) as response:
             status = int(getattr(response, "status", None) or response.getcode())
@@ -242,6 +278,92 @@ def _json_request(
             errors=(f"{method} {url} returned invalid JSON: {exc.msg}",),
         )
     return HttpJsonResponse(status=status, payload=payload, raw_text=raw[:2000])
+
+
+def _json_request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    timeout: float,
+    body: Mapping[str, Any] | None = None,
+) -> HttpJsonResponse:
+    encoded_body = None
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+    if body is not None:
+        encoded_body = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=encoded_body, headers=headers, method=method)
+    return _parse_http_json_response(method, url, request=request, timeout=timeout)
+
+
+def _multipart_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\r", "").replace("\n", "")
+
+
+def _encode_multipart_body(
+    fields: Mapping[str, str],
+    *,
+    file_field: str,
+    file_path: Path,
+    file_bytes: bytes,
+) -> tuple[bytes, str]:
+    boundary = f"atlas-deflection-{uuid.uuid4().hex}"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.extend((
+            f"--{boundary}\r\n".encode("ascii"),
+            (
+                'Content-Disposition: form-data; '
+                f'name="{_multipart_escape(name)}"\r\n\r\n'
+            ).encode("utf-8"),
+            value.encode("utf-8"),
+            b"\r\n",
+        ))
+    filename = _multipart_escape(file_path.name or "support-tickets.csv")
+    chunks.extend((
+        f"--{boundary}\r\n".encode("ascii"),
+        (
+            'Content-Disposition: form-data; '
+            f'name="{_multipart_escape(file_field)}"; filename="{filename}"\r\n'
+            "Content-Type: text/csv\r\n\r\n"
+        ).encode("utf-8"),
+        file_bytes,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode("ascii"),
+    ))
+    return b"".join(chunks), boundary
+
+
+def _multipart_submit_request(
+    url: str,
+    *,
+    token: str,
+    timeout: float,
+    fields: Mapping[str, str],
+    csv_file: Path,
+) -> HttpJsonResponse:
+    file_path = csv_file.expanduser()
+    body, boundary = _encode_multipart_body(
+        fields,
+        file_field="csv_file",
+        file_path=file_path,
+        file_bytes=file_path.read_bytes(),
+    )
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+        method="POST",
+    )
+    return _parse_http_json_response("POST", url, request=request, timeout=timeout)
 
 
 def _forbidden_key_paths(value: Any, *, prefix: str = "$") -> list[str]:
@@ -294,7 +416,11 @@ def _validate_snapshot(snapshot: Any, *, label: str) -> list[str]:
     return errors
 
 
-def _validate_submit_envelope(payload: Any) -> tuple[str, Mapping[str, Any] | None, dict[str, Any], list[str]]:
+def _validate_submit_envelope(
+    payload: Any,
+    *,
+    submit_mode: str = "json_blob_url",
+) -> tuple[str, Mapping[str, Any] | None, dict[str, Any], list[str]]:
     errors: list[str] = []
     diagnostics: dict[str, Any] = {}
     if not isinstance(payload, Mapping):
@@ -358,6 +484,7 @@ def _validate_submit_envelope(payload: Any) -> tuple[str, Mapping[str, Any] | No
                     "submitted_row_count",
                     "truncated_row_count",
                     "max_source_material_rows",
+                    "uploaded_bytes",
                     "blob_bytes",
                     "support_platform",
                 )
@@ -365,6 +492,13 @@ def _validate_submit_envelope(payload: Any) -> tuple[str, Mapping[str, Any] | No
             }
             if metadata.get("source") != "portfolio_deflection_submit":
                 errors.append("input_provider.metadata.source must be portfolio_deflection_submit")
+            expected_byte_key = "uploaded_bytes" if submit_mode == "multipart" else "blob_bytes"
+            expected_byte_value = metadata.get(expected_byte_key)
+            if not isinstance(expected_byte_value, int) or expected_byte_value <= 0:
+                errors.append(
+                    f"input_provider.metadata.{expected_byte_key} must be a positive integer "
+                    f"for {submit_mode} submit"
+                )
     return request_id, snapshot if isinstance(snapshot, Mapping) else None, diagnostics, errors
 
 
@@ -387,6 +521,8 @@ def _preflight_summary(
         "phase": "preflight",
         "preflight_errors": list(errors),
         "required_inputs": _required_input_status(args),
+        "submit_mode": _submit_mode(args),
+        "csv_file_size": _csv_file_size(args),
         "blob_host": _redacted_blob_host(_clean(args.blob_url)),
         "submit": {"ok": False, "skipped": True, "not_run_reason": reason},
         "snapshot": {"ok": False, "skipped": True, "not_run_reason": reason},
@@ -417,13 +553,23 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     start = time.perf_counter()
     errors: list[str] = []
     submit_url = _join_url(_clean(args.base_url), _clean(args.submit_path))
-    submit_response = _json_request(
-        "POST",
-        submit_url,
-        token=_clean(args.token),
-        timeout=float(args.timeout),
-        body=_submit_body(args),
-    )
+    submit_mode = _submit_mode(args)
+    if submit_mode == "multipart":
+        submit_response = _multipart_submit_request(
+            submit_url,
+            token=_clean(args.token),
+            timeout=float(args.timeout),
+            fields=_submit_fields(args),
+            csv_file=Path(args.csv_file),
+        )
+    else:
+        submit_response = _json_request(
+            "POST",
+            submit_url,
+            token=_clean(args.token),
+            timeout=float(args.timeout),
+            body=_submit_body(args),
+        )
     submit_errors = list(submit_response.errors)
     request_id = ""
     submit_snapshot: Mapping[str, Any] | None = None
@@ -432,7 +578,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         submit_errors.append(f"submit status must be 200, got {submit_response.status}")
     else:
         request_id, submit_snapshot, diagnostics, envelope_errors = _validate_submit_envelope(
-            submit_response.payload
+            submit_response.payload,
+            submit_mode=submit_mode,
         )
         submit_errors.extend(envelope_errors)
     errors.extend(submit_errors)
@@ -492,6 +639,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "ok": not errors,
         "phase": "complete",
         "request_id": request_id or None,
+        "submit_mode": submit_mode,
+        "csv_file_size": _csv_file_size(args),
         "blob_host": _redacted_blob_host(_clean(args.blob_url)),
         "submit": {
             **_status_summary(submit_response),

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -55,7 +55,54 @@ def _base_args(tmp_path: Path) -> list[str]:
     ]
 
 
-def _submit_payload(*, request_id: str = "content-ops-123", snapshot: Any = SNAPSHOT) -> dict[str, Any]:
+def _base_csv_args(tmp_path: Path, csv_file: Path) -> list[str]:
+    return [
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-secret",
+        "--account-id",
+        "acct-123",
+        "--csv-file",
+        str(csv_file),
+        "--support-platform",
+        "zendesk",
+        "--company-name",
+        "Acme Co.",
+        "--contact-email",
+        "lead@example.com",
+        "--output-result",
+        str(tmp_path / "result.json"),
+    ]
+
+
+def _write_csv(tmp_path: Path) -> Path:
+    csv_file = tmp_path / "tickets.csv"
+    csv_file.write_text(
+        "ticket_id,subject,body\n"
+        "1,Export reports,How do I export reports?\n",
+        encoding="utf-8",
+    )
+    return csv_file
+
+
+def _submit_payload(
+    *,
+    request_id: str = "content-ops-123",
+    snapshot: Any = SNAPSHOT,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    base_metadata = {
+        "source": "portfolio_deflection_submit",
+        "source_row_count": 3,
+        "submitted_row_count": 3,
+        "truncated_row_count": 0,
+        "max_source_material_rows": 1000,
+        "blob_bytes": 200,
+        "support_platform": "zendesk",
+    }
+    if metadata is not None:
+        base_metadata = metadata
     return {
         "status": "completed",
         "request_id": request_id,
@@ -75,15 +122,7 @@ def _submit_payload(*, request_id: str = "content-ops-123", snapshot: Any = SNAP
         ],
         "input_provider": {
             "provider": "portfolio_deflection_submit",
-            "metadata": {
-                "source": "portfolio_deflection_submit",
-                "source_row_count": 3,
-                "submitted_row_count": 3,
-                "truncated_row_count": 0,
-                "max_source_material_rows": 1000,
-                "blob_bytes": 200,
-                "support_platform": "zendesk",
-            },
+            "metadata": base_metadata,
             "warnings": [],
         },
     }
@@ -111,12 +150,22 @@ class FakeResponse:
 
 def _fake_open(sequence: list[tuple[int, Any]], calls: list[dict[str, Any]]):
     def _open(request, *, timeout):
-        body = json.loads(request.data.decode("utf-8")) if request.data else None
+        headers = dict(request.header_items())
+        header_lookup = {key.lower(): value for key, value in headers.items()}
+        content_type = header_lookup.get("content-type", "")
+        body_bytes = request.data or b""
+        body_text = body_bytes.decode("utf-8", errors="replace") if body_bytes else ""
+        body = None
+        if body_bytes and content_type.startswith("application/json"):
+            body = json.loads(body_text)
         calls.append({
             "url": request.full_url,
             "method": request.get_method(),
-            "headers": dict(request.header_items()),
+            "headers": headers,
+            "content_type": content_type,
             "body": body,
+            "body_text": body_text,
+            "body_bytes": body_bytes,
             "timeout": timeout,
         })
         status, payload = sequence.pop(0)
@@ -164,6 +213,29 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
     ]
 
 
+def test_validate_args_fails_closed_for_missing_csv_file(tmp_path) -> None:
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-secret",
+        "--account-id",
+        "acct-123",
+        "--csv-file",
+        str(tmp_path / "missing.csv"),
+        "--support-platform",
+        "zendesk",
+        "--company-name",
+        "Acme Co.",
+        "--contact-email",
+        "lead@example.com",
+    ])
+
+    assert smoke._validate_args(args) == [
+        "--csv-file must point to a readable support-ticket CSV file"
+    ]
+
+
 def test_validate_submit_envelope_accepts_locked_gated_result() -> None:
     request_id, snapshot, diagnostics, errors = smoke._validate_submit_envelope(_submit_payload())
 
@@ -172,6 +244,38 @@ def test_validate_submit_envelope_accepts_locked_gated_result() -> None:
     assert snapshot == SNAPSHOT
     assert diagnostics["provider"] == "portfolio_deflection_submit"
     assert diagnostics["metadata"]["source_row_count"] == 3
+
+
+def test_validate_submit_envelope_requires_json_blob_byte_counter() -> None:
+    payload = _submit_payload(metadata={
+        "source": "portfolio_deflection_submit",
+        "source_row_count": 3,
+        "submitted_row_count": 3,
+        "truncated_row_count": 0,
+        "max_source_material_rows": 1000,
+        "support_platform": "zendesk",
+    })
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(payload)
+
+    assert (
+        "input_provider.metadata.blob_bytes must be a positive integer for json_blob_url submit"
+        in errors
+    )
+
+
+def test_validate_submit_envelope_requires_multipart_upload_byte_counter() -> None:
+    payload = _submit_payload()
+
+    _request_id, _snapshot, _diagnostics, errors = smoke._validate_submit_envelope(
+        payload,
+        submit_mode="multipart",
+    )
+
+    assert (
+        "input_provider.metadata.uploaded_bytes must be a positive integer for multipart submit"
+        in errors
+    )
 
 
 def test_validate_submit_envelope_rejects_missing_deflection_step() -> None:
@@ -252,6 +356,54 @@ def test_run_success_posts_submit_and_probes_snapshot_and_locked_artifact(monkey
     serialized = json.dumps(summary)
     assert "token-secret" not in serialized
     assert "signed-secret" not in serialized
+
+
+def test_run_success_posts_multipart_csv_and_probes_locked_artifact(monkeypatch, tmp_path):
+    csv_file = _write_csv(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open(
+            [
+                (
+                    200,
+                    _submit_payload(
+                        metadata={
+                            "source": "portfolio_deflection_submit",
+                            "source_row_count": 3,
+                            "submitted_row_count": 3,
+                            "truncated_row_count": 0,
+                            "max_source_material_rows": 1000,
+                            "uploaded_bytes": csv_file.stat().st_size,
+                            "support_platform": "zendesk",
+                        }
+                    ),
+                ),
+                (200, SNAPSHOT),
+                (403, {"detail": "payment_required"}),
+            ],
+            calls,
+        ),
+    )
+    args = smoke._build_parser().parse_args(_base_csv_args(tmp_path, csv_file))
+
+    summary = smoke.run(args)
+
+    assert summary["ok"] is True
+    assert summary["submit_mode"] == "multipart"
+    assert summary["csv_file_size"] == csv_file.stat().st_size
+    assert summary["blob_host"] == ""
+    assert calls[0]["body"] is None
+    assert calls[0]["content_type"].startswith("multipart/form-data; boundary=")
+    assert 'name="csv_file"; filename="tickets.csv"' in calls[0]["body_text"]
+    assert "How do I export reports?" in calls[0]["body_text"]
+    assert 'name="support_platform"' in calls[0]["body_text"]
+    assert "blob_url" not in calls[0]["body_text"]
+    assert summary["submit"]["diagnostics"]["metadata"]["uploaded_bytes"] == csv_file.stat().st_size
+    serialized = json.dumps(summary)
+    assert "token-secret" not in serialized
+    assert "How do I export reports?" not in serialized
 
 
 def test_run_fails_closed_when_snapshot_does_not_match_submit(monkeypatch, tmp_path):
@@ -375,3 +527,39 @@ def test_main_preflight_writes_redacted_result(tmp_path, capsys):
     serialized = captured.out + result_path.read_text(encoding="utf-8")
     assert "token-secret" not in serialized
     assert "signed-secret" not in serialized
+
+
+def test_main_multipart_preflight_records_mode_without_csv_contents(tmp_path, capsys):
+    csv_file = _write_csv(tmp_path)
+    result_path = tmp_path / "preflight.json"
+
+    exit_code = smoke.main([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-secret",
+        "--account-id",
+        "acct-123",
+        "--csv-file",
+        str(csv_file),
+        "--support-platform",
+        "zendesk",
+        "--company-name",
+        "Acme Co.",
+        "--contact-email",
+        "lead@example.com",
+        "--preflight-only",
+        "--json",
+        "--output-result",
+        str(result_path),
+    ])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["submit_mode"] == "multipart"
+    assert payload["csv_file_size"] == csv_file.stat().st_size
+    serialized = captured.out + result_path.read_text(encoding="utf-8")
+    assert "token-secret" not in serialized
+    assert "How do I export reports?" not in serialized


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Multipart-Smoke.md
Slice phase: Functional validation

Update the hosted FAQ deflection submit handoff smoke so operators can prove the #1184 production contract: authenticated multipart CSV upload from the portfolio side into ATLAS, followed by the existing execute-envelope, snapshot, and unpaid-artifact checks. The legacy JSON `blob_url` mode remains available as rollback coverage, and the smoke now fails closed unless the response includes the mode-specific byte counter.

## Intentional
- The smoke still rejects localhost API hosts because this remains a hosted handoff proof.
- `blob_url` support remains because the backend still accepts that compatibility contract.
- The script hand-builds multipart with the Python standard library so extracted CI does not need `requests`.

## Deferred
- Removing the legacy JSON `blob_url` smoke mode remains deferred until the portfolio production path no longer needs rollback coverage.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` - 16 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2862 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-multipart-smoke.md` - passed.

## Diff size
4 files, +508 / -45.
