### PR TITLE
PR-FAQ-Deflection-Portfolio-Upload-Shell

### DIFF
--- a/.github/workflows/portfolio_ui_checks.yml
+++ b/.github/workflows/portfolio_ui_checks.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Test FAQ deflection upload shell
+        run: npm run test:deflection-upload-shell
+
       - name: Test FAQ deflection result page
         run: npm run test:deflection-result
 

--- a/plans/PR-FAQ-Deflection-Portfolio-Upload-Shell.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Upload-Shell.md
@@ -1,0 +1,108 @@
+# PR-FAQ-Deflection-Portfolio-Upload-Shell
+
+## Why this slice exists
+
+The FAQ deflection portfolio result page can now show the free snapshot, create
+Checkout, hydrate ATLAS state through a server proxy, and render the paid
+artifact after unlock. The missing portfolio-owned entry point is the submit
+page before that result route.
+
+The backend multipart submit contract has now landed on `main`, but wiring the
+portfolio server-to-ATLAS upload is a separate trust-boundary slice. This PR
+adds the customer-facing portfolio upload shell and a fail-closed portfolio
+submit endpoint so the next slice can replace the guarded response with the
+server-side ATLAS handoff without also introducing the page.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Add a portfolio FAQ deflection upload route at `/services/faq-deflection`.
+2. Render a CSV upload shell with company/contact/platform/account fields and
+   client-side file readiness state.
+3. Add a portfolio server submit endpoint that rejects requests with a
+   non-2xx guard response until the live ATLAS forwarding slice lands.
+4. Link the upload route into the services page and keep the result route
+   unchanged.
+5. Add focused portfolio tests and enroll them in the existing portfolio UI CI
+   workflow.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Upload-Shell.md`
+- `.github/workflows/portfolio_ui_checks.yml`
+- `portfolio-ui/package.json`
+- `portfolio-ui/src/App.tsx`
+- `portfolio-ui/src/pages/Services.tsx`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The new React route is a portfolio-owned shell for preparing the CSV handoff.
+It keeps all entered data in local component state, validates that the selected
+file looks like a CSV and is within the 50 MB portfolio cap, and marks the
+submit action disabled until the server contract is wired. No browser code
+contains ATLAS host or JWT configuration.
+
+The new `/api/content-ops/deflection/submit` handler is intentionally
+fail-closed. It accepts only `POST`, sets `Cache-Control: no-store`, and returns
+`503 { ok: false, error: "deflection_submit_backend_pending" }`. It does not
+call ATLAS or read service credentials. This gives the portfolio a stable route
+and test marker without pretending the portfolio server-to-ATLAS forwarding
+path is live before that trust-boundary slice is built.
+
+## Intentional
+
+- The shell does not upload to ATLAS yet. This keeps the customer-facing route
+  and the server credential forwarding path in separate reviewable slices.
+- The server endpoint returns non-2xx while live forwarding is pending so no
+  user can mistake the shell for a completed report generation path.
+- The upload page uses existing portfolio styling and route-level lazy loading
+  instead of adding a design-system dependency.
+- The result page remains the only route that can unlock or render the paid
+  artifact.
+
+## Deferred
+
+- Wire the server submit endpoint to the ATLAS multipart submit contract now
+  that the backend contract is on `main`.
+- Add private Vercel Blob persistence if the portfolio needs to store uploads
+  before forwarding bytes to ATLAS.
+- Parked hardening: none.
+
+## Verification
+
+- Command: npm run test:deflection-upload-shell --prefix portfolio-ui
+  - Result: passed, 6 checks.
+- Command: npm run test:deflection-result --prefix portfolio-ui
+  - Result: passed, 11 checks.
+- Command: npm run test:deflection-atlas-proxy --prefix portfolio-ui
+  - Result: passed, 11 checks.
+- Command: npm run build --prefix portfolio-ui
+  - Result: passed using the existing ignored
+  root `portfolio-ui/node_modules` install for local verification; `npm ci` in
+  this worktree is blocked by pre-existing portfolio lockfile drift.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Result: extracted_reasoning_core 295 passed; extracted_content_pipeline
+    2859 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-upload-shell.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| Upload shell route/page | ~220 |
+| Guarded submit endpoint | ~45 |
+| Tests/package/workflow | ~120 |
+| Services link | ~20 |
+| **Total** | **~495** |
+
+This slice is above 400 LOC because it adds a new customer-facing route, the
+fail-closed server boundary, and CI-enrolled tests together. Splitting the page
+from the guarded endpoint would leave the shell without the trust-boundary
+regression checks reviewers need.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -1,0 +1,23 @@
+const SUBMIT_PENDING_ERROR = "deflection_submit_backend_pending";
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(payload));
+}
+
+export { SUBMIT_PENDING_ERROR };
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    json(res, 405, { ok: false, error: "method_not_allowed" });
+    return;
+  }
+
+  json(res, 503, {
+    ok: false,
+    error: SUBMIT_PENDING_ERROR,
+  });
+}

--- a/portfolio-ui/package.json
+++ b/portfolio-ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test:deflection-upload-shell": "node scripts/faq-deflection-upload-shell.test.mjs",
     "test:deflection-atlas-proxy": "node scripts/faq-deflection-atlas-proxy.test.mjs",
     "test:deflection-result": "node scripts/faq-deflection-result-page.test.mjs",
     "preview": "vite preview"

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import submitHandler, {
+  SUBMIT_PENDING_ERROR,
+} from "../api/content-ops/deflection/submit.js";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
+const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "utf8");
+const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
+const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
+const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+function mockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(value) {
+      this.body = value;
+    },
+  };
+}
+
+await test("upload shell route is wired into the portfolio app and services page", () => {
+  assert.match(appSource, /FaqDeflectionUpload/);
+  assert.match(appSource, /\/services\/faq-deflection/);
+  assert.match(servicesSource, /\/services\/faq-deflection/);
+  assert.match(servicesSource, /FAQ Deflection Upload/);
+});
+
+await test("upload shell exposes stable validation and submit guard markers", () => {
+  for (const marker of [
+    "data-atlas-deflection-upload",
+    "data-atlas-deflection-csv-file",
+    "data-atlas-deflection-company",
+    "data-atlas-deflection-contact-email",
+    "data-atlas-deflection-support-platform",
+    "data-atlas-deflection-account-id-input",
+    "data-atlas-deflection-submit-guard",
+  ]) {
+    assert.match(uploadSource, new RegExp(marker));
+  }
+  assert.match(uploadSource, /MAX_CSV_BYTES = 50 \* 1024 \* 1024/);
+  assert.match(uploadSource, /Submit pending backend contract/);
+});
+
+await test("upload shell and submit guard do not expose ATLAS service credentials", () => {
+  for (const source of [uploadSource, submitSource]) {
+    assert.doesNotMatch(source, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
+    assert.doesNotMatch(source, /Authorization/);
+    assert.doesNotMatch(source, /\/paid\b/);
+  }
+});
+
+await test("portfolio submit endpoint fails closed until live forwarding lands", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error("submit endpoint must not call ATLAS while guarded");
+  };
+  const res = mockResponse();
+  try {
+    await submitHandler({ method: "POST" }, res);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.headers["Cache-Control"], "no-store");
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    error: SUBMIT_PENDING_ERROR,
+  });
+});
+
+await test("portfolio submit endpoint only accepts POST", async () => {
+  const res = mockResponse();
+  await submitHandler({ method: "GET" }, res);
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.headers.Allow, "POST");
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    error: "method_not_allowed",
+  });
+});
+
+await test("upload shell test is enrolled in package scripts", () => {
+  assert.equal(
+    packageJson.scripts["test:deflection-upload-shell"],
+    "node scripts/faq-deflection-upload-shell.test.mjs",
+  );
+});

--- a/portfolio-ui/src/App.tsx
+++ b/portfolio-ui/src/App.tsx
@@ -6,6 +6,7 @@ const Home = lazy(() => import("@/pages/Home"));
 const Projects = lazy(() => import("@/pages/Projects"));
 const ProjectDetail = lazy(() => import("@/pages/ProjectDetail"));
 const Services = lazy(() => import("@/pages/Services"));
+const FaqDeflectionUpload = lazy(() => import("@/pages/FaqDeflectionUpload"));
 const FaqDeflectionResult = lazy(() => import("@/pages/FaqDeflectionResult"));
 const Systems = lazy(() => import("@/pages/Systems"));
 const Insights = lazy(() => import("@/pages/Insights"));
@@ -31,6 +32,7 @@ export default function App() {
           <Route path="/projects" element={<Projects />} />
           <Route path="/projects/:slug" element={<ProjectDetail />} />
           <Route path="/services" element={<Services />} />
+          <Route path="/services/faq-deflection" element={<FaqDeflectionUpload />} />
           <Route
             path="/services/faq-deflection/results/:requestId"
             element={<FaqDeflectionResult />}

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  FileSpreadsheet,
+  LockKeyhole,
+  Upload,
+} from "lucide-react";
+import { SeoHead } from "@/components/seo/SeoHead";
+
+const SUBMIT_ENDPOINT = "/api/content-ops/deflection/submit";
+const MAX_CSV_BYTES = 50 * 1024 * 1024;
+const SUPPORT_PLATFORMS = [
+  { value: "zendesk", label: "Zendesk" },
+  { value: "intercom", label: "Intercom" },
+  { value: "help-scout", label: "Help Scout" },
+  { value: "freshdesk", label: "Freshdesk" },
+] as const;
+
+type UploadState =
+  | { status: "empty" }
+  | { status: "ready"; fileName: string; fileSize: number }
+  | { status: "invalid"; message: string };
+
+function formatBytes(bytes: number) {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} bytes`;
+}
+
+function fileState(file: File | undefined): UploadState {
+  if (!file) return { status: "empty" };
+  const lowerName = file.name.toLowerCase();
+  if (!lowerName.endsWith(".csv")) {
+    return { status: "invalid", message: "Select a CSV export." };
+  }
+  if (file.size <= 0) {
+    return { status: "invalid", message: "The selected CSV is empty." };
+  }
+  if (file.size > MAX_CSV_BYTES) {
+    return { status: "invalid", message: "CSV exports must be 50 MB or smaller." };
+  }
+  return { status: "ready", fileName: file.name, fileSize: file.size };
+}
+
+export default function FaqDeflectionUpload() {
+  const [companyName, setCompanyName] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [accountId, setAccountId] = useState("");
+  const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
+  const [upload, setUpload] = useState<UploadState>({ status: "empty" });
+
+  const fieldsReady = useMemo(
+    () =>
+      Boolean(
+        companyName.trim() &&
+          contactEmail.trim() &&
+          accountId.trim() &&
+          supportPlatform &&
+          upload.status === "ready",
+      ),
+    [accountId, companyName, contactEmail, supportPlatform, upload.status],
+  );
+
+  return (
+    <>
+      <SeoHead
+        meta={{
+          title: "FAQ Deflection Upload",
+          description:
+            "Prepare a support-ticket CSV for the FAQ deflection report handoff.",
+          canonicalPath: "/services/faq-deflection",
+          noindex: true,
+        }}
+      />
+
+      <section
+        className="mx-auto max-w-6xl px-6 py-10 md:py-14"
+        data-atlas-deflection-upload
+        data-atlas-deflection-submit-endpoint={SUBMIT_ENDPOINT}
+      >
+        <Link
+          to="/services"
+          className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-surface-200 transition-colors hover:text-white"
+        >
+          <ArrowLeft size={16} />
+          Services
+        </Link>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <form
+            className="rounded-lg border border-surface-700/60 bg-surface-800/35 p-6"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-primary-500/15 text-primary-300">
+                <FileSpreadsheet size={22} />
+              </div>
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.16em] text-primary-300">
+                  FAQ deflection
+                </p>
+                <h1 className="text-3xl font-bold tracking-normal text-white md:text-4xl">
+                  Support-ticket CSV upload
+                </h1>
+              </div>
+            </div>
+
+            <div className="mt-8 grid gap-5 md:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-surface-100">Company</span>
+                <input
+                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
+                  data-atlas-deflection-company
+                  value={companyName}
+                  onChange={(event) => setCompanyName(event.target.value)}
+                  placeholder="Acme Co."
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-surface-100">Contact email</span>
+                <input
+                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
+                  data-atlas-deflection-contact-email
+                  type="email"
+                  value={contactEmail}
+                  onChange={(event) => setContactEmail(event.target.value)}
+                  placeholder="lead@example.com"
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-surface-100">Support platform</span>
+                <select
+                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 text-sm text-white outline-none transition focus:border-primary-400"
+                  data-atlas-deflection-support-platform
+                  value={supportPlatform}
+                  onChange={(event) => setSupportPlatform(event.target.value)}
+                >
+                  {SUPPORT_PLATFORMS.map((platform) => (
+                    <option key={platform.value} value={platform.value}>
+                      {platform.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-surface-100">ATLAS account ID</span>
+                <input
+                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 font-mono text-xs text-white outline-none transition focus:border-primary-400"
+                  data-atlas-deflection-account-id-input
+                  value={accountId}
+                  onChange={(event) => setAccountId(event.target.value)}
+                  placeholder="2b2b950d-f64b-4852-bc30-f92a34cdf169"
+                />
+              </label>
+            </div>
+
+            <label className="mt-6 block rounded-lg border border-dashed border-surface-600 bg-surface-900/55 p-5 transition focus-within:border-primary-400">
+              <span className="flex items-center gap-3 text-sm font-medium text-surface-100">
+                <Upload size={18} className="text-primary-300" />
+                CSV export
+              </span>
+              <input
+                className="mt-4 block w-full cursor-pointer rounded-lg border border-surface-700 bg-surface-900 text-sm text-surface-100 file:mr-4 file:border-0 file:bg-primary-500 file:px-4 file:py-3 file:text-sm file:font-semibold file:text-surface-900"
+                data-atlas-deflection-csv-file
+                type="file"
+                accept=".csv,text/csv"
+                onChange={(event) => setUpload(fileState(event.target.files?.[0]))}
+              />
+              <span className="mt-3 block text-xs text-surface-200/60">
+                50 MB cap. CSV bytes stay on the portfolio side until the server
+                submit contract is enabled.
+              </span>
+            </label>
+
+            <div className="mt-5 min-h-12">
+              {upload.status === "ready" && (
+                <div className="flex items-start gap-3 rounded-lg border border-primary-500/30 bg-primary-500/10 p-4 text-sm text-primary-100">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary-300" />
+                  <p>
+                    {upload.fileName} selected ({formatBytes(upload.fileSize)}).
+                  </p>
+                </div>
+              )}
+              {upload.status === "invalid" && (
+                <div className="flex items-start gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 p-4 text-sm text-amber-100">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-amber-300" />
+                  <p>{upload.message}</p>
+                </div>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-surface-700 px-4 py-3 text-sm font-semibold text-surface-200/65"
+              data-atlas-deflection-submit-guard
+              disabled
+              aria-disabled="true"
+            >
+              <LockKeyhole size={16} />
+              Submit pending backend contract
+            </button>
+          </form>
+
+          <aside className="h-fit rounded-lg border border-surface-700/60 bg-surface-800/45 p-6">
+            <h2 className="text-lg font-semibold text-white">Handoff state</h2>
+            <dl className="mt-5 space-y-4 text-sm">
+              <div>
+                <dt className="text-surface-200/60">Upload fields</dt>
+                <dd className="mt-1 text-surface-100">
+                  {fieldsReady ? "Ready" : "Waiting for required values"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-surface-200/60">Server endpoint</dt>
+                <dd className="mt-1 break-all font-mono text-xs text-surface-100">
+                  {SUBMIT_ENDPOINT}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-surface-200/60">Current response</dt>
+                <dd className="mt-1 font-mono text-xs text-surface-100">
+                  deflection_submit_backend_pending
+                </dd>
+              </div>
+            </dl>
+            <p className="mt-5 text-sm leading-6 text-surface-200/70">
+              The live handoff remains closed until the ATLAS multipart submit
+              contract is merged on main.
+            </p>
+          </aside>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/portfolio-ui/src/pages/Services.tsx
+++ b/portfolio-ui/src/pages/Services.tsx
@@ -195,6 +195,12 @@ const processPhases: ProcessPhase[] = [
 
 const servicesCrossLinks = [
   {
+    to: "/services/faq-deflection",
+    title: "FAQ Deflection Upload",
+    blurb:
+      "Prepare a support-ticket CSV for the guarded FAQ deflection report handoff.",
+  },
+  {
     to: "/projects",
     title: "Project Deep Dives",
     blurb:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Upload-Shell.md
Slice phase: Vertical slice

Add a guarded portfolio upload shell for FAQ deflection reports at `/services/faq-deflection`. The page captures the CSV handoff fields and validates the selected CSV locally, while the server submit endpoint fails closed until the live portfolio server-to-ATLAS forwarding slice lands.

## Intentional
- The shell does not upload to ATLAS yet so the customer-facing route and server credential forwarding path stay in separate reviewable slices.
- `/api/content-ops/deflection/submit` returns a non-2xx guarded response and does not call ATLAS or read service credentials.
- The result page remains the only route that can unlock or render the paid artifact.
- The new upload test is enrolled in the existing portfolio UI CI lane.

## Deferred
- Wire the server submit endpoint to the ATLAS multipart submit contract now that the backend contract is on `main`.
- Add private Vercel Blob persistence if the portfolio needs to store uploads before forwarding bytes to ATLAS.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - passed, 6 checks.
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 11 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2859 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-upload-shell.md` - passed.

## Diff size
8 files, +494 / -0
