### PR TITLE
PR-FAQ-Deflection-Portfolio-Live-Submit

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Live-Submit.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Live-Submit.md
@@ -1,0 +1,122 @@
+# PR-FAQ-Deflection-Portfolio-Live-Submit
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Portfolio-Upload-Shell added the customer-facing portfolio
+upload route and a fail-closed submit endpoint. PR-FAQ-Deflection-Submit-
+Multipart-CSV is now on `main`, so the portfolio can complete the next trust
+boundary slice: accept the browser CSV form, forward raw multipart bytes to
+ATLAS from the server, and return the canonical result path without exposing
+ATLAS credentials to the browser.
+
+This is the thinnest live submit path after the upload shell. It does not add
+Blob persistence or rich progress tracking; it proves the server-to-server
+handoff and keeps the result page responsible for hydrating real snapshot and
+paid artifact state.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Enable the portfolio upload page to submit `multipart/form-data` to the
+   portfolio server endpoint.
+2. Forward the raw multipart body from the portfolio server to ATLAS
+   `/api/v1/content-ops/deflection-reports/submit` with the server-only B2B
+   JWT.
+3. Bind the submit response to the configured `ATLAS_ACCOUNT_ID`; reject browser
+   account mismatches before calling ATLAS.
+4. Return only `request_id`, `account_id`, and `result_path` to the browser,
+   then redirect to the hosted result page.
+5. Keep paid artifact rendering and snapshot hydration owned by the existing
+   result page/proxy path.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Live-Submit.md`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The browser page builds a `FormData` body with `csv_file`, `support_platform`,
+`company_name`, `contact_email`, and `limit`. It sends the user-entered
+`account_id` in an `X-Atlas-Account-Id` header only for server-side binding
+validation; ATLAS still derives account scope from the service JWT.
+
+The portfolio endpoint validates:
+
+```text
+method === POST
+Content-Type includes multipart/form-data
+ATLAS_API_BASE_URL, ATLAS_B2B_JWT, and ATLAS_ACCOUNT_ID are configured
+X-Atlas-Account-Id matches ATLAS_ACCOUNT_ID
+Content-Length/body stay below the Vercel Functions request cap for this live path
+```
+
+It then forwards the raw multipart bytes to ATLAS with
+`Authorization: Bearer <ATLAS_B2B_JWT>` and the configured timeout as an
+`AbortController` signal. On ATLAS success, the response is projected to
+`{ ok, request_id, account_id, result_path }`; the execute envelope is not
+returned to the browser. The browser redirects to `result_path`, where the
+existing server-rendered result page hydrates the real snapshot and paid artifact
+state.
+
+## Intentional
+
+- The portfolio endpoint does not parse CSV rows or synthesize snapshot counts.
+  ATLAS remains the source of truth for report creation and result hydration.
+- The public response does not include the ATLAS execute envelope, support
+  ticket rows, JWT, or env-var names.
+- The browser supplies `account_id` for continuity only; the server enforces
+  equality with the configured service account before forwarding.
+- The live portfolio path caps selected CSVs at 4 MB so Vercel can deliver the
+  request to the API route; the backend's larger submit limit remains available
+  for a later direct/Blob upload flow.
+- Freshdesk is submitted as `other`, and Help Scout as `help_scout`, matching
+  the ATLAS submit validator's accepted support-platform values.
+- Private Blob persistence remains deferred. This slice submits the browser
+  selected CSV directly through the portfolio server.
+
+## Deferred
+
+- Add private Vercel Blob persistence if uploads need durable storage before
+  forwarding bytes to ATLAS or need to preserve the backend's larger 50 MB CSV
+  submit limit from the browser.
+- Add richer progress/retry UX after the live submit path has production
+  verification.
+- Parked hardening: none.
+
+## Verification
+
+- Command: npm run test:deflection-upload-shell --prefix portfolio-ui
+  - Result: passed, 10 checks.
+- Command: npm run test:deflection-result --prefix portfolio-ui
+  - Result: passed, 11 checks.
+- Command: npm run test:deflection-atlas-proxy --prefix portfolio-ui
+  - Result: passed, 11 checks.
+- Command: npm run build --prefix portfolio-ui
+  - Result: passed using the existing ignored
+  root `portfolio-ui/node_modules` install for local verification; `npm ci` in
+  this worktree is blocked by pre-existing portfolio lockfile drift.
+- Command: bash scripts/run_extracted_pipeline_checks.sh
+  - Result: extracted_reasoning_core 295 passed; extracted_content_pipeline
+    2859 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-live-submit.md
+  - Result: passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~115 |
+| Submit endpoint forwarding | ~185 |
+| Upload page live submit | ~90 |
+| Tests | ~215 |
+| **Total** | **~605** |
+
+This slice is above 400 LOC because the trust-boundary forwarding endpoint,
+browser submit state, and negative fixtures need to ship together. Splitting
+the tests away from the endpoint would leave the credential boundary
+under-proven.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -1,4 +1,17 @@
-const SUBMIT_PENDING_ERROR = "deflection_submit_backend_pending";
+import { atlasUrl, clean, configFromEnv } from "./atlas-report.js";
+import { resultPath } from "./checkout.js";
+
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit";
+const MAX_CSV_BYTES = 4 * 1024 * 1024;
+const MAX_MULTIPART_OVERHEAD_BYTES = 256 * 1024;
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
 
 function json(res, statusCode, payload) {
   res.statusCode = statusCode;
@@ -7,7 +20,136 @@ function json(res, statusCode, payload) {
   res.end(JSON.stringify(payload));
 }
 
-export { SUBMIT_PENDING_ERROR };
+function header(req, name) {
+  const lower = name.toLowerCase();
+  return clean(req.headers?.[lower]) || clean(req.headers?.[name]);
+}
+
+function publicSubmitConfig(env = process.env) {
+  const config = configFromEnv(env);
+  const errors = [];
+  if (!config.baseUrl) errors.push("atlas_base_url_missing");
+  if (!config.token) errors.push("atlas_token_missing");
+  if (!config.accountId || !UUID_RE.test(config.accountId)) {
+    errors.push("atlas_account_missing");
+  }
+  return { config, errors };
+}
+
+function rejectOversizeContentLength(req) {
+  const raw = header(req, "content-length");
+  if (!raw) return null;
+  const length = Number.parseInt(raw, 10);
+  if (!Number.isFinite(length)) return null;
+  if (length > MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES) {
+    return {
+      ok: false,
+      statusCode: 413,
+      error: "deflection_submit_csv_too_large",
+    };
+  }
+  return null;
+}
+
+async function readRawBody(req, maxBytes = MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES) {
+  if (Buffer.isBuffer(req.body)) {
+    if (req.body.length > maxBytes) return { ok: false, statusCode: 413 };
+    return { ok: true, body: req.body };
+  }
+  if (typeof req.body === "string") {
+    const body = Buffer.from(req.body);
+    if (body.length > maxBytes) return { ok: false, statusCode: 413 };
+    return { ok: true, body };
+  }
+  if (req.body instanceof ArrayBuffer) {
+    const body = Buffer.from(req.body);
+    if (body.length > maxBytes) return { ok: false, statusCode: 413 };
+    return { ok: true, body };
+  }
+
+  const chunks = [];
+  let total = 0;
+  try {
+    for await (const chunk of req) {
+      const buffer = Buffer.from(chunk);
+      total += buffer.length;
+      if (total > maxBytes) return { ok: false, statusCode: 413 };
+      chunks.push(buffer);
+    }
+  } catch {
+    return { ok: false, statusCode: 400 };
+  }
+  return { ok: true, body: Buffer.concat(chunks) };
+}
+
+function projectSubmitPayload(payload, accountId) {
+  const requestId = clean(payload?.request_id);
+  if (!requestId || !REQUEST_ID_RE.test(requestId)) {
+    return null;
+  }
+  return {
+    ok: true,
+    request_id: requestId,
+    account_id: accountId,
+    result_path: resultPath(requestId, accountId, ""),
+  };
+}
+
+async function forwardSubmit({ config, contentType, body, fetchImpl = fetch }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(atlasUrl(config.baseUrl, SUBMIT_PATH), {
+      method: "POST",
+      headers: {
+        "Accept": "application/json",
+        "Authorization": `Bearer ${config.token}`,
+        "Content-Type": contentType,
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      statusCode: error?.name === "AbortError" ? 504 : 502,
+      error: "atlas_submit_unreachable",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+  const text = await response.text();
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return { ok: false, statusCode: 502, error: "atlas_submit_invalid_json" };
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      statusCode: response.status >= 400 && response.status < 500 ? response.status : 502,
+      error: "atlas_submit_failed",
+      atlas_status: response.status,
+    };
+  }
+  const projected = projectSubmitPayload(payload, config.accountId);
+  if (!projected) {
+    return { ok: false, statusCode: 502, error: "atlas_submit_contract_violation" };
+  }
+  return { ok: true, statusCode: 200, payload: projected };
+}
+
+export {
+  MAX_CSV_BYTES,
+  MAX_MULTIPART_OVERHEAD_BYTES,
+  SUBMIT_PATH,
+  forwardSubmit,
+  projectSubmitPayload,
+};
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
@@ -16,8 +158,57 @@ export default async function handler(req, res) {
     return;
   }
 
-  json(res, 503, {
-    ok: false,
-    error: SUBMIT_PENDING_ERROR,
-  });
+  const contentType = header(req, "content-type");
+  if (!contentType.includes("multipart/form-data")) {
+    json(res, 415, { ok: false, error: "multipart_required" });
+    return;
+  }
+
+  const { config: submitConfig, errors } = publicSubmitConfig();
+  if (errors.length > 0) {
+    json(res, 503, { ok: false, error: "atlas_submit_not_configured" });
+    return;
+  }
+
+  const accountId = header(req, "x-atlas-account-id");
+  if (!accountId || !UUID_RE.test(accountId) || accountId !== submitConfig.accountId) {
+    json(res, 400, { ok: false, error: "invalid_account_id" });
+    return;
+  }
+
+  const oversize = rejectOversizeContentLength(req);
+  if (oversize) {
+    json(res, oversize.statusCode, { ok: false, error: oversize.error });
+    return;
+  }
+
+  const bodyResult = await readRawBody(req);
+  if (!bodyResult.ok) {
+    json(res, bodyResult.statusCode, {
+      ok: false,
+      error:
+        bodyResult.statusCode === 413
+          ? "deflection_submit_csv_too_large"
+          : "deflection_submit_body_unreadable",
+    });
+    return;
+  }
+
+  let result;
+  try {
+    result = await forwardSubmit({ config: submitConfig, contentType, body: bodyResult.body });
+  } catch {
+    json(res, 502, { ok: false, error: "atlas_submit_unreachable" });
+    return;
+  }
+
+  if (!result.ok) {
+    json(res, result.statusCode, {
+      ok: false,
+      error: result.error,
+      atlas_status: result.atlas_status,
+    });
+    return;
+  }
+  json(res, 200, result.payload);
 }

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -3,7 +3,10 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import submitHandler, {
-  SUBMIT_PENDING_ERROR,
+  MAX_CSV_BYTES,
+  MAX_MULTIPART_OVERHEAD_BYTES,
+  SUBMIT_PATH,
+  forwardSubmit,
 } from "../api/content-ops/deflection/submit.js";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -12,6 +15,37 @@ const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "
 const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
 const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
 const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+
+const ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
+const ENV = {
+  ATLAS_API_BASE_URL: "https://atlas.example.com",
+  ATLAS_B2B_JWT: "secret-service-token",
+  ATLAS_ACCOUNT_ID: ACCOUNT_ID,
+};
+const MULTIPART_BODY = Buffer.from(
+  [
+    "--atlas",
+    'Content-Disposition: form-data; name="support_platform"',
+    "",
+    "zendesk",
+    "--atlas",
+    'Content-Disposition: form-data; name="company_name"',
+    "",
+    "Acme Co.",
+    "--atlas",
+    'Content-Disposition: form-data; name="contact_email"',
+    "",
+    "lead@acme.example",
+    "--atlas",
+    'Content-Disposition: form-data; name="csv_file"; filename="tickets.csv"',
+    "Content-Type: text/csv",
+    "",
+    "ticket_id,message",
+    "ticket-1,How do I export reports?",
+    "--atlas--",
+    "",
+  ].join("\r\n"),
+);
 
 async function test(name, fn) {
   try {
@@ -37,6 +71,38 @@ function mockResponse() {
   };
 }
 
+function request({ method = "POST", headers = {}, body = MULTIPART_BODY } = {}) {
+  return {
+    method,
+    headers: {
+      "content-type": "multipart/form-data; boundary=atlas",
+      "content-length": String(body.length),
+      "x-atlas-account-id": ACCOUNT_ID,
+      ...headers,
+    },
+    body,
+  };
+}
+
+async function withEnv(nextEnv, fn) {
+  const previous = {};
+  for (const key of Object.keys(nextEnv)) {
+    previous[key] = process.env[key];
+    process.env[key] = nextEnv[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(nextEnv)) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
 await test("upload shell route is wired into the portfolio app and services page", () => {
   assert.match(appSource, /FaqDeflectionUpload/);
   assert.match(appSource, /\/services\/faq-deflection/);
@@ -44,7 +110,7 @@ await test("upload shell route is wired into the portfolio app and services page
   assert.match(servicesSource, /FAQ Deflection Upload/);
 });
 
-await test("upload shell exposes stable validation and submit guard markers", () => {
+await test("upload shell exposes live submit markers and avoids browser credentials", () => {
   for (const marker of [
     "data-atlas-deflection-upload",
     "data-atlas-deflection-csv-file",
@@ -52,53 +118,176 @@ await test("upload shell exposes stable validation and submit guard markers", ()
     "data-atlas-deflection-contact-email",
     "data-atlas-deflection-support-platform",
     "data-atlas-deflection-account-id-input",
-    "data-atlas-deflection-submit-guard",
+    "data-atlas-deflection-submit",
   ]) {
     assert.match(uploadSource, new RegExp(marker));
   }
-  assert.match(uploadSource, /MAX_CSV_BYTES = 50 \* 1024 \* 1024/);
-  assert.match(uploadSource, /Submit pending backend contract/);
+  assert.match(uploadSource, /MAX_CSV_BYTES = 4 \* 1024 \* 1024/);
+  assert.match(uploadSource, /value: "help_scout"/);
+  assert.match(uploadSource, /value: "other", label: "Freshdesk \/ other"/);
+  assert.doesNotMatch(uploadSource, /value: "freshdesk"/);
+  assert.doesNotMatch(uploadSource, /value: "help-scout"/);
+  assert.match(uploadSource, /new FormData/);
+  assert.match(uploadSource, /X-Atlas-Account-Id/);
+  assert.doesNotMatch(uploadSource, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
+  assert.doesNotMatch(uploadSource, /Authorization/);
+  assert.doesNotMatch(uploadSource, /\/paid\b/);
 });
 
-await test("upload shell and submit guard do not expose ATLAS service credentials", () => {
-  for (const source of [uploadSource, submitSource]) {
-    assert.doesNotMatch(source, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
-    assert.doesNotMatch(source, /Authorization/);
-    assert.doesNotMatch(source, /\/paid\b/);
-  }
+await test("portfolio submit endpoint pins raw multipart body handling", () => {
+  assert.match(submitSource, /bodyParser:\s*false/);
 });
 
-await test("portfolio submit endpoint fails closed until live forwarding lands", async () => {
+await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", async () => {
   const previousFetch = globalThis.fetch;
-  let fetchCalled = false;
-  globalThis.fetch = async () => {
-    fetchCalled = true;
-    throw new Error("submit endpoint must not call ATLAS while guarded");
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ request_id: "content-ops-abc123", status: "completed" });
+      },
+    };
   };
   const res = mockResponse();
   try {
-    await submitHandler({ method: "POST" }, res);
+    await withEnv(ENV, async () => {
+      await submitHandler(request(), res);
+    });
   } finally {
     globalThis.fetch = previousFetch;
   }
 
-  assert.equal(fetchCalled, false);
-  assert.equal(res.statusCode, 503);
+  assert.equal(res.statusCode, 200);
   assert.equal(res.headers["Cache-Control"], "no-store");
   assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    request_id: "content-ops-abc123",
+    account_id: ACCOUNT_ID,
+    result_path: `/services/faq-deflection/results/content-ops-abc123?account_id=${ACCOUNT_ID}`,
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal(calls[0].options.headers["Content-Type"], "multipart/form-data; boundary=atlas");
+  assert.equal(Buffer.compare(calls[0].options.body, MULTIPART_BODY), 0);
+  assert.equal(calls[0].options.signal instanceof AbortSignal, true);
+  assert.equal(res.body.includes(ENV.ATLAS_B2B_JWT), false);
+});
+
+await test("portfolio submit forwarding times out hung ATLAS calls", async () => {
+  const result = await forwardSubmit({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1,
+    },
+    contentType: "multipart/form-data; boundary=atlas",
+    body: MULTIPART_BODY,
+    fetchImpl: async (_url, options) =>
+      new Promise((_resolve, reject) => {
+        assert.equal(options.signal instanceof AbortSignal, true);
+        options.signal.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      }),
+  });
+
+  assert.deepEqual(result, {
     ok: false,
-    error: SUBMIT_PENDING_ERROR,
+    statusCode: 504,
+    error: "atlas_submit_unreachable",
   });
 });
 
-await test("portfolio submit endpoint only accepts POST", async () => {
+await test("portfolio submit endpoint rejects account mismatch before ATLAS", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error("must not call ATLAS");
+  };
   const res = mockResponse();
-  await submitHandler({ method: "GET" }, res);
-  assert.equal(res.statusCode, 405);
-  assert.equal(res.headers.Allow, "POST");
+  try {
+    await withEnv(ENV, async () => {
+      await submitHandler(
+        request({ headers: { "x-atlas-account-id": "3b2b950d-f64b-4852-bc30-f92a34cdf169" } }),
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { ok: false, error: "invalid_account_id" });
+});
+
+await test("portfolio submit endpoint rejects oversize bodies before ATLAS", async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error("must not call ATLAS");
+  };
+  const res = mockResponse();
+  try {
+    await withEnv(ENV, async () => {
+      await submitHandler(
+        request({
+          headers: {
+            "content-length": String(MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES + 1),
+          },
+        }),
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 413);
   assert.deepEqual(JSON.parse(res.body), {
     ok: false,
+    error: "deflection_submit_csv_too_large",
+  });
+});
+
+await test("portfolio submit endpoint hides missing config details", async () => {
+  const res = mockResponse();
+  await withEnv({ ATLAS_API_BASE_URL: "", ATLAS_B2B_JWT: "", ATLAS_ACCOUNT_ID: "" }, async () => {
+    await submitHandler(request(), res);
+  });
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: false,
+    error: "atlas_submit_not_configured",
+  });
+  assert.equal(res.body.includes("ATLAS_B2B_JWT"), false);
+});
+
+await test("portfolio submit endpoint only accepts POST multipart requests", async () => {
+  const getRes = mockResponse();
+  await submitHandler(request({ method: "GET" }), getRes);
+  assert.equal(getRes.statusCode, 405);
+  assert.equal(getRes.headers.Allow, "POST");
+  assert.deepEqual(JSON.parse(getRes.body), {
+    ok: false,
     error: "method_not_allowed",
+  });
+
+  const jsonRes = mockResponse();
+  await submitHandler(request({ headers: { "content-type": "application/json" } }), jsonRes);
+  assert.equal(jsonRes.statusCode, 415);
+  assert.deepEqual(JSON.parse(jsonRes.body), {
+    ok: false,
+    error: "multipart_required",
   });
 });
 

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -5,24 +5,30 @@ import {
   ArrowLeft,
   CheckCircle2,
   FileSpreadsheet,
-  LockKeyhole,
+  Loader2,
+  Send,
   Upload,
 } from "lucide-react";
 import { SeoHead } from "@/components/seo/SeoHead";
 
 const SUBMIT_ENDPOINT = "/api/content-ops/deflection/submit";
-const MAX_CSV_BYTES = 50 * 1024 * 1024;
+const MAX_CSV_BYTES = 4 * 1024 * 1024;
 const SUPPORT_PLATFORMS = [
   { value: "zendesk", label: "Zendesk" },
   { value: "intercom", label: "Intercom" },
-  { value: "help-scout", label: "Help Scout" },
-  { value: "freshdesk", label: "Freshdesk" },
+  { value: "help_scout", label: "Help Scout" },
+  { value: "other", label: "Freshdesk / other" },
 ] as const;
 
 type UploadState =
   | { status: "empty" }
-  | { status: "ready"; fileName: string; fileSize: number }
+  | { status: "ready"; file: File; fileName: string; fileSize: number }
   | { status: "invalid"; message: string };
+
+type SubmitState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "error"; message: string };
 
 function formatBytes(bytes: number) {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -40,9 +46,9 @@ function fileState(file: File | undefined): UploadState {
     return { status: "invalid", message: "The selected CSV is empty." };
   }
   if (file.size > MAX_CSV_BYTES) {
-    return { status: "invalid", message: "CSV exports must be 50 MB or smaller." };
+    return { status: "invalid", message: "CSV exports must be 4 MB or smaller." };
   }
-  return { status: "ready", fileName: file.name, fileSize: file.size };
+  return { status: "ready", file, fileName: file.name, fileSize: file.size };
 }
 
 export default function FaqDeflectionUpload() {
@@ -51,6 +57,7 @@ export default function FaqDeflectionUpload() {
   const [accountId, setAccountId] = useState("");
   const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
   const [upload, setUpload] = useState<UploadState>({ status: "empty" });
+  const [submit, setSubmit] = useState<SubmitState>({ status: "idle" });
 
   const fieldsReady = useMemo(
     () =>
@@ -63,6 +70,41 @@ export default function FaqDeflectionUpload() {
       ),
     [accountId, companyName, contactEmail, supportPlatform, upload.status],
   );
+  const canSubmit = fieldsReady && submit.status !== "submitting";
+
+  const startSubmit = async () => {
+    if (upload.status !== "ready" || !fieldsReady) return;
+    setSubmit({ status: "submitting" });
+    const form = new FormData();
+    form.set("csv_file", upload.file);
+    form.set("support_platform", supportPlatform);
+    form.set("company_name", companyName.trim());
+    form.set("contact_email", contactEmail.trim());
+    form.set("limit", "1000");
+
+    try {
+      const response = await fetch(SUBMIT_ENDPOINT, {
+        method: "POST",
+        headers: { "X-Atlas-Account-Id": accountId.trim() },
+        body: form,
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        result_path?: unknown;
+        error?: unknown;
+      } | null;
+      if (!response.ok || !payload || typeof payload.result_path !== "string") {
+        const message =
+          payload && typeof payload.error === "string"
+            ? payload.error
+            : "FAQ deflection submit could not be started.";
+        setSubmit({ status: "error", message });
+        return;
+      }
+      window.location.assign(payload.result_path);
+    } catch {
+      setSubmit({ status: "error", message: "FAQ deflection submit could not be reached." });
+    }
+  };
 
   return (
     <>
@@ -92,7 +134,10 @@ export default function FaqDeflectionUpload() {
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_340px]">
           <form
             className="rounded-lg border border-surface-700/60 bg-surface-800/35 p-6"
-            onSubmit={(event) => event.preventDefault()}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void startSubmit();
+            }}
           >
             <div className="flex flex-wrap items-center gap-3">
               <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-primary-500/15 text-primary-300">
@@ -173,8 +218,8 @@ export default function FaqDeflectionUpload() {
                 onChange={(event) => setUpload(fileState(event.target.files?.[0]))}
               />
               <span className="mt-3 block text-xs text-surface-200/60">
-                50 MB cap. CSV bytes stay on the portfolio side until the server
-                submit contract is enabled.
+                4 MB cap. CSV bytes are forwarded through the portfolio server
+                to ATLAS; the service JWT never reaches the browser.
               </span>
             </label>
 
@@ -197,14 +242,25 @@ export default function FaqDeflectionUpload() {
 
             <button
               type="submit"
-              className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-surface-700 px-4 py-3 text-sm font-semibold text-surface-200/65"
-              data-atlas-deflection-submit-guard
-              disabled
-              aria-disabled="true"
+              className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-3 text-sm font-semibold text-surface-900 transition hover:brightness-110 disabled:cursor-not-allowed disabled:bg-surface-700 disabled:text-surface-200/65"
+              data-atlas-deflection-submit
+              disabled={!canSubmit}
             >
-              <LockKeyhole size={16} />
-              Submit pending backend contract
+              {submit.status === "submitting" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Creating report
+                </>
+              ) : (
+                <>
+                  <Send size={16} />
+                  Create locked report
+                </>
+              )}
             </button>
+            {submit.status === "error" && (
+              <p className="mt-3 text-xs leading-5 text-amber-200">{submit.message}</p>
+            )}
           </form>
 
           <aside className="h-fit rounded-lg border border-surface-700/60 bg-surface-800/45 p-6">
@@ -223,15 +279,16 @@ export default function FaqDeflectionUpload() {
                 </dd>
               </div>
               <div>
-                <dt className="text-surface-200/60">Current response</dt>
+                <dt className="text-surface-200/60">Submit mode</dt>
                 <dd className="mt-1 font-mono text-xs text-surface-100">
-                  deflection_submit_backend_pending
+                  portfolio_server_forwarding
                 </dd>
               </div>
             </dl>
             <p className="mt-5 text-sm leading-6 text-surface-200/70">
-              The live handoff remains closed until the ATLAS multipart submit
-              contract is merged on main.
+              The portfolio forwards the multipart CSV server-side, then sends
+              the browser to the hosted result page for snapshot hydration and
+              Checkout.
             </p>
           </aside>
         </div>


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Live-Submit.md
Slice phase: Vertical slice

Enable the portfolio FAQ deflection upload route to forward browser multipart CSV uploads through the portfolio server to ATLAS. The browser still never receives ATLAS host/JWT config; the public submit response is projected to `request_id`, `account_id`, and `result_path` only.

## Intentional
- The portfolio endpoint forwards raw multipart bytes and does not parse CSV rows or synthesize snapshot counts.
- Browser `account_id` is validated against the configured `ATLAS_ACCOUNT_ID` before ATLAS is called.
- The portfolio endpoint sends the configured timeout as an abort signal while forwarding to ATLAS.
- Browser CSV selection is capped at 4 MB for this Vercel API live path; larger browser uploads stay deferred to the private Blob/direct-upload follow-up.
- Freshdesk maps to ATLAS `other`, and Help Scout submits as `help_scout`, so every visible platform choice uses a supported backend value.
- The ATLAS execute envelope is not returned to the browser; the hosted result page remains responsible for snapshot/artifact hydration.
- Private Blob persistence remains deferred.

## Deferred
- Add private Vercel Blob persistence if uploads need durable storage before forwarding bytes to ATLAS or need to preserve the backend's larger 50 MB CSV submit limit from the browser.
- Add richer progress/retry UX after the live submit path has production verification.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - passed, 10 checks.
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 11 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2859 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-live-submit.md` - passed.

## Diff size
4 files, +536 / -41
