### PR TITLE
PR-Agents-Session-PR-Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ atlas-ui/.vite/
 
 # Progress logs (session artifacts)
 PROGRESS_*.md
+SESSION_STATE.local.md
 
 # Hybrid reasoning checks JSON report output
 artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,41 @@ If the plan changes mid-implementation (you discovered something the
 plan missed), update the plan doc in the same commit. The plan and
 code ship together.
 
+### 3a.1. Session ownership map
+
+Every builder session must maintain a local `SESSION_STATE.local.md`
+at the repository root, using `docs/SESSION_STATE_TEMPLATE.md` as the
+shape. This file is ignored by git because it is volatile session
+state, but it is mandatory working context.
+
+Update the map:
+
+- at session start or after compaction/restart reorientation;
+- before opening a PR;
+- after pushing a PR update;
+- after merging a PR;
+- before handing back to the operator.
+
+The map must name the current lane, current task, owned active PR
+number/title/branch/plan/head SHA when one exists, PRs this session may
+touch, PRs this session must not touch, and the last safe action.
+
+Before inspecting comments, pushing updates, closing, or merging any
+PR, the builder must verify all of the following:
+
+1. `gh pr list --state open` has been checked in this resume window.
+2. `git log --oneline -15 origin/main` has been checked for already
+   landed work.
+3. The target PR is listed in `SESSION_STATE.local.md` under "Owned
+   Active PR" or "PRs This Session May Touch".
+4. The local branch and expected head SHA match the target PR when a
+   merge or force-push is about to happen.
+
+If any check fails, stop and ask the operator. A PR in the same lane is
+not automatically owned. A PR that "looks abandoned" is not owned. A PR
+opened by another session is not owned unless the operator explicitly
+reassigns it and the map is updated first.
+
 ### 3b. Per-package guardrails
 
 Touching a package under `extracted_*/` requires the package's audit

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -15,9 +15,11 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >
 > 1. **Read first, in order:** `AGENTS.md` (the multi-session PR contract), `CLAUDE.md`, `CANONICAL.md`, `INTEGRATION_MAP.md`, `BUILD_SPEC.md`, `CONTEXT.md`. Then run `git log --oneline -20` and `gh pr list --state open` to see where things actually stand. Do not infer state from this prompt — those sources are truth.
 >
-> 2. **Your current lane:** [ONE line — e.g. "Content-Ops macro-writeback" or "deflection/Stripe monetization". If unsure, read CONTEXT.md + open PRs to find the active slice.] Stay in this lane. **Do not close, merge, or modify PRs outside your current task** — if a PR looks abandoned, ask the operator; don't close it.
+> 2. **Session ownership map:** read `SESSION_STATE.local.md` if it exists. If it does not exist, create it from `docs/SESSION_STATE_TEMPLATE.md` before any PR action. Fill in your assigned lane, current task, owned active PR (or `none`), open PRs that are explicitly **not yours**, current worktree, and last safe action. A PR that is not listed as owned in this file is not yours.
 >
-> 3. **Recurring mistakes — do NOT repeat these (each has cost a review cycle):**
+> 3. **Your current lane:** [ONE line — e.g. "Content-Ops macro-writeback" or "deflection/Stripe monetization". If unsure, read CONTEXT.md + open PRs to find the active slice.] Stay in this lane. **Do not close, merge, or modify PRs outside your current task** — if a PR looks abandoned, ask the operator; don't close it. If an open PR is in the same lane but is not marked owned in `SESSION_STATE.local.md`, treat it as someone else's PR.
+>
+> 4. **Recurring mistakes — do NOT repeat these (each has cost a review cycle):**
 >    - **Config:** every setting goes through `atlas_brain/config.py` typed `ATLAS_*` fields. **Never** read `os.environ` directly — especially for secrets.
 >    - **Test placement:** the `extracted-checks` CI suite (`run_extracted_pipeline_checks.sh`) runs with **no torch and no asyncpg**. Any test that imports `atlas_brain.services.*` or `atlas_brain.storage.database` (or anything pulling torch/asyncpg at module top) breaks *collection of the whole suite*. Host-DB/API tests go in the main suite; or import flat `_content_ops_*` modules and use lazy imports.
 >    - **Secondary writes are best-effort:** audit/history/notification writes that happen *after* a side-effectful op (publish, send, charge) must be wrapped (try/except + log) so they can't fail an already-successful operation.
@@ -27,9 +29,9 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - **Fixtures must match real producer output**, not hand-crafted shapes.
 >    - **The PR body's stated safety claim must be *enforced in code*, not just named.**
 >
-> 4. **Plan first** (`plans/PR-<Slice>.md`, the 7 sections, <400 LOC soft cap), open PRs ready-for-review (not draft), and run the per-package validation gauntlet before pushing (see CLAUDE.md "Per-package validation gauntlets").
+> 5. **Plan first** (`plans/PR-<Slice>.md`, the 7 sections, <400 LOC soft cap), open PRs ready-for-review (not draft), and run the per-package validation gauntlet before pushing (see CLAUDE.md "Per-package validation gauntlets").
 >
-> 5. **Context discipline (keeps the session from compacting mid-work):**
+> 6. **Context discipline (keeps the session from compacting mid-work):**
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
 >    - Keep the session short. If you've been alive across several PRs, expect to compact soon; finish the current slice, then let the operator restart you fresh with this bootstrap rather than running on.
@@ -42,9 +44,10 @@ Paste this when the session shows drift signals — a closed-unmerged PR, work i
 
 > Stop. You likely just compacted. Before any further action:
 > 1. Do **not** close, merge, or modify any PR — run `gh pr list --state open` and confirm which one is *yours* this task.
-> 2. Your current lane is **[X]**. If what you're about to do isn't in that lane, stop and ask.
-> 3. Don't start new work or re-do merged work — run `git log --oneline -15` to see what's already landed.
-> 4. Re-read your plan doc `plans/PR-<slice>.md` and `AGENTS.md`.
+> 2. Read `SESSION_STATE.local.md`. If it is missing, stale, or does not list the PR under "Owned Active PR" / "PRs This Session May Touch", stop and ask the operator.
+> 3. Your current lane is **[X]**. If what you're about to do isn't in that lane, stop and ask.
+> 4. Don't start new work or re-do merged work — run `git log --oneline -15` to see what's already landed.
+> 5. Re-read your plan doc `plans/PR-<slice>.md` and `AGENTS.md`.
 >
 > Confirm your current PR # and lane back to me before continuing.
 

--- a/docs/SESSION_STATE_TEMPLATE.md
+++ b/docs/SESSION_STATE_TEMPLATE.md
@@ -1,0 +1,70 @@
+# SESSION_STATE.local.md Template
+
+Create `SESSION_STATE.local.md` at the repository root from this template for
+each builder session. Keep it local; it is ignored by git.
+
+Update it before opening a PR, after pushing a PR update, after merging a PR,
+and after any compaction/restart reorientation. If current GitHub state
+conflicts with this file, stop and ask the operator instead of guessing.
+
+```md
+# Atlas Builder Session State
+
+Last updated: YYYY-MM-DD HH:MM TZ
+Session role: builder
+Operator-assigned lane: <one sentence>
+Current task: <one sentence>
+
+## Owned Active PR
+
+Status: none | planned | open | merged
+PR: #<number or none>
+Title: <title or none>
+URL: <url or none>
+Branch: <branch or none>
+Plan: plans/PR-<Slice>.md
+Expected head SHA: <sha or none>
+Ownership lane: <lane from plan>
+Allowed actions: inspect | update | merge-on-operator-signal | none
+
+## PRs This Session May Touch
+
+- #<number> <title> -- reason this session owns it
+
+## PRs This Session Must Not Touch
+
+- #<number> <title> -- owner/session/lane if known
+
+## Recent PRs Merged By This Session
+
+- #<number> <title> -- merged at <sha/time>
+
+## Current Worktree
+
+Path: <absolute worktree path>
+Branch: <branch>
+Base: origin/main @ <sha>
+Dirty state expected: yes | no
+
+## Last Safe Action
+
+<One sentence: e.g. "Opened #1234 and stopped; waiting for operator signal.">
+
+## Resume Checklist
+
+- [ ] Read this file before any PR action.
+- [ ] Run `gh pr list --state open`.
+- [ ] Run `git log --oneline -15 origin/main`.
+- [ ] Confirm the current PR is listed under "Owned Active PR" or "PRs This
+      Session May Touch" before inspecting comments, pushing updates, or
+      merging.
+- [ ] Treat every other open PR as "must not touch" unless the operator
+      explicitly reassigns it.
+```
+
+## Ownership Rule
+
+If a PR is not listed as owned in `SESSION_STATE.local.md`, it is not yours.
+Lane proximity is not ownership. Similar file paths are not ownership. A PR
+opened by another active session is not yours unless the operator explicitly
+reassigns it and the map is updated first.

--- a/plans/PR-Agents-Session-PR-Map.md
+++ b/plans/PR-Agents-Session-PR-Map.md
@@ -1,0 +1,89 @@
+# PR-Agents-Session-PR-Map
+
+## Why this slice exists
+
+Builder sessions have drifted after context compaction: resuming in the wrong
+lane, merging PRs that were not created by the current task, and editing code
+owned by an open PR from another session. The existing bootstrap says to check
+open PRs, but it does not give the builder a persistent ownership ledger to
+distinguish "mine" from "not mine" after compaction.
+
+This slice adds a required local session ownership map. It makes PR ownership a
+first-class checkpoint before merge, comment handling, or new-code work.
+
+## Scope (this PR)
+
+Ownership lane: repo-workflow/session-discipline
+Slice phase: Workflow/process
+
+1. Add a durable template for a local `SESSION_STATE.local.md` ownership map.
+2. Ignore the local map so volatile PR state does not churn in commits.
+3. Update `AGENTS.md` so builders must read/update the map and treat unlisted
+   PRs as not theirs.
+4. Update the fresh-session and drift-redirect bootstrap prompts to require the
+   map before PR actions.
+5. Teach the plan/code consistency audit to skip path claims that are
+   intentionally ignored by git, so local-only artifacts do not pass locally and
+   fail in CI.
+
+### Files touched
+
+- `plans/PR-Agents-Session-PR-Map.md`
+- `.gitignore`
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `docs/SESSION_STATE_TEMPLATE.md`
+- `scripts/audit_plan_code_consistency.py`
+- `tests/test_audit_plan_code_consistency.py`
+
+## Mechanism
+
+`docs/SESSION_STATE_TEMPLATE.md` defines the local state shape:
+
+- current lane and task
+- owned active PR, branch, plan, and expected head
+- merged PRs from this session
+- explicit "not mine" open PRs
+- last safe action and resume checklist
+
+`AGENTS.md` makes that map mandatory before PR mutation. If the current PR is
+absent from the owned slot, or the map is missing/stale after compaction, the
+builder must stop and ask instead of inferring ownership from lane proximity.
+
+The plan/code consistency audit now checks git-ignore status before reporting a
+missing path claim. That keeps deliberately local artifacts like the session map
+from producing a local-green/CI-red split.
+
+## Intentional
+
+- The actual `SESSION_STATE.local.md` file is ignored. It is a local continuity
+  artifact, not repo truth.
+- This does not add an automated GitHub gate. The immediate problem is agent
+  behavior after compaction; the contract and template give the session a
+  stable object to re-read.
+- Existing open PR #1188 is not touched. It is explicitly outside this process
+  slice.
+- Ignored path claims are not treated as missing because they cannot exist in
+  the clean CI checkout by design.
+
+## Deferred
+
+- Parked hardening: none.
+- A future tooling slice can add a script that checks `SESSION_STATE.local.md`
+  against `gh pr list` and fails before merge when ownership is ambiguous.
+
+## Verification
+
+- `python -m pytest tests/test_audit_plan_code_consistency.py -q`
+- Local PR review bundle with the PR body file supplied.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 89 |
+| AGENTS contract | 35 |
+| Bootstrap prompt | 17 |
+| Template + ignore | 71 |
+| Audit skip + test | 36 |
+| **Total** | **248** |

--- a/scripts/audit_plan_code_consistency.py
+++ b/scripts/audit_plan_code_consistency.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -77,6 +78,20 @@ def _path_resolves(claim: str) -> bool:
     return False
 
 
+def _path_is_gitignored(claim: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", "--", claim],
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, ValueError):
+        return False
+    return result.returncode == 0
+
+
 def collect_def_names() -> set[str]:
     names: set[str] = set()
     for root in ("scripts", "atlas_brain"):
@@ -96,7 +111,11 @@ def collect_def_names() -> set[str]:
 
 def audit_claims(plan_text: str) -> tuple[list[str], list[str]]:
     path_claims, function_claims = parse_claims(plan_text)
-    missing_paths = sorted(claim for claim in path_claims if not _path_resolves(claim))
+    missing_paths = sorted(
+        claim
+        for claim in path_claims
+        if not _path_is_gitignored(claim) and not _path_resolves(claim)
+    )
     defs = collect_def_names() if function_claims else set()
     missing_functions = sorted(function_claims - defs)
     return missing_paths, missing_functions

--- a/tests/test_audit_plan_code_consistency.py
+++ b/tests/test_audit_plan_code_consistency.py
@@ -96,6 +96,21 @@ def test_audit_claims_reports_missing_path_and_function(auditor):
     assert missing_functions == ["function_that_does_not_exist"]
 
 
+def test_audit_claims_ignores_gitignored_local_session_state(auditor):
+    plan = textwrap.dedent("""\
+        # Example
+
+        ## Scope (this PR)
+
+        `SESSION_STATE.local.md`
+    """)
+
+    missing_paths, missing_functions = auditor.audit_claims(plan)
+
+    assert missing_paths == []
+    assert missing_functions == []
+
+
 def test_audit_claims_accepts_existing_root_path_and_function(auditor):
     plan = textwrap.dedent("""\
         # Example


### PR DESCRIPTION
Plan: plans/PR-Agents-Session-PR-Map.md
Slice phase: Workflow/process

Add a required local `SESSION_STATE.local.md` ownership map so builder sessions can recover after compaction without guessing which PRs are theirs. The map records the active lane, owned PR, explicit "must not touch" PRs, last safe action, and resume checklist. This also fixes the plan/code audit so gitignored local artifacts are not reported missing in clean CI checkouts.

## Intentional
- The actual session map is ignored by git because it is volatile local state.
- Ignored path claims are not treated as missing by the audit because they cannot exist in CI by design.
- This is a contract/template slice, not an automated merge gate.
- Existing open PR #1188 is not touched.

## Deferred
- A future tooling slice can add a dedicated script that checks the local map against `gh pr list` before merge.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/audit_plan_code_consistency.py tests/test_audit_plan_code_consistency.py` - passed.
- `python -m pytest tests/test_audit_plan_code_consistency.py -q` - 7 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/agents-session-pr-map.md` - passed.

## Diff size
7 files, +248 / -8
