### PR TITLE
PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry.md
@@ -1,0 +1,95 @@
+# PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry
+
+## Why this slice exists
+
+The hosted portfolio result page now fetches ATLAS snapshot and artifact state
+server-side, renders paid artifact Markdown only after `artifact_status:
+"unlocked"`, and starts Stripe Checkout from the customer path. Issue #1161
+called out the remaining customer-flow race: after Checkout redirects back with
+`checkout=success`, the browser can arrive before ATLAS receives and verifies
+Stripe's webhook. The current hosted page probes `/artifact` once during server
+render, then leaves the customer on the locked snapshot view until they manually
+refresh.
+
+This slice adds a bounded success-return retry that reuses the existing public
+portfolio report proxy. It improves the paid-return handoff without weakening
+the paywall trust boundary: the browser only polls for `artifact_status` and
+reloads the hosted page after ATLAS reports the paid artifact unlocked.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Production hardening
+
+1. Detect the `checkout=success` plus locked-artifact state on the hosted result
+   page.
+2. Add a bounded browser retry loop that polls
+   `/api/content-ops/deflection/report` for the same `request_id` and
+   `account_id`.
+3. Reload the hosted result page only after the proxy reports
+   `artifact_status: "unlocked"`.
+4. Keep paid artifact rendering exclusively owned by the server-rendered hosted
+   page after ATLAS unlocks the artifact.
+5. Add focused tests for the retry script, non-success checkout state, and the
+   no-paid-copy boundary.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+
+## Mechanism
+
+`renderResultPage(...)` already receives the server-side proxy envelope. This
+slice derives:
+
+```text
+checkoutStatus === "success" && artifactStatus === "locked"
+```
+
+When that predicate is true, the hosted page emits a small retry script. The
+script polls the existing same-origin report proxy with the validated
+`request_id` and `account_id`, waits between attempts, and calls
+`window.location.reload()` only when the JSON envelope says
+`artifact_status === "unlocked"`. The script does not read or render
+`artifact.markdown`; the reload path lets the existing server renderer fetch
+and escape the paid artifact.
+
+## Intentional
+
+- The retry is bounded. It is not an open-ended poller and does not turn the
+  hosted result page into an async job UI.
+- The browser does not render paid content from the JSON proxy. It checks only
+  the status field, then reloads for the server-rendered paid artifact path.
+- Missing or failed artifact states do not retry. A `checkout=success` return
+  with `artifact_status: "missing"` is more likely a wrong request/account than
+  a webhook race.
+- This does not change Stripe Checkout creation or ATLAS webhook handling.
+
+## Deferred
+
+- Richer progress messaging or manual retry controls can be added after the
+  live paid-return path is observed in production.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 13 checks.
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
+- `npm run build --prefix portfolio-ui` - passed using the existing ignored root
+  `portfolio-ui/node_modules` install for local verification; `npm ci` in this
+  worktree is blocked by pre-existing portfolio lockfile drift.
+- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core
+  295 passed; extracted_content_pipeline 2864 passed, 10 skipped, 1 warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-checkout-success-retry.md` -
+  passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Hosted retry script | ~55 |
+| Tests | ~35 |
+| **Total** | **~175** |

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -93,6 +93,50 @@ function renderPaidArtifact(report) {
         </section>`;
 }
 
+function renderArtifactRetryScript({ requestId, accountId, shouldRetry }) {
+  if (!shouldRetry) return "";
+
+  return `\n  <script data-atlas-deflection-artifact-retry>
+    (() => {
+      const retryMessage = document.getElementById("checkout-message");
+      const retryRequestId = ${scriptJson(requestId)};
+      const retryAccountId = ${scriptJson(accountId)};
+      const retryDelays = [1500, 3000, 5000, 8000, 13000];
+      let retryAttempt = 0;
+      const reportUrl = () => "/api/content-ops/deflection/report?request_id="
+        + encodeURIComponent(retryRequestId)
+        + "&account_id="
+        + encodeURIComponent(retryAccountId);
+      const pollArtifactUnlock = async () => {
+        if (retryMessage) retryMessage.textContent = "Checking unlock status...";
+        try {
+          const response = await fetch(reportUrl(), {
+            headers: { "Accept": "application/json" }
+          });
+          const payload = await response.json().catch(() => null);
+          if (response.ok && payload && payload.artifact_status === "unlocked") {
+            window.location.reload();
+            return;
+          }
+        } catch {
+          // Keep the paid boundary fail-closed; the customer can refresh manually.
+        }
+        if (retryAttempt >= retryDelays.length) {
+          if (retryMessage) retryMessage.textContent = "Payment is confirmed. Refresh in a moment if the report is still locked.";
+          return;
+        }
+        const delay = retryDelays[retryAttempt];
+        retryAttempt += 1;
+        window.setTimeout(pollArtifactUnlock, delay);
+      };
+      if (retryRequestId && retryAccountId) {
+        window.setTimeout(pollArtifactUnlock, retryDelays[retryAttempt]);
+        retryAttempt += 1;
+      }
+    })();
+  </script>`;
+}
+
 function renderResultPage({ requestId, accountId, checkoutStatus = "", report = null }) {
   const safeRequestId = escapeHtml(requestId);
   const safeAccountId = escapeHtml(accountId);
@@ -100,6 +144,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
   const resultHref = resultPath(requestId || "missing-request", accountId, "");
   const artifactStatus = report && report.ok ? report.artifact_status : "snapshot_unavailable";
   const isUnlocked = artifactStatus === "unlocked";
+  const shouldRetryArtifact = checkoutStatus === "success" && artifactStatus === "locked";
   const buttonDisabled = requestId && accountId && !isUnlocked ? "" : "disabled";
   const unlockHeading = isUnlocked ? "Full report unlocked" : "Unlock full report";
   const unlockCopy = isUnlocked
@@ -157,6 +202,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     data-atlas-deflection-request-id="${safeRequestId}"
     data-atlas-deflection-account-id="${safeAccountId}"
     data-atlas-deflection-report-source="${CHECKOUT_SOURCE}"
+    data-atlas-deflection-artifact-retry="${shouldRetryArtifact ? "true" : "false"}"
   >
     <a href="/services">Services</a>
     <div class="grid">
@@ -209,6 +255,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
       });
     }
   </script>
+  ${renderArtifactRetryScript({ requestId, accountId, shouldRetry: shouldRetryArtifact })}
 </body>
 </html>`;
 }

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -273,8 +273,46 @@ await test("hosted result page renders real snapshot metrics from the proxy enve
   assert.match(html, /How do I reset billing access\?/);
   assert.match(html, /artifact_status/);
   assert.match(html, /locked/);
+  assert.match(html, /data-atlas-deflection-artifact-retry="false"/);
   assert.doesNotMatch(html, /# Paid report/);
   assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
+});
+
+await test("hosted result page retries artifact status after successful checkout", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    checkoutStatus: "success",
+    report: {
+      ok: true,
+      snapshot: SNAPSHOT,
+      artifact_status: "locked",
+    },
+  });
+  assert.match(html, /data-atlas-deflection-artifact-retry="true"/);
+  assert.match(html, /script data-atlas-deflection-artifact-retry/);
+  assert.match(html, /\/api\/content-ops\/deflection\/report\?request_id=/);
+  assert.match(html, /payload\.artifact_status === "unlocked"/);
+  assert.match(html, /window\.location\.reload\(\)/);
+  assert.doesNotMatch(html, /payload\.artifact\b/);
+  assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
+});
+
+await test("hosted result page does not retry once artifact is unlocked", () => {
+  const html = renderResultPage({
+    requestId: REQUEST_ID,
+    accountId: ACCOUNT_ID,
+    checkoutStatus: "success",
+    report: {
+      ok: true,
+      snapshot: SNAPSHOT,
+      artifact_status: "unlocked",
+      artifact: PAID_ARTIFACT,
+    },
+  });
+  assert.match(html, /data-atlas-deflection-artifact-retry="false"/);
+  assert.doesNotMatch(html, /script data-atlas-deflection-artifact-retry/);
+  assert.match(html, /data-atlas-deflection-paid-report/);
 });
 
 await test("hosted result page renders escaped paid artifact only after unlock", () => {


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Checkout-Success-Retry.md
Slice phase: Production hardening

Add a bounded checkout-success artifact retry on the hosted FAQ deflection result page. When Stripe returns the customer before ATLAS has processed the verified webhook, the page polls the existing same-origin report proxy for `artifact_status: "unlocked"` and reloads only after ATLAS reports the artifact unlocked.

## Intentional
- The retry is bounded and runs only for `checkout=success` with a locked artifact.
- The browser checks only `artifact_status`; it does not render paid artifact payloads from the JSON proxy.
- Missing, unavailable, or already unlocked artifact states do not start the retry loop.
- Stripe Checkout creation and ATLAS webhook handling are unchanged.

## Deferred
- Richer progress messaging or manual retry controls can be added after the live paid-return path is observed in production.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 13 checks.
- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
- `npm run build --prefix portfolio-ui` - passed using the existing ignored root `portfolio-ui/node_modules` install for local verification; `npm ci` in this worktree is blocked by pre-existing portfolio lockfile drift.
- `bash scripts/run_extracted_pipeline_checks.sh` - extracted_reasoning_core 295 passed; extracted_content_pipeline 2864 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-checkout-success-retry.md` - passed.

## Diff size
3 files, +180 / -0
