### PR TITLE
PR-Agents-Session-Map-Guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,16 @@ PR, the builder must verify all of the following:
 4. The local branch and expected head SHA match the target PR when a
    merge or force-push is about to happen.
 
+Run the local guard before PR mutation whenever the target PR metadata
+is known:
+
+```bash
+python scripts/check_session_pr_ownership.py \
+  --pr <number> \
+  --branch <headRefName> \
+  --head-sha <headRefOid>
+```
+
 If any check fails, stop and ask the operator. A PR in the same lane is
 not automatically owned. A PR that "looks abandoned" is not owned. A PR
 opened by another session is not owned unless the operator explicitly

--- a/plans/PR-Agents-Session-Map-Guard.md
+++ b/plans/PR-Agents-Session-Map-Guard.md
@@ -1,0 +1,83 @@
+# PR-Agents-Session-Map-Guard
+
+## Why this slice exists
+
+PR-Agents-Session-PR-Map made ownership mapping mandatory, but the deferred
+tooling gap remains: before a builder inspects, updates, force-pushes, or
+merges a PR, there should be a repeatable local command that checks the target
+PR is actually listed as owned in the session map.
+
+This slice adds that local guard so ownership checks are mechanical instead of
+purely memory-based after compaction.
+
+## Scope (this PR)
+
+Ownership lane: repo-workflow/session-discipline
+Slice phase: Workflow/process
+
+1. Add a stdlib script that validates a PR number, branch, and optional head
+   SHA against `SESSION_STATE.local.md`.
+2. Fail closed when the state file is missing, the PR is listed as "must not
+   touch", the PR is not listed as owned, the branch mismatches, the expected
+   head SHA is omitted, or the expected head SHA mismatches.
+3. Add focused tests for the positive path and each failure branch.
+4. Document the guard in `AGENTS.md` as the command to run before PR mutation.
+
+### Files touched
+
+- `plans/PR-Agents-Session-Map-Guard.md`
+- `scripts/check_session_pr_ownership.py`
+- `tests/test_check_session_pr_ownership.py`
+- `AGENTS.md`
+
+## Mechanism
+
+The script accepts explicit PR metadata:
+
+```bash
+python scripts/check_session_pr_ownership.py \
+  --pr 1189 \
+  --branch claude/pr-agents-session-pr-map \
+  --head-sha <sha>
+```
+
+It parses the local session map sections, treats "must not touch" as a hard
+block, accepts ownership only from "Owned Active PR" or "PRs This Session May
+Touch", and compares branch/head values when present. If the map records an
+expected head SHA, the caller must supply `--head-sha`; otherwise the command
+fails closed. It prints deterministic errors and exits non-zero on ambiguity.
+
+## Intentional
+
+- The script does not call GitHub. Builders should pass metadata from
+  `gh pr view` so the guard remains easy to test and can run without network.
+- This is a local operator/builder guard, not a CI gate. CI does not have the
+  ignored session map.
+- The guard is not wired into every script yet. It gives the builder a concrete
+  command to run before PR mutation.
+
+## Deferred
+
+- Parked hardening: none.
+- A future shell integration can wrap merge/update commands and call this guard
+  automatically.
+
+## Verification
+
+- `python -m py_compile scripts/check_session_pr_ownership.py tests/test_check_session_pr_ownership.py`
+- `python -m pytest tests/test_check_session_pr_ownership.py -q`
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/agents-session-map-guard.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 83 |
+| Guard script | 158 |
+| Tests | 173 |
+| AGENTS docs | 10 |
+| **Total** | **424** |
+
+The slice is slightly over the soft cap because this is a checker surface:
+every failure branch needs a focused negative fixture so the guard cannot
+silently false-green ambiguous ownership.

--- a/scripts/check_session_pr_ownership.py
+++ b/scripts/check_session_pr_ownership.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Check that a PR is owned by the current local builder session."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STATE_FILE = ROOT / "SESSION_STATE.local.md"
+SECTION_RE = re.compile(r"^##\s+(.+?)\s*$")
+PR_RE = re.compile(r"#(?P<number>\d+)\b")
+
+
+@dataclass(frozen=True)
+class SessionOwnership:
+    owned_pr: int | None
+    owned_branch: str
+    owned_head: str
+    may_touch: frozenset[int]
+    must_not_touch: frozenset[int]
+
+
+def _clean(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def _section_map(text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        match = SECTION_RE.match(line)
+        if match:
+            current = match.group(1).strip().lower()
+            sections[current] = []
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return sections
+
+
+def _field(section: Sequence[str], name: str) -> str:
+    prefix = f"{name}:"
+    for line in section:
+        if line.startswith(prefix):
+            return _clean(line[len(prefix) :])
+    return ""
+
+
+def _parse_pr_field(value: str) -> int | None:
+    if value.lower() == "none":
+        return None
+    match = PR_RE.search(value)
+    if not match:
+        return None
+    return int(match.group("number"))
+
+
+def _parse_pr_list(lines: Sequence[str]) -> frozenset[int]:
+    numbers: set[int] = set()
+    for line in lines:
+        match = PR_RE.search(line)
+        if match:
+            numbers.add(int(match.group("number")))
+    return frozenset(numbers)
+
+
+def parse_session_state(text: str) -> SessionOwnership:
+    sections = _section_map(text)
+    owned = sections.get("owned active pr", [])
+    return SessionOwnership(
+        owned_pr=_parse_pr_field(_field(owned, "PR")),
+        owned_branch=_field(owned, "Branch"),
+        owned_head=_field(owned, "Expected head SHA"),
+        may_touch=_parse_pr_list(sections.get("prs this session may touch", [])),
+        must_not_touch=_parse_pr_list(sections.get("prs this session must not touch", [])),
+    )
+
+
+def ownership_errors(
+    ownership: SessionOwnership,
+    *,
+    pr: int,
+    branch: str,
+    head_sha: str = "",
+) -> list[str]:
+    errors: list[str] = []
+    if pr in ownership.must_not_touch:
+        errors.append(f"PR #{pr} is listed under PRs This Session Must Not Touch")
+        return errors
+    if ownership.owned_pr != pr and pr not in ownership.may_touch:
+        errors.append(
+            f"PR #{pr} is not listed under Owned Active PR or PRs This Session May Touch"
+        )
+    if ownership.owned_pr == pr:
+        if ownership.owned_branch and ownership.owned_branch != branch:
+            errors.append(
+                f"branch mismatch for PR #{pr}: state has {ownership.owned_branch}, "
+                f"target has {branch}"
+            )
+        expected = ownership.owned_head
+        if expected and expected.lower() != "none":
+            if not head_sha:
+                errors.append(
+                    f"head SHA required for PR #{pr} because session state records "
+                    f"expected head {expected}"
+                )
+            elif expected != head_sha:
+                errors.append(
+                    f"head SHA mismatch for PR #{pr}: state has {expected}, "
+                    f"target has {head_sha}"
+                )
+    return errors
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate that a target PR is owned by SESSION_STATE.local.md."
+    )
+    parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--head-sha", default="")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    state_path = args.state_file
+    if not state_path.exists():
+        print(f"session state file not found: {state_path}", file=sys.stderr)
+        return 2
+    try:
+        ownership = parse_session_state(state_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"could not read session state file: {exc}", file=sys.stderr)
+        return 2
+    errors = ownership_errors(
+        ownership,
+        pr=args.pr,
+        branch=_clean(args.branch),
+        head_sha=_clean(args.head_sha),
+    )
+    if errors:
+        print("session PR ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"session PR ownership check passed for PR #{args.pr}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_session_pr_ownership.py
+++ b/tests/test_check_session_pr_ownership.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check_session_pr_ownership.py"
+SPEC = importlib.util.spec_from_file_location("check_session_pr_ownership", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+guard = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = guard
+SPEC.loader.exec_module(guard)
+
+
+def _state_text(
+    *,
+    owned_pr: str = "#1189",
+    branch: str = "claude/pr-agents-session-pr-map",
+    head_sha: str = "abc123",
+    may_touch: str = "- #1189 PR-Agents-Session-PR-Map -- owned\n",
+    must_not_touch: str = "- #1190 PR-FAQ -- not ours\n",
+) -> str:
+    return f"""# Atlas Builder Session State
+
+## Owned Active PR
+
+PR: {owned_pr}
+Branch: {branch}
+Expected head SHA: {head_sha}
+
+## PRs This Session May Touch
+
+{may_touch}
+## PRs This Session Must Not Touch
+
+{must_not_touch}
+"""
+
+
+def test_parse_session_state_extracts_owned_and_blocked_prs() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    assert ownership.owned_pr == 1189
+    assert ownership.owned_branch == "claude/pr-agents-session-pr-map"
+    assert ownership.owned_head == "abc123"
+    assert ownership.may_touch == frozenset({1189})
+    assert ownership.must_not_touch == frozenset({1190})
+
+
+def test_ownership_errors_accepts_owned_pr_branch_and_head() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    assert guard.ownership_errors(
+        ownership,
+        pr=1189,
+        branch="claude/pr-agents-session-pr-map",
+        head_sha="abc123",
+    ) == []
+
+
+def test_ownership_errors_blocks_must_not_touch_before_other_checks() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    errors = guard.ownership_errors(
+        ownership,
+        pr=1190,
+        branch="claude/pr-faq-deflection",
+        head_sha="other",
+    )
+
+    assert errors == ["PR #1190 is listed under PRs This Session Must Not Touch"]
+
+
+def test_ownership_errors_rejects_unlisted_pr() -> None:
+    ownership = guard.parse_session_state(_state_text(must_not_touch=""))
+
+    errors = guard.ownership_errors(
+        ownership,
+        pr=1191,
+        branch="claude/pr-other",
+        head_sha="abc123",
+    )
+
+    assert errors == [
+        "PR #1191 is not listed under Owned Active PR or PRs This Session May Touch"
+    ]
+
+
+def test_ownership_errors_rejects_owned_branch_mismatch() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    errors = guard.ownership_errors(
+        ownership,
+        pr=1189,
+        branch="claude/pr-other",
+        head_sha="abc123",
+    )
+
+    assert errors == [
+        "branch mismatch for PR #1189: state has claude/pr-agents-session-pr-map, "
+        "target has claude/pr-other"
+    ]
+
+
+def test_ownership_errors_rejects_owned_head_mismatch() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    errors = guard.ownership_errors(
+        ownership,
+        pr=1189,
+        branch="claude/pr-agents-session-pr-map",
+        head_sha="def456",
+    )
+
+    assert errors == [
+        "head SHA mismatch for PR #1189: state has abc123, target has def456"
+    ]
+
+
+def test_ownership_errors_requires_target_head_when_state_records_one() -> None:
+    ownership = guard.parse_session_state(_state_text())
+
+    errors = guard.ownership_errors(
+        ownership,
+        pr=1189,
+        branch="claude/pr-agents-session-pr-map",
+    )
+
+    assert errors == [
+        "head SHA required for PR #1189 because session state records expected head abc123"
+    ]
+
+
+def test_main_fails_when_state_file_is_missing(tmp_path, capsys) -> None:
+    code = guard.main([
+        "--state-file",
+        str(tmp_path / "missing.md"),
+        "--pr",
+        "1189",
+        "--branch",
+        "claude/pr-agents-session-pr-map",
+    ])
+
+    assert code == 2
+    assert "session state file not found" in capsys.readouterr().err
+
+
+def test_main_accepts_may_touch_pr_when_owned_slot_is_empty(tmp_path, capsys) -> None:
+    state_file = tmp_path / "SESSION_STATE.local.md"
+    state_file.write_text(
+        _state_text(
+            owned_pr="none",
+            branch="none",
+            head_sha="none",
+            may_touch="- #1189 PR-Agents-Session-PR-Map -- reassigned\n",
+            must_not_touch="",
+        ),
+        encoding="utf-8",
+    )
+
+    code = guard.main([
+        "--state-file",
+        str(state_file),
+        "--pr",
+        "1189",
+        "--branch",
+        "claude/pr-agents-session-pr-map",
+    ])
+
+    assert code == 0
+    assert "session PR ownership check passed for PR #1189" in capsys.readouterr().out


### PR DESCRIPTION
Plan: plans/PR-Agents-Session-Map-Guard.md
Slice phase: Workflow/process

Add a local `check_session_pr_ownership.py` guard so builders can mechanically verify a target PR is owned by the current ignored session map before inspecting comments, updating, force-pushing, or merging. When the map records an expected head SHA, the guard now requires the caller to supply the target head instead of false-greening a partial command.

## Intentional
- The guard does not call GitHub; builders pass PR metadata from `gh pr view`.
- This is a local builder/operator guard, not a CI gate, because CI does not have `SESSION_STATE.local.md`.
- Automatic shell wrapping is deferred.

## Deferred
- A future shell integration can wrap merge/update commands and call this guard automatically.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/check_session_pr_ownership.py tests/test_check_session_pr_ownership.py` - passed.
- `python -m pytest tests/test_check_session_pr_ownership.py -q` - 9 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/agents-session-map-guard.md` - passed.

## Diff size
4 files, +424 / -0
