### PR TITLE
PR-FAQ-Deflection-Private-Blob-Persistence

### DIFF
--- a/plans/PR-FAQ-Deflection-Private-Blob-Persistence.md
+++ b/plans/PR-FAQ-Deflection-Private-Blob-Persistence.md
@@ -1,0 +1,120 @@
+# PR-FAQ-Deflection-Private-Blob-Persistence
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Portfolio-Live-Submit proved the hosted browser-to-ATLAS
+handoff by forwarding the selected CSV through the portfolio server, but it
+explicitly deferred private Vercel Blob persistence. That direct multipart path
+keeps uploads under the Vercel Functions request body cap and does not preserve
+the selected CSV before ATLAS submission.
+
+This slice adds the durable private-Blob handoff that #1188 deferred: the
+browser uploads the CSV to Vercel Blob with private access, then the portfolio
+server reads that private object with its server token and forwards multipart
+bytes to ATLAS. Rich progress/retry UX remains the next product slice.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Vertical slice
+
+1. Add `@vercel/blob` to `portfolio-ui` and create a server upload-token route
+   for private FAQ deflection CSV uploads.
+2. Change the upload page to persist the selected CSV to private Blob before
+   report submission.
+3. Extend the portfolio submit endpoint to accept a server-only JSON Blob
+   reference, read the private object, reconstruct the ATLAS multipart submit,
+   and project the existing result payload.
+4. Keep the service JWT, Blob read/write token, and ATLAS execute envelope out
+   of browser responses.
+5. Add focused tests for token-route validation, browser wiring, private Blob
+   submit forwarding, and fail-closed config/error branches.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Private-Blob-Persistence.md`
+- `portfolio-ui/package.json`
+- `portfolio-ui/package-lock.json`
+- `portfolio-ui/api/content-ops/deflection/upload.js`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The browser calls `upload(file.name, file, { access: "private",
+handleUploadUrl: "/api/content-ops/deflection/upload" })` from
+`@vercel/blob/client`. The upload token route uses `handleUpload(...)` and
+allows only CSV-shaped content for a deflection-specific pathname prefix.
+
+After Blob upload completes, the page posts JSON to the existing submit route:
+
+```json
+{
+  "blob_url": "https://...",
+  "blob_pathname": "faq-deflection/uploads/...",
+  "support_platform": "zendesk",
+  "company_name": "Acme Co.",
+  "contact_email": "lead@example.com",
+  "limit": 1000
+}
+```
+
+The submit route keeps the existing raw multipart mode for local rollback, but
+the new JSON mode validates the configured account binding, reads the private
+Blob using the server `BLOB_READ_WRITE_TOKEN`, reconstructs a `FormData` body
+with `csv_file` and the same metadata fields, and forwards that body to ATLAS
+with the service JWT. The browser still receives only `{ ok, request_id,
+account_id, result_path }`. The server routes lazy-import the Blob SDK only on
+real Blob operations so the lean portfolio Node checks can import the modules
+without an install step.
+
+## Intentional
+
+- This slice uses Vercel's private Blob client-upload flow rather than a
+  server-side `put(...)`, because the direct browser-to-Blob transfer avoids the
+  Vercel Functions request body cap that forced the temporary 4 MB portfolio
+  limit.
+- The existing multipart submit path remains as a rollback/local-test path.
+  Private Blob JSON submit is the browser path.
+- The Blob URL is treated as an opaque private object reference. It is not
+  rendered as a download link and cannot expose content without the server
+  token.
+- Blob SDK imports are lazy server-side imports. The tested helper paths use
+  injected fakes so dependency-light CI can collect the modules.
+- Rich progress bars, resumable upload retry controls, and abandoned-upload
+  cleanup are deferred to the next slice.
+
+## Deferred
+
+- Upload progress/retry UX is the next slice in this lane.
+- Operational cleanup for orphaned private blobs after failed ATLAS submission
+  remains deferred until the live persistence path has production observations.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` - passed, 13 checks.
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 11 checks.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 14 checks.
+- `npm run build --prefix portfolio-ui` - passed; sitemap generation skipped because
+  `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not configured.
+- Temporarily hid `portfolio-ui/node_modules`, then imported
+  `submit.js` and `upload.js` with Node - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-private-blob-persistence.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 120 |
+| Blob upload route | 118 |
+| Submit endpoint private Blob path | 164 |
+| Upload page wiring | 73 |
+| Tests | 145 |
+| Package metadata | 171 |
+| **Total** | **791** |
+
+This slice is above the soft cap because the token route, browser upload handoff,
+server-side private Blob read, and contract tests need to land together for an
+end-to-end private persistence path.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -5,7 +5,9 @@ const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit";
 const MAX_CSV_BYTES = 4 * 1024 * 1024;
+const MAX_BLOB_CSV_BYTES = 50 * 1024 * 1024;
 const MAX_MULTIPART_OVERHEAD_BYTES = 256 * 1024;
+const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 
 export const config = {
   api: {
@@ -34,6 +36,13 @@ function publicSubmitConfig(env = process.env) {
     errors.push("atlas_account_missing");
   }
   return { config, errors };
+}
+
+function privateBlobSubmitConfig(env = process.env) {
+  const result = publicSubmitConfig(env);
+  const blobToken = clean(env.BLOB_READ_WRITE_TOKEN);
+  if (!blobToken) result.errors.push("blob_token_missing");
+  return { ...result, blobToken };
 }
 
 function rejectOversizeContentLength(req) {
@@ -82,6 +91,35 @@ async function readRawBody(req, maxBytes = MAX_CSV_BYTES + MAX_MULTIPART_OVERHEA
   return { ok: true, body: Buffer.concat(chunks) };
 }
 
+async function readJsonBody(req) {
+  if (req.body && typeof req.body === "object" && !Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === "string") return JSON.parse(req.body);
+  if (Buffer.isBuffer(req.body)) return JSON.parse(req.body.toString("utf8"));
+  const chunks = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+async function streamToBuffer(stream, maxBytes) {
+  const reader = stream.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const buffer = Buffer.from(value);
+      total += buffer.length;
+      if (total > maxBytes) return { ok: false, statusCode: 413 };
+      chunks.push(buffer);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { ok: true, body: Buffer.concat(chunks) };
+}
+
 function projectSubmitPayload(payload, accountId) {
   const requestId = clean(payload?.request_id);
   if (!requestId || !REQUEST_ID_RE.test(requestId)) {
@@ -98,15 +136,16 @@ function projectSubmitPayload(payload, accountId) {
 async function forwardSubmit({ config, contentType, body, fetchImpl = fetch }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  const headers = {
+    "Accept": "application/json",
+    "Authorization": `Bearer ${config.token}`,
+  };
+  if (contentType) headers["Content-Type"] = contentType;
   let response;
   try {
     response = await fetchImpl(atlasUrl(config.baseUrl, SUBMIT_PATH), {
       method: "POST",
-      headers: {
-        "Accept": "application/json",
-        "Authorization": `Bearer ${config.token}`,
-        "Content-Type": contentType,
-      },
+      headers,
       body,
       signal: controller.signal,
     });
@@ -143,12 +182,94 @@ async function forwardSubmit({ config, contentType, body, fetchImpl = fetch }) {
   return { ok: true, statusCode: 200, payload: projected };
 }
 
+function validBlobPathname(value) {
+  const pathname = clean(value);
+  if (!pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX)) return "";
+  if (!pathname.toLowerCase().endsWith(".csv")) return "";
+  if (pathname.includes("..") || pathname.includes("\\") || pathname.startsWith("/")) return "";
+  return pathname;
+}
+
+function fileNameFromPathname(pathname) {
+  const name = pathname.split("/").filter(Boolean).pop() || "tickets.csv";
+  return name.toLowerCase().endsWith(".csv") ? name : "tickets.csv";
+}
+
+async function getPrivateBlob(pathname, options) {
+  const { get } = await import("@vercel/blob");
+  return get(pathname, options);
+}
+
+async function readPrivateCsvBlob({
+  pathname,
+  token,
+  getBlobImpl = getPrivateBlob,
+  maxBytes = MAX_BLOB_CSV_BYTES,
+}) {
+  const safePathname = validBlobPathname(pathname);
+  if (!safePathname) return { ok: false, statusCode: 400, error: "invalid_blob_reference" };
+  try {
+    const result = await getBlobImpl(safePathname, {
+      access: "private",
+      token,
+      useCache: false,
+    });
+    if (!result || result.statusCode !== 200 || !result.stream) {
+      return { ok: false, statusCode: 404, error: "private_blob_unavailable" };
+    }
+    if (Number.isFinite(result.blob?.size) && result.blob.size > maxBytes) {
+      return { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" };
+    }
+    const body = await streamToBuffer(result.stream, maxBytes);
+    if (!body.ok) {
+      return { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" };
+    }
+    return {
+      ok: true,
+      body: body.body,
+      contentType: clean(result.blob?.contentType) || "text/csv",
+      fileName: fileNameFromPathname(safePathname),
+    };
+  } catch {
+    return { ok: false, statusCode: 502, error: "private_blob_unavailable" };
+  }
+}
+
+async function submitPrivateBlob({
+  config,
+  blobToken,
+  payload,
+  fetchImpl = fetch,
+  getBlobImpl = getPrivateBlob,
+}) {
+  const blob = await readPrivateCsvBlob({
+    pathname: payload?.blob_pathname,
+    token: blobToken,
+    getBlobImpl,
+  });
+  if (!blob.ok) return blob;
+
+  const form = new FormData();
+  form.set("csv_file", new Blob([blob.body], { type: blob.contentType }), blob.fileName);
+  form.set("support_platform", clean(payload?.support_platform));
+  form.set("company_name", clean(payload?.company_name));
+  form.set("contact_email", clean(payload?.contact_email));
+  form.set("limit", clean(payload?.limit) || "1000");
+
+  return forwardSubmit({ config, contentType: "", body: form, fetchImpl });
+}
+
 export {
+  BLOB_UPLOAD_PATH_PREFIX,
+  MAX_BLOB_CSV_BYTES,
   MAX_CSV_BYTES,
   MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
   forwardSubmit,
   projectSubmitPayload,
+  readPrivateCsvBlob,
+  submitPrivateBlob,
+  validBlobPathname,
 };
 
 export default async function handler(req, res) {
@@ -159,12 +280,15 @@ export default async function handler(req, res) {
   }
 
   const contentType = header(req, "content-type");
-  if (!contentType.includes("multipart/form-data")) {
+  const isPrivateBlobSubmit = contentType.includes("application/json");
+  if (!contentType.includes("multipart/form-data") && !isPrivateBlobSubmit) {
     json(res, 415, { ok: false, error: "multipart_required" });
     return;
   }
 
-  const { config: submitConfig, errors } = publicSubmitConfig();
+  const { config: submitConfig, blobToken, errors } = isPrivateBlobSubmit
+    ? privateBlobSubmitConfig()
+    : publicSubmitConfig();
   if (errors.length > 0) {
     json(res, 503, { ok: false, error: "atlas_submit_not_configured" });
     return;
@@ -173,6 +297,32 @@ export default async function handler(req, res) {
   const accountId = header(req, "x-atlas-account-id");
   if (!accountId || !UUID_RE.test(accountId) || accountId !== submitConfig.accountId) {
     json(res, 400, { ok: false, error: "invalid_account_id" });
+    return;
+  }
+
+  if (isPrivateBlobSubmit) {
+    let payload;
+    try {
+      payload = await readJsonBody(req);
+    } catch {
+      json(res, 400, { ok: false, error: "invalid_blob_submit" });
+      return;
+    }
+
+    const result = await submitPrivateBlob({
+      config: submitConfig,
+      blobToken,
+      payload,
+    });
+    if (!result.ok) {
+      json(res, result.statusCode, {
+        ok: false,
+        error: result.error,
+        atlas_status: result.atlas_status,
+      });
+      return;
+    }
+    json(res, 200, result.payload);
     return;
   }
 

--- a/portfolio-ui/api/content-ops/deflection/upload.js
+++ b/portfolio-ui/api/content-ops/deflection/upload.js
@@ -1,0 +1,118 @@
+import { clean } from "./atlas-report.js";
+
+const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
+const MAX_BLOB_CSV_BYTES = 50 * 1024 * 1024;
+const CSV_CONTENT_TYPES = ["text/csv", "application/vnd.ms-excel", "application/csv"];
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function json(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req) {
+  if (req.body && typeof req.body === "object") return req.body;
+  if (typeof req.body === "string") return JSON.parse(req.body);
+  const chunks = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : {};
+}
+
+function parseClientPayload(raw) {
+  if (!raw) return {};
+  try {
+    const payload = JSON.parse(raw);
+    return payload && typeof payload === "object" ? payload : {};
+  } catch {
+    return {};
+  }
+}
+
+function uploadConfigFromEnv(env = process.env) {
+  const accountId = clean(env.ATLAS_ACCOUNT_ID);
+  const token = clean(env.BLOB_READ_WRITE_TOKEN);
+  const errors = [];
+  if (!token) errors.push("blob_token_missing");
+  if (!accountId || !UUID_RE.test(accountId)) errors.push("atlas_account_missing");
+  return { accountId, token, errors };
+}
+
+function uploadTokenConfig(pathname, clientPayload, env = process.env) {
+  const config = uploadConfigFromEnv(env);
+  const payload = parseClientPayload(clientPayload);
+  const accountId = clean(payload.account_id);
+  const errors = [...config.errors];
+  if (!pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX) || !pathname.toLowerCase().endsWith(".csv")) {
+    errors.push("invalid_blob_pathname");
+  }
+  if (!accountId || accountId !== config.accountId) {
+    errors.push("invalid_account_id");
+  }
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    token: config.token,
+    options: {
+      allowedContentTypes: CSV_CONTENT_TYPES,
+      maximumSizeInBytes: MAX_BLOB_CSV_BYTES,
+      addRandomSuffix: true,
+      tokenPayload: JSON.stringify({ account_id: config.accountId }),
+    },
+  };
+}
+
+async function handleBlobUpload(options) {
+  const { handleUpload } = await import("@vercel/blob/client");
+  return handleUpload(options);
+}
+
+export {
+  BLOB_UPLOAD_PATH_PREFIX,
+  CSV_CONTENT_TYPES,
+  MAX_BLOB_CSV_BYTES,
+  handleBlobUpload,
+  parseClientPayload,
+  uploadTokenConfig,
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    json(res, 405, { ok: false, error: "method_not_allowed" });
+    return;
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch {
+    json(res, 400, { ok: false, error: "invalid_upload_request" });
+    return;
+  }
+
+  const envConfig = uploadConfigFromEnv();
+  if (envConfig.errors.length > 0) {
+    json(res, 503, { ok: false, error: "deflection_blob_upload_not_configured" });
+    return;
+  }
+
+  try {
+    const response = await handleBlobUpload({
+      body,
+      request: req,
+      token: envConfig.token,
+      onBeforeGenerateToken: async (pathname, clientPayload) => {
+        const result = uploadTokenConfig(pathname, clientPayload);
+        if (!result.ok) throw new Error("deflection_blob_upload_not_allowed");
+        return result.options;
+      },
+      onUploadCompleted: async () => {},
+    });
+    json(res, 200, response);
+  } catch {
+    json(res, 400, { ok: false, error: "deflection_blob_upload_not_allowed" });
+  }
+}

--- a/portfolio-ui/package-lock.json
+++ b/portfolio-ui/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "name": "portfolio-ui",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
+        "@vercel/blob": "^2.4.0",
         "clsx": "^2.1.1",
         "gsap": "^3.15.0",
         "lucide-react": "^1.8.0",
@@ -571,7 +571,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -592,6 +592,22 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -640,12 +656,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -875,7 +913,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -1246,6 +1284,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -1284,6 +1345,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -1619,6 +1686,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1702,13 +1782,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1939,6 +2019,13 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -2023,6 +2110,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
@@ -2094,6 +2194,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -2291,6 +2400,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -2312,19 +2433,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -2367,6 +2475,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2514,19 +2631,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     }
   }

--- a/portfolio-ui/package.json
+++ b/portfolio-ui/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vercel/blob": "^2.4.0",
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",
     "lucide-react": "^1.8.0",

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -3,17 +3,30 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import submitHandler, {
+  BLOB_UPLOAD_PATH_PREFIX,
+  MAX_BLOB_CSV_BYTES,
   MAX_CSV_BYTES,
   MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
   forwardSubmit,
+  readPrivateCsvBlob,
+  submitPrivateBlob,
 } from "../api/content-ops/deflection/submit.js";
+import {
+  CSV_CONTENT_TYPES,
+  MAX_BLOB_CSV_BYTES as MAX_UPLOAD_CSV_BYTES,
+  uploadTokenConfig,
+} from "../api/content-ops/deflection/upload.js";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
 const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "utf8");
 const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
 const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
+const blobUploadRouteSource = await readFile(
+  resolve(root, "api/content-ops/deflection/upload.js"),
+  "utf8",
+);
 const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
 
 const ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
@@ -21,6 +34,7 @@ const ENV = {
   ATLAS_API_BASE_URL: "https://atlas.example.com",
   ATLAS_B2B_JWT: "secret-service-token",
   ATLAS_ACCOUNT_ID: ACCOUNT_ID,
+  BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_token",
 };
 const MULTIPART_BODY = Buffer.from(
   [
@@ -119,15 +133,23 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-support-platform",
     "data-atlas-deflection-account-id-input",
     "data-atlas-deflection-submit",
+    "data-atlas-deflection-upload-endpoint",
   ]) {
     assert.match(uploadSource, new RegExp(marker));
   }
-  assert.match(uploadSource, /MAX_CSV_BYTES = 4 \* 1024 \* 1024/);
+  assert.match(uploadSource, /MAX_CSV_BYTES = 50 \* 1024 \* 1024/);
+  assert.match(uploadSource, /@vercel\/blob\/client/);
+  assert.doesNotMatch(blobUploadRouteSource, /^import .*@vercel\/blob\/client/m);
+  assert.match(blobUploadRouteSource, /import\("@vercel\/blob\/client"\)/);
+  assert.match(uploadSource, /access: "private"/);
+  assert.match(uploadSource, /blob_pathname: blob\.pathname/);
+  assert.match(uploadSource, /private_blob_persistence/);
   assert.match(uploadSource, /value: "help_scout"/);
   assert.match(uploadSource, /value: "other", label: "Freshdesk \/ other"/);
   assert.doesNotMatch(uploadSource, /value: "freshdesk"/);
   assert.doesNotMatch(uploadSource, /value: "help-scout"/);
-  assert.match(uploadSource, /new FormData/);
+  assert.doesNotMatch(uploadSource, /new FormData/);
+  assert.match(uploadSource, /JSON\.stringify/);
   assert.match(uploadSource, /X-Atlas-Account-Id/);
   assert.doesNotMatch(uploadSource, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
   assert.doesNotMatch(uploadSource, /Authorization/);
@@ -136,6 +158,8 @@ await test("upload shell exposes live submit markers and avoids browser credenti
 
 await test("portfolio submit endpoint pins raw multipart body handling", () => {
   assert.match(submitSource, /bodyParser:\s*false/);
+  assert.doesNotMatch(submitSource, /^import .*@vercel\/blob/m);
+  assert.match(submitSource, /import\("@vercel\/blob"\)/);
 });
 
 await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", async () => {
@@ -176,6 +200,112 @@ await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", as
   assert.equal(Buffer.compare(calls[0].options.body, MULTIPART_BODY), 0);
   assert.equal(calls[0].options.signal instanceof AbortSignal, true);
   assert.equal(res.body.includes(ENV.ATLAS_B2B_JWT), false);
+});
+
+await test("private blob upload token config fails closed on path and account binding", () => {
+  const ok = uploadTokenConfig(
+    `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+    JSON.stringify({ account_id: ACCOUNT_ID }),
+    ENV,
+  );
+  assert.equal(ok.ok, true);
+  assert.equal(ok.token, ENV.BLOB_READ_WRITE_TOKEN);
+  assert.equal(ok.options.maximumSizeInBytes, MAX_UPLOAD_CSV_BYTES);
+  assert.deepEqual(ok.options.allowedContentTypes, CSV_CONTENT_TYPES);
+  assert.equal(ok.options.addRandomSuffix, true);
+
+  assert.deepEqual(
+    uploadTokenConfig("other/tickets.csv", JSON.stringify({ account_id: ACCOUNT_ID }), ENV),
+    { ok: false, errors: ["invalid_blob_pathname"] },
+  );
+  assert.deepEqual(uploadTokenConfig(`${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`, "{}", ENV), {
+    ok: false,
+    errors: ["invalid_account_id"],
+  });
+});
+
+await test("private blob submit reads server-side blob and forwards ATLAS multipart", async () => {
+  const calls = [];
+  const csv = "ticket_id,message\nticket-1,How do I export reports?";
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      support_platform: "zendesk",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    getBlobImpl: async (pathname, options) => {
+      assert.equal(pathname, `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`);
+      assert.deepEqual(options, {
+        access: "private",
+        token: ENV.BLOB_READ_WRITE_TOKEN,
+        useCache: false,
+      });
+      return {
+        statusCode: 200,
+        stream: new Blob([csv], { type: "text/csv" }).stream(),
+        blob: {
+          size: Buffer.byteLength(csv),
+          contentType: "text/csv",
+        },
+      };
+    },
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ request_id: "content-ops-private123" });
+        },
+      };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.result_path.includes("content-ops-private123"), true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
+  assert.equal("Content-Type" in calls[0].options.headers, false);
+  assert.equal(calls[0].options.body instanceof FormData, true);
+  assert.equal(calls[0].options.body.get("support_platform"), "zendesk");
+  assert.equal(calls[0].options.body.get("company_name"), "Acme Co.");
+  assert.equal(await calls[0].options.body.get("csv_file").text(), csv);
+});
+
+await test("private blob reader rejects unsafe or oversized blob references", async () => {
+  assert.deepEqual(
+    await readPrivateCsvBlob({
+      pathname: "../tickets.csv",
+      token: ENV.BLOB_READ_WRITE_TOKEN,
+      getBlobImpl: async () => {
+        throw new Error("must not call blob store");
+      },
+    }),
+    { ok: false, statusCode: 400, error: "invalid_blob_reference" },
+  );
+
+  assert.deepEqual(
+    await readPrivateCsvBlob({
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      token: ENV.BLOB_READ_WRITE_TOKEN,
+      getBlobImpl: async () => ({
+        statusCode: 200,
+        stream: new Blob(["x"]).stream(),
+        blob: { size: MAX_BLOB_CSV_BYTES + 1, contentType: "text/csv" },
+      }),
+    }),
+    { ok: false, statusCode: 413, error: "deflection_submit_csv_too_large" },
+  );
 });
 
 await test("portfolio submit forwarding times out hung ATLAS calls", async () => {
@@ -272,7 +402,7 @@ await test("portfolio submit endpoint hides missing config details", async () =>
   assert.equal(res.body.includes("ATLAS_B2B_JWT"), false);
 });
 
-await test("portfolio submit endpoint only accepts POST multipart requests", async () => {
+await test("portfolio submit endpoint only accepts POST multipart or JSON blob requests", async () => {
   const getRes = mockResponse();
   await submitHandler(request({ method: "GET" }), getRes);
   assert.equal(getRes.statusCode, 405);
@@ -282,16 +412,17 @@ await test("portfolio submit endpoint only accepts POST multipart requests", asy
     error: "method_not_allowed",
   });
 
-  const jsonRes = mockResponse();
-  await submitHandler(request({ headers: { "content-type": "application/json" } }), jsonRes);
-  assert.equal(jsonRes.statusCode, 415);
-  assert.deepEqual(JSON.parse(jsonRes.body), {
+  const textRes = mockResponse();
+  await submitHandler(request({ headers: { "content-type": "text/plain" } }), textRes);
+  assert.equal(textRes.statusCode, 415);
+  assert.deepEqual(JSON.parse(textRes.body), {
     ok: false,
     error: "multipart_required",
   });
 });
 
 await test("upload shell test is enrolled in package scripts", () => {
+  assert.equal(packageJson.dependencies["@vercel/blob"], "^2.4.0");
   assert.equal(
     packageJson.scripts["test:deflection-upload-shell"],
     "node scripts/faq-deflection-upload-shell.test.mjs",

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { upload as uploadBlob } from "@vercel/blob/client";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -12,7 +13,9 @@ import {
 import { SeoHead } from "@/components/seo/SeoHead";
 
 const SUBMIT_ENDPOINT = "/api/content-ops/deflection/submit";
-const MAX_CSV_BYTES = 4 * 1024 * 1024;
+const BLOB_UPLOAD_ENDPOINT = "/api/content-ops/deflection/upload";
+const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
+const MAX_CSV_BYTES = 50 * 1024 * 1024;
 const SUPPORT_PLATFORMS = [
   { value: "zendesk", label: "Zendesk" },
   { value: "intercom", label: "Intercom" },
@@ -27,6 +30,7 @@ type UploadState =
 
 type SubmitState =
   | { status: "idle" }
+  | { status: "uploading" }
   | { status: "submitting" }
   | { status: "error"; message: string };
 
@@ -46,9 +50,18 @@ function fileState(file: File | undefined): UploadState {
     return { status: "invalid", message: "The selected CSV is empty." };
   }
   if (file.size > MAX_CSV_BYTES) {
-    return { status: "invalid", message: "CSV exports must be 4 MB or smaller." };
+    return { status: "invalid", message: "CSV exports must be 50 MB or smaller." };
   }
   return { status: "ready", file, fileName: file.name, fileSize: file.size };
+}
+
+function blobPathname(fileName: string) {
+  const cleaned = fileName
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const csvName = cleaned.endsWith(".csv") ? cleaned : "tickets.csv";
+  return `${BLOB_UPLOAD_PATH_PREFIX}${Date.now()}-${csvName}`;
 }
 
 export default function FaqDeflectionUpload() {
@@ -70,23 +83,36 @@ export default function FaqDeflectionUpload() {
       ),
     [accountId, companyName, contactEmail, supportPlatform, upload.status],
   );
-  const canSubmit = fieldsReady && submit.status !== "submitting";
+  const canSubmit = fieldsReady && submit.status !== "uploading" && submit.status !== "submitting";
 
   const startSubmit = async () => {
     if (upload.status !== "ready" || !fieldsReady) return;
-    setSubmit({ status: "submitting" });
-    const form = new FormData();
-    form.set("csv_file", upload.file);
-    form.set("support_platform", supportPlatform);
-    form.set("company_name", companyName.trim());
-    form.set("contact_email", contactEmail.trim());
-    form.set("limit", "1000");
+    const trimmedAccountId = accountId.trim();
 
     try {
+      setSubmit({ status: "uploading" });
+      const blob = await uploadBlob(blobPathname(upload.fileName), upload.file, {
+        access: "private",
+        contentType: "text/csv",
+        handleUploadUrl: BLOB_UPLOAD_ENDPOINT,
+        clientPayload: JSON.stringify({ account_id: trimmedAccountId }),
+        multipart: upload.fileSize > 4 * 1024 * 1024,
+      });
+
+      setSubmit({ status: "submitting" });
       const response = await fetch(SUBMIT_ENDPOINT, {
         method: "POST",
-        headers: { "X-Atlas-Account-Id": accountId.trim() },
-        body: form,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Atlas-Account-Id": trimmedAccountId,
+        },
+        body: JSON.stringify({
+          blob_pathname: blob.pathname,
+          support_platform: supportPlatform,
+          company_name: companyName.trim(),
+          contact_email: contactEmail.trim(),
+          limit: "1000",
+        }),
       });
       const payload = (await response.json().catch(() => null)) as {
         result_path?: unknown;
@@ -102,7 +128,7 @@ export default function FaqDeflectionUpload() {
       }
       window.location.assign(payload.result_path);
     } catch {
-      setSubmit({ status: "error", message: "FAQ deflection submit could not be reached." });
+      setSubmit({ status: "error", message: "FAQ deflection upload could not be completed." });
     }
   };
 
@@ -122,6 +148,7 @@ export default function FaqDeflectionUpload() {
         className="mx-auto max-w-6xl px-6 py-10 md:py-14"
         data-atlas-deflection-upload
         data-atlas-deflection-submit-endpoint={SUBMIT_ENDPOINT}
+        data-atlas-deflection-upload-endpoint={BLOB_UPLOAD_ENDPOINT}
       >
         <Link
           to="/services"
@@ -218,8 +245,9 @@ export default function FaqDeflectionUpload() {
                 onChange={(event) => setUpload(fileState(event.target.files?.[0]))}
               />
               <span className="mt-3 block text-xs text-surface-200/60">
-                4 MB cap. CSV bytes are forwarded through the portfolio server
-                to ATLAS; the service JWT never reaches the browser.
+                50 MB cap. CSV bytes are first stored in private Vercel Blob,
+                then forwarded to ATLAS server-side; service tokens never reach
+                the browser.
               </span>
             </label>
 
@@ -246,7 +274,12 @@ export default function FaqDeflectionUpload() {
               data-atlas-deflection-submit
               disabled={!canSubmit}
             >
-              {submit.status === "submitting" ? (
+              {submit.status === "uploading" ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Uploading CSV
+                </>
+              ) : submit.status === "submitting" ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Creating report
@@ -281,14 +314,14 @@ export default function FaqDeflectionUpload() {
               <div>
                 <dt className="text-surface-200/60">Submit mode</dt>
                 <dd className="mt-1 font-mono text-xs text-surface-100">
-                  portfolio_server_forwarding
+                  private_blob_persistence
                 </dd>
               </div>
             </dl>
             <p className="mt-5 text-sm leading-6 text-surface-200/70">
-              The portfolio forwards the multipart CSV server-side, then sends
-              the browser to the hosted result page for snapshot hydration and
-              Checkout.
+              The portfolio persists the CSV to private Blob, reads it back on
+              the server, then sends the browser to the hosted result page for
+              snapshot hydration and Checkout.
             </p>
           </aside>
         </div>


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Private-Blob-Persistence.md
Slice phase: Vertical slice

Add private Vercel Blob persistence to the hosted FAQ deflection upload flow: the browser uploads the CSV to private Blob, then the portfolio server reads that private object and forwards multipart bytes to ATLAS with the service JWT.

## Intentional
- Uses Vercel private Blob client upload instead of server-side `put(...)` so the browser upload is not bound by the Vercel Functions request body cap.
- Keeps the existing raw multipart submit path as a rollback/local-test path; the browser path uses private Blob JSON submit.
- Submits a Blob pathname, not an arbitrary URL, so the server reads from its configured private Blob store.
- Lazy-imports the Blob SDK in server routes so dependency-light portfolio checks can import tested modules without an install step.
- Rich progress bars, resumable retry controls, and orphaned-upload cleanup are deferred.

## Deferred
- Upload progress/retry UX is the next slice in this lane.
- Operational cleanup for orphaned private blobs after failed ATLAS submission remains deferred until the live persistence path has production observations.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - 13 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` - 11 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - 14 checks passed.
- `npm run build --prefix portfolio-ui` - passed; sitemap generation skipped because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not configured.
- Temporarily hid `portfolio-ui/node_modules`, then imported `submit.js` and `upload.js` with Node - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-private-blob-persistence.md` - passed.

## Diff size
7 files, +724 / -67
