### PR TITLE
PR-FAQ-Deflection-Upload-Progress-Retry-UX

### DIFF
--- a/plans/PR-FAQ-Deflection-Upload-Progress-Retry-UX.md
+++ b/plans/PR-FAQ-Deflection-Upload-Progress-Retry-UX.md
@@ -1,0 +1,88 @@
+# PR-FAQ-Deflection-Upload-Progress-Retry-UX
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Private-Blob-Persistence moved the FAQ deflection browser
+upload to private Vercel Blob and explicitly deferred richer upload progress and
+retry UX. The current page only flips the submit button between "Uploading CSV"
+and "Creating report"; if the Blob upload or ATLAS submit fails, the buyer sees
+an error but no explicit retry affordance or progress context.
+
+This slice adds the narrow UX layer on top of the now-merged private Blob
+contract: visible upload progress during Blob transfer and a retry state that
+lets the buyer resubmit the same selected CSV after a transient failure.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Product polish
+
+1. Surface `@vercel/blob/client` upload progress from `onUploadProgress` in the
+   FAQ deflection upload page.
+2. Render an accessible progress bar and phase text while the CSV is uploading.
+3. Change the failed submit state to an explicit retry affordance while keeping
+   the selected CSV and form values intact.
+4. Keep private Blob persistence, account binding, and server submit contracts
+   unchanged.
+5. Extend the focused upload-shell source tests to pin the progress/retry UX
+   markers and ensure credentials still stay out of browser code.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Upload-Progress-Retry-UX.md`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The upload page already calls:
+
+```ts
+uploadBlob(pathname, file, { access: "private", ... })
+```
+
+This slice adds an `onUploadProgress` callback that updates
+`SubmitState.status === "uploading"` with a bounded percentage. While that state
+is active, the form renders a `role="progressbar"` element with stable data
+markers for the hosted smoke/source tests.
+
+If either the Blob upload or the subsequent server submit fails, the state moves
+to `{ status: "error", message }`. The main submit button remains enabled when
+the selected CSV and required fields are still valid, changes label to
+`Retry upload`, and calls the same `startSubmit` path. No partial Blob reference
+is trusted or reused from a failed attempt.
+
+## Intentional
+
+- Retry is manual and re-runs the full private Blob upload + server submit. The
+  page does not cache a prior Blob pathname because failed submits can leave
+  ambiguous server state.
+- This slice does not add background polling, resumable multipart controls, or
+  abandoned-blob cleanup.
+- Progress is browser-only UI state. The server token, service JWT, and ATLAS
+  envelope boundaries remain unchanged from #1195.
+
+## Deferred
+
+- Abandoned private Blob cleanup remains deferred until production observations
+  show whether failed upload attempts create meaningful storage churn.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` - passed, 13 checks.
+- `npm run test:deflection-result --prefix portfolio-ui` - passed, 12 checks.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - passed, 14 checks.
+- `npm run build --prefix portfolio-ui` - passed after hydrating this fresh
+  worktree with `npm install --prefix portfolio-ui`; sitemap generation skipped
+  because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not configured.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-upload-progress-retry-ux.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Upload page progress/retry UI | 50 |
+| Focused tests | 8 |
+| **Total** | **146** |

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -134,6 +134,8 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-account-id-input",
     "data-atlas-deflection-submit",
     "data-atlas-deflection-upload-endpoint",
+    "data-atlas-deflection-upload-progress",
+    "data-atlas-deflection-retry",
   ]) {
     assert.match(uploadSource, new RegExp(marker));
   }
@@ -142,6 +144,12 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.doesNotMatch(blobUploadRouteSource, /^import .*@vercel\/blob\/client/m);
   assert.match(blobUploadRouteSource, /import\("@vercel\/blob\/client"\)/);
   assert.match(uploadSource, /access: "private"/);
+  assert.match(uploadSource, /onUploadProgress/);
+  assert.match(uploadSource, /boundedProgress\(event\.percentage\)/);
+  assert.match(uploadSource, /role="progressbar"/);
+  assert.match(uploadSource, /aria-valuenow=\{submit\.percentage\}/);
+  assert.match(uploadSource, /Retry upload/);
+  assert.match(uploadSource, /starts a new private upload/);
   assert.match(uploadSource, /blob_pathname: blob\.pathname/);
   assert.match(uploadSource, /private_blob_persistence/);
   assert.match(uploadSource, /value: "help_scout"/);

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   FileSpreadsheet,
   Loader2,
+  RotateCcw,
   Send,
   Upload,
 } from "lucide-react";
@@ -30,7 +31,7 @@ type UploadState =
 
 type SubmitState =
   | { status: "idle" }
-  | { status: "uploading" }
+  | { status: "uploading"; percentage: number }
   | { status: "submitting" }
   | { status: "error"; message: string };
 
@@ -64,6 +65,11 @@ function blobPathname(fileName: string) {
   return `${BLOB_UPLOAD_PATH_PREFIX}${Date.now()}-${csvName}`;
 }
 
+function boundedProgress(percentage: number | undefined) {
+  if (!Number.isFinite(percentage)) return 0;
+  return Math.max(0, Math.min(100, Math.round(percentage ?? 0)));
+}
+
 export default function FaqDeflectionUpload() {
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
@@ -84,19 +90,26 @@ export default function FaqDeflectionUpload() {
     [accountId, companyName, contactEmail, supportPlatform, upload.status],
   );
   const canSubmit = fieldsReady && submit.status !== "uploading" && submit.status !== "submitting";
+  const isRetry = submit.status === "error";
 
   const startSubmit = async () => {
     if (upload.status !== "ready" || !fieldsReady) return;
     const trimmedAccountId = accountId.trim();
 
     try {
-      setSubmit({ status: "uploading" });
+      setSubmit({ status: "uploading", percentage: 0 });
       const blob = await uploadBlob(blobPathname(upload.fileName), upload.file, {
         access: "private",
         contentType: "text/csv",
         handleUploadUrl: BLOB_UPLOAD_ENDPOINT,
         clientPayload: JSON.stringify({ account_id: trimmedAccountId }),
         multipart: upload.fileSize > 4 * 1024 * 1024,
+        onUploadProgress: (event) => {
+          setSubmit({
+            status: "uploading",
+            percentage: boundedProgress(event.percentage),
+          });
+        },
       });
 
       setSubmit({ status: "submitting" });
@@ -266,6 +279,30 @@ export default function FaqDeflectionUpload() {
                   <p>{upload.message}</p>
                 </div>
               )}
+              {submit.status === "uploading" && (
+                <div
+                  className="rounded-lg border border-primary-500/25 bg-primary-500/10 p-4"
+                  data-atlas-deflection-upload-progress
+                >
+                  <div className="flex items-center justify-between gap-3 text-xs font-medium text-primary-100">
+                    <span>Uploading CSV to private Blob</span>
+                    <span>{submit.percentage}%</span>
+                  </div>
+                  <div
+                    className="mt-3 h-2 overflow-hidden rounded-full bg-surface-900"
+                    role="progressbar"
+                    aria-label="CSV upload progress"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={submit.percentage}
+                  >
+                    <div
+                      className="h-full rounded-full bg-primary-300 transition-[width]"
+                      style={{ width: `${submit.percentage}%` }}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
 
             <button
@@ -284,6 +321,11 @@ export default function FaqDeflectionUpload() {
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Creating report
                 </>
+              ) : isRetry ? (
+                <>
+                  <RotateCcw size={16} />
+                  Retry upload
+                </>
               ) : (
                 <>
                   <Send size={16} />
@@ -292,7 +334,9 @@ export default function FaqDeflectionUpload() {
               )}
             </button>
             {submit.status === "error" && (
-              <p className="mt-3 text-xs leading-5 text-amber-200">{submit.message}</p>
+              <p className="mt-3 text-xs leading-5 text-amber-200" data-atlas-deflection-retry>
+                {submit.message} Retry keeps the selected CSV and starts a new private upload.
+              </p>
             )}
           </form>
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Upload-Progress-Retry-UX.md
Slice phase: Product polish

Add visible progress and manual retry UX to the hosted FAQ deflection upload flow now that private Vercel Blob persistence is merged.

## Intentional
- Retry is manual and re-runs the full private Blob upload plus server submit; the page does not trust or reuse a partial failed Blob reference.
- Progress is browser-only UI state and does not change service JWT, Blob token, or ATLAS envelope boundaries.
- Abandoned private Blob cleanup remains deferred until production observations show storage churn.

## Deferred
- Abandoned private Blob cleanup remains deferred.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - 13 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` - 12 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` - 14 checks passed.
- `npm run build --prefix portfolio-ui` - passed after `npm install --prefix portfolio-ui` hydrated this fresh worktree; sitemap generation skipped because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not configured.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-upload-progress-retry-ux.md` - passed.

## Diff size
3 files, +143 / -3
