### PR TITLE
PR-FAQ-Deflection-Private-Blob-Cleanup

### DIFF
--- a/plans/PR-FAQ-Deflection-Private-Blob-Cleanup.md
+++ b/plans/PR-FAQ-Deflection-Private-Blob-Cleanup.md
@@ -1,0 +1,88 @@
+# PR-FAQ-Deflection-Private-Blob-Cleanup
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Private-Blob-Persistence moved large FAQ deflection CSV uploads
+through private Vercel Blob, and PR-FAQ-Deflection-Upload-Progress-Retry-UX
+made failed uploads retryable from the browser. The remaining production
+hardening gap is server-side cleanup: after the portfolio API has consumed a
+private Blob and attempted the ATLAS submit, the Blob object should be deleted
+best-effort so successful and failed submit attempts do not leave stale private
+CSV objects behind.
+
+This slice is intentionally small because the browser upload, retry UX, and
+ATLAS forwarding contracts are already merged.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Production hardening
+
+1. Add a lazy private Blob delete helper to the FAQ deflection submit API.
+2. Delete the validated private Blob pathname after the server has read the
+   Blob and attempted the ATLAS submit.
+3. Keep cleanup best-effort: delete failures must not change the already
+   produced ATLAS submit result.
+4. Extend the upload shell tests to prove cleanup on success, cleanup on ATLAS
+   failure, and cleanup failure masking.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Private-Blob-Cleanup.md`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+`readPrivateCsvBlob()` returns the validated Blob pathname along with the CSV
+payload. `submitPrivateBlob()` forwards the CSV to ATLAS exactly as before,
+then calls `cleanupPrivateCsvBlob()` with the validated pathname and Blob token:
+
+```js
+const result = await forwardSubmit(...);
+await cleanupPrivateCsvBlob({ pathname: blob.pathname, token: blobToken, deleteBlobImpl });
+return result;
+```
+
+`cleanupPrivateCsvBlob()` validates the pathname again, lazy-imports
+`@vercel/blob`'s `del`, catches any delete error, and returns a cleanup status
+only for tests. The route response continues to expose only the existing submit
+success or failure payload.
+
+## Intentional
+
+- Cleanup runs after the ATLAS submit attempt, including ATLAS failure
+  envelopes, because the private Blob has already been consumed into the server
+  request path.
+- Cleanup does not run when the Blob reference is invalid, unavailable, or too
+  large; no ATLAS submit was attempted in those cases.
+- Cleanup status is not returned to the browser. It is a secondary write and
+  must not change the user-facing submit result.
+- The Vercel Blob SDK remains lazy-imported so the route stays importable in
+  local shell tests without requiring live Blob credentials or runtime wiring.
+
+## Deferred
+
+- Production observability for cleanup failures is deferred until the portfolio
+  API has a shared logging/telemetry surface for Vercel serverless routes.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 16 checks passed.
+- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
+- `npm run build --prefix portfolio-ui` -- passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 88 |
+| Submit API cleanup | 35 |
+| Focused tests | 126 |
+| **Total** | **248** |
+
+Actual diff is 3 files, +247 / -1. Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -200,6 +200,11 @@ async function getPrivateBlob(pathname, options) {
   return get(pathname, options);
 }
 
+async function deletePrivateBlob(pathname, options) {
+  const { del } = await import("@vercel/blob");
+  return del(pathname, options);
+}
+
 async function readPrivateCsvBlob({
   pathname,
   token,
@@ -226,6 +231,7 @@ async function readPrivateCsvBlob({
     }
     return {
       ok: true,
+      pathname: safePathname,
       body: body.body,
       contentType: clean(result.blob?.contentType) || "text/csv",
       fileName: fileNameFromPathname(safePathname),
@@ -235,12 +241,31 @@ async function readPrivateCsvBlob({
   }
 }
 
+async function cleanupPrivateCsvBlob({
+  pathname,
+  token,
+  deleteBlobImpl = deletePrivateBlob,
+}) {
+  const safePathname = validBlobPathname(pathname);
+  if (!safePathname) return { ok: false, skipped: true, error: "invalid_blob_reference" };
+  try {
+    await deleteBlobImpl(safePathname, { token });
+    return { ok: true };
+  } catch (error) {
+    console.warn("faq_deflection_private_blob_cleanup_failed", {
+      error: clean(error?.message) || "unknown",
+    });
+    return { ok: false, error: "private_blob_cleanup_failed" };
+  }
+}
+
 async function submitPrivateBlob({
   config,
   blobToken,
   payload,
   fetchImpl = fetch,
   getBlobImpl = getPrivateBlob,
+  deleteBlobImpl = deletePrivateBlob,
 }) {
   const blob = await readPrivateCsvBlob({
     pathname: payload?.blob_pathname,
@@ -256,7 +281,13 @@ async function submitPrivateBlob({
   form.set("contact_email", clean(payload?.contact_email));
   form.set("limit", clean(payload?.limit) || "1000");
 
-  return forwardSubmit({ config, contentType: "", body: form, fetchImpl });
+  const result = await forwardSubmit({ config, contentType: "", body: form, fetchImpl });
+  await cleanupPrivateCsvBlob({
+    pathname: blob.pathname,
+    token: blobToken,
+    deleteBlobImpl,
+  });
+  return result;
 }
 
 export {
@@ -265,6 +296,7 @@ export {
   MAX_CSV_BYTES,
   MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
+  cleanupPrivateCsvBlob,
   forwardSubmit,
   projectSubmitPayload,
   readPrivateCsvBlob,

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -8,6 +8,7 @@ import submitHandler, {
   MAX_CSV_BYTES,
   MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
+  cleanupPrivateCsvBlob,
   forwardSubmit,
   readPrivateCsvBlob,
   submitPrivateBlob,
@@ -168,6 +169,7 @@ await test("portfolio submit endpoint pins raw multipart body handling", () => {
   assert.match(submitSource, /bodyParser:\s*false/);
   assert.doesNotMatch(submitSource, /^import .*@vercel\/blob/m);
   assert.match(submitSource, /import\("@vercel\/blob"\)/);
+  assert.match(submitSource, /const \{ del \} = await import\("@vercel\/blob"\)/);
 });
 
 await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", async () => {
@@ -234,6 +236,7 @@ await test("private blob upload token config fails closed on path and account bi
 
 await test("private blob submit reads server-side blob and forwards ATLAS multipart", async () => {
   const calls = [];
+  const deleteCalls = [];
   const csv = "ticket_id,message\nticket-1,How do I export reports?";
   const result = await submitPrivateBlob({
     config: {
@@ -276,6 +279,9 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
         },
       };
     },
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
   });
 
   assert.equal(result.ok, true);
@@ -288,6 +294,126 @@ await test("private blob submit reads server-side blob and forwards ATLAS multip
   assert.equal(calls[0].options.body.get("support_platform"), "zendesk");
   assert.equal(calls[0].options.body.get("company_name"), "Acme Co.");
   assert.equal(await calls[0].options.body.get("csv_file").text(), csv);
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+});
+
+await test("private blob cleanup preserves ATLAS failure result", async () => {
+  const deleteCalls = [];
+  const csv = "ticket_id,message\nticket-1,How do I export reports?";
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      support_platform: "zendesk",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    getBlobImpl: async () => ({
+      statusCode: 200,
+      stream: new Blob([csv], { type: "text/csv" }).stream(),
+      blob: {
+        size: Buffer.byteLength(csv),
+        contentType: "text/csv",
+      },
+    }),
+    fetchImpl: async () => ({
+      ok: false,
+      status: 502,
+      async text() {
+        return JSON.stringify({ error: "upstream failed" });
+      },
+    }),
+    deleteBlobImpl: async (pathname, options) => {
+      deleteCalls.push({ pathname, options });
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    statusCode: 502,
+    error: "atlas_submit_failed",
+    atlas_status: 502,
+  });
+  assert.deepEqual(deleteCalls, [
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      options: { token: ENV.BLOB_READ_WRITE_TOKEN },
+    },
+  ]);
+});
+
+await test("private blob cleanup failure does not mask submit success", async () => {
+  const csv = "ticket_id,message\nticket-1,How do I export reports?";
+  const previousWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const result = await submitPrivateBlob({
+      config: {
+        baseUrl: ENV.ATLAS_API_BASE_URL,
+        token: ENV.ATLAS_B2B_JWT,
+        accountId: ACCOUNT_ID,
+        timeoutMs: 1000,
+      },
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      payload: {
+        blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+        support_platform: "zendesk",
+        company_name: "Acme Co.",
+        contact_email: "lead@acme.example",
+        limit: "1000",
+      },
+      getBlobImpl: async () => ({
+        statusCode: 200,
+        stream: new Blob([csv], { type: "text/csv" }).stream(),
+        blob: {
+          size: Buffer.byteLength(csv),
+          contentType: "text/csv",
+        },
+      }),
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ request_id: "content-ops-cleanup123" });
+        },
+      }),
+      deleteBlobImpl: async () => {
+        throw new Error("delete unavailable");
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.payload.request_id, "content-ops-cleanup123");
+  } finally {
+    console.warn = previousWarn;
+  }
+});
+
+await test("private blob cleanup rejects unsafe references before deleting", async () => {
+  let deleteCalled = false;
+  assert.deepEqual(
+    await cleanupPrivateCsvBlob({
+      pathname: "../tickets.csv",
+      token: ENV.BLOB_READ_WRITE_TOKEN,
+      deleteBlobImpl: async () => {
+        deleteCalled = true;
+      },
+    }),
+    { ok: false, skipped: true, error: "invalid_blob_reference" },
+  );
+  assert.equal(deleteCalled, false);
 });
 
 await test("private blob reader rejects unsafe or oversized blob references", async () => {


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Private-Blob-Cleanup.md
Slice phase: Production hardening

This slice deletes consumed private FAQ deflection CSV Blob objects after the portfolio submit API has read the Blob and attempted the ATLAS submit, keeping cleanup best-effort so delete failures cannot change an already-produced submit result.

## Intentional
- Cleanup runs after the ATLAS submit attempt, including ATLAS failure envelopes, because the private Blob has already been consumed into the server request path.
- Cleanup does not run when the Blob reference is invalid, unavailable, or too large; no ATLAS submit was attempted in those cases.
- Cleanup status is not returned to the browser.
- The Vercel Blob SDK remains lazy-imported.

## Deferred
- Production observability for cleanup failures is deferred until the portfolio API has a shared logging/telemetry surface for Vercel serverless routes.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 16 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
- `npm run build --prefix portfolio-ui` -- passed after hydrating local `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.

## Diff size
3 files, +247 / -1.
