### PR TITLE
PR-FAQ-Deflection-Cleanup-Observability

### DIFF
--- a/plans/PR-FAQ-Deflection-Cleanup-Observability.md
+++ b/plans/PR-FAQ-Deflection-Cleanup-Observability.md
@@ -1,0 +1,93 @@
+# PR-FAQ-Deflection-Cleanup-Observability
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Private-Blob-Cleanup closed the orphaned private Blob cleanup
+gap and intentionally deferred production observability for cleanup failures
+until the portfolio API had a shared logging/telemetry surface. Today the
+cleanup failure path emits an inline `console.warn`, which is enough to avoid
+silence but not enough to give later portfolio server routes a reusable,
+sanitized event shape.
+
+This slice adds the smallest shared server-side event helper for the FAQ
+deflection portfolio API and routes cleanup failures through it. The cleanup
+write remains secondary and best-effort.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Production hardening
+
+1. Add a deflection-scoped server event helper for sanitized structured warning
+   events.
+2. Route private Blob cleanup failures through that helper with the safe
+   validated Blob pathname and a fixed public error reason.
+3. Prove event-field redaction and logger-failure isolation in the focused
+   upload shell tests.
+4. Keep browser responses, Blob cleanup timing, and ATLAS submit behavior
+   unchanged.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Cleanup-Observability.md`
+- `portfolio-ui/api/content-ops/deflection/events.js`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+`events.js` exports `emitDeflectionServerEvent()`. It accepts an event name,
+field object, and optional logger; drops secret-shaped field names, redacts
+secret-shaped string values, bounds remaining strings, and catches logger
+failures so observability cannot break a request path.
+
+`cleanupPrivateCsvBlob()` keeps the existing delete catch, but emits:
+
+```js
+emitDeflectionServerEvent("faq_deflection_private_blob_cleanup_failed", {
+  pathname: safePathname,
+  error: "delete_failed",
+});
+```
+
+The helper returns event metadata for tests only. Route responses still expose
+only the existing submit success or failure payload.
+
+## Intentional
+
+- This is not a full telemetry backend. It creates a shared, sanitized event
+  surface for the portfolio deflection API while preserving Vercel log
+  compatibility.
+- The cleanup event includes the validated Blob pathname and a fixed public
+  error reason, not the Blob token, URL, ATLAS JWT, contact email, SDK error
+  message, or CSV content.
+- Logger failures are swallowed by the event helper because logging is a
+  secondary write after the submit path has already produced a result.
+- Cleanup still does not run for invalid, unavailable, or oversized Blob reads.
+
+## Deferred
+
+- Shipping these server events to a durable sink remains deferred until the
+  portfolio deployment has an operator-selected telemetry backend.
+
+Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 18 checks passed.
+- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
+- `npm run build --prefix portfolio-ui` -- passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 93 |
+| Event helper | 43 |
+| Submit wiring | 11 |
+| Focused tests | 137 |
+| **Total** | **284** |
+
+Current diff is 4 files, +242 / -42. Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/events.js
+++ b/portfolio-ui/api/content-ops/deflection/events.js
@@ -1,0 +1,43 @@
+const EVENT_NAME_RE = /^[a-z][a-z0-9_]{2,100}$/;
+const SECRET_FIELD_RE = /(authorization|jwt|secret|token|credential|password|email|csv|body|content)/i;
+const SECRET_VALUE_RE = /(authorization|bearer\s+[A-Za-z0-9._~+/=-]+|jwt|secret|token|credential|password|[?&][A-Za-z0-9_.-]*(token|secret|credential|password|jwt)=)/i;
+const MAX_FIELD_LENGTH = 240;
+
+function safeEventName(value) {
+  return typeof value === "string" && EVENT_NAME_RE.test(value)
+    ? value
+    : "faq_deflection_server_event";
+}
+
+function sanitizeEventValue(value) {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "boolean" || typeof value === "number") return value;
+  if (typeof value !== "string") return String(value).slice(0, MAX_FIELD_LENGTH);
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (SECRET_VALUE_RE.test(trimmed)) return "[redacted]";
+  return trimmed.slice(0, MAX_FIELD_LENGTH);
+}
+
+function sanitizeDeflectionEventFields(fields = {}) {
+  const safe = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (!key || SECRET_FIELD_RE.test(key)) continue;
+    const sanitized = sanitizeEventValue(value);
+    if (sanitized !== undefined) safe[key] = sanitized;
+  }
+  return safe;
+}
+
+function emitDeflectionServerEvent(eventName, fields = {}, logger = console.warn) {
+  const event = safeEventName(eventName);
+  const safeFields = sanitizeDeflectionEventFields(fields);
+  try {
+    logger(event, safeFields);
+    return { ok: true, event, fields: safeFields };
+  } catch {
+    return { ok: false, event, fields: safeFields };
+  }
+}
+
+export { emitDeflectionServerEvent, sanitizeDeflectionEventFields };

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -1,5 +1,6 @@
 import { atlasUrl, clean, configFromEnv } from "./atlas-report.js";
 import { resultPath } from "./checkout.js";
+import { emitDeflectionServerEvent } from "./events.js";
 
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -245,6 +246,7 @@ async function cleanupPrivateCsvBlob({
   pathname,
   token,
   deleteBlobImpl = deletePrivateBlob,
+  eventLogger = console.warn,
 }) {
   const safePathname = validBlobPathname(pathname);
   if (!safePathname) return { ok: false, skipped: true, error: "invalid_blob_reference" };
@@ -252,9 +254,10 @@ async function cleanupPrivateCsvBlob({
     await deleteBlobImpl(safePathname, { token });
     return { ok: true };
   } catch (error) {
-    console.warn("faq_deflection_private_blob_cleanup_failed", {
-      error: clean(error?.message) || "unknown",
-    });
+    emitDeflectionServerEvent("faq_deflection_private_blob_cleanup_failed", {
+      pathname: safePathname,
+      error: "delete_failed",
+    }, eventLogger);
     return { ok: false, error: "private_blob_cleanup_failed" };
   }
 }
@@ -266,6 +269,7 @@ async function submitPrivateBlob({
   fetchImpl = fetch,
   getBlobImpl = getPrivateBlob,
   deleteBlobImpl = deletePrivateBlob,
+  eventLogger = console.warn,
 }) {
   const blob = await readPrivateCsvBlob({
     pathname: payload?.blob_pathname,
@@ -286,6 +290,7 @@ async function submitPrivateBlob({
     pathname: blob.pathname,
     token: blobToken,
     deleteBlobImpl,
+    eventLogger,
   });
   return result;
 }

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -18,6 +18,10 @@ import {
   MAX_BLOB_CSV_BYTES as MAX_UPLOAD_CSV_BYTES,
   uploadTokenConfig,
 } from "../api/content-ops/deflection/upload.js";
+import {
+  emitDeflectionServerEvent,
+  sanitizeDeflectionEventFields,
+} from "../api/content-ops/deflection/events.js";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
@@ -356,49 +360,104 @@ await test("private blob cleanup preserves ATLAS failure result", async () => {
 
 await test("private blob cleanup failure does not mask submit success", async () => {
   const csv = "ticket_id,message\nticket-1,How do I export reports?";
-  const previousWarn = console.warn;
-  console.warn = () => {};
-  try {
-    const result = await submitPrivateBlob({
-      config: {
-        baseUrl: ENV.ATLAS_API_BASE_URL,
-        token: ENV.ATLAS_B2B_JWT,
-        accountId: ACCOUNT_ID,
-        timeoutMs: 1000,
+  const events = [];
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      timeoutMs: 1000,
+    },
+    blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+    payload: {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      support_platform: "zendesk",
+      company_name: "Acme Co.",
+      contact_email: "lead@acme.example",
+      limit: "1000",
+    },
+    getBlobImpl: async () => ({
+      statusCode: 200,
+      stream: new Blob([csv], { type: "text/csv" }).stream(),
+      blob: {
+        size: Buffer.byteLength(csv),
+        contentType: "text/csv",
       },
-      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
-      payload: {
-        blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
-        support_platform: "zendesk",
-        company_name: "Acme Co.",
-        contact_email: "lead@acme.example",
-        limit: "1000",
+    }),
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ request_id: "content-ops-cleanup123" });
       },
-      getBlobImpl: async () => ({
-        statusCode: 200,
-        stream: new Blob([csv], { type: "text/csv" }).stream(),
-        blob: {
-          size: Buffer.byteLength(csv),
-          contentType: "text/csv",
-        },
-      }),
-      fetchImpl: async () => ({
-        ok: true,
-        status: 200,
-        async text() {
-          return JSON.stringify({ request_id: "content-ops-cleanup123" });
-        },
-      }),
-      deleteBlobImpl: async () => {
-        throw new Error("delete unavailable");
-      },
-    });
+    }),
+    deleteBlobImpl: async () => {
+      throw new Error("delete unavailable");
+    },
+    eventLogger: (event, fields) => {
+      events.push({ event, fields });
+    },
+  });
 
-    assert.equal(result.ok, true);
-    assert.equal(result.payload.request_id, "content-ops-cleanup123");
-  } finally {
-    console.warn = previousWarn;
-  }
+  assert.equal(result.ok, true);
+  assert.equal(result.payload.request_id, "content-ops-cleanup123");
+  assert.deepEqual(events, [
+    {
+      event: "faq_deflection_private_blob_cleanup_failed",
+      fields: {
+        pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+        error: "delete_failed",
+      },
+    },
+  ]);
+});
+
+await test("private blob cleanup event logging is secondary", async () => {
+  const result = await cleanupPrivateCsvBlob({
+    pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+    token: ENV.BLOB_READ_WRITE_TOKEN,
+    deleteBlobImpl: async () => {
+      throw new Error("delete unavailable");
+    },
+    eventLogger: () => {
+      throw new Error("logger unavailable");
+    },
+  });
+
+  assert.deepEqual(result, { ok: false, error: "private_blob_cleanup_failed" });
+});
+
+await test("deflection server events redact secret-shaped fields", () => {
+  assert.deepEqual(
+    sanitizeDeflectionEventFields({
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      token: ENV.BLOB_READ_WRITE_TOKEN,
+      Authorization: "Bearer secret",
+      contact_email: "lead@acme.example",
+      error: "x".repeat(300),
+      detail: `delete failed for https://blob.example.com/file.csv?token=${ENV.BLOB_READ_WRITE_TOKEN}`,
+      ok: false,
+      count: 3,
+    }),
+    {
+      pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      error: "x".repeat(240),
+      detail: "[redacted]",
+      ok: false,
+      count: 3,
+    },
+  );
+
+  const emitted = emitDeflectionServerEvent(
+    "not a valid event name",
+    { token: "secret", outcome: "cleanup_failed" },
+    () => {},
+  );
+  assert.deepEqual(emitted, {
+    ok: true,
+    event: "faq_deflection_server_event",
+    fields: { outcome: "cleanup_failed" },
+  });
 });
 
 await test("private blob cleanup rejects unsafe references before deleting", async () => {


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Cleanup-Observability.md
Slice phase: Production hardening

This slice adds a small shared server-side event helper for FAQ deflection portfolio API warnings and routes private Blob cleanup failures through it, preserving the best-effort cleanup contract while making failures structured and sanitized in logs.

## Intentional
- This is not a full telemetry backend; it keeps Vercel-compatible server logging while creating a reusable event shape.
- Cleanup events include the validated Blob pathname and bounded error string, not tokens, service credentials, emails, CSV content, or browser responses.
- Logger failures are swallowed because logging is a secondary write after the submit path has produced a result.

## Deferred
- Shipping these server events to a durable sink remains deferred until the portfolio deployment has an operator-selected telemetry backend.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 18 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
- `npm run build --prefix portfolio-ui` -- passed after hydrating local `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.

## Diff size
4 files, +236 / -41.
