### PR TITLE
PR-FAQ-Deflection-Submit-Deploy-Parity

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
@@ -121,6 +121,26 @@ Both submit modes then verify:
 - `GET /api/v1/content-ops/deflection-reports/{request_id}/artifact` returns
   `403` before payment.
 
+### Stale Deploy Diagnostic
+
+If the multipart hosted smoke fails with:
+
+```text
+deployed submit route rejected multipart as a JSON body
+```
+
+then the host accepted auth but did not serve the current multipart submit
+contract. The exact FastAPI shape is a `422` with
+`detail[0].type == "model_attributes_type"` at `loc == ["body"]`, which is the
+old JSON-body route behavior when it receives `multipart/form-data`.
+
+Treat this as deployment/runtime drift, not bad portfolio input. Rebuild and
+redeploy ATLAS from a commit that includes the multipart
+`submit_deflection_report(request: Request)` route, the extracted package copy
+in the Docker image, and the `python-multipart` dependency. Re-run the smoke
+after deploy; do not continue to Stripe paid-unlock validation until submit
+returns a real `request_id`.
+
 ## Portfolio Result Page Smoke
 
 After the hosted submit smoke returns a `request_id`, validate the portfolio

--- a/plans/PR-FAQ-Deflection-Submit-Deploy-Parity.md
+++ b/plans/PR-FAQ-Deflection-Submit-Deploy-Parity.md
@@ -1,0 +1,94 @@
+# PR-FAQ-Deflection-Submit-Deploy-Parity
+
+## Why this slice exists
+
+The source tree now has the multipart FAQ deflection submit route and the
+hosted smoke for the portfolio handoff, but the redeployed ATLAS host still
+returned the old FastAPI/Pydantic JSON-body validation error for a multipart
+CSV submit on May 30, 2026:
+
+`detail[0].type == "model_attributes_type"` at `loc == ["body"]`.
+
+That proves auth and reachability are not the blocker; the deployed runtime is
+serving a stale JSON-only submit contract or importing stale route code. The
+next slice needs a fail-closed deploy-parity diagnostic so the operator can tell
+whether the live host is actually running the multipart contract before moving
+on to paid unlock validation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Functional validation
+
+1. Teach the hosted submit smoke to recognize the stale JSON-body FastAPI 422
+   that occurs when a multipart CSV hits the old submit route.
+2. Return a clear, non-secret diagnostic in the result artifact while keeping
+   snapshot/artifact probes skipped after the failed submit.
+3. Add focused failure fixtures so the detector catches the stale-route shape
+   and does not fire for JSON-mode or unrelated 422 responses.
+4. Document the diagnostic and remediation in the submit handoff runbook.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Deploy-Parity.md`
+- `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+## Mechanism
+
+The smoke already parses HTTP error payloads. This slice adds a small predicate
+over the submit response:
+
+```python
+if submit_mode == "multipart" and status == 422 and detail includes
+model_attributes_type at loc ["body"]:
+    emit "deployed submit route rejected multipart as JSON body ..."
+```
+
+The diagnostic is appended to the existing submit errors. The smoke still
+requires submit `200` before it hydrates snapshot or artifact routes, so a stale
+deploy cannot create a false-green request id or paid-gate proof.
+
+## Intentional
+
+- This slice does not change the submit route implementation. The current
+  source already has the multipart `Request` route, Docker image copy entries,
+  and `python-multipart` dependency; the observed failure is deploy/runtime
+  parity.
+- The detector is restricted to multipart mode and the exact FastAPI
+  `model_attributes_type` body error so ordinary validation errors are not
+  mislabeled as stale deploys.
+- The smoke does not print raw response bodies or uploaded CSV contents in the
+  diagnostic.
+
+## Deferred
+
+- Parked hardening: none. Existing `HARDENING.md` entries do not touch this
+  smoke or submit handoff lane.
+- Live green proof remains deferred until the deployed host serves the
+  multipart route and the operator provides a representative CSV input.
+- Stripe paid-unlock live proof remains the next validation step after submit
+  returns a real `request_id`.
+
+## Verification
+
+- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py` - passed.
+- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` - 20 passed.
+- Live diagnostic run against `https://atlas-brain.tailc7bd29.ts.net` with the
+  B2B JWT/account env from the local root `.env` and a temporary CSV fixture -
+  expected fail, exit 1: submit `422` with
+  `deployed submit route rejected multipart as a JSON body`; snapshot/artifact
+  skipped with `submit_failed`. This confirms the current deployed host is
+  reachable/authenticated but still serving the stale JSON-body submit route.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-submit-deploy-parity-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 83 |
+| Smoke script | 35 |
+| Tests | 75 |
+| Runbook | 20 |
+| **Total** | **213** |

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -502,6 +502,33 @@ def _validate_submit_envelope(
     return request_id, snapshot if isinstance(snapshot, Mapping) else None, diagnostics, errors
 
 
+def _stale_multipart_submit_route_errors(response: HttpJsonResponse, *, submit_mode: str) -> list[str]:
+    if submit_mode != "multipart" or response.status != 422:
+        return []
+    payload = response.payload
+    if not isinstance(payload, Mapping):
+        return []
+    detail = payload.get("detail")
+    if not isinstance(detail, Sequence) or isinstance(detail, (str, bytes, bytearray)):
+        return []
+    for item in detail:
+        if not isinstance(item, Mapping):
+            continue
+        loc = item.get("loc")
+        if (
+            item.get("type") == "model_attributes_type"
+            and isinstance(loc, Sequence)
+            and not isinstance(loc, (str, bytes, bytearray))
+            and tuple(loc) == ("body",)
+        ):
+            return [
+                "deployed submit route rejected multipart as a JSON body; "
+                "expected multipart CSV Request route, so the host is likely "
+                "serving stale route code or importing a stale extracted_content_pipeline"
+            ]
+    return []
+
+
 def _status_summary(response: HttpJsonResponse) -> dict[str, Any]:
     return {
         "status": response.status,
@@ -574,6 +601,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     request_id = ""
     submit_snapshot: Mapping[str, Any] | None = None
     diagnostics: dict[str, Any] = {}
+    submit_errors.extend(
+        _stale_multipart_submit_route_errors(submit_response, submit_mode=submit_mode)
+    )
     if submit_response.status != 200:
         submit_errors.append(f"submit status must be 200, got {submit_response.status}")
     else:

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -326,6 +326,53 @@ def test_validate_submit_envelope_rejects_singular_source_id_leak() -> None:
     assert any("$.top_questions[0].source_id" in error for error in errors)
 
 
+def test_stale_multipart_submit_route_detector_identifies_json_body_422() -> None:
+    response = smoke.HttpJsonResponse(
+        status=422,
+        payload={
+            "detail": [
+                {
+                    "type": "model_attributes_type",
+                    "loc": ["body"],
+                    "msg": "Input should be a valid dictionary or object to extract fields from",
+                }
+            ]
+        },
+        raw_text="",
+    )
+
+    errors = smoke._stale_multipart_submit_route_errors(response, submit_mode="multipart")
+
+    assert errors == [
+        "deployed submit route rejected multipart as a JSON body; "
+        "expected multipart CSV Request route, so the host is likely "
+        "serving stale route code or importing a stale extracted_content_pipeline"
+    ]
+
+
+def test_stale_multipart_submit_route_detector_rejects_json_mode() -> None:
+    response = smoke.HttpJsonResponse(
+        status=422,
+        payload={"detail": [{"type": "model_attributes_type", "loc": ["body"]}]},
+        raw_text="",
+    )
+
+    assert smoke._stale_multipart_submit_route_errors(
+        response,
+        submit_mode="json_blob_url",
+    ) == []
+
+
+def test_stale_multipart_submit_route_detector_rejects_unrelated_422() -> None:
+    response = smoke.HttpJsonResponse(
+        status=422,
+        payload={"detail": [{"type": "missing", "loc": ["body", "csv_file"]}]},
+        raw_text="",
+    )
+
+    assert smoke._stale_multipart_submit_route_errors(response, submit_mode="multipart") == []
+
+
 def test_run_success_posts_submit_and_probes_snapshot_and_locked_artifact(monkeypatch, tmp_path):
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(
@@ -401,6 +448,52 @@ def test_run_success_posts_multipart_csv_and_probes_locked_artifact(monkeypatch,
     assert 'name="support_platform"' in calls[0]["body_text"]
     assert "blob_url" not in calls[0]["body_text"]
     assert summary["submit"]["diagnostics"]["metadata"]["uploaded_bytes"] == csv_file.stat().st_size
+    serialized = json.dumps(summary)
+    assert "token-secret" not in serialized
+    assert "How do I export reports?" not in serialized
+
+
+def test_run_fails_with_stale_multipart_submit_route_diagnostic(monkeypatch, tmp_path):
+    csv_file = _write_csv(tmp_path)
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        smoke,
+        "_open_http_request",
+        _fake_open(
+            [
+                (
+                    422,
+                    {
+                        "detail": [
+                            {
+                                "type": "model_attributes_type",
+                                "loc": ["body"],
+                                "msg": (
+                                    "Input should be a valid dictionary or object to "
+                                    "extract fields from"
+                                ),
+                            }
+                        ]
+                    },
+                )
+            ],
+            calls,
+        ),
+    )
+    args = smoke._build_parser().parse_args(_base_csv_args(tmp_path, csv_file))
+
+    summary = smoke.run(args)
+
+    assert summary["ok"] is False
+    assert len(calls) == 1
+    assert summary["snapshot"]["not_run_reason"] == "submit_failed"
+    assert summary["artifact"]["not_run_reason"] == "submit_failed"
+    assert (
+        "deployed submit route rejected multipart as a JSON body; expected multipart CSV "
+        "Request route, so the host is likely serving stale route code or importing a "
+        "stale extracted_content_pipeline"
+    ) in summary["errors"]
+    assert "submit status must be 200, got 422" in summary["errors"]
     serialized = json.dumps(summary)
     assert "token-secret" not in serialized
     assert "How do I export reports?" not in serialized


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Deploy-Parity.md
Slice phase: Functional validation

The live ATLAS host is reachable with the B2B JWT, but multipart submit still returns the old FastAPI JSON-body `422` shape. This slice makes the hosted submit smoke fail with a precise deploy-parity diagnostic for that stale route shape instead of a generic submit failure, and documents the remediation path before Stripe paid-unlock validation continues.

## Intentional
- This does not change the submit route implementation; current source already has the multipart `Request` route, Docker image copy entries, and `python-multipart` dependency.
- The detector only fires for multipart mode plus the exact `model_attributes_type` body-level FastAPI error, so ordinary validation failures are not mislabeled as stale deploys.
- The result artifact does not print bearer tokens, raw response bodies, or uploaded CSV contents.

## Deferred
- Live green proof remains deferred until the deployed host serves the multipart route and submit returns a real `request_id`.
- Stripe paid-unlock live proof remains the next validation step after submit is green.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` - 20 passed.
- Live diagnostic run against `https://atlas-brain.tailc7bd29.ts.net` with local B2B JWT/account env and a temporary CSV fixture - expected fail, exit 1: submit `422` with `deployed submit route rejected multipart as a JSON body`; snapshot/artifact skipped with `submit_failed`.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-submit-deploy-parity-pr-body.md` - passed.

## Diff size
4 files, +237 / -0