### PR TITLE
PR-FAQ-Deflection-Submit-Request-Mapping-Fix

### DIFF
--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1188,47 +1188,54 @@ async def _load_deflection_submit_rows_from_request(
     *,
     max_bytes: int,
 ) -> tuple[dict[str, Any], list[Any], int, str]:
-    if isinstance(request, Mapping):
-        data = _deflection_submit_payload_to_mapping(request)
+    if _is_deflection_submit_http_request(request):
+        content_type = _request_content_type(request)
+        if "multipart/form-data" in content_type:
+            _reject_oversize_deflection_submit_multipart(request, max_bytes=max_bytes)
+            try:
+                form = await request.form(max_part_size=max_bytes)
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Multipart deflection submit body could not be parsed.",
+                ) from exc
+            csv_file = form.get("csv_file") if hasattr(form, "get") else None
+            if csv_file is None:
+                raise HTTPException(status_code=422, detail="csv_file is required")
+            data = _deflection_submit_form_to_mapping(form)
+            rows, byte_count = await _load_deflection_submit_upload_rows(
+                csv_file,
+                max_bytes=max_bytes,
+            )
+            return data, rows, byte_count, "uploaded_bytes"
+
+        try:
+            payload = await request.json()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="JSON deflection submit body could not be parsed.",
+            ) from exc
+        data = _deflection_submit_payload_to_mapping(payload)
         rows, byte_count = await _load_deflection_submit_blob_rows(
             data["blob_url"],
             max_bytes=max_bytes,
         )
         return data, rows, byte_count, "blob_bytes"
 
-    content_type = _request_content_type(request)
-    if "multipart/form-data" in content_type:
-        _reject_oversize_deflection_submit_multipart(request, max_bytes=max_bytes)
-        try:
-            form = await request.form(max_part_size=max_bytes)
-        except Exception as exc:
-            raise HTTPException(
-                status_code=400,
-                detail="Multipart deflection submit body could not be parsed.",
-            ) from exc
-        csv_file = form.get("csv_file") if hasattr(form, "get") else None
-        if csv_file is None:
-            raise HTTPException(status_code=422, detail="csv_file is required")
-        data = _deflection_submit_form_to_mapping(form)
-        rows, byte_count = await _load_deflection_submit_upload_rows(
-            csv_file,
-            max_bytes=max_bytes,
-        )
-        return data, rows, byte_count, "uploaded_bytes"
-
-    try:
-        payload = await request.json()
-    except Exception as exc:
-        raise HTTPException(
-            status_code=400,
-            detail="JSON deflection submit body could not be parsed.",
-        ) from exc
-    data = _deflection_submit_payload_to_mapping(payload)
+    data = _deflection_submit_payload_to_mapping(request)
     rows, byte_count = await _load_deflection_submit_blob_rows(
         data["blob_url"],
         max_bytes=max_bytes,
     )
     return data, rows, byte_count, "blob_bytes"
+
+
+def _is_deflection_submit_http_request(value: Any) -> bool:
+    return (
+        hasattr(value, "headers")
+        and (hasattr(value, "form") or hasattr(value, "json"))
+    )
 
 
 def _request_content_type(request: Any) -> str:

--- a/plans/PR-FAQ-Deflection-Submit-Request-Mapping-Fix.md
+++ b/plans/PR-FAQ-Deflection-Submit-Request-Mapping-Fix.md
@@ -1,0 +1,88 @@
+# PR-FAQ-Deflection-Submit-Request-Mapping-Fix
+
+## Why this slice exists
+
+The hosted FAQ deflection submit handoff still fails for multipart CSV uploads.
+The source route is no longer JSON-only, but a local FastAPI `TestClient`
+reproduction exposed the real runtime bug: Starlette `Request` implements
+`Mapping`, and `_load_deflection_submit_rows_from_request` checks
+`isinstance(request, Mapping)` before it checks the HTTP content type. Live
+FastAPI requests therefore enter the legacy JSON/blob mapping path instead of
+the multipart parser.
+
+The prior direct endpoint tests passed because their fake multipart request was
+not a `Mapping`. This slice closes that test gap and fixes the route order so
+the actual hosted request object follows the multipart branch.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Functional validation
+
+1. Treat HTTP request-like objects as requests before accepting plain mapping
+   payloads for the legacy JSON blob-url submit path.
+2. Preserve the existing direct mapping support for tests and non-HTTP callers.
+3. Add a FastAPI `TestClient` multipart regression that exercises real request
+   dispatch instead of direct endpoint invocation.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Request-Mapping-Fix.md`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_deflection_submit.py`
+
+## Mechanism
+
+`_load_deflection_submit_rows_from_request` now identifies request-like objects
+by their HTTP surface (`headers` plus `form` or `json`) before falling back to
+the plain `Mapping` path:
+
+```python
+if _is_deflection_submit_http_request(request):
+    inspect content-type and parse multipart/json
+elif isinstance(request, Mapping):
+    legacy blob_url mapping path
+```
+
+This keeps dict payloads working while preventing Starlette `Request` from
+being validated as `DeflectionReportSubmitModel`.
+
+## Intentional
+
+- This slice does not change the public submit contract, artifact gating, or
+  paid trust boundary.
+- The legacy JSON blob-url submit path remains available; only live HTTP
+  request classification changes.
+- No Docker or deployment scripts are touched; this is the route runtime bug
+  that shows up under real FastAPI dispatch.
+
+## Deferred
+
+- Parked hardening: none. Existing `HARDENING.md` entries do not touch this
+  submit route.
+- Live hosted submit proof remains a follow-up operator run after this PR
+  lands and ATLAS is redeployed.
+
+## Verification
+
+- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` - 18 passed.
+- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py` - passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed; 295 reasoning-core
+  tests passed, then 2865 extracted-content-pipeline tests passed, 10 skipped,
+  1 warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-submit-request-mapping-fix-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 76 |
+| Route fix | 20 |
+| TestClient regression | 55 |
+| **Total** | **151** |
+
+Actual diff is 3 files, +169 / -27.

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -5,6 +5,8 @@ import socket
 import urllib.error
 from typing import Any
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 
 import extracted_content_pipeline.api.control_surfaces as api_module
@@ -254,6 +256,51 @@ async def test_deflection_submit_accepts_multipart_csv_bytes() -> None:
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+
+
+def test_deflection_submit_fastapi_dispatch_accepts_multipart_csv_bytes() -> None:
+    csv_data = _csv_bytes([
+        "ticket_id,subject,message,resolution_text,pain_category",
+        (
+            "ticket-export-1,Export attribution,"
+            "How do I export attribution reports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        (
+            "ticket-export-2,Report download,"
+            "Where is the report download for attribution exports?,"
+            "Open Analytics and click Download report.,exports"
+        ),
+        "ticket-sso-1,SSO setup,How do I enable SSO for my team?,,auth",
+    ])
+    store = InMemoryDeflectionReportArtifactStore()
+    app = FastAPI()
+    app.include_router(_router(store))
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/ops/deflection-reports/submit",
+            data={
+                "support_platform": "zendesk",
+                "company_name": "Acme Co.",
+                "contact_email": "lead@acme.example",
+                "limit": "2",
+            },
+            files={"csv_file": ("tickets.csv", csv_data, "text/csv")},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "completed"
+    assert payload["request_id"].startswith("content-ops-")
+    gated_result = payload["steps"][0]["result"]
+    assert gated_result["full_report"] == {
+        "status": "locked",
+        "reason": "payment_required",
+    }
+    assert payload["input_provider"]["metadata"]["uploaded_bytes"] == len(csv_data)
+    assert payload["input_provider"]["metadata"]["support_platform"] == "zendesk"
+    assert "markdown" not in str(gated_result)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Request-Mapping-Fix.md
Slice phase: Functional validation

The live multipart submit failure is a route runtime bug, not Docker: Starlette `Request` implements `Mapping`, so `_load_deflection_submit_rows_from_request` classified real FastAPI requests as legacy JSON/blob mappings before it inspected `multipart/form-data`. This slice classifies HTTP request-like objects first and adds a real FastAPI `TestClient` multipart regression so direct endpoint tests cannot miss it again.

## Intentional
- The public submit contract is unchanged.
- The legacy JSON blob-url submit path remains available for rollback coverage.
- No Docker or deployment scripts are touched; this fixes the route/runtime classification bug.

## Deferred
- Live hosted submit proof remains a follow-up operator run after this PR lands and ATLAS is redeployed.

## Parked hardening
- None.

## Verification
- `python -m pytest tests/test_extracted_content_deflection_submit.py -q` - 18 passed.
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_deflection_submit.py` - passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed; 295 reasoning-core tests passed, then 2865 extracted-content-pipeline tests passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-submit-request-mapping-fix-pr-body.md` - passed.

## Diff size
3 files, +164 / -27