### PR TITLE
PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke.md
@@ -1,0 +1,90 @@
+# PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke
+
+## Why this slice exists
+
+With the ATLAS backend paid-flow contract already in place, the next handoff
+risk is the portfolio result page: it must expose the exact request and account
+metadata that Checkout uses, so the hosted smoke can verify the customer-facing
+page before any paid artifact is released.
+
+The existing smoke already checks those page hooks, but the portfolio result
+page only rendered the Checkout metadata in text. The unlock CTA itself did not
+carry the `data-checkout-*` attributes that the smoke validates, leaving the
+hosted result-page handoff false-red even when the underlying Checkout endpoint
+was correctly building Stripe metadata.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Functional validation
+
+1. Bind the result page unlock CTA to the Checkout metadata source,
+   `request_id`, and `account_id` as machine-readable attributes.
+2. Keep the existing fail-closed paid boundary: the page still calls portfolio
+   Checkout only, never the privileged ATLAS `/paid` route.
+3. Tighten the portfolio result-page test so the hosted HTML contract cannot
+   regress back to text-only metadata.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke.md`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+
+## Mechanism
+
+`renderResultPage` already receives the canonical `requestId`, `accountId`, and
+`CHECKOUT_SOURCE`. This slice threads those values onto the
+`data-atlas-deflection-unlock` button:
+
+```html
+<button
+  data-atlas-deflection-unlock
+  data-checkout-source="content_ops_deflection_report"
+  data-checkout-request_id="..."
+  data-checkout-account_id="..."
+>
+```
+
+The React fallback route gets the same attributes so both the Vercel rewrite
+HTML and SPA page keep the same instrumentation contract.
+
+## Intentional
+
+- This does not create a new live smoke script; the existing
+  `scripts/smoke_content_ops_deflection_portfolio_result_page.py` is already
+  the contract runner.
+- This does not change Stripe session creation, amount validation, webhook
+  handling, or artifact fetching.
+- The page continues to render only snapshot fields before payment; paid report
+  rendering remains gated on the ATLAS artifact route returning `200`.
+
+## Deferred
+
+- Parked hardening: none. The existing `HARDENING.md` FAQ deflection note is
+  for the Intel report UI lane, not the portfolio result page.
+- Running the hosted smoke against the production portfolio URL remains the
+  deploy verification step after this PR lands; this slice fixes the local
+  contract gap that would block that smoke.
+
+## Verification
+
+- `npm run test:deflection-result` from `portfolio-ui/` - 12 checks passed.
+- `npm run test:deflection-atlas-proxy` from `portfolio-ui/` - 14 checks passed.
+- `npm run test:deflection-upload-shell` from `portfolio-ui/` - 18 checks passed.
+- `python -m pytest tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` - 8 passed.
+- `npm run build` from `portfolio-ui/` - passed; Vite emitted the existing large chunk advisory and skipped sitemap generation because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` was not set.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 70 |
+| Result page attributes | 8 |
+| React fallback attributes | 4 |
+| Test tightening | 30 |
+| **Total** | **112** |
+
+Actual diff is 5 files, +130 / -4.

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -237,7 +237,14 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
           <div><dt>artifact_status</dt><dd>${escapeHtml(artifactStatus)}</dd></div>
           <div><dt>checkout</dt><dd>${safeCheckoutStatus || "locked"}</dd></div>
         </dl>
-        <button type="button" data-atlas-deflection-unlock ${buttonDisabled}>${unlockButtonLabel}</button>
+        <button
+          type="button"
+          data-atlas-deflection-unlock
+          data-checkout-source="${CHECKOUT_SOURCE}"
+          data-checkout-request_id="${safeRequestId}"
+          data-checkout-account_id="${safeAccountId}"
+          ${buttonDisabled}
+        >${unlockButtonLabel}</button>
         <p id="checkout-message" class="muted" role="status"></p>
       </aside>
     </div>

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -82,6 +82,20 @@ function mockResponse() {
   };
 }
 
+function assertUnlockCta(html, { disabled }) {
+  const match = html.match(/<button\b[\s\S]*?data-atlas-deflection-unlock[\s\S]*?>/);
+  assert.ok(match, "unlock CTA button must render");
+  const button = match[0];
+  assert.match(button, /data-checkout-source="content_ops_deflection_report"/);
+  assert.match(button, new RegExp(`data-checkout-request_id="${REQUEST_ID}"`));
+  assert.match(button, new RegExp(`data-checkout-account_id="${ACCOUNT_ID}"`));
+  if (disabled) {
+    assert.match(button, /\sdisabled(?:\s|>)/);
+  } else {
+    assert.doesNotMatch(button, /\sdisabled(?:\s|>)/);
+  }
+}
+
 function withEnv(nextEnv, fn) {
   const previous = {};
   for (const key of Object.keys(nextEnv)) {
@@ -276,7 +290,7 @@ await test("hosted result page renders real snapshot metrics from the proxy enve
   assert.match(html, /data-atlas-deflection-artifact-retry="false"/);
   assert.match(html, /Unlock full report/);
   assert.match(html, /Continue to Checkout/);
-  assert.match(html, /<button type="button" data-atlas-deflection-unlock >/);
+  assertUnlockCta(html, { disabled: false });
   assert.doesNotMatch(html, /# Paid report/);
   assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
 });
@@ -296,7 +310,7 @@ await test("hosted result page retries artifact status after successful checkout
   assert.match(html, /script data-atlas-deflection-artifact-retry/);
   assert.match(html, /Payment processing/);
   assert.match(html, /Checking unlock status/);
-  assert.match(html, /<button type="button" data-atlas-deflection-unlock disabled>/);
+  assertUnlockCta(html, { disabled: true });
   assert.match(html, /\/api\/content-ops\/deflection\/report\?request_id=/);
   assert.match(html, /payload\.artifact_status === "unlocked"/);
   assert.match(html, /window\.location\.reload\(\)/);
@@ -319,7 +333,7 @@ await test("hosted result page explains cancelled checkout without retrying", ()
   assert.match(html, /data-atlas-deflection-artifact-retry="false"/);
   assert.doesNotMatch(html, /script data-atlas-deflection-artifact-retry/);
   assert.match(html, /Continue to Checkout/);
-  assert.match(html, /<button type="button" data-atlas-deflection-unlock >/);
+  assertUnlockCta(html, { disabled: false });
   assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
 });
 

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -78,6 +78,18 @@ await test("result page exposes validation markers and checkout metadata", () =>
   assert.match(html, /content_ops_deflection_report/);
   assert.match(html, /content-ops-abc123/);
   assert.match(html, /2b2b950d-f64b-4852-bc30-f92a34cdf169/);
+  assert.match(html, /data-checkout-source="content_ops_deflection_report"/);
+  assert.match(html, /data-checkout-request_id="content-ops-abc123"/);
+  assert.match(
+    html,
+    /data-checkout-account_id="2b2b950d-f64b-4852-bc30-f92a34cdf169"/,
+  );
+  assert.match(resultPageSource, /data-checkout-source=/);
+  assert.match(resultPageSource, /data-checkout-request_id=/);
+  assert.match(resultPageSource, /data-checkout-account_id=/);
+  assert.match(pageSource, /data-checkout-source=/);
+  assert.match(pageSource, /data-checkout-request_id=/);
+  assert.match(pageSource, /data-checkout-account_id=/);
 });
 
 await test("result pages never embed ATLAS service credentials or paid-route calls", () => {

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -336,6 +336,9 @@ export default function FaqDeflectionResult() {
               type="button"
               className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-3 text-sm font-semibold text-surface-900 transition hover:brightness-110 disabled:cursor-not-allowed disabled:bg-surface-700 disabled:text-surface-200/60"
               data-atlas-deflection-unlock
+              data-checkout-source={CHECKOUT_SOURCE}
+              data-checkout-request_id={requestId ?? ""}
+              data-checkout-account_id={accountId}
               disabled={!canCheckout}
               onClick={startCheckout}
             >


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke.md
Slice phase: Functional validation

With the ATLAS backend paid-flow contract already in place, this slice closes the portfolio result-page handoff gap by binding the unlock CTA to the same Checkout metadata that the hosted smoke validates.

## Intentional
- This does not create a new live smoke script; the existing `scripts/smoke_content_ops_deflection_portfolio_result_page.py` remains the contract runner.
- This does not change Stripe session creation, amount validation, webhook handling, or artifact fetching.
- The page still renders only snapshot fields before payment; paid report rendering remains gated on ATLAS artifact `200`.

## Deferred
- Hosted production portfolio smoke remains the deploy verification after this PR lands.

## Parked hardening
- None. The existing FAQ deflection `HARDENING.md` note is for the Intel report UI lane, not this portfolio result page.

## Verification
- `npm run test:deflection-upload-shell` from `portfolio-ui/` - 18 checks passed.
- `npm run test:deflection-result` from `portfolio-ui/` - 12 checks passed.
- `npm run test:deflection-atlas-proxy` from `portfolio-ui/` - 14 checks passed.
- `python -m pytest tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` - 8 passed.
- `npm run build` from `portfolio-ui/` - passed; Vite emitted the existing large chunk advisory and skipped sitemap generation because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` was not set.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-live-e2e-smoke-pr-body.md` - passed.

## Diff size
5 files, +130 / -4