### PR TITLE
PR-FAQ-Deflection-Portfolio-Hosted-Smoke

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md
@@ -1,0 +1,140 @@
+# Content Ops FAQ Deflection Portfolio Hosted Smoke - 2026-05-30
+
+## Summary
+
+The hosted ATLAS submit path passed and produced a fresh unpaid FAQ deflection
+report, but the production portfolio result-page handoff did not pass.
+
+ATLAS returned the expected report states:
+
+- submit: `200`
+- snapshot: `200`
+- unpaid artifact: `403`
+
+The production portfolio URL returned `404`, so this run does not prove the
+production customer-facing result page. No bearer token, Stripe secret, or CSV
+contents are recorded here.
+
+## Inputs
+
+| Input | Value |
+|---|---|
+| ATLAS API base URL | `https://atlas-brain.tailc7bd29.ts.net` |
+| Portfolio production host | `https://juancanfield.com` |
+| Submit CSV fixture | `extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv` |
+| Submit mode | multipart |
+| Request id | `content-ops-cb59b80f08cf4c2b9ceef769501e2fb7` |
+| Account id | `2b2b950d-f64b-4852-bc30-f92a34cdf169` |
+
+## Commands
+
+The submit smoke used the local root `.env` / `.env.local` credentials without
+printing the bearer token:
+
+```bash
+python scripts/smoke_content_ops_deflection_submit_handoff.py \
+  --csv-file extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --company-name "Atlas SaaS Demo" \
+  --contact-email ops@example.com \
+  --support-platform zendesk \
+  --limit 1000 \
+  --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/submit-result.json \
+  --json
+```
+
+The result-page smoke targeted the production portfolio URL:
+
+```bash
+python scripts/smoke_content_ops_deflection_portfolio_result_page.py \
+  --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-result.json \
+  --json
+```
+
+with:
+
+```text
+ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL=https://juancanfield.com/services/faq-deflection/results/content-ops-cb59b80f08cf4c2b9ceef769501e2fb7?account_id=2b2b950d-f64b-4852-bc30-f92a34cdf169
+ATLAS_DEFLECTION_REQUEST_ID=content-ops-cb59b80f08cf4c2b9ceef769501e2fb7
+```
+
+## Result
+
+Status: not accepted as a production portfolio proof.
+
+| Check | Result | Notes |
+|---|---|---|
+| Hosted ATLAS submit | Passed | Multipart submit returned `200` with `portfolio_deflection_submit`. |
+| Hosted ATLAS snapshot | Passed | Snapshot endpoint returned `200`. |
+| Hosted ATLAS unpaid artifact | Passed | Artifact endpoint returned `403` before payment. |
+| Production portfolio result page | Failed | Result URL returned `404`; required page hooks were absent. |
+
+The result-page smoke reported:
+
+```json
+{
+  "ok": false,
+  "page": {"status": 404},
+  "snapshot": {"status": 200},
+  "artifact": {"status": 403},
+  "errors": [
+    "portfolio result page returned status 404",
+    "portfolio result page missing marker: data-atlas-deflection-result",
+    "portfolio result page missing marker: data-atlas-deflection-request-id",
+    "portfolio result page missing marker: data-atlas-deflection-unlock",
+    "portfolio result page missing marker: content_ops_deflection_report",
+    "portfolio result page missing marker: request_id",
+    "portfolio result page missing marker: account_id",
+    "portfolio result page missing unlock CTA element",
+    "portfolio result page missing request_id value",
+    "portfolio result page missing account_id value"
+  ]
+}
+```
+
+## Diagnosis
+
+`https://juancanfield.com` is the Vercel production deployment for
+`canfieldjuan/atlas-portfolio`, project `atlas-portfolio`, root directory
+`web`. That production Next app is separate from this ATLAS repository's
+`portfolio-ui` Vite app.
+
+The production host currently returns `404` for both:
+
+```text
+https://juancanfield.com/services/faq-deflection
+https://juancanfield.com/services/faq-deflection/results/{request_id}?account_id={account_id}
+```
+
+The related `canfieldjuan/atlas-portfolio` PR #160 preview is deployed, but its
+preview URL returned `401` to this smoke, so it is not usable as an unauthenticated
+hosted proof from the ATLAS validation harness.
+
+## Interpretation
+
+The ATLAS backend handoff is healthy for this request: the report exists, the
+snapshot is readable, and the paid artifact is locked before payment. The
+customer-facing production proof is blocked because the production portfolio
+deployment does not serve the expected result route.
+
+The next product action is in `canfieldjuan/atlas-portfolio`: land or expose the
+result route on the production portfolio host, then rerun this same smoke using
+the production result URL.
+
+## Artifacts
+
+Local artifacts from this run:
+
+| Artifact | Path |
+|---|---|
+| Submit result | `tmp/faq_deflection_portfolio_hosted_smoke_20260530/submit-result.json` |
+| Production result-page smoke | `tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-result.json` |
+| PR #160 preview result-page smoke | `tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-preview-result.json` |
+
+## Verification
+
+- Submit smoke: passed with `ok: true`, `submit.status: 200`,
+  `snapshot.status: 200`, and `artifact.status: 403`.
+- Production result-page smoke: failed with `page.status: 404` while ATLAS
+  snapshot/artifact checks still returned `200`/`403`.
+- Vercel inspection: `juancanfield.com` resolves to project `atlas-portfolio`,
+  root directory `web`.

--- a/plans/PR-FAQ-Deflection-Portfolio-Hosted-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Hosted-Smoke.md
@@ -1,0 +1,83 @@
+# PR-FAQ-Deflection-Portfolio-Hosted-Smoke
+
+## Why this slice exists
+
+The portfolio result page now exposes the machine-readable Checkout metadata
+that `scripts/smoke_content_ops_deflection_portfolio_result_page.py` validates.
+The remaining handoff question is whether the production portfolio URL can read
+a fresh unpaid ATLAS report and keep the artifact locked before payment.
+
+This slice records that hosted proof, or the exact hosted blocker, using the
+existing submit and result-page smokes. It closes the deploy-verification
+deferred item from `PR-FAQ-Deflection-Portfolio-Live-E2E-Smoke`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Functional validation
+
+1. Generate a fresh unpaid deflection report through the hosted ATLAS submit
+   smoke using the checked SaaS demo CSV fixture.
+2. Validate the production portfolio result URL for that `request_id` and
+   account id with the existing result-page smoke.
+3. Add a redacted validation artifact that names the command, statuses,
+   request id, and any blocker without recording bearer tokens or CSV contents.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Hosted-Smoke.md`
+- `docs/extraction/validation/content_ops_faq_deflection_portfolio_hosted_smoke_2026-05-30.md`
+
+## Mechanism
+
+The run uses the existing hosted smoke chain:
+
+```bash
+python scripts/smoke_content_ops_deflection_submit_handoff.py ...
+python scripts/smoke_content_ops_deflection_portfolio_result_page.py ...
+```
+
+The result page URL is built from the production portfolio host:
+
+```text
+https://juancanfield.com/services/faq-deflection/results/{request_id}?account_id={account_id}
+```
+
+The result-page smoke then checks the hosted HTML hooks, Checkout metadata
+values, ATLAS snapshot `200`, and ATLAS artifact `403` before payment.
+
+## Intentional
+
+- This does not mark the report paid; the slice is the pre-payment portfolio
+  result-page proof.
+- This does not add another smoke script; the existing submit and result-page
+  smokes are the source of truth.
+- The validation document redacts credentials and records only non-secret run
+  metadata.
+
+## Deferred
+
+- Parked hardening: none. The same-lane `HARDENING.md` entry targets the Intel
+  report UI lane, not the production portfolio result-page proof.
+- Stripe paid-unlock rendering through the production portfolio page remains a
+  follow-up after this pre-payment hosted smoke is recorded.
+
+## Verification
+
+- `python scripts/smoke_content_ops_deflection_submit_handoff.py --csv-file extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --company-name "Atlas SaaS Demo" --contact-email ops@example.com --support-platform zendesk --limit 1000 --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/submit-result.json --json` - passed; submit `200`, snapshot `200`, unpaid artifact `403`.
+- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-result.json --json` - failed as expected for this blocker artifact; production portfolio page returned `404` while ATLAS snapshot/artifact stayed `200`/`403`.
+- `vercel inspect https://juancanfield.com` from `atlas-portfolio/web` - confirmed production host maps to Vercel project `atlas-portfolio`, root directory `web`.
+- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-preview-result.json --json` against the `atlas-portfolio` PR #160 preview - failed with preview `401`, so the preview is not usable as an unauthenticated hosted proof.
+- `python -m pytest tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` - 8 passed.
+- `python -m json.tool` over the three local smoke artifacts - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-hosted-smoke-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 83 |
+| Validation artifact | 140 |
+| **Total** | **223** |
+
+Actual diff is 2 files, +223 / -0.


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Hosted-Smoke.md
Slice phase: Functional validation

This slice records the hosted portfolio result-page smoke after the CTA metadata contract landed. ATLAS passed submit/snapshot/locked-artifact for a fresh report, but the production portfolio host returned `404`, so the proof is blocked in the external `atlas-portfolio` deployment rather than the ATLAS backend.

## Intentional
- This does not mark the report paid; it is the pre-payment portfolio result-page proof.
- This does not add another smoke script; the existing submit and result-page smokes remain the source of truth.
- Credentials, Stripe secrets, and CSV contents are not recorded.

## Deferred
- Stripe paid-unlock rendering through the production portfolio page remains a follow-up after the production route is exposed.

## Parked hardening
- None. The same-lane `HARDENING.md` entry targets the Intel report UI lane, not this hosted portfolio proof.

## Verification
- `python scripts/smoke_content_ops_deflection_submit_handoff.py --csv-file extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv --company-name "Atlas SaaS Demo" --contact-email ops@example.com --support-platform zendesk --limit 1000 --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/submit-result.json --json` - passed; submit `200`, snapshot `200`, unpaid artifact `403`.
- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-result.json --json` - failed as expected for this blocker artifact; production portfolio page returned `404` while ATLAS snapshot/artifact stayed `200`/`403`.
- `vercel inspect https://juancanfield.com` - confirmed production host maps to Vercel project `atlas-portfolio`, root directory `web`.
- `python scripts/smoke_content_ops_deflection_portfolio_result_page.py --output-result tmp/faq_deflection_portfolio_hosted_smoke_20260530/result-page-preview-result.json --json` against the `atlas-portfolio` PR #160 preview - failed with preview `401`, so the preview is not usable as an unauthenticated hosted proof.
- `python -m pytest tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` - 8 passed.
- `python -m json.tool` over the three local smoke artifacts - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/faq-deflection-portfolio-hosted-smoke-pr-body.md` - passed.

## Diff size
2 files, +223 / -0