### PR TITLE
PR-FAQ-Deflection-Submit-Live-Validation

### DIFF
--- a/plans/PR-FAQ-Deflection-Submit-Live-Validation.md
+++ b/plans/PR-FAQ-Deflection-Submit-Live-Validation.md
@@ -1,0 +1,89 @@
+# PR-FAQ-Deflection-Submit-Live-Validation
+
+## Why this slice exists
+
+Issue #1161 now has the paid Stripe/artifact leg verified end-to-end, and the
+latest remaining public-funnel gap is the submit leg: portfolio upload ->
+private Blob -> multipart POST to the now-live ATLAS `/submit`. The portfolio
+route already reads private Blob objects server-side and forwards multipart
+bytes, so this slice should not reimplement that path. It adds the missing
+operator live-smoke harness around the existing production helper so the team
+can prove the deployed submit loop after #1200 without building a parallel
+submit implementation.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Functional validation
+
+1. Add a portfolio-side live submit smoke that calls the existing
+   `submitPrivateBlob()` helper against a configured ATLAS host.
+2. Support two validation modes: a real private Blob pathname with the Blob
+   token, or a local CSV fixture injected through the same Blob-read seam.
+3. Redact secrets from smoke output and return only request/result metadata.
+4. Enroll the smoke command and source-level checks in the existing upload-shell
+   test.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Live-Validation.md`
+- `portfolio-ui/package.json`
+- `portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The new smoke imports `submitPrivateBlob()` from the portfolio submit route. If
+`--blob-pathname` and `--blob-token` are provided, it lets the production helper
+read and clean up the real private Blob. If `--csv-file` is provided instead,
+the script injects a fake Blob reader backed by that local CSV while still
+posting the reconstructed multipart `FormData` to live ATLAS:
+
+```text
+submitPrivateBlob({
+  config: { baseUrl, token, accountId, timeoutMs },
+  payload: { blob_pathname, support_platform, company_name, contact_email, limit },
+  getBlobImpl: csvFile ? localFixtureBlobReader : getPrivateBlob,
+})
+```
+
+This keeps the validation on the exact server helper used by the browser
+handoff while avoiding a new PII-serving URL or signed-proxy surface.
+
+## Intentional
+
+- This does not change the customer browser flow or route response shape.
+- The smoke is operator-run; it is not enrolled in automatic CI because it needs
+  a deployed ATLAS host and service JWT.
+- Local CSV fixture mode is explicitly a validation fallback. Production wiring
+  still uses private Vercel Blob pathname + server token.
+- The smoke prints no bearer token, Blob token, raw CSV body, or ATLAS response
+  body.
+
+## Deferred
+
+- Running the smoke against the deployed portfolio/ATLAS environment remains an
+  operator step after this PR lands and environment values are available.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 19 checks passed.
+- `npm run smoke:deflection-submit-live --prefix portfolio-ui -- --preflight-only --base-url https://atlas.example.com --token test-token --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --json` -- passed preflight.
+- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
+- `node --check portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs` -- passed.
+- `npm run build --prefix portfolio-ui` -- passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 89 |
+| Live smoke script | 214 |
+| Package command | 1 |
+| Focused source tests | 41 |
+| **Total** | **345** |
+
+Actual diff is 4 files, +345 / -0. Under the 400 LOC soft cap.

--- a/portfolio-ui/package.json
+++ b/portfolio-ui/package.json
@@ -9,6 +9,7 @@
     "test:deflection-upload-shell": "node scripts/faq-deflection-upload-shell.test.mjs",
     "test:deflection-atlas-proxy": "node scripts/faq-deflection-atlas-proxy.test.mjs",
     "test:deflection-result": "node scripts/faq-deflection-result-page.test.mjs",
+    "smoke:deflection-submit-live": "node scripts/faq-deflection-submit-live-smoke.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
+++ b/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import {
+  BLOB_UPLOAD_PATH_PREFIX,
+  MAX_BLOB_CSV_BYTES,
+  submitPrivateBlob,
+} from "../api/content-ops/deflection/submit.js";
+
+const SUPPORT_PLATFORMS = new Set(["zendesk", "intercom", "help_scout", "other"]);
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LOCAL_HOSTS = new Set(["localhost", "0.0.0.0", "::1"]);
+const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_FIXTURE_PATHNAME = `${BLOB_UPLOAD_PATH_PREFIX}live-smoke.csv`;
+const SAMPLE_CSV = [
+  "ticket_id,subject,message,resolution_text,pain_category",
+  "ticket-1,Export reports,How do I export attribution reports?,Open Analytics and download the CSV.,exports",
+  "ticket-2,Reset invite,How can I resend an invite?,Open team settings and resend the pending invite.,accounts",
+  "",
+].join("\n");
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
+  const options = {
+    baseUrl: clean(sourceEnv.ATLAS_API_BASE_URL),
+    token: clean(sourceEnv.ATLAS_B2B_JWT || sourceEnv.ATLAS_TOKEN),
+    accountId: clean(sourceEnv.ATLAS_ACCOUNT_ID || sourceEnv.ATLAS_FAQ_SEARCH_ACCOUNT_ID),
+    blobPathname: clean(sourceEnv.ATLAS_DEFLECTION_BLOB_PATHNAME),
+    blobToken: clean(sourceEnv.BLOB_READ_WRITE_TOKEN),
+    csvFile: clean(sourceEnv.ATLAS_DEFLECTION_SUBMIT_CSV_FILE),
+    supportPlatform: clean(sourceEnv.ATLAS_DEFLECTION_SUPPORT_PLATFORM) || "zendesk",
+    companyName: clean(sourceEnv.ATLAS_DEFLECTION_COMPANY_NAME) || "Atlas Smoke Co.",
+    contactEmail: clean(sourceEnv.ATLAS_DEFLECTION_CONTACT_EMAIL) || "smoke@example.com",
+    limit: clean(sourceEnv.ATLAS_DEFLECTION_LIMIT) || "1000",
+    timeoutMs: Number.parseInt(clean(sourceEnv.ATLAS_PROXY_TIMEOUT_MS), 10) || DEFAULT_TIMEOUT_MS,
+    outputResult: clean(sourceEnv.ATLAS_DEFLECTION_SUBMIT_RESULT_FILE),
+    json: false,
+    preflightOnly: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--preflight-only") {
+      options.preflightOnly = true;
+    } else if (arg.startsWith("--")) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      options[key] = value;
+      index += 1;
+    }
+  }
+
+  options.timeoutMs = Number.parseInt(String(options.timeoutMs), 10);
+  options.limit = String(options.limit);
+  return options;
+}
+
+function validationErrors(options) {
+  const errors = [];
+  if (!clean(options.baseUrl) || !URL.canParse(options.baseUrl)) {
+    errors.push("ATLAS_API_BASE_URL or --base-url must be an absolute HTTPS URL");
+  } else {
+    const url = new URL(options.baseUrl);
+    const host = url.hostname.toLowerCase();
+    if (url.protocol !== "https:" || LOCAL_HOSTS.has(host) || host.startsWith("127.")) {
+      errors.push("ATLAS_API_BASE_URL or --base-url must point to a deployed HTTPS host");
+    }
+  }
+  if (!clean(options.token)) errors.push("ATLAS_B2B_JWT, ATLAS_TOKEN, or --token is required");
+  if (!UUID_RE.test(clean(options.accountId))) {
+    errors.push("ATLAS_ACCOUNT_ID or --account-id must be an ATLAS account UUID");
+  }
+  if (!SUPPORT_PLATFORMS.has(clean(options.supportPlatform))) {
+    errors.push("--support-platform must be one of: help_scout, intercom, other, zendesk");
+  }
+  const limit = Number.parseInt(clean(options.limit), 10);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+    errors.push("--limit must be between 1 and 1000");
+  }
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+    errors.push("--timeout-ms must be a positive integer");
+  }
+  if (clean(options.blobPathname) && !clean(options.blobToken)) {
+    errors.push("BLOB_READ_WRITE_TOKEN or --blob-token is required with --blob-pathname");
+  }
+  if (clean(options.blobPathname) && clean(options.csvFile)) {
+    errors.push("use either --blob-pathname or --csv-file, not both");
+  }
+  if (!clean(options.blobPathname) && !clean(options.csvFile)) {
+    return errors;
+  }
+  if (clean(options.blobPathname) && !options.blobPathname.startsWith(BLOB_UPLOAD_PATH_PREFIX)) {
+    errors.push("--blob-pathname must stay under faq-deflection/uploads/");
+  }
+  return errors;
+}
+
+async function localCsvBlobReader(csvFile) {
+  const body = csvFile ? await readFile(csvFile) : Buffer.from(SAMPLE_CSV);
+  if (body.length > MAX_BLOB_CSV_BYTES) {
+    return { statusCode: 200, stream: new Blob([body]).stream(), blob: { size: body.length } };
+  }
+  return {
+    statusCode: 200,
+    stream: new Blob([body], { type: "text/csv" }).stream(),
+    blob: {
+      size: body.length,
+      contentType: "text/csv",
+    },
+  };
+}
+
+function resultPayload(result, options, sourceMode) {
+  return {
+    ok: result.ok,
+    source_mode: sourceMode,
+    statusCode: result.statusCode,
+    request_id: result.payload?.request_id,
+    account_id: result.payload?.account_id,
+    result_path: result.payload?.result_path,
+    error: result.error,
+    atlas_status: result.atlas_status,
+    base_host: URL.canParse(options.baseUrl) ? new URL(options.baseUrl).host : "",
+  };
+}
+
+async function runSubmitSmoke(options) {
+  const errors = validationErrors(options);
+  if (errors.length > 0) {
+    return { ok: false, status: "preflight_failed", errors };
+  }
+
+  const sourceMode = clean(options.blobPathname) ? "private_blob" : "local_csv_fixture";
+  if (options.preflightOnly) {
+    return { ok: true, status: "preflight_ok", source_mode: sourceMode };
+  }
+
+  const payload = {
+    blob_pathname: clean(options.blobPathname) || DEFAULT_FIXTURE_PATHNAME,
+    support_platform: clean(options.supportPlatform),
+    company_name: clean(options.companyName),
+    contact_email: clean(options.contactEmail),
+    limit: clean(options.limit),
+  };
+  const usesLocalFixture = sourceMode === "local_csv_fixture";
+  const result = await submitPrivateBlob({
+    config: {
+      baseUrl: clean(options.baseUrl),
+      token: clean(options.token),
+      accountId: clean(options.accountId),
+      timeoutMs: options.timeoutMs,
+    },
+    blobToken: usesLocalFixture ? "local-fixture" : clean(options.blobToken),
+    payload,
+    getBlobImpl: usesLocalFixture
+      ? async () => localCsvBlobReader(clean(options.csvFile))
+      : undefined,
+    deleteBlobImpl: usesLocalFixture ? async () => {} : undefined,
+  });
+  const projected = resultPayload(result, options, sourceMode);
+  if (result.ok && !REQUEST_ID_RE.test(clean(projected.request_id))) {
+    return { ...projected, ok: false, error: "invalid_request_id" };
+  }
+  return projected;
+}
+
+function printResult(payload, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  if (payload.ok) {
+    console.log(`faq deflection submit smoke passed (${payload.source_mode})`);
+    if (payload.request_id) console.log(`request_id=${payload.request_id}`);
+    if (payload.result_path) console.log(`result_path=${payload.result_path}`);
+    return;
+  }
+  console.error(`faq deflection submit smoke failed: ${payload.error || payload.status}`);
+  if (Array.isArray(payload.errors)) {
+    for (const error of payload.errors) console.error(`- ${error}`);
+  }
+}
+
+async function main() {
+  const options = parseArgs();
+  const result = await runSubmitSmoke(options);
+  if (clean(options.outputResult)) {
+    await writeFile(options.outputResult, `${JSON.stringify(result, null, 2)}\n`);
+  }
+  printResult(result, options.json);
+  return result.ok ? 0 : 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(`faq deflection submit smoke failed: ${error.message}`);
+      process.exitCode = 1;
+    });
+}
+
+export { parseArgs, runSubmitSmoke, validationErrors };

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -22,12 +22,21 @@ import {
   emitDeflectionServerEvent,
   sanitizeDeflectionEventFields,
 } from "../api/content-ops/deflection/events.js";
+import {
+  parseArgs as parseSubmitSmokeArgs,
+  runSubmitSmoke,
+  validationErrors as submitSmokeValidationErrors,
+} from "./faq-deflection-submit-live-smoke.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const appSource = await readFile(resolve(root, "src/App.tsx"), "utf8");
 const servicesSource = await readFile(resolve(root, "src/pages/Services.tsx"), "utf8");
 const uploadSource = await readFile(resolve(root, "src/pages/FaqDeflectionUpload.tsx"), "utf8");
 const submitSource = await readFile(resolve(root, "api/content-ops/deflection/submit.js"), "utf8");
+const submitSmokeSource = await readFile(
+  resolve(root, "scripts/faq-deflection-submit-live-smoke.mjs"),
+  "utf8",
+);
 const blobUploadRouteSource = await readFile(
   resolve(root, "api/content-ops/deflection/upload.js"),
   "utf8",
@@ -174,6 +183,34 @@ await test("portfolio submit endpoint pins raw multipart body handling", () => {
   assert.doesNotMatch(submitSource, /^import .*@vercel\/blob/m);
   assert.match(submitSource, /import\("@vercel\/blob"\)/);
   assert.match(submitSource, /const \{ del \} = await import\("@vercel\/blob"\)/);
+});
+
+await test("submit live smoke exercises the production private blob helper", async () => {
+  assert.match(submitSmokeSource, /submitPrivateBlob/);
+  assert.match(submitSmokeSource, /local_csv_fixture/);
+  assert.doesNotMatch(submitSmokeSource, /ATLAS_B2B_JWT[^\\n]*console\\.log/);
+  assert.deepEqual(
+    submitSmokeValidationErrors({
+      baseUrl: "http://localhost:8000",
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      timeoutMs: 1000,
+    }),
+    ["ATLAS_API_BASE_URL or --base-url must point to a deployed HTTPS host"],
+  );
+
+  const options = parseSubmitSmokeArgs(["--preflight-only"], {
+    ATLAS_API_BASE_URL: ENV.ATLAS_API_BASE_URL,
+    ATLAS_B2B_JWT: ENV.ATLAS_B2B_JWT,
+    ATLAS_ACCOUNT_ID: ACCOUNT_ID,
+  });
+  assert.deepEqual(await runSubmitSmoke(options), {
+    ok: true,
+    status: "preflight_ok",
+    source_mode: "local_csv_fixture",
+  });
 });
 
 await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", async () => {
@@ -619,5 +656,9 @@ await test("upload shell test is enrolled in package scripts", () => {
   assert.equal(
     packageJson.scripts["test:deflection-upload-shell"],
     "node scripts/faq-deflection-upload-shell.test.mjs",
+  );
+  assert.equal(
+    packageJson.scripts["smoke:deflection-submit-live"],
+    "node scripts/faq-deflection-submit-live-smoke.mjs",
   );
 });


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Live-Validation.md
Slice phase: Functional validation

Issue #1161 leaves one public-funnel gap after the paid Stripe/artifact leg: proving portfolio upload/private Blob submit against the now-live multipart ATLAS `/submit`. This slice adds an operator live-smoke command around the existing production `submitPrivateBlob()` helper instead of creating another submit implementation.

## Intentional
- This does not change the browser flow or portfolio submit route response shape.
- The smoke is operator-run, not automatic CI, because it needs a deployed ATLAS host and service JWT.
- Local CSV fixture mode is a validation fallback; production uses private Vercel Blob pathname + server token.
- Smoke output redacts secrets and does not print bearer tokens, Blob tokens, raw CSV bodies, or raw ATLAS response bodies.

## Deferred
- Running the smoke against the deployed portfolio/ATLAS environment remains an operator step after this PR lands and environment values are available.
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 19 checks passed.
- `npm run smoke:deflection-submit-live --prefix portfolio-ui -- --preflight-only --base-url https://atlas.example.com --token test-token --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 --json` -- passed preflight.
- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
- `node --check portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs` -- passed.
- `npm run build --prefix portfolio-ui` -- passed after hydrating local `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`.

## Diff size
4 files, +345 / -0.
