### PR TITLE
PR-FAQ-Deflection-Submit-Configured-Account

### DIFF
--- a/plans/PR-FAQ-Deflection-Submit-Configured-Account.md
+++ b/plans/PR-FAQ-Deflection-Submit-Configured-Account.md
@@ -1,0 +1,103 @@
+# PR-FAQ-Deflection-Submit-Configured-Account
+
+## Why this slice exists
+
+Issue #1161's remaining public funnel is the portfolio upload -> private Blob
+-> ATLAS multipart submit -> hosted results loop. The private Blob submit path
+is now implemented and live-smokeable, but the public upload form still asks the
+buyer to paste the ATLAS service `account_id`. That is an internal handoff
+value already configured server-side for the B2B-Growth service JWT and Stripe
+metadata, not a buyer input.
+
+This slice removes that manual account step from the customer intake path and
+binds the private-Blob submit mode to the configured server account before it
+returns the canonical result URL.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Product polish
+
+1. Remove the ATLAS account-id input from the FAQ deflection upload form,
+   private Blob token request, and browser submit request.
+2. Bind private Blob upload tokens and JSON/private-Blob submits to the
+   configured `ATLAS_ACCOUNT_ID` on the portfolio server while preserving the
+   existing multipart rollback guard.
+3. Keep the public response shape unchanged: `{ ok, request_id, account_id,
+   result_path }`.
+4. Update focused upload-shell tests so the browser cannot regress to asking
+   for account IDs or sending account-binding headers.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Configured-Account.md`
+- `portfolio-ui/api/content-ops/deflection/upload.js`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/src/pages/FaqDeflectionUpload.tsx`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The upload page keeps collecting only buyer-owned fields:
+
+```text
+company_name, contact_email, support_platform, csv_file
+```
+
+The private Blob token route no longer requires `clientPayload.account_id`; it
+validates only the configured server account and deflection CSV pathname, then
+stores the configured account in the Blob token payload. After upload completes,
+the browser posts the `blob_pathname` and form metadata to the portfolio submit
+endpoint without `X-Atlas-Account-Id`. The server already loads
+`ATLAS_ACCOUNT_ID` through `configFromEnv`; for JSON private-Blob submit mode it
+uses that configured account as the binding value. If a legacy client sends an
+account header on the JSON path, it must match the configured account before
+ATLAS is called.
+
+The raw multipart rollback path keeps requiring `X-Atlas-Account-Id` so local
+tests and older direct-submit clients retain the explicit mismatch guard.
+
+## Intentional
+
+- `account_id` still appears in the result URL and Checkout metadata because
+  the existing result-page, report-proxy, and Stripe contract use it to bind the
+  public route to the configured ATLAS service account.
+- This does not change ATLAS submit, Stripe Checkout, artifact fetch, or result
+  page rendering.
+- The raw multipart portfolio endpoint remains available for rollback/local
+  tests and keeps the existing account mismatch rejection.
+- The JSON private-Blob path remains fail-closed when `ATLAS_ACCOUNT_ID` is not
+  configured.
+
+## Deferred
+
+- Reworking the result-page URL to avoid carrying `account_id` is deferred; it
+  crosses result-page, Checkout, smoke, and Stripe metadata contracts and is not
+  required to remove the buyer-facing account field.
+- Running the live submit smoke against deployed environment values remains an
+  operator step.
+- Parked hardening: none.
+
+## Verification
+
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 20 checks passed.
+- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
+- `npm run build --prefix portfolio-ui` -- passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite
+  emitted the existing large chunk advisory and skipped sitemap generation
+  because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not set.
+- Pending: `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-configured-account.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 103 |
+| Upload token account binding | 2 |
+| Submit endpoint account binding | 10 |
+| Upload form simplification | 23 |
+| Focused tests | 55 |
+| **Total** | **193** |
+
+Actual diff is 5 files, +170 / -23. Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -331,7 +331,15 @@ export default async function handler(req, res) {
     return;
   }
 
-  const accountId = header(req, "x-atlas-account-id");
+  const requestedAccountId = header(req, "x-atlas-account-id");
+  const accountId = isPrivateBlobSubmit ? submitConfig.accountId : requestedAccountId;
+  if (
+    requestedAccountId &&
+    (!UUID_RE.test(requestedAccountId) || requestedAccountId !== submitConfig.accountId)
+  ) {
+    json(res, 400, { ok: false, error: "invalid_account_id" });
+    return;
+  }
   if (!accountId || !UUID_RE.test(accountId) || accountId !== submitConfig.accountId) {
     json(res, 400, { ok: false, error: "invalid_account_id" });
     return;

--- a/portfolio-ui/api/content-ops/deflection/upload.js
+++ b/portfolio-ui/api/content-ops/deflection/upload.js
@@ -48,7 +48,7 @@ function uploadTokenConfig(pathname, clientPayload, env = process.env) {
   if (!pathname.startsWith(BLOB_UPLOAD_PATH_PREFIX) || !pathname.toLowerCase().endsWith(".csv")) {
     errors.push("invalid_blob_pathname");
   }
-  if (!accountId || accountId !== config.accountId) {
+  if (accountId && accountId !== config.accountId) {
     errors.push("invalid_account_id");
   }
   if (errors.length > 0) return { ok: false, errors };

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -145,7 +145,6 @@ await test("upload shell exposes live submit markers and avoids browser credenti
     "data-atlas-deflection-company",
     "data-atlas-deflection-contact-email",
     "data-atlas-deflection-support-platform",
-    "data-atlas-deflection-account-id-input",
     "data-atlas-deflection-submit",
     "data-atlas-deflection-upload-endpoint",
     "data-atlas-deflection-upload-progress",
@@ -166,13 +165,14 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.match(uploadSource, /starts a new private upload/);
   assert.match(uploadSource, /blob_pathname: blob\.pathname/);
   assert.match(uploadSource, /private_blob_persistence/);
+  assert.match(uploadSource, /Bound server-side to the configured report workspace/);
   assert.match(uploadSource, /value: "help_scout"/);
   assert.match(uploadSource, /value: "other", label: "Freshdesk \/ other"/);
   assert.doesNotMatch(uploadSource, /value: "freshdesk"/);
   assert.doesNotMatch(uploadSource, /value: "help-scout"/);
   assert.doesNotMatch(uploadSource, /new FormData/);
   assert.match(uploadSource, /JSON\.stringify/);
-  assert.match(uploadSource, /X-Atlas-Account-Id/);
+  assert.doesNotMatch(uploadSource, /X-Atlas-Account-Id|account_id/);
   assert.doesNotMatch(uploadSource, /ATLAS_B2B_JWT|ATLAS_API_BASE_URL|ATLAS_TOKEN/);
   assert.doesNotMatch(uploadSource, /Authorization/);
   assert.doesNotMatch(uploadSource, /\/paid\b/);
@@ -256,7 +256,7 @@ await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", as
 await test("private blob upload token config fails closed on path and account binding", () => {
   const ok = uploadTokenConfig(
     `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
-    JSON.stringify({ account_id: ACCOUNT_ID }),
+    "",
     ENV,
   );
   assert.equal(ok.ok, true);
@@ -269,9 +269,20 @@ await test("private blob upload token config fails closed on path and account bi
     uploadTokenConfig("other/tickets.csv", JSON.stringify({ account_id: ACCOUNT_ID }), ENV),
     { ok: false, errors: ["invalid_blob_pathname"] },
   );
-  assert.deepEqual(uploadTokenConfig(`${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`, "{}", ENV), {
+  assert.deepEqual(
+    uploadTokenConfig(
+      `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      JSON.stringify({ account_id: "3b2b950d-f64b-4852-bc30-f92a34cdf169" }),
+      ENV,
+    ),
+    { ok: false, errors: ["invalid_account_id"] },
+  );
+  assert.deepEqual(uploadTokenConfig(`${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`, "{}", {
+    ...ENV,
+    ATLAS_ACCOUNT_ID: "",
+  }), {
     ok: false,
-    errors: ["invalid_account_id"],
+    errors: ["atlas_account_missing"],
   });
 });
 
@@ -587,6 +598,40 @@ await test("portfolio submit endpoint rejects account mismatch before ATLAS", as
   assert.equal(fetchCalled, false);
   assert.equal(res.statusCode, 400);
   assert.deepEqual(JSON.parse(res.body), { ok: false, error: "invalid_account_id" });
+
+  const blobRes = mockResponse();
+  await withEnv(ENV, async () => {
+    await submitHandler(
+      request({
+        headers: {
+          "content-type": "application/json",
+          "x-atlas-account-id": "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+        },
+        body: JSON.stringify({ blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv` }),
+      }),
+      blobRes,
+    );
+  });
+  assert.equal(blobRes.statusCode, 400);
+  assert.deepEqual(JSON.parse(blobRes.body), { ok: false, error: "invalid_account_id" });
+});
+
+await test("private blob submit uses configured account when browser omits account header", async () => {
+  const res = mockResponse();
+  await withEnv(ENV, async () => {
+    await submitHandler(
+      request({
+        headers: {
+          "content-type": "application/json",
+          "x-atlas-account-id": undefined,
+        },
+        body: JSON.stringify({ blob_pathname: "../tickets.csv" }),
+      }),
+      res,
+    );
+  });
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { ok: false, error: "invalid_blob_reference" });
 });
 
 await test("portfolio submit endpoint rejects oversize bodies before ATLAS", async () => {

--- a/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionUpload.tsx
@@ -73,7 +73,6 @@ function boundedProgress(percentage: number | undefined) {
 export default function FaqDeflectionUpload() {
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
-  const [accountId, setAccountId] = useState("");
   const [supportPlatform, setSupportPlatform] = useState<string>(SUPPORT_PLATFORMS[0].value);
   const [upload, setUpload] = useState<UploadState>({ status: "empty" });
   const [submit, setSubmit] = useState<SubmitState>({ status: "idle" });
@@ -83,18 +82,16 @@ export default function FaqDeflectionUpload() {
       Boolean(
         companyName.trim() &&
           contactEmail.trim() &&
-          accountId.trim() &&
           supportPlatform &&
           upload.status === "ready",
       ),
-    [accountId, companyName, contactEmail, supportPlatform, upload.status],
+    [companyName, contactEmail, supportPlatform, upload.status],
   );
   const canSubmit = fieldsReady && submit.status !== "uploading" && submit.status !== "submitting";
   const isRetry = submit.status === "error";
 
   const startSubmit = async () => {
     if (upload.status !== "ready" || !fieldsReady) return;
-    const trimmedAccountId = accountId.trim();
 
     try {
       setSubmit({ status: "uploading", percentage: 0 });
@@ -102,7 +99,6 @@ export default function FaqDeflectionUpload() {
         access: "private",
         contentType: "text/csv",
         handleUploadUrl: BLOB_UPLOAD_ENDPOINT,
-        clientPayload: JSON.stringify({ account_id: trimmedAccountId }),
         multipart: upload.fileSize > 4 * 1024 * 1024,
         onUploadProgress: (event) => {
           setSubmit({
@@ -117,7 +113,6 @@ export default function FaqDeflectionUpload() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Atlas-Account-Id": trimmedAccountId,
         },
         body: JSON.stringify({
           blob_pathname: blob.pathname,
@@ -233,16 +228,12 @@ export default function FaqDeflectionUpload() {
                 </select>
               </label>
 
-              <label className="block">
-                <span className="text-sm font-medium text-surface-100">ATLAS account ID</span>
-                <input
-                  className="mt-2 w-full rounded-lg border border-surface-700 bg-surface-900 px-3 py-3 font-mono text-xs text-white outline-none transition focus:border-primary-400"
-                  data-atlas-deflection-account-id-input
-                  value={accountId}
-                  onChange={(event) => setAccountId(event.target.value)}
-                  placeholder="2b2b950d-f64b-4852-bc30-f92a34cdf169"
-                />
-              </label>
+              <div className="rounded-lg border border-surface-700/70 bg-surface-900/60 px-3 py-3">
+                <span className="text-sm font-medium text-surface-100">ATLAS account</span>
+                <p className="mt-2 text-xs leading-5 text-surface-200/65">
+                  Bound server-side to the configured report workspace.
+                </p>
+              </div>
             </div>
 
             <label className="mt-6 block rounded-lg border border-dashed border-surface-600 bg-surface-900/55 p-5 transition focus-within:border-primary-400">


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Configured-Account.md
Slice phase: Product polish

Issue #1161's remaining public submit funnel is now implemented server-side, but the upload form still asked buyers for the internal ATLAS service `account_id`. This slice removes that buyer-facing account step and binds the private Blob upload/submit path to the configured portfolio server account.

## Intentional
- `account_id` still appears in the result URL and Checkout metadata because the existing result-page, report-proxy, and Stripe contract use it to bind the public route to the configured ATLAS service account.
- This does not change ATLAS submit, Stripe Checkout, artifact fetch, or result page rendering.
- The raw multipart portfolio endpoint remains available for rollback/local tests and keeps the existing account mismatch rejection.
- The JSON private-Blob path remains fail-closed when `ATLAS_ACCOUNT_ID` is not configured.

## Deferred
- Reworking the result-page URL to avoid carrying `account_id` is deferred; it crosses result-page, Checkout, smoke, and Stripe metadata contracts and is not required to remove the buyer-facing account field.
- Running the live submit smoke against deployed environment values remains an operator step.
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 20 checks passed.
- `npm run test:deflection-result --prefix portfolio-ui` -- 12 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
- `npm run build --prefix portfolio-ui` -- passed after hydrating local `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite emitted the existing large chunk advisory and skipped sitemap generation because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not set.

## Diff size
5 files, +170 / -23.
