### PR TITLE
PR-Stripe-Billing-Hardening

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -4,21 +4,29 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/api/auth.py"
+      - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
+      - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_b2b_vendor_briefing.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml"
+      - "atlas_brain/api/auth.py"
+      - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
+      - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_b2b_vendor_briefing.py"
 
 jobs:
   atlas-content-ops-deflection-stripe-paid-checks:
@@ -42,6 +50,8 @@ jobs:
       - name: Run Content Ops deflection Stripe paid tests
         run: |
           python -m pytest \
+            tests/test_atlas_billing_stripe_hardening.py \
+            tests/test_b2b_vendor_briefing.py \
             tests/test_atlas_billing_content_ops_deflection_stripe_paid.py \
             tests/test_atlas_billing_content_ops_deflection_paid_flow.py \
             -q

--- a/atlas_brain/api/auth.py
+++ b/atlas_brain/api/auth.py
@@ -17,7 +17,7 @@ from ..config import settings
 from ..storage.database import get_db_pool
 
 # Import PLAN_LIMITS for default asin limit
-from .billing import PLAN_LIMITS
+from .billing import PLAN_LIMITS, _configure_stripe_module
 
 logger = logging.getLogger("atlas.api.auth")
 
@@ -216,7 +216,7 @@ async def register(req: RegisterRequest):
     if cfg.stripe_secret_key:
         try:
             import stripe
-            stripe.api_key = cfg.stripe_secret_key
+            _configure_stripe_module(stripe, cfg.stripe_secret_key)
             customer = stripe.Customer.create(
                 email=req.email,
                 name=req.account_name,

--- a/atlas_brain/api/b2b_vendor_briefing.py
+++ b/atlas_brain/api/b2b_vendor_briefing.py
@@ -21,6 +21,7 @@ from ..auth.dependencies import AuthUser, require_auth
 from ..config import settings
 from ..services.crm_provider import get_crm_provider
 from ..storage.database import get_db_pool
+from .billing import _configure_stripe_module
 from ..autonomous.tasks.b2b_vendor_briefing import (
     build_gate_url,
     build_vendor_briefing,
@@ -561,7 +562,7 @@ async def vendor_checkout(body: VendorCheckoutRequest):
     cfg = settings.saas_auth
     if not cfg.stripe_secret_key:
         raise HTTPException(status_code=503, detail="Stripe not configured")
-    stripe.api_key = cfg.stripe_secret_key
+    _configure_stripe_module(stripe, cfg.stripe_secret_key)
 
     price_id = (
         cfg.stripe_vendor_standard_price_id
@@ -614,7 +615,7 @@ async def checkout_session_info(session_id: str = Query(..., min_length=10)):
     cfg = settings.saas_auth
     if not cfg.stripe_secret_key:
         raise HTTPException(status_code=503, detail="Stripe not configured")
-    stripe.api_key = cfg.stripe_secret_key
+    _configure_stripe_module(stripe, cfg.stripe_secret_key)
 
     try:
         session = stripe.checkout.Session.retrieve(session_id)

--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -3,6 +3,7 @@
 import logging
 import uuid as _uuid
 from collections.abc import Mapping
+from hashlib import sha256
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -47,6 +48,7 @@ LLM_PLAN_LIMITS = {
 }
 
 PRICE_TO_PLAN = {}  # populated at module init from config
+STRIPE_API_VERSION = "2026-05-27.dahlia"
 
 
 def _init_price_map():
@@ -76,13 +78,45 @@ def _init_price_map():
         PRICE_TO_PLAN[cfg.stripe_llm_pro_price_id] = "llm_pro"
 
 
+def _warn_if_unrestricted_stripe_key(secret_key: str) -> None:
+    if secret_key.startswith("sk_"):
+        logger.warning(
+            "ATLAS_SAAS_STRIPE_SECRET_KEY is configured with a full Stripe secret key; "
+            "use a restricted rk_ key scoped to Atlas billing operations when possible"
+        )
+
+
+def _configure_stripe_module(stripe_module: Any, secret_key: str) -> Any:
+    stripe_module.api_key = secret_key
+    stripe_module.api_version = STRIPE_API_VERSION
+    _warn_if_unrestricted_stripe_key(secret_key)
+    return stripe_module
+
+
+def _stripe_customer_idempotency_key(account_id: str) -> str:
+    return f"atlas-customer:{account_id}"
+
+
+def _stripe_checkout_idempotency_key(
+    *,
+    account_id: str,
+    user_id: str,
+    price_id: str,
+    success_url: str,
+    cancel_url: str,
+) -> str:
+    digest = sha256(
+        "\0".join((price_id, success_url, cancel_url)).encode("utf-8")
+    ).hexdigest()[:32]
+    return f"atlas-checkout:{account_id}:{user_id}:{digest}"
+
+
 def _get_stripe():
     import stripe
     cfg = settings.saas_auth
     if not cfg.stripe_secret_key:
         raise HTTPException(status_code=503, detail="Stripe not configured")
-    stripe.api_key = cfg.stripe_secret_key
-    return stripe
+    return _configure_stripe_module(stripe, cfg.stripe_secret_key)
 
 
 # -- Request/Response schemas --
@@ -182,6 +216,7 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
             email=user_row["email"] if user_row else "",
             name=account["name"],
             metadata={"account_id": str(user.account_id)},
+            idempotency_key=_stripe_customer_idempotency_key(str(user.account_id)),
             timeout=10,
         )
         customer_id = customer.id
@@ -203,6 +238,13 @@ async def create_checkout(req: CheckoutRequest, user: AuthUser = Depends(require
         success_url=req.success_url,
         cancel_url=req.cancel_url,
         metadata={"account_id": str(user.account_id)},
+        idempotency_key=_stripe_checkout_idempotency_key(
+            account_id=str(user.account_id),
+            user_id=str(user.user_id),
+            price_id=price_id,
+            success_url=req.success_url,
+            cancel_url=req.cancel_url,
+        ),
         timeout=10,
     )
 
@@ -267,7 +309,7 @@ async def stripe_webhook(request: Request):
         raise HTTPException(status_code=503, detail="Stripe not configured")
 
     import stripe
-    stripe.api_key = cfg.stripe_secret_key
+    _configure_stripe_module(stripe, cfg.stripe_secret_key)
 
     body = await request.body()
     if len(body) > 65536:

--- a/plans/PR-Stripe-Billing-Hardening.md
+++ b/plans/PR-Stripe-Billing-Hardening.md
@@ -1,0 +1,123 @@
+# PR-Stripe-Billing-Hardening
+
+## Why this slice exists
+
+The Atlas billing Stripe integration currently mutates the global Stripe module
+with the configured key and relies on the account/default API version. Review
+flagged three moderate hardening gaps: API version drift, using a full `sk_`
+secret where a restricted `rk_` key is preferred, and missing idempotency keys
+on billing-side Customer and Checkout creation.
+
+This slice closes the code-enforceable pieces in `atlas_brain/api/billing.py`
+without changing the public billing endpoints or Stripe product contracts. A
+review follow-up also migrates the adjacent in-tree Stripe callers that share
+the process-wide Stripe module so the billing API-version pin cannot leak into
+routes that still only reset `stripe.api_key`.
+
+## Scope (this PR)
+
+Ownership lane: atlas-billing/stripe
+Slice phase: Production hardening
+
+1. Centralize billing Stripe SDK setup in `billing.py` and pin the Stripe API
+   version used by billing calls.
+2. Keep the existing `ATLAS_SAAS_STRIPE_SECRET_KEY` config field but log a
+   warning when it looks like a full `sk_` key instead of the preferred
+   restricted `rk_` key.
+3. Add deterministic idempotency keys to `stripe.Customer.create` and
+   `stripe.checkout.Session.create` in the authenticated billing checkout
+   route.
+4. Apply the same Stripe SDK setup helper to adjacent auth/vendor Stripe callers
+   that would otherwise inherit the process-wide billing API version.
+5. Add focused tests for API-version pinning, restricted-key warning behavior,
+   the idempotency key values passed to Stripe, and vendor checkout/session
+   version pinning.
+
+### Files touched
+
+- `plans/PR-Stripe-Billing-Hardening.md`
+- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `atlas_brain/api/auth.py`
+- `atlas_brain/api/b2b_vendor_briefing.py`
+- `atlas_brain/api/billing.py`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `tests/test_atlas_billing_stripe_hardening.py`
+- `tests/test_b2b_vendor_briefing.py`
+
+## Mechanism
+
+`_get_stripe()` delegates to a small `_configure_stripe_module()` helper:
+
+```text
+stripe.api_key = cfg.stripe_secret_key
+stripe.api_version = STRIPE_API_VERSION
+```
+
+The same helper is used by the webhook route before signature verification.
+The configured key field is unchanged, so operators can replace an `sk_` with
+an `rk_` without a config migration. If an `sk_` key is still present, the code
+logs a warning naming the restricted-key expectation without logging the key.
+
+Checkout creation gains stable Stripe idempotency keys:
+
+```text
+atlas-customer:<account_id>
+atlas-checkout:<account_id>:<user_id>:<sha256(price_id/success_url/cancel_url)>
+```
+
+Those keys are deterministic for a retry/double-submit of the same operation
+and do not contain Stripe secrets or raw URLs.
+
+Because `stripe.api_version` is process-wide on the imported Stripe module,
+the same helper is also used in the adjacent signup and vendor-briefing routes
+that were previously resetting only `stripe.api_key`. That keeps all in-tree
+module-level Stripe usage on the pinned version instead of letting billing
+requests change another route's version implicitly.
+
+## Intentional
+
+- This does not fail startup on existing `sk_` keys. The safer `rk_` key is an
+  operator secret rotation through the same env field; warning first avoids
+  breaking current deployments during the hardening pass.
+- The webhook event payload shape is ultimately controlled by the Stripe
+  webhook endpoint API version in Stripe's dashboard. This PR pins the SDK
+  version used by Atlas billing code and documents the expected version in one
+  constant, but an operator still must pin the dashboard endpoint to match.
+- This does not touch portfolio-ui Stripe Checkout; that code uses direct
+  Stripe HTTP calls and is outside module-level Stripe SDK usage.
+- Adjacent auth/vendor Stripe callers are migrated only to prevent the
+  process-wide billing API-version pin from leaking across routes. Their own
+  endpoint semantics and idempotency behavior are otherwise left unchanged.
+
+## Deferred
+
+- Add idempotency discipline to adjacent non-billing Stripe create calls in a
+  follow-up PR if those routes stay in production use.
+- Add Stripe dashboard/runbook verification for webhook endpoint API-version
+  pinning and restricted-key permissions.
+- Optional webhook IP allowlisting remains deferred; signature verification is
+  still the primary control.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/api/billing.py atlas_brain/api/auth.py atlas_brain/api/b2b_vendor_briefing.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py` -- passed.
+- `python -m pytest tests/test_atlas_billing_stripe_hardening.py -q` -- 3 passed, 1 warning.
+- `python -m pytest tests/test_b2b_vendor_briefing.py -q` -- 41 passed, 1 warning.
+- `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 22 passed, 1 warning.
+- `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 63 passed, 1 warning.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/stripe-billing-hardening.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 123 |
+| Workflow enrollment | 10 |
+| Adjacent Stripe caller setup | 9 |
+| Billing helper/idempotency code | 48 |
+| Existing webhook assertion | 1 |
+| Focused tests | 206 |
+| **Total** | **397** |
+
+Actual diff is 8 files, +390 / -7. Under the 400 LOC soft cap.

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -214,6 +214,7 @@ async def test_stripe_webhook_routes_deflection_checkout_to_paid_gate(
 
     assert response == {"status": "ok"}
     assert fake_stripe.api_key == "sk_test"
+    assert fake_stripe.api_version == billing.STRIPE_API_VERSION
     assert pool.fetchval_calls[0][1] == ("evt_deflection_paid",)
     update_query, update_args = pool.execute_calls[0]
     insert_query, insert_args = pool.execute_calls[1]

--- a/tests/test_atlas_billing_stripe_hardening.py
+++ b/tests/test_atlas_billing_stripe_hardening.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from atlas_brain.api import billing
+from atlas_brain.auth.dependencies import AuthUser
+
+
+class _CustomerApi:
+    created: list[dict[str, Any]] = []
+
+    @classmethod
+    def create(cls, **kwargs: Any) -> SimpleNamespace:
+        cls.created.append(kwargs)
+        return SimpleNamespace(id="cus_test_created")
+
+
+class _CheckoutSessionApi:
+    created: list[dict[str, Any]] = []
+
+    @classmethod
+    def create(cls, **kwargs: Any) -> SimpleNamespace:
+        cls.created.append(kwargs)
+        return SimpleNamespace(url="https://checkout.stripe.test/session")
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        if "FROM saas_accounts" in query:
+            return {"stripe_customer_id": None, "name": "Acme Co."}
+        if "FROM saas_users" in query:
+            return {"email": "owner@example.com"}
+        raise AssertionError(query)
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.execute_calls.append((query, args))
+        return "UPDATE 1"
+
+
+def _fake_stripe() -> SimpleNamespace:
+    _CustomerApi.created = []
+    _CheckoutSessionApi.created = []
+    return SimpleNamespace(
+        api_key="",
+        api_version="",
+        Customer=_CustomerApi,
+        checkout=SimpleNamespace(Session=_CheckoutSessionApi),
+    )
+
+
+def test_configure_stripe_module_pins_api_version_and_warns_on_full_secret_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stripe = _fake_stripe()
+
+    with caplog.at_level(logging.WARNING, logger="atlas.api.billing"):
+        configured = billing._configure_stripe_module(stripe, "sk_test_full_secret")
+
+    assert configured is stripe
+    assert stripe.api_key == "sk_test_full_secret"
+    assert stripe.api_version == billing.STRIPE_API_VERSION
+    assert "restricted rk_ key" in caplog.text
+    assert "sk_test_full_secret" not in caplog.text
+
+    caplog.clear()
+    billing._configure_stripe_module(stripe, "rk_test_restricted")
+    assert stripe.api_key == "rk_test_restricted"
+    assert stripe.api_version == billing.STRIPE_API_VERSION
+    assert "restricted rk_ key" not in caplog.text
+
+
+def test_billing_idempotency_keys_are_stable_and_parameter_scoped() -> None:
+    account_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    first = billing._stripe_checkout_idempotency_key(
+        account_id=account_id,
+        user_id=user_id,
+        price_id="price_growth",
+        success_url="https://app.example.com/success",
+        cancel_url="https://app.example.com/cancel",
+    )
+    replay = billing._stripe_checkout_idempotency_key(
+        account_id=account_id,
+        user_id=user_id,
+        price_id="price_growth",
+        success_url="https://app.example.com/success",
+        cancel_url="https://app.example.com/cancel",
+    )
+    changed_url = billing._stripe_checkout_idempotency_key(
+        account_id=account_id,
+        user_id=user_id,
+        price_id="price_growth",
+        success_url="https://app.example.com/success",
+        cancel_url="https://app.example.com/other-cancel",
+    )
+
+    assert billing._stripe_customer_idempotency_key(account_id) == (
+        f"atlas-customer:{account_id}"
+    )
+    assert first == replay
+    assert first != changed_url
+    assert first.startswith(f"atlas-checkout:{account_id}:{user_id}:")
+    assert "https://" not in first
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_passes_pinned_version_and_idempotency_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    fake_stripe = _fake_stripe()
+    pool = _Pool()
+
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(billing.settings.saas_auth, "stripe_secret_key", "rk_test_billing")
+    monkeypatch.setattr(
+        billing.settings.saas_auth,
+        "stripe_growth_price_id",
+        "price_growth",
+    )
+    monkeypatch.setattr(billing, "get_db_pool", lambda: pool)
+
+    response = await billing.create_checkout(
+        billing.CheckoutRequest(
+            plan="growth",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
+        ),
+        AuthUser(
+            user_id=user_id,
+            account_id=account_id,
+            plan="trial",
+            plan_status="trialing",
+            role="owner",
+        ),
+    )
+
+    assert response.checkout_url == "https://checkout.stripe.test/session"
+    assert fake_stripe.api_key == "rk_test_billing"
+    assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+    assert _CustomerApi.created[0]["idempotency_key"] == (
+        f"atlas-customer:{account_id}"
+    )
+    assert _CustomerApi.created[0]["metadata"] == {"account_id": account_id}
+    assert pool.execute_calls[0][1] == ("cus_test_created", uuid.UUID(account_id))
+
+    checkout = _CheckoutSessionApi.created[0]
+    assert checkout["idempotency_key"] == billing._stripe_checkout_idempotency_key(
+        account_id=account_id,
+        user_id=user_id,
+        price_id="price_growth",
+        success_url="https://app.example.com/success",
+        cancel_url="https://app.example.com/cancel",
+    )
+    assert checkout["customer"] == "cus_test_created"
+    assert checkout["line_items"] == [{"price": "price_growth", "quantity": 1}]

--- a/tests/test_b2b_vendor_briefing.py
+++ b/tests/test_b2b_vendor_briefing.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from atlas_brain.api import b2b_vendor_briefing as briefing_api
+from atlas_brain.api import billing
 from atlas_brain.auth.dependencies import AuthUser, require_auth
 from atlas_brain.autonomous.tasks import b2b_vendor_briefing as briefing_mod
 from atlas_brain.services.b2b import vendor_briefing_ports as briefing_ports
@@ -143,6 +144,7 @@ def test_vendor_checkout_trims_customer_email_before_stripe(monkeypatch):
     create = MagicMock(return_value=fake_session)
     fake_stripe = SimpleNamespace(
         api_key=None,
+        api_version=None,
         StripeError=Exception,
         checkout=SimpleNamespace(Session=SimpleNamespace(create=create)),
     )
@@ -162,6 +164,8 @@ def test_vendor_checkout_trims_customer_email_before_stripe(monkeypatch):
 
     assert response.status_code == 200
     kwargs = create.call_args.kwargs
+    assert fake_stripe.api_key == "sk_test"
+    assert fake_stripe.api_version == billing.STRIPE_API_VERSION
     assert kwargs["customer_email"] == "ops@example.com"
     assert kwargs["metadata"]["vendor_name"] == "Zendesk"
     assert "vendor=Zendesk" in kwargs["success_url"]
@@ -173,6 +177,7 @@ def test_vendor_checkout_omits_blank_customer_email(monkeypatch):
     create = MagicMock(return_value=SimpleNamespace(id="cs_test", url="https://checkout.test/session"))
     fake_stripe = SimpleNamespace(
         api_key=None,
+        api_version=None,
         StripeError=Exception,
         checkout=SimpleNamespace(Session=SimpleNamespace(create=create)),
     )
@@ -195,6 +200,7 @@ def test_checkout_session_info_rejects_blank_session_id_before_stripe(monkeypatc
     retrieve = MagicMock(side_effect=AssertionError("Stripe should not be called"))
     fake_stripe = SimpleNamespace(
         api_key=None,
+        api_version=None,
         StripeError=Exception,
         checkout=SimpleNamespace(Session=SimpleNamespace(retrieve=retrieve)),
     )
@@ -207,6 +213,39 @@ def test_checkout_session_info_rejects_blank_session_id_before_stripe(monkeypatc
 
     assert response.status_code == 422
     assert response.json()["detail"] == "session_id is required"
+
+
+def test_checkout_session_info_pins_stripe_api_version(monkeypatch):
+    monkeypatch.setattr(briefing_api.settings.saas_auth, "stripe_secret_key", "sk_test", raising=False)
+    session = SimpleNamespace(
+        customer_details=SimpleNamespace(email="ops@example.com"),
+        customer_email=None,
+        metadata={"vendor_name": "Zendesk", "tier": "standard"},
+        payment_status="unpaid",
+    )
+    retrieve = MagicMock(return_value=session)
+    fake_stripe = SimpleNamespace(
+        api_key=None,
+        api_version=None,
+        StripeError=Exception,
+        checkout=SimpleNamespace(Session=SimpleNamespace(retrieve=retrieve)),
+    )
+    import sys
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    app = _make_app()
+
+    with TestClient(app) as client:
+        response = client.get("/b2b/briefings/checkout-session?session_id=cs_test_12345")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "email": "ops@example.com",
+        "vendor_name": "Zendesk",
+        "tier": "standard",
+    }
+    assert fake_stripe.api_key == "sk_test"
+    assert fake_stripe.api_version == billing.STRIPE_API_VERSION
+    retrieve.assert_called_once_with("cs_test_12345")
 
 
 def test_report_data_rejects_blank_token_before_db_touch(monkeypatch):


### PR DESCRIPTION
Plan: plans/PR-Stripe-Billing-Hardening.md
Slice phase: Production hardening

Review flagged three moderate Stripe hardening gaps in Atlas billing: unpinned API version, full `sk_` key posture instead of a restricted `rk_` key, and missing idempotency keys on Customer/Checkout creation. This slice centralizes billing Stripe setup, pins the billing SDK version, warns on full secret keys, adds deterministic idempotency keys to the billing create calls, and moves adjacent module-level Stripe SDK callers onto the same version-pinning helper so the process-wide pin cannot leak across routes.

## Intentional
- This does not fail startup on existing `sk_` keys. The safer `rk_` key is an operator secret rotation through the same env field; warning first avoids breaking current deployments during the hardening pass.
- The webhook event payload shape is ultimately controlled by the Stripe webhook endpoint API version in Stripe's dashboard. This PR pins the SDK version used by Atlas billing code and documents the expected version in one constant, but an operator still must pin the dashboard endpoint to match.
- This does not touch portfolio-ui Stripe Checkout; that code uses direct Stripe HTTP calls and is outside module-level Stripe SDK usage.
- Adjacent auth/vendor Stripe callers are migrated only to prevent the process-wide billing API-version pin from leaking across routes. Their own endpoint semantics and idempotency behavior are otherwise left unchanged.

## Deferred
- Add idempotency discipline to adjacent non-billing Stripe create calls in a follow-up PR if those routes stay in production use.
- Add Stripe dashboard/runbook verification for webhook endpoint API-version pinning and restricted-key permissions.
- Optional webhook IP allowlisting remains deferred; signature verification is still the primary control.
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/api/billing.py atlas_brain/api/auth.py atlas_brain/api/b2b_vendor_briefing.py tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py` -- passed.
- `python -m pytest tests/test_atlas_billing_stripe_hardening.py -q` -- 3 passed, 1 warning.
- `python -m pytest tests/test_b2b_vendor_briefing.py -q` -- 41 passed, 1 warning.
- `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 22 passed, 1 warning.
- `python -m pytest tests/test_atlas_billing_stripe_hardening.py tests/test_b2b_vendor_briefing.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 63 passed, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/stripe-billing-hardening.md` -- passed.

## Diff size
8 files, +390 / -7.
