### PR TITLE
PR-FAQ-Deflection-Portfolio-Checkout-RAK

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Checkout-RAK.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Checkout-RAK.md
@@ -1,0 +1,97 @@
+# PR-FAQ-Deflection-Portfolio-Checkout-RAK
+
+## Why this slice exists
+
+Issue #1161's latest Stripe hardening note calls out that the portfolio
+Checkout route should not rely on a full shared Stripe secret key for
+production buyer traffic. The portfolio is a separate service that only needs
+to create Checkout Sessions, so the safer production posture is a restricted
+API key with Checkout write scope.
+
+This slice keeps the already-verified Checkout contract intact while making the
+server route prefer `ATLAS_SAAS_STRIPE_RAK` and fail closed on live full-secret
+fallbacks.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Production hardening
+
+1. Add a small portfolio Checkout key selector that prefers
+   `ATLAS_SAAS_STRIPE_RAK`.
+2. Keep the existing `STRIPE_SECRET_KEY` preview/test fallback, but reject
+   `sk_live_` full secret keys so production cannot silently use the broad key.
+3. Use the selected key for configured Price validation and Checkout Session
+   creation without exposing key material in responses.
+4. Keep configured Price preflight validation on preview/full-key fallback, but
+   skip Stripe Price reads when the selected key is a checkout-only RAK.
+5. Add focused tests for RAK preference, test-secret fallback, live-secret
+   rejection, and checkout-only RAK compatibility with configured Prices.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Checkout-RAK.md`
+- `portfolio-ui/api/content-ops/deflection/checkout.js`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+
+## Mechanism
+
+The route resolves Stripe credentials before request parsing:
+
+```text
+ATLAS_SAAS_STRIPE_RAK (must start with rk_) -> preferred
+STRIPE_SECRET_KEY / ATLAS_SAAS_STRIPE_SECRET_KEY -> preview fallback
+sk_live_ fallback -> rejected
+```
+
+The returned config carries only the selected key in memory and a generic error
+code for client responses. `stripeAuthHeaders(...)` still creates the Stripe
+Basic auth header server-side for the same direct Checkout HTTP call. The body
+contract, metadata, one-time amount floor, and success/cancel URL behavior are
+unchanged.
+
+When a configured Stripe Price is used with a checkout-only RAK, the route skips
+the preflight `GET /v1/prices/{id}` because that read is outside the key's
+intended scope. Preview/full-key fallback still runs the existing Price
+validation, and ATLAS still enforces `amount_total >= 150000`, `usd`, and
+metadata on the signed webhook before unlocking the report.
+
+## Intentional
+
+- This does not add Stripe SDK dependencies; the route already uses direct
+  Stripe HTTP calls and the hardening only changes credential selection.
+- Test-mode `sk_test_` fallback remains allowed so previews can keep working
+  until the restricted test key is provisioned.
+- `sk_live_` is rejected rather than warned because production fallback to a
+  full secret key is exactly the blast-radius issue this slice closes.
+- Checkout-only RAKs do not read configured Prices before creating Checkout.
+  A mispriced session still fails to unlock at the ATLAS webhook amount floor;
+  this keeps the route compatible with the least-privilege key.
+- This does not touch the open submit/configured-account PR #1204.
+
+## Deferred
+
+- Provisioning the restricted key in Stripe and Vercel env is an operator
+  handoff; the PR only enforces the expected runtime posture.
+- A live Stripe Checkout smoke with the restricted key remains deferred until
+  the key exists in the deployed environment.
+- Parked hardening: none.
+
+## Verification
+
+- `node --check portfolio-ui/api/content-ops/deflection/checkout.js && node --check portfolio-ui/scripts/faq-deflection-result-page.test.mjs` -- passed.
+- `npm run test:deflection-result --prefix portfolio-ui` -- 15 checks passed.
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 19 checks passed.
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-checkout-rak.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 97 |
+| Checkout key selector | 38 |
+| Focused tests | 145 |
+| **Total** | **280** |
+
+Actual diff is 3 files, +272 / -8. Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/checkout.js
+++ b/portfolio-ui/api/content-ops/deflection/checkout.js
@@ -32,6 +32,25 @@ function stripeAuthHeaders(stripeSecretKey) {
   };
 }
 
+function stripeCheckoutKeyConfig(env = process.env) {
+  const restrictedKey = clean(env.ATLAS_SAAS_STRIPE_RAK);
+  if (restrictedKey) {
+    if (!restrictedKey.startsWith("rk_")) {
+      return { ok: false, error: "checkout_restricted_key_invalid" };
+    }
+    return { ok: true, key: restrictedKey, source: "restricted" };
+  }
+
+  const fallbackKey = clean(env.STRIPE_SECRET_KEY || env.ATLAS_SAAS_STRIPE_SECRET_KEY);
+  if (!fallbackKey) {
+    return { ok: false, error: "checkout_not_configured" };
+  }
+  if (fallbackKey.startsWith("sk_live_")) {
+    return { ok: false, error: "checkout_restricted_key_required" };
+  }
+  return { ok: true, key: fallbackKey, source: "fallback" };
+}
+
 function publicBaseUrl(req) {
   const configured = clean(process.env.DEFLECTION_CHECKOUT_PUBLIC_BASE_URL);
   if (configured) return configured.replace(/\/+$/, "");
@@ -173,6 +192,7 @@ export {
   buildStripeCheckoutBody,
   checkoutUrls,
   resultPath,
+  stripeCheckoutKeyConfig,
   validateConfiguredPrice,
   validatePayload,
 };
@@ -184,9 +204,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  const stripeSecretKey = clean(process.env.STRIPE_SECRET_KEY);
-  if (!stripeSecretKey) {
-    json(res, 503, { error: "checkout_not_configured" });
+  const stripeKey = stripeCheckoutKeyConfig();
+  if (!stripeKey.ok) {
+    json(res, 503, { error: stripeKey.error });
     return;
   }
 
@@ -209,10 +229,12 @@ export default async function handler(req, res) {
     json(res, 503, { error: "checkout_url_not_configured", details: urls.errors });
     return;
   }
-  const priceValidation = await validateConfiguredPrice(stripeSecretKey);
-  if (!priceValidation.ok) {
-    json(res, 503, { error: "checkout_price_not_configured", details: priceValidation.message });
-    return;
+  if (stripeKey.source !== "restricted") {
+    const priceValidation = await validateConfiguredPrice(stripeKey.key);
+    if (!priceValidation.ok) {
+      json(res, 503, { error: "checkout_price_not_configured", details: priceValidation.message });
+      return;
+    }
   }
 
   const body = buildStripeCheckoutBody({
@@ -221,7 +243,7 @@ export default async function handler(req, res) {
     successUrl: urls.successUrl,
     cancelUrl: urls.cancelUrl,
   });
-  const session = await createCheckoutSession(body, stripeSecretKey);
+  const session = await createCheckoutSession(body, stripeKey.key);
   if (!session.ok) {
     json(res, 502, { error: "stripe_checkout_failed", details: session.message });
     return;

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -7,6 +7,7 @@ import handler, {
   buildStripeCheckoutBody,
   checkoutUrls,
   resultPath,
+  stripeCheckoutKeyConfig,
   validateConfiguredPrice,
   validatePayload,
 } from "../api/content-ops/deflection/checkout.js";
@@ -204,6 +205,93 @@ await test("configured Stripe Price must validate against webhook floor before C
   assert.equal(calls[0].url, "https://api.stripe.com/v1/prices/price_deflection_low");
 });
 
+await test("restricted Checkout key skips configured Price read preflight", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
+  const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_live_full_secret";
+  process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
+  process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_deflection_report";
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { url: "https://checkout.stripe.com/c/session" };
+      },
+    };
+  };
+
+  const req = {
+    method: "POST",
+    headers: {
+      host: "portfolio.example.com",
+      "x-forwarded-proto": "https",
+    },
+    body: {
+      request_id: "content-ops-abc123",
+      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    },
+  };
+  const res = mockResponse();
+
+  try {
+    await handler(req, res);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
+    if (previousPriceId === undefined) {
+      delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+    } else {
+      process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), { url: "https://checkout.stripe.com/c/session" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(calls[0].options.body.get("line_items[0][price]"), "price_deflection_report");
+});
+
+await test("checkout key config prefers restricted key and rejects live secret fallback", () => {
+  assert.deepEqual(
+    stripeCheckoutKeyConfig({
+      ATLAS_SAAS_STRIPE_RAK: "rk_test_checkout_only",
+      STRIPE_SECRET_KEY: "sk_live_full_secret",
+    }),
+    { ok: true, key: "rk_test_checkout_only", source: "restricted" },
+  );
+  assert.deepEqual(
+    stripeCheckoutKeyConfig({ STRIPE_SECRET_KEY: "sk_test_preview" }),
+    { ok: true, key: "sk_test_preview", source: "fallback" },
+  );
+  assert.deepEqual(
+    stripeCheckoutKeyConfig({ ATLAS_SAAS_STRIPE_SECRET_KEY: "sk_test_atlas_preview" }),
+    { ok: true, key: "sk_test_atlas_preview", source: "fallback" },
+  );
+  assert.deepEqual(stripeCheckoutKeyConfig({ STRIPE_SECRET_KEY: "sk_live_full_secret" }), {
+    ok: false,
+    error: "checkout_restricted_key_required",
+  });
+  assert.deepEqual(stripeCheckoutKeyConfig({ ATLAS_SAAS_STRIPE_RAK: "sk_test_wrong" }), {
+    ok: false,
+    error: "checkout_restricted_key_invalid",
+  });
+});
+
 await test("checkout return path preserves result identifiers", () => {
   const path = resultPath(
     "content-ops-abc123",
@@ -276,9 +364,11 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
   assert.doesNotMatch(checkoutSource, /\/content-ops\/deflection-reports\/.+\/paid/);
   const previousFetch = globalThis.fetch;
   const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   const calls = [];
   process.env.STRIPE_SECRET_KEY = "sk_test_123";
+  process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
   delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options });
@@ -313,6 +403,11 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
     } else {
       process.env.STRIPE_SECRET_KEY = previousSecret;
     }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
     if (previousPriceId === undefined) {
       delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
     } else {
@@ -324,6 +419,56 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
   assert.deepEqual(JSON.parse(res.body), { url: "https://checkout.stripe.com/c/session" });
   assert.equal(calls.length, 1);
   assert.equal(calls[0].url, "https://api.stripe.com/v1/checkout/sessions");
+  assert.equal(
+    calls[0].options.headers.Authorization,
+    `Basic ${Buffer.from("rk_test_checkout_only:").toString("base64")}`,
+  );
   assert.equal(calls[0].options.body.get("metadata[source]"), CHECKOUT_SOURCE);
   assert.equal(calls[0].options.body.get("metadata[request_id]"), "content-ops-abc123");
+});
+
+await test("handler rejects live full secret fallback before calling Stripe", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_live_full_secret";
+  delete process.env.ATLAS_SAAS_STRIPE_RAK;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    throw new Error("Stripe should not be called");
+  };
+
+  const req = {
+    method: "POST",
+    headers: {
+      host: "portfolio.example.com",
+      "x-forwarded-proto": "https",
+    },
+    body: {
+      request_id: "content-ops-abc123",
+      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    },
+  };
+  const res = mockResponse();
+
+  try {
+    await handler(req, res);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+    if (previousRak === undefined) {
+      delete process.env.ATLAS_SAAS_STRIPE_RAK;
+    } else {
+      process.env.ATLAS_SAAS_STRIPE_RAK = previousRak;
+    }
+  }
+
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(JSON.parse(res.body), { error: "checkout_restricted_key_required" });
+  assert.equal(calls.length, 0);
 });


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Checkout-RAK.md
Slice phase: Production hardening

Issue #1161's latest Stripe hardening note calls out that the portfolio Checkout route should not rely on a full shared Stripe secret key for production buyer traffic. This slice keeps the verified Checkout contract intact while making the route prefer `ATLAS_SAAS_STRIPE_RAK`, allowing test-secret fallback for preview, rejecting live full-secret fallback, and keeping configured Price flows compatible with checkout-only restricted keys.

## Intentional
- This does not add Stripe SDK dependencies; the route already uses direct Stripe HTTP calls and the hardening only changes credential selection.
- Test-mode `sk_test_` fallback remains allowed so previews can keep working until the restricted test key is provisioned.
- `sk_live_` is rejected rather than warned because production fallback to a full secret key is exactly the blast-radius issue this slice closes.
- Checkout-only RAKs do not read configured Prices before creating Checkout. A mispriced session still fails to unlock at the ATLAS webhook amount floor; this keeps the route compatible with the least-privilege key.
- This does not touch the open submit/configured-account PR #1204.

## Deferred
- Provisioning the restricted key in Stripe and Vercel env is an operator handoff; the PR only enforces the expected runtime posture.
- A live Stripe Checkout smoke with the restricted key remains deferred until the key exists in the deployed environment.
- Parked hardening: none.

## Parked hardening
- None.

## Verification
- `node --check portfolio-ui/api/content-ops/deflection/checkout.js && node --check portfolio-ui/scripts/faq-deflection-result-page.test.mjs` -- passed.
- `npm run test:deflection-result --prefix portfolio-ui` -- 15 checks passed.
- `npm run test:deflection-upload-shell --prefix portfolio-ui` -- 19 checks passed.
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` -- 14 checks passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-portfolio-checkout-rak.md` -- passed.

## Diff size
3 files, +272 / -8.
