### PR TITLE
PR-FAQ-Deflection-Submit-Configured-Account-Smoke

### DIFF
--- a/plans/PR-FAQ-Deflection-Submit-Configured-Account-Smoke.md
+++ b/plans/PR-FAQ-Deflection-Submit-Configured-Account-Smoke.md
@@ -1,0 +1,94 @@
+# PR-FAQ-Deflection-Submit-Configured-Account-Smoke
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Submit-Configured-Account removed the buyer-facing ATLAS
+account field from the FAQ deflection upload form and bound private Blob submit
+requests to the configured server account. The existing live submit smoke still
+calls `submitPrivateBlob()` directly, so it proves the helper but not the
+public portfolio submit route that now owns the configured-account contract.
+
+This slice adds a route-handler mode to the existing smoke so an operator can
+validate the real `/api/content-ops/deflection/submit` JSON/private-Blob path
+without reintroducing a browser-supplied account id.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Functional validation
+
+1. Extend the portfolio submit live smoke with `--route-handler` mode.
+2. In route-handler mode, call the default portfolio submit API handler with
+   JSON private-Blob payload and no `X-Atlas-Account-Id` header.
+3. Require a real private Blob pathname/token for route-handler mode; local CSV
+   fixture mode remains helper-only.
+4. Redact the smoke output to request/result metadata only.
+5. Add focused tests for the new validation mode and its preflight failures.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Configured-Account-Smoke.md`
+- `portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The current smoke keeps its default helper path:
+
+```text
+submitPrivateBlob(...) -> ATLAS multipart submit
+```
+
+The new `--route-handler` mode builds the same JSON body the browser sends
+after private Blob upload:
+
+```json
+{
+  "blob_pathname": "faq-deflection/uploads/...",
+  "support_platform": "zendesk",
+  "company_name": "Acme Co.",
+  "contact_email": "lead@example.com",
+  "limit": "1000"
+}
+```
+
+It then calls the portfolio submit route handler with `Content-Type:
+application/json`, the configured server env values, and no account header.
+That exercises the server's configured `ATLAS_ACCOUNT_ID`, private Blob read,
+ATLAS multipart forwarding, projection, and cleanup path.
+
+## Intentional
+
+- Route-handler mode requires a real private Blob pathname and token because
+  the route handler intentionally owns the Blob SDK boundary; local CSV fixture
+  mode stays on the helper seam where a fake reader can be injected.
+- This does not change customer browser behavior or API responses.
+- The smoke still prints no bearer token, Blob token, raw CSV content, or raw
+  ATLAS response body.
+- This does not touch Checkout or Stripe key behavior from #1206.
+
+## Deferred
+
+- Running route-handler mode against the deployed portfolio/ATLAS environment
+  remains an operator step once a private Blob fixture is available.
+- Parked hardening: none.
+
+## Verification
+
+- `node --check portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs`
+- `node --check portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` (21 checks)
+- `npm run test:deflection-result --prefix portfolio-ui` (15 checks)
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` (14 checks)
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-configured-account-smoke.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 94 |
+| Smoke route-handler mode | 123 |
+| Focused tests | 89 |
+| **Total** | **306** |
+
+Under the 400 LOC soft cap.

--- a/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
+++ b/portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
-import {
+import submitHandler, {
   BLOB_UPLOAD_PATH_PREFIX,
   MAX_BLOB_CSV_BYTES,
   submitPrivateBlob,
@@ -40,6 +40,7 @@ function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
     outputResult: clean(sourceEnv.ATLAS_DEFLECTION_SUBMIT_RESULT_FILE),
     json: false,
     preflightOnly: false,
+    routeHandler: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -48,6 +49,8 @@ function parseArgs(argv = process.argv.slice(2), sourceEnv = process.env) {
       options.json = true;
     } else if (arg === "--preflight-only") {
       options.preflightOnly = true;
+    } else if (arg === "--route-handler") {
+      options.routeHandler = true;
     } else if (arg.startsWith("--")) {
       const key = arg.slice(2).replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
       const value = argv[index + 1];
@@ -92,6 +95,12 @@ function validationErrors(options) {
   if (clean(options.blobPathname) && !clean(options.blobToken)) {
     errors.push("BLOB_READ_WRITE_TOKEN or --blob-token is required with --blob-pathname");
   }
+  if (options.routeHandler && !clean(options.blobPathname)) {
+    errors.push("--route-handler requires --blob-pathname");
+  }
+  if (options.routeHandler && clean(options.csvFile)) {
+    errors.push("--route-handler cannot use --csv-file");
+  }
   if (clean(options.blobPathname) && clean(options.csvFile)) {
     errors.push("use either --blob-pathname or --csv-file, not both");
   }
@@ -133,15 +142,123 @@ function resultPayload(result, options, sourceMode) {
   };
 }
 
+function routePayloadFromOptions(options) {
+  return {
+    blob_pathname: clean(options.blobPathname),
+    support_platform: clean(options.supportPlatform),
+    company_name: clean(options.companyName),
+    contact_email: clean(options.contactEmail),
+    limit: clean(options.limit),
+  };
+}
+
+function mockRouteResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(value) {
+      this.body = value || "";
+    },
+  };
+}
+
+async function withRouteEnv(options, fn) {
+  const nextEnv = {
+    ATLAS_API_BASE_URL: clean(options.baseUrl),
+    ATLAS_B2B_JWT: clean(options.token),
+    ATLAS_TOKEN: "",
+    ATLAS_ACCOUNT_ID: clean(options.accountId),
+    BLOB_READ_WRITE_TOKEN: clean(options.blobToken),
+    ATLAS_PROXY_TIMEOUT_MS: String(options.timeoutMs),
+  };
+  const previous = {};
+  for (const key of Object.keys(nextEnv)) {
+    previous[key] = process.env[key];
+    if (nextEnv[key]) {
+      process.env[key] = nextEnv[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(nextEnv)) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
+function routeResultPayload(statusCode, payload, options) {
+  const ok = statusCode >= 200 && statusCode < 300 && payload?.ok === true;
+  return {
+    ok,
+    source_mode: "portfolio_submit_route",
+    statusCode,
+    request_id: payload?.request_id,
+    account_id: payload?.account_id,
+    result_path: payload?.result_path,
+    error: ok ? undefined : clean(payload?.error) || "portfolio_submit_route_failed",
+    atlas_status: payload?.atlas_status,
+    base_host: URL.canParse(options.baseUrl) ? new URL(options.baseUrl).host : "",
+  };
+}
+
+async function runRouteHandlerSmoke(options, handlerImpl = submitHandler) {
+  const res = mockRouteResponse();
+  const req = {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(routePayloadFromOptions(options)),
+  };
+  await withRouteEnv(options, async () => {
+    await handlerImpl(req, res);
+  });
+  let payload = {};
+  try {
+    payload = res.body ? JSON.parse(res.body) : {};
+  } catch {
+    return {
+      ok: false,
+      source_mode: "portfolio_submit_route",
+      statusCode: res.statusCode,
+      error: "portfolio_submit_route_invalid_json",
+      base_host: URL.canParse(options.baseUrl) ? new URL(options.baseUrl).host : "",
+    };
+  }
+  const projected = routeResultPayload(res.statusCode, payload, options);
+  if (projected.ok && !REQUEST_ID_RE.test(clean(projected.request_id))) {
+    return { ...projected, ok: false, error: "invalid_request_id" };
+  }
+  return projected;
+}
+
 async function runSubmitSmoke(options) {
   const errors = validationErrors(options);
   if (errors.length > 0) {
     return { ok: false, status: "preflight_failed", errors };
   }
 
-  const sourceMode = clean(options.blobPathname) ? "private_blob" : "local_csv_fixture";
+  const sourceMode = options.routeHandler
+    ? "portfolio_submit_route"
+    : clean(options.blobPathname)
+      ? "private_blob"
+      : "local_csv_fixture";
   if (options.preflightOnly) {
     return { ok: true, status: "preflight_ok", source_mode: sourceMode };
+  }
+  if (options.routeHandler) {
+    return runRouteHandlerSmoke(options);
   }
 
   const payload = {
@@ -211,4 +328,4 @@ if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
     });
 }
 
-export { parseArgs, runSubmitSmoke, validationErrors };
+export { parseArgs, runRouteHandlerSmoke, runSubmitSmoke, validationErrors };

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -24,6 +24,7 @@ import {
 } from "../api/content-ops/deflection/events.js";
 import {
   parseArgs as parseSubmitSmokeArgs,
+  runRouteHandlerSmoke,
   runSubmitSmoke,
   validationErrors as submitSmokeValidationErrors,
 } from "./faq-deflection-submit-live-smoke.mjs";
@@ -187,7 +188,9 @@ await test("portfolio submit endpoint pins raw multipart body handling", () => {
 
 await test("submit live smoke exercises the production private blob helper", async () => {
   assert.match(submitSmokeSource, /submitPrivateBlob/);
+  assert.match(submitSmokeSource, /submitHandler/);
   assert.match(submitSmokeSource, /local_csv_fixture/);
+  assert.match(submitSmokeSource, /portfolio_submit_route/);
   assert.doesNotMatch(submitSmokeSource, /ATLAS_B2B_JWT[^\\n]*console\\.log/);
   assert.deepEqual(
     submitSmokeValidationErrors({
@@ -200,6 +203,33 @@ await test("submit live smoke exercises the production private blob helper", asy
     }),
     ["ATLAS_API_BASE_URL or --base-url must point to a deployed HTTPS host"],
   );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      supportPlatform: "zendesk",
+      limit: "1000",
+      timeoutMs: 1000,
+      routeHandler: true,
+    }).includes("--route-handler requires --blob-pathname"),
+    true,
+  );
+  assert.equal(
+    submitSmokeValidationErrors({
+      baseUrl: ENV.ATLAS_API_BASE_URL,
+      token: ENV.ATLAS_B2B_JWT,
+      accountId: ACCOUNT_ID,
+      blobPathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      blobToken: ENV.BLOB_READ_WRITE_TOKEN,
+      csvFile: "tickets.csv",
+      supportPlatform: "zendesk",
+      limit: "1000",
+      timeoutMs: 1000,
+      routeHandler: true,
+    }).includes("--route-handler cannot use --csv-file"),
+    true,
+  );
 
   const options = parseSubmitSmokeArgs(["--preflight-only"], {
     ATLAS_API_BASE_URL: ENV.ATLAS_API_BASE_URL,
@@ -210,6 +240,65 @@ await test("submit live smoke exercises the production private blob helper", asy
     ok: true,
     status: "preflight_ok",
     source_mode: "local_csv_fixture",
+  });
+
+  const routeOptions = parseSubmitSmokeArgs([
+    "--route-handler",
+    "--preflight-only",
+    "--blob-pathname",
+    `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+  ], {
+    ...ENV,
+  });
+  assert.deepEqual(await runSubmitSmoke(routeOptions), {
+    ok: true,
+    status: "preflight_ok",
+    source_mode: "portfolio_submit_route",
+  });
+});
+
+await test("submit live smoke route-handler mode omits buyer account header", async () => {
+  const options = parseSubmitSmokeArgs([
+    "--route-handler",
+    "--blob-pathname",
+    `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+  ], {
+    ...ENV,
+  });
+  const result = await runRouteHandlerSmoke(options, async (req, res) => {
+    assert.equal(req.method, "POST");
+    assert.equal(req.headers["content-type"], "application/json");
+    assert.equal("x-atlas-account-id" in req.headers, false);
+    assert.equal(process.env.ATLAS_API_BASE_URL, ENV.ATLAS_API_BASE_URL);
+    assert.equal(process.env.ATLAS_B2B_JWT, ENV.ATLAS_B2B_JWT);
+    assert.equal(process.env.ATLAS_ACCOUNT_ID, ACCOUNT_ID);
+    assert.equal(process.env.BLOB_READ_WRITE_TOKEN, ENV.BLOB_READ_WRITE_TOKEN);
+    assert.deepEqual(JSON.parse(req.body), {
+      blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv`,
+      support_platform: "zendesk",
+      company_name: "Atlas Smoke Co.",
+      contact_email: "smoke@example.com",
+      limit: "1000",
+    });
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({
+      ok: true,
+      request_id: "content-ops-route123",
+      account_id: ACCOUNT_ID,
+      result_path: `/services/faq-deflection/results/content-ops-route123?account_id=${ACCOUNT_ID}`,
+    }));
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    source_mode: "portfolio_submit_route",
+    statusCode: 200,
+    request_id: "content-ops-route123",
+    account_id: ACCOUNT_ID,
+    result_path: `/services/faq-deflection/results/content-ops-route123?account_id=${ACCOUNT_ID}`,
+    error: undefined,
+    atlas_status: undefined,
+    base_host: "atlas.example.com",
   });
 });
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Configured-Account-Smoke.md
Slice phase: Functional validation

Adds a `--route-handler` mode to the FAQ deflection live submit smoke so the public portfolio submit API handler can be validated with a JSON private-Blob payload, configured server account, and no buyer-supplied `X-Atlas-Account-Id` header.

## Intentional
- Route-handler mode requires a real private Blob pathname and token because the route handler owns the Blob SDK boundary; local CSV fixture mode remains helper-only.
- This does not change customer browser behavior or API responses.
- The smoke output remains redacted to request/result metadata and does not print bearer tokens, Blob tokens, raw CSV content, or raw ATLAS response bodies.
- This does not touch Checkout or Stripe key behavior from #1206.

## Deferred
- Running route-handler mode against the deployed portfolio/ATLAS environment remains an operator step once a private Blob fixture is available.

## Parked hardening
- None.

## Verification
- `node --check portfolio-ui/scripts/faq-deflection-submit-live-smoke.mjs`
- `node --check portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
- `npm run test:deflection-upload-shell --prefix portfolio-ui` (21 checks)
- `npm run test:deflection-result --prefix portfolio-ui` (15 checks)
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` (14 checks)
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-configured-account-smoke.md`

## Diff size
3 files, +303 / -3
