### PR TITLE
PR-FAQ-Deflection-Result-Configured-Account

### DIFF
--- a/plans/PR-FAQ-Deflection-Result-Configured-Account.md
+++ b/plans/PR-FAQ-Deflection-Result-Configured-Account.md
@@ -1,0 +1,100 @@
+# PR-FAQ-Deflection-Result-Configured-Account
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Submit-Configured-Account removed the buyer-facing account id
+field from the FAQ deflection upload form, but intentionally deferred the
+follow-up because the existing result page, report proxy, Checkout route, and
+smokes still carried `account_id` in the public result URL and browser Checkout
+payload.
+
+Now that the submit path is bound to the configured server account and the
+route-handler smoke is merged, the customer-facing result URL can carry only
+the Content Ops `request_id`. The portfolio server should derive the ATLAS
+account id from `ATLAS_ACCOUNT_ID` for snapshot/artifact fetches and Stripe
+metadata.
+
+## Scope (this PR)
+
+Ownership lane: portfolio-ui/faq-deflection
+Slice phase: Product polish
+
+1. Remove `account_id` from generated FAQ deflection result URLs and Checkout
+   return URLs.
+2. Let result-page and report proxy requests derive the ATLAS account binding
+   from configured server env while still rejecting mismatched legacy query
+   values.
+3. Let the Checkout route derive Stripe metadata `account_id` from configured
+   server env while accepting only matching legacy payloads.
+4. Remove the result page's browser-side account id data attributes and
+   Checkout request body field.
+5. Update focused portfolio result/upload tests to lock the configured-account
+   behavior and the no-account public URL shape.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Result-Configured-Account.md`
+- `portfolio-ui/api/content-ops/deflection/atlas-report.js`
+- `portfolio-ui/api/content-ops/deflection/checkout.js`
+- `portfolio-ui/api/content-ops/deflection/result-page.js`
+- `portfolio-ui/src/pages/FaqDeflectionResult.tsx`
+- `portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-result-page.test.mjs`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+`resultPath()` stops appending `account_id` and preserves only the optional
+Checkout return token:
+
+```text
+/services/faq-deflection/results/{request_id}
+/services/faq-deflection/results/{request_id}?checkout=success
+```
+
+The report proxy keeps the same ATLAS calls, but `loadDeflectionReport()` uses
+`ATLAS_ACCOUNT_ID` when the browser omits `account_id`. If a legacy URL or API
+caller sends an account id, it must still be a UUID and match the configured
+account before ATLAS is called.
+
+The Checkout route similarly reads `ATLAS_ACCOUNT_ID` server-side for Stripe
+metadata. The browser posts only `{ request_id }`, and legacy `account_id`
+payloads fail closed on mismatch.
+
+## Intentional
+
+- Stripe metadata still includes `account_id`; the change is where that value
+  comes from, not the ATLAS webhook contract.
+- The public submit response can continue to include `account_id` for
+  compatibility, but its `result_path` no longer carries it.
+- Legacy account-id query/body inputs are rejected on mismatch instead of
+  silently ignored.
+- This does not change ATLAS submit, private Blob upload, Stripe key selection,
+  or artifact rendering semantics.
+
+## Deferred
+
+- Running the full hosted upload -> submit -> result -> Checkout loop remains
+  an operator/live-environment step.
+- Parked hardening: none.
+
+## Verification
+
+- `node --check portfolio-ui/api/content-ops/deflection/checkout.js && node --check portfolio-ui/api/content-ops/deflection/atlas-report.js && node --check portfolio-ui/api/content-ops/deflection/result-page.js && node --check portfolio-ui/api/content-ops/deflection/report.js && node --check portfolio-ui/scripts/faq-deflection-result-page.test.mjs && node --check portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs && node --check portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+- `npm run test:deflection-result --prefix portfolio-ui` (16 checks)
+- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` (15 checks)
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` (21 checks)
+- `npm run build --prefix portfolio-ui` (passed after `npm install --prefix portfolio-ui`; Vite emitted the existing large-chunk advisory and skipped sitemap generation because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not set)
+- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-result-configured-account.md`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 100 |
+| Result/report/checkout route changes | 49 |
+| React result fallback page | 21 |
+| Focused tests | 164 |
+| **Total** | **334** |
+
+Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/atlas-report.js
+++ b/portfolio-ui/api/content-ops/deflection/atlas-report.js
@@ -23,14 +23,14 @@ function reportRequestErrors({ requestId, accountId }, config) {
   if (!requestId || !REQUEST_ID_RE.test(requestId)) {
     errors.push("request_id must be a valid Content Ops request id");
   }
-  if (!accountId || !UUID_RE.test(accountId)) {
+  if (accountId && !UUID_RE.test(accountId)) {
     errors.push("account_id must be a valid ATLAS account UUID");
   }
   if (!config.baseUrl) errors.push("ATLAS_API_BASE_URL is not configured");
   if (!config.token) errors.push("ATLAS_B2B_JWT is not configured");
   if (!config.accountId || !UUID_RE.test(config.accountId)) {
     errors.push("ATLAS_ACCOUNT_ID is not configured");
-  } else if (accountId && accountId !== config.accountId) {
+  } else if (accountId && UUID_RE.test(accountId) && accountId !== config.accountId) {
     errors.push("account_id does not match the configured ATLAS account");
   }
   return errors;
@@ -176,7 +176,7 @@ async function loadDeflectionReport({
 }) {
   const config = configFromEnv(env);
   const cleanedRequestId = clean(requestId);
-  const cleanedAccountId = clean(accountId);
+  const cleanedAccountId = clean(accountId) || config.accountId;
   const errors = reportRequestErrors(
     { requestId: cleanedRequestId, accountId: cleanedAccountId },
     config,

--- a/portfolio-ui/api/content-ops/deflection/checkout.js
+++ b/portfolio-ui/api/content-ops/deflection/checkout.js
@@ -73,24 +73,31 @@ async function readBody(req) {
   return raw ? JSON.parse(raw) : {};
 }
 
-function validatePayload(payload) {
+function validatePayload(payload, env = process.env) {
   const requestId = clean(payload?.request_id);
-  const accountId = clean(payload?.account_id);
+  const requestedAccountId = clean(payload?.account_id);
+  const accountId = clean(env.ATLAS_ACCOUNT_ID);
   const errors = [];
   if (!requestId || !REQUEST_ID_RE.test(requestId)) {
     errors.push("request_id must be a valid Content Ops request id");
   }
   if (!accountId || !UUID_RE.test(accountId)) {
+    errors.push("ATLAS_ACCOUNT_ID must be configured as an ATLAS account UUID");
+  }
+  if (requestedAccountId && !UUID_RE.test(requestedAccountId)) {
     errors.push("account_id must be a valid ATLAS account UUID");
+  } else if (requestedAccountId && requestedAccountId !== accountId) {
+    errors.push("account_id does not match the configured ATLAS account");
   }
   return { requestId, accountId, errors };
 }
 
-function resultPath(requestId, accountId, checkout) {
+function resultPath(requestId, _accountId = "", checkout = "") {
   const path = `/services/faq-deflection/results/${encodeURIComponent(requestId)}`;
-  const params = new URLSearchParams({ account_id: accountId });
+  const params = new URLSearchParams();
   if (checkout) params.set("checkout", checkout);
-  return `${path}?${params.toString()}`;
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
 }
 
 function checkoutUrls(req, requestId, accountId) {
@@ -218,7 +225,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  const { requestId, accountId, errors } = validatePayload(payload);
+  const { requestId, accountId, errors } = validatePayload(payload, process.env);
   if (errors.length > 0) {
     json(res, 400, { error: "invalid_checkout_request", details: errors });
     return;

--- a/portfolio-ui/api/content-ops/deflection/result-page.js
+++ b/portfolio-ui/api/content-ops/deflection/result-page.js
@@ -93,20 +93,17 @@ function renderPaidArtifact(report) {
         </section>`;
 }
 
-function renderArtifactRetryScript({ requestId, accountId, shouldRetry }) {
+function renderArtifactRetryScript({ requestId, shouldRetry }) {
   if (!shouldRetry) return "";
 
   return `\n  <script data-atlas-deflection-artifact-retry>
     (() => {
       const retryMessage = document.getElementById("checkout-message");
       const retryRequestId = ${scriptJson(requestId)};
-      const retryAccountId = ${scriptJson(accountId)};
       const retryDelays = [1500, 3000, 5000, 8000, 13000];
       let retryAttempt = 0;
       const reportUrl = () => "/api/content-ops/deflection/report?request_id="
-        + encodeURIComponent(retryRequestId)
-        + "&account_id="
-        + encodeURIComponent(retryAccountId);
+        + encodeURIComponent(retryRequestId);
       const pollArtifactUnlock = async () => {
         if (retryMessage) retryMessage.textContent = "Checking unlock status...";
         try {
@@ -129,7 +126,7 @@ function renderArtifactRetryScript({ requestId, accountId, shouldRetry }) {
         retryAttempt += 1;
         window.setTimeout(pollArtifactUnlock, delay);
       };
-      if (retryRequestId && retryAccountId) {
+      if (retryRequestId) {
         window.setTimeout(pollArtifactUnlock, retryDelays[retryAttempt]);
         retryAttempt += 1;
       }
@@ -139,13 +136,12 @@ function renderArtifactRetryScript({ requestId, accountId, shouldRetry }) {
 
 function renderResultPage({ requestId, accountId, checkoutStatus = "", report = null }) {
   const safeRequestId = escapeHtml(requestId);
-  const safeAccountId = escapeHtml(accountId);
   const safeCheckoutStatus = escapeHtml(checkoutStatus);
   const resultHref = resultPath(requestId || "missing-request", accountId, "");
   const artifactStatus = report && report.ok ? report.artifact_status : "snapshot_unavailable";
   const isUnlocked = artifactStatus === "unlocked";
   const shouldRetryArtifact = checkoutStatus === "success" && artifactStatus === "locked";
-  const buttonDisabled = requestId && accountId && !isUnlocked && !shouldRetryArtifact ? "" : "disabled";
+  const buttonDisabled = requestId && !isUnlocked && !shouldRetryArtifact ? "" : "disabled";
   const unlockHeading = isUnlocked
     ? "Full report unlocked"
     : shouldRetryArtifact
@@ -212,7 +208,6 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     class="shell"
     data-atlas-deflection-result
     data-atlas-deflection-request-id="${safeRequestId}"
-    data-atlas-deflection-account-id="${safeAccountId}"
     data-atlas-deflection-report-source="${CHECKOUT_SOURCE}"
     data-atlas-deflection-artifact-retry="${shouldRetryArtifact ? "true" : "false"}"
   >
@@ -232,7 +227,6 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
         <dl class="meta">
           <div><dt>Checkout metadata source</dt><dd>${CHECKOUT_SOURCE}</dd></div>
           <div><dt>request_id</dt><dd>${safeRequestId || "Missing request id"}</dd></div>
-          <div><dt>account_id</dt><dd>${safeAccountId || "Missing account id"}</dd></div>
           <div><dt>canonical result path</dt><dd>${escapeHtml(resultHref)}</dd></div>
           <div><dt>artifact_status</dt><dd>${escapeHtml(artifactStatus)}</dd></div>
           <div><dt>checkout</dt><dd>${safeCheckoutStatus || "locked"}</dd></div>
@@ -242,7 +236,6 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
           data-atlas-deflection-unlock
           data-checkout-source="${CHECKOUT_SOURCE}"
           data-checkout-request_id="${safeRequestId}"
-          data-checkout-account_id="${safeAccountId}"
           ${buttonDisabled}
         >${unlockButtonLabel}</button>
         <p id="checkout-message" class="muted" role="status"></p>
@@ -253,8 +246,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
     const button = document.querySelector("[data-atlas-deflection-unlock]");
     const message = document.getElementById("checkout-message");
     const requestId = ${scriptJson(requestId)};
-    const accountId = ${scriptJson(accountId)};
-    if (button && requestId && accountId) {
+    if (button && requestId) {
       button.addEventListener("click", async () => {
         button.disabled = true;
         message.textContent = "Opening Checkout...";
@@ -262,7 +254,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
           const response = await fetch("/api/content-ops/deflection/checkout", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ request_id: requestId, account_id: accountId })
+            body: JSON.stringify({ request_id: requestId })
           });
           const payload = await response.json();
           if (!response.ok || !payload.url) throw new Error(payload.error || "checkout_failed");
@@ -274,7 +266,7 @@ function renderResultPage({ requestId, accountId, checkoutStatus = "", report = 
       });
     }
   </script>
-  ${renderArtifactRetryScript({ requestId, accountId, shouldRetry: shouldRetryArtifact })}
+  ${renderArtifactRetryScript({ requestId, shouldRetry: shouldRetryArtifact })}
 </body>
 </html>`;
 }
@@ -301,7 +293,7 @@ export default async function handler(req, res) {
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-store");
   const report =
-    requestId && accountId
+    requestId
       ? await loadDeflectionReport({ requestId, accountId })
       : null;
   res.end(

--- a/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs
@@ -88,7 +88,7 @@ function assertUnlockCta(html, { disabled }) {
   const button = match[0];
   assert.match(button, /data-checkout-source="content_ops_deflection_report"/);
   assert.match(button, new RegExp(`data-checkout-request_id="${REQUEST_ID}"`));
-  assert.match(button, new RegExp(`data-checkout-account_id="${ACCOUNT_ID}"`));
+  assert.doesNotMatch(button, /data-checkout-account_id=/);
   if (disabled) {
     assert.match(button, /\sdisabled(?:\s|>)/);
   } else {
@@ -127,6 +127,20 @@ await test("proxy rejects account mismatch before calling ATLAS", async () => {
   assert.equal(result.statusCode, 400);
   assert.deepEqual(result.details, ["account_id does not match the configured ATLAS account"]);
   assert.equal(calls.length, 0);
+});
+
+await test("proxy uses configured account when browser omits account id", async () => {
+  const { calls, fetchImpl } = mockFetch([response(SNAPSHOT, 200), response({}, 403)]);
+  const result = await loadDeflectionReport({
+    requestId: REQUEST_ID,
+    env: ENV,
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.account_id, ACCOUNT_ID);
+  assert.equal(result.artifact_status, "locked");
+  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${atlasPath(REQUEST_ID, "snapshot")}`);
+  assert.equal(calls[1].url, `${ENV.ATLAS_API_BASE_URL}${atlasPath(REQUEST_ID, "artifact")}`);
 });
 
 await test("proxy returns locked snapshot envelope without artifact payload", async () => {
@@ -231,8 +245,8 @@ await test("public report API hides config details from browser responses", asyn
     const req = {
       method: "GET",
       headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
-      query: { request_id: REQUEST_ID, account_id: ACCOUNT_ID },
-      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}&account_id=${ACCOUNT_ID}`,
+      query: { request_id: REQUEST_ID },
+      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}`,
     };
     const res = mockResponse();
     await reportHandler(req, res);
@@ -255,8 +269,8 @@ await test("public report API returns sanitized locked envelope and never the to
     const req = {
       method: "GET",
       headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
-      query: { request_id: REQUEST_ID, account_id: ACCOUNT_ID },
-      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}&account_id=${ACCOUNT_ID}`,
+      query: { request_id: REQUEST_ID },
+      url: `/api/content-ops/deflection/report?request_id=${REQUEST_ID}`,
     };
     const res = mockResponse();
     try {
@@ -314,6 +328,7 @@ await test("hosted result page retries artifact status after successful checkout
   assert.match(html, /\/api\/content-ops\/deflection\/report\?request_id=/);
   assert.match(html, /payload\.artifact_status === "unlocked"/);
   assert.match(html, /window\.location\.reload\(\)/);
+  assert.doesNotMatch(html, /account_id=/);
   assert.doesNotMatch(html, /payload\.artifact\b/);
   assert.doesNotMatch(html, /data-atlas-deflection-paid-report/);
 });

--- a/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-result-page.test.mjs
@@ -50,6 +50,25 @@ function mockResponse() {
   };
 }
 
+async function withEnv(nextEnv, fn) {
+  const previous = {};
+  for (const key of Object.keys(nextEnv)) {
+    previous[key] = process.env[key];
+    process.env[key] = nextEnv[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(nextEnv)) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
 await test("route is wired at the hosted FAQ deflection result path", () => {
   assert.match(appSource, /FaqDeflectionResult/);
   assert.match(appSource, /\/services\/faq-deflection\/results\/:requestId/);
@@ -69,7 +88,6 @@ await test("result page exposes validation markers and checkout metadata", () =>
     "data-atlas-deflection-request-id",
     "data-atlas-deflection-unlock",
     "request_id",
-    "account_id",
   ]) {
     assert.match(pageSource, new RegExp(marker));
     assert.match(resultPageSource, new RegExp(marker));
@@ -78,19 +96,15 @@ await test("result page exposes validation markers and checkout metadata", () =>
   assert.match(pageSource, /content_ops_deflection_report/);
   assert.match(html, /content_ops_deflection_report/);
   assert.match(html, /content-ops-abc123/);
-  assert.match(html, /2b2b950d-f64b-4852-bc30-f92a34cdf169/);
   assert.match(html, /data-checkout-source="content_ops_deflection_report"/);
   assert.match(html, /data-checkout-request_id="content-ops-abc123"/);
-  assert.match(
-    html,
-    /data-checkout-account_id="2b2b950d-f64b-4852-bc30-f92a34cdf169"/,
-  );
+  assert.doesNotMatch(html, /2b2b950d-f64b-4852-bc30-f92a34cdf169/);
+  assert.doesNotMatch(html, /data-checkout-account_id|data-atlas-deflection-account-id/);
+  assert.doesNotMatch(pageSource, /account_id|data-checkout-account_id|data-atlas-deflection-account-id/);
   assert.match(resultPageSource, /data-checkout-source=/);
   assert.match(resultPageSource, /data-checkout-request_id=/);
-  assert.match(resultPageSource, /data-checkout-account_id=/);
   assert.match(pageSource, /data-checkout-source=/);
   assert.match(pageSource, /data-checkout-request_id=/);
-  assert.match(pageSource, /data-checkout-account_id=/);
 });
 
 await test("result pages never embed ATLAS service credentials or paid-route calls", () => {
@@ -107,21 +121,89 @@ await test("snapshot guard names paid report fields that must not render pre-pay
   assert.match(pageSource, /collectForbiddenKeys/);
 });
 
-await test("checkout endpoint validates request and account identifiers", () => {
+await test("checkout endpoint validates request and configured account identifiers", async () => {
+  const env = { ATLAS_ACCOUNT_ID: "2b2b950d-f64b-4852-bc30-f92a34cdf169" };
   const valid = validatePayload({
     request_id: "content-ops-abc123",
-    account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
-  });
+  }, env);
   assert.deepEqual(valid.errors, []);
+  assert.equal(valid.accountId, "2b2b950d-f64b-4852-bc30-f92a34cdf169");
+
+  const legacy = validatePayload({
+    request_id: "content-ops-abc123",
+    account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+  }, env);
+  assert.deepEqual(legacy.errors, []);
 
   const invalid = validatePayload({
     request_id: "../bad",
     account_id: "not-a-uuid",
-  });
+  }, env);
   assert.deepEqual(invalid.errors, [
     "request_id must be a valid Content Ops request id",
     "account_id must be a valid ATLAS account UUID",
   ]);
+
+  const mismatch = validatePayload({
+    request_id: "content-ops-abc123",
+    account_id: "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+  }, env);
+  assert.deepEqual(mismatch.errors, [
+    "account_id does not match the configured ATLAS account",
+  ]);
+});
+
+await test("hosted result page loads report with configured account when URL omits account id", async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      status: calls.length === 1 ? 200 : 403,
+      async text() {
+        return JSON.stringify(
+          calls.length === 1
+            ? {
+                summary: { generated: 1, drafted_answer_count: 0, no_proven_answer_count: 1 },
+                top_questions: [
+                  {
+                    rank: 1,
+                    question: "How do I export reports?",
+                    weighted_frequency: 3,
+                    customer_wording: "export reports",
+                  },
+                ],
+              }
+            : { detail: "locked" },
+        );
+      },
+    };
+  };
+  const res = mockResponse();
+  try {
+    await withEnv({
+      ATLAS_API_BASE_URL: "https://atlas.example.com",
+      ATLAS_B2B_JWT: "secret-service-token",
+      ATLAS_ACCOUNT_ID: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
+    }, async () => {
+      await resultPageHandler(
+        {
+          url: "/services/faq-deflection/results/content-ops-abc123",
+          headers: { host: "portfolio.example.com", "x-forwarded-proto": "https" },
+          query: { request_id: "content-ops-abc123" },
+        },
+        res,
+      );
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(calls.length, 2);
+  assert.match(res.body, /How do I export reports\?/);
+  assert.match(res.body, /data-atlas-deflection-artifact-retry="false"/);
+  assert.doesNotMatch(res.body, /account_id=/);
 });
 
 await test("hosted result page rejects script-breaking account_id input", async () => {
@@ -143,11 +225,11 @@ await test("hosted result page rejects script-breaking account_id input", async 
 
 await test("rendered inline script escapes script terminators defensively", () => {
   const html = renderResultPage({
-    requestId: "content-ops-abc123",
-    accountId: "</script><img src=x onerror=alert(1)>",
+    requestId: "</script><img src=x onerror=alert(1)>",
+    accountId: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
   });
-  assert.doesNotMatch(html, /const accountId = "<\/script>/);
-  assert.match(html, /const accountId = "\\u003c\/script>/);
+  assert.doesNotMatch(html, /const requestId = "<\/script>/);
+  assert.match(html, /const requestId = "\\u003c\/script>/);
 });
 
 await test("checkout body carries the Stripe metadata contract and one-time price", () => {
@@ -210,10 +292,12 @@ await test("restricted Checkout key skips configured Price read preflight", asyn
   const previousSecret = process.env.STRIPE_SECRET_KEY;
   const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
   const calls = [];
   process.env.STRIPE_SECRET_KEY = "sk_live_full_secret";
   process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
   process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = "price_deflection_report";
+  process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options });
     return {
@@ -233,7 +317,6 @@ await test("restricted Checkout key skips configured Price read preflight", asyn
     },
     body: {
       request_id: "content-ops-abc123",
-      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     },
   };
   const res = mockResponse();
@@ -256,6 +339,11 @@ await test("restricted Checkout key skips configured Price read preflight", asyn
       delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
     } else {
       process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.ATLAS_ACCOUNT_ID;
+    } else {
+      process.env.ATLAS_ACCOUNT_ID = previousAccountId;
     }
   }
 
@@ -300,7 +388,7 @@ await test("checkout return path preserves result identifiers", () => {
   );
   assert.equal(
     path,
-    "/services/faq-deflection/results/content-ops-abc123?account_id=2b2b950d-f64b-4852-bc30-f92a34cdf169&checkout=success",
+    "/services/faq-deflection/results/content-ops-abc123?checkout=success",
   );
 });
 
@@ -366,9 +454,11 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
   const previousSecret = process.env.STRIPE_SECRET_KEY;
   const previousRak = process.env.ATLAS_SAAS_STRIPE_RAK;
   const previousPriceId = process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
+  const previousAccountId = process.env.ATLAS_ACCOUNT_ID;
   const calls = [];
   process.env.STRIPE_SECRET_KEY = "sk_test_123";
   process.env.ATLAS_SAAS_STRIPE_RAK = "rk_test_checkout_only";
+  process.env.ATLAS_ACCOUNT_ID = "2b2b950d-f64b-4852-bc30-f92a34cdf169";
   delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options });
@@ -389,7 +479,6 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
     },
     body: {
       request_id: "content-ops-abc123",
-      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     },
   };
   const res = mockResponse();
@@ -412,6 +501,11 @@ await test("handler creates Stripe Checkout without calling privileged ATLAS pai
       delete process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID;
     } else {
       process.env.STRIPE_DEFLECTION_REPORT_PRICE_ID = previousPriceId;
+    }
+    if (previousAccountId === undefined) {
+      delete process.env.ATLAS_ACCOUNT_ID;
+    } else {
+      process.env.ATLAS_ACCOUNT_ID = previousAccountId;
     }
   }
 
@@ -447,7 +541,6 @@ await test("handler rejects live full secret fallback before calling Stripe", as
     },
     body: {
       request_id: "content-ops-abc123",
-      account_id: "2b2b950d-f64b-4852-bc30-f92a34cdf169",
     },
   };
   const res = mockResponse();

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -286,7 +286,7 @@ await test("submit live smoke route-handler mode omits buyer account header", as
       ok: true,
       request_id: "content-ops-route123",
       account_id: ACCOUNT_ID,
-      result_path: `/services/faq-deflection/results/content-ops-route123?account_id=${ACCOUNT_ID}`,
+      result_path: "/services/faq-deflection/results/content-ops-route123",
     }));
   });
   assert.deepEqual(result, {
@@ -295,7 +295,7 @@ await test("submit live smoke route-handler mode omits buyer account header", as
     statusCode: 200,
     request_id: "content-ops-route123",
     account_id: ACCOUNT_ID,
-    result_path: `/services/faq-deflection/results/content-ops-route123?account_id=${ACCOUNT_ID}`,
+    result_path: "/services/faq-deflection/results/content-ops-route123",
     error: undefined,
     atlas_status: undefined,
     base_host: "atlas.example.com",
@@ -330,7 +330,7 @@ await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", as
     ok: true,
     request_id: "content-ops-abc123",
     account_id: ACCOUNT_ID,
-    result_path: `/services/faq-deflection/results/content-ops-abc123?account_id=${ACCOUNT_ID}`,
+    result_path: "/services/faq-deflection/results/content-ops-abc123",
   });
   assert.equal(calls.length, 1);
   assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);

--- a/portfolio-ui/src/pages/FaqDeflectionResult.tsx
+++ b/portfolio-ui/src/pages/FaqDeflectionResult.tsx
@@ -148,11 +148,10 @@ function formatCount(value: number) {
 export default function FaqDeflectionResult() {
   const { requestId } = useParams();
   const [searchParams] = useSearchParams();
-  const accountId = searchParams.get("account_id")?.trim() ?? "";
   const checkoutStatus = searchParams.get("checkout")?.trim() ?? "";
   const [snapshotState, setSnapshotState] = useState<SnapshotState>({ status: "missing" });
   const [checkout, setCheckout] = useState<CheckoutState>({ status: "idle" });
-  const canCheckout = Boolean(requestId && accountId && checkout.status !== "submitting");
+  const canCheckout = Boolean(requestId && checkout.status !== "submitting");
 
   useEffect(() => {
     setSnapshotState(readStoredSnapshot(requestId));
@@ -169,13 +168,13 @@ export default function FaqDeflectionResult() {
   }, [snapshotState]);
 
   const startCheckout = async () => {
-    if (!requestId || !accountId) return;
+    if (!requestId) return;
     setCheckout({ status: "submitting" });
     try {
       const response = await fetch(CHECKOUT_ENDPOINT, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ request_id: requestId, account_id: accountId }),
+        body: JSON.stringify({ request_id: requestId }),
       });
       const payload = (await response.json().catch(() => null)) as { url?: unknown; error?: unknown } | null;
       if (!response.ok || !payload || typeof payload.url !== "string") {
@@ -210,7 +209,6 @@ export default function FaqDeflectionResult() {
         className="mx-auto max-w-6xl px-6 py-10 md:py-14"
         data-atlas-deflection-result
         data-atlas-deflection-request-id={requestId ?? ""}
-        data-atlas-deflection-account-id={accountId}
         data-atlas-deflection-report-source={CHECKOUT_SOURCE}
       >
         <Link
@@ -324,12 +322,6 @@ export default function FaqDeflectionResult() {
                   {requestId || "Missing request id"}
                 </dd>
               </div>
-              <div>
-                <dt className="text-surface-200/60">account_id</dt>
-                <dd className="mt-1 break-all font-mono text-xs text-surface-100">
-                  {accountId || "Missing account id"}
-                </dd>
-              </div>
             </dl>
 
             <button
@@ -338,7 +330,6 @@ export default function FaqDeflectionResult() {
               data-atlas-deflection-unlock
               data-checkout-source={CHECKOUT_SOURCE}
               data-checkout-request_id={requestId ?? ""}
-              data-checkout-account_id={accountId}
               disabled={!canCheckout}
               onClick={startCheckout}
             >
@@ -355,12 +346,6 @@ export default function FaqDeflectionResult() {
               )}
             </button>
 
-            {!accountId && (
-              <p className="mt-3 text-xs leading-5 text-amber-200">
-                Missing account_id. Return to the submit flow to create a
-                Checkout session for the right ATLAS tenant.
-              </p>
-            )}
             {checkout.status === "error" && (
               <p className="mt-3 text-xs leading-5 text-amber-200">{checkout.message}</p>
             )}


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Result-Configured-Account.md
Slice phase: Product polish

Removes the configured ATLAS account id from FAQ deflection customer result URLs and browser Checkout requests. Result/report/Checkout server routes now derive the account binding from `ATLAS_ACCOUNT_ID`, while legacy account-id query/body inputs still fail closed on mismatch.

## Intentional
- Stripe metadata still includes `account_id`; the value now comes from server configuration instead of the browser.
- The public submit response can continue to include `account_id` for compatibility, but `result_path` no longer carries it.
- Legacy account-id query/body inputs are rejected on mismatch instead of silently ignored.
- This does not change ATLAS submit, private Blob upload, Stripe key selection, or artifact rendering semantics.

## Deferred
- Running the full hosted upload -> submit -> result -> Checkout loop remains an operator/live-environment step.

## Parked hardening
- None.

## Verification
- `node --check portfolio-ui/api/content-ops/deflection/checkout.js && node --check portfolio-ui/api/content-ops/deflection/atlas-report.js && node --check portfolio-ui/api/content-ops/deflection/result-page.js && node --check portfolio-ui/api/content-ops/deflection/report.js && node --check portfolio-ui/scripts/faq-deflection-result-page.test.mjs && node --check portfolio-ui/scripts/faq-deflection-atlas-proxy.test.mjs && node --check portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
- `npm run test:deflection-result --prefix portfolio-ui` (16 checks)
- `npm run test:deflection-atlas-proxy --prefix portfolio-ui` (15 checks)
- `npm run test:deflection-upload-shell --prefix portfolio-ui` (21 checks)
- `npm run build --prefix portfolio-ui`
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-result-configured-account.md`

## Diff size
8 files, +263 / -71
