### PR TITLE
PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account

### DIFF
--- a/plans/PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account.md
+++ b/plans/PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account.md
@@ -1,0 +1,85 @@
+# PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account
+
+## Why this slice exists
+
+PR-FAQ-Deflection-Result-Configured-Account removed `account_id` from the public
+FAQ deflection result URL and browser Checkout payload. The hosted portfolio
+result-page smoke still validates the older contract by requiring the account id
+marker, the `data-checkout-account_id` attribute, and the raw account id value in
+customer-facing HTML.
+
+That makes the smoke stale exactly where it should be the live guard for the
+configured-account handoff. This slice updates the smoke to prove the result
+page is account-less in the browser while still using the operator-provided
+account id for server-side ATLAS snapshot/artifact verification.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Functional validation
+
+1. Remove the hosted portfolio result-page smoke's requirement that customer
+   HTML contains `account_id`.
+2. Keep the smoke's `--account-id` input for ATLAS API validation and result
+   artifact traceability.
+3. Fail the smoke when the hosted page exposes the configured account id through
+   the result URL, unlock CTA, or page body.
+4. Update focused smoke tests so fixtures match the merged configured-account
+   producer output.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account.md`
+- `scripts/smoke_content_ops_deflection_portfolio_result_page.py`
+- `tests/test_smoke_content_ops_deflection_portfolio_result_page.py`
+
+## Mechanism
+
+`REQUIRED_PAGE_MARKERS` stops listing `account_id`, and `_page_errors()` keeps
+validating the unlock CTA's source and `request_id` binding. It then fails
+closed if the page carries either the legacy `data-checkout-account_id`
+attribute or the configured account id value anywhere in the HTML.
+
+Argument validation also rejects legacy public result URLs whose path or query
+string carries `account_id` or the configured account id value, so a smoke run
+cannot fetch an account-less page body from an account-bearing browser URL and
+return a false green.
+
+The CLI contract still requires `--account-id` because the smoke directly checks
+the ATLAS snapshot and locked artifact endpoints for that tenant. The difference
+is that the tenant binding is no longer expected to be visible to the browser.
+
+## Intentional
+
+- This does not remove the `--account-id` argument; the hosted smoke still needs
+  it to validate ATLAS API state for the tenant.
+- This does not change the portfolio implementation. PR #1208 already changed
+  the producer; this slice aligns the hosted validation guard with that
+  contract.
+- The result payload can still record `inputs.account_id`; it is a local
+  operator artifact, not customer-facing page output.
+- Local review's cross-layer hints are same-name `_validate_args` helpers in
+  unrelated scripts, not callers of this smoke module.
+
+## Deferred
+
+- A live hosted rerun with current production credentials remains an operator
+  validation step after this smoke contract lands.
+- Parked hardening: none.
+
+## Verification
+
+- Python compile check for the smoke script and focused smoke test - passed.
+- Focused pytest for `tests/test_smoke_content_ops_deflection_portfolio_result_page.py` - 10 passed.
+- Local PR review with the prepared PR body file - passed after the review fix.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 85 |
+| Smoke contract update | 35 |
+| Focused tests | 55 |
+| **Total** | **175** |
+
+Under the 400 LOC soft cap.

--- a/scripts/smoke_content_ops_deflection_portfolio_result_page.py
+++ b/scripts/smoke_content_ops_deflection_portfolio_result_page.py
@@ -39,7 +39,6 @@ REQUIRED_PAGE_MARKERS = (
     "data-atlas-deflection-unlock",
     "content_ops_deflection_report",
     "request_id",
-    "account_id",
 )
 
 try:
@@ -119,12 +118,32 @@ def _hosted_url_errors(value: str, *, label: str) -> list[str]:
     return []
 
 
+def _result_url_account_errors(value: str, *, account_id: str) -> list[str]:
+    errors: list[str] = []
+    try:
+        parsed = urllib.parse.urlparse(value)
+    except ValueError:
+        return []
+    public_location = f"{parsed.path}?{parsed.query}"
+    if "account_id" in public_location:
+        errors.append("--result-url must not include account_id")
+    if account_id and account_id in public_location:
+        errors.append("--result-url must not include the account_id value")
+    return errors
+
+
 def _validate_args(args: argparse.Namespace) -> list[str]:
     errors: list[str] = []
     if not _clean(args.result_url):
         errors.append("ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL or --result-url is required")
     else:
         errors.extend(_hosted_url_errors(_clean(args.result_url), label="--result-url"))
+        errors.extend(
+            _result_url_account_errors(
+                _clean(args.result_url),
+                account_id=_clean(args.account_id),
+            )
+        )
     if not _clean(args.base_url):
         errors.append("ATLAS_API_BASE_URL or --base-url is required")
     else:
@@ -248,14 +267,18 @@ def _page_errors(html: str, *, request_id: str, account_id: str) -> list[str]:
         for attr, expected in (
             ("data-checkout-source", "content_ops_deflection_report"),
             ("data-checkout-request_id", request_id),
-            ("data-checkout-account_id", account_id),
         ):
             actual = unlock_attrs.get(attr)
             if actual != expected:
                 errors.append(f"portfolio result page unlock CTA {attr} must be {expected}")
-    for value, label in ((request_id, "request_id"), (account_id, "account_id")):
-        if value not in html:
-            errors.append(f"portfolio result page missing {label} value")
+        if "data-checkout-account_id" in unlock_attrs:
+            errors.append("portfolio result page unlock CTA must not expose account_id")
+    if request_id not in html:
+        errors.append("portfolio result page missing request_id value")
+    if "account_id" in html:
+        errors.append("portfolio result page must not expose account_id marker")
+    if account_id and account_id in html:
+        errors.append("portfolio result page must not expose account_id value")
     return errors
 
 

--- a/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
+++ b/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
@@ -60,8 +60,7 @@ def _page_html() -> str:
       <section data-atlas-deflection-request-id="content-ops-123"></section>
       <a data-atlas-deflection-unlock
          data-checkout-source="content_ops_deflection_report"
-         data-checkout-request_id="content-ops-123"
-         data-checkout-account_id="acct-123">Unlock full report</a>
+         data-checkout-request_id="content-ops-123">Unlock full report</a>
     </main>
     """
 
@@ -135,6 +134,19 @@ def test_validate_args_fails_closed_for_missing_and_unsafe_inputs() -> None:
     ]
 
 
+def test_validate_args_rejects_account_id_in_public_result_url(tmp_path) -> None:
+    args = smoke._build_parser().parse_args([
+        *_base_args(tmp_path),
+        "--result-url",
+        "https://portfolio.example.com/deflection/result/content-ops-123?account_id=acct-123",
+    ])
+
+    assert smoke._validate_args(args) == [
+        "--result-url must not include account_id",
+        "--result-url must not include the account_id value",
+    ]
+
+
 def test_preflight_only_writes_missing_inputs_without_network(monkeypatch, tmp_path, capsys) -> None:
     def _unexpected(*_args, **_kwargs):
         raise AssertionError("preflight must not call network")
@@ -161,19 +173,17 @@ def test_page_errors_require_portfolio_hooks_and_metadata_values() -> None:
 
     assert "portfolio result page missing marker: data-atlas-deflection-unlock" in errors
     assert "portfolio result page missing marker: content_ops_deflection_report" in errors
-    assert "portfolio result page missing account_id value" in errors
 
 
-def test_page_errors_bind_checkout_metadata_to_unlock_cta() -> None:
+def test_page_errors_bind_checkout_request_to_unlock_cta() -> None:
     html = """
     <main data-atlas-deflection-result>
       <section data-atlas-deflection-request-id="content-ops-123">
-        content-ops-123 acct-123 content_ops_deflection_report request_id account_id
+        content-ops-123 content_ops_deflection_report request_id
       </section>
       <a data-atlas-deflection-unlock
          data-checkout-source="content_ops_deflection_report"
-         data-checkout-request_id="stale-request"
-         data-checkout-account_id="stale-account">Unlock full report</a>
+         data-checkout-request_id="stale-request">Unlock full report</a>
     </main>
     """
 
@@ -185,8 +195,31 @@ def test_page_errors_bind_checkout_metadata_to_unlock_cta() -> None:
 
     assert errors == [
         "portfolio result page unlock CTA data-checkout-request_id must be content-ops-123",
-        "portfolio result page unlock CTA data-checkout-account_id must be acct-123",
     ]
+
+
+def test_page_errors_reject_browser_exposed_account_id() -> None:
+    html = """
+    <main data-atlas-deflection-result>
+      <section data-atlas-deflection-request-id="content-ops-123">
+        content-ops-123 content_ops_deflection_report request_id acct-123
+      </section>
+      <a data-atlas-deflection-unlock
+         data-checkout-source="content_ops_deflection_report"
+         data-checkout-request_id="content-ops-123"
+         data-checkout-account_id="acct-123">Unlock full report</a>
+    </main>
+    """
+
+    errors = smoke._page_errors(
+        html,
+        request_id="content-ops-123",
+        account_id="acct-123",
+    )
+
+    assert "portfolio result page unlock CTA must not expose account_id" in errors
+    assert "portfolio result page must not expose account_id marker" in errors
+    assert "portfolio result page must not expose account_id value" in errors
 
 
 def test_snapshot_errors_reject_paid_report_leaks() -> None:


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Portfolio-Smoke-Configured-Account.md
Slice phase: Functional validation

PR-FAQ-Deflection-Result-Configured-Account removed `account_id` from the public FAQ deflection result URL and browser Checkout payload, but the hosted portfolio result-page smoke still validated the older browser-visible account-id contract. This aligns the smoke with the merged configured-account handoff: the smoke still accepts `--account-id` for server-side ATLAS validation, but the public result URL and customer-facing HTML must not expose that account id.

## Intentional
- `--account-id` remains required because the smoke validates ATLAS snapshot/artifact state for the tenant.
- The result payload still records `inputs.account_id`; that is a local operator artifact, not page output.
- This only updates the validation guard; PR #1208 already updated the portfolio producer.
- Local review's cross-layer hints are same-name `_validate_args` helpers in unrelated scripts, not callers of this smoke module.

## Deferred
- A live hosted rerun with current production credentials remains an operator validation step after this smoke contract lands.

## Parked hardening
- None.

## Verification
- Python compile check for the smoke script and focused smoke test - passed.
- Focused pytest for `tests/test_smoke_content_ops_deflection_portfolio_result_page.py` - 10 passed.
- Local PR review with this prepared PR body file - passed after the review fix.

## Diff size
3 files, under the 400 LOC soft cap.
