### PR TITLE
PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation

### DIFF
--- a/plans/PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation.md
+++ b/plans/PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation.md
@@ -1,0 +1,82 @@
+# PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation
+
+## Why this slice exists
+
+The FAQ deflection upload product path now sends the selected CSV to private
+Vercel Blob, then submits a server-side JSON Blob reference to the portfolio
+submit route. The older browser-to-portfolio raw multipart path remains in
+`portfolio-ui/api/content-ops/deflection/submit.js`, but no current public UI
+uses it.
+
+Keeping that compatibility path preserves extra body-reading and account-header
+surface area after the private-Blob path has become the real intake flow. This
+slice deprecates direct multipart at the portfolio edge so uploads use the
+configured server account and private Blob handoff only.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Production hardening
+
+1. Reject direct `multipart/form-data` requests to the portfolio submit route
+   with an explicit deprecated-path response before config or ATLAS access.
+2. Keep JSON private-Blob submit behavior unchanged.
+3. Remove raw multipart body-reading helpers and exports that are no longer
+   reachable.
+4. Update focused portfolio upload-shell tests to prove the UI uses private
+   Blob JSON submit and direct multipart cannot reach ATLAS.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation.md`
+- `portfolio-ui/api/content-ops/deflection/submit.js`
+- `portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs`
+
+## Mechanism
+
+The route now accepts only JSON private-Blob submits after the `POST` method
+check. If `Content-Type` includes `multipart/form-data`, it returns `410` with
+`direct_multipart_deprecated` and exits before loading ATLAS config, checking
+account headers, reading the request body, or calling `fetch()`.
+
+Non-JSON/non-multipart requests still return `415`, now with a JSON-specific
+error. The private-Blob path continues to read the configured server account,
+load the private CSV object, reconstruct ATLAS `FormData`, and call
+`forwardSubmit()`.
+
+## Intentional
+
+- This deprecates only the portfolio edge's direct multipart compatibility
+  path. ATLAS still accepts multipart because the portfolio server reconstructs
+  multipart from private Blob for the real flow.
+- The submit live smoke's `--csv-file` local fixture path remains useful for
+  direct helper validation; route-handler mode remains private-Blob JSON only.
+- This keeps matching legacy `X-Atlas-Account-Id` headers tolerated on JSON
+  submits for now, while mismatches still fail closed.
+
+## Deferred
+
+- Removing the submit smoke's local CSV fixture mode is deferred because it
+  validates `submitPrivateBlob()` without needing a live Blob object.
+- Parked hardening: none.
+
+## Verification
+
+- Node syntax check for the submit route and focused upload-shell test - passed.
+- `npm run test:deflection-upload-shell --prefix portfolio-ui` - 20 checks passed.
+- `npm run build --prefix portfolio-ui` - passed after hydrating local
+  `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite
+  emitted the existing large-chunk advisory and skipped sitemap generation
+  because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not set.
+- Local PR review with the prepared PR body file - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 90 |
+| Submit route deprecation and helper removal | 120 |
+| Focused tests | 95 |
+| **Total** | **305** |
+
+Under the 400 LOC soft cap.

--- a/portfolio-ui/api/content-ops/deflection/submit.js
+++ b/portfolio-ui/api/content-ops/deflection/submit.js
@@ -5,9 +5,7 @@ import { emitDeflectionServerEvent } from "./events.js";
 const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{5,160}$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SUBMIT_PATH = "/api/v1/content-ops/deflection-reports/submit";
-const MAX_CSV_BYTES = 4 * 1024 * 1024;
 const MAX_BLOB_CSV_BYTES = 50 * 1024 * 1024;
-const MAX_MULTIPART_OVERHEAD_BYTES = 256 * 1024;
 const BLOB_UPLOAD_PATH_PREFIX = "faq-deflection/uploads/";
 
 export const config = {
@@ -44,52 +42,6 @@ function privateBlobSubmitConfig(env = process.env) {
   const blobToken = clean(env.BLOB_READ_WRITE_TOKEN);
   if (!blobToken) result.errors.push("blob_token_missing");
   return { ...result, blobToken };
-}
-
-function rejectOversizeContentLength(req) {
-  const raw = header(req, "content-length");
-  if (!raw) return null;
-  const length = Number.parseInt(raw, 10);
-  if (!Number.isFinite(length)) return null;
-  if (length > MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES) {
-    return {
-      ok: false,
-      statusCode: 413,
-      error: "deflection_submit_csv_too_large",
-    };
-  }
-  return null;
-}
-
-async function readRawBody(req, maxBytes = MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES) {
-  if (Buffer.isBuffer(req.body)) {
-    if (req.body.length > maxBytes) return { ok: false, statusCode: 413 };
-    return { ok: true, body: req.body };
-  }
-  if (typeof req.body === "string") {
-    const body = Buffer.from(req.body);
-    if (body.length > maxBytes) return { ok: false, statusCode: 413 };
-    return { ok: true, body };
-  }
-  if (req.body instanceof ArrayBuffer) {
-    const body = Buffer.from(req.body);
-    if (body.length > maxBytes) return { ok: false, statusCode: 413 };
-    return { ok: true, body };
-  }
-
-  const chunks = [];
-  let total = 0;
-  try {
-    for await (const chunk of req) {
-      const buffer = Buffer.from(chunk);
-      total += buffer.length;
-      if (total > maxBytes) return { ok: false, statusCode: 413 };
-      chunks.push(buffer);
-    }
-  } catch {
-    return { ok: false, statusCode: 400 };
-  }
-  return { ok: true, body: Buffer.concat(chunks) };
 }
 
 async function readJsonBody(req) {
@@ -298,8 +250,6 @@ async function submitPrivateBlob({
 export {
   BLOB_UPLOAD_PATH_PREFIX,
   MAX_BLOB_CSV_BYTES,
-  MAX_CSV_BYTES,
-  MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
   cleanupPrivateCsvBlob,
   forwardSubmit,
@@ -318,21 +268,22 @@ export default async function handler(req, res) {
 
   const contentType = header(req, "content-type");
   const isPrivateBlobSubmit = contentType.includes("application/json");
-  if (!contentType.includes("multipart/form-data") && !isPrivateBlobSubmit) {
-    json(res, 415, { ok: false, error: "multipart_required" });
+  if (contentType.includes("multipart/form-data")) {
+    json(res, 410, { ok: false, error: "direct_multipart_deprecated" });
+    return;
+  }
+  if (!isPrivateBlobSubmit) {
+    json(res, 415, { ok: false, error: "private_blob_json_required" });
     return;
   }
 
-  const { config: submitConfig, blobToken, errors } = isPrivateBlobSubmit
-    ? privateBlobSubmitConfig()
-    : publicSubmitConfig();
+  const { config: submitConfig, blobToken, errors } = privateBlobSubmitConfig();
   if (errors.length > 0) {
     json(res, 503, { ok: false, error: "atlas_submit_not_configured" });
     return;
   }
 
   const requestedAccountId = header(req, "x-atlas-account-id");
-  const accountId = isPrivateBlobSubmit ? submitConfig.accountId : requestedAccountId;
   if (
     requestedAccountId &&
     (!UUID_RE.test(requestedAccountId) || requestedAccountId !== submitConfig.accountId)
@@ -340,63 +291,24 @@ export default async function handler(req, res) {
     json(res, 400, { ok: false, error: "invalid_account_id" });
     return;
   }
-  if (!accountId || !UUID_RE.test(accountId) || accountId !== submitConfig.accountId) {
+  if (!submitConfig.accountId || !UUID_RE.test(submitConfig.accountId)) {
     json(res, 400, { ok: false, error: "invalid_account_id" });
     return;
   }
 
-  if (isPrivateBlobSubmit) {
-    let payload;
-    try {
-      payload = await readJsonBody(req);
-    } catch {
-      json(res, 400, { ok: false, error: "invalid_blob_submit" });
-      return;
-    }
-
-    const result = await submitPrivateBlob({
-      config: submitConfig,
-      blobToken,
-      payload,
-    });
-    if (!result.ok) {
-      json(res, result.statusCode, {
-        ok: false,
-        error: result.error,
-        atlas_status: result.atlas_status,
-      });
-      return;
-    }
-    json(res, 200, result.payload);
-    return;
-  }
-
-  const oversize = rejectOversizeContentLength(req);
-  if (oversize) {
-    json(res, oversize.statusCode, { ok: false, error: oversize.error });
-    return;
-  }
-
-  const bodyResult = await readRawBody(req);
-  if (!bodyResult.ok) {
-    json(res, bodyResult.statusCode, {
-      ok: false,
-      error:
-        bodyResult.statusCode === 413
-          ? "deflection_submit_csv_too_large"
-          : "deflection_submit_body_unreadable",
-    });
-    return;
-  }
-
-  let result;
+  let payload;
   try {
-    result = await forwardSubmit({ config: submitConfig, contentType, body: bodyResult.body });
+    payload = await readJsonBody(req);
   } catch {
-    json(res, 502, { ok: false, error: "atlas_submit_unreachable" });
+    json(res, 400, { ok: false, error: "invalid_blob_submit" });
     return;
   }
 
+  const result = await submitPrivateBlob({
+    config: submitConfig,
+    blobToken,
+    payload,
+  });
   if (!result.ok) {
     json(res, result.statusCode, {
       ok: false,

--- a/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
+++ b/portfolio-ui/scripts/faq-deflection-upload-shell.test.mjs
@@ -5,8 +5,6 @@ import { fileURLToPath } from "node:url";
 import submitHandler, {
   BLOB_UPLOAD_PATH_PREFIX,
   MAX_BLOB_CSV_BYTES,
-  MAX_CSV_BYTES,
-  MAX_MULTIPART_OVERHEAD_BYTES,
   SUBMIT_PATH,
   cleanupPrivateCsvBlob,
   forwardSubmit,
@@ -179,11 +177,13 @@ await test("upload shell exposes live submit markers and avoids browser credenti
   assert.doesNotMatch(uploadSource, /\/paid\b/);
 });
 
-await test("portfolio submit endpoint pins raw multipart body handling", () => {
+await test("portfolio submit endpoint pins private Blob submit handling", () => {
   assert.match(submitSource, /bodyParser:\s*false/);
   assert.doesNotMatch(submitSource, /^import .*@vercel\/blob/m);
   assert.match(submitSource, /import\("@vercel\/blob"\)/);
   assert.match(submitSource, /const \{ del \} = await import\("@vercel\/blob"\)/);
+  assert.match(submitSource, /direct_multipart_deprecated/);
+  assert.doesNotMatch(submitSource, /readRawBody|MAX_MULTIPART_OVERHEAD_BYTES/);
 });
 
 await test("submit live smoke exercises the production private blob helper", async () => {
@@ -302,43 +302,31 @@ await test("submit live smoke route-handler mode omits buyer account header", as
   });
 });
 
-await test("portfolio submit endpoint forwards raw multipart bytes to ATLAS", async () => {
+await test("portfolio submit endpoint rejects direct multipart before ATLAS", async () => {
   const previousFetch = globalThis.fetch;
-  const calls = [];
+  let fetchCalled = false;
   globalThis.fetch = async (url, options) => {
-    calls.push({ url, options });
-    return {
-      ok: true,
-      status: 200,
-      async text() {
-        return JSON.stringify({ request_id: "content-ops-abc123", status: "completed" });
-      },
-    };
+    fetchCalled = true;
+    throw new Error(`must not call ATLAS: ${url} ${options?.method}`);
   };
   const res = mockResponse();
   try {
-    await withEnv(ENV, async () => {
-      await submitHandler(request(), res);
+    await withEnv({ ATLAS_API_BASE_URL: "", ATLAS_B2B_JWT: "", ATLAS_ACCOUNT_ID: "" }, async () => {
+      await submitHandler(
+        request({
+          headers: { "content-length": "999999999" },
+        }),
+        res,
+      );
     });
   } finally {
     globalThis.fetch = previousFetch;
   }
 
-  assert.equal(res.statusCode, 200);
+  assert.equal(fetchCalled, false);
+  assert.equal(res.statusCode, 410);
   assert.equal(res.headers["Cache-Control"], "no-store");
-  assert.deepEqual(JSON.parse(res.body), {
-    ok: true,
-    request_id: "content-ops-abc123",
-    account_id: ACCOUNT_ID,
-    result_path: "/services/faq-deflection/results/content-ops-abc123",
-  });
-  assert.equal(calls.length, 1);
-  assert.equal(calls[0].url, `${ENV.ATLAS_API_BASE_URL}${SUBMIT_PATH}`);
-  assert.equal(calls[0].options.method, "POST");
-  assert.equal(calls[0].options.headers.Authorization, `Bearer ${ENV.ATLAS_B2B_JWT}`);
-  assert.equal(calls[0].options.headers["Content-Type"], "multipart/form-data; boundary=atlas");
-  assert.equal(Buffer.compare(calls[0].options.body, MULTIPART_BODY), 0);
-  assert.equal(calls[0].options.signal instanceof AbortSignal, true);
+  assert.deepEqual(JSON.parse(res.body), { ok: false, error: "direct_multipart_deprecated" });
   assert.equal(res.body.includes(ENV.ATLAS_B2B_JWT), false);
 });
 
@@ -677,7 +665,13 @@ await test("portfolio submit endpoint rejects account mismatch before ATLAS", as
   try {
     await withEnv(ENV, async () => {
       await submitHandler(
-        request({ headers: { "x-atlas-account-id": "3b2b950d-f64b-4852-bc30-f92a34cdf169" } }),
+        request({
+          headers: {
+            "content-type": "application/json",
+            "x-atlas-account-id": "3b2b950d-f64b-4852-bc30-f92a34cdf169",
+          },
+          body: JSON.stringify({ blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv` }),
+        }),
         res,
       );
     });
@@ -723,40 +717,16 @@ await test("private blob submit uses configured account when browser omits accou
   assert.deepEqual(JSON.parse(res.body), { ok: false, error: "invalid_blob_reference" });
 });
 
-await test("portfolio submit endpoint rejects oversize bodies before ATLAS", async () => {
-  const previousFetch = globalThis.fetch;
-  let fetchCalled = false;
-  globalThis.fetch = async () => {
-    fetchCalled = true;
-    throw new Error("must not call ATLAS");
-  };
-  const res = mockResponse();
-  try {
-    await withEnv(ENV, async () => {
-      await submitHandler(
-        request({
-          headers: {
-            "content-length": String(MAX_CSV_BYTES + MAX_MULTIPART_OVERHEAD_BYTES + 1),
-          },
-        }),
-        res,
-      );
-    });
-  } finally {
-    globalThis.fetch = previousFetch;
-  }
-  assert.equal(fetchCalled, false);
-  assert.equal(res.statusCode, 413);
-  assert.deepEqual(JSON.parse(res.body), {
-    ok: false,
-    error: "deflection_submit_csv_too_large",
-  });
-});
-
 await test("portfolio submit endpoint hides missing config details", async () => {
   const res = mockResponse();
   await withEnv({ ATLAS_API_BASE_URL: "", ATLAS_B2B_JWT: "", ATLAS_ACCOUNT_ID: "" }, async () => {
-    await submitHandler(request(), res);
+    await submitHandler(
+      request({
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ blob_pathname: `${BLOB_UPLOAD_PATH_PREFIX}tickets.csv` }),
+      }),
+      res,
+    );
   });
   assert.equal(res.statusCode, 503);
   assert.deepEqual(JSON.parse(res.body), {
@@ -766,7 +736,7 @@ await test("portfolio submit endpoint hides missing config details", async () =>
   assert.equal(res.body.includes("ATLAS_B2B_JWT"), false);
 });
 
-await test("portfolio submit endpoint only accepts POST multipart or JSON blob requests", async () => {
+await test("portfolio submit endpoint only accepts POST JSON blob requests", async () => {
   const getRes = mockResponse();
   await submitHandler(request({ method: "GET" }), getRes);
   assert.equal(getRes.statusCode, 405);
@@ -776,12 +746,20 @@ await test("portfolio submit endpoint only accepts POST multipart or JSON blob r
     error: "method_not_allowed",
   });
 
+  const multipartRes = mockResponse();
+  await submitHandler(request(), multipartRes);
+  assert.equal(multipartRes.statusCode, 410);
+  assert.deepEqual(JSON.parse(multipartRes.body), {
+    ok: false,
+    error: "direct_multipart_deprecated",
+  });
+
   const textRes = mockResponse();
   await submitHandler(request({ headers: { "content-type": "text/plain" } }), textRes);
   assert.equal(textRes.statusCode, 415);
   assert.deepEqual(JSON.parse(textRes.body), {
     ok: false,
-    error: "multipart_required",
+    error: "private_blob_json_required",
   });
 });
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Direct-Multipart-Deprecation.md
Slice phase: Production hardening

The FAQ deflection upload product path now uses private Vercel Blob plus a JSON submit to the portfolio route. This PR deprecates the old direct browser multipart submit path at the portfolio edge, keeping JSON private-Blob submit as the only accepted live route mode while ATLAS still receives reconstructed multipart from the server.

## Intentional
- ATLAS still accepts multipart; only the portfolio edge rejects direct browser multipart.
- The submit smoke's local CSV fixture mode remains because it validates `submitPrivateBlob()` without needing a live Blob object.
- Matching legacy `X-Atlas-Account-Id` headers on JSON submits are tolerated for now; mismatches still fail closed.

## Deferred
- Removing the submit smoke's local CSV fixture mode is deferred.

## Parked hardening
- None.

## Verification
- Node syntax check for the submit route and focused upload-shell test - passed.
- `npm run test:deflection-upload-shell --prefix portfolio-ui` - 20 checks passed.
- `npm run build --prefix portfolio-ui` - passed after hydrating local `portfolio-ui/node_modules` with `npm install --prefix portfolio-ui`; Vite emitted the existing large-chunk advisory and skipped sitemap generation because `PORTFOLIO_SITE_URL` / `VITE_SITE_URL` is not set.
- Local PR review with this prepared PR body file - passed.

## Diff size
3 files, under the 400 LOC soft cap.
