### PR TITLE
PR-FAQ-Deflection-Submit-Fixture-Default

### DIFF
--- a/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
+++ b/docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md
@@ -13,11 +13,12 @@ deflection report response.
 - `ATLAS_ACCOUNT_ID` or `ATLAS_FAQ_SEARCH_ACCOUNT_ID`: the account id that
   maps to the bearer token. The submit route derives account scope from auth;
   the portfolio needs this value for Stripe Checkout metadata.
-- `ATLAS_DEFLECTION_SUBMIT_CSV_FILE`: local support-ticket CSV fixture for the
-  preferred multipart hosted smoke. For synthetic live validation, use
+- `ATLAS_DEFLECTION_SUBMIT_CSV_FILE`: optional local support-ticket CSV for the
+  preferred multipart hosted smoke. When omitted and no blob URL is provided,
+  the smoke uses
   `docs/extraction/validation/fixtures/faq_deflection_live_upload_sample.csv`.
-  For customer data, use a representative private-Blob export downloaded by the
-  operator or portfolio server-side code path.
+  For customer data, point this to a representative private-Blob export
+  downloaded by the operator or portfolio server-side code path.
 - `ATLAS_DEFLECTION_SUBMIT_BLOB_URL`: optional legacy HTTPS support-ticket CSV
   blob URL. This fallback remains available for rollback coverage but is not
   the preferred production PII posture.
@@ -78,7 +79,9 @@ It has 12 synthetic closed support tickets with repeated export, billing,
 security, and team/admin themes so the generated free snapshot has meaningful
 clusters without storing customer data.
 
-To use it with the hosted ATLAS submit smoke:
+The hosted ATLAS submit smoke uses this fixture by default when neither
+`ATLAS_DEFLECTION_SUBMIT_CSV_FILE` nor `ATLAS_DEFLECTION_SUBMIT_BLOB_URL` is
+set. To override the default explicitly:
 
 ```bash
 export ATLAS_DEFLECTION_SUBMIT_CSV_FILE=docs/extraction/validation/fixtures/faq_deflection_live_upload_sample.csv

--- a/plans/PR-FAQ-Deflection-Submit-Fixture-Default.md
+++ b/plans/PR-FAQ-Deflection-Submit-Fixture-Default.md
@@ -1,0 +1,84 @@
+# PR-FAQ-Deflection-Submit-Fixture-Default
+
+## Why this slice exists
+
+The checked live-upload CSV fixture now exists and is validated against the real
+support-ticket ingest path, but the hosted submit smoke still requires the
+operator to remember and export `ATLAS_DEFLECTION_SUBMIT_CSV_FILE` before the
+snapshot proof can run. That keeps the new fixture one step away from the
+default validation path.
+
+This slice makes the hosted submit smoke use the checked fixture by default
+when neither an explicit CSV file nor a legacy blob URL is provided.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/deflection-report-gating
+Slice phase: Product polish
+
+1. Add a single default fixture path constant in the hosted submit smoke.
+2. Default `--csv-file` to that fixture when
+   `ATLAS_DEFLECTION_SUBMIT_CSV_FILE` and `ATLAS_DEFLECTION_SUBMIT_BLOB_URL`
+   are both omitted.
+3. Update the runbook so operators know the checked fixture is now the default
+   smoke input.
+4. Add focused tests for parser defaults and the explicit blob override.
+
+### Files touched
+
+- `plans/PR-FAQ-Deflection-Submit-Fixture-Default.md`
+- `docs/extraction/validation/content_ops_faq_deflection_submit_handoff_runbook.md`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+
+## Mechanism
+
+The smoke defines `DEFAULT_CSV_FILE` as the checked fixture under
+`docs/extraction/validation/fixtures/faq_deflection_live_upload_sample.csv`.
+The parser resolves CSV input in this order:
+
+1. `ATLAS_DEFLECTION_SUBMIT_CSV_FILE`
+2. `--csv-file`
+3. the checked fixture, only when no legacy blob URL is provided
+
+The blob URL remains an explicit rollback path. When
+`ATLAS_DEFLECTION_SUBMIT_BLOB_URL` or `--blob-url` is set and no CSV is set,
+the parser leaves `csv_file` unset so the smoke still exercises the legacy JSON
+submit path.
+
+## Intentional
+
+- This does not change the hosted submit route, portfolio upload page, or
+  generated report behavior. It only changes the operator smoke default.
+- The legacy blob fallback stays available and wins over the default fixture
+  when explicitly provided.
+- Existing environment access in this script is left as-is; this slice does not
+  broaden secret/config handling beyond the current smoke harness.
+
+## Deferred
+
+- Live hosted execution remains operator-driven because deployed API URL, auth,
+  account id, company name, and contact email are runtime values.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for
+  `scripts/smoke_content_ops_deflection_submit_handoff.py` and
+  `tests/test_smoke_content_ops_deflection_submit_handoff.py` - passed.
+- Focused pytest for `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+  - 22 passed.
+- Local PR review with the prepared PR body file - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 84 |
+| Smoke script | 21 |
+| Tests | 27 |
+| Runbook | 13 |
+| **Total** | **145** |
+
+Under the 400 LOC soft cap.

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -20,6 +20,14 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CSV_FILE = (
+    ROOT
+    / "docs"
+    / "extraction"
+    / "validation"
+    / "fixtures"
+    / "faq_deflection_live_upload_sample.csv"
+)
 LOCAL_BASE_URL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
 SUPPORT_PLATFORMS = frozenset({"zendesk", "intercom", "help_scout", "other"})
 CSV_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
@@ -67,6 +75,11 @@ def _env(*names: str) -> str:
     return ""
 
 
+def _env_path(*names: str) -> Path | None:
+    value = _env(*names)
+    return Path(value) if value else None
+
+
 def _build_parser() -> argparse.ArgumentParser:
     _load_dotenv_files()
     parser = argparse.ArgumentParser(
@@ -75,7 +88,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-url", default=_env("ATLAS_API_BASE_URL"))
     parser.add_argument("--token", default=_env("ATLAS_B2B_JWT", "ATLAS_TOKEN"))
     parser.add_argument("--account-id", default=_env("ATLAS_ACCOUNT_ID", "ATLAS_FAQ_SEARCH_ACCOUNT_ID"))
-    parser.add_argument("--csv-file", type=Path, default=_env("ATLAS_DEFLECTION_SUBMIT_CSV_FILE") or None)
+    parser.add_argument("--csv-file", type=Path, default=_env_path("ATLAS_DEFLECTION_SUBMIT_CSV_FILE"))
     parser.add_argument("--blob-url", default=_env("ATLAS_DEFLECTION_SUBMIT_BLOB_URL"))
     parser.add_argument("--support-platform", default=_env("ATLAS_DEFLECTION_SUPPORT_PLATFORM") or "zendesk")
     parser.add_argument("--company-name", default=_env("ATLAS_DEFLECTION_COMPANY_NAME"))
@@ -97,7 +110,13 @@ def _clean(value: Any) -> str:
     return str(value).strip()
 
 
+def _apply_default_csv_file(args: argparse.Namespace) -> None:
+    if not _clean(args.csv_file) and not _clean(args.blob_url):
+        args.csv_file = DEFAULT_CSV_FILE
+
+
 def _validate_args(args: argparse.Namespace) -> list[str]:
+    _apply_default_csv_file(args)
     errors: list[str] = []
     if not _clean(args.base_url):
         errors.append("ATLAS_API_BASE_URL or --base-url is required")

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -236,6 +236,33 @@ def test_validate_args_fails_closed_for_missing_csv_file(tmp_path) -> None:
     ]
 
 
+def test_validate_args_defaults_to_checked_fixture_when_no_source_is_provided() -> None:
+    args = smoke._build_parser().parse_args([
+        "--base-url",
+        "https://atlas.example.com",
+        "--token",
+        "token-secret",
+        "--account-id",
+        "acct-123",
+        "--support-platform",
+        "zendesk",
+        "--company-name",
+        "Acme Co.",
+        "--contact-email",
+        "lead@example.com",
+    ])
+
+    assert smoke._validate_args(args) == []
+    assert args.csv_file == smoke.DEFAULT_CSV_FILE
+
+
+def test_validate_args_keeps_explicit_blob_source_over_default_fixture() -> None:
+    args = smoke._build_parser().parse_args(_base_args(Path("/tmp")))
+
+    assert smoke._validate_args(args) == []
+    assert args.csv_file is None
+
+
 def test_validate_submit_envelope_accepts_locked_gated_result() -> None:
     request_id, snapshot, diagnostics, errors = smoke._validate_submit_envelope(_submit_payload())
 


### PR DESCRIPTION
Plan: plans/PR-FAQ-Deflection-Submit-Fixture-Default.md
Slice phase: Product polish

The hosted FAQ deflection submit smoke now defaults to the checked live-upload CSV fixture when no explicit CSV or legacy blob URL is provided. That makes the fixture the default operator path for live upload and snapshot validation while preserving the blob fallback for rollback coverage.

## Intentional
- This changes only the operator smoke default, not the hosted submit route, portfolio upload page, or generated report behavior.
- The legacy blob fallback remains available and wins over the default fixture when explicitly provided.
- Existing environment access in this smoke harness is left as-is; this slice does not broaden secret/config handling.

## Deferred
- Live hosted execution remains operator-driven because deployed API URL, auth, account id, company name, and contact email are runtime values.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_submit_handoff.py` - passed.
- `python -m pytest tests/test_smoke_content_ops_deflection_submit_handoff.py -q` - 22 passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-deflection-submit-fixture-default.md` - passed.

## Diff size
4 files, +139 / -6.
