### PR TITLE
PR-FAQ-Macro-Writeback-Intercom-Adapter

### DIFF
--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4788,6 +4788,16 @@ class B2BCampaignConfig(BaseSettings):
         ),
         description="Zendesk base URL override for hosted Content Ops FAQ macro writeback.",
     )
+    content_ops_intercom_access_token: str = Field(
+        default="",
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_INTERCOM_ACCESS_TOKEN"),
+        description="Intercom access token for hosted Content Ops FAQ macro writeback.",
+    )
+    content_ops_intercom_base_url: str = Field(
+        default="",
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_INTERCOM_BASE_URL"),
+        description="Intercom API base URL override for hosted Content Ops FAQ macro writeback.",
+    )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",

--- a/extracted_content_pipeline/faq_macro_writeback_intercom.py
+++ b/extracted_content_pipeline/faq_macro_writeback_intercom.py
@@ -1,0 +1,161 @@
+"""Intercom saved-reply writeback adapter for approved FAQ macro drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+import httpx
+
+from .campaign_ports import JsonDict, TenantScope
+from .faq_macro_writeback import (
+    MacroPublishResult,
+    MacroWritebackMapping,
+    MacroWritebackMappingRepository,
+    SupportMacroDraft,
+)
+
+
+INTERCOM_PLATFORM = "intercom"
+DEFAULT_INTERCOM_BASE_URL = "https://api.intercom.io"
+DEFAULT_INTERCOM_VERSION = "Unstable"
+
+
+@dataclass(frozen=True)
+class IntercomMacroCredentials:
+    access_token: str = field(repr=False)
+    base_url: str = DEFAULT_INTERCOM_BASE_URL
+    intercom_version: str = DEFAULT_INTERCOM_VERSION
+
+    def normalized_base_url(self) -> str:
+        return _clean(self.base_url).rstrip("/")
+
+    def is_complete(self) -> bool:
+        return bool(self.normalized_base_url() and _clean(self.access_token))
+
+
+class IntercomMacroCredentialsProvider(Protocol):
+    async def credentials_for_scope(self, scope: TenantScope) -> IntercomMacroCredentials | None:
+        """Return Intercom credentials for one tenant scope."""
+
+
+@dataclass(frozen=True)
+class StaticIntercomMacroCredentialsProvider:
+    credentials: IntercomMacroCredentials | None
+
+    async def credentials_for_scope(self, scope: TenantScope) -> IntercomMacroCredentials | None:
+        _ = scope
+        return self.credentials
+
+
+@dataclass(frozen=True)
+class IntercomMacroTransportError(Exception):
+    status_code: int
+    message: str = "intercom_request_failed"
+
+    def __str__(self) -> str:
+        return f"{self.message}: status={self.status_code}"
+
+
+class IntercomMacroTransport(Protocol):
+    async def request(self, method: str, url: str, *, headers: Mapping[str, str], json: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Send one Intercom saved-reply request and return a JSON object."""
+
+
+class IntercomHTTPMacroTransport:
+    async def request(self, method: str, url: str, *, headers: Mapping[str, str], json: Mapping[str, Any]) -> Mapping[str, Any]:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.request(method, url, headers=dict(headers), json=dict(json))
+        if response.status_code >= 400:
+            raise IntercomMacroTransportError(status_code=response.status_code)
+        payload = response.json()
+        return payload if isinstance(payload, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class IntercomMacroPublishProvider:
+    credentials_provider: IntercomMacroCredentialsProvider
+    mapping_repository: MacroWritebackMappingRepository
+    transport: IntercomMacroTransport = field(default_factory=IntercomHTTPMacroTransport)
+
+    async def publish(self, macros: Sequence[SupportMacroDraft], *, scope: TenantScope) -> Sequence[MacroPublishResult]:
+        credentials = await self.credentials_provider.credentials_for_scope(scope)
+        if credentials is None or not credentials.is_complete():
+            return tuple(MacroPublishResult(macro=m, status="failed", error="intercom_credentials_missing") for m in macros)
+        return tuple([await self._publish_one(m, credentials=credentials, scope=scope) for m in macros])
+
+    async def _publish_one(self, macro: SupportMacroDraft, *, credentials: IntercomMacroCredentials, scope: TenantScope) -> MacroPublishResult:
+        if not macro.faq_draft_id or not macro.faq_item_id:
+            return MacroPublishResult(macro=macro, status="failed", error="intercom_macro_missing_faq_identity")
+        try:
+            existing = await self.mapping_repository.get_mapping(
+                platform=INTERCOM_PLATFORM,
+                faq_draft_id=macro.faq_draft_id,
+                faq_item_id=macro.faq_item_id,
+                scope=scope,
+            )
+            if existing is not None and not existing.external_id:
+                return MacroPublishResult(macro=macro, status="failed", error="intercom_macro_mapping_pending_reconcile")
+            payload = _payload(macro)
+            headers = _headers(credentials, macro=macro, scope=scope)
+            if existing is None:
+                await self.mapping_repository.reserve_mapping(_mapping(macro, external_id="", publish_status="pending"), scope=scope)
+                data = await self.transport.request("POST", f"{credentials.normalized_base_url()}/macros", headers=headers, json=payload)
+                status = "published"
+            else:
+                data = await self.transport.request(
+                    "PUT",
+                    f"{credentials.normalized_base_url()}/macros/{existing.external_id}",
+                    headers=headers,
+                    json=payload,
+                )
+                status = "updated"
+            external_id = _external_id(data, fallback=existing.external_id if existing else "")
+            if not external_id:
+                return MacroPublishResult(macro=macro, status="failed", error="intercom_macro_response_invalid")
+            saved = await self.mapping_repository.upsert_mapping(_mapping(macro, external_id=external_id, publish_status="published"), scope=scope)
+            return MacroPublishResult(macro=macro, status=status, external_id=saved.external_id)
+        except Exception as exc:
+            return MacroPublishResult(macro=macro, status="failed", error=_safe_error(exc))
+
+
+def _payload(macro: SupportMacroDraft) -> JsonDict:
+    return {"name": macro.title, "body_text": macro.body, "visible_to": "everyone", "available_on": ["inbox", "messenger"]}
+
+
+def _headers(credentials: IntercomMacroCredentials, *, macro: SupportMacroDraft, scope: TenantScope) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_clean(credentials.access_token)}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Intercom-Version": _clean(credentials.intercom_version) or DEFAULT_INTERCOM_VERSION,
+        "Idempotency-Key": ":".join((
+            "atlas-faq-macro-writeback",
+            _clean(scope.account_id) or "unscoped",
+            _clean(macro.faq_draft_id),
+            _clean(macro.faq_item_id),
+        )),
+    }
+
+
+def _external_id(data: Mapping[str, Any], *, fallback: str = "") -> str:
+    return (_clean(data.get("id")) or _clean(fallback)) if data.get("type") == "macro" else ""
+
+
+def _mapping(macro: SupportMacroDraft, *, external_id: str, publish_status: str) -> MacroWritebackMapping:
+    return MacroWritebackMapping(
+        platform=INTERCOM_PLATFORM,
+        faq_draft_id=macro.faq_draft_id,
+        faq_item_id=macro.faq_item_id,
+        external_id=external_id,
+        publish_status=publish_status,
+        metadata={"title": macro.title, "category": macro.category},
+    )
+
+
+def _safe_error(exc: Exception) -> str:
+    return str(exc) if isinstance(exc, IntercomMacroTransportError) else exc.__class__.__name__
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())

--- a/plans/PR-FAQ-Macro-Writeback-Intercom-Adapter.md
+++ b/plans/PR-FAQ-Macro-Writeback-Intercom-Adapter.md
@@ -1,0 +1,64 @@
+# PR-FAQ-Macro-Writeback-Intercom-Adapter
+
+## Why this slice exists
+Macro writeback now has provider-neutral preview DTOs, the double publish gate,
+idempotency mappings, publish history, and Zendesk as the first adapter. This
+slice adds Intercom saved replies behind the same `MacroPublishProvider` port.
+
+## Scope (this PR)
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+
+1. Add `faq_macro_writeback_intercom.py` for credentials, transport, payload mapping, idempotent create/update, and fail-closed response guards.
+2. Add typed Intercom `ATLAS_*` config fields in `atlas_brain/config.py`.
+3. Add no-network extracted-checks tests for the double gate, create/update, pending refusal, idempotency, credentials, malformed envelopes, and per-item failure isolation.
+4. Enroll the Intercom test in the extracted pipeline runner.
+
+### Files touched
+- `plans/PR-FAQ-Macro-Writeback-Intercom-Adapter.md`
+- `atlas_brain/config.py`
+- `extracted_content_pipeline/faq_macro_writeback_intercom.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_extracted_ticket_faq_macro_writeback_intercom.py`
+
+## Mechanism
+The provider asks a scoped credentials provider for Intercom credentials. Missing
+credentials return `intercom_credentials_missing` without mapping lookup or
+transport calls. Existing mappings update `/macros/{external_id}`; missing
+mappings reserve pending, create `/macros`, then complete the mapping. Pending
+rows without an external id fail closed so retries do not create duplicates.
+Requests include Bearer auth and an idempotency key derived from account id plus
+FAQ identity. Responses must be a macro object with `type == "macro"` and `id`.
+
+## Intentional
+
+- Transport is mocked in CI; no live Intercom API calls are made.
+- No route, scheduler, UI, live smoke, or provider-selection switch is added.
+- Tokens are excluded from repr, mapping metadata, and sanitized errors.
+
+## Deferred
+
+- Future PR: host provider selection plus tenant Intercom credential storage.
+- Future PR: live Intercom smoke after tenant credential storage exists.
+
+Parked hardening: none.
+
+## Verification
+
+- Python compile check for the Intercom adapter and tests - passed.
+- Focused pytest for Intercom adapter coverage - 5 passed.
+- Extracted pipeline CI enrollment audit - passed, 141 matching tests enrolled.
+- Local PR review bundle with the prepared PR body file - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 64 |
+| Config fields | 10 |
+| Intercom adapter | 161 |
+| Intercom tests | 162 |
+| Runner enrollment | 1 |
+| **Total** | **398** |
+
+Under the 400 LOC soft cap.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -40,6 +40,7 @@ pytest \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \
   tests/test_extracted_ticket_faq_macro_writeback_publish.py \
   tests/test_extracted_ticket_faq_macro_writeback_reconcile_cli.py \
+  tests/test_extracted_ticket_faq_macro_writeback_intercom.py \
   tests/test_extracted_ticket_faq_macro_writeback_zendesk.py \
   tests/test_extracted_ticket_faq_output_ingestion.py \
   tests/test_smoke_content_ops_faq_output_proof.py \

--- a/tests/test_extracted_ticket_faq_macro_writeback_intercom.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_intercom.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping, SupportMacroDraft, build_macro_writeback_preview
+from extracted_content_pipeline.faq_macro_writeback_intercom import (
+    INTERCOM_PLATFORM,
+    IntercomMacroCredentials,
+    IntercomMacroPublishProvider,
+    IntercomMacroTransportError,
+    StaticIntercomMacroCredentialsProvider,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+class _Repo:
+    def __init__(self, existing: MacroWritebackMapping | None = None) -> None:
+        self.existing = existing
+        self.get_calls: list[dict[str, Any]] = []
+        self.reserve_calls: list[dict[str, Any]] = []
+        self.upsert_calls: list[dict[str, Any]] = []
+
+    async def get_mapping(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return self.existing
+
+    async def reserve_mapping(self, mapping: MacroWritebackMapping, *, scope: TenantScope):
+        self.reserve_calls.append({"mapping": mapping, "scope": scope})
+        return mapping
+
+    async def upsert_mapping(self, mapping: MacroWritebackMapping, *, scope: TenantScope):
+        self.upsert_calls.append({"mapping": mapping, "scope": scope})
+        return mapping
+
+
+class _Transport:
+    def __init__(self, *responses: Mapping[str, Any] | Exception) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def request(self, method: str, url: str, *, headers: Mapping[str, str], json: Mapping[str, Any]):
+        self.calls.append({"method": method, "url": url, "headers": dict(headers), "json": dict(json)})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _macro(item_id: str = "draft-1:item-1", title: str = "How do I export?") -> SupportMacroDraft:
+    return SupportMacroDraft(title=title, body="Open Reports, then choose Export.", category="exports", faq_draft_id="11111111-1111-1111-1111-111111111111", faq_item_id=item_id)
+
+
+def _provider(repo: _Repo, transport: _Transport, credentials: IntercomMacroCredentials | None = None):
+    return IntercomMacroPublishProvider(
+        credentials_provider=StaticIntercomMacroCredentialsProvider(credentials or IntercomMacroCredentials(access_token="secret-token")),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_intercom_provider_creates_saved_reply_and_persists_mapping() -> None:
+    repo = _Repo()
+    transport = _Transport({"type": "macro", "id": "macro-1"})
+
+    result = (await _provider(repo, transport).publish([_macro()], scope=TenantScope(account_id="acct-1")))[0]
+
+    assert result.status == "published"
+    assert result.external_id == "macro-1"
+    assert transport.calls[0] == {
+        "method": "POST",
+        "url": "https://api.intercom.io/macros",
+        "headers": {
+            "Authorization": "Bearer secret-token",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Intercom-Version": "Unstable",
+            "Idempotency-Key": "atlas-faq-macro-writeback:acct-1:11111111-1111-1111-1111-111111111111:draft-1:item-1",
+        },
+        "json": {"name": "How do I export?", "body_text": "Open Reports, then choose Export.", "visible_to": "everyone", "available_on": ["inbox", "messenger"]},
+    }
+    assert repo.reserve_calls[0]["mapping"].publish_status == "pending"
+    saved = repo.upsert_calls[0]["mapping"]
+    assert saved.platform == INTERCOM_PLATFORM
+    assert saved.external_id == "macro-1"
+    assert "secret-token" not in saved.as_dict()["metadata"].values()
+
+
+@pytest.mark.asyncio
+async def test_intercom_provider_updates_existing_and_refuses_pending_mapping() -> None:
+    existing = MacroWritebackMapping(platform=INTERCOM_PLATFORM, faq_draft_id="11111111-1111-1111-1111-111111111111", faq_item_id="draft-1:item-1", external_id="macro-1")
+    repo = _Repo(existing)
+    transport = _Transport({"type": "macro", "id": "macro-1"})
+
+    updated = (await _provider(repo, transport).publish([_macro()], scope=TenantScope(account_id="acct-1")))[0]
+
+    assert updated.status == "updated"
+    assert transport.calls[0]["method"] == "PUT"
+    assert repo.reserve_calls == []
+
+    repo = _Repo(MacroWritebackMapping(platform=INTERCOM_PLATFORM, faq_draft_id=existing.faq_draft_id, faq_item_id=existing.faq_item_id, external_id="", publish_status="pending"))
+    failed = (await _provider(repo, _Transport({"type": "macro", "id": "macro-1"})).publish([_macro()], scope=TenantScope(account_id="acct-1")))[0]
+    assert failed.status == "failed"
+    assert failed.error == "intercom_macro_mapping_pending_reconcile"
+    assert repo.reserve_calls == []
+
+
+@pytest.mark.asyncio
+async def test_intercom_provider_fails_closed_for_missing_credentials_and_bad_envelope() -> None:
+    repo = _Repo()
+    transport = _Transport({"type": "macro", "id": "macro-1"})
+    provider = IntercomMacroPublishProvider(
+        credentials_provider=StaticIntercomMacroCredentialsProvider(None),
+        mapping_repository=repo,
+        transport=transport,
+    )
+
+    missing = (await provider.publish([_macro()], scope=TenantScope(account_id="acct-1")))[0]
+    assert missing.status == "failed"
+    assert missing.error == "intercom_credentials_missing"
+    assert repo.get_calls == []
+    assert transport.calls == []
+
+    repo = _Repo()
+    malformed = (await _provider(repo, _Transport({"type": "list", "data": []})).publish([_macro()], scope=TenantScope(account_id="acct-1")))[0]
+    assert malformed.status == "failed"
+    assert malformed.error == "intercom_macro_response_invalid"
+    assert repo.upsert_calls == []
+
+
+@pytest.mark.asyncio
+async def test_intercom_provider_isolates_per_item_transport_failures() -> None:
+    results = await _provider(
+        _Repo(),
+        _Transport(IntercomMacroTransportError(status_code=429), {"type": "macro", "id": "macro-2"}),
+    ).publish([_macro(item_id="draft-1:item-1"), _macro(item_id="draft-1:item-2")], scope=TenantScope(account_id="acct-1"))
+
+    assert [item.status for item in results] == ["failed", "published"]
+    assert results[0].error == "intercom_request_failed: status=429"
+    assert results[1].external_id == "macro-2"
+
+
+def test_macro_writeback_double_gate_blocks_near_misses_and_allows_verified_approved() -> None:
+    approved = TicketFAQDraft(
+        target_id="target-1", target_mode="vendor_retention", title="FAQ", markdown="", id="11111111-1111-1111-1111-111111111111", status="approved",
+        items=(
+            {"question": "Allowed?", "answer_evidence_status": "resolution_evidence", "resolution_text": "Yes."},
+            {"question": "Unverified?", "answer_evidence_status": "needs_review", "resolution_text": "No."},
+        ),
+    )
+    unapproved = TicketFAQDraft(
+        target_id="target-1", target_mode="vendor_retention", title="FAQ", markdown="", id="22222222-2222-2222-2222-222222222222", status="draft_needs_review",
+        items=({"question": "Draft?", "answer_evidence_status": "resolution_evidence", "resolution_text": "No."},),
+    )
+
+    preview = build_macro_writeback_preview([approved, unapproved])
+
+    assert [macro.title for macro in preview.macros] == ["Allowed?"]
+    assert [item.reason for item in preview.skipped] == ["answer_not_verified", "draft_not_approved"]


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Intercom-Adapter.md
Slice phase: Vertical slice

Adds the Intercom saved-reply adapter behind the existing FAQ macro writeback port, mirroring the Zendesk adapter shape while preserving double-gate publishing, per-tenant credential fail-closed behavior, idempotent mapping-backed upsert, mocked transport tests, and per-item failure reporting.

## Intentional
- Transport is mocked in CI; no live Intercom API calls are made.
- No route, scheduler, UI, live smoke, or provider-selection switch is added.
- Tokens are excluded from repr, mapping metadata, and sanitized errors.

## Deferred
- Future PR: host provider selection plus tenant Intercom credential storage.
- Future PR: live Intercom smoke after tenant credential storage exists.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback_intercom.py tests/test_extracted_ticket_faq_macro_writeback_intercom.py atlas_brain/config.py` - passed.
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback_intercom.py -q` - 5 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py` - passed, 141 matching tests enrolled.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/atlas-pr-bodies/faq-macro-writeback-intercom-adapter.md` - passed.

## Diff size
5 files, +398 / -0.
