### PR TITLE
PR-FAQ-Macro-Writeback-Scheduled-Publish

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -7,13 +7,11 @@ on:
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
-      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
-      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_b2b_vendor_briefing.py"
   push:
     branches:
@@ -23,13 +21,11 @@ on:
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
-      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
-      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_b2b_vendor_briefing.py"
 
 jobs:
@@ -56,7 +52,6 @@ jobs:
           python -m pytest \
             tests/test_atlas_billing_stripe_hardening.py \
             tests/test_b2b_vendor_briefing.py \
-            tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
             tests/test_atlas_billing_content_ops_deflection_stripe_paid.py \
             tests/test_atlas_billing_content_ops_deflection_paid_flow.py \
             -q

--- a/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml
@@ -7,11 +7,13 @@ on:
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
+      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_b2b_vendor_briefing.py"
   push:
     branches:
@@ -21,11 +23,13 @@ on:
       - "atlas_brain/api/auth.py"
       - "atlas_brain/api/b2b_vendor_briefing.py"
       - "atlas_brain/api/billing.py"
+      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/config.py"
       - "extracted_content_pipeline/deflection_report_access.py"
       - "tests/test_atlas_billing_content_ops_deflection_paid_flow.py"
       - "tests/test_atlas_billing_content_ops_deflection_stripe_paid.py"
       - "tests/test_atlas_billing_stripe_hardening.py"
+      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_b2b_vendor_briefing.py"
 
 jobs:
@@ -52,6 +56,7 @@ jobs:
           python -m pytest \
             tests/test_atlas_billing_stripe_hardening.py \
             tests/test_b2b_vendor_briefing.py \
+            tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
             tests/test_atlas_billing_content_ops_deflection_stripe_paid.py \
             tests/test_atlas_billing_content_ops_deflection_paid_flow.py \
             -q

--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -1,0 +1,49 @@
+name: Atlas Content Ops Macro Writeback Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/config.py"
+      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_scheduler.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "atlas_brain/autonomous/scheduler.py"
+      - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
+      - "atlas_brain/autonomous/tasks/__init__.py"
+      - "atlas_brain/config.py"
+      - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
+      - "tests/test_scheduler.py"
+
+jobs:
+  atlas-content-ops-macro-writeback-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops macro writeback scheduler tests
+        run: |
+          python -m pytest \
+            tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
+            tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \
+            -q

--- a/atlas_brain/autonomous/scheduler.py
+++ b/atlas_brain/autonomous/scheduler.py
@@ -966,6 +966,11 @@ class TaskScheduler:
                     settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_interval_seconds
                 ),
             }
+            _enabled_overrides = {
+                "content_ops_faq_macro_writeback_scheduled_publish": (
+                    settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_enabled
+                ),
+            }
 
             # Resolve configurable cron expressions at runtime
             _cron_overrides = {
@@ -1003,6 +1008,8 @@ class TaskScheduler:
                 # Apply runtime interval override if the definition left it as None
                 if task_def.get("interval_seconds") is None and task_def["name"] in _interval_overrides:
                     task_def = {**task_def, "interval_seconds": _interval_overrides[task_def["name"]]}
+                if task_def["name"] in _enabled_overrides:
+                    task_def = {**task_def, "enabled": _enabled_overrides[task_def["name"]]}
                 existing = await repo.get_by_name(task_def["name"])
                 if existing is not None:
                     # Merge any new metadata keys from the definition into the existing row.

--- a/atlas_brain/autonomous/scheduler.py
+++ b/atlas_brain/autonomous/scheduler.py
@@ -851,6 +851,15 @@ class TaskScheduler:
             "metadata": {"builtin_handler": "llm_provider_cost_sync"},
         },
         {
+            "name": "content_ops_faq_macro_writeback_scheduled_publish",
+            "description": "Publish approved verified Content Ops FAQ drafts to tenant Zendesk macros",
+            "task_type": "builtin",
+            "schedule_type": "interval",
+            "interval_seconds": None,  # resolved from settings.b2b_campaign
+            "timeout_seconds": 600,
+            "metadata": {"builtin_handler": "content_ops_faq_macro_writeback_scheduled_publish"},
+        },
+        {
             "name": "falsification_check",
             "description": "Nightly check of cached reasoning conclusions against fresh vendor signals",
             "task_type": "builtin",
@@ -953,6 +962,9 @@ class TaskScheduler:
                 "b2b_scrape_target_pruning": settings.b2b_scrape.source_low_yield_pruning_interval_seconds,
                 "b2b_parser_upgrade_maintenance": settings.b2b_scrape.parser_upgrade_maintenance_interval_seconds,
                 "llm_provider_cost_sync": settings.provider_cost.interval_seconds,
+                "content_ops_faq_macro_writeback_scheduled_publish": (
+                    settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_interval_seconds
+                ),
             }
 
             # Resolve configurable cron expressions at runtime
@@ -1094,6 +1106,9 @@ class TaskScheduler:
                 "b2b_watchlist_alert_delivery": settings.b2b_watchlist_delivery.interval_seconds,
                 "b2b_scrape_target_pruning": settings.b2b_scrape.source_low_yield_pruning_interval_seconds,
                 "b2b_parser_upgrade_maintenance": settings.b2b_scrape.parser_upgrade_maintenance_interval_seconds,
+                "content_ops_faq_macro_writeback_scheduled_publish": (
+                    settings.b2b_campaign.content_ops_faq_macro_writeback_scheduled_interval_seconds
+                ),
             }
 
             # Merge pipeline interval overrides

--- a/atlas_brain/autonomous/tasks/__init__.py
+++ b/atlas_brain/autonomous/tasks/__init__.py
@@ -61,6 +61,7 @@ _BUILTIN_TASKS = [
     ("b2b_witness_quality_maintenance", "run", "b2b_witness_quality_maintenance"),
     ("b2b_evidence_claim_audit", "run", "b2b_evidence_claim_audit"),
     ("provider_cost_sync", "run", "llm_provider_cost_sync"),
+    ("faq_macro_writeback_scheduled_publish", "run", "content_ops_faq_macro_writeback_scheduled_publish"),
     ("cleaning_sms_reminder", "run", "cleaning_sms_reminder"),
 ]
 

--- a/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
+++ b/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
@@ -51,23 +51,41 @@ class StoredOnlyZendeskMacroCredentialsProvider:
         return await lookup_zendesk_credentials(self.pool, account_id=scope.account_id)
 
 
-@dataclass(frozen=True)
+@dataclass
 class PostgresScheduledFAQMacroCandidateRepository:
     pool: Any
     faq_repository: TicketFAQRepository
     mapping_repository: MacroWritebackMappingRepository
+    last_enrolled_tenant_count: int = 0
 
     async def list_tenants(self, *, limit: int) -> Sequence[ZendeskTenant]:
         rows = await self.pool.fetch(
             """
-            SELECT DISTINCT z.account_id::text AS account_id
-              FROM content_ops_zendesk_credentials z
-             WHERE z.revoked_at IS NULL
-             ORDER BY z.account_id ASC
+            WITH enrolled AS (
+                SELECT DISTINCT z.account_id::text AS account_id
+                  FROM content_ops_zendesk_credentials z
+                 WHERE z.revoked_at IS NULL
+            ),
+            last_publish AS (
+                SELECT account_id::text AS account_id, MAX(updated_at) AS last_published_at
+                  FROM ticket_faq_macro_writebacks
+                 WHERE platform = $2
+                   AND publish_status = 'published'
+                 GROUP BY account_id
+            )
+            SELECT e.account_id,
+                   COUNT(*) OVER() AS enrolled_count
+              FROM enrolled e
+              LEFT JOIN last_publish p ON p.account_id = e.account_id
+             ORDER BY p.last_published_at ASC NULLS FIRST,
+                      hashtext(e.account_id || date_trunc('hour', NOW())::text) ASC,
+                      e.account_id ASC
              LIMIT $1
             """,
             max(1, int(limit)),
+            ZENDESK_PLATFORM,
         )
+        self.last_enrolled_tenant_count = int(rows[0]["enrolled_count"] or 0) if rows else 0
         return tuple(ZendeskTenant(account_id=str(row["account_id"] or "")) for row in rows)
 
     async def list_candidate_faq_ids(self, tenant: ZendeskTenant, *, limit: int) -> Sequence[str]:
@@ -89,15 +107,26 @@ class PostgresScheduledFAQMacroCandidateRepository:
 
 async def run_scheduled_faq_macro_writeback(*, candidate_repository: Any, publish_service: Any, max_tenants: int, max_drafts_per_tenant: int) -> dict[str, Any]:
     tenants = await candidate_repository.list_tenants(limit=max_tenants)
+    enrolled_tenant_count = int(getattr(candidate_repository, "last_enrolled_tenant_count", len(tenants)) or len(tenants))
+    tenants_deferred = max(0, enrolled_tenant_count - len(tenants))
     result: dict[str, Any] = {
+        "enrolled_tenants": enrolled_tenant_count,
         "tenants_checked": len(tenants),
+        "tenants_deferred_by_limit": tenants_deferred,
         "tenants_skipped_no_credentials": 0,
         "drafts_selected": 0,
         "drafts_published_ok": 0,
         "drafts_failed": 0,
         "tenants": [],
-        "_skip_synthesis": True,
+        "_skip_synthesis": "Scheduled FAQ macro writeback complete",
     }
+    if tenants_deferred:
+        logger.warning(
+            "scheduled FAQ macro publish deferred %s of %s enrolled tenants due to max_tenants=%s",
+            tenants_deferred,
+            enrolled_tenant_count,
+            max_tenants,
+        )
     for tenant in tenants:
         tenant_result: dict[str, Any] = {"account_id": tenant.account_id, "drafts": []}
         if not tenant.has_zendesk_credentials:

--- a/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
+++ b/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
@@ -1,0 +1,184 @@
+"""Autonomous task for scheduled FAQ-to-Zendesk macro writeback."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import (
+    APPROVED_FAQ_STATUS,
+    MacroWritebackMappingRepository,
+    SupportMacroDraft,
+    build_macro_writeback_preview,
+)
+from extracted_content_pipeline.faq_macro_writeback_postgres import (
+    PostgresFAQMacroPublishAttemptRepository,
+    PostgresFAQMacroWritebackMappingRepository,
+)
+from extracted_content_pipeline.faq_macro_writeback_publish import FAQMacroWritebackPublishService
+from extracted_content_pipeline.faq_macro_writeback_zendesk import (
+    ZENDESK_PLATFORM,
+    ZendeskMacroCredentials,
+    ZendeskMacroPublishProvider,
+)
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQRepository
+from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepository
+
+from ..._content_ops_zendesk_credentials import lookup_zendesk_credentials
+from ...config import settings
+from ...storage.database import get_db_pool
+
+logger = logging.getLogger("atlas.autonomous.tasks.faq_macro_writeback_scheduled_publish")
+MAX_TENANTS_PER_RUN = 25
+MAX_DRAFTS_PER_TENANT = 25
+
+
+@dataclass(frozen=True)
+class ZendeskTenant:
+    account_id: str
+    has_zendesk_credentials: bool = True
+
+
+@dataclass(frozen=True)
+class StoredOnlyZendeskMacroCredentialsProvider:
+    pool: Any
+
+    async def credentials_for_scope(self, scope: TenantScope) -> ZendeskMacroCredentials | None:
+        if not scope.account_id:
+            return None
+        return await lookup_zendesk_credentials(self.pool, account_id=scope.account_id)
+
+
+@dataclass(frozen=True)
+class PostgresScheduledFAQMacroCandidateRepository:
+    pool: Any
+    faq_repository: TicketFAQRepository
+    mapping_repository: MacroWritebackMappingRepository
+
+    async def list_tenants(self, *, limit: int) -> Sequence[ZendeskTenant]:
+        rows = await self.pool.fetch(
+            """
+            SELECT DISTINCT z.account_id::text AS account_id
+              FROM content_ops_zendesk_credentials z
+             WHERE z.revoked_at IS NULL
+             ORDER BY z.account_id ASC
+             LIMIT $1
+            """,
+            max(1, int(limit)),
+        )
+        return tuple(ZendeskTenant(account_id=str(row["account_id"] or "")) for row in rows)
+
+    async def list_candidate_faq_ids(self, tenant: ZendeskTenant, *, limit: int) -> Sequence[str]:
+        scope = TenantScope(account_id=tenant.account_id)
+        drafts = await self.faq_repository.list_drafts(
+            scope=scope,
+            status=APPROVED_FAQ_STATUS,
+            limit=max(1, int(limit)),
+        )
+        selected: list[str] = []
+        for draft in drafts:
+            preview = build_macro_writeback_preview([draft])
+            if not preview.macros:
+                continue
+            if await _has_unpublished_macro(preview.macros, self.mapping_repository, scope=scope):
+                selected.append(draft.id)
+        return tuple(selected)
+
+
+async def run_scheduled_faq_macro_writeback(*, candidate_repository: Any, publish_service: Any, max_tenants: int, max_drafts_per_tenant: int) -> dict[str, Any]:
+    tenants = await candidate_repository.list_tenants(limit=max_tenants)
+    result: dict[str, Any] = {
+        "tenants_checked": len(tenants),
+        "tenants_skipped_no_credentials": 0,
+        "drafts_selected": 0,
+        "drafts_published_ok": 0,
+        "drafts_failed": 0,
+        "tenants": [],
+        "_skip_synthesis": True,
+    }
+    for tenant in tenants:
+        tenant_result: dict[str, Any] = {"account_id": tenant.account_id, "drafts": []}
+        if not tenant.has_zendesk_credentials:
+            result["tenants_skipped_no_credentials"] += 1
+            tenant_result["status"] = "skipped_no_zendesk_credentials"
+            result["tenants"].append(tenant_result)
+            continue
+        scope = TenantScope(account_id=tenant.account_id)
+        faq_ids = tuple(await candidate_repository.list_candidate_faq_ids(tenant, limit=max_drafts_per_tenant))
+        result["drafts_selected"] += len(faq_ids)
+        for faq_id in faq_ids:
+            try:
+                summary = await publish_service.publish_faq_draft(faq_id, scope=scope)
+                item = summary.as_dict()
+            except Exception as exc:
+                logger.warning("scheduled FAQ macro publish failed account_id=%s faq_id=%s: %s", tenant.account_id, faq_id, exc)
+                item = {"faq_id": faq_id, "ok": False, "error": exc.__class__.__name__}
+            if item.get("ok"):
+                result["drafts_published_ok"] += 1
+            else:
+                result["drafts_failed"] += 1
+            tenant_result["drafts"].append(item)
+        tenant_result["status"] = "processed" if faq_ids else "no_candidates"
+        result["tenants"].append(tenant_result)
+    return result
+
+
+async def run(task: Any) -> dict[str, Any]:
+    del task
+    cfg = settings.b2b_campaign
+    if not cfg.content_ops_faq_macro_writeback_scheduled_enabled:
+        return {"_skip_synthesis": "Scheduled FAQ macro writeback disabled"}
+    pool = get_db_pool()
+    if not pool.is_initialized:
+        return {"_skip_synthesis": "Database pool not initialized"}
+    mapping_repository = PostgresFAQMacroWritebackMappingRepository(pool)
+    faq_repository = PostgresTicketFAQRepository(pool=pool)
+    provider = ZendeskMacroPublishProvider(
+        credentials_provider=StoredOnlyZendeskMacroCredentialsProvider(pool),
+        mapping_repository=mapping_repository,
+    )
+    publish_service = FAQMacroWritebackPublishService(
+        faq_repository=faq_repository,
+        provider=provider,
+        attempt_repository=PostgresFAQMacroPublishAttemptRepository(pool),
+    )
+    return await run_scheduled_faq_macro_writeback(
+        candidate_repository=PostgresScheduledFAQMacroCandidateRepository(
+            pool=pool,
+            faq_repository=faq_repository,
+            mapping_repository=mapping_repository,
+        ),
+        publish_service=publish_service,
+        max_tenants=MAX_TENANTS_PER_RUN,
+        max_drafts_per_tenant=MAX_DRAFTS_PER_TENANT,
+    )
+
+
+async def _has_unpublished_macro(
+    macros: Sequence[SupportMacroDraft],
+    mapping_repository: MacroWritebackMappingRepository,
+    *,
+    scope: TenantScope,
+) -> bool:
+    for macro in macros:
+        mapping = await mapping_repository.get_mapping(
+            platform=ZENDESK_PLATFORM,
+            faq_draft_id=macro.faq_draft_id,
+            faq_item_id=macro.faq_item_id,
+            scope=scope,
+        )
+        if (
+            mapping is None
+            or mapping.publish_status != "published"
+            or not mapping.external_id
+            or _clean(mapping.metadata.get("title")) != _clean(macro.title)
+            or _clean(mapping.metadata.get("category")) != _clean(macro.category)
+        ):
+            return True
+    return False
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4788,6 +4788,17 @@ class B2BCampaignConfig(BaseSettings):
         ),
         description="Zendesk base URL override for hosted Content Ops FAQ macro writeback.",
     )
+    content_ops_faq_macro_writeback_scheduled_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_FAQ_MACRO_WRITEBACK_SCHEDULED_ENABLED"),
+        description="Enable autonomous publishing of approved Content Ops FAQ drafts to tenant Zendesk macros.",
+    )
+    content_ops_faq_macro_writeback_scheduled_interval_seconds: int = Field(
+        default=3600,
+        ge=60,
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_FAQ_MACRO_WRITEBACK_SCHEDULED_INTERVAL_SECONDS"),
+        description="Interval for autonomous Content Ops FAQ-to-Zendesk macro publishing.",
+    )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",

--- a/plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md
+++ b/plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md
@@ -7,7 +7,7 @@ Intercom remains parked because #1214 proved its macro API is read-only.
 Ownership lane: content-ops/faq-macro-writeback
 Slice phase: Vertical slice
 1. Add and register an interval-based autonomous task gated by typed config.
-2. Select stored-credential Zendesk tenants and approved+verified FAQ drafts without completed mappings.
+2. Select stored-credential Zendesk tenants by least-recent publish coverage and approved+verified FAQ drafts without completed mappings.
 3. Call existing `FAQMacroWritebackPublishService.publish_faq_draft(...)` per draft and aggregate status.
 4. Add focused main-suite tests with fakes; no live Zendesk calls.
 ### Files touched
@@ -16,37 +16,47 @@ Slice phase: Vertical slice
 - `atlas_brain/autonomous/scheduler.py`
 - `atlas_brain/autonomous/tasks/__init__.py`
 - `atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py`
-- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
 - `tests/test_autonomous_faq_macro_writeback_scheduled_publish.py`
+- `tests/test_scheduler.py`
 ## Mechanism
 The task uses normal autonomous interval registration. At runtime it opens the
 DB pool, builds the existing FAQ repository, mapping/attempt repositories, and
 Zendesk provider with a stored-tenant-only credential source. Candidate
-selection starts from active `content_ops_zendesk_credentials`, filters approved
-drafts through the shared macro preview helper, skips drafts whose Zendesk
-mappings are already published, then calls `publish_faq_draft` per candidate.
-Per-draft exceptions are caught and reported so the batch continues.
+selection starts from active `content_ops_zendesk_credentials`, orders enrolled
+tenants by never/least-recent Zendesk publish coverage, logs/reports any tenants
+deferred by the per-run cap, filters approved drafts through the shared macro
+preview helper, skips drafts whose Zendesk mappings are already published, then
+calls `publish_faq_draft` per candidate. Per-draft exceptions are caught and
+reported so the batch continues.
 ## Intentional
 - No Intercom code is added or revived; #1214 stays parked because Intercom
   macros are GET-only.
 - No host/global Zendesk config fallback; missing tenant credentials skip.
 - No reimplemented Zendesk transport, payloads, history, or final double gate.
 - No live Zendesk smoke in CI; tests use fakes around the orchestrator.
+- The per-run tenant cap remains 25, but capped runs are observable and the
+  tenant order rotates toward never/least-recently published tenants.
 ## Deferred
 - Future PR: content-hash "needs update" detection for body-only FAQ edits.
 - Future PR: operator-facing telemetry beyond the task result summary.
 Parked hardening: none.
 ## Verification
 - Python compile check for the new task, tests, config, and scheduler - passed.
-- Focused pytest for scheduled publish orchestration - 3 passed.
+- Focused pytest for scheduled publish orchestration + scheduler opt-in regression - 6 passed.
+- ASCII check for extracted package Python files - passed.
 - Atlas-brain CI enrollment audit - passed, 140 matching tests enrolled.
 - Evidence-claim wiring regression sweep for scheduler registration - 4 passed.
 - Local PR review bundle with the prepared PR body file - passed.
 ## Estimated diff size
 | Area | LOC |
 |---|---:|
-| Plan | 52 |
-| Config/scheduler/workflow | 32 |
-| Task | 184 |
-| Tests | 126 |
-| **Total** | **394** |
+| Plan | 63 |
+| Config/scheduler/workflow | 83 |
+| Task | 213 |
+| Tests | 214 |
+| **Total** | **573** |
+
+Over the 400 LOC soft cap because review feedback required both scheduler
+seeding coverage and a dedicated macro-writeback workflow, not just the task
+orchestrator.

--- a/plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md
+++ b/plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md
@@ -1,0 +1,52 @@
+# PR-FAQ-Macro-Writeback-Scheduled-Publish
+## Why this slice exists
+FAQ macro writeback is manual today. This slice adds the recurring Zendesk
+publisher so approved, verified FAQ drafts can write back after a report sale.
+Intercom remains parked because #1214 proved its macro API is read-only.
+## Scope (this PR)
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Vertical slice
+1. Add and register an interval-based autonomous task gated by typed config.
+2. Select stored-credential Zendesk tenants and approved+verified FAQ drafts without completed mappings.
+3. Call existing `FAQMacroWritebackPublishService.publish_faq_draft(...)` per draft and aggregate status.
+4. Add focused main-suite tests with fakes; no live Zendesk calls.
+### Files touched
+- `plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md`
+- `atlas_brain/config.py`
+- `atlas_brain/autonomous/scheduler.py`
+- `atlas_brain/autonomous/tasks/__init__.py`
+- `atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py`
+- `.github/workflows/atlas_content_ops_deflection_stripe_paid_checks.yml`
+- `tests/test_autonomous_faq_macro_writeback_scheduled_publish.py`
+## Mechanism
+The task uses normal autonomous interval registration. At runtime it opens the
+DB pool, builds the existing FAQ repository, mapping/attempt repositories, and
+Zendesk provider with a stored-tenant-only credential source. Candidate
+selection starts from active `content_ops_zendesk_credentials`, filters approved
+drafts through the shared macro preview helper, skips drafts whose Zendesk
+mappings are already published, then calls `publish_faq_draft` per candidate.
+Per-draft exceptions are caught and reported so the batch continues.
+## Intentional
+- No Intercom code is added or revived; #1214 stays parked because Intercom
+  macros are GET-only.
+- No host/global Zendesk config fallback; missing tenant credentials skip.
+- No reimplemented Zendesk transport, payloads, history, or final double gate.
+- No live Zendesk smoke in CI; tests use fakes around the orchestrator.
+## Deferred
+- Future PR: content-hash "needs update" detection for body-only FAQ edits.
+- Future PR: operator-facing telemetry beyond the task result summary.
+Parked hardening: none.
+## Verification
+- Python compile check for the new task, tests, config, and scheduler - passed.
+- Focused pytest for scheduled publish orchestration - 3 passed.
+- Atlas-brain CI enrollment audit - passed, 140 matching tests enrolled.
+- Evidence-claim wiring regression sweep for scheduler registration - 4 passed.
+- Local PR review bundle with the prepared PR body file - passed.
+## Estimated diff size
+| Area | LOC |
+|---|---:|
+| Plan | 52 |
+| Config/scheduler/workflow | 32 |
+| Task | 184 |
+| Tests | 126 |
+| **Total** | **394** |

--- a/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
+++ b/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
@@ -46,9 +46,10 @@ class _MappingRepo:
 
 
 class _TenantRepo:
-    def __init__(self, tenants, candidates) -> None:
+    def __init__(self, tenants, candidates, *, enrolled_count: int | None = None) -> None:
         self.tenants = tuple(tenants)
         self.candidates = candidates
+        self.last_enrolled_tenant_count = enrolled_count if enrolled_count is not None else len(self.tenants)
 
     async def list_tenants(self, *, limit: int):
         return self.tenants[:limit]
@@ -105,6 +106,46 @@ async def test_scheduled_publish_skips_missing_credentials_and_isolates_failures
     assert result["drafts_failed"] == 1
     assert result["drafts_published_ok"] == 1
     assert result["tenants"][1]["drafts"][0]["error"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_publish_reports_tenant_cap_truncation(caplog) -> None:
+    tenants = tuple(ZendeskTenant(f"acct-{idx:02d}") for idx in range(25))
+
+    result = await run_scheduled_faq_macro_writeback(
+        candidate_repository=_TenantRepo(tenants, {}, enrolled_count=27),
+        publish_service=_PublishService(),
+        max_tenants=25,
+        max_drafts_per_tenant=10,
+    )
+
+    assert result["enrolled_tenants"] == 27
+    assert result["tenants_checked"] == 25
+    assert result["tenants_deferred_by_limit"] == 2
+    assert "deferred 2 of 27 enrolled tenants" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_postgres_tenant_selection_rotates_by_publish_recency() -> None:
+    class _Pool:
+        async def fetch(self, query, limit, platform):
+            assert "MAX(updated_at) AS last_published_at" in query
+            assert "ORDER BY p.last_published_at ASC NULLS FIRST" in query
+            assert "COUNT(*) OVER() AS enrolled_count" in query
+            assert limit == 25
+            assert platform == ZENDESK_PLATFORM
+            return ({"account_id": "acct-never", "enrolled_count": 26},)
+
+    repo = PostgresScheduledFAQMacroCandidateRepository(
+        pool=_Pool(),
+        faq_repository=_FAQRepo(()),
+        mapping_repository=_MappingRepo(),
+    )
+
+    tenants = await repo.list_tenants(limit=25)
+
+    assert tenants == (ZendeskTenant("acct-never"),)
+    assert repo.last_enrolled_tenant_count == 26
 
 
 @pytest.mark.asyncio

--- a/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
+++ b/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pytest
+
+from atlas_brain.autonomous.tasks.faq_macro_writeback_scheduled_publish import (
+    PostgresScheduledFAQMacroCandidateRepository,
+    StoredOnlyZendeskMacroCredentialsProvider,
+    ZendeskTenant,
+    run_scheduled_faq_macro_writeback,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping
+from extracted_content_pipeline.faq_macro_writeback_publish import FAQMacroPublishSummary
+from extracted_content_pipeline.faq_macro_writeback_zendesk import ZENDESK_PLATFORM
+from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
+
+
+def _draft(faq_id: str, *, status: str = "approved", evidence: str = "resolution_evidence") -> TicketFAQDraft:
+    return TicketFAQDraft(
+        id=faq_id, target_id="target-1", target_mode="vendor_retention", title="FAQ", markdown="", status=status,
+        items=({"question": f"{faq_id}?", "answer_evidence_status": evidence, "resolution_text": "Use the export button."},),
+    )
+
+
+class _FAQRepo:
+    def __init__(self, drafts) -> None:
+        self.drafts = tuple(drafts)
+        self.calls = []
+
+    async def list_drafts(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.drafts
+
+
+class _MappingRepo:
+    def __init__(self, published: set[str] | None = None) -> None:
+        self.published = published or set()
+        self.calls = []
+
+    async def get_mapping(self, **kwargs):
+        self.calls.append(kwargs)
+        faq_id = str(kwargs["faq_draft_id"])
+        if faq_id not in self.published:
+            return None
+        return MacroWritebackMapping(platform=ZENDESK_PLATFORM, faq_draft_id=faq_id, faq_item_id=str(kwargs["faq_item_id"]), external_id=f"macro-{faq_id}", publish_status="published", metadata={"title": f"{faq_id}?", "category": ""})
+
+
+class _TenantRepo:
+    def __init__(self, tenants, candidates) -> None:
+        self.tenants = tuple(tenants)
+        self.candidates = candidates
+
+    async def list_tenants(self, *, limit: int):
+        return self.tenants[:limit]
+
+    async def list_candidate_faq_ids(self, tenant: ZendeskTenant, *, limit: int):
+        return tuple(self.candidates.get(tenant.account_id, ()))[:limit]
+
+
+class _PublishService:
+    def __init__(self, failures: set[str] | None = None) -> None:
+        self.failures = failures or set()
+        self.calls = []
+
+    async def publish_faq_draft(self, faq_id: str, *, scope: TenantScope):
+        self.calls.append({"faq_id": faq_id, "scope": scope})
+        if faq_id in self.failures:
+            raise RuntimeError("rate limited")
+        return FAQMacroPublishSummary(faq_id=faq_id, found=True, draft_status="approved", publishable_count=1, published_count=1, results=({"status": "published"},))
+
+
+@pytest.mark.asyncio
+async def test_candidate_selection_uses_shared_gate_and_mapping_idempotency() -> None:
+    faq_repo = _FAQRepo((
+        _draft("allowed"),
+        _draft("unverified", evidence="needs_review"),
+        _draft("unapproved", status="draft_needs_review"),
+        _draft("mapped"),
+    ))
+    mapping_repo = _MappingRepo({"mapped"})
+    repo = PostgresScheduledFAQMacroCandidateRepository(pool=object(), faq_repository=faq_repo, mapping_repository=mapping_repo)
+
+    candidates = await repo.list_candidate_faq_ids(ZendeskTenant("acct-1"), limit=10)
+
+    assert candidates == ("allowed",)
+    assert faq_repo.calls[0]["status"] == "approved"
+    assert all(call["platform"] == ZENDESK_PLATFORM for call in mapping_repo.calls)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_publish_skips_missing_credentials_and_isolates_failures() -> None:
+    tenants = (ZendeskTenant("missing", has_zendesk_credentials=False), ZendeskTenant("acct-1"))
+    service = _PublishService({"faq-1"})
+
+    result = await run_scheduled_faq_macro_writeback(
+        candidate_repository=_TenantRepo(tenants, {"missing": ("bad",), "acct-1": ("faq-1", "faq-2")}),
+        publish_service=service,
+        max_tenants=10,
+        max_drafts_per_tenant=10,
+    )
+
+    assert result["tenants_skipped_no_credentials"] == 1
+    assert [call["faq_id"] for call in service.calls] == ["faq-1", "faq-2"]
+    assert result["tenants"][0]["status"] == "skipped_no_zendesk_credentials"
+    assert result["drafts_failed"] == 1
+    assert result["drafts_published_ok"] == 1
+    assert result["tenants"][1]["drafts"][0]["error"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_stored_only_credentials_provider_has_no_unscoped_fallback(monkeypatch) -> None:
+    calls: list[str] = []
+
+    async def lookup(pool: object, *, account_id: str):
+        calls.append(account_id)
+        return None
+
+    monkeypatch.setattr(
+        "atlas_brain.autonomous.tasks.faq_macro_writeback_scheduled_publish.lookup_zendesk_credentials",
+        lookup,
+    )
+    provider = StoredOnlyZendeskMacroCredentialsProvider(pool=object())
+
+    assert await provider.credentials_for_scope(TenantScope()) is None
+    assert await provider.credentials_for_scope(TenantScope(account_id="acct-1")) is None
+    assert calls == ["acct-1"]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -720,3 +720,50 @@ class TestDefaults:
 
         assert repo.create.await_count == 2
         assert s.register_and_schedule.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo")
+    async def test_content_ops_faq_macro_writeback_default_seed_respects_opt_in(self, mock_repo_fn, monkeypatch):
+        s = _scheduler()
+        s._DEFAULT_TASKS = [
+            {
+                "name": "content_ops_faq_macro_writeback_scheduled_publish",
+                "task_type": "builtin",
+                "schedule_type": "interval",
+                "interval_seconds": None,
+                "timeout_seconds": 600,
+                "metadata": {"builtin_handler": "content_ops_faq_macro_writeback_scheduled_publish"},
+            },
+        ]
+
+        repo = AsyncMock()
+        repo.get_by_name = AsyncMock(return_value=None)
+        repo.create = AsyncMock(
+            return_value=ScheduledTask(
+                id=uuid4(),
+                name="content_ops_faq_macro_writeback_scheduled_publish",
+                task_type="builtin",
+                schedule_type="interval",
+                interval_seconds=3600,
+                timeout_seconds=600,
+                enabled=False,
+            )
+        )
+        mock_repo_fn.return_value = repo
+        monkeypatch.setattr(s, "register_and_schedule", AsyncMock())
+        from atlas_brain.config import settings
+
+        monkeypatch.setattr(
+            settings.b2b_campaign,
+            "content_ops_faq_macro_writeback_scheduled_enabled",
+            False,
+        )
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_interval_overrides", lambda: {})
+        monkeypatch.setattr("atlas_brain.pipelines.get_pipeline_default_tasks", lambda: [])
+
+        await s._ensure_default_tasks()
+
+        create_kwargs = repo.create.await_args.kwargs
+        assert create_kwargs["enabled"] is False
+        assert create_kwargs["interval_seconds"] == 3600
+        s.register_and_schedule.assert_not_awaited()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Scheduled-Publish.md
Slice phase: Vertical slice

Adds the scheduled Zendesk FAQ macro publisher as a thin autonomous orchestrator over the merged writeback stack: stored-credential tenant selection, approved+verified candidate filtering, existing mapping idempotency, and per-draft calls into `FAQMacroWritebackPublishService.publish_faq_draft(...)`. Review feedback is folded in: default task seeding honors the opt-in flag, capped tenant runs prefer never/least-recent publish coverage and report deferrals, and the focused CI enrollment now lives in a macro-writeback workflow instead of the deflection Stripe lane.

## Intentional
- No Intercom code is added or revived; #1214 stays parked because Intercom macros are GET-only.
- No host/global Zendesk config fallback; missing tenant credentials skip.
- No reimplemented Zendesk transport, payloads, history, or final double gate.
- No live Zendesk smoke in CI; tests use fakes around the orchestrator.
- The per-run tenant cap remains 25, but capped runs are observable and ordered for coverage rather than silently alphabetical.

## Deferred
- Future PR: content-hash "needs update" detection for body-only FAQ edits.
- Future PR: operator-facing telemetry beyond the task result summary.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_scheduler.py atlas_brain/autonomous/scheduler.py` - passed.
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in -q` - 6 passed, 1 warning from existing torch/pynvml import.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - passed, 140 matching tests enrolled.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/local_pr_review.sh` - passed.
- Pre-push hook reran `bash scripts/local_pr_review.sh` - passed.

## Diff size
8 files, +572 / -0. Over the 400 LOC soft cap because review feedback required scheduler seeding coverage and a dedicated macro-writeback workflow in addition to the thin orchestrator.