### PR TITLE
PR-FAQ-Macro-Writeback-Content-Hash-Update

### DIFF
--- a/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
+++ b/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
@@ -12,6 +12,7 @@ from extracted_content_pipeline.faq_macro_writeback import (
     MacroWritebackMappingRepository,
     SupportMacroDraft,
     build_macro_writeback_preview,
+    macro_content_hash,
 )
 from extracted_content_pipeline.faq_macro_writeback_postgres import (
     PostgresFAQMacroPublishAttemptRepository,
@@ -204,6 +205,7 @@ async def _has_unpublished_macro(
             or not mapping.external_id
             or _clean(mapping.metadata.get("title")) != _clean(macro.title)
             or _clean(mapping.metadata.get("category")) != _clean(macro.category)
+            or _clean(mapping.metadata.get("content_hash")) != macro_content_hash(macro)
         ):
             return True
     return False

--- a/extracted_content_pipeline/faq_macro_writeback.py
+++ b/extracted_content_pipeline/faq_macro_writeback.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal, Mapping, Protocol, Sequence
 
@@ -167,6 +169,18 @@ class DryRunMacroPublishProvider:
         return tuple(MacroPublishResult(macro=macro, status="dry_run") for macro in macros)
 
 
+def macro_content_hash(macro: SupportMacroDraft) -> str:
+    """Return a stable digest of the customer-facing macro content."""
+
+    payload = {
+        "title": _clean_text(macro.title),
+        "body": _canonical_body(macro.body),
+        "category": _clean_text(macro.category),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def build_macro_writeback_preview(
     drafts: Sequence[TicketFAQDraft],
 ) -> MacroWritebackPreview:
@@ -236,6 +250,11 @@ def _macro_body(item: Mapping[str, Any]) -> str:
         return "\n".join(f"{index}. {step}" for index, step in enumerate(steps, start=1))
 
     return _clean_text(item.get("answer"))
+
+
+def _canonical_body(value: Any) -> str:
+    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    return "\n".join(line.rstrip() for line in text.split("\n"))
 
 
 def _item_id(

--- a/extracted_content_pipeline/faq_macro_writeback_zendesk.py
+++ b/extracted_content_pipeline/faq_macro_writeback_zendesk.py
@@ -15,6 +15,7 @@ from .faq_macro_writeback import (
     MacroWritebackMapping,
     MacroWritebackMappingRepository,
     SupportMacroDraft,
+    macro_content_hash,
 )
 
 
@@ -209,10 +210,7 @@ class ZendeskMacroPublishProvider:
                         faq_item_id=macro.faq_item_id,
                         external_id="",
                         publish_status="pending",
-                        metadata={
-                            "title": macro.title,
-                            "category": macro.category,
-                        },
+                        metadata=_mapping_metadata(macro),
                     ),
                     scope=scope,
                 )
@@ -253,10 +251,7 @@ class ZendeskMacroPublishProvider:
                             fallback=existing.external_url if existing else "",
                         ),
                         publish_status="published",
-                        metadata={
-                            "title": macro.title,
-                            "category": macro.category,
-                        },
+                        metadata=_mapping_metadata(macro),
                     ),
                     scope=scope,
                 )
@@ -394,10 +389,7 @@ class ZendeskMacroPublishProvider:
                 external_id=external_id,
                 external_url=_clean(match.get("url")),
                 publish_status="published",
-                metadata={
-                    "title": macro.title,
-                    "category": macro.category,
-                },
+                metadata=_mapping_metadata(macro),
             ),
             scope=scope,
         )
@@ -421,6 +413,14 @@ def _description(macro: SupportMacroDraft) -> str:
     if macro.category:
         return f"FAQ macro generated from {macro.category} support tickets."
     return "FAQ macro generated from support tickets."
+
+
+def _mapping_metadata(macro: SupportMacroDraft) -> JsonDict:
+    return {
+        "title": macro.title,
+        "category": macro.category,
+        "content_hash": macro_content_hash(macro),
+    }
 
 
 def _headers(credentials: ZendeskMacroCredentials) -> dict[str, str]:

--- a/plans/PR-FAQ-Macro-Writeback-Content-Hash-Update.md
+++ b/plans/PR-FAQ-Macro-Writeback-Content-Hash-Update.md
@@ -1,0 +1,64 @@
+# PR-FAQ-Macro-Writeback-Content-Hash-Update
+## Why this slice exists
+PR-FAQ-Macro-Writeback-Scheduled-Publish intentionally deferred body-only FAQ
+edit detection. The scheduled publisher currently selects a previously
+published macro for update when the mapping is missing, pending, unpublished,
+or when title/category drift. If an approved FAQ answer changes but its
+question and topic stay the same, the scheduled task can skip the draft and
+leave Zendesk with stale customer-facing macro text.
+## Scope (this PR)
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+1. Add a deterministic content hash for the platform-agnostic macro body
+   contract.
+2. Store that hash in Zendesk mapping metadata on create/update/reservation.
+3. Select scheduled publish candidates when a published mapping is missing the
+   hash or has a stale hash, so body-only edits update instead of no-op.
+4. Add focused tests for hash stability, Zendesk metadata persistence, and
+   scheduled candidate selection on body-only edits.
+### Files touched
+- `plans/PR-FAQ-Macro-Writeback-Content-Hash-Update.md`
+- `extracted_content_pipeline/faq_macro_writeback.py`
+- `extracted_content_pipeline/faq_macro_writeback_zendesk.py`
+- `atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py`
+- `tests/test_extracted_ticket_faq_macro_writeback.py`
+- `tests/test_extracted_ticket_faq_macro_writeback_zendesk.py`
+- `tests/test_autonomous_faq_macro_writeback_scheduled_publish.py`
+## Mechanism
+The macro core exposes a small helper that canonicalizes the publish-relevant
+fields (`title`, `body`, `category`) and returns a stable SHA-256 digest.
+Zendesk writes that digest into mapping metadata whenever it reserves or
+persists a mapping. The scheduled selector continues to reuse the shared
+preview/double gate, but `_has_unpublished_macro(...)` also compares the stored
+`content_hash` with the current macro digest. A missing stored hash is treated
+as needs-update so existing mappings backfill safely on their next scheduled
+pass.
+## Intentional
+- No migration is needed; mapping metadata is already JSONB and optional.
+- No live Zendesk API calls; CI uses existing fake transport/repository tests.
+- No adapter work for Freshdesk, Help Scout, or Gorgias in this slice. Their
+  write APIs are logged locally for future adapter slices, but this PR hardens
+  the shipped Zendesk path.
+- The selector still calls the existing publish service; the double gate and
+  provider idempotency remain the source of truth.
+## Deferred
+- Future PR: operator-facing telemetry beyond the scheduled task result
+  summary if operators need a dashboard view of update/backfill counts.
+Parked hardening: none.
+## Verification
+- Python compile check for the changed modules and tests - passed.
+- Focused pytest for macro core, Zendesk adapter, and scheduled selector - 25 passed.
+- Extracted package validation - passed.
+- Extracted reasoning-import guard - passed.
+- Extracted standalone audit with fail-on-debt - passed.
+- ASCII check for extracted package Python files - passed.
+- Full extracted pipeline CI mirror - 2877 passed, 10 skipped, 1 existing torch/pynvml warning.
+## Estimated diff size
+| Area | LOC |
+|---|---:|
+| Plan | 64 |
+| Core helper | 19 |
+| Zendesk adapter | 24 |
+| Scheduler selector | 2 |
+| Tests | 80 |
+| **Total** | **189** |

--- a/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
+++ b/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
@@ -9,7 +9,11 @@ from atlas_brain.autonomous.tasks.faq_macro_writeback_scheduled_publish import (
     run_scheduled_faq_macro_writeback,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
-from extracted_content_pipeline.faq_macro_writeback import MacroWritebackMapping
+from extracted_content_pipeline.faq_macro_writeback import (
+    MacroWritebackMapping,
+    SupportMacroDraft,
+    macro_content_hash,
+)
 from extracted_content_pipeline.faq_macro_writeback_publish import FAQMacroPublishSummary
 from extracted_content_pipeline.faq_macro_writeback_zendesk import ZENDESK_PLATFORM
 from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
@@ -33,8 +37,9 @@ class _FAQRepo:
 
 
 class _MappingRepo:
-    def __init__(self, published: set[str] | None = None) -> None:
+    def __init__(self, published: set[str] | None = None, *, published_body: str = "Use the export button.") -> None:
         self.published = published or set()
+        self.published_body = published_body
         self.calls = []
 
     async def get_mapping(self, **kwargs):
@@ -42,7 +47,26 @@ class _MappingRepo:
         faq_id = str(kwargs["faq_draft_id"])
         if faq_id not in self.published:
             return None
-        return MacroWritebackMapping(platform=ZENDESK_PLATFORM, faq_draft_id=faq_id, faq_item_id=str(kwargs["faq_item_id"]), external_id=f"macro-{faq_id}", publish_status="published", metadata={"title": f"{faq_id}?", "category": ""})
+        faq_item_id = str(kwargs["faq_item_id"])
+        return MacroWritebackMapping(
+            platform=ZENDESK_PLATFORM,
+            faq_draft_id=faq_id,
+            faq_item_id=faq_item_id,
+            external_id=f"macro-{faq_id}",
+            publish_status="published",
+            metadata={
+                "title": f"{faq_id}?",
+                "category": "",
+                "content_hash": macro_content_hash(
+                    SupportMacroDraft(
+                        title=f"{faq_id}?",
+                        body=self.published_body,
+                        faq_draft_id=faq_id,
+                        faq_item_id=faq_item_id,
+                    )
+                ),
+            },
+        )
 
 
 class _TenantRepo:
@@ -86,6 +110,17 @@ async def test_candidate_selection_uses_shared_gate_and_mapping_idempotency() ->
     assert candidates == ("allowed",)
     assert faq_repo.calls[0]["status"] == "approved"
     assert all(call["platform"] == ZENDESK_PLATFORM for call in mapping_repo.calls)
+
+
+@pytest.mark.asyncio
+async def test_candidate_selection_republishes_body_only_macro_changes() -> None:
+    faq_repo = _FAQRepo((_draft("body-changed"),))
+    mapping_repo = _MappingRepo({"body-changed"}, published_body="Use the old export button.")
+    repo = PostgresScheduledFAQMacroCandidateRepository(pool=object(), faq_repository=faq_repo, mapping_repository=mapping_repo)
+
+    candidates = await repo.list_candidate_faq_ids(ZendeskTenant("acct-1"), limit=10)
+
+    assert candidates == ("body-changed",)
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ticket_faq_macro_writeback.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback.py
@@ -6,6 +6,7 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.faq_macro_writeback import (
     DryRunMacroPublishProvider,
     build_macro_writeback_preview,
+    macro_content_hash,
 )
 from extracted_content_pipeline.ticket_faq_markdown import build_ticket_faq_markdown
 from extracted_content_pipeline.ticket_faq_ports import TicketFAQDraft
@@ -129,6 +130,40 @@ def test_macro_writeback_preview_falls_back_to_numbered_steps() -> None:
         "1. Open Settings.\n"
         "2. Choose Reset password."
     )
+
+
+def test_macro_content_hash_tracks_customer_facing_body_changes() -> None:
+    preview = build_macro_writeback_preview([
+        _draft(
+            items=(
+                {
+                    "faq_item_id": "faq-item-1",
+                    "topic": "billing confusion",
+                    "question": "How do I export?",
+                    "resolution_text": "Open Reports and choose Export.",
+                    "answer_evidence_status": "resolution_evidence",
+                },
+            )
+        )
+    ])
+    original = preview.macros[0]
+    same_content = type(original)(
+        title="  How   do I export? ",
+        body="Open Reports and choose Export.\n",
+        category=" billing confusion ",
+        faq_draft_id=original.faq_draft_id,
+        faq_item_id=original.faq_item_id,
+    )
+    changed_body = type(original)(
+        title=original.title,
+        body="Open Reports, choose Export, then select CSV.",
+        category=original.category,
+        faq_draft_id=original.faq_draft_id,
+        faq_item_id=original.faq_item_id,
+    )
+
+    assert macro_content_hash(original) == macro_content_hash(same_content)
+    assert macro_content_hash(original) != macro_content_hash(changed_body)
 
 
 def test_macro_writeback_preview_uses_real_faq_generator_resolution_steps() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback_zendesk.py
@@ -9,6 +9,7 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.faq_macro_writeback import (
     MacroWritebackMapping,
     SupportMacroDraft,
+    macro_content_hash,
 )
 from extracted_content_pipeline.faq_macro_writeback_zendesk import (
     StaticZendeskMacroCredentialsProvider,
@@ -159,11 +160,13 @@ async def test_zendesk_provider_creates_macro_and_persists_mapping() -> None:
     assert saved.metadata == {
         "title": "Why was I charged twice?",
         "category": "billing",
+        "content_hash": macro_content_hash(_macro()),
     }
     assert "secret-token" not in saved.as_dict()["metadata"].values()
     reserved = repo.reserve_calls[0]["mapping"]
     assert reserved.publish_status == "pending"
     assert reserved.external_id == ""
+    assert reserved.metadata["content_hash"] == macro_content_hash(_macro())
 
 
 @pytest.mark.asyncio
@@ -258,6 +261,7 @@ async def test_zendesk_provider_reconciles_pending_mapping_before_update() -> No
     assert reconciled.external_id == "123"
     assert reconciled.external_url == "https://example.zendesk.com/api/v2/macros/123"
     assert saved.external_url == "https://example.zendesk.com/api/v2/macros/123"
+    assert saved.metadata["content_hash"] == macro_content_hash(_macro())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Content-Hash-Update.md
Slice phase: Production hardening

Adds deterministic content hashes for FAQ macro writeback so the scheduled Zendesk publisher detects approved+verified answer/body-only edits, republishes stale macros, and stores the digest in mapping metadata during create/update/reservation.

## Intentional
- No migration; mapping metadata is already JSONB and optional.
- No live Zendesk API calls; CI uses existing fake transport/repository tests.
- No adapter work for Freshdesk, Help Scout, or Gorgias in this slice; this hardens the shipped Zendesk path.
- The selector still calls the existing publish service; the double gate and provider idempotency remain the source of truth.

## Deferred
- Future PR: operator-facing telemetry beyond the scheduled task result summary if operators need a dashboard view of update/backfill counts.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_macro_writeback.py extracted_content_pipeline/faq_macro_writeback_zendesk.py atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py tests/test_extracted_ticket_faq_macro_writeback.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_autonomous_faq_macro_writeback_scheduled_publish.py` - passed.
- `python -m pytest tests/test_extracted_ticket_faq_macro_writeback.py tests/test_extracted_ticket_faq_macro_writeback_zendesk.py tests/test_autonomous_faq_macro_writeback_scheduled_publish.py -q` - 25 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2877 passed, 10 skipped, 1 existing torch/pynvml warning.

## Diff size
7 files, +174 / -15.
