### PR TITLE
PR-FAQ-Macro-Writeback-Scheduled-Telemetry

### DIFF
--- a/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
+++ b/.github/workflows/atlas_content_ops_macro_writeback_checks.yml
@@ -4,23 +4,27 @@ on:
   pull_request:
     paths:
       - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "atlas_brain/autonomous/runner.py"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_scheduler.py"
+      - "tests/test_synthesis.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_macro_writeback_checks.yml"
+      - "atlas_brain/autonomous/runner.py"
       - "atlas_brain/autonomous/scheduler.py"
       - "atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py"
       - "atlas_brain/autonomous/tasks/__init__.py"
       - "atlas_brain/config.py"
       - "tests/test_autonomous_faq_macro_writeback_scheduled_publish.py"
       - "tests/test_scheduler.py"
+      - "tests/test_synthesis.py"
 
 jobs:
   atlas-content-ops-macro-writeback-checks:
@@ -46,4 +50,8 @@ jobs:
           python -m pytest \
             tests/test_autonomous_faq_macro_writeback_scheduled_publish.py \
             tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in \
+            tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary \
+            tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message \
+            tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal \
+            tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape \
             -q

--- a/atlas_brain/autonomous/runner.py
+++ b/atlas_brain/autonomous/runner.py
@@ -114,7 +114,8 @@ class HeadlessRunner:
         if isinstance(meta, str):
             import json as _json
             meta = _json.loads(meta)
-        handler_name = (meta or {}).get("builtin_handler")
+        meta = meta or {}
+        handler_name = meta.get("builtin_handler")
         if not handler_name:
             return AgentResult(
                 success=False,
@@ -136,8 +137,33 @@ class HeadlessRunner:
         try:
             result = await handler(task)
 
+            if isinstance(result, dict):
+                skip_msg = self._is_trivial_result(result)
+                if skip_msg and meta.get("notify_skipped_result"):
+                    logger.info(
+                        "Notifying skipped-synthesis result for task '%s'",
+                        task.name,
+                    )
+                    try:
+                        await self._notify_result(skip_msg, task)
+                    except Exception:
+                        logger.warning(
+                            "Failed to notify skipped-synthesis result for task '%s'",
+                            task.name,
+                            exc_info=True,
+                        )
+                    return AgentResult(
+                        success=True,
+                        response_text=skip_msg,
+                        metadata={
+                            "raw_result": result,
+                            "synthesis_skipped": True,
+                            "skipped_result_notification_attempted": True,
+                        },
+                    )
+
             # Post-processing: LLM synthesis via skill
-            skill_name = (task.metadata or {}).get("synthesis_skill")
+            skill_name = meta.get("synthesis_skill")
             if skill_name and isinstance(result, dict):
                 skip_msg = self._is_trivial_result(result)
                 if skip_msg:
@@ -152,7 +178,7 @@ class HeadlessRunner:
                         metadata={"raw_result": result, "synthesis_skipped": True},
                     )
                 else:
-                    synthesis_llm = (task.metadata or {}).get("synthesis_llm")
+                    synthesis_llm = meta.get("synthesis_llm")
                     synthesized = await self._synthesize_with_skill(
                         result, skill_name, task.name, synthesis_llm=synthesis_llm,
                     )

--- a/atlas_brain/autonomous/scheduler.py
+++ b/atlas_brain/autonomous/scheduler.py
@@ -857,7 +857,11 @@ class TaskScheduler:
             "schedule_type": "interval",
             "interval_seconds": None,  # resolved from settings.b2b_campaign
             "timeout_seconds": 600,
-            "metadata": {"builtin_handler": "content_ops_faq_macro_writeback_scheduled_publish"},
+            "metadata": {
+                "builtin_handler": "content_ops_faq_macro_writeback_scheduled_publish",
+                "notify_skipped_result": True,
+                "notify_tags": "ticket,repeat",
+            },
         },
         {
             "name": "falsification_check",

--- a/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
+++ b/atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py
@@ -119,7 +119,6 @@ async def run_scheduled_faq_macro_writeback(*, candidate_repository: Any, publis
         "drafts_published_ok": 0,
         "drafts_failed": 0,
         "tenants": [],
-        "_skip_synthesis": "Scheduled FAQ macro writeback complete",
     }
     if tenants_deferred:
         logger.warning(
@@ -152,6 +151,7 @@ async def run_scheduled_faq_macro_writeback(*, candidate_repository: Any, publis
             tenant_result["drafts"].append(item)
         tenant_result["status"] = "processed" if faq_ids else "no_candidates"
         result["tenants"].append(tenant_result)
+    result["_skip_synthesis"] = summarize_scheduled_faq_macro_writeback(result)
     return result
 
 
@@ -213,3 +213,15 @@ async def _has_unpublished_macro(
 
 def _clean(value: Any) -> str:
     return " ".join(str(value or "").strip().split())
+
+
+def summarize_scheduled_faq_macro_writeback(result: dict[str, Any]) -> str:
+    return (
+        "Scheduled FAQ macro writeback complete: "
+        f"{int(result.get('tenants_checked') or 0)} tenants checked, "
+        f"{int(result.get('tenants_deferred_by_limit') or 0)} deferred, "
+        f"{int(result.get('tenants_skipped_no_credentials') or 0)} skipped without Zendesk credentials, "
+        f"{int(result.get('drafts_selected') or 0)} drafts selected, "
+        f"{int(result.get('drafts_published_ok') or 0)} published, "
+        f"{int(result.get('drafts_failed') or 0)} failed."
+    )

--- a/plans/PR-FAQ-Macro-Writeback-Scheduled-Telemetry.md
+++ b/plans/PR-FAQ-Macro-Writeback-Scheduled-Telemetry.md
@@ -1,0 +1,66 @@
+# PR-FAQ-Macro-Writeback-Scheduled-Telemetry
+## Why this slice exists
+PR-FAQ-Macro-Writeback-Scheduled-Publish intentionally deferred
+operator-facing telemetry beyond the task result summary. The scheduled
+publisher now returns a `_skip_synthesis` result so the runner avoids an LLM
+summary, but the runner only notifies synthesized results. That leaves a
+successful recurring Zendesk publish run silent even when autonomous result
+notifications are enabled.
+## Scope (this PR)
+Ownership lane: content-ops/faq-macro-writeback
+Slice phase: Production hardening
+1. Add a runner metadata opt-in that sends `_skip_synthesis` builtin results
+   through the existing best-effort `_notify_result(...)` path.
+2. Register the scheduled FAQ macro publisher with that opt-in and notification
+   tags.
+3. Make the scheduled publisher's skipped-synthesis message include the
+   aggregate tenant/draft counts it already computes.
+4. Add focused tests for the runner opt-in, scheduler metadata, and scheduled
+   summary content.
+### Files touched
+- `plans/PR-FAQ-Macro-Writeback-Scheduled-Telemetry.md`
+- `.github/workflows/atlas_content_ops_macro_writeback_checks.yml`
+- `atlas_brain/autonomous/runner.py`
+- `atlas_brain/autonomous/scheduler.py`
+- `atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py`
+- `tests/test_synthesis.py`
+- `tests/test_scheduler.py`
+- `tests/test_autonomous_faq_macro_writeback_scheduled_publish.py`
+## Mechanism
+The runner already centralizes notification delivery in `_notify_result(...)`,
+which catches per-channel failures and respects the global autonomous notify
+settings plus per-task `notify` metadata. This slice adds one small hook after
+a builtin handler returns: if the result has a non-empty `_skip_synthesis`
+string and the task metadata sets `notify_skipped_result`, the runner sends
+that string through `_notify_result(...)` and returns the normal skipped
+metadata. The scheduled macro task opts into that hook and replaces its static
+skip string with a compact count summary after aggregation.
+## Intentional
+- No dashboard or history UI is added; this is only the autonomous notification
+  path and compact run summary.
+- No LLM synthesis is introduced for macro publish results; `_skip_synthesis`
+  remains the deterministic path.
+- No publish selection, Zendesk transport, credential lookup, or idempotency
+  logic changes. Those were shipped in #1215 and #1216.
+- Notification delivery remains best-effort and uses the existing
+  `_notify_result(...)` channel handling rather than a task-specific sender.
+## Deferred
+- Future PR: operator-facing dashboard/history surfaces if the compact
+  autonomous notification is not enough for day-to-day operations.
+Parked hardening: none.
+## Verification
+- Python compile check for runner, scheduler, scheduled task, and tests -
+  passed.
+- Focused CI-enrolled macro-writeback workflow command with scheduled task,
+  scheduler metadata, and runner skipped-notify tests - 12 passed.
+- Broader synthesis + scheduled publish focused pytest - 25 passed.
+- ASCII check for extracted package Python files - passed.
+- Diff whitespace check - passed.
+## Estimated diff size
+| Area | LOC |
+|---|---:|
+| Plan | 65 |
+| Workflow | 10 |
+| Runner/scheduler/task | 45 |
+| Tests | 80 |
+| **Total** | **200** |

--- a/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
+++ b/tests/test_autonomous_faq_macro_writeback_scheduled_publish.py
@@ -7,6 +7,7 @@ from atlas_brain.autonomous.tasks.faq_macro_writeback_scheduled_publish import (
     StoredOnlyZendeskMacroCredentialsProvider,
     ZendeskTenant,
     run_scheduled_faq_macro_writeback,
+    summarize_scheduled_faq_macro_writeback,
 )
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.faq_macro_writeback import (
@@ -141,6 +142,10 @@ async def test_scheduled_publish_skips_missing_credentials_and_isolates_failures
     assert result["drafts_failed"] == 1
     assert result["drafts_published_ok"] == 1
     assert result["tenants"][1]["drafts"][0]["error"] == "RuntimeError"
+    assert result["_skip_synthesis"] == (
+        "Scheduled FAQ macro writeback complete: 2 tenants checked, 0 deferred, "
+        "1 skipped without Zendesk credentials, 2 drafts selected, 1 published, 1 failed."
+    )
 
 
 @pytest.mark.asyncio
@@ -158,6 +163,24 @@ async def test_scheduled_publish_reports_tenant_cap_truncation(caplog) -> None:
     assert result["tenants_checked"] == 25
     assert result["tenants_deferred_by_limit"] == 2
     assert "deferred 2 of 27 enrolled tenants" in caplog.text
+
+
+def test_scheduled_publish_summary_includes_aggregate_counts() -> None:
+    summary = summarize_scheduled_faq_macro_writeback(
+        {
+            "tenants_checked": 3,
+            "tenants_deferred_by_limit": 2,
+            "tenants_skipped_no_credentials": 1,
+            "drafts_selected": 5,
+            "drafts_published_ok": 4,
+            "drafts_failed": 1,
+        }
+    )
+
+    assert summary == (
+        "Scheduled FAQ macro writeback complete: 3 tenants checked, 2 deferred, "
+        "1 skipped without Zendesk credentials, 5 drafts selected, 4 published, 1 failed."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -664,6 +664,21 @@ class TestDefaults:
         s = _scheduler()
         assert s.scheduled_count == 0
 
+    def test_content_ops_faq_macro_writeback_default_notifies_skipped_summary(self):
+        s = _scheduler()
+        task_def = next(
+            task
+            for task in s._DEFAULT_TASKS
+            if task["name"] == "content_ops_faq_macro_writeback_scheduled_publish"
+        )
+
+        assert (
+            task_def["metadata"]["builtin_handler"]
+            == "content_ops_faq_macro_writeback_scheduled_publish"
+        )
+        assert task_def["metadata"]["notify_skipped_result"] is True
+        assert task_def["metadata"]["notify_tags"] == "ticket,repeat"
+
     @pytest.mark.asyncio
     @patch("atlas_brain.storage.repositories.scheduled_task.get_scheduled_task_repo")
     async def test_ensure_default_tasks_continues_when_seeded_task_registration_fails(self, mock_repo_fn, monkeypatch):

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -25,8 +25,9 @@ from atlas_brain.storage.models import ScheduledTask
 def _builtin_task(
     handler: str = "gmail_digest",
     synthesis_skill: str | None = None,
+    metadata: dict | None = None,
 ) -> ScheduledTask:
-    metadata = {"builtin_handler": handler}
+    metadata = {"builtin_handler": handler, **(metadata or {})}
     if synthesis_skill:
         metadata["synthesis_skill"] = synthesis_skill
     return ScheduledTask(
@@ -271,3 +272,60 @@ class TestRunBuiltinSynthesis:
 
         assert result.success is True
         assert result.response_text == str(SAMPLE_RAW_RESULT)
+
+    @pytest.mark.asyncio
+    async def test_skip_synthesis_notify_opt_in_uses_fallback_message(self, runner):
+        async def skipped_handler(task):
+            return {
+                "count": 2,
+                "_skip_synthesis": "Scheduled FAQ macro writeback complete: 2 published.",
+            }
+
+        runner.register_builtin("skipped_digest", skipped_handler)
+        runner._notify_result = AsyncMock()
+        task = _builtin_task(
+            handler="skipped_digest",
+            metadata={"notify_skipped_result": True},
+        )
+
+        result = await runner._run_builtin(task)
+
+        assert result.success is True
+        assert result.response_text == "Scheduled FAQ macro writeback complete: 2 published."
+        assert result.metadata["synthesis_skipped"] is True
+        assert result.metadata["skipped_result_notification_attempted"] is True
+        runner._notify_result.assert_awaited_once_with(result.response_text, task)
+
+    @pytest.mark.asyncio
+    async def test_skip_synthesis_notify_failure_is_nonfatal(self, runner):
+        async def skipped_handler(task):
+            return {"_skip_synthesis": "Scheduled FAQ macro writeback complete."}
+
+        runner.register_builtin("skipped_digest", skipped_handler)
+        runner._notify_result = AsyncMock(side_effect=RuntimeError("ntfy unavailable"))
+        task = _builtin_task(
+            handler="skipped_digest",
+            metadata={"notify_skipped_result": True},
+        )
+
+        result = await runner._run_builtin(task)
+
+        assert result.success is True
+        assert result.response_text == "Scheduled FAQ macro writeback complete."
+
+    @pytest.mark.asyncio
+    async def test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape(self, runner):
+        async def skipped_handler(task):
+            return {"_skip_synthesis": "Scheduled FAQ macro writeback complete."}
+
+        runner.register_builtin("skipped_digest", skipped_handler)
+        runner._notify_result = AsyncMock()
+        task = _builtin_task(handler="skipped_digest")
+
+        result = await runner._run_builtin(task)
+
+        assert result.success is True
+        assert result.response_text == str(
+            {"_skip_synthesis": "Scheduled FAQ macro writeback complete."}
+        )
+        runner._notify_result.assert_not_awaited()


### PR DESCRIPTION
Plan: plans/PR-FAQ-Macro-Writeback-Scheduled-Telemetry.md
Slice phase: Production hardening

The scheduled FAQ macro publisher returns `_skip_synthesis` to avoid LLM summarization, but skipped-synthesis builtin results were not notified. This adds a metadata-gated runner hook so the scheduled Zendesk publish task can notify with a compact deterministic count summary after each run.

## Intentional
- Reuse the existing runner `_notify_result(...)` path; no task-specific notification transport.
- Keep scheduled publish deterministic and LLM-free via `_skip_synthesis`.
- Leave publish selection, Zendesk credentials, and idempotency unchanged.

## Deferred
- Future PR: operator-facing dashboard/history surfaces if compact notifications are not enough.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/autonomous/runner.py atlas_brain/autonomous/scheduler.py atlas_brain/autonomous/tasks/faq_macro_writeback_scheduled_publish.py tests/test_synthesis.py tests/test_scheduler.py tests/test_autonomous_faq_macro_writeback_scheduled_publish.py`
- `python -m pytest tests/test_autonomous_faq_macro_writeback_scheduled_publish.py tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_seed_respects_opt_in tests/test_scheduler.py::TestDefaults::test_content_ops_faq_macro_writeback_default_notifies_skipped_summary tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_opt_in_uses_fallback_message tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_notify_failure_is_nonfatal tests/test_synthesis.py::TestRunBuiltinSynthesis::test_skip_synthesis_without_notify_opt_in_keeps_existing_response_shape -q` -- 12 passed, 1 existing torch/pynvml warning.
- `pytest tests/test_synthesis.py tests/test_autonomous_faq_macro_writeback_scheduled_publish.py` -- 25 passed, 1 existing torch/pynvml warning.
- `bash scripts/check_ascii_python.sh`
- `bash scripts/local_pr_review.sh --current-pr-body-file <prepared body> origin/main`
- `git diff --check`

## Diff size
8 files, +218 / -6
