### PR TITLE
PR-Invoicing-Approval-Blockers-Import-Cycles

### DIFF
--- a/.github/workflows/atlas_invoicing_checks.yml
+++ b/.github/workflows/atlas_invoicing_checks.yml
@@ -1,0 +1,47 @@
+name: Atlas Invoicing Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_invoicing_checks.yml"
+      - "atlas_brain/mcp/invoicing_server.py"
+      - "atlas_brain/services/__init__.py"
+      - "atlas_brain/storage/repositories/invoice.py"
+      - "atlas_brain/templates/email/__init__.py"
+      - "tests/test_monthly_invoice_generation.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_invoicing_checks.yml"
+      - "atlas_brain/mcp/invoicing_server.py"
+      - "atlas_brain/services/__init__.py"
+      - "atlas_brain/storage/repositories/invoice.py"
+      - "atlas_brain/templates/email/__init__.py"
+      - "tests/test_monthly_invoice_generation.py"
+
+jobs:
+  atlas-invoicing-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run invoicing approval blocker tests
+        run: |
+          python -m pytest \
+            tests/test_monthly_invoice_generation.py \
+            -k "update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities" \
+            -q

--- a/atlas_brain/mcp/invoicing_server.py
+++ b/atlas_brain/mcp/invoicing_server.py
@@ -988,14 +988,6 @@ async def approve_and_send(
     if not invoices_to_send:
         return json.dumps({"success": True, "message": f"No {status_filter} invoices found", "processed": 0})
 
-    from ..services.invoice_pdf import render_invoice_pdf
-    from ..services.email_provider import get_email_provider
-    from ..templates.email.invoice import BUSINESS_NAME, BUSINESS_PHONE, BUSINESS_EMAIL
-    from ..config import settings
-
-    save_base = os.path.expanduser(settings.invoicing.auto_invoice_save_path)
-    email_provider = get_email_provider()
-
     results = {
         "processed": 0,
         "sent": 0,
@@ -1045,6 +1037,14 @@ async def approve_and_send(
             })
             results["processed"] += 1
             continue
+
+        from ..config import settings
+        from ..services.email_provider import get_email_provider
+        from ..services.invoice_pdf import render_invoice_pdf
+        from ..templates.email.invoice import BUSINESS_EMAIL, BUSINESS_NAME, BUSINESS_PHONE
+
+        save_base = os.path.expanduser(settings.invoicing.auto_invoice_save_path)
+        email_provider = get_email_provider()
 
         # Generate PDF
         try:

--- a/atlas_brain/services/__init__.py
+++ b/atlas_brain/services/__init__.py
@@ -9,6 +9,9 @@ This module provides:
 Note: VLM (moondream) and VOS were removed — they are not used.
 """
 
+from importlib import import_module
+from typing import Any
+
 from .protocols import (
     InferenceMetrics,
     LLMService,
@@ -25,7 +28,6 @@ from . import llm  # noqa: F401
 
 # New services
 from .embedding import SentenceTransformerEmbedding
-from .reminders import ReminderService, get_reminder_service
 
 __all__ = [
     # Protocols
@@ -43,3 +45,12 @@ __all__ = [
     "ReminderService",
     "get_reminder_service",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"ReminderService", "get_reminder_service"}:
+        module = import_module(".reminders", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/atlas_brain/storage/repositories/invoice.py
+++ b/atlas_brain/storage/repositories/invoice.py
@@ -17,6 +17,33 @@ from ..exceptions import DatabaseUnavailableError, DatabaseOperationError
 logger = logging.getLogger("atlas.storage.invoice")
 
 
+def _line_items_are_billable(items: list[dict]) -> bool:
+    """Return True when every line item has positive quantity and unit price."""
+    if not items:
+        return False
+    try:
+        return all(
+            Decimal(str(item.get("quantity", 0))) > 0
+            and Decimal(str(item.get("unit_price", 0))) > 0
+            for item in items
+        )
+    except Exception:
+        return False
+
+
+def _line_items_with_amounts(items: list[dict], *, overwrite: bool) -> list[dict]:
+    """Return line items with calculated amounts, optionally replacing stale values."""
+    normalized: list[dict] = []
+    for item in items:
+        line = dict(item)
+        if overwrite or "amount" not in line:
+            line["amount"] = float(
+                Decimal(str(line.get("quantity", 1))) * Decimal(str(line.get("unit_price", 0)))
+            )
+        normalized.append(line)
+    return normalized
+
+
 class InvoiceRepository:
     """Repository for invoice and payment storage and retrieval."""
 
@@ -271,19 +298,26 @@ class InvoiceRepository:
             )
 
         # Recalculate amounts if line_items or rates change
-        items = line_items if line_items is not None else current["line_items"]
+        items = _line_items_with_amounts(
+            line_items if line_items is not None else current["line_items"],
+            overwrite=line_items is not None,
+        )
         tax_r = tax_rate if tax_rate is not None else float(current["tax_rate"])
         disc = discount_amount if discount_amount is not None else float(current["discount_amount"])
+        metadata = current.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        if (
+            line_items is not None
+            and metadata.get("needs_hours")
+            and _line_items_are_billable(items)
+        ):
+            metadata = {**metadata, "needs_hours": False}
 
         subtotal = sum(
             Decimal(str(item.get("quantity", 1))) * Decimal(str(item.get("unit_price", 0)))
             for item in items
         )
-        for item in items:
-            if "amount" not in item:
-                item["amount"] = float(
-                    Decimal(str(item.get("quantity", 1))) * Decimal(str(item.get("unit_price", 0)))
-                )
         tax_amt = subtotal * Decimal(str(tax_r))
         total = subtotal + tax_amt - Decimal(str(disc))
 
@@ -301,7 +335,8 @@ class InvoiceRepository:
                     total_amount = $9,
                     invoice_for = COALESCE($10, invoice_for),
                     contact_name = COALESCE($11, contact_name),
-                    updated_at = $12
+                    metadata = $12::jsonb,
+                    updated_at = $13
                 WHERE id = $1
                 RETURNING *
                 """,
@@ -316,6 +351,7 @@ class InvoiceRepository:
                 float(total),
                 invoice_for,
                 contact_name,
+                json.dumps(metadata),
                 datetime.now(timezone.utc),
             )
             return self._row_to_dict(row) if row else None

--- a/atlas_brain/templates/email/__init__.py
+++ b/atlas_brain/templates/email/__init__.py
@@ -1,5 +1,8 @@
 """Email templates for Effingham Office Maids."""
 
+from importlib import import_module
+from typing import Any
+
 from .estimate_confirmation import (
     BUSINESS_NAME,
     BUSINESS_PHONE,
@@ -17,20 +20,6 @@ from .proposal import (
 from .invoice import (
     render_invoice_html,
     render_invoice_text,
-)
-
-from .vendor_briefing import render_vendor_briefing_html
-from .vendor_checkout_confirmation import (
-    render_checkout_confirmation_html,
-    render_checkout_confirmation_text,
-)
-from .vendor_report_delivery import (
-    render_report_delivery_html,
-    render_report_delivery_text,
-)
-from .report_subscription_delivery import (
-    render_report_subscription_delivery_html,
-    render_report_subscription_delivery_text,
 )
 
 __all__ = [
@@ -52,3 +41,23 @@ __all__ = [
     "render_report_subscription_delivery_html",
     "render_report_subscription_delivery_text",
 ]
+
+_LAZY_EXPORT_MODULES = {
+    "render_vendor_briefing_html": ".vendor_briefing",
+    "render_checkout_confirmation_html": ".vendor_checkout_confirmation",
+    "render_checkout_confirmation_text": ".vendor_checkout_confirmation",
+    "render_report_delivery_html": ".vendor_report_delivery",
+    "render_report_delivery_text": ".vendor_report_delivery",
+    "render_report_subscription_delivery_html": ".report_subscription_delivery",
+    "render_report_subscription_delivery_text": ".report_subscription_delivery",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_name, __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/plans/PR-Invoicing-Approval-Blockers-Import-Cycles.md
+++ b/plans/PR-Invoicing-Approval-Blockers-Import-Cycles.md
@@ -1,0 +1,72 @@
+# PR-Invoicing-Approval-Blockers-Import-Cycles
+## Why this slice exists
+Worktree cleanup found a preserved clean branch,
+`codex/invoicing-approval-blockers-preserved`, with one unmerged commit that
+fixed invoice approval blockers and import cycles. Current `origin/main`
+already absorbed part of that work, but the remaining gaps still matter:
+blocked draft invoices import PDF/email machinery before they can be skipped,
+some package `__init__` modules eagerly import settings-dependent modules, and
+updating a monthly placeholder invoice with billable hours does not clear the
+`metadata.needs_hours` blocker.
+## Scope (this PR)
+Ownership lane: invoicing
+Slice phase: Production hardening
+1. Keep the send path from importing PDF/email dependencies until after status,
+   `needs_hours`, email, and dry-run blockers pass.
+2. Lazily resolve remaining package-level exports that can pull
+   settings-dependent modules during imports.
+3. Clear `metadata.needs_hours` only when explicit line-item updates make every
+   line billable, and recalculate replacement line-item amounts before the
+   draft becomes sendable.
+4. Add focused tests for the blocker-clearing helper and invoice update path.
+### Files touched
+- `plans/PR-Invoicing-Approval-Blockers-Import-Cycles.md`
+- `atlas_brain/mcp/invoicing_server.py`
+- `atlas_brain/services/__init__.py`
+- `atlas_brain/storage/repositories/invoice.py`
+- `atlas_brain/templates/email/__init__.py`
+- `.github/workflows/atlas_invoicing_checks.yml`
+- `tests/test_monthly_invoice_generation.py`
+## Mechanism
+The old preserved commit is ported selectively onto current main. The invoice
+repository adds a small `_line_items_are_billable(...)` predicate and, when
+`update_invoice(...)` receives replacement `line_items`, clears an existing
+`metadata.needs_hours` flag only if every line has positive quantity and unit
+price. Explicit replacement line items also have their `amount` fields
+recalculated before persistence, so stale placeholder amounts cannot survive
+into the email/PDF renderers after the blocker clears. The update SQL persists
+the adjusted metadata with the recalculated totals.
+
+`approve_and_send(...)` keeps the existing blocker order but moves PDF,
+settings, email-provider, and invoice-email-template imports to the point where
+a non-dry-run invoice is actually about to be sent. The services and email
+template package exports use `__getattr__` for the settings-dependent optional
+exports, mirroring the lazy `atlas_brain.auth` pattern that already exists on
+current main.
+## Intentional
+- The current main already has lazy `atlas_brain.auth` exports and
+  case-insensitive invoice number lookup, so this PR does not reapply those
+  parts of the preserved branch.
+- No migration is needed; invoice metadata is already JSONB.
+- No email send behavior changes for invoices that pass blockers; imports move
+  later, but the rendered PDF/email path is unchanged.
+## Deferred
+- Future PR: decide whether the preserved `codex/invoicing-approval-blockers-preserved`
+  branch can be deleted after this PR lands.
+Parked hardening: none.
+## Verification
+- Py compile passed for the changed Python files:
+  `python -m py_compile ...`
+- Focused pytest passed:
+  `pytest tests/test_monthly_invoice_generation.py -k 'update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities' -q`
+  Result: 2 passed, 41 deselected.
+- Local PR review passed with the staged PR body:
+  `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`
+## Estimated diff size
+| Area | LOC |
+|---|---:|
+| Plan | 75 |
+| CI workflow | 45 |
+| Invoicing/runtime code | 120 |
+| Tests | 85 |
+| **Total** | **325** |

--- a/tests/test_monthly_invoice_generation.py
+++ b/tests/test_monthly_invoice_generation.py
@@ -1263,6 +1263,90 @@ async def test_approve_and_send_skips_needs_hours_drafts():
 
 
 @pytest.mark.asyncio
+async def test_update_invoice_clears_needs_hours_when_line_items_are_billable(monkeypatch):
+    """Filling real hours should unblock a draft for the pending review queue."""
+    import json
+    from decimal import Decimal
+
+    from atlas_brain.storage.repositories import invoice as invoice_repo_mod
+
+    invoice_id = uuid4()
+    persisted_metadata = {}
+
+    class FakePool:
+        is_initialized = True
+
+        async def fetchrow(self, _query, *args):
+            persisted_metadata.update(json.loads(args[11]))
+            return {
+                "id": invoice_id,
+                "invoice_number": "INV-2026-TEST",
+                "status": "draft",
+                "line_items": args[1],
+                "due_date": args[2],
+                "notes": args[3],
+                "tax_rate": Decimal(str(args[4])),
+                "tax_amount": Decimal(str(args[5])),
+                "discount_amount": Decimal(str(args[6])),
+                "subtotal": Decimal(str(args[7])),
+                "total_amount": Decimal(str(args[8])),
+                "invoice_for": args[9],
+                "contact_name": args[10],
+                "amount_paid": Decimal("0"),
+                "amount_due": Decimal(str(args[8])),
+                "metadata": args[11],
+            }
+
+    async def fake_get_by_id(_invoice_id):
+        return {
+            "id": invoice_id,
+            "status": "draft",
+            "line_items": [
+                {"date": "03/07/2026", "description": "Brookstone (hours TBD)", "quantity": 0, "unit_price": 35.0},
+            ],
+            "tax_rate": 0.0,
+            "discount_amount": 0.0,
+            "metadata": {"needs_hours": True},
+        }
+
+    repo = invoice_repo_mod.InvoiceRepository()
+    monkeypatch.setattr(invoice_repo_mod, "get_db_pool", lambda: FakePool())
+    monkeypatch.setattr(repo, "get_by_id", fake_get_by_id)
+
+    billable_items = [
+        {
+            "date": "03/07/2026",
+            "description": "Brookstone cleaning",
+            "quantity": 2.5,
+            "unit_price": 35.0,
+            "amount": 0.0,
+        },
+    ]
+    updated = await repo.update_invoice(invoice_id=invoice_id, line_items=billable_items)
+
+    assert updated is not None
+    assert persisted_metadata["needs_hours"] is False
+    assert updated["metadata"]["needs_hours"] is False
+    assert updated["total_amount"] == 87.5
+    assert updated["line_items"][0]["amount"] == 87.5
+
+
+def test_line_items_are_billable_requires_all_positive_quantities():
+    from atlas_brain.storage.repositories.invoice import _line_items_are_billable
+
+    assert _line_items_are_billable([
+        {"description": "Cleaning", "quantity": 2.5, "unit_price": 35.0},
+    ])
+    assert not _line_items_are_billable([
+        {"description": "Cleaning", "quantity": 0, "unit_price": 35.0},
+    ])
+    assert not _line_items_are_billable([
+        {"description": "Cleaning", "quantity": 2.5, "unit_price": 0},
+    ])
+    assert not _line_items_are_billable([])
+
+
+@pytest.mark.asyncio
 async def test_export_invoice_pdf():
     """export_invoice_pdf should generate PDF bytes for a real invoice."""
     import json


### PR DESCRIPTION
Plan: plans/PR-Invoicing-Approval-Blockers-Import-Cycles.md
Slice phase: Production hardening

Ports the still-actionable invoicing approval-blocker/import-cycle fixes from the preserved cleanup branch onto current main: blocked drafts skip PDF/email setup before send work starts, settings-dependent package exports resolve lazily, and replacing hourly placeholder line items with billable lines clears the `metadata.needs_hours` blocker while recalculating replacement line-item amounts so stale placeholder `amount` values cannot render as $0.

## Intentional
- Current main already has lazy `atlas_brain.auth` exports and case-insensitive invoice number lookup, so this PR does not reapply those preserved-branch changes.
- No migration is needed; invoice metadata is already JSONB.
- No email send behavior changes for invoices that pass blockers; imports move later, but the rendered PDF/email path is unchanged.

## Deferred
- Future PR: decide whether the preserved `codex/invoicing-approval-blockers-preserved` branch can be deleted after this PR lands.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/mcp/invoicing_server.py atlas_brain/services/__init__.py atlas_brain/storage/repositories/invoice.py atlas_brain/templates/email/__init__.py tests/test_monthly_invoice_generation.py`
- `pytest tests/test_monthly_invoice_generation.py -k 'update_invoice_clears_needs_hours_when_line_items_are_billable or line_items_are_billable_requires_all_positive_quantities' -q` (2 passed, 41 deselected)
- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`

## Diff size
7 files, +289 / -30
