### PR TITLE
PR-Workflow-Teardown-On-Merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,30 @@ unless the operator explicitly asks for a draft. Automated review tools
 do not review draft PRs, so draft mode burns review time and hides
 feedback until the PR is manually marked ready.
 
+### 1g. Teardown on merge
+
+`origin/main` is the only source of truth; local branches and worktrees
+are **disposable**. When a PR merges, tear down its branch and worktree
+the same session:
+
+- `git branch -D <branch>` (squash-merge leaves the local branch
+  unmerged by content, so `-d` refuses — `-D` is expected here).
+- `git worktree remove <dir>` for any worktree dedicated to it
+  (`--force` if it still holds throwaway state).
+
+Do **not** let merged branches or finished worktrees linger. They drift
+behind `origin/main`, accumulate stale staged state, and become the
+hundreds-of-commits-behind worktree and the 300-file dirty index that
+just mirrors already-landed PRs — the exact mess a cleanup session has
+to untangle. Before resurrecting anything from a stale local branch,
+check it against `origin/main` first (`git cherry -v origin/main
+<branch>`); the equivalent change has usually already landed.
+
+Cleanup safety: never run `git clean -f` without a `git clean -nd`
+dry-run first, and read the list. Untracked secret files live in the
+tree (`.env.bak-*`, `*.production.env`, gitignored per the env section)
+and a blanket clean — especially with `-x` — deletes them.
+
 ---
 
 ## 2. Reviewer verdict shape

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,13 +93,15 @@ feedback until the PR is manually marked ready.
 ### 1g. Teardown on merge
 
 `origin/main` is the only source of truth; local branches and worktrees
-are **disposable**. When a PR merges, tear down its branch and worktree
-the same session:
+are **disposable**. When a PR merges, tear down its worktree and branch
+the same session — **worktree first, then branch** (a branch checked out
+in a worktree cannot be deleted: `git branch -D` fails with `'<branch>'
+is already used by worktree at ...`):
 
+- `git worktree remove <dir>` for any worktree dedicated to it
+  (`--force` if it still holds throwaway state). This frees the branch.
 - `git branch -D <branch>` (squash-merge leaves the local branch
   unmerged by content, so `-d` refuses — `-D` is expected here).
-- `git worktree remove <dir>` for any worktree dedicated to it
-  (`--force` if it still holds throwaway state).
 
 Do **not** let merged branches or finished worktrees linger. They drift
 behind `origin/main`, accumulate stale staged state, and become the

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -36,7 +36,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
 >    - Keep the session short. If you've been alive across several PRs, expect to compact soon; finish the current slice, then let the operator restart you fresh with this bootstrap rather than running on.
 >
-> 7. **Teardown on merge (AGENTS.md §1g):** when your PR merges, delete its branch and worktree the same session (`git branch -D <branch>`, `git worktree remove <dir>`). `origin/main` is the only source of truth; local branches/worktrees are disposable. Leftover branches/worktrees drift behind main and turn into stale dirty state that mirrors already-landed PRs. Never `git clean -f` without a `git clean -nd` dry-run first — untracked secret files (`.env.bak-*`, `*.production.env`) live in the tree and a blanket clean deletes them.
+> 7. **Teardown on merge (AGENTS.md §1g):** when your PR merges, tear down its worktree and branch the same session — **worktree first, then branch** (`git worktree remove <dir>` then `git branch -D <branch>`; deleting a branch still checked out in a worktree fails). `origin/main` is the only source of truth; local branches/worktrees are disposable. Leftover branches/worktrees drift behind main and turn into stale dirty state that mirrors already-landed PRs. Never `git clean -f` without a `git clean -nd` dry-run first — untracked secret files (`.env.bak-*`, `*.production.env`) live in the tree and a blanket clean deletes them.
 
 ---
 

--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -35,6 +35,8 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - After opening or updating a PR, **stop** — do not poll CI or wait for review (AGENTS.md §3c). Report the PR URL + the local checks you already ran, then hand back to the operator; resume only on the operator's signal.
 >    - During iteration, read **targeted ranges** of large files (e.g. `control_surfaces.py` is ~1.4k lines), not whole files; and run the **single relevant test file**, not the full suite. Run the full `run_extracted_pipeline_checks.sh` gauntlet **once**, right before pushing — not on every change.
 >    - Keep the session short. If you've been alive across several PRs, expect to compact soon; finish the current slice, then let the operator restart you fresh with this bootstrap rather than running on.
+>
+> 7. **Teardown on merge (AGENTS.md §1g):** when your PR merges, delete its branch and worktree the same session (`git branch -D <branch>`, `git worktree remove <dir>`). `origin/main` is the only source of truth; local branches/worktrees are disposable. Leftover branches/worktrees drift behind main and turn into stale dirty state that mirrors already-landed PRs. Never `git clean -f` without a `git clean -nd` dry-run first — untracked secret files (`.env.bak-*`, `*.production.env`) live in the tree and a blanket clean deletes them.
 
 ---
 

--- a/plans/PR-Workflow-Teardown-On-Merge.md
+++ b/plans/PR-Workflow-Teardown-On-Merge.md
@@ -1,0 +1,78 @@
+# PR-Workflow-Teardown-On-Merge
+
+## Why this slice exists
+
+A worktree-cleanup session (2026-06-01) found two stale-state messes that each
+cost real time to untangle: a worktree pinned to local `main` that had drifted
+458 commits behind `origin/main` with 172 staged files (all already landed via
+PR #694), and a primary checkout carrying a ~300-file dirty index plus three
+local commits that merely mirrored already-merged PRs. The root cause was not a
+bug — it was the absence of a teardown discipline: branches and worktrees were
+created for work that then landed via PR, but the local copies were never torn
+down, so they drifted and accumulated. The companion `.gitignore` hardening
+(#1219) fixes the `git clean` landmine; this slice makes the prevention rule
+explicit so the mess does not recur.
+
+## Scope (this PR)
+
+Ownership lane: workflow/process
+Slice phase: Workflow/process
+
+1. Add AGENTS.md §1g "Teardown on merge": delete branch + worktree when a PR
+   merges; `origin/main` is the only source of truth; check stale branches
+   against `origin/main` before resurrecting; never `git clean -f` without a
+   dry-run.
+2. Add a matching item 7 to the SESSION_BOOTSTRAP.md fresh-session checklist so
+   each builder session inherits the rule.
+
+### Files touched
+
+- `plans/PR-Workflow-Teardown-On-Merge.md`
+- `AGENTS.md`
+- `docs/SESSION_BOOTSTRAP.md`
+
+## Mechanism
+
+Docs-only. AGENTS.md gains §1g at the end of the "1. PR shape" lifecycle
+(after §1f "Open ready for review"), closing the loop open -> review -> merge ->
+teardown. SESSION_BOOTSTRAP.md §1 gains item 7 pointing at §1g, phrased for a
+fresh builder session. Both restate the same three habits: tear down on merge,
+treat local branches/worktrees as disposable mirrors of `origin/main`, and
+dry-run `git clean` because untracked secret files (`.env.bak-*`,
+`*.production.env`, now gitignored via #1219) live in the tree.
+
+## Intentional
+
+- Docs/process only; no code, no behavior change.
+- `-D` (not `-d`) is named for branch deletion because squash-merge leaves the
+  local branch unmerged by content and `-d` refuses it — a predictable footgun.
+- The clean-safety note references the same patterns #1219 added, keeping the
+  two hygiene slices consistent.
+
+## Deferred
+
+- A scripted cleanup helper / git aliases (dry-run-first `clean`, prune-merged
+  branches) — separate tooling slice if desired.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- `git diff` is limited to the two doc files + this plan.
+- AGENTS.md §1g renders under "1. PR shape" after §1f; SESSION_BOOTSTRAP.md
+  item 7 renders in the §1 fresh-session checklist.
+- No Python sources are touched, so the ASCII and import gates do not apply;
+  the local PR review hook covers plan/code consistency and PR drift.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| AGENTS.md §1g | ~24 |
+| SESSION_BOOTSTRAP.md item 7 | ~2 |
+| Plan doc | ~75 |
+| **Total** | ~100 |
+
+Docs/process only; well under the 400-LOC soft cap.


### PR DESCRIPTION
Plan: plans/PR-Workflow-Teardown-On-Merge.md

Ownership lane: workflow/process
Slice phase: Workflow/process

## Why this slice exists

A worktree-cleanup session (2026-06-01) found two stale-state messes that each cost real time: a worktree pinned to local `main` drifted 458 commits behind `origin/main` with 172 staged files (work already landed via #694), and a primary checkout carried a ~300-file dirty index plus three local commits that merely mirrored already-merged PRs. Root cause: no teardown discipline — branches/worktrees created for work that then landed via PR were never torn down, so they drifted and accumulated. The companion `.gitignore` hardening (#1219) fixes the `git clean` landmine; this slice makes the prevention rule explicit.

## Scope

Docs/process only.
- AGENTS.md §1g "Teardown on merge": delete branch + worktree on merge; `origin/main` is the only source of truth; check stale branches against `origin/main` before resurrecting; never `git clean -f` without a `git clean -nd` dry-run (untracked secret files live in the tree).
- SESSION_BOOTSTRAP.md §1 item 7: the same rule for fresh builder sessions.

## Intentional

- No code, no behavior change.
- `-D` (not `-d`) is named for branch deletion because squash-merge leaves the local branch unmerged by content and `-d` refuses it.
- The clean-safety note references the same patterns #1219 added, keeping the two hygiene slices consistent.

## Deferred

- A scripted cleanup helper / git aliases (dry-run-first `clean`, prune-merged branches) — separate tooling slice if desired.

## Verification

- `git diff` limited to the two docs + the plan.
- Local PR review hook (plan/code consistency, PR drift, ASCII) passes.

## Estimated diff size

~40 lines across two docs + plan. Well under the 400-LOC soft cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
