### PR TITLE
PR-Content-Ops-API-Key-Auth

### DIFF
--- a/.github/workflows/atlas_content_ops_auth_checks.yml
+++ b/.github/workflows/atlas_content_ops_auth_checks.yml
@@ -1,0 +1,42 @@
+name: Atlas Content Ops Auth Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_auth_checks.yml"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/auth/dependencies.py"
+      - "tests/test_auth_dependencies.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_auth_checks.yml"
+      - "atlas_brain/api/__init__.py"
+      - "atlas_brain/auth/dependencies.py"
+      - "tests/test_auth_dependencies.py"
+
+jobs:
+  atlas-content-ops-auth-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops auth tests
+        run: |
+          python -m pytest \
+            tests/test_auth_dependencies.py \
+            -q

--- a/atlas_brain/api/__init__.py
+++ b/atlas_brain/api/__init__.py
@@ -60,7 +60,7 @@ from .b2b_evidence import router as b2b_evidence_router
 from .b2b_vendor_claims import router as b2b_vendor_claims_router
 from .b2b_challenger_claims import router as b2b_challenger_claims_router
 from fastapi import Depends
-from ..auth.dependencies import require_b2b_plan
+from ..auth.dependencies import require_b2b_plan_or_api_key
 
 logger = logging.getLogger("atlas.api")
 
@@ -141,11 +141,10 @@ router.include_router(b2b_challenger_claims_router)
 # returns 503 ("Content Ops execution services are not configured.")
 # until the host wires execution services in a follow-up slice.
 #
-# Auth: gated behind require_b2b_plan("b2b_growth") -- same dependency
-# the existing /api/v1/b2b/campaigns router uses, since Content Ops is
-# the same B2B audience. Without this every /api/v1/content-ops/*
-# endpoint would be reachable without a token (the frontend's
-# ProtectedRoute is UI-only gating).
+# Auth: gated behind require_b2b_plan_or_api_key("b2b_growth") so dashboard
+# JWTs and scoped service API keys both keep the same B2B account boundary.
+# Without this every /api/v1/content-ops/* endpoint would be reachable without
+# a token (the frontend's ProtectedRoute is UI-only gating).
 #
 # The `extracted_content_pipeline` import is inside the try so the
 # host's prod Docker image (which copies only ./atlas_brain) doesn't
@@ -195,13 +194,14 @@ try:
     from ..storage.database import get_db_pool
 
     async def _capture_content_ops_auth_user(
-        user: AuthUser = Depends(require_b2b_plan("b2b_growth")),
+        user: AuthUser = Depends(require_b2b_plan_or_api_key("b2b_growth")),
     ) -> AuthUser:
         """Bridge the per-request AuthUser to the
         `_content_ops_scope` ContextVar so the route's
         `scope_provider` can read it. Composing on top of
-        `require_b2b_plan` keeps the existing auth gate (paying
-        tier check, B2B product check, past-due guard) intact.
+        `require_b2b_plan_or_api_key` keeps the existing auth gate (paying tier
+        check, B2B product check, past-due guard) intact while allowing scoped
+        service API keys.
         Closes the Codex P1 cross-tenant safety issue from
         PR #454 (E2): drafts now persist under the
         authenticated tenant's account_id rather than empty

--- a/atlas_brain/auth/dependencies.py
+++ b/atlas_brain/auth/dependencies.py
@@ -26,6 +26,8 @@ class AuthUser:
     trial_ends_at: Optional[datetime] = field(default=None, repr=False)
     is_admin: bool = False
     is_platform_admin: bool = False
+    auth_method: str = "jwt"
+    api_key_scopes: tuple[str, ...] = field(default_factory=tuple, repr=False)
 
 
 def _synthetic_admin() -> AuthUser:
@@ -221,21 +223,60 @@ def require_b2b_plan(min_plan: str):
     min_idx = B2B_PLAN_ORDER.index(min_plan)
 
     async def _check(user: AuthUser = Depends(require_auth)) -> AuthUser:
-        if user.plan_status == "past_due":
-            raise HTTPException(
-                status_code=402,
-                detail="Payment past due",
-            )
-        if user.product not in ("b2b_retention", "b2b_challenger"):
+        return _enforce_b2b_plan(user, min_plan=min_plan, min_idx=min_idx)
+
+    return _check
+
+
+CONTENT_OPS_API_KEY_SCOPES = frozenset(
+    {
+        "content_ops:*",
+        "content_ops:deflection:*",
+    }
+)
+
+
+def _enforce_b2b_plan(user: AuthUser, *, min_plan: str, min_idx: int) -> AuthUser:
+    if user.plan_status == "past_due":
+        raise HTTPException(
+            status_code=402,
+            detail="Payment past due",
+        )
+    if user.product not in ("b2b_retention", "b2b_challenger"):
+        raise HTTPException(
+            status_code=403,
+            detail="B2B product required",
+        )
+    user_idx = B2B_PLAN_ORDER.index(user.plan) if user.plan in B2B_PLAN_ORDER else -1
+    if user_idx < min_idx:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Plan '{min_plan}' or higher required (current: '{user.plan}')",
+        )
+    return user
+
+
+def _api_key_allows_content_ops(user: AuthUser) -> bool:
+    if user.auth_method != "api_key":
+        return True
+    scopes = {scope.strip() for scope in user.api_key_scopes if scope and scope.strip()}
+    return bool(scopes & CONTENT_OPS_API_KEY_SCOPES)
+
+
+def require_b2b_plan_or_api_key(min_plan: str):
+    """Enforce the B2B plan gate for JWT or scoped service API-key callers."""
+    if min_plan not in B2B_PLAN_ORDER:
+        raise ValueError(
+            f"Invalid B2B plan tier '{min_plan}'. Expected one of {B2B_PLAN_ORDER}"
+        )
+    min_idx = B2B_PLAN_ORDER.index(min_plan)
+
+    async def _check(user: AuthUser = Depends(require_auth_or_api_key)) -> AuthUser:
+        _enforce_b2b_plan(user, min_plan=min_plan, min_idx=min_idx)
+        if not _api_key_allows_content_ops(user):
             raise HTTPException(
                 status_code=403,
-                detail="B2B product required",
-            )
-        user_idx = B2B_PLAN_ORDER.index(user.plan) if user.plan in B2B_PLAN_ORDER else -1
-        if user_idx < min_idx:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Plan '{min_plan}' or higher required (current: '{user.plan}')",
+                detail="Content Ops API key scope required",
             )
         return user
 
@@ -366,6 +407,8 @@ async def require_api_key(request: Request) -> AuthUser:
         trial_ends_at=trial_ends,
         is_admin=False,
         is_platform_admin=False,
+        auth_method="api_key",
+        api_key_scopes=tuple(str(scope) for scope in row.get("scopes") or ()),
     )
 
     client_ip = request.client.host if request.client else None
@@ -381,8 +424,8 @@ async def require_auth_or_api_key(request: Request) -> AuthUser:
     checks. This helper dispatches by token shape so both auth
     methods work.
 
-    Used only by LLM Gateway endpoints (PR-D4); atlas's existing
-    products are dashboard-only and keep their JWT-only chains.
+    Used by LLM Gateway endpoints and selected server-to-server Content Ops
+    routes that need revocable long-lived service credentials.
     """
     if not settings.saas_auth.enabled:
         return _synthetic_admin()

--- a/plans/PR-Content-Ops-API-Key-Auth.md
+++ b/plans/PR-Content-Ops-API-Key-Auth.md
@@ -1,0 +1,109 @@
+# Plan: Content Ops API-key auth
+
+## Why this slice exists
+
+The hosted FAQ deflection funnel currently uses `ATLAS_B2B_JWT` as the portfolio
+server's ATLAS credential. That token is a normal login JWT with the deployed
+ATLAS default 24-hour lifetime, so the live funnel breaks every day unless an
+operator manually renews and redeploys the portfolio.
+
+ATLAS already has long-lived `atls_live_*` API keys for server-to-server calls,
+but the Content Ops route mount still gates requests through JWT-only
+`require_b2b_plan("b2b_growth")`. This slice makes the Content Ops routes accept
+a scoped B2B service API key while preserving the existing B2B plan/product gate.
+The final diff is slightly over the 400-line soft cap because the review-driven
+coverage must exercise the real API-key dispatch path, scope tagging, and B2B
+gate together for this revenue-path auth boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Production hardening
+
+1. Add a B2B plan dependency that accepts either the existing dashboard JWT or a
+   customer/service `atls_live_*` API key.
+2. Require Content Ops API keys to carry an explicit Content Ops scope such as
+   `content_ops:deflection:*` or `content_ops:*`; JWT callers remain unchanged.
+3. Mount the Content Ops routers through the new dependency so the deflection
+   submit/snapshot/artifact paths can use long-lived service keys.
+4. Add focused auth tests for JWT compatibility, scoped API-key acceptance,
+   full API-key dispatch tagging, insufficient API-key scope rejection,
+   plan/product rejection, and the Content Ops route mount.
+5. Add a dedicated `.github/workflows/atlas_content_ops_auth_checks.yml`
+   workflow and enroll the new atlas-brain test in both path filters and the
+   pytest run step.
+
+### Files touched
+
+- `plans/PR-Content-Ops-API-Key-Auth.md` - this plan doc.
+- `atlas_brain/auth/dependencies.py` - B2B JWT-or-API-key dependency and scope
+  enforcement.
+- `atlas_brain/api/__init__.py` - Content Ops route mount uses the new
+  dependency.
+- `tests/test_auth_dependencies.py` - focused dependency and route-mount tests.
+- `.github/workflows/atlas_content_ops_auth_checks.yml` - dedicated CI lane.
+
+## Mechanism
+
+`require_api_key()` already resolves an `atls_live_*` bearer token into the same
+`AuthUser` shape as JWT auth. This slice records the API-key scopes on that
+`AuthUser`, then adds:
+
+```python
+def require_b2b_plan_or_api_key(min_plan: str):
+    async def _check(user: AuthUser = Depends(require_auth_or_api_key)) -> AuthUser:
+        ...
+```
+
+The shared B2B plan check still rejects past-due accounts, non-B2B products, and
+plans below `b2b_growth`. If the caller is an API key, the dependency also
+requires one of:
+
+- `content_ops:*`
+- `content_ops:deflection:*`
+
+The Content Ops mount swaps `_capture_content_ops_auth_user` from
+`require_b2b_plan("b2b_growth")` to `require_b2b_plan_or_api_key("b2b_growth")`.
+Downstream scope capture still writes the authenticated account into the
+ContextVar, so tenant scoping stays unchanged.
+
+## Intentional
+
+- This does not lengthen JWT expiry. Login JWTs stay short-lived; service access
+  moves to revocable API keys.
+- Existing JWT dashboard callers continue to work without scope strings because
+  JWT authorization is still governed by the B2B product/plan gate.
+- Existing default `llm:*` API keys and broad `*` keys do not pass the Content
+  Ops gate. The portfolio service key must be minted with an explicit Content
+  Ops scope.
+- Cross-layer caller hints were inspected: existing `AuthUser` constructors are
+  unaffected because the new fields have defaults, and existing
+  `require_b2b_plan` callers keep the same plan/product/past-due behavior via
+  the shared helper covered in `tests/test_auth_dependencies.py`.
+
+## Deferred
+
+- Portfolio env migration is the follow-up slice: mint
+  `atlas-portfolio-deflection-prod` with `content_ops:deflection:*`, set
+  `ATLAS_B2B_SERVICE_TOKEN`, update portfolio to prefer it over
+  `ATLAS_B2B_JWT`, redeploy, then remove the short-lived JWT.
+
+Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/auth/dependencies.py atlas_brain/api/__init__.py tests/test_auth_dependencies.py` - passed.
+- `python -m pytest tests/test_auth_dependencies.py -q` - 24 passed after
+  reviewer coverage update.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-api-key-auth-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~90 |
+| Auth dependency | ~60 |
+| Route mount | ~5 |
+| Focused tests | ~210 |
+| Workflow | ~55 |
+| **Total** | 435 |

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -1,13 +1,34 @@
+import uuid
+from types import SimpleNamespace
+
 import pytest
+from fastapi import HTTPException
 
 from atlas_brain.auth.dependencies import (
     AuthUser,
     B2B_PLAN_ORDER,
+    CONTENT_OPS_API_KEY_SCOPES,
     PLAN_ORDER,
     _effective_is_admin,
     require_b2b_plan,
+    require_b2b_plan_or_api_key,
     require_plan,
 )
+
+
+class _FakeRequest:
+    def __init__(self, token: str):
+        self.headers = {"authorization": f"Bearer {token}"}
+        self.client = SimpleNamespace(host="127.0.0.1")
+
+
+class _FakePool:
+    def __init__(self, account_row: dict[str, object]):
+        self.account_row = account_row
+        self.touched: tuple[uuid.UUID, str | None] | None = None
+
+    async def fetchrow(self, *_args, **_kwargs):
+        return self.account_row
 
 
 def test_effective_is_admin_true_from_flag():
@@ -58,7 +79,179 @@ def test_require_b2b_plan_accepts_known_b2b_tiers():
         assert callable(dependency)
 
 
+def test_require_b2b_plan_or_api_key_rejects_unknown_b2b_tier():
+    with pytest.raises(ValueError, match="Invalid B2B plan tier 'starter'"):
+        require_b2b_plan_or_api_key("starter")
+
+
+def test_require_b2b_plan_or_api_key_accepts_known_b2b_tiers():
+    for plan in B2B_PLAN_ORDER:
+        dependency = require_b2b_plan_or_api_key(plan)
+        assert callable(dependency)
+
+
 def test_require_plan_accepts_known_consumer_tiers():
     for plan in PLAN_ORDER:
         dependency = require_plan(plan)
         assert callable(dependency)
+
+
+def _b2b_user(**overrides) -> AuthUser:
+    defaults = {
+        "user_id": "user-1",
+        "account_id": "account-1",
+        "plan": "b2b_growth",
+        "plan_status": "active",
+        "role": "member",
+        "product": "b2b_retention",
+    }
+    defaults.update(overrides)
+    return AuthUser(**defaults)
+
+
+async def _api_key_user_from_dispatch(monkeypatch, *, scopes: tuple[str, ...]) -> tuple[AuthUser, _FakePool]:
+    import atlas_brain.auth.api_keys as api_keys_mod
+    import atlas_brain.auth.dependencies as dependencies_mod
+    import atlas_brain.storage.database as database_mod
+
+    raw_key = "atls_live_abcdefghijklmnopqrstuvwxyz234567"
+    key_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    pool = _FakePool(
+        {
+            "plan": "b2b_growth",
+            "plan_status": "active",
+            "product": "b2b_retention",
+            "trial_ends_at": None,
+        }
+    )
+
+    async def fake_lookup_api_key(_pool, presented_key):
+        assert _pool is pool
+        assert presented_key == raw_key
+        return {
+            "id": key_id,
+            "account_id": account_id,
+            "user_id": user_id,
+            "scopes": list(scopes),
+        }
+
+    async def fake_touch_api_key(_pool, *, key_id: uuid.UUID, client_ip: str | None):
+        assert _pool is pool
+        pool.touched = (key_id, client_ip)
+
+    monkeypatch.setattr(
+        dependencies_mod,
+        "settings",
+        SimpleNamespace(saas_auth=SimpleNamespace(enabled=True)),
+    )
+    monkeypatch.setattr(database_mod, "get_db_pool", lambda: pool)
+    monkeypatch.setattr(api_keys_mod, "lookup_api_key", fake_lookup_api_key)
+    monkeypatch.setattr(api_keys_mod, "touch_api_key", fake_touch_api_key)
+
+    user = await dependencies_mod.require_auth_or_api_key(_FakeRequest(raw_key))
+    return user, pool
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_accepts_jwt_dashboard_user_without_scopes():
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(auth_method="jwt", api_key_scopes=())
+
+    assert await dependency(user) is user
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", sorted(CONTENT_OPS_API_KEY_SCOPES))
+async def test_require_b2b_plan_or_api_key_accepts_content_ops_api_key_scope(scope):
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(auth_method="api_key", api_key_scopes=(scope,))
+
+    assert await dependency(user) is user
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scopes", [(), ("*",), ("llm:*",), ("content_ops:macro:*",)])
+async def test_require_b2b_plan_or_api_key_rejects_api_key_without_content_ops_scope(scopes):
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(auth_method="api_key", api_key_scopes=scopes)
+
+    with pytest.raises(HTTPException) as exc:
+        await dependency(user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Content Ops API key scope required"
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_rejects_api_key_scopes_from_dispatch(monkeypatch):
+    user, pool = await _api_key_user_from_dispatch(monkeypatch, scopes=("llm:*",))
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+
+    assert user.auth_method == "api_key"
+    assert user.api_key_scopes == ("llm:*",)
+    assert pool.touched is not None
+    with pytest.raises(HTTPException) as exc:
+        await dependency(user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Content Ops API key scope required"
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_accepts_content_ops_scope_from_dispatch(monkeypatch):
+    user, pool = await _api_key_user_from_dispatch(monkeypatch, scopes=("content_ops:*",))
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+
+    assert user.auth_method == "api_key"
+    assert user.api_key_scopes == ("content_ops:*",)
+    assert pool.touched is not None
+    assert await dependency(user) is user
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_rejects_non_b2b_product():
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(product="consumer")
+
+    with pytest.raises(HTTPException) as exc:
+        await dependency(user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "B2B product required"
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_rejects_lower_b2b_plan():
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(plan="b2b_starter")
+
+    with pytest.raises(HTTPException) as exc:
+        await dependency(user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == (
+        "Plan 'b2b_growth' or higher required (current: 'b2b_starter')"
+    )
+
+
+@pytest.mark.asyncio
+async def test_require_b2b_plan_or_api_key_rejects_past_due_account():
+    dependency = require_b2b_plan_or_api_key("b2b_growth")
+    user = _b2b_user(plan_status="past_due")
+
+    with pytest.raises(HTTPException) as exc:
+        await dependency(user)
+
+    assert exc.value.status_code == 402
+    assert exc.value.detail == "Payment past due"
+
+
+def test_content_ops_route_mount_uses_b2b_api_key_auth_dependency():
+    from pathlib import Path
+
+    source = Path("atlas_brain/api/__init__.py").read_text(encoding="utf-8")
+
+    assert 'Depends(require_b2b_plan_or_api_key("b2b_growth"))' in source
+    assert 'Depends(require_b2b_plan("b2b_growth"))' not in source


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-API-Key-Auth.md
Slice phase: Production hardening

Moves the Content Ops route mount from JWT-only B2B auth to a scoped JWT-or-API-key dependency so the FAQ deflection portfolio can use a durable `atls_live_*` service credential instead of a 24-hour login JWT.

## Intentional
- JWT expiry stays short; durable service access uses revocable API keys.
- Existing JWT dashboard callers still pass through the B2B product/plan gate without API-key scopes.
- Default `llm:*` API keys and broad `*` keys do not pass the Content Ops gate; the portfolio key must be minted with an explicit Content Ops scope.
- Cross-layer caller hints were inspected: existing `AuthUser` constructors are unaffected because the new fields have defaults, and existing `require_b2b_plan` callers keep the same plan/product/past-due behavior via the shared helper covered in `tests/test_auth_dependencies.py`.

## Deferred
- Portfolio env migration follows after ATLAS accepts scoped service keys: mint `atlas-portfolio-deflection-prod` with `content_ops:deflection:*`, set `ATLAS_B2B_SERVICE_TOKEN`, update portfolio to prefer it over `ATLAS_B2B_JWT`, redeploy, then remove the short-lived JWT.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/auth/dependencies.py atlas_brain/api/__init__.py tests/test_auth_dependencies.py` - passed.
- `python -m pytest tests/test_auth_dependencies.py -q` - 24 passed after reviewer coverage update.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-api-key-auth-pr-body.md` - passed after reviewer coverage update.

## Diff size
5 files, +411 / -24
