### PR TITLE
PR-Docs-Preserve-Product-Audit-Notes

### DIFF
--- a/docs/audits/ai_content_ops_landing_page_user_workflow_gap_log_2026-05-22.md
+++ b/docs/audits/ai_content_ops_landing_page_user_workflow_gap_log_2026-05-22.md
@@ -1,0 +1,165 @@
+# AI Content Ops Landing Page User Workflow Gap Log - 2026-05-22
+
+> Archived context: this note was preserved from a local worktree cleanup.
+> Treat it as a historical gap log, not current implementation truth. Current
+> capability truth lives in the codebase, merged plan docs, and PR history.
+
+## Why this exists
+
+This log captures the product workflow questions raised after reviewing the
+blog SEO/AEO/GEO contract:
+
+- How do users provide their own SEO, AEO, and GEO inputs?
+- How do users review generated drafts?
+- How do users edit or repair drafts before publishing?
+- What gaps remain before landing pages can be sold as a clean product flow?
+
+The landing-page backend is ahead of the public/product workflow. Several
+implementation slices already exist or are partially implemented, but the
+operator experience still needs a clear end-to-end path.
+
+## Current Landing Page Capability
+
+Landing page generation currently works from a `MarketingCampaign` input with:
+
+- `campaign_name`
+- `offer`
+- `audience`
+- `vendors`
+- `categories`
+- `tags`
+- selected context fields such as `industry`, `pain_points`,
+  `differentiators`, `customer_segments`, `key_metrics`, `proof_points`, and
+  `competitive_alternatives`
+
+The generated draft shape includes:
+
+- page title
+- slug
+- hero block
+- ordered sections
+- CTA
+- metadata (`title_tag`, `description`, `og_image_url`, etc.)
+- reference IDs
+
+Landing-page review/export rows already surface:
+
+- `seo_aeo_readiness`
+- `geo_readiness`
+- generation token usage
+- parse attempts
+- reasoning usage summary
+
+The quality gate also blocks or warns on several readiness-adjacent defects,
+including invalid slugs, placeholder CTA URLs, unresolved placeholders, generic
+section titles, missing/long metadata title tags, and inconsistent metadata.
+
+## User Input Gap
+
+Users do not yet have a clean landing-page form for SEO/AEO/GEO strategy.
+Today, most advanced inputs must be provided through raw JSON or embedded in
+the campaign/context payload.
+
+Needed first-class fields:
+
+- target keyword
+- secondary keywords
+- search intent
+- primary offer/entity
+- audience/entity
+- buyer pain or problem statement
+- objections or FAQ questions
+- proof points and allowed reference IDs
+- source period or freshness context
+- internal links
+- CTA label and URL
+- forbidden claims or phrasing
+
+These should map into the existing `MarketingCampaign.context` contract rather
+than inventing a parallel request shape.
+
+## Review Gap
+
+Generated Asset Review can list landing-page drafts, show previews, expose
+facts, open details, approve, reject, and export CSV.
+
+The important gap is not visibility. The important gap is editability.
+
+Users need to be able to review:
+
+- hero headline/subheadline
+- CTA label and URL
+- page sections
+- SEO title tag
+- meta description
+- proof/reference IDs
+- SEO/AEO readiness
+- GEO readiness
+
+Then they need to change those fields in the app.
+
+## Editing And Recheck Gap
+
+The current review API is status-oriented. It can approve or reject drafts, but
+it does not provide a product editing flow for generated landing pages.
+
+Needed backend shape:
+
+- `PATCH /content-assets/landing_page/drafts/{id}`
+- tenant-scoped update
+- structured patch for title, slug, hero, sections, CTA, meta, and reference IDs
+- re-run landing-page readiness checks after update
+- return the same review/export row shape the UI already knows how to render
+
+Needed UI shape:
+
+- edit mode in the asset detail drawer
+- structured fields for hero, CTA, and meta
+- section editor for ordered body sections
+- reference/proof ID editor
+- save and recheck action
+- clear display of missing checks after save
+
+## Repair Gap
+
+Landing-page quality repair exists as a generation-time mechanism and a UI
+control for repair attempts, but users still need an explicit product action:
+
+- Fix missing readiness checks
+- Regenerate with the same strategy inputs
+- Regenerate after changing SEO/AEO/GEO fields
+
+The first product version can repair the full landing page. Section-level repair
+can be deferred until draft editing is stable.
+
+## Product Boundary
+
+Safe claim after the current/backend-complete layer:
+
+> Landing page drafts include SEO metadata, answer-first page structure,
+> objection/proof coverage, CTA consistency, and SEO/AEO/GEO readiness checks
+> for review before publishing.
+
+Safe claim after edit/recheck ships:
+
+> Users can generate, review, edit, and recheck landing page drafts against
+> SEO/AEO/GEO readiness before publishing.
+
+Still avoid:
+
+> Guaranteed rankings, guaranteed AI citations, or guaranteed conversion lift.
+
+## Recommended Next Product Slice
+
+The next slice should not be another prompt-only change. The highest-value gap
+is the user-facing workflow:
+
+1. Add a structured landing-page SEO/AEO/GEO input panel on New Run.
+2. Persist those fields through `MarketingCampaign.context`.
+3. Show landing-page readiness panels in review if not already present in the
+   active branch.
+4. Add landing-page draft edit and recheck.
+
+The first implementation PR should be the input panel if the goal is better
+generation quality. It should be edit/recheck if the goal is making the product
+usable by a non-technical reviewer.

--- a/docs/audits/faq_generator_landing_blog_coupling_gap_log_2026-05-22.md
+++ b/docs/audits/faq_generator_landing_blog_coupling_gap_log_2026-05-22.md
@@ -1,0 +1,83 @@
+# Gap Log: FAQ Generator <-> Landing/Blog Coupling
+
+Date: 2026-05-22
+Archived context: this note was preserved from a local worktree cleanup. Treat
+it as a historical gap log, not current implementation truth. Current capability
+truth lives in the codebase, merged plan docs, and PR history.
+
+Scope: Whether the FAQ generator work (`ticket_faq_*`) is wired to the
+landing-page / blog-post generator work, and what FAQ lacks relative to them.
+Method: cross-reference greps + read of the content-ops execution framework,
+the FAQ generator, the landing/blog generators, and their export/persistence/
+public-serving layers at working-tree HEAD.
+
+This log records observed gaps and supporting evidence only. It does not
+prescribe a target design or how the pieces should be coupled.
+
+---
+
+## Gap 1 - No code coupling between FAQ and landing/blog (framework siblings only)
+
+- `ticket_faq_markdown.py`, `ticket_faq_export.py`, `ticket_faq_postgres.py`,
+  `ticket_faq_input_contract.py` import only FAQ modules + `campaign_ports` /
+  `ticket_faq_ports` / `storage._jsonb_helpers`. No `landing_page_*` or
+  `blog_*` imports.
+- No `landing_page_*` or `blog_*` module references any FAQ symbol.
+- The only shared surface is the execution framework, not data:
+  - `generated_assets.py:54` `ASSET_CHOICES = ("blog_post", "report",
+    "landing_page", "sales_brief", "faq_markdown")` - all five are sibling
+    outputs of one `/content-ops/execute` pipeline.
+  - `generation_plan.py` has a per-output `_<output>_config_for_request` +
+    dispatch branch (`_faq_markdown_config_for_request` at ~210, dispatch at
+    ~394; landing at ~166/330; blog at ~193/365).
+  - `content_ops_execution.py` holds all outputs in one services bundle.
+  - `generated_assets.py` routes export/status per asset (FAQ at lines
+    669-718).
+- No data flow in either direction: FAQ output does not feed blog/landing,
+  and blog/landing output does not feed FAQ.
+
+## Gap 2 - FAQ has no SEO / structured-data / public-web infrastructure that landing and blog have
+
+What landing/blog have and FAQ lacks:
+
+| Capability | Landing / Blog | FAQ (`ticket_faq_*`) |
+|---|---|---|
+| schema.org JSON-LD | `landing_page_structured_data.py` (`WebPage` + `FAQPage` + `Question`/`Answer`, canonical wiring); blog structured data | none |
+| robots policy | `public_landing_page_robots()` (`landing_page_export.py:166`) | none |
+| sitemap candidates | `list_public_sitemap_candidates()` (`landing_page_postgres.py`) | none |
+| SEO/AEO/GEO readiness | `landing_page_readiness.py`; blog `seo_aeo_readiness`/`geo_readiness` | none |
+| slug / canonical URL | landing `meta` + slug | none |
+| public web route | `/landing_page/public/sitemap.xml` + `/landing_page/public/{id}` (`generated_assets.py:549/568`); blog via `atlas_brain/api/blog_public.py` | none - FAQ is only returned as markdown text from the execute route and persisted as drafts |
+
+## Gap 3 - FAQ content is deterministic/templated (no LLM)
+
+- The FAQ generator produces answers via a fixed template, not an LLM:
+  `ticket_faq_markdown.py:667` ->
+  `"answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s)."`
+- Plan/registry marks the FAQ output `reasoning_requirement="absent"`, whereas
+  blog_post / landing_page are `"optional_host_context"`.
+
+## Gap 4 - FAQ signal does not feed the embedded `faq` metadata that blog/landing already carry
+
+- Blog generation already emits an embedded `faq` Q&A list as metadata
+  (`blog_generation.py:546` `"faq": _mapping_list(parsed.get("faq"))`, also
+  601; persisted in `blog_post_postgres.py` faq column at 100/133/141/174/224).
+  This is independent of the ticket-FAQ generator.
+- The ticket-FAQ generator's per-item Q&A (`question`, `answer`,
+  `question_source`, `source_ids`, frequency - `ticket_faq_markdown.py`
+  ~645-667) is not connected to that embedded `faq` field.
+
+---
+
+## Neutral facts relevant to the gaps (not recommendations)
+
+- The schema.org `FAQPage` JSON-LD builder already exists, but inside
+  `landing_page_structured_data.py` (line ~87) and is typed to
+  `LandingPageDraft`; it builds an embedded FAQ subgraph within a `WebPage`
+  node, not a standalone page.
+- FAQ output items already carry a `question`/`answer`/`heading`/`source_ids`
+  shape (`ticket_faq_markdown.py` ~187, 645-667).
+- FAQ has its own persistence/export (`ticket_faq_postgres.py`,
+  `ticket_faq_export.py`) but the export columns are minimal (target_id,
+  title, markdown, items, status) - no readiness/robots/slug/structured-data
+  columns.

--- a/docs/products/ticket-deflection-gtm.md
+++ b/docs/products/ticket-deflection-gtm.md
@@ -1,0 +1,158 @@
+# Ticket Deflection - Go-To-Market Source-of-Truth
+
+Date: 2026-05-23
+Archived context: this note was preserved from a local worktree cleanup. Treat
+it as historical GTM input, not current implementation truth. Current capability
+truth lives in the codebase, merged plan docs, and PR history.
+
+Status: Draft / pre-campaign. Capability + proof + assets are repo-derived facts;
+positioning, pricing, channel, and the 30-day goal are operator decisions.
+
+This doc answers a GTM funnel questionnaire from what the Atlas repo actually
+contains, so a campaign (landing page, emails, lead magnet, offer, targeting)
+can be built on facts instead of hand-waving. Every claim is tagged:
+
+- `[REPO FACT]` - verifiable in the codebase/docs today.
+- `[REPO+NOTES - confirm]` - repo signal + prior productization notes suggest a
+  default; operator should confirm.
+- `[YOUR CALL]` - a business decision the code cannot make.
+
+## How much the repo answers
+
+Of the 13 funnel fields: ~5 answered cold, ~5 partial (confirm), ~3 pure
+business calls. The repo nails *what you sell, the mechanism, the proof, and the
+assets* (facts about working code). It cannot decide *price, channel, or the
+30-day goal*.
+
+## Critical clarification: two ticket-fed products
+
+The repo has two products fed by support tickets. The funnel language fits the
+first; the second is adjacent and shares ingestion.
+
+- (A) **Ticket Deflection -> FAQ** (`extracted_content_pipeline/ticket_faq_markdown.py`):
+  turn repeat tickets into self-serve FAQ/help content so customers stop
+  emailing support. **Built and validated at 50k rows.** This doc is about (A).
+- (B) **Churn / at-risk-account prediction** (the B2B reasoning engine): rank
+  accounts by churn risk from ticket signals. **Planned, tabled mid-validation**,
+  but it has a more-developed GTM kit (ICP, outreach template, discovery script)
+  worth reusing if the offer pivots toward retention.
+
+## Filled funnel template
+
+```text
+1. What I sell:
+   [REPO FACT] A done-for-you / audit service that ingests support tickets and
+   generates self-serve FAQ + help-center content (plus a landing page and blog
+   post from the same data) to deflect repeat tickets. Closest funnel options:
+   "Ticket analysis/audit" + "Support automation" (NOT a chatbot).
+   Evidence: extracted_content_pipeline/ticket_faq_markdown.py,
+   support_ticket_input_package.py (outputs: faq_markdown, landing_page, blog_post).
+
+2. Is it built yet or still an idea:
+   [REPO FACT] The generator is built and validated. NOT built: any ticketing
+   API integration (today it takes CSV/JSON/JSONL uploads only). Auth + Stripe
+   billing scaffolding exists; tenant-scoping + a real connector are the gaps.
+
+3. Ideal customer:
+   [REPO+NOTES - confirm] Repo examples + proof imply mid-market orgs with high
+   repeat-ticket volume and a help center. Prior churn-product ICP was
+   "B2B SaaS, $5M-$100M ARR, VP Customer Success" - transferable but that's the
+   churn angle. For deflection, "high ticket volume" matters more than industry.
+   -> Lock the segment.
+
+4. Company size:
+   [REPO+NOTES - confirm] Mid-market is the repo-implied default (example data:
+   HubSpot/LegacyCRM users). No formal doc. -> Confirm.
+
+5. Industry/niche:
+   [REPO+NOTES - confirm] Pipeline is industry-agnostic (generic ticket schema).
+   Proof ran on CFPB (financial complaints); examples are logistics + food.
+   Works anywhere; the niche is a strategic choice, not a code constraint.
+
+6. Tools/platforms I know or target:
+   [REPO FACT] TODAY: any platform's exported tickets (CSV/JSON/JSONL), manual.
+   No Zendesk/Gorgias/Intercom API client exists (vendor_registry has Zendesk/
+   HubSpot as name-normalization aliases only, not integrations).
+   [NOTES] A Zendesk-first adapter is the planned first connector (~5 dev-days),
+   then Intercom -> Freshdesk. Do not claim live integrations yet.
+
+7. Best problem I can solve:
+   [REPO FACT] Concrete mechanism (not hand-waving): ingest tickets -> cluster
+   repeat questions by pain_category -> score by failure-risk + opportunity ->
+   extract customer-worded questions -> generate article-style self-serve FAQ
+   with next steps. = "Reducing repetitive tickets" + "Improving help-center
+   articles." Funnel-ready phrasing:
+   "We analyze your last 90 days of tickets, find the top repeat issues, and
+   generate self-serve FAQ content that deflects avoidable tickets."
+
+8. Proof/results I have:
+   [REPO FACT] Technical proof, not client outcomes (be honest about this):
+   - 50,000 real CFPB ticket rows -> bounded FAQ, all scale gates passed,
+     1:41.86 wall, 593MB RSS
+     (docs/extraction/validation/content_ops_faq_50k_gated_validation_2026-05-23.md)
+   - 1,000-row run + a full generate->export->review->update DB lifecycle run
+   - A "Support Ticket Deflection" demo with a live DB backend
+   NO before/after client numbers yet -> position the first offer as a
+   low-friction audit/pilot.
+
+9. Offer I want to sell:
+   [REPO+NOTES - confirm] The built path = Option A (Audit) or B (Audit + sprint).
+   The code's own default CTA is literally an audit: "Upload Ticket CSV --
+   Free Analysis" -> /systems/ai-content-ops/intake. -> Choose A vs B.
+
+10. Price range:
+    [YOUR CALL] No committed pricing in the repo. Prior notes have bands for
+    OTHER products (Amazon $99-299/mo; B2B churn $2-20k/mo) - do not reuse
+    blindly. The funnel's "free audit -> $2,500-5,000 sprint" fits the built path.
+
+11. Lead channel I want to start with:
+    [YOUR CALL] The repo gives the assets: it generates landing pages, blog
+    posts, and B2B campaigns from ticket data, plus an email MCP server + CRM.
+    Prior notes favor cold email + a validation-call kit (reusable outreach
+    template + discovery script already written).
+
+12. Assets I already have:
+    [REPO FACT - the richest box] FAQ generator (built+validated), landing-page
+    generator, blog-post generator, B2B campaign generator, the "Upload Ticket
+    CSV" intake CTA + /systems/ai-content-ops/intake route, the live-DB
+    deflection demo, email MCP + CRM + invoicing, auth + Stripe billing
+    scaffolding, the atlas-intel-ui dashboard, the 50k validation doc (proof),
+    and a written outreach template + 30-min discovery script (prior notes).
+
+13. Goal for the next 30 days:
+    [YOUR CALL] Repo+notes make these fastest: "validate the offer" (a tabled
+    5-prospect-call kit is ready), OR "build a lead magnet" (the free ticket
+    audit IS the lead magnet), OR "create a landing page" (the generator does it).
+```
+
+## Three honest gaps (so the campaign does not overclaim)
+
+1. **No live integrations.** Upload-based today. A Zendesk connector is ~5
+   dev-days, not done. The audit offer should say "export your tickets / send a
+   CSV," not "connect Zendesk."
+2. **Proof is technical, not outcome.** You can show it runs on 50k real rows
+   and produces clean FAQ; you cannot yet say "cut tickets 30% for client X."
+   Lead with a free audit that produces *their* FAQ as the proof.
+3. **Pricing / channel / goal are not in the code.** Operator decisions.
+   Everything upstream of them, the repo already answers.
+
+## Key evidence paths
+
+- Generator: `extracted_content_pipeline/ticket_faq_markdown.py`
+- Input adapter: `extracted_content_pipeline/support_ticket_input_package.py`,
+  `support_ticket_input_provider.py` (outputs faq_markdown / landing_page / blog_post)
+- Examples: `extracted_content_pipeline/examples/support_ticket_sources.csv`,
+  `support_ticket_bundle.json`
+- 50k proof: `docs/extraction/validation/content_ops_faq_50k_gated_validation_2026-05-23.md`
+- Scale-gate harness: `scripts/smoke_content_ops_faq_scale_run.py`
+- Operational risk parked: `HARDENING.md` (FAQSCALE-1 - large synchronous runs
+  need hosted limits/backpressure/background execution before exposing large
+  uploads as synchronous customer requests)
+- Adjacent product status: `CLAUDE.md` (Content Ops = active iteration)
+
+## Suggested next step
+
+Lock fields 3/4/5 (ICP), 9 (offer A vs B), and 10 (price). Once those are set,
+the pipeline can generate the actual landing-page copy and the audit lead magnet
+from the same ticket data, and the prior outreach template + discovery script
+can seed the cold-email sequence.

--- a/plans/PR-Docs-Preserve-Product-Audit-Notes.md
+++ b/plans/PR-Docs-Preserve-Product-Audit-Notes.md
@@ -1,0 +1,76 @@
+# PR-Docs-Preserve-Product-Audit-Notes
+
+## Why this slice exists
+
+Worktree cleanup preserved several local archive artifacts rather than deleting
+them blindly. A follow-up comparison showed most archived files are already on
+`origin/main`, generated report outputs, or superseded plans. Three product and
+audit notes remain useful historical context but are missing from main. This
+slice preserves only those notes in-repo and marks them as archived context so
+future readers do not mistake stale claims for current product state.
+
+## Scope (this PR)
+
+Ownership lane: docs/product-history-preservation
+Slice phase: Workflow/process
+
+1. Restore the two missing audit logs from the preserved markdown archive.
+2. Restore the ticket-deflection GTM note from the preserved markdown archive.
+3. Add a short archive-status note to each restored document, clarifying that
+   current implementation truth remains the live code, plans, and merged PRs.
+4. Do not restore generated demand reports, superseded plan drafts, local skill
+   files, or PR-body temp files.
+
+### Files touched
+
+- `docs/audits/ai_content_ops_landing_page_user_workflow_gap_log_2026-05-22.md`
+- `docs/audits/faq_generator_landing_blog_coupling_gap_log_2026-05-22.md`
+- `docs/products/ticket-deflection-gtm.md`
+- `plans/PR-Docs-Preserve-Product-Audit-Notes.md`
+
+## Mechanism
+
+The archived notes already exist locally from
+`Atlas-primary-untracked-markdown`; this PR commits those three notes after
+adding an explicit archived-context banner near the top of each file. The
+banner points readers back to current code, merged plans, and PR history for
+truth on built capabilities.
+
+No code paths, generated reports, or product behavior change.
+
+## Intentional
+
+- The generated `reports/demand/*.md` outputs stay archived only. The generator
+  and its tests are already on main, and committing generated snapshots would
+  create maintenance churn without improving runtime behavior.
+- `plans/PR-Stripe-Integration-Hardening.md` stays archived only because the
+  actual hardening shipped as `PR-Stripe-Billing-Hardening` (#1205).
+- The old FAQ deflection handoff PR body stays archived only because PR bodies
+  are not source-of-truth repo artifacts.
+
+## Deferred
+
+- If these restored notes become product-owned docs, a future product-docs
+  slice can refresh stale claims and move them out of archived context.
+
+Parked hardening: none.
+
+## Verification
+
+- `git diff --check -- $(git diff --name-only origin/main)`
+- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>`
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Landing-page workflow audit log | 165 |
+| FAQ coupling audit log | 83 |
+| Ticket deflection GTM note | 158 |
+| Plan doc | 76 |
+| **Total** | **482** |
+
+This exceeds the 400 LOC target because the three documents are preserved
+together as one cleanup decision: restore useful archived notes, leave all other
+archived artifacts out. Splitting would add process overhead without reducing
+review risk because the change is docs-only and mechanical.


### PR DESCRIPTION
Plan: plans/PR-Docs-Preserve-Product-Audit-Notes.md
Slice phase: Workflow/process

Preserve the useful product/audit notes found during worktree archive review while keeping generated reports, superseded plans, local skills, and PR-body temp files out of main. Each restored note gets an archived-context banner so readers treat it as historical input, not current implementation truth.

## Intentional
- Keep generated `reports/demand/*.md` outputs archived only; the generator and tests are already on main.
- Keep `plans/PR-Stripe-Integration-Hardening.md` archived only because the implementation shipped as `PR-Stripe-Billing-Hardening` (#1205).
- Keep old PR-body temp files archived only.

## Deferred
- Future product-docs slice can refresh stale claims if these notes become product-owned docs.

## Parked hardening
- None.

## Verification
- `git diff --check -- $(git diff --name-only origin/main)`
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-docs-preserve-product-audit-notes-pr-body.md`

## Diff size
4 files, +482 / -0
