### PR TITLE
PR-Landing-Page-UI-E2E-Validation

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Test Content Ops FAQ configuration inputs
         run: npm run test:content-ops-faq-configuration-inputs
 
+      - name: Test Content Ops landing-page review deep link
+        run: npm run test:content-ops-landing-page-e2e-ui
+
       - name: Build
         run: npm run build
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -19,6 +19,7 @@
     "test:content-ops-faq-source-selection": "node --test scripts/content-ops-faq-source-selection.test.mjs",
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",
+    "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/content-ops-landing-page-e2e-ui.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-landing-page-e2e-ui.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+const apiSource = readFileSync(
+  new URL('../src/api/contentOps.ts', import.meta.url),
+  'utf8',
+)
+
+test('landing-page execution summary links saved drafts to asset review', () => {
+  assert.ok(newRunSource.includes('function generatedAssetReviewHref'))
+  assert.ok(newRunSource.includes('if (idFiltered && savedIds.length === 0) return null'))
+  assert.ok(newRunSource.includes("params.set('asset', output)"))
+  assert.ok(newRunSource.includes("params.set('status', 'draft')"))
+  assert.ok(newRunSource.includes("params.append('id', id)"))
+  assert.ok(newRunSource.includes('<Link'))
+  assert.ok(newRunSource.includes('Review generated drafts'))
+})
+
+test('generated asset review initializes from landing-page deep-link params', () => {
+  assert.ok(reviewSource.includes('useSearchParams'))
+  assert.ok(reviewSource.includes('assetFromSearchParams(searchParams)'))
+  assert.ok(reviewSource.includes('statusFromSearchParams(searchParams)'))
+  assert.ok(reviewSource.includes('idFiltersFromSearchParams(searchParams)'))
+  assert.ok(reviewSource.includes('assetSupportsIdFilter(asset) && focusedIds.length > 0'))
+})
+
+test('asset review passes focused ids through the existing drafts API', () => {
+  assert.ok(reviewSource.includes('id: assetSupportsIdFilter(asset) && focusedIds.length > 0'))
+  assert.ok(reviewSource.includes('fetchGeneratedAssetDrafts(asset, params)'))
+  assert.ok(reviewSource.includes('Showing {focusedIds.length} generated draft'))
+  assert.ok(reviewSource.includes('Show latest {activeAsset.label.toLowerCase()}'))
+})
+
+test('frontend asset API serializes id arrays as repeated query keys', () => {
+  assert.ok(apiSource.includes('id?: string | string[]'))
+  assert.ok(apiSource.includes('Array.isArray(value)'))
+  assert.ok(apiSource.includes('search.append(key, String(item))'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -522,6 +522,7 @@ export interface GeneratedAssetListParams {
   slug?: string
   topic_type?: string
   brief_type?: string
+  id?: string | string[]
   format?: string
   limit?: number
 }
@@ -779,6 +780,12 @@ function queryString(params: object): string {
   const search = new URLSearchParams()
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        search.append(key, String(item))
+      }
+      continue
+    }
     search.set(key, String(value))
   }
   const query = search.toString()

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import {
   ArrowRight,
   CheckCircle2,
@@ -184,10 +184,49 @@ const inputClassName =
   'w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:border-cyan-400 focus:outline-none'
 const textAreaClassName =
   'w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm leading-6 text-slate-100 placeholder:text-slate-600 focus:border-cyan-400 focus:outline-none'
+const ID_FILTERED_ASSETS = new Set<GeneratedAssetType>([
+  'blog_post',
+  'landing_page',
+])
+
+function assetFromSearchParams(params: URLSearchParams): GeneratedAssetType {
+  const asset = params.get('asset')
+  return ASSETS.some((item) => item.id === asset)
+    ? asset as GeneratedAssetType
+    : 'report'
+}
+
+function statusFromSearchParams(params: URLSearchParams): StatusFilter {
+  const status = params.get('status')
+  return STATUSES.includes(status as StatusFilter)
+    ? status as StatusFilter
+    : 'draft'
+}
+
+function idFiltersFromSearchParams(params: URLSearchParams): string[] {
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const raw of params.getAll('id')) {
+    const id = raw.trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+  }
+  return ids
+}
+
+function assetSupportsIdFilter(asset: GeneratedAssetType): boolean {
+  return ID_FILTERED_ASSETS.has(asset)
+}
 
 export default function ContentOpsAssetsReview() {
-  const [asset, setAsset] = useState<GeneratedAssetType>('report')
-  const [status, setStatus] = useState<StatusFilter>('draft')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [asset, setAsset] = useState<GeneratedAssetType>(() =>
+    assetFromSearchParams(searchParams),
+  )
+  const [status, setStatus] = useState<StatusFilter>(() =>
+    statusFromSearchParams(searchParams),
+  )
   const [limit, setLimit] = useState(20)
   const [data, setData] = useState<GeneratedAssetListResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -204,12 +243,19 @@ export default function ContentOpsAssetsReview() {
   const [macroPublishHistory, setMacroPublishHistory] =
     useState<MacroPublishHistoryState>({ kind: 'idle' })
 
+  const focusedIds = useMemo(
+    () => idFiltersFromSearchParams(searchParams),
+    [searchParams],
+  )
   const params = useMemo(
     () => ({
       status: status === 'all' ? '' : status,
+      id: assetSupportsIdFilter(asset) && focusedIds.length > 0
+        ? focusedIds
+        : undefined,
       limit,
     }),
-    [limit, status],
+    [asset, focusedIds, limit, status],
   )
 
   const load = useCallback(async (isRefresh = false) => {
@@ -311,6 +357,30 @@ export default function ContentOpsAssetsReview() {
     } finally {
       setExporting(false)
     }
+  }
+
+  const handleAssetChange = (nextAsset: GeneratedAssetType) => {
+    setAsset(nextAsset)
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current)
+        next.set('asset', nextAsset)
+        next.delete('id')
+        return next
+      },
+      { replace: true },
+    )
+  }
+
+  const clearFocusedIds = () => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current)
+        next.delete('id')
+        return next
+      },
+      { replace: true },
+    )
   }
 
   const handleSaveLandingPageDraft = async (
@@ -457,7 +527,7 @@ export default function ContentOpsAssetsReview() {
           <button
             key={item.id}
             type="button"
-            onClick={() => setAsset(item.id)}
+            onClick={() => handleAssetChange(item.id)}
             className={clsx(
               'rounded-lg border p-4 text-left transition',
               asset === item.id
@@ -556,6 +626,21 @@ export default function ContentOpsAssetsReview() {
           </div>
         )}
         <MacroPublishResultBanner outcome={macroPublishOutcome} />
+        {assetSupportsIdFilter(asset) && focusedIds.length > 0 && (
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-100">
+            <span>
+              Showing {focusedIds.length} generated draft
+              {focusedIds.length === 1 ? '' : 's'} from the previous run.
+            </span>
+            <button
+              type="button"
+              onClick={clearFocusedIds}
+              className="rounded-md border border-cyan-500/40 px-2.5 py-1 text-xs font-medium text-cyan-100 hover:bg-cyan-500/10"
+            >
+              Show latest {activeAsset.label.toLowerCase()}
+            </button>
+          </div>
+        )}
         {error && data && (
           <div className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
             Refresh failed: {error.message}

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { Link } from 'react-router-dom'
 import {
   ChevronRight,
   FileUp,
@@ -76,6 +77,7 @@ import {
 import type {
   ContentOpsZendeskCredential,
   GeneratedAssetDraft,
+  GeneratedAssetType,
 } from '../api/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
@@ -143,6 +145,17 @@ const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
+const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
+  'blog_post',
+  'report',
+  'landing_page',
+  'sales_brief',
+  'faq_markdown',
+]
+const ID_FILTERED_REVIEW_OUTPUTS = new Set<string>([
+  'blog_post',
+  'landing_page',
+])
 const FAQ_INTENT_RULES_DISPLAY_FALLBACK = {
   label: 'Intent rules',
   placeholder:
@@ -3396,10 +3409,22 @@ function ExecutionStepSummary({
     return <SignalExtractionSummary result={result} />
   }
   if (output === 'email_campaign') {
-    return <GeneratedAssetSummary result={result} generatedLabel="Drafts generated" />
+    return (
+      <GeneratedAssetSummary
+        output={output}
+        result={result}
+        generatedLabel="Drafts generated"
+      />
+    )
   }
   if (['blog_post', 'report', 'landing_page', 'sales_brief'].includes(output)) {
-    return <GeneratedAssetSummary result={result} generatedLabel="Assets generated" />
+    return (
+      <GeneratedAssetSummary
+        output={output}
+        result={result}
+        generatedLabel="Assets generated"
+      />
+    )
   }
   if (output === 'faq_markdown') {
     return <FAQMarkdownExecutionSummary result={result} />
@@ -3833,9 +3858,11 @@ function numberMeta(value: number | null, label: string): string {
 }
 
 function GeneratedAssetSummary({
+  output,
   result,
   generatedLabel,
 }: {
+  output: string
   result: Record<string, unknown>
   generatedLabel: string
 }) {
@@ -3850,6 +3877,7 @@ function GeneratedAssetSummary({
     typeof result.reasoning_contexts_used === 'number'
       ? result.reasoning_contexts_used
       : null
+  const reviewHref = generatedAssetReviewHref(output, savedIds)
 
   if (
     requested === null &&
@@ -3911,8 +3939,36 @@ function GeneratedAssetSummary({
           ))}
         </div>
       )}
+      {reviewHref && (
+        <Link
+          to={reviewHref}
+          className="inline-flex items-center gap-1.5 rounded-md border border-cyan-500/40 px-2.5 py-1 text-xs font-medium text-cyan-200 hover:bg-cyan-500/10"
+        >
+          Review generated drafts
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      )}
     </div>
   )
+}
+
+function generatedAssetReviewHref(output: string, savedIds: string[]): string | null {
+  if (!isGeneratedAssetOutput(output)) return null
+  const idFiltered = ID_FILTERED_REVIEW_OUTPUTS.has(output)
+  if (idFiltered && savedIds.length === 0) return null
+  const params = new URLSearchParams()
+  params.set('asset', output)
+  params.set('status', 'draft')
+  if (idFiltered) {
+    for (const id of savedIds) {
+      params.append('id', id)
+    }
+  }
+  return `/content-ops/assets?${params.toString()}`
+}
+
+function isGeneratedAssetOutput(output: string): output is GeneratedAssetType {
+  return GENERATED_ASSET_OUTPUTS.includes(output as GeneratedAssetType)
 }
 
 function ReasoningAuditBadge({ audit }: { audit: ContentOpsStepReasoningAudit }) {

--- a/plans/PR-Landing-Page-UI-E2E-Validation.md
+++ b/plans/PR-Landing-Page-UI-E2E-Validation.md
@@ -1,0 +1,109 @@
+# PR: Landing Page UI E2E Validation
+
+## Why this slice exists
+
+The landing-page generation stack is mostly productized: `/content-ops/new`
+can execute `landing_page`, the host input provider can package support-ticket
+and saved FAQ report source material, asset review can edit/approve generated
+landing pages, and `/lp/:id/:slug` can render approved pages. The remaining UI
+gap is the handoff between those pieces: after execution, the new-run screen
+shows raw saved IDs but does not take the operator directly to the matching
+landing-page review queue. That makes the path feel unfinished and easy to
+mis-operate when testing live generation.
+
+This slice finishes that handoff and locks it with focused UI/API contract
+tests.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/landing-pages-productization
+
+Slice phase: Vertical slice
+
+1. Add review links to generated-asset execution summaries so a completed
+   `landing_page` run points directly at the review screen.
+2. Teach the generated-asset review screen to honor `asset`, `status`, and
+   repeated `id` query parameters on initial load.
+3. Preserve the backend's existing `id` query contract by serializing array
+   params as repeated keys from the frontend API helper.
+4. Add a focused frontend script test for the new-run -> review deep link and
+   review-page query handling.
+5. Enroll that focused test in `atlas-intel-ui-checks` so the PR's regression
+   lock runs in CI.
+
+### Files touched
+
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/scripts/content-ops-landing-page-e2e-ui.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `plans/PR-Landing-Page-UI-E2E-Validation.md`
+
+## Mechanism
+
+`GeneratedAssetSummary` will receive the step `output`, derive a review href
+for reviewable asset outputs, and include saved landing-page IDs as repeated
+`id` query parameters:
+
+```text
+/content-ops/assets?asset=landing_page&status=draft&id=<saved-id>
+```
+
+`ContentOpsAssetsReview` will read those query parameters on load, initialize
+the asset/status filters, and pass the `id` array through
+`fetchGeneratedAssetDrafts(...)`. The API query serializer will append arrays
+with repeated keys so FastAPI receives `id: list[str]` instead of one comma
+joined string.
+
+For `landing_page` and `blog_post`, the review link is suppressed unless the
+run returned at least one saved ID, preventing an ID-scoped output from opening
+the general review queue after a skipped or failed persistence result.
+
+## Intentional
+
+- This is not another generation, quality-gate, or public-rendering rewrite.
+  Those pieces already exist; the missing surface is the UI transition from
+  generated draft IDs to review/approval/public URL.
+- The review page uses query params as an initial deep-link/filter affordance.
+  It does not attempt to keep every later tab/status change perfectly synced
+  back to the URL in this slice.
+- `id` filters are attached only where the backend supports them
+  (`landing_page` and `blog_post`). Other reviewable assets still get an asset
+  + status link without ID filtering because the link cannot accidentally imply
+  a specific saved draft.
+
+## Deferred
+
+- Blog productization remains a later lane. This PR may keep the shared
+  generated-asset helper compatible with `blog_post`, but it does not build the
+  public `/blog` route.
+- Hosted browser validation against a live Vercel/API deployment remains a
+  follow-up once this UI contract lands.
+- Parked hardening: none. `HARDENING.md` was scanned; no landing-page entries
+  touch this slice.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit
+  findings already parked in `HARDENING.md`.
+- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4
+  passed.
+- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
+- `cd atlas-intel-ui && npm run build` - passed; TypeScript and Vite build
+  completed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /home/juan-canfield/Desktop/landing-page-ui-e2e-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~80 |
+| New-run review link | ~55 |
+| Asset-review query handling | ~65 |
+| API query serialization | ~15 |
+| Frontend script test + package script | ~75 |
+| CI enrollment | ~5 |
+| **Total** | **~295** |


### PR DESCRIPTION
Plan: plans/PR-Landing-Page-UI-E2E-Validation.md
Slice phase: Vertical slice

Finish the landing-page generation-to-review UI handoff: completed landing-page runs now link saved draft IDs straight into generated-asset review, and the review screen honors the matching asset/status/id deep-link query so the operator can approve the page and open its public URL without manually copying IDs.

## Intentional
- Scope is the UI handoff only; generation, approval, and public rendering paths already exist.
- ID filters are attached only for backend-supported review assets (`landing_page` and `blog_post`), and those ID-scoped links are hidden if a run returns no saved IDs.

## Deferred
- Blog productization remains a later lane.
- Hosted browser validation against live deployment remains a follow-up after this contract lands.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit findings already parked in `HARDENING.md`.
- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4 passed.
- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
- `cd atlas-intel-ui && npm run build` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/landing-page-ui-e2e-pr-body.md` - passed.

## Diff size
7 files, about +320 / -7 LOC.
