### PR TITLE
PR-Blog-Public-Generated-Posts

### DIFF
--- a/.github/workflows/atlas_blog_public_checks.yml
+++ b/.github/workflows/atlas_blog_public_checks.yml
@@ -1,0 +1,37 @@
+name: Atlas Blog Public Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_blog_public_checks.yml"
+      - "atlas_brain/api/blog_public.py"
+      - "tests/test_blog_public.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_blog_public_checks.yml"
+      - "atlas_brain/api/blog_public.py"
+      - "tests/test_blog_public.py"
+
+jobs:
+  atlas-blog-public-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run public blog API tests
+        run: python -m pytest tests/test_blog_public.py -q

--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Test landing-page prerender verifier
         run: npm run test:landing-page-prerender
 
+      - name: Test public generated blog posts
+        run: npm run test:blog-public-generated-posts
+
       - name: Test Content Ops deflection report UI
         run: npm run test:content-ops-deflection-report-ui
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -20,6 +20,7 @@
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
+    "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
+++ b/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
@@ -14,6 +14,14 @@ const blogPostPageSource = readFileSync(
   new URL('../src/pages/BlogPost.tsx', import.meta.url),
   'utf8',
 )
+const publicLandingPageSource = readFileSync(
+  new URL('../src/pages/PublicLandingPage.tsx', import.meta.url),
+  'utf8',
+)
+const safeMarkdownSource = readFileSync(
+  new URL('../src/lib/safeMarkdown.ts', import.meta.url),
+  'utf8',
+)
 
 test('public blog adapter fetches list and detail from backend public routes', () => {
   assert.ok(blogApiSource.includes("const BASE = `${API_BASE}/api/v1/blog`"))
@@ -40,9 +48,21 @@ test('blog detail fetches generated post only when slug is not static', () => {
 })
 
 test('blog detail sanitizes rendered markdown before html injection', () => {
-  assert.ok(blogPostPageSource.includes('renderSafeMarkdown(content)'))
-  assert.ok(blogPostPageSource.includes('sanitizeRenderedHtml(html)'))
-  assert.ok(blogPostPageSource.includes("element.removeAttribute(attr.name)"))
-  assert.ok(blogPostPageSource.includes("name.startsWith('on')"))
-  assert.ok(blogPostPageSource.includes("!safeUrl(attr.value)"))
+  assert.ok(
+    blogPostPageSource.includes(
+      "import { renderSafeMarkdown, sanitizeRenderedHtml } from '../lib/safeMarkdown'",
+    ),
+  )
+  assert.ok(
+    publicLandingPageSource.includes("import { renderSafeMarkdown } from '../lib/safeMarkdown'"),
+  )
+  assert.ok(blogPostPageSource.includes('renderContentWithCharts(post.content, post.charts, !staticPost)'))
+  assert.ok(safeMarkdownSource.includes('markdown.replace(/[<>]/g'))
+  assert.ok(safeMarkdownSource.includes('char === \'<\' ? \'&lt;\' : \'&gt;\''))
+  assert.ok(safeMarkdownSource.includes("element.removeAttribute(attr.name)"))
+  assert.ok(safeMarkdownSource.includes("name.startsWith('on')"))
+  assert.ok(safeMarkdownSource.includes("!safeUrl(attr.value)"))
+  assert.ok(!blogPostPageSource.includes('const UNSAFE_HTML_RE'))
+  assert.ok(!blogPostPageSource.includes('function sanitizeRenderedHtml'))
+  assert.ok(!publicLandingPageSource.includes('function renderSafeMarkdown'))
 })

--- a/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
+++ b/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
@@ -35,4 +35,14 @@ test('blog detail fetches generated post only when slug is not static', () => {
   assert.ok(blogPostPageSource.includes('if (!slug || staticPost)'))
   assert.ok(blogPostPageSource.includes('fetchPublicBlogPost(slug)'))
   assert.ok(blogPostPageSource.includes('loadingGeneratedPost'))
+  assert.ok(!blogPostPageSource.includes('setGeneratedPost(null)'))
+  assert.ok(!blogPostPageSource.includes('setLoadingGeneratedPost(false)'))
+})
+
+test('blog detail sanitizes rendered markdown before html injection', () => {
+  assert.ok(blogPostPageSource.includes('renderSafeMarkdown(content)'))
+  assert.ok(blogPostPageSource.includes('sanitizeRenderedHtml(html)'))
+  assert.ok(blogPostPageSource.includes("element.removeAttribute(attr.name)"))
+  assert.ok(blogPostPageSource.includes("name.startsWith('on')"))
+  assert.ok(blogPostPageSource.includes("!safeUrl(attr.value)"))
 })

--- a/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
+++ b/atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const blogApiSource = readFileSync(
+  new URL('../src/api/blog.ts', import.meta.url),
+  'utf8',
+)
+const blogPageSource = readFileSync(
+  new URL('../src/pages/Blog.tsx', import.meta.url),
+  'utf8',
+)
+const blogPostPageSource = readFileSync(
+  new URL('../src/pages/BlogPost.tsx', import.meta.url),
+  'utf8',
+)
+
+test('public blog adapter fetches list and detail from backend public routes', () => {
+  assert.ok(blogApiSource.includes("const BASE = `${API_BASE}/api/v1/blog`"))
+  assert.ok(blogApiSource.includes("getPublicBlogJson<PublicBlogListWire>('/published')"))
+  assert.ok(blogApiSource.includes("`/published/${encodeURIComponent(slug)}`"))
+  assert.ok(blogApiSource.includes('publicBlogPostFromWire'))
+})
+
+test('blog index merges generated posts ahead of static fallback posts', () => {
+  assert.ok(blogPageSource.includes('fetchPublicBlogPosts'))
+  assert.ok(blogPageSource.includes('useState<BlogPost[]>(POSTS)'))
+  assert.ok(blogPageSource.includes('setPosts(mergeBlogPosts(generatedPosts, POSTS))'))
+  assert.ok(blogPageSource.includes('function mergeBlogPosts'))
+})
+
+test('blog detail fetches generated post only when slug is not static', () => {
+  assert.ok(blogPostPageSource.includes('const staticPost = POSTS.find'))
+  assert.ok(blogPostPageSource.includes('const post = staticPost ?? generatedPost'))
+  assert.ok(blogPostPageSource.includes('if (!slug || staticPost)'))
+  assert.ok(blogPostPageSource.includes('fetchPublicBlogPost(slug)'))
+  assert.ok(blogPostPageSource.includes('loadingGeneratedPost'))
+})

--- a/atlas-intel-ui/src/api/blog.ts
+++ b/atlas-intel-ui/src/api/blog.ts
@@ -1,0 +1,139 @@
+import { API_BASE } from './config'
+import type { BlogPost, ChartSpec, FaqItem } from '../content/blog'
+
+const BASE = `${API_BASE}/api/v1/blog`
+
+interface PublicBlogPostWire {
+  slug?: string
+  title?: string
+  description?: string
+  date?: string
+  author?: string
+  tags?: unknown
+  content?: string
+  charts?: unknown
+  topic_type?: string
+  data_context?: Record<string, unknown>
+  seo_title?: string | null
+  seo_description?: string | null
+  target_keyword?: string | null
+  secondary_keywords?: unknown
+  faq?: unknown
+  related_slugs?: unknown
+}
+
+interface PublicBlogListWire {
+  posts?: PublicBlogPostWire[]
+  total?: number
+}
+
+interface PublicBlogDetailWire {
+  post?: PublicBlogPostWire | null
+}
+
+export async function fetchPublicBlogPosts(): Promise<BlogPost[]> {
+  const response = await getPublicBlogJson<PublicBlogListWire>('/published')
+  return Array.isArray(response.posts)
+    ? response.posts
+        .map(publicBlogPostFromWire)
+        .filter((post): post is BlogPost => Boolean(post))
+    : []
+}
+
+export async function fetchPublicBlogPost(slug: string): Promise<BlogPost | null> {
+  const response = await getPublicBlogJson<PublicBlogDetailWire>(
+    `/published/${encodeURIComponent(slug)}`,
+  )
+  return response.post ? publicBlogPostFromWire(response.post) : null
+}
+
+function publicBlogPostFromWire(value: PublicBlogPostWire): BlogPost | null {
+  const slug = textValue(value.slug)
+  const title = textValue(value.title)
+  const content = textValue(value.content)
+  if (!slug || !title || !content) return null
+  return {
+    slug,
+    title,
+    description: textValue(value.description) || title,
+    date: dateValue(value.date),
+    author: textValue(value.author) || 'Atlas Intelligence',
+    tags: stringList(value.tags),
+    content,
+    charts: chartList(value.charts),
+    topic_type: textValue(value.topic_type) || undefined,
+    data_context: value.data_context ?? undefined,
+    seo_title: textValue(value.seo_title) || undefined,
+    seo_description: textValue(value.seo_description) || undefined,
+    target_keyword: textValue(value.target_keyword) || undefined,
+    secondary_keywords: stringList(value.secondary_keywords),
+    faq: faqList(value.faq),
+    related_slugs: stringList(value.related_slugs),
+  }
+}
+
+function maybeFallbackApiPath(url: string): string | null {
+  if (!url.includes('/api/v1/')) return null
+  return url.replace('/api/v1/', '/api/')
+}
+
+async function getPublicBlogJson<T>(path: string): Promise<T> {
+  const url = `${BASE}${path}`
+  let response = await fetch(url)
+  if (response.status === 404) {
+    const fallback = maybeFallbackApiPath(url)
+    if (fallback) response = await fetch(fallback)
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`API ${response.status}: ${text || response.statusText}`)
+  }
+  return response.json() as Promise<T>
+}
+
+function textValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function dateValue(value: unknown): string {
+  const text = textValue(value)
+  return text ? text.slice(0, 10) : new Date().toISOString().slice(0, 10)
+}
+
+function stringList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(textValue).filter(Boolean)
+  const text = textValue(value)
+  return text ? text.split(',').map((item) => item.trim()).filter(Boolean) : []
+}
+
+function chartList(value: unknown): ChartSpec[] {
+  return Array.isArray(value) ? value.filter(isChartSpec) : []
+}
+
+function isChartSpec(value: unknown): value is ChartSpec {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const chart = value as Record<string, unknown>
+  const chartType = textValue(chart.chart_type)
+  return Boolean(
+    textValue(chart.chart_id) &&
+      ['bar', 'horizontal_bar', 'radar', 'line'].includes(chartType) &&
+      textValue(chart.title) &&
+      Array.isArray(chart.data) &&
+      chart.config &&
+      typeof chart.config === 'object' &&
+      !Array.isArray(chart.config),
+  )
+}
+
+function faqList(value: unknown): FaqItem[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return null
+      const record = item as Record<string, unknown>
+      const question = textValue(record.question)
+      const answer = textValue(record.answer)
+      return question && answer ? { question, answer } : null
+    })
+    .filter((item): item is FaqItem => Boolean(item))
+}

--- a/atlas-intel-ui/src/lib/safeMarkdown.ts
+++ b/atlas-intel-ui/src/lib/safeMarkdown.ts
@@ -1,0 +1,39 @@
+import { marked } from 'marked'
+
+export function renderSafeMarkdown(markdown: string): string {
+  const escapedMarkdown = markdown.replace(/[<>]/g, (char) =>
+    char === '<' ? '&lt;' : '&gt;',
+  )
+  const html = marked.parse(escapedMarkdown, { async: false }) as string
+  return sanitizeRenderedHtml(html)
+}
+
+export function sanitizeRenderedHtml(html: string): string {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  for (const element of Array.from(template.content.querySelectorAll('*'))) {
+    for (const attr of Array.from(element.attributes)) {
+      const name = attr.name.toLowerCase()
+      if (name.startsWith('on') || name === 'style') {
+        element.removeAttribute(attr.name)
+        continue
+      }
+      if ((name === 'href' || name === 'src') && !safeUrl(attr.value)) {
+        element.removeAttribute(attr.name)
+      }
+    }
+  }
+  return template.innerHTML
+}
+
+export function safeUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.startsWith('https://') ||
+    normalized.startsWith('http://') ||
+    normalized.startsWith('mailto:') ||
+    normalized.startsWith('tel:') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('#')
+  )
+}

--- a/atlas-intel-ui/src/pages/Blog.tsx
+++ b/atlas-intel-ui/src/pages/Blog.tsx
@@ -1,9 +1,11 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import PublicLayout from '../components/PublicLayout'
 import BlogCardVisual from '../components/BlogCardVisual'
 import SeoHead from '../components/SeoHead'
 import { POSTS } from '../content/blog'
+import type { BlogPost } from '../content/blog'
+import { fetchPublicBlogPosts } from '../api/blog'
 
 const AtlasRobotScene = lazy(() => import('../components/AtlasRobotScene'))
 
@@ -18,6 +20,22 @@ function formatDate(iso: string) {
 const BLOG_DESCRIPTION = 'Amazon seller intelligence, review monitoring strategies, and competitive analysis insights.'
 
 export default function Blog() {
+  const [posts, setPosts] = useState<BlogPost[]>(POSTS)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchPublicBlogPosts()
+      .then((generatedPosts) => {
+        if (!cancelled) setPosts(mergeBlogPosts(generatedPosts, POSTS))
+      })
+      .catch(() => {
+        if (!cancelled) setPosts(POSTS)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   return (
     <>
       <SeoHead
@@ -41,7 +59,7 @@ export default function Blog() {
         {/* Post grid */}
         <section className="max-w-5xl mx-auto px-6 pb-24">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {POSTS.map(post => (
+            {posts.map(post => (
               <Link
                 key={post.slug}
                 to={`/blog/${post.slug}`}
@@ -72,4 +90,11 @@ export default function Blog() {
       </PublicLayout>
     </>
   )
+}
+
+function mergeBlogPosts(generatedPosts: BlogPost[], staticPosts: BlogPost[]): BlogPost[] {
+  const bySlug = new Map<string, BlogPost>()
+  for (const post of staticPosts) bySlug.set(post.slug, post)
+  for (const post of generatedPosts) bySlug.set(post.slug, post)
+  return [...bySlug.values()].sort((a, b) => b.date.localeCompare(a.date))
 }

--- a/atlas-intel-ui/src/pages/BlogPost.tsx
+++ b/atlas-intel-ui/src/pages/BlogPost.tsx
@@ -8,6 +8,7 @@ import BlogCardVisual from '../components/BlogCardVisual'
 import { POSTS } from '../content/blog'
 import type { ChartSpec, BlogPost as BlogPostType } from '../content/blog'
 import { fetchPublicBlogPost } from '../api/blog'
+import { renderSafeMarkdown, sanitizeRenderedHtml } from '../lib/safeMarkdown'
 
 const BlogChart = lazy(() => import('../components/BlogChartRenderer'))
 
@@ -20,16 +21,19 @@ function formatDate(iso: string) {
 }
 
 const CHART_PLACEHOLDER_RE = /(\{\{chart:[^}]+\}\})/
-const UNSAFE_HTML_RE = 'script, iframe, object, embed, link, meta, style, base'
 
 type GeneratedPostState = {
   slug: string
   post: BlogPostType | null
 }
 
-function renderContentWithCharts(content: string, charts?: ChartSpec[]) {
+function renderContentWithCharts(
+  content: string,
+  charts: ChartSpec[] | undefined,
+  escapeRawHtml: boolean,
+) {
   if (!charts || charts.length === 0) {
-    const html = renderSafeMarkdown(content)
+    const html = renderBlogMarkdown(content, escapeRawHtml)
     return <div className="blog-prose" dangerouslySetInnerHTML={{ __html: html }} />
   }
 
@@ -52,49 +56,17 @@ function renderContentWithCharts(content: string, charts?: ChartSpec[]) {
           return null
         }
         if (!part.trim()) return null
-        const html = renderSafeMarkdown(part)
+        const html = renderBlogMarkdown(part, escapeRawHtml)
         return <div key={i} dangerouslySetInnerHTML={{ __html: html }} />
       })}
     </div>
   )
 }
 
-function renderSafeMarkdown(markdown: string): string {
+function renderBlogMarkdown(markdown: string, escapeRawHtml: boolean): string {
+  if (escapeRawHtml) return renderSafeMarkdown(markdown)
   const html = marked.parse(markdown, { async: false }) as string
   return sanitizeRenderedHtml(html)
-}
-
-function sanitizeRenderedHtml(html: string): string {
-  const template = document.createElement('template')
-  template.innerHTML = html
-  for (const element of Array.from(template.content.querySelectorAll(UNSAFE_HTML_RE))) {
-    element.remove()
-  }
-  for (const element of Array.from(template.content.querySelectorAll('*'))) {
-    for (const attr of Array.from(element.attributes)) {
-      const name = attr.name.toLowerCase()
-      if (name.startsWith('on') || name === 'style') {
-        element.removeAttribute(attr.name)
-        continue
-      }
-      if ((name === 'href' || name === 'src') && !safeUrl(attr.value)) {
-        element.removeAttribute(attr.name)
-      }
-    }
-  }
-  return template.innerHTML
-}
-
-function safeUrl(value: string): boolean {
-  const normalized = value.trim().toLowerCase()
-  return (
-    normalized.startsWith('https://') ||
-    normalized.startsWith('http://') ||
-    normalized.startsWith('mailto:') ||
-    normalized.startsWith('tel:') ||
-    normalized.startsWith('/') ||
-    normalized.startsWith('#')
-  )
 }
 
 export default function BlogPost() {
@@ -125,8 +97,8 @@ export default function BlogPost() {
 
   const renderedContent = useMemo(() => {
     if (!post) return null
-    return renderContentWithCharts(post.content, post.charts)
-  }, [post])
+    return renderContentWithCharts(post.content, post.charts, !staticPost)
+  }, [post, staticPost])
 
   const seoKeywords = useMemo(() => {
     if (!post) return undefined

--- a/atlas-intel-ui/src/pages/BlogPost.tsx
+++ b/atlas-intel-ui/src/pages/BlogPost.tsx
@@ -1,12 +1,13 @@
 import { useParams, Link } from 'react-router-dom'
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { marked } from 'marked'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Loader2 } from 'lucide-react'
 import PublicLayout from '../components/PublicLayout'
 import SeoHead from '../components/SeoHead'
 import BlogCardVisual from '../components/BlogCardVisual'
 import { POSTS } from '../content/blog'
 import type { ChartSpec, BlogPost as BlogPostType } from '../content/blog'
+import { fetchPublicBlogPost } from '../api/blog'
 
 const BlogChart = lazy(() => import('../components/BlogChartRenderer'))
 
@@ -54,7 +55,33 @@ function renderContentWithCharts(content: string, charts?: ChartSpec[]) {
 
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>()
-  const post = POSTS.find(p => p.slug === slug)
+  const staticPost = POSTS.find(p => p.slug === slug)
+  const [generatedPost, setGeneratedPost] = useState<BlogPostType | null>(null)
+  const [loadingGeneratedPost, setLoadingGeneratedPost] = useState(false)
+  const post = staticPost ?? generatedPost
+
+  useEffect(() => {
+    if (!slug || staticPost) {
+      setGeneratedPost(null)
+      setLoadingGeneratedPost(false)
+      return
+    }
+    let cancelled = false
+    setLoadingGeneratedPost(true)
+    fetchPublicBlogPost(slug)
+      .then((nextPost) => {
+        if (!cancelled) setGeneratedPost(nextPost)
+      })
+      .catch(() => {
+        if (!cancelled) setGeneratedPost(null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingGeneratedPost(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug, staticPost])
 
   const renderedContent = useMemo(() => {
     if (!post) return null
@@ -136,6 +163,16 @@ export default function BlogPost() {
       .map(s => POSTS.find(p => p.slug === s))
       .filter((p): p is BlogPostType => !!p)
   }, [post])
+
+  if (!post && loadingGeneratedPost) {
+    return (
+      <PublicLayout>
+        <section className="max-w-3xl mx-auto flex min-h-[40vh] items-center justify-center px-6 py-24">
+          <Loader2 className="h-6 w-6 animate-spin text-cyan-300" />
+        </section>
+      </PublicLayout>
+    )
+  }
 
   if (!post) {
     return (

--- a/atlas-intel-ui/src/pages/BlogPost.tsx
+++ b/atlas-intel-ui/src/pages/BlogPost.tsx
@@ -20,10 +20,16 @@ function formatDate(iso: string) {
 }
 
 const CHART_PLACEHOLDER_RE = /(\{\{chart:[^}]+\}\})/
+const UNSAFE_HTML_RE = 'script, iframe, object, embed, link, meta, style, base'
+
+type GeneratedPostState = {
+  slug: string
+  post: BlogPostType | null
+}
 
 function renderContentWithCharts(content: string, charts?: ChartSpec[]) {
   if (!charts || charts.length === 0) {
-    const html = marked.parse(content, { async: false }) as string
+    const html = renderSafeMarkdown(content)
     return <div className="blog-prose" dangerouslySetInnerHTML={{ __html: html }} />
   }
 
@@ -46,37 +52,71 @@ function renderContentWithCharts(content: string, charts?: ChartSpec[]) {
           return null
         }
         if (!part.trim()) return null
-        const html = marked.parse(part, { async: false }) as string
+        const html = renderSafeMarkdown(part)
         return <div key={i} dangerouslySetInnerHTML={{ __html: html }} />
       })}
     </div>
   )
 }
 
+function renderSafeMarkdown(markdown: string): string {
+  const html = marked.parse(markdown, { async: false }) as string
+  return sanitizeRenderedHtml(html)
+}
+
+function sanitizeRenderedHtml(html: string): string {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  for (const element of Array.from(template.content.querySelectorAll(UNSAFE_HTML_RE))) {
+    element.remove()
+  }
+  for (const element of Array.from(template.content.querySelectorAll('*'))) {
+    for (const attr of Array.from(element.attributes)) {
+      const name = attr.name.toLowerCase()
+      if (name.startsWith('on') || name === 'style') {
+        element.removeAttribute(attr.name)
+        continue
+      }
+      if ((name === 'href' || name === 'src') && !safeUrl(attr.value)) {
+        element.removeAttribute(attr.name)
+      }
+    }
+  }
+  return template.innerHTML
+}
+
+function safeUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.startsWith('https://') ||
+    normalized.startsWith('http://') ||
+    normalized.startsWith('mailto:') ||
+    normalized.startsWith('tel:') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('#')
+  )
+}
+
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>()
   const staticPost = POSTS.find(p => p.slug === slug)
-  const [generatedPost, setGeneratedPost] = useState<BlogPostType | null>(null)
-  const [loadingGeneratedPost, setLoadingGeneratedPost] = useState(false)
+  const [generatedPostState, setGeneratedPostState] = useState<GeneratedPostState | null>(null)
+  const generatedPostResolvedForSlug = Boolean(generatedPostState && generatedPostState.slug === slug)
+  const generatedPost = generatedPostState && generatedPostState.slug === slug
+    ? generatedPostState.post
+    : null
+  const loadingGeneratedPost = Boolean(slug && !staticPost && !generatedPostResolvedForSlug)
   const post = staticPost ?? generatedPost
 
   useEffect(() => {
-    if (!slug || staticPost) {
-      setGeneratedPost(null)
-      setLoadingGeneratedPost(false)
-      return
-    }
+    if (!slug || staticPost) return
     let cancelled = false
-    setLoadingGeneratedPost(true)
     fetchPublicBlogPost(slug)
       .then((nextPost) => {
-        if (!cancelled) setGeneratedPost(nextPost)
+        if (!cancelled) setGeneratedPostState({ slug, post: nextPost })
       })
       .catch(() => {
-        if (!cancelled) setGeneratedPost(null)
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingGeneratedPost(false)
+        if (!cancelled) setGeneratedPostState({ slug, post: null })
       })
     return () => {
       cancelled = true

--- a/atlas-intel-ui/src/pages/PublicLandingPage.tsx
+++ b/atlas-intel-ui/src/pages/PublicLandingPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { marked } from 'marked'
 import { ArrowRight, Loader2 } from 'lucide-react'
 import {
   fetchPublicLandingPageDraft,
@@ -8,6 +7,7 @@ import {
 } from '../api/contentOps'
 import PublicLayout from '../components/PublicLayout'
 import SeoHead from '../components/SeoHead'
+import { renderSafeMarkdown } from '../lib/safeMarkdown'
 
 type LandingPageSectionView = {
   id: string
@@ -249,44 +249,6 @@ function recordValue(value: unknown): Record<string, unknown> | null {
 
 function textValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
-}
-
-function renderSafeMarkdown(markdown: string): string {
-  const escapedMarkdown = markdown.replace(/[<>]/g, (char) =>
-    char === '<' ? '&lt;' : '&gt;',
-  )
-  const html = marked.parse(escapedMarkdown, { async: false }) as string
-  return sanitizeRenderedHtml(html)
-}
-
-function sanitizeRenderedHtml(html: string): string {
-  const template = document.createElement('template')
-  template.innerHTML = html
-  for (const element of Array.from(template.content.querySelectorAll('*'))) {
-    for (const attr of Array.from(element.attributes)) {
-      const name = attr.name.toLowerCase()
-      if (name.startsWith('on') || name === 'style') {
-        element.removeAttribute(attr.name)
-        continue
-      }
-      if ((name === 'href' || name === 'src') && !safeUrl(attr.value)) {
-        element.removeAttribute(attr.name)
-      }
-    }
-  }
-  return template.innerHTML
-}
-
-function safeUrl(value: string): boolean {
-  const normalized = value.trim().toLowerCase()
-  return (
-    normalized.startsWith('https://') ||
-    normalized.startsWith('http://') ||
-    normalized.startsWith('mailto:') ||
-    normalized.startsWith('tel:') ||
-    normalized.startsWith('/') ||
-    normalized.startsWith('#')
-  )
 }
 
 function structuredDataWithCanonical(value: unknown, canonical: string): object | undefined {

--- a/atlas_brain/api/blog_public.py
+++ b/atlas_brain/api/blog_public.py
@@ -134,7 +134,7 @@ async def get_published_post(slug: str) -> dict:
     slug = _clean_required_text(slug, "slug")
     pool = get_db_pool()
     row = await pool.fetchrow(
-        """
+        f"""
         SELECT id, slug, title, description, topic_type, tags,
                content, charts, data_context,
                seo_title, seo_description, target_keyword,
@@ -142,7 +142,7 @@ async def get_published_post(slug: str) -> dict:
                llm_model, source_report_date,
                published_at, created_at
         FROM blog_posts
-        WHERE slug = $1 AND status IN ('published', 'approved')
+        WHERE slug = $1 AND {PUBLIC_BLOG_STATUS_FILTER}
         """,
         slug,
     )

--- a/atlas_brain/api/blog_public.py
+++ b/atlas_brain/api/blog_public.py
@@ -17,6 +17,7 @@ from ..storage.database import get_db_pool
 logger = logging.getLogger("atlas.api.blog_public")
 
 router = APIRouter(prefix="/blog", tags=["blog-public"])
+PUBLIC_BLOG_STATUS_FILTER = "status IN ('published', 'approved')"
 
 
 def _unwrap_param_default(value: object | None) -> object | None:
@@ -68,7 +69,7 @@ async def list_published_posts(
     offset = _clean_int_query(offset, default=0)
     pool = get_db_pool()
 
-    filters = ["status = 'published'"]
+    filters = [PUBLIC_BLOG_STATUS_FILTER]
     params: list[Any] = []
     idx = 1
 
@@ -141,7 +142,7 @@ async def get_published_post(slug: str) -> dict:
                llm_model, source_report_date,
                published_at, created_at
         FROM blog_posts
-        WHERE slug = $1 AND status = 'published'
+        WHERE slug = $1 AND status IN ('published', 'approved')
         """,
         slug,
     )

--- a/plans/PR-Blog-Public-Generated-Posts.md
+++ b/plans/PR-Blog-Public-Generated-Posts.md
@@ -86,8 +86,9 @@ the slug from the public API and renders the same `BlogPost` template.
   warning from the local environment.
 - `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit
   findings already parked in `HARDENING.md`.
-- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 3
+- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4
   passed.
+- `cd atlas-intel-ui && npm run lint` - passed.
 - `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4
   passed.
 - `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.

--- a/plans/PR-Blog-Public-Generated-Posts.md
+++ b/plans/PR-Blog-Public-Generated-Posts.md
@@ -1,0 +1,116 @@
+# PR: Blog Public Generated Posts
+
+## Why this slice exists
+
+PR #1223 finished the landing-page generation-to-review handoff. The matching
+blog path is still not productized: Content Ops can generate and approve
+`blog_post` drafts, and the backend already exposes public blog endpoints, but
+those endpoints only read `status = 'published'` while generated-asset review
+sets drafts to `approved`. The React `/blog` and `/blog/:slug` pages also still
+render only static `POSTS`, so approved generated blog posts do not show up in
+the public product surface.
+
+This slice makes approved generated blog posts visible on the public blog
+pages while keeping the existing static posts as a safe fallback.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-public-productization
+
+Slice phase: Vertical slice
+
+1. Update the public blog API to treat `approved` generated posts as public
+   alongside legacy `published` posts.
+2. Add a small frontend public-blog API adapter for `/api/v1/blog/published`
+   and `/api/v1/blog/published/{slug}`.
+3. Make `/blog` load generated public posts at runtime and merge them ahead of
+   static posts by slug.
+4. Make `/blog/:slug` fetch generated posts when the slug is not static, while
+   preserving the static rendering path for existing prerendered content.
+5. Add focused backend and frontend tests for approved visibility and runtime
+   generated-post fetching.
+6. Enroll both focused suites in CI.
+
+### Files touched
+
+- `atlas_brain/api/blog_public.py`
+- `tests/test_blog_public.py`
+- `atlas-intel-ui/src/api/blog.ts`
+- `atlas-intel-ui/src/pages/Blog.tsx`
+- `atlas-intel-ui/src/pages/BlogPost.tsx`
+- `atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `.github/workflows/atlas_blog_public_checks.yml`
+- `plans/PR-Blog-Public-Generated-Posts.md`
+
+## Mechanism
+
+The backend public query keeps the existing `/blog/published` route names for
+compatibility, but its public status predicate becomes:
+
+```sql
+status IN ('published', 'approved')
+```
+
+The frontend adapter converts the backend wire shape into the existing
+`BlogPost` view model. The list page starts with static `POSTS`, fetches public
+generated posts, and merges by slug with generated posts taking precedence. The
+detail page uses the static post immediately when present; otherwise it fetches
+the slug from the public API and renders the same `BlogPost` template.
+
+## Intentional
+
+- No generation, review, or blog-admin rewrite. This is the public read path
+  for already generated and approved posts.
+- Static posts remain in place for existing prerendered SEO pages and as a
+  fallback if the public API is unavailable.
+- The backend route names remain `/published` to avoid breaking existing
+  callers; only the public eligibility predicate expands to include approved
+  generated-asset drafts.
+
+## Deferred
+
+- Full static prerender/sitemap ingestion for generated blog posts remains a
+  later SEO/GEO hardening slice. This vertical slice makes the public pages
+  usable at runtime.
+- A consolidated frontend API fetch helper remains out of scope; existing
+  modules already duplicate small fetch wrappers.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  current blog entries focus on generator content quality, not this public
+  read path.
+
+## Verification
+
+- `pytest tests/test_blog_public.py -q` - 4 passed, 1 existing torch CUDA
+  warning from the local environment.
+- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit
+  findings already parked in `HARDENING.md`.
+- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 3
+  passed.
+- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4
+  passed.
+- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
+- `cd atlas-intel-ui && npm run build` - passed; TypeScript and Vite build
+  completed.
+- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /home/juan-canfield/Desktop/blog-public-generated-posts-pr-body.md` -
+  passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~95 |
+| Backend API + tests | ~45 |
+| Frontend API adapter | ~85 |
+| Blog pages | ~120 |
+| Frontend tests + CI enrollment | ~75 |
+| Backend CI enrollment | ~35 |
+| **Total** | **~455** |
+
+The slice may slightly exceed the 400 LOC target because the backend status
+predicate and both frontend public routes must land together to produce a usable
+generated-blog public path, and the host API test must be enrolled in a
+dedicated Atlas workflow.

--- a/plans/PR-Blog-Public-Generated-Posts.md
+++ b/plans/PR-Blog-Public-Generated-Posts.md
@@ -27,17 +27,21 @@ Slice phase: Vertical slice
    static posts by slug.
 4. Make `/blog/:slug` fetch generated posts when the slug is not static, while
    preserving the static rendering path for existing prerendered content.
-5. Add focused backend and frontend tests for approved visibility and runtime
-   generated-post fetching.
-6. Enroll both focused suites in CI.
+5. Reuse the public landing-page escape-first Markdown sanitizer for generated
+   blog content before any HTML injection.
+6. Add focused backend and frontend tests for approved visibility, runtime
+   generated-post fetching, and sanitizer wiring.
+7. Enroll both focused suites in CI.
 
 ### Files touched
 
 - `atlas_brain/api/blog_public.py`
 - `tests/test_blog_public.py`
 - `atlas-intel-ui/src/api/blog.ts`
+- `atlas-intel-ui/src/lib/safeMarkdown.ts`
 - `atlas-intel-ui/src/pages/Blog.tsx`
 - `atlas-intel-ui/src/pages/BlogPost.tsx`
+- `atlas-intel-ui/src/pages/PublicLandingPage.tsx`
 - `atlas-intel-ui/scripts/blog-public-generated-posts.test.mjs`
 - `atlas-intel-ui/package.json`
 - `.github/workflows/atlas_intel_ui_checks.yml`
@@ -58,6 +62,10 @@ The frontend adapter converts the backend wire shape into the existing
 generated posts, and merges by slug with generated posts taking precedence. The
 detail page uses the static post immediately when present; otherwise it fetches
 the slug from the public API and renders the same `BlogPost` template.
+Generated blog content uses the same escape-first `renderSafeMarkdown` helper
+as public landing pages, so raw HTML from approved generated content is rendered
+as inert text before the sanitized HTML sink. Static in-repo blog posts keep the
+trusted raw-HTML rendering path so existing prerendered posts do not regress.
 
 ## Intentional
 
@@ -65,6 +73,9 @@ the slug from the public API and renders the same `BlogPost` template.
   for already generated and approved posts.
 - Static posts remain in place for existing prerendered SEO pages and as a
   fallback if the public API is unavailable.
+- Static in-repo blog content keeps its trusted HTML path; only generated blog
+  content uses escape-first rendering because existing static posts are authored
+  as HTML strings.
 - The backend route names remain `/published` to avoid breaking existing
   callers; only the public eligibility predicate expands to include approved
   generated-asset drafts.
@@ -106,10 +117,10 @@ the slug from the public API and renders the same `BlogPost` template.
 | Plan | ~95 |
 | Backend API + tests | ~45 |
 | Frontend API adapter | ~85 |
-| Blog pages | ~120 |
-| Frontend tests + CI enrollment | ~75 |
+| Blog pages + shared sanitizer | ~165 |
+| Frontend tests + CI enrollment | ~90 |
 | Backend CI enrollment | ~35 |
-| **Total** | **~455** |
+| **Total** | **~515** |
 
 The slice may slightly exceed the 400 LOC target because the backend status
 predicate and both frontend public routes must land together to produce a usable

--- a/tests/test_blog_public.py
+++ b/tests/test_blog_public.py
@@ -11,10 +11,12 @@ async def test_list_published_posts_normalizes_blank_topic_and_query_defaults(mo
     class Pool:
         async def fetch(self, query, *args):
             assert "topic_type = $1" not in query
+            assert "status IN ('published', 'approved')" in query
             assert args == (50, 0)
             return []
 
         async def fetchval(self, query, *args):
+            assert "status IN ('published', 'approved')" in query
             assert args == ()
             return 0
 
@@ -30,6 +32,7 @@ async def test_list_published_posts_trims_active_topic_type(monkeypatch):
     class Pool:
         async def fetch(self, query, *args):
             assert "topic_type = $1" in query
+            assert "status IN ('published', 'approved')" in query
             assert args == ("competitive_set", 25, 5)
             return []
 
@@ -65,5 +68,6 @@ async def test_get_published_post_trims_slug_before_lookup(monkeypatch):
 
     result = await mod.get_published_post("  launch-post  ")
 
+    assert "status IN ('published', 'approved')" in pool.fetchrow.await_args.args[0]
     assert pool.fetchrow.await_args.args[1] == "launch-post"
     assert result == {"post": None}


### PR DESCRIPTION
Plan: plans/PR-Blog-Public-Generated-Posts.md
Slice phase: Vertical slice

Make approved generated `blog_post` drafts visible on the public blog pages. The backend public blog routes now treat `approved` generated posts as public alongside legacy `published` posts, and the React `/blog` + `/blog/:slug` pages fetch public generated posts at runtime while keeping static posts as the prerendered fallback. Generated blog content reuses the public landing-page escape-first Markdown sanitizer before HTML injection.

## Intentional
- Static posts remain in place for existing prerendered SEO pages and as the fallback if the public API is unavailable.
- Static in-repo blog content keeps its trusted HTML path; generated blog content uses escape-first rendering because existing static posts are authored as HTML strings.
- Existing `/blog/published` route names stay stable; only the public eligibility predicate expands to include approved generated drafts.
- This does not rewrite generation, review, or blog admin.

## Deferred
- Generated blog static prerender/sitemap ingestion remains a later SEO/GEO hardening slice.
- A consolidated frontend API fetch helper remains out of scope.

## Parked hardening
- None.

## Verification
- `pytest tests/test_blog_public.py -q` - 4 passed, 1 existing torch CUDA warning from the local environment.
- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit findings already parked in `HARDENING.md`.
- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4 passed.
- `cd atlas-intel-ui && npm run lint` - passed.
- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4 passed.
- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
- `cd atlas-intel-ui && npm run build` - passed.
- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/blog-public-generated-posts-pr-body.md` - passed.

## Diff size
12 files, +508 / -52 LOC.
