### PR TITLE
Allow rotated Stripe webhook signing secrets

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -93,6 +93,44 @@ def _configure_stripe_module(stripe_module: Any, secret_key: str) -> Any:
     return stripe_module
 
 
+def _stripe_webhook_secret_candidates(secret_config: str) -> tuple[str, ...]:
+    """Return ordered Stripe webhook signing secrets from config.
+
+    Stripe exposes separate signing secrets for live, test, and rotated webhook
+    endpoints. A comma-separated value lets ATLAS accept a bounded rotation set
+    without weakening the signed-webhook trust boundary.
+    """
+
+    return tuple(
+        secret.strip()
+        for secret in str(secret_config or "").split(",")
+        if secret.strip()
+    )
+
+
+def _construct_stripe_webhook_event(
+    stripe_module: Any,
+    body: bytes,
+    signature: str,
+    secret_config: str,
+) -> Any:
+    """Verify a Stripe webhook against one or more configured secrets."""
+
+    secrets = _stripe_webhook_secret_candidates(secret_config)
+    if not secrets:
+        raise ValueError("Webhook secret not configured")
+
+    last_error: Exception | None = None
+    for secret in secrets:
+        try:
+            return stripe_module.Webhook.construct_event(body, signature, secret)
+        except Exception as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise ValueError("Webhook secret not configured")
+
+
 def _stripe_customer_idempotency_key(account_id: str) -> str:
     return f"atlas-customer:{account_id}"
 
@@ -319,11 +357,16 @@ async def stripe_webhook(request: Request):
     if not sig:
         raise HTTPException(status_code=400, detail="Missing stripe-signature header")
 
-    if not cfg.stripe_webhook_secret:
+    if not _stripe_webhook_secret_candidates(cfg.stripe_webhook_secret):
         raise HTTPException(status_code=503, detail="Webhook secret not configured")
 
     try:
-        event = stripe.Webhook.construct_event(body, sig, cfg.stripe_webhook_secret)
+        event = _construct_stripe_webhook_event(
+            stripe,
+            body,
+            sig,
+            cfg.stripe_webhook_secret,
+        )
     except Exception as e:
         logger.warning("Stripe webhook signature verification failed: %s", e)
         raise HTTPException(status_code=400, detail="Invalid signature")

--- a/plans/PR-Stripe-Webhook-Secret-Rotation.md
+++ b/plans/PR-Stripe-Webhook-Secret-Rotation.md
@@ -1,0 +1,69 @@
+# PR-Stripe-Webhook-Secret-Rotation
+
+## Why this slice exists
+
+Paid-unlock live validation needs Stripe test-mode Checkout to unlock a real
+deflection report through the same webhook trust path as production. Stripe live
+and test webhook endpoints use different `whsec_` signing secrets, but ATLAS
+currently verifies `/webhooks/stripe` against one configured secret. Replacing
+the live secret for a test run would make live unlock fragile, so ATLAS needs to
+accept an explicit rotation set before the test-mode paid-unlock smoke can run.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-deflection-paid-unlock
+Slice phase: Production hardening
+
+1. Allow `ATLAS_SAAS_STRIPE_WEBHOOK_SECRET` to contain a comma-separated list of
+   Stripe webhook signing secrets.
+2. Keep fail-closed behavior: missing/invalid signatures still reject before DB
+   work.
+3. Add focused fixtures proving fallback secret acceptance and all-secret
+   rejection.
+
+### Files touched
+
+- `atlas_brain/api/billing.py`
+- `tests/test_atlas_billing_stripe_hardening.py`
+- `plans/PR-Stripe-Webhook-Secret-Rotation.md`
+
+## Mechanism
+
+The webhook route will parse the configured webhook secret string into ordered
+non-empty candidates. Signature verification tries each candidate with
+`stripe.Webhook.construct_event(...)` and accepts the first match. If no
+candidate matches, the route returns the existing `400 Invalid signature`
+response.
+
+The existing Content Ops deflection Stripe paid workflow already enrolls the
+Stripe hardening test file in both PR/push path filters and the pytest run-step,
+satisfying the atlas_brain CI enrollment rule for the new fixtures in that file.
+
+## Intentional
+
+- No new environment variable: keeping one comma-separated
+  `ATLAS_SAAS_STRIPE_WEBHOOK_SECRET` value avoids changing deployment surfaces
+  and supports normal secret rotation as well as live/test validation.
+- No unsigned or privileged unlock path: paid unlock remains gated only by a
+  Stripe-signed `checkout.session.completed` webhook.
+- No Stripe API calls in tests: fixtures mock the transport boundary at the
+  Stripe module and exercise the route's real verification loop.
+
+## Deferred
+
+- Run the hosted test-mode paid-unlock smoke after this PR lands and the test
+  webhook secret plus test report price are provisioned.
+- Parked hardening: none.
+
+## Verification
+
+- python -m pytest tests/test_atlas_billing_stripe_hardening.py -q
+- python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q
+- bash scripts/local_pr_review.sh --allow-dirty
+
+## Estimated diff size
+
+| Area | Estimate |
+| --- | ---: |
+| Code + tests + plan | ~170 |
+| **Total** | **~170** |

--- a/tests/test_atlas_billing_stripe_hardening.py
+++ b/tests/test_atlas_billing_stripe_hardening.py
@@ -78,6 +78,61 @@ def test_configure_stripe_module_pins_api_version_and_warns_on_full_secret_key(
     assert "restricted rk_ key" not in caplog.text
 
 
+def test_stripe_webhook_secret_candidates_trim_and_drop_empty_values() -> None:
+    assert billing._stripe_webhook_secret_candidates(
+        " whsec_live , ,whsec_test\n, whsec_rotated "
+    ) == ("whsec_live", "whsec_test", "whsec_rotated")
+    assert billing._stripe_webhook_secret_candidates(" , ") == ()
+
+
+class _StripeWebhookApi:
+    calls: list[tuple[bytes, str, str]] = []
+    valid_secret = "whsec_valid"
+
+    @classmethod
+    def construct_event(cls, body: bytes, signature: str, secret: str) -> SimpleNamespace:
+        cls.calls.append((body, signature, secret))
+        if secret != cls.valid_secret:
+            raise ValueError(f"bad secret: {secret}")
+        return SimpleNamespace(id="evt_valid", type="checkout.session.completed")
+
+
+def test_construct_stripe_webhook_event_accepts_later_valid_secret() -> None:
+    stripe = SimpleNamespace(Webhook=_StripeWebhookApi)
+    _StripeWebhookApi.calls = []
+
+    event = billing._construct_stripe_webhook_event(
+        stripe,
+        b'{"id":"evt_valid"}',
+        "t=123,v1=sig",
+        "whsec_old, whsec_valid",
+    )
+
+    assert event.id == "evt_valid"
+    assert _StripeWebhookApi.calls == [
+        (b'{"id":"evt_valid"}', "t=123,v1=sig", "whsec_old"),
+        (b'{"id":"evt_valid"}', "t=123,v1=sig", "whsec_valid"),
+    ]
+
+
+def test_construct_stripe_webhook_event_rejects_when_all_secrets_fail() -> None:
+    stripe = SimpleNamespace(Webhook=_StripeWebhookApi)
+    _StripeWebhookApi.calls = []
+
+    with pytest.raises(ValueError, match="bad secret: whsec_other"):
+        billing._construct_stripe_webhook_event(
+            stripe,
+            b'{"id":"evt_bad"}',
+            "t=123,v1=bad",
+            "whsec_old, whsec_other",
+        )
+
+    assert _StripeWebhookApi.calls == [
+        (b'{"id":"evt_bad"}', "t=123,v1=bad", "whsec_old"),
+        (b'{"id":"evt_bad"}', "t=123,v1=bad", "whsec_other"),
+    ]
+
+
 def test_billing_idempotency_keys_are_stable_and_parameter_scoped() -> None:
     account_id = str(uuid.uuid4())
     user_id = str(uuid.uuid4())


### PR DESCRIPTION
Plan: plans/PR-Stripe-Webhook-Secret-Rotation.md
Slice phase: Production hardening

Paid-unlock live validation needs Stripe test-mode Checkout to unlock through the same webhook trust path as production. This allows ATLAS to verify Stripe webhooks against an ordered comma-separated signing-secret set, so live/test webhook endpoints and normal secret rotation can coexist without replacing the live secret during validation.

## Intentional
- Keep one ATLAS_SAAS_STRIPE_WEBHOOK_SECRET deployment surface; comma-separated values are a bounded rotation set.
- Preserve fail-closed invalid-signature behavior; no fake webhook or privileged paid unlock path.
- Reuse the already-enrolled Stripe hardening test file in atlas_content_ops_deflection_stripe_paid_checks.yml.

## Deferred
- Run the hosted test-mode paid-unlock smoke after this lands and the test webhook secret plus test report price are provisioned.

## Parked hardening
- None.

## Verification
- python -m pytest tests/test_atlas_billing_stripe_hardening.py -q (6 passed, 1 warning)
- python -m pytest tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q (19 passed, 1 warning)
- bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file plans/PR-Stripe-Webhook-Secret-Rotation.md (passed)

## Diff size
3 files, +169 / -2