### PR TITLE
PR-Blog-Review-Public-Link

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Test Content Ops landing-page review deep link
         run: npm run test:content-ops-landing-page-e2e-ui
 
+      - name: Test Content Ops blog review public link
+        run: npm run test:content-ops-blog-review-public-link
+
       - name: Build
         run: npm run build
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -20,6 +20,7 @@
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
+    "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-blog-review-public-link.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-blog-review-public-link.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+
+test('asset review detail drawer exposes approved generated blog public URLs', () => {
+  assert.ok(reviewSource.includes('const publicUrl = publicAssetUrl(row, asset)'))
+  assert.ok(reviewSource.includes('const publicUrlPending = publicAssetUrlPending(row, asset)'))
+  assert.ok(reviewSource.includes("if (asset === 'blog_post')"))
+  assert.ok(reviewSource.includes("return `${window.location.origin}/blog/${encodeURIComponent(slug)}`"))
+  assert.ok(reviewSource.includes("Approved blog posts are available at /blog/:slug."))
+  assert.ok(reviewSource.includes("Approve this {asset === 'blog_post' ? 'blog post' : 'landing page'}"))
+})
+
+test('asset review keeps landing-page public URLs id and slug based', () => {
+  assert.ok(reviewSource.includes("if (asset === 'landing_page')"))
+  assert.ok(reviewSource.includes("return `${window.location.origin}/lp/${encodeURIComponent(id)}/${encodeURIComponent(slug)}`"))
+  assert.ok(reviewSource.includes("return asset === 'landing_page' && Boolean(assetId(row))"))
+  assert.ok(!reviewSource.includes('publicLandingPageUrl('))
+})

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -1083,12 +1083,8 @@ function AssetDetailDrawer({
   const repairHistory = assetRepairHistory(row)
   const structuredData =
     asset === 'landing_page' ? structuredDataSummary(row.structured_data) : null
-  const publicUrl = publicLandingPageUrl(row, asset)
-  const publicUrlPending =
-    asset === 'landing_page' &&
-    Boolean(assetId(row)) &&
-    Boolean(textValue(row.slug)) &&
-    status !== 'approved'
+  const publicUrl = publicAssetUrl(row, asset)
+  const publicUrlPending = publicAssetUrlPending(row, asset)
   const canEditLandingPage =
     asset === 'landing_page' && Boolean(assetId(row)) && status !== 'approved'
   const canRepairLandingPage =
@@ -1288,12 +1284,14 @@ function AssetDetailDrawer({
                     </button>
                   </div>
                   <p className="mt-3 text-xs text-slate-500">
-                    Public rendering is approved-only. This v1 URL is marked noindex.
+                    {asset === 'landing_page'
+                      ? 'Public rendering is approved-only. This v1 URL is marked noindex.'
+                      : 'Public rendering is approved-only. Approved blog posts are available at /blog/:slug.'}
                   </p>
                 </>
               ) : (
                 <p className="text-sm text-slate-400">
-                  Approve this landing page to make its public URL available.
+                  Approve this {asset === 'blog_post' ? 'blog post' : 'landing page'} to make its public URL available.
                 </p>
               )}
             </div>
@@ -2056,16 +2054,33 @@ function assetId(row: GeneratedAssetDraft): string {
   return textValue(row.id)
 }
 
-function publicLandingPageUrl(
+function publicAssetUrl(
   row: GeneratedAssetDraft,
   asset: GeneratedAssetType,
 ): string | null {
-  if (asset !== 'landing_page') return null
   if (textValue(row.status) !== 'approved') return null
-  const id = assetId(row)
   const slug = textValue(row.slug)
-  if (!id || !slug) return null
-  return `${window.location.origin}/lp/${encodeURIComponent(id)}/${encodeURIComponent(slug)}`
+  if (!slug) return null
+  if (asset === 'blog_post') {
+    return `${window.location.origin}/blog/${encodeURIComponent(slug)}`
+  }
+  if (asset === 'landing_page') {
+    const id = assetId(row)
+    if (!id) return null
+    return `${window.location.origin}/lp/${encodeURIComponent(id)}/${encodeURIComponent(slug)}`
+  }
+  return null
+}
+
+function publicAssetUrlPending(
+  row: GeneratedAssetDraft,
+  asset: GeneratedAssetType,
+): boolean {
+  if (textValue(row.status) === 'approved') return false
+  const slug = textValue(row.slug)
+  if (!slug) return false
+  if (asset === 'blog_post') return true
+  return asset === 'landing_page' && Boolean(assetId(row))
 }
 
 function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string {

--- a/plans/PR-Blog-Review-Public-Link.md
+++ b/plans/PR-Blog-Review-Public-Link.md
@@ -1,0 +1,100 @@
+# PR: Blog Review Public Link
+
+## Why this slice exists
+
+PR #1224 made approved generated blog posts publicly readable at `/blog/:slug`,
+but the generated-asset review UI still only surfaces a public URL for approved
+landing pages. That leaves the operator handoff incomplete: after approving a
+generated `blog_post`, the drawer does not show the URL that can be opened,
+copied, or checked.
+
+This slice completes the review-to-public handoff for generated blogs by adding
+the same public-link affordance already present for landing pages.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-public-productization
+
+Slice phase: Product polish
+
+1. Extend the generated-asset review drawer public URL helper so approved
+   `blog_post` rows with a slug produce `/blog/:slug`.
+2. Preserve the existing landing-page URL behavior at `/lp/:id/:slug`.
+3. Show a pending approval message for blog posts that have a slug but are not
+   approved yet.
+4. Add a focused frontend source regression test for the blog public-link
+   behavior and enroll it in the Atlas Intel UI workflow.
+
+### Files touched
+
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-blog-review-public-link.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `plans/PR-Blog-Review-Public-Link.md`
+
+## Mechanism
+
+The drawer already computes:
+
+```ts
+const publicUrl = publicLandingPageUrl(row, asset)
+```
+
+This PR replaces the landing-page-only helper with a small asset-aware helper:
+
+```ts
+publicAssetUrl(row, 'blog_post') -> /blog/:slug, approved only
+publicAssetUrl(row, 'landing_page') -> /lp/:id/:slug, approved only
+```
+
+The pending-state helper similarly becomes asset-aware so both landing pages and
+blog posts can explain why the public link is not available before approval.
+The UI panel stays in the detail drawer; no backend or public blog route change
+is needed because #1224 already made approved generated posts public.
+
+## Intentional
+
+- No public API changes. The public blog runtime route and approved-status
+  predicate shipped in #1224.
+- No list-card public-link button. The detail drawer remains the operator
+  handoff surface, matching the existing landing-page behavior.
+- Blog public URLs are slug-only. Generated blog public routes do not include
+  draft IDs.
+
+## Deferred
+
+- Static prerender/sitemap ingestion for generated blogs remains the later
+  SEO/GEO hardening slice deferred by #1224.
+- A full browser E2E around approving a draft and opening the public URL remains
+  deferred; this slice is the UI wiring/contract handoff.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  their blog entries are content-generation correctness issues, not this review
+  drawer URL handoff.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit
+  findings already parked in `HARDENING.md`.
+- `cd atlas-intel-ui && npm run test:content-ops-blog-review-public-link` - 2
+  passed.
+- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4
+  passed.
+- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4 passed.
+- `cd atlas-intel-ui && npm run lint` - passed.
+- `cd atlas-intel-ui && npm run build` - passed; TypeScript and Vite build
+  completed.
+- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
+- `cd atlas-intel-ui && npm run verify:landing-page-geo` - skipped because no
+  generated landing-page sitemap entries were present locally.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /home/juan-canfield/Desktop/blog-review-public-link-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Review drawer helper/UI | ~45 |
+| Focused frontend test + script/workflow enrollment | ~55 |
+| **Total** | **~175** |


### PR DESCRIPTION
Plan: plans/PR-Blog-Review-Public-Link.md
Slice phase: Product polish

Expose the generated blog public `/blog/:slug` URL from the generated-asset review drawer after approval, matching the existing landing-page handoff now that #1224 made approved generated blog posts public at runtime.

## Intentional
- No public API changes; #1224 already widened public blog visibility for approved generated posts.
- The public link remains in the detail drawer rather than the list card, matching the existing landing-page operator handoff.
- Blog public URLs are slug-only; generated blog routes do not include draft IDs.

## Deferred
- Generated blog static prerender/sitemap ingestion remains a later SEO/GEO hardening slice.
- Full browser E2E around approving a draft and opening the public URL remains deferred; this slice covers the UI contract.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit findings already parked in `HARDENING.md`.
- `cd atlas-intel-ui && npm run test:content-ops-blog-review-public-link` - 2 passed.
- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4 passed.
- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4 passed.
- `cd atlas-intel-ui && npm run lint` - passed.
- `cd atlas-intel-ui && npm run build` - passed.
- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
- `cd atlas-intel-ui && npm run verify:landing-page-geo` - skipped because no generated landing-page sitemap entries were present locally.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/blog-review-public-link-pr-body.md` - passed.

## Diff size
5 files, +155 / -13 LOC.
