### PR TITLE
PR-Blog-Generated-Sitemap-Prerender

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Test public generated blog posts
         run: npm run test:blog-public-generated-posts
 
+      - name: Test generated blog sitemap prerender
+        run: npm run test:blog-generated-sitemap-prerender
+
       - name: Test Content Ops deflection report UI
         run: npm run test:content-ops-deflection-report-ui
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -22,6 +22,7 @@
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
+    "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",
     "test:sitemap-bridge": "node --test scripts/landing-page-sitemap-bridge.test.mjs",
     "verify:blog-geo": "node scripts/verify-blog-geo-prerender.mjs",

--- a/atlas-intel-ui/scripts/blog-generated-sitemap-prerender.test.mjs
+++ b/atlas-intel-ui/scripts/blog-generated-sitemap-prerender.test.mjs
@@ -47,6 +47,18 @@ function jsonResponse(payload, status = 200) {
   }
 }
 
+function warningSink() {
+  const warnings = []
+  return {
+    warnings,
+    logger: {
+      warn(message) {
+        warnings.push(message)
+      },
+    },
+  }
+}
+
 test('resolveGeneratedBlogPostsUrl prefers explicit feed and falls back to API base', () => {
   assert.equal(
     resolveGeneratedBlogPostsUrl({
@@ -116,48 +128,74 @@ test('fetchGeneratedBlogPrerenderEntries is a no-op without a feed URL', async (
   assert.deepEqual(entries, [])
 })
 
-test('fetchGeneratedBlogSitemapUrls fails when configured feed is unavailable', async () => {
-  await assert.rejects(
-    fetchGeneratedBlogSitemapUrls({
-      postsUrl: 'https://api.example.com/api/v1/blog/published',
-      publicSiteUrl: SITE_URL,
-      fetchImpl: async () => jsonResponse({}, 503),
-    }),
-    /Failed to fetch generated blog posts: HTTP 503/,
-  )
+test('fetchGeneratedBlogSitemapUrls fail-softs when configured feed is unavailable', async () => {
+  const { logger, warnings } = warningSink()
+  const urls = await fetchGeneratedBlogSitemapUrls({
+    postsUrl: 'https://api.example.com/api/v1/blog/published',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => jsonResponse({}, 503),
+    logger,
+  })
+
+  assert.deepEqual(urls, [])
+  assert.deepEqual(warnings, [
+    'Skipping generated blog feed: Failed to fetch generated blog posts: HTTP 503',
+  ])
 })
 
-test('fetchGeneratedBlogSitemapUrls fails closed on malformed response envelope', async () => {
-  await assert.rejects(
-    fetchGeneratedBlogSitemapUrls({
-      postsUrl: 'https://api.example.com/api/v1/blog/published',
-      publicSiteUrl: SITE_URL,
-      fetchImpl: async () => jsonResponse({ results: [post()] }),
-    }),
-    /Generated blog response posts must be an array/,
-  )
+test('fetchGeneratedBlogSitemapUrls fail-softs on malformed response envelope', async () => {
+  const { logger, warnings } = warningSink()
+  const urls = await fetchGeneratedBlogSitemapUrls({
+    postsUrl: 'https://api.example.com/api/v1/blog/published',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => jsonResponse({ results: [post()] }),
+    logger,
+  })
+
+  assert.deepEqual(urls, [])
+  assert.deepEqual(warnings, [
+    'Skipping generated blog feed: Generated blog response posts must be an array',
+  ])
 })
 
-test('fetchGeneratedBlogSitemapUrls fails closed on malformed public post', async () => {
-  await assert.rejects(
-    fetchGeneratedBlogSitemapUrls({
-      postsUrl: 'https://api.example.com/api/v1/blog/published',
-      publicSiteUrl: SITE_URL,
-      fetchImpl: async () => jsonResponse({ posts: [post({ content: '' })] }),
+test('fetchGeneratedBlogSitemapUrls skips malformed public posts and keeps the batch', async () => {
+  const { logger, warnings } = warningSink()
+  const urls = await fetchGeneratedBlogSitemapUrls({
+    postsUrl: 'https://api.example.com/api/v1/blog/published',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => jsonResponse({
+      posts: [
+        post({ slug: 'bad-post', content: '' }),
+        post({ slug: 'good-post' }),
+      ],
     }),
-    /Generated blog post 1 missing content/,
-  )
+    logger,
+  })
+
+  assert.deepEqual(urls, [{
+    loc: `${SITE_URL}/blog/good-post`,
+    lastmod: '2026-06-01',
+    priority: '0.7',
+    changefreq: 'monthly',
+  }])
+  assert.deepEqual(warnings, [
+    'Skipping generated blog post 1: Generated blog post 1 missing content',
+  ])
 })
 
-test('fetchGeneratedBlogSitemapUrls rejects unsafe generated slugs', async () => {
-  await assert.rejects(
-    fetchGeneratedBlogSitemapUrls({
-      postsUrl: 'https://api.example.com/api/v1/blog/published',
-      publicSiteUrl: SITE_URL,
-      fetchImpl: async () => jsonResponse({ posts: [post({ slug: '../escape' })] }),
-    }),
-    /Generated blog post 1 has unsafe slug/,
-  )
+test('fetchGeneratedBlogSitemapUrls skips unsafe generated slugs', async () => {
+  const { logger, warnings } = warningSink()
+  const urls = await fetchGeneratedBlogSitemapUrls({
+    postsUrl: 'https://api.example.com/api/v1/blog/published',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => jsonResponse({ posts: [post({ slug: '../escape' })] }),
+    logger,
+  })
+
+  assert.deepEqual(urls, [])
+  assert.deepEqual(warnings, [
+    'Skipping generated blog post 1: Generated blog post 1 has unsafe slug',
+  ])
 })
 
 test('vite build wires generated blogs into sitemap and prerender with escaped HTML', () => {

--- a/atlas-intel-ui/scripts/blog-generated-sitemap-prerender.test.mjs
+++ b/atlas-intel-ui/scripts/blog-generated-sitemap-prerender.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  fetchGeneratedBlogPrerenderEntries,
+  fetchGeneratedBlogSitemapUrls,
+  resolveGeneratedBlogPostsUrl,
+} from './blog-sitemap-bridge.mjs'
+
+const SITE_URL = 'https://atlas-intel-ui-two.vercel.app'
+const viteConfigSource = readFileSync(
+  new URL('../vite.config.ts', import.meta.url),
+  'utf-8',
+)
+
+function post(overrides = {}) {
+  return {
+    slug: 'generated-post',
+    title: 'Generated Post',
+    description: 'A generated post.',
+    date: '2026-06-01T12:00:00Z',
+    author: 'Atlas Intelligence',
+    tags: ['content-ops'],
+    content: '## Summary\n\nGenerated body with {{chart:demo-chart}}.',
+    charts: [{
+      chart_id: 'demo-chart',
+      chart_type: 'bar',
+      title: 'Demo Chart',
+      data: [{ label: 'A', value: 1 }],
+      config: { x_key: 'label', bars: [{ dataKey: 'value' }] },
+    }],
+    faq: [{ question: 'Can this be indexed?', answer: 'Yes.' }],
+    seo_title: 'Generated SEO Title',
+    seo_description: 'Generated SEO description.',
+    ...overrides,
+  }
+}
+
+function jsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return payload
+    },
+  }
+}
+
+test('resolveGeneratedBlogPostsUrl prefers explicit feed and falls back to API base', () => {
+  assert.equal(
+    resolveGeneratedBlogPostsUrl({
+      VITE_PUBLIC_BLOG_POSTS_URL: ' https://api.example.com/blog-feed ',
+      VITE_API_BASE: 'https://fallback.example.com',
+    }),
+    'https://api.example.com/blog-feed',
+  )
+  assert.equal(
+    resolveGeneratedBlogPostsUrl({ VITE_API_BASE: 'https://api.example.com/' }),
+    'https://api.example.com/api/v1/blog/published?limit=200',
+  )
+  assert.equal(resolveGeneratedBlogPostsUrl({}), '')
+})
+
+test('fetchGeneratedBlogSitemapUrls maps valid generated posts and dedupes exclusions', async () => {
+  const urls = await fetchGeneratedBlogSitemapUrls({
+    postsUrl: 'https://api.example.com/api/v1/blog/published?limit=200',
+    publicSiteUrl: SITE_URL,
+    excludeSlugs: ['static-post'],
+    fetchImpl: async (url) => {
+      assert.equal(url, 'https://api.example.com/api/v1/blog/published?limit=200')
+      return jsonResponse({
+        posts: [
+          post(),
+          post({ slug: 'static-post' }),
+          post({ slug: 'generated-post' }),
+          post({ slug: 'private-post', robots: 'noindex,follow' }),
+        ],
+      })
+    },
+  })
+
+  assert.deepEqual(urls, [{
+    loc: `${SITE_URL}/blog/generated-post`,
+    lastmod: '2026-06-01',
+    priority: '0.7',
+    changefreq: 'monthly',
+  }])
+})
+
+test('fetchGeneratedBlogPrerenderEntries preserves generated post metadata', async () => {
+  const entries = await fetchGeneratedBlogPrerenderEntries({
+    postsUrl: 'https://api.example.com/api/v1/blog/published',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => jsonResponse({ posts: [post()] }),
+  })
+
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].path, '/blog/generated-post')
+  assert.equal(entries[0].loc, `${SITE_URL}/blog/generated-post`)
+  assert.equal(entries[0].post.seoTitle, 'Generated SEO Title')
+  assert.equal(entries[0].post.seoDescription, 'Generated SEO description.')
+  assert.equal(entries[0].post.charts[0].chart_id, 'demo-chart')
+  assert.equal(entries[0].post.faq[0].question, 'Can this be indexed?')
+})
+
+test('fetchGeneratedBlogPrerenderEntries is a no-op without a feed URL', async () => {
+  const entries = await fetchGeneratedBlogPrerenderEntries({
+    postsUrl: '',
+    publicSiteUrl: SITE_URL,
+    fetchImpl: async () => {
+      throw new Error('fetch should not run')
+    },
+  })
+
+  assert.deepEqual(entries, [])
+})
+
+test('fetchGeneratedBlogSitemapUrls fails when configured feed is unavailable', async () => {
+  await assert.rejects(
+    fetchGeneratedBlogSitemapUrls({
+      postsUrl: 'https://api.example.com/api/v1/blog/published',
+      publicSiteUrl: SITE_URL,
+      fetchImpl: async () => jsonResponse({}, 503),
+    }),
+    /Failed to fetch generated blog posts: HTTP 503/,
+  )
+})
+
+test('fetchGeneratedBlogSitemapUrls fails closed on malformed response envelope', async () => {
+  await assert.rejects(
+    fetchGeneratedBlogSitemapUrls({
+      postsUrl: 'https://api.example.com/api/v1/blog/published',
+      publicSiteUrl: SITE_URL,
+      fetchImpl: async () => jsonResponse({ results: [post()] }),
+    }),
+    /Generated blog response posts must be an array/,
+  )
+})
+
+test('fetchGeneratedBlogSitemapUrls fails closed on malformed public post', async () => {
+  await assert.rejects(
+    fetchGeneratedBlogSitemapUrls({
+      postsUrl: 'https://api.example.com/api/v1/blog/published',
+      publicSiteUrl: SITE_URL,
+      fetchImpl: async () => jsonResponse({ posts: [post({ content: '' })] }),
+    }),
+    /Generated blog post 1 missing content/,
+  )
+})
+
+test('fetchGeneratedBlogSitemapUrls rejects unsafe generated slugs', async () => {
+  await assert.rejects(
+    fetchGeneratedBlogSitemapUrls({
+      postsUrl: 'https://api.example.com/api/v1/blog/published',
+      publicSiteUrl: SITE_URL,
+      fetchImpl: async () => jsonResponse({ posts: [post({ slug: '../escape' })] }),
+    }),
+    /Generated blog post 1 has unsafe slug/,
+  )
+})
+
+test('vite build wires generated blogs into sitemap and prerender with escaped HTML', () => {
+  assert.ok(viteConfigSource.includes('fetchGeneratedBlogSitemapUrls'))
+  assert.ok(viteConfigSource.includes('...generatedBlogUrls'))
+  assert.ok(viteConfigSource.includes('fetchGeneratedBlogPrerenderEntries'))
+  assert.ok(viteConfigSource.includes('...generatedBlogRoutes'))
+  assert.ok(viteConfigSource.includes('trustedHtml: false'))
+  assert.ok(viteConfigSource.includes('escapeGeneratedMarkdownHtml(post.content)'))
+})

--- a/atlas-intel-ui/scripts/blog-sitemap-bridge.d.mts
+++ b/atlas-intel-ui/scripts/blog-sitemap-bridge.d.mts
@@ -5,6 +5,7 @@ export function fetchGeneratedBlogSitemapUrls(args?: {
   publicSiteUrl?: string
   excludeSlugs?: string[]
   fetchImpl?: typeof fetch
+  logger?: Pick<Console, 'warn'>
 }): Promise<Array<{
   loc: string
   lastmod: string
@@ -17,4 +18,5 @@ export function fetchGeneratedBlogPrerenderEntries(args?: {
   publicSiteUrl?: string
   excludeSlugs?: string[]
   fetchImpl?: typeof fetch
+  logger?: Pick<Console, 'warn'>
 }): Promise<unknown[]>

--- a/atlas-intel-ui/scripts/blog-sitemap-bridge.d.mts
+++ b/atlas-intel-ui/scripts/blog-sitemap-bridge.d.mts
@@ -1,0 +1,20 @@
+export function resolveGeneratedBlogPostsUrl(env?: Record<string, string | undefined>): string
+
+export function fetchGeneratedBlogSitemapUrls(args?: {
+  postsUrl?: string
+  publicSiteUrl?: string
+  excludeSlugs?: string[]
+  fetchImpl?: typeof fetch
+}): Promise<Array<{
+  loc: string
+  lastmod: string
+  priority: string
+  changefreq: string
+}>>
+
+export function fetchGeneratedBlogPrerenderEntries(args?: {
+  postsUrl?: string
+  publicSiteUrl?: string
+  excludeSlugs?: string[]
+  fetchImpl?: typeof fetch
+}): Promise<unknown[]>

--- a/atlas-intel-ui/scripts/blog-sitemap-bridge.mjs
+++ b/atlas-intel-ui/scripts/blog-sitemap-bridge.mjs
@@ -118,29 +118,50 @@ function blogLoc(publicSiteUrl, slug) {
   return `${siteBase.origin}/blog/${encodeURIComponent(slug)}`
 }
 
+function warn(logger, message) {
+  if (logger && typeof logger.warn === 'function') {
+    logger.warn(message)
+  }
+}
+
 async function fetchGeneratedBlogPosts({
   postsUrl,
   fetchImpl = globalThis.fetch,
+  logger = console,
 } = {}) {
   const feedUrl = clean(postsUrl)
   if (!feedUrl) return []
   if (typeof fetchImpl !== 'function') {
-    throw new Error('Generated blog sitemap bridge requires a fetch implementation')
+    warn(logger, 'Skipping generated blog feed: fetch is unavailable')
+    return []
   }
 
-  const response = await fetchImpl(feedUrl)
-  if (!response || !response.ok) {
-    const status = response?.status ? `HTTP ${response.status}` : 'no response'
-    throw new Error(`Failed to fetch generated blog posts: ${status}`)
+  let envelope
+  try {
+    const response = await fetchImpl(feedUrl)
+    if (!response || !response.ok) {
+      const status = response?.status ? `HTTP ${response.status}` : 'no response'
+      throw new Error(`Failed to fetch generated blog posts: ${status}`)
+    }
+    envelope = recordValue(await response.json(), 'response')
+    if (!Array.isArray(envelope.posts)) {
+      throw new Error('Generated blog response posts must be an array')
+    }
+  } catch (error) {
+    warn(logger, `Skipping generated blog feed: ${error.message}`)
+    return []
   }
 
-  const envelope = recordValue(await response.json(), 'response')
-  if (!Array.isArray(envelope.posts)) {
-    throw new Error('Generated blog response posts must be an array')
+  const posts = []
+  for (const [index, item] of envelope.posts.entries()) {
+    try {
+      const post = generatedBlogPostFromWire(item, index)
+      if (post) posts.push(post)
+    } catch (error) {
+      warn(logger, `Skipping generated blog post ${index + 1}: ${error.message}`)
+    }
   }
-  return envelope.posts
-    .map(generatedBlogPostFromWire)
-    .filter((post) => post !== null)
+  return posts
 }
 
 function excludeSlugSet(excludeSlugs) {
@@ -152,22 +173,27 @@ export async function fetchGeneratedBlogSitemapUrls({
   publicSiteUrl,
   excludeSlugs = [],
   fetchImpl = globalThis.fetch,
+  logger = console,
 } = {}) {
   const excluded = excludeSlugSet(excludeSlugs)
   const seen = new Set()
-  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl })
+  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl, logger })
   const urls = []
   for (const post of posts) {
     if (excluded.has(post.slug)) continue
-    const loc = blogLoc(publicSiteUrl, post.slug)
-    if (seen.has(loc)) continue
-    seen.add(loc)
-    urls.push({
-      loc,
-      lastmod: post.date,
-      priority: '0.7',
-      changefreq: 'monthly',
-    })
+    try {
+      const loc = blogLoc(publicSiteUrl, post.slug)
+      if (seen.has(loc)) continue
+      seen.add(loc)
+      urls.push({
+        loc,
+        lastmod: post.date,
+        priority: '0.7',
+        changefreq: 'monthly',
+      })
+    } catch (error) {
+      warn(logger, `Skipping generated blog sitemap URL for ${post.slug}: ${error.message}`)
+    }
   }
   return urls
 }
@@ -177,19 +203,24 @@ export async function fetchGeneratedBlogPrerenderEntries({
   publicSiteUrl,
   excludeSlugs = [],
   fetchImpl = globalThis.fetch,
+  logger = console,
 } = {}) {
   const excluded = excludeSlugSet(excludeSlugs)
   const seen = new Set()
-  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl })
+  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl, logger })
   const entries = []
   for (const post of posts) {
     if (excluded.has(post.slug) || seen.has(post.slug)) continue
     seen.add(post.slug)
-    entries.push({
-      path: `/blog/${post.slug}`,
-      loc: blogLoc(publicSiteUrl, post.slug),
-      post,
-    })
+    try {
+      entries.push({
+        path: `/blog/${post.slug}`,
+        loc: blogLoc(publicSiteUrl, post.slug),
+        post,
+      })
+    } catch (error) {
+      warn(logger, `Skipping generated blog prerender entry for ${post.slug}: ${error.message}`)
+    }
   }
   return entries
 }

--- a/atlas-intel-ui/scripts/blog-sitemap-bridge.mjs
+++ b/atlas-intel-ui/scripts/blog-sitemap-bridge.mjs
@@ -1,0 +1,195 @@
+function clean(value) {
+  return String(value || '').trim()
+}
+
+function stripTrailingSlash(value) {
+  return value.replace(/\/+$/, '')
+}
+
+export function resolveGeneratedBlogPostsUrl(env = process.env) {
+  const configured = clean(env.VITE_PUBLIC_BLOG_POSTS_URL)
+  if (configured) return configured
+
+  const apiBase = stripTrailingSlash(clean(env.VITE_API_BASE))
+  return apiBase ? `${apiBase}/api/v1/blog/published?limit=200` : ''
+}
+
+function recordValue(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Generated blog ${label} must be an object`)
+  }
+  return value
+}
+
+function requiredText(record, field, label) {
+  const value = clean(record[field])
+  if (!value) throw new Error(`Generated blog ${label} missing ${field}`)
+  return value
+}
+
+function optionalText(record, field) {
+  return clean(record[field])
+}
+
+function slugValue(record, label) {
+  const slug = requiredText(record, 'slug', label)
+  if (slug.includes('/') || slug.includes('\\') || slug.includes('..')) {
+    throw new Error(`Generated blog ${label} has unsafe slug`)
+  }
+  return slug
+}
+
+function dateValue(record, label) {
+  const date = requiredText(record, 'date', label).slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Generated blog ${label} has invalid date`)
+  }
+  return date
+}
+
+function stringList(value, label, field) {
+  if (value === null || value === undefined || value === '') return []
+  if (Array.isArray(value)) return value.map(clean).filter(Boolean)
+  if (typeof value === 'string') {
+    return value.split(',').map(item => item.trim()).filter(Boolean)
+  }
+  throw new Error(`Generated blog ${label} ${field} must be an array or string`)
+}
+
+function chartList(value, label) {
+  if (value === null || value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`Generated blog ${label} charts must be an array`)
+  return value.map((item, index) => {
+    const chart = recordValue(item, `${label} chart ${index + 1}`)
+    const chartType = requiredText(chart, 'chart_type', `${label} chart ${index + 1}`)
+    if (!['bar', 'horizontal_bar', 'radar', 'line'].includes(chartType)) {
+      throw new Error(`Generated blog ${label} chart ${index + 1} has invalid chart_type`)
+    }
+    if (!Array.isArray(chart.data)) {
+      throw new Error(`Generated blog ${label} chart ${index + 1} data must be an array`)
+    }
+    recordValue(chart.config, `${label} chart ${index + 1} config`)
+    return {
+      chart_id: requiredText(chart, 'chart_id', `${label} chart ${index + 1}`),
+      chart_type: chartType,
+      title: requiredText(chart, 'title', `${label} chart ${index + 1}`),
+      data: chart.data,
+      config: chart.config,
+    }
+  })
+}
+
+function faqList(value, label) {
+  if (value === null || value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`Generated blog ${label} faq must be an array`)
+  return value.map((item, index) => {
+    const faq = recordValue(item, `${label} faq ${index + 1}`)
+    return {
+      question: requiredText(faq, 'question', `${label} faq ${index + 1}`),
+      answer: requiredText(faq, 'answer', `${label} faq ${index + 1}`),
+    }
+  })
+}
+
+function generatedBlogPostFromWire(value, index) {
+  const label = `post ${index + 1}`
+  const record = recordValue(value, label)
+  const robots = optionalText(record, 'robots').toLowerCase()
+  if (robots.includes('noindex')) return null
+  const title = requiredText(record, 'title', label)
+  return {
+    slug: slugValue(record, label),
+    title,
+    description: optionalText(record, 'description') || title,
+    date: dateValue(record, label),
+    author: optionalText(record, 'author') || 'Atlas Intelligence',
+    tags: stringList(record.tags, label, 'tags'),
+    content: requiredText(record, 'content', label),
+    charts: chartList(record.charts, label),
+    faq: faqList(record.faq, label),
+    seoTitle: optionalText(record, 'seo_title') || optionalText(record, 'seoTitle'),
+    seoDescription:
+      optionalText(record, 'seo_description') || optionalText(record, 'seoDescription'),
+  }
+}
+
+function blogLoc(publicSiteUrl, slug) {
+  const siteBase = new URL(stripTrailingSlash(clean(publicSiteUrl)))
+  return `${siteBase.origin}/blog/${encodeURIComponent(slug)}`
+}
+
+async function fetchGeneratedBlogPosts({
+  postsUrl,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const feedUrl = clean(postsUrl)
+  if (!feedUrl) return []
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('Generated blog sitemap bridge requires a fetch implementation')
+  }
+
+  const response = await fetchImpl(feedUrl)
+  if (!response || !response.ok) {
+    const status = response?.status ? `HTTP ${response.status}` : 'no response'
+    throw new Error(`Failed to fetch generated blog posts: ${status}`)
+  }
+
+  const envelope = recordValue(await response.json(), 'response')
+  if (!Array.isArray(envelope.posts)) {
+    throw new Error('Generated blog response posts must be an array')
+  }
+  return envelope.posts
+    .map(generatedBlogPostFromWire)
+    .filter((post) => post !== null)
+}
+
+function excludeSlugSet(excludeSlugs) {
+  return new Set((excludeSlugs || []).map(clean).filter(Boolean))
+}
+
+export async function fetchGeneratedBlogSitemapUrls({
+  postsUrl,
+  publicSiteUrl,
+  excludeSlugs = [],
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const excluded = excludeSlugSet(excludeSlugs)
+  const seen = new Set()
+  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl })
+  const urls = []
+  for (const post of posts) {
+    if (excluded.has(post.slug)) continue
+    const loc = blogLoc(publicSiteUrl, post.slug)
+    if (seen.has(loc)) continue
+    seen.add(loc)
+    urls.push({
+      loc,
+      lastmod: post.date,
+      priority: '0.7',
+      changefreq: 'monthly',
+    })
+  }
+  return urls
+}
+
+export async function fetchGeneratedBlogPrerenderEntries({
+  postsUrl,
+  publicSiteUrl,
+  excludeSlugs = [],
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const excluded = excludeSlugSet(excludeSlugs)
+  const seen = new Set()
+  const posts = await fetchGeneratedBlogPosts({ postsUrl, fetchImpl })
+  const entries = []
+  for (const post of posts) {
+    if (excluded.has(post.slug) || seen.has(post.slug)) continue
+    seen.add(post.slug)
+    entries.push({
+      path: `/blog/${post.slug}`,
+      loc: blogLoc(publicSiteUrl, post.slug),
+      post,
+    })
+  }
+  return entries
+}

--- a/atlas-intel-ui/vite.config.ts
+++ b/atlas-intel-ui/vite.config.ts
@@ -11,7 +11,6 @@ import { resolve, join } from 'node:path'
 import {
   chartPlaceholderIds,
   collectBlogSourceMetadata,
-  type BlogSourceMetadata,
   type ChartSpec,
   type ChartValue,
   type FaqItem,
@@ -22,6 +21,11 @@ import {
   resolveLandingPagePublicApiBase,
   resolveLandingPageSitemapUrl,
 } from './scripts/landing-page-sitemap-bridge.mjs'
+import {
+  fetchGeneratedBlogPrerenderEntries,
+  fetchGeneratedBlogSitemapUrls,
+  resolveGeneratedBlogPostsUrl,
+} from './scripts/blog-sitemap-bridge.mjs'
 
 const BASE_URL = 'https://atlas-intel-ui-two.vercel.app'
 const DEFAULT_OG_IMAGE = `${BASE_URL}/og-default.png`
@@ -54,6 +58,13 @@ function sitemapPlugin() {
     name: 'generate-sitemap',
     async closeBundle() {
       const posts = collectBlogSourceMetadata(import.meta.dirname)
+      const staticBlogSlugs = posts.map(post => post.slug)
+      const generatedBlogPostsUrl = resolveGeneratedBlogPostsUrl()
+      const generatedBlogUrls = await fetchGeneratedBlogSitemapUrls({
+        postsUrl: generatedBlogPostsUrl,
+        publicSiteUrl: BASE_URL,
+        excludeSlugs: staticBlogSlugs,
+      })
       const generatedLandingPageUrls = await fetchLandingPageSitemapUrls({
         sitemapUrl: resolveLandingPageSitemapUrl(),
         publicSiteUrl: BASE_URL,
@@ -69,6 +80,7 @@ function sitemapPlugin() {
           priority: '0.7',
           changefreq: 'monthly',
         })),
+        ...generatedBlogUrls,
         ...generatedLandingPageUrls,
         { loc: `${BASE_URL}/`, priority: '0.3', changefreq: 'monthly' },
       ])
@@ -119,6 +131,25 @@ interface PublicLandingPagePrerenderEntry {
   path: string
   loc: string
   page: Record<string, unknown>
+}
+
+interface BlogPrerenderPost {
+  slug: string
+  title: string
+  description: string
+  date: string
+  author: string
+  content: string
+  charts: ChartSpec[]
+  faq: FaqItem[]
+  seoTitle?: string
+  seoDescription?: string
+}
+
+interface GeneratedBlogPrerenderEntry {
+  path: string
+  loc: string
+  post: BlogPrerenderPost
 }
 
 interface LandingPageSectionView {
@@ -182,6 +213,18 @@ function renderChartFallbacks(content: string, charts: ChartSpec[]): string {
   )
 }
 
+function escapeGeneratedMarkdownHtml(value: string): string {
+  return value.replace(/[<>]/g, char => (char === '<' ? '&lt;' : '&gt;'))
+}
+
+function sanitizeGeneratedRenderedHtml(html: string): string {
+  return html
+    .replace(/\s(?:on[a-z]+|style)=(["']).*?\1/gi, '')
+    .replace(/\s(href|src)=(["'])(.*?)\2/gi, (_match, attr: string, quote: string, value: string) => (
+      safePublicHref(value) ? ` ${attr}=${quote}${value}${quote}` : ''
+    ))
+}
+
 function buildFaqHtml(faq: FaqItem[]): string {
   if (!faq.length) return ''
 
@@ -199,8 +242,13 @@ ${items}
       </section>`
 }
 
-function buildBlogBodyHtml(post: BlogSourceMetadata): string {
-  const articleHtml = marked.parse(renderChartFallbacks(post.content, post.charts), { async: false }) as string
+function buildBlogBodyHtml(
+  post: BlogPrerenderPost,
+  { trustedHtml = true }: { trustedHtml?: boolean } = {},
+): string {
+  const content = trustedHtml ? post.content : escapeGeneratedMarkdownHtml(post.content)
+  const renderedHtml = marked.parse(renderChartFallbacks(content, post.charts), { async: false }) as string
+  const articleHtml = trustedHtml ? renderedHtml : sanitizeGeneratedRenderedHtml(renderedHtml)
   const faqHtml = buildFaqHtml(post.faq)
   return `
     <article data-prerendered-blog-article="true">
@@ -406,6 +454,64 @@ function landingPageRoute(entry: PublicLandingPagePrerenderEntry): PrerenderedRo
   }
 }
 
+function blogPostRoute(
+  post: BlogPrerenderPost,
+  {
+    path = `/blog/${post.slug}`,
+    canonical = `${BASE_URL}/blog/${post.slug}`,
+    trustedHtml = true,
+  }: { path?: string; canonical?: string; trustedHtml?: boolean } = {},
+): PrerenderedRoute {
+  const seoTitle = post.seoTitle || post.title
+  const seoDesc = post.seoDescription || post.description
+  const faqJsonLd = buildFaqJsonLd(post.faq)
+  const graph: object[] = [
+    {
+      '@type': 'BlogPosting',
+      headline: seoTitle,
+      description: seoDesc,
+      datePublished: post.date,
+      dateModified: post.date,
+      image: DEFAULT_OG_IMAGE,
+      author: {
+        '@type': 'Organization',
+        name: 'Atlas Intelligence',
+        sameAs: ATLAS_SAME_AS,
+      },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Atlas Intelligence',
+        url: BASE_URL,
+        sameAs: ATLAS_SAME_AS,
+        logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
+      },
+      mainEntityOfPage: { '@type': 'WebPage', '@id': canonical },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/landing` },
+        { '@type': 'ListItem', position: 2, name: 'Blog', item: `${BASE_URL}/blog` },
+        { '@type': 'ListItem', position: 3, name: seoTitle, item: canonical },
+      ],
+    },
+  ]
+  if (faqJsonLd) graph.push(faqJsonLd)
+
+  return {
+    path,
+    title: `${seoTitle} | Atlas Intelligence`,
+    description: seoDesc,
+    canonical,
+    ogType: 'article',
+    bodyHtml: buildBlogBodyHtml(post, { trustedHtml }),
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@graph': graph,
+    },
+  }
+}
+
 function prerenderPlugin() {
   return {
     name: 'prerender-public-routes',
@@ -415,6 +521,20 @@ function prerenderPlugin() {
       if (!existsSync(indexHtmlPath)) return
 
       const baseHtml = readFileSync(indexHtmlPath, 'utf-8')
+      const staticPosts = collectBlogSourceMetadata(import.meta.dirname)
+      const staticBlogSlugs = staticPosts.map(post => post.slug)
+      const generatedBlogPostsUrl = resolveGeneratedBlogPostsUrl()
+      const generatedBlogRoutes = (
+        await fetchGeneratedBlogPrerenderEntries({
+          postsUrl: generatedBlogPostsUrl,
+          publicSiteUrl: BASE_URL,
+          excludeSlugs: staticBlogSlugs,
+        }) as GeneratedBlogPrerenderEntry[]
+      ).map(entry => blogPostRoute(entry.post, {
+        path: entry.path,
+        canonical: entry.loc,
+        trustedHtml: false,
+      }))
       const landingPageRoutes = (
         await fetchLandingPagePrerenderEntries({
           sitemapUrl: resolveLandingPageSitemapUrl(),
@@ -423,57 +543,7 @@ function prerenderPlugin() {
         }) as PublicLandingPagePrerenderEntry[]
       ).map(landingPageRoute)
 
-      const blogRoutes: PrerenderedRoute[] = []
-      for (const post of collectBlogSourceMetadata(import.meta.dirname)) {
-        const seoTitle = post.seoTitle || post.title
-        const seoDesc = post.seoDescription || post.description
-        const faqJsonLd = buildFaqJsonLd(post.faq)
-        const graph: object[] = [
-          {
-            '@type': 'BlogPosting',
-            headline: seoTitle,
-            description: seoDesc,
-            datePublished: post.date,
-            dateModified: post.date,
-            image: DEFAULT_OG_IMAGE,
-            author: {
-              '@type': 'Organization',
-              name: 'Atlas Intelligence',
-              sameAs: ATLAS_SAME_AS,
-            },
-            publisher: {
-              '@type': 'Organization',
-              name: 'Atlas Intelligence',
-              url: BASE_URL,
-              sameAs: ATLAS_SAME_AS,
-              logo: { '@type': 'ImageObject', url: DEFAULT_OG_IMAGE },
-            },
-            mainEntityOfPage: { '@type': 'WebPage', '@id': `${BASE_URL}/blog/${post.slug}` },
-          },
-          {
-            '@type': 'BreadcrumbList',
-            itemListElement: [
-              { '@type': 'ListItem', position: 1, name: 'Home', item: `${BASE_URL}/landing` },
-              { '@type': 'ListItem', position: 2, name: 'Blog', item: `${BASE_URL}/blog` },
-              { '@type': 'ListItem', position: 3, name: seoTitle, item: `${BASE_URL}/blog/${post.slug}` },
-            ],
-          },
-        ]
-        if (faqJsonLd) graph.push(faqJsonLd)
-
-        blogRoutes.push({
-          path: `/blog/${post.slug}`,
-          title: `${seoTitle} | Atlas Intelligence`,
-          description: seoDesc,
-          canonical: `${BASE_URL}/blog/${post.slug}`,
-          ogType: 'article',
-          bodyHtml: buildBlogBodyHtml(post),
-          jsonLd: {
-            '@context': 'https://schema.org',
-            '@graph': graph,
-          },
-        })
-      }
+      const blogRoutes = staticPosts.map(post => blogPostRoute(post))
 
       const LANDING_JSON_LD = {
         '@context': 'https://schema.org',
@@ -531,6 +601,7 @@ function prerenderPlugin() {
           ogType: 'website',
         },
         ...blogRoutes,
+        ...generatedBlogRoutes,
         ...landingPageRoutes,
       ]
 

--- a/plans/PR-Blog-Generated-Sitemap-Prerender.md
+++ b/plans/PR-Blog-Generated-Sitemap-Prerender.md
@@ -22,17 +22,17 @@ Slice phase: Production hardening
 1. Add a small generated-blog build bridge that resolves an optional
    `VITE_PUBLIC_BLOG_POSTS_URL` feed, falling back to
    `VITE_API_BASE/api/v1/blog/published` when configured.
-2. Convert the existing public blog list envelope into strict build-time blog
-   entries with slug, title, description, date, author, content, charts, FAQ,
-   and SEO metadata.
+2. Convert the existing public blog list envelope into build-time blog entries
+   with slug, title, description, date, author, content, charts, FAQ, and SEO
+   metadata.
 3. Wire generated blog entries into the sitemap plugin with `/blog/:slug`
    URLs and `lastmod` from the public post date.
 4. Wire generated blog entries into the prerender plugin, while keeping static
    posts on their trusted static HTML path.
 5. Escape generated blog HTML before Markdown rendering so DB-backed approved
    content cannot inject raw HTML into prerendered output.
-6. Add mocked transport tests for feed resolution, request shape, malformed
-   envelope failure, malformed post failure, dedupe, sitemap rows, and
+6. Add mocked transport tests for feed resolution, request shape, fail-soft
+   feed errors, malformed-post skipping, dedupe, sitemap rows, and
    prerender-entry shape.
 7. Enroll the focused test in `atlas-intel-ui/package.json` and the Atlas
    Intel UI workflow.
@@ -59,10 +59,11 @@ GET ${VITE_API_BASE}/api/v1/blog/published
 ```
 
 If no URL is configured, the bridge returns an empty set so local and CI builds
-do not need a live backend. If a URL is configured, the response envelope must
-be an object with `posts: []`, and each public post must contain the fields
-needed to build a canonical page. Missing or malformed envelope/post data fails
-closed instead of silently producing a partial sitemap.
+do not need a live backend. If a URL is configured but the feed is unreachable
+or the envelope is malformed, the bridge warns and returns an empty generated
+set so deployment continues with static blog pages. Individual malformed posts
+warn and are skipped so one bad approved draft cannot fail the whole site
+build.
 
 `vite.config.ts` will share one blog-route builder for static and generated
 posts. Static in-repo posts keep their existing HTML rendering behavior.
@@ -106,6 +107,9 @@ renderer.
 - `cd atlas-intel-ui && npm run build` - passed; baseline build generated 17
   sitemap URLs and 16 public prerendered routes with no generated blog feed
   configured.
+- `cd atlas-intel-ui && VITE_PUBLIC_BLOG_POSTS_URL=<malformed data-url> npm
+  run build` - passed; bridge warned twice and continued with 17 sitemap URLs
+  and 16 public prerendered routes.
 - `cd atlas-intel-ui && VITE_PUBLIC_BLOG_POSTS_URL=<data-url fixture> npm run
   build` - passed; fixture build generated 18 sitemap URLs and 17 public
   prerendered routes, including `/blog/generated-prerender-fixture`.
@@ -118,24 +122,24 @@ renderer.
 - `cd atlas-intel-ui && npm run verify:landing-page-geo` - passed by skipping
   because no generated landing-page sitemap entries were present locally.
 - `bash scripts/local_pr_review.sh --current-pr-body-file
-  /home/juan-canfield/Desktop/blog-generated-sitemap-prerender-pr-body.md` - to
-  run.
+  /home/juan-canfield/Desktop/blog-generated-sitemap-prerender-pr-body.md` -
+  passed.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Plan | 138 |
-| Generated blog bridge + declaration | 215 |
-| Focused bridge tests | 170 |
+| Plan | 145 |
+| Generated blog bridge + declaration | 248 |
+| Focused bridge tests | 208 |
 | Vite sitemap/prerender wiring | 179 |
 | package/workflow enrollment | 4 |
-| **Total** | **709** |
+| **Total** | **784** |
 
 The slice may land slightly over the 400 LOC target because it needs both the
-strict build bridge and mocked negative fixtures to prove malformed public API
-envelopes fail closed. Splitting the bridge and Vite wiring would leave no
-usable generated-blog sitemap/prerender path; splitting the negative fixtures
-would violate AGENTS.md §3i for the new build-time parser/bridge.
+build bridge and mocked negative fixtures to prove malformed public API
+envelopes fail soft with warnings. Splitting the bridge and Vite wiring would
+leave no usable generated-blog sitemap/prerender path; splitting the negative
+fixtures would violate AGENTS.md §3i for the new build-time parser/bridge.
 
-Final diff summary: 7 files, +655 / -54.
+Final diff summary: 7 files, +730 / -54.

--- a/plans/PR-Blog-Generated-Sitemap-Prerender.md
+++ b/plans/PR-Blog-Generated-Sitemap-Prerender.md
@@ -1,0 +1,141 @@
+# PR: Blog Generated Sitemap Prerender
+
+## Why this slice exists
+
+PR #1224 made approved generated blog posts publicly readable at runtime, and
+PR #1226 added the review-drawer handoff link. Both plans deliberately deferred
+static sitemap/prerender ingestion for generated blogs, so approved DB-backed
+posts can be opened at `/blog/:slug` but are still absent from the build-time
+SEO/GEO artifacts crawlers consume.
+
+This slice closes that deferred hardening item by teaching the Atlas Intel UI
+build to ingest approved generated blog posts from the existing public blog API
+when a public feed/base URL is configured, then include those posts in
+`sitemap.xml` and generated `/blog/:slug/index.html` files.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/blog-generated-sitemap-prerender
+
+Slice phase: Production hardening
+
+1. Add a small generated-blog build bridge that resolves an optional
+   `VITE_PUBLIC_BLOG_POSTS_URL` feed, falling back to
+   `VITE_API_BASE/api/v1/blog/published` when configured.
+2. Convert the existing public blog list envelope into strict build-time blog
+   entries with slug, title, description, date, author, content, charts, FAQ,
+   and SEO metadata.
+3. Wire generated blog entries into the sitemap plugin with `/blog/:slug`
+   URLs and `lastmod` from the public post date.
+4. Wire generated blog entries into the prerender plugin, while keeping static
+   posts on their trusted static HTML path.
+5. Escape generated blog HTML before Markdown rendering so DB-backed approved
+   content cannot inject raw HTML into prerendered output.
+6. Add mocked transport tests for feed resolution, request shape, malformed
+   envelope failure, malformed post failure, dedupe, sitemap rows, and
+   prerender-entry shape.
+7. Enroll the focused test in `atlas-intel-ui/package.json` and the Atlas
+   Intel UI workflow.
+
+### Files touched
+
+- `atlas-intel-ui/scripts/blog-sitemap-bridge.mjs`
+- `atlas-intel-ui/scripts/blog-sitemap-bridge.d.mts`
+- `atlas-intel-ui/scripts/blog-generated-sitemap-prerender.test.mjs`
+- `atlas-intel-ui/vite.config.ts`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `plans/PR-Blog-Generated-Sitemap-Prerender.md`
+
+## Mechanism
+
+The build bridge is frontend-build-only. It does not add a new backend route;
+it consumes the public route shipped by #1224:
+
+```text
+GET ${VITE_PUBLIC_BLOG_POSTS_URL}
+or
+GET ${VITE_API_BASE}/api/v1/blog/published
+```
+
+If no URL is configured, the bridge returns an empty set so local and CI builds
+do not need a live backend. If a URL is configured, the response envelope must
+be an object with `posts: []`, and each public post must contain the fields
+needed to build a canonical page. Missing or malformed envelope/post data fails
+closed instead of silently producing a partial sitemap.
+
+`vite.config.ts` will share one blog-route builder for static and generated
+posts. Static in-repo posts keep their existing HTML rendering behavior.
+Generated posts pass through an escape-first Markdown path before prerender
+HTML insertion, matching the safety intent from #1224's runtime generated-post
+renderer.
+
+## Intentional
+
+- No backend API changes. The public blog list/detail routes already exist and
+  expose approved generated posts.
+- No live API dependency in CI. Tests mock `fetch`, and the build remains a
+  no-op for generated blog ingestion unless `VITE_PUBLIC_BLOG_POSTS_URL` or
+  `VITE_API_BASE` is configured.
+- No Content Ops generation/review UI changes. This is only the build-time
+  discovery/prerender hardening for already approved posts.
+- Static posts stay in the trusted HTML path because existing source posts are
+  authored as HTML/Markdown hybrids; generated posts use escape-first rendering.
+
+## Deferred
+
+- Browser E2E against a live approved generated blog post remains out of scope;
+  the operator can validate live after deployment by setting the feed/base env.
+- A shared public blog wire-model module between runtime TS and build-time Node
+  remains deferred because the current Vite build scripts are plain `.mjs`
+  modules and the existing runtime adapter is TS/browser-oriented.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  existing blog entries are generator content-quality issues, not this
+  sitemap/prerender build bridge.
+
+## Verification
+
+- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit
+  findings already parked in `HARDENING.md`.
+- `cd atlas-intel-ui && npm run test:blog-generated-sitemap-prerender` - 9
+  passed.
+- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4 passed.
+- `cd atlas-intel-ui && npm run test:sitemap-bridge` - 10 passed.
+- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
+- `cd atlas-intel-ui && npm run lint` - passed.
+- `cd atlas-intel-ui && npm run build` - passed; baseline build generated 17
+  sitemap URLs and 16 public prerendered routes with no generated blog feed
+  configured.
+- `cd atlas-intel-ui && VITE_PUBLIC_BLOG_POSTS_URL=<data-url fixture> npm run
+  build` - passed; fixture build generated 18 sitemap URLs and 17 public
+  prerendered routes, including `/blog/generated-prerender-fixture`.
+- `cd atlas-intel-ui && rg -n
+  "generated-prerender-fixture|<script>alert|javascript:alert|&lt;script&gt;"
+  dist/sitemap.xml dist/blog/generated-prerender-fixture/index.html` -
+  confirmed the generated URL was emitted, raw `<script>` was escaped, and the
+  unsafe markdown link did not retain an `href`.
+- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
+- `cd atlas-intel-ui && npm run verify:landing-page-geo` - passed by skipping
+  because no generated landing-page sitemap entries were present locally.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /home/juan-canfield/Desktop/blog-generated-sitemap-prerender-pr-body.md` - to
+  run.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | 138 |
+| Generated blog bridge + declaration | 215 |
+| Focused bridge tests | 170 |
+| Vite sitemap/prerender wiring | 179 |
+| package/workflow enrollment | 4 |
+| **Total** | **709** |
+
+The slice may land slightly over the 400 LOC target because it needs both the
+strict build bridge and mocked negative fixtures to prove malformed public API
+envelopes fail closed. Splitting the bridge and Vite wiring would leave no
+usable generated-blog sitemap/prerender path; splitting the negative fixtures
+would violate AGENTS.md §3i for the new build-time parser/bridge.
+
+Final diff summary: 7 files, +655 / -54.


### PR DESCRIPTION
Plan: plans/PR-Blog-Generated-Sitemap-Prerender.md
Slice phase: Production hardening

Approved generated blog posts are already public at runtime after #1224/#1226,
but they were still missing from build-time sitemap and prerender artifacts.
This PR adds an optional generated-blog build bridge that consumes the existing
public blog list feed when configured, adds generated `/blog/:slug` URLs to the
sitemap, and prerenders generated blog pages with an escape-first body path.

## Intentional
- No backend API changes. The public blog list/detail routes already expose approved generated posts.
- No live API dependency in CI. The generated-blog bridge is a no-op unless `VITE_PUBLIC_BLOG_POSTS_URL` or `VITE_API_BASE` is configured, and configured feed errors warn/fall back to static-only build output.
- Static posts keep the trusted HTML path; generated posts escape raw `<`/`>` before Markdown rendering and scrub unsafe rendered attributes.

## Deferred
- Browser E2E against a live approved generated blog post remains out of scope; the operator can validate live after deployment by setting the feed/base env.
- A shared public blog wire-model module between runtime TS and build-time Node remains deferred because the current Vite build scripts are plain `.mjs` modules and the runtime adapter is TS/browser-oriented.

## Parked hardening
- None. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned; existing blog entries are generator content-quality issues, not this sitemap/prerender build bridge.

## Verification
- `cd atlas-intel-ui && npm ci` - passed; npm reports the existing 6 audit findings already parked in `HARDENING.md`.
- `cd atlas-intel-ui && npm run test:blog-generated-sitemap-prerender` - 9 passed.
- `cd atlas-intel-ui && npm run test:blog-public-generated-posts` - 4 passed.
- `cd atlas-intel-ui && npm run test:sitemap-bridge` - 10 passed.
- `cd atlas-intel-ui && npm run test:landing-page-prerender` - 4 passed.
- `cd atlas-intel-ui && npm run lint` - passed.
- `cd atlas-intel-ui && npm run build` - passed; baseline build generated 17 sitemap URLs and 16 public prerendered routes with no generated blog feed configured.
- `cd atlas-intel-ui && VITE_PUBLIC_BLOG_POSTS_URL=<malformed data-url> npm run build` - passed; bridge warned twice and continued with 17 sitemap URLs and 16 public prerendered routes.
- `cd atlas-intel-ui && VITE_PUBLIC_BLOG_POSTS_URL=<data-url fixture> npm run build` - passed; fixture build generated 18 sitemap URLs and 17 public prerendered routes, including `/blog/generated-prerender-fixture`.
- `cd atlas-intel-ui && rg -n "generated-prerender-fixture|<script>alert|javascript:alert|&lt;script&gt;" dist/sitemap.xml dist/blog/generated-prerender-fixture/index.html` - confirmed the generated URL was emitted, raw `<script>` was escaped, and the unsafe markdown link did not retain an `href`.
- `cd atlas-intel-ui && npm run verify:blog-geo` - verified 14 blog pages.
- `cd atlas-intel-ui && npm run verify:landing-page-geo` - passed by skipping because no generated landing-page sitemap entries were present locally.
- `bash scripts/local_pr_review.sh --current-pr-body-file /home/juan-canfield/Desktop/blog-generated-sitemap-prerender-pr-body.md` - passed.

## Diff size
7 files, +730 / -54
