### PR TITLE
PR-Content-Ops-Upload-Source-Run-Handoff

### DIFF
--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -20,6 +20,7 @@
     "test:content-ops-deflection-report-ui": "node --test scripts/content-ops-deflection-report-ui.test.mjs",
     "test:content-ops-faq-configuration-inputs": "node --test scripts/content-ops-faq-configuration-inputs.test.mjs",
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
+    "test:content-ops-upload-source-run-handoff": "node --test scripts/content-ops-upload-source-run-handoff.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs
@@ -118,6 +118,7 @@ test('uploaded file inspect uses multipart file endpoint', async () => {
     file_format: 'csv',
     max_source_text_chars: 900,
     sample_limit: 5,
+    include_source_material: true,
     default_fields: { company_name: 'Acme' },
   })
 
@@ -138,6 +139,7 @@ test('uploaded file inspect uses multipart file endpoint', async () => {
   assert.equal(init.body.get('file_format'), 'csv')
   assert.equal(init.body.get('max_source_text_chars'), '900')
   assert.equal(init.body.get('sample_limit'), '5')
+  assert.equal(init.body.get('include_source_material'), 'true')
   assert.equal(
     init.body.get('default_fields'),
     JSON.stringify({ company_name: 'Acme' }),
@@ -155,6 +157,7 @@ test('inline inspect uses deprecated JSON compatibility endpoint', async () => {
     max_source_text_chars: 900,
     sample_limit: 5,
     default_fields: { company_name: 'Acme' },
+    include_source_material: true,
   })
 
   assert.equal(calls.length, 1)
@@ -173,6 +176,7 @@ test('inline inspect uses deprecated JSON compatibility endpoint', async () => {
     max_source_text_chars: 900,
     sample_limit: 5,
     default_fields: { company_name: 'Acme' },
+    include_source_material: true,
   })
 })
 
@@ -190,6 +194,7 @@ test('uploaded file import uses multipart file endpoint', async () => {
     file_format: 'csv',
     max_source_text_chars: 1200,
     sample_limit: 3,
+    include_source_material: true,
     default_fields: { company_name: 'Acme' },
     replace_existing: true,
     dry_run: false,
@@ -207,6 +212,7 @@ test('uploaded file import uses multipart file endpoint', async () => {
   assert.equal(init.headers['Content-Type'], undefined)
   assert.ok(init.body instanceof FormData)
   assert.equal(init.body.get('file').name, 'tickets.csv')
+  assert.equal(init.body.get('include_source_material'), 'true')
   assert.equal(init.body.get('replace_existing'), 'true')
   assert.equal(init.body.get('dry_run'), 'false')
 })
@@ -222,6 +228,7 @@ test('inline import uses deprecated JSON compatibility endpoint', async () => {
     max_source_text_chars: 1200,
     sample_limit: 3,
     default_fields: { company_name: 'Acme' },
+    include_source_material: true,
     replace_existing: true,
     dry_run: false,
   })
@@ -243,6 +250,7 @@ test('inline import uses deprecated JSON compatibility endpoint', async () => {
     max_source_text_chars: 1200,
     sample_limit: 3,
     default_fields: { company_name: 'Acme' },
+    include_source_material: true,
     replace_existing: true,
     dry_run: false,
   })

--- a/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function loadFromWireModule() {
+  const source = readFileSync(
+    new URL('../src/domain/contentOps/fromWire.ts', import.meta.url),
+    'utf8',
+  )
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fromWireIngestionDiagnostics,
+  toWireIngestionImportRequest,
+} = await loadFromWireModule()
+
+test('domain mapper preserves full ingestion source material separately from samples', () => {
+  const diagnostics = fromWireIngestionDiagnostics({
+    ok: true,
+    mode: 'source_rows',
+    source: 'tickets.csv',
+    opportunity_count: 2,
+    warning_count: 0,
+    warning_counts: {},
+    missing_field_counts: {},
+    source_type_counts: { support_ticket: 2 },
+    samples: [{ target_id: 'ticket-1' }],
+    source_material: [
+      { target_id: 'ticket-1', text: 'Billing question' },
+      { target_id: 'ticket-2', text: 'Setup question' },
+    ],
+    warnings: [],
+  })
+
+  assert.deepEqual(
+    diagnostics.samples.map((row) => row.target_id),
+    ['ticket-1'],
+  )
+  assert.deepEqual(
+    diagnostics.sourceMaterial.map((row) => row.target_id),
+    ['ticket-1', 'ticket-2'],
+  )
+})
+
+test('domain import request can opt into full source material', () => {
+  assert.deepEqual(
+    toWireIngestionImportRequest({
+      rows: [{ target_id: 'ticket-1' }],
+      sourceRows: true,
+      source: 'tickets.csv',
+      targetMode: 'vendor_retention',
+      maxSourceTextChars: 1200,
+      sampleLimit: 25,
+      defaultFields: { company_name: 'Acme' },
+      includeSourceMaterial: true,
+      replaceExisting: false,
+      dryRun: true,
+    }),
+    {
+      rows: [{ target_id: 'ticket-1' }],
+      source_rows: true,
+      source: 'tickets.csv',
+      target_mode: 'vendor_retention',
+      max_source_text_chars: 1200,
+      sample_limit: 25,
+      default_fields: { company_name: 'Acme' },
+      include_source_material: true,
+      replace_existing: false,
+      dry_run: true,
+    },
+  )
+})
+
+test('new run import handoff applies source material to the run inputs', () => {
+  assert.ok(newRunSource.includes('include_source_material: true'))
+  assert.ok(newRunSource.includes('includeSourceMaterial: true'))
+  assert.ok(newRunSource.includes('function updateSourceMaterialInputJson'))
+  assert.ok(newRunSource.includes('next.source_material = sourceMaterial.map'))
+  assert.ok(newRunSource.includes('Use rows for run'))
+  assert.ok(newRunSource.includes('onApplySourceMaterial(sourceMaterial)'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -251,6 +251,7 @@ export interface ContentOpsIngestionInspectRequest {
   max_source_text_chars?: number                    // 1..10000
   sample_limit?: number                             // 0..25
   default_fields?: Record<string, unknown>
+  include_source_material?: boolean                 // default false
 }
 
 export interface ContentOpsIngestionImportRequest
@@ -268,6 +269,7 @@ export interface ContentOpsIngestionFileInspectRequest {
   max_source_text_chars?: number
   sample_limit?: number
   default_fields?: Record<string, unknown>
+  include_source_material?: boolean
 }
 
 export interface ContentOpsIngestionFileImportRequest
@@ -293,6 +295,7 @@ export interface ContentOpsIngestionDiagnosticsResponse {
   missing_field_counts: Record<string, number>
   source_type_counts: Record<string, number>
   samples: Array<Record<string, unknown>>
+  source_material?: Array<Record<string, unknown>>
   warnings: ContentOpsIngestionWarning[]
 }
 
@@ -743,6 +746,11 @@ function ingestionFileFormData(
     body.max_source_text_chars,
   )
   appendOptionalNumber(formData, 'sample_limit', body.sample_limit)
+  appendOptionalBoolean(
+    formData,
+    'include_source_material',
+    body.include_source_material,
+  )
   if (body.default_fields) {
     formData.set('default_fields', JSON.stringify(body.default_fields))
   }

--- a/atlas-intel-ui/src/domain/contentOps/fromWire.ts
+++ b/atlas-intel-ui/src/domain/contentOps/fromWire.ts
@@ -306,6 +306,7 @@ export function toWireIngestionInspectRequest(
     max_source_text_chars: domain.maxSourceTextChars,
     sample_limit: domain.sampleLimit,
     default_fields: { ...domain.defaultFields },
+    include_source_material: domain.includeSourceMaterial,
   }
 }
 
@@ -332,6 +333,7 @@ export function fromWireIngestionDiagnostics(
     missingFieldCounts: { ...wire.missing_field_counts },
     sourceTypeCounts: { ...wire.source_type_counts },
     samples: wire.samples.map((row) => ({ ...row })),
+    sourceMaterial: (wire.source_material ?? []).map((row) => ({ ...row })),
     warnings: wire.warnings.map((warning) => ({
       code: warning.code,
       message: warning.message,

--- a/atlas-intel-ui/src/domain/contentOps/types.ts
+++ b/atlas-intel-ui/src/domain/contentOps/types.ts
@@ -202,6 +202,7 @@ export interface ContentOpsIngestionInspectRequest {
   maxSourceTextChars: number
   sampleLimit: number
   defaultFields: Record<string, unknown>
+  includeSourceMaterial: boolean
 }
 
 export interface ContentOpsIngestionImportRequest
@@ -227,6 +228,7 @@ export interface ContentOpsIngestionDiagnostics {
   missingFieldCounts: Record<string, number>
   sourceTypeCounts: Record<string, number>
   samples: Array<Record<string, unknown>>
+  sourceMaterial: Array<Record<string, unknown>>
   warnings: ContentOpsIngestionWarning[]
 }
 

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -271,6 +271,8 @@ export default function ContentOpsNewRun() {
     useState<IngestionInspectState>({ kind: 'idle' })
   const [ingestionImportState, setIngestionImportState] =
     useState<IngestionImportState>({ kind: 'idle' })
+  const [sourceMaterialApplyError, setSourceMaterialApplyError] =
+    useState<string | null>(null)
   // Codex P2 fix: request-id ref so a stale in-flight preview/plan
   // response can't overwrite a result the user has since invalidated
   // by editing the form. Both preview and plan share the same id
@@ -373,6 +375,7 @@ export default function ContentOpsNewRun() {
     setSubmitState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
     setPlanState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
     setExecutionState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
+    setSourceMaterialApplyError(null)
   }
 
   const markIngestionStale = () => {
@@ -385,6 +388,7 @@ export default function ContentOpsNewRun() {
     setIngestionImportState((prev) =>
       prev.kind === 'idle' ? prev : { kind: 'idle' },
     )
+    setSourceMaterialApplyError(null)
   }
 
   const handleLandingPageRepairAttemptsChange = (value: string) => {
@@ -710,6 +714,7 @@ export default function ContentOpsNewRun() {
             file_format: 'auto',
             max_source_text_chars: catalog.ingestionLimits.maxSourceTextChars,
             sample_limit: catalog.ingestionLimits.maxSampleLimit,
+            include_source_material: false,
             default_fields: parsedDefaultFields.fields,
           })
         : await inspectContentOpsIngestion(
@@ -721,6 +726,7 @@ export default function ContentOpsNewRun() {
               maxSourceTextChars: catalog.ingestionLimits.maxSourceTextChars,
               sampleLimit: catalog.ingestionLimits.maxSampleLimit,
               defaultFields: parsedDefaultFields.fields,
+              includeSourceMaterial: false,
             }),
           )
       if (requestId !== ingestionInspectRequestIdRef.current) return
@@ -776,6 +782,7 @@ export default function ContentOpsNewRun() {
     const inlineRows = parsedRows?.ok ? parsedRows.rows : []
 
     setIngestionImportState({ kind: 'submitting' })
+    setSourceMaterialApplyError(null)
     try {
       const outcome = selectedIngestionFile
         ? await importContentOpsIngestionFile({
@@ -786,6 +793,7 @@ export default function ContentOpsNewRun() {
             file_format: 'auto',
             max_source_text_chars: catalog.ingestionLimits.maxSourceTextChars,
             sample_limit: catalog.ingestionLimits.maxSampleLimit,
+            include_source_material: true,
             default_fields: parsedDefaultFields.fields,
             replace_existing: ingestionReplaceExisting,
             dry_run: ingestionDryRun,
@@ -799,6 +807,7 @@ export default function ContentOpsNewRun() {
               maxSourceTextChars: catalog.ingestionLimits.maxSourceTextChars,
               sampleLimit: catalog.ingestionLimits.maxSampleLimit,
               defaultFields: parsedDefaultFields.fields,
+              includeSourceMaterial: true,
               replaceExisting: ingestionReplaceExisting,
               dryRun: ingestionDryRun,
             }),
@@ -839,6 +848,19 @@ export default function ContentOpsNewRun() {
         message: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  const handleApplyImportedSourceMaterial = (
+    sourceMaterial: Array<Record<string, unknown>>,
+  ) => {
+    const updated = updateSourceMaterialInputJson(inputsJson, sourceMaterial)
+    if (!updated.ok) {
+      setSourceMaterialApplyError(updated.message)
+      return
+    }
+    setInputsJson(updated.value)
+    setSourceMaterialApplyError(null)
+    markStale()
   }
 
   const handleLoadIngestionFile = async (
@@ -1395,7 +1417,11 @@ export default function ContentOpsNewRun() {
           </label>
           <IngestionFileLoadResult state={ingestionFileLoadState} />
           <IngestionInspectResult state={ingestionInspectState} />
-          <IngestionImportResult state={ingestionImportState} />
+          <IngestionImportResult
+            state={ingestionImportState}
+            applyError={sourceMaterialApplyError}
+            onApplySourceMaterial={handleApplyImportedSourceMaterial}
+          />
         </section>
 
         {/* Options */}
@@ -2515,7 +2541,15 @@ function supportsAutoDetection(formats: string[]): boolean {
   return formats.includes('auto')
 }
 
-function IngestionImportResult({ state }: { state: IngestionImportState }) {
+function IngestionImportResult({
+  state,
+  applyError,
+  onApplySourceMaterial,
+}: {
+  state: IngestionImportState
+  applyError: string | null
+  onApplySourceMaterial: (sourceMaterial: Array<Record<string, unknown>>) => void
+}) {
   if (state.kind === 'idle' || state.kind === 'submitting') {
     return null
   }
@@ -2561,18 +2595,39 @@ function IngestionImportResult({ state }: { state: IngestionImportState }) {
   }
 
   const result = state.response.importResult
+  const sourceMaterial = state.response.diagnostics.sourceMaterial
   return (
     <div className="mt-3 rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs">
-      <div className="mb-2 flex flex-wrap items-center gap-3">
-        <span className="rounded-full bg-emerald-500/20 px-2.5 py-0.5 font-medium text-emerald-200">
-          {result.dryRun ? 'Dry run complete' : 'Import complete'}
-        </span>
-        <span className="text-slate-300">Inserted: {result.inserted}</span>
-        <span className="text-slate-300">Skipped: {result.skipped}</span>
-        {result.replaceExisting && (
-          <span className="text-amber-200">Replace existing enabled</span>
-        )}
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="rounded-full bg-emerald-500/20 px-2.5 py-0.5 font-medium text-emerald-200">
+            {result.dryRun ? 'Dry run complete' : 'Import complete'}
+          </span>
+          <span className="text-slate-300">Inserted: {result.inserted}</span>
+          <span className="text-slate-300">Skipped: {result.skipped}</span>
+          {result.replaceExisting && (
+            <span className="text-amber-200">Replace existing enabled</span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onApplySourceMaterial(sourceMaterial)}
+          disabled={sourceMaterial.length === 0}
+          className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-xs font-medium text-cyan-200 hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Upload className="h-3.5 w-3.5" />
+          Use rows for run
+        </button>
       </div>
+      <div className="mb-2 text-slate-300">
+        Source material available: {sourceMaterial.length.toLocaleString('en-US')}{' '}
+        row{sourceMaterial.length === 1 ? '' : 's'}
+      </div>
+      {applyError && (
+        <div className="mb-2 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+          Could not apply rows: {applyError}
+        </div>
+      )}
       {result.targetIds.length > 0 && (
         <Section label="Target ids">
           <div className="break-all font-mono text-[11px] text-slate-300">
@@ -2799,6 +2854,24 @@ function updateSourceFaqIdsInputJson(
     next[SOURCE_FAQ_IDS_INPUT] = values
   }
 
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function updateSourceMaterialInputJson(
+  current: string,
+  sourceMaterial: Array<Record<string, unknown>>,
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+  if (sourceMaterial.length === 0) {
+    return {
+      ok: false,
+      message: 'Imported source material is empty.',
+    }
+  }
+
+  const next = { ...parsed.value }
+  next.source_material = sourceMaterial.map((row) => ({ ...row }))
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
 }
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -557,6 +557,7 @@ if BaseModel is not None:
         max_source_text_chars: int = Field(1200, ge=1, le=_MAX_INPUT_STRING_CHARS)
         sample_limit: int = Field(3, ge=0, le=_MAX_INGESTION_SAMPLE_LIMIT)
         default_fields: dict[str, Any] = Field(default_factory=dict)
+        include_source_material: bool = False
 
         @field_validator("rows")
         @classmethod
@@ -873,7 +874,10 @@ def create_content_ops_control_surface_router(
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return report.as_dict()
+        return _ingestion_diagnostics_response(
+            report,
+            include_source_material=_flag_enabled(data.get("include_source_material")),
+        )
 
     @router.post("/ingestion/import", deprecated=True)
     async def import_ingestion(
@@ -893,7 +897,10 @@ def create_content_ops_control_surface_router(
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        diagnostics = report.as_dict()
+        diagnostics = _ingestion_diagnostics_response(
+            report,
+            include_source_material=_flag_enabled(data.get("include_source_material")),
+        )
         if not report.ok:
             raise HTTPException(
                 status_code=400,
@@ -930,6 +937,7 @@ def create_content_ops_control_surface_router(
         max_source_text_chars: int = Form(1200),
         sample_limit: int = Form(3),
         default_fields: str | None = Form(None),
+        include_source_material: bool = Form(False),
     ) -> dict[str, Any]:
         report = await _inspect_uploaded_ingestion_file(
             file,
@@ -941,7 +949,11 @@ def create_content_ops_control_surface_router(
             sample_limit=sample_limit,
             default_fields=default_fields,
         )
-        return _file_ingestion_response(report, source=source)
+        return _file_ingestion_response(
+            report,
+            source=source,
+            include_source_material=_flag_enabled(include_source_material),
+        )
 
     @router.post("/ingestion/files/import")
     async def import_ingestion_file_upload(
@@ -955,6 +967,7 @@ def create_content_ops_control_surface_router(
         default_fields: str | None = Form(None),
         replace_existing: bool = Form(False),
         dry_run: bool = Form(False),
+        include_source_material: bool = Form(False),
     ) -> dict[str, Any]:
         target_mode_value = _clean(target_mode) or "vendor_retention"
         report = await _inspect_uploaded_ingestion_file(
@@ -967,7 +980,11 @@ def create_content_ops_control_surface_router(
             sample_limit=sample_limit,
             default_fields=default_fields,
         )
-        diagnostics = _file_ingestion_response(report, source=source)
+        diagnostics = _file_ingestion_response(
+            report,
+            source=source,
+            include_source_material=_flag_enabled(include_source_material),
+        )
         if not report.ok:
             raise HTTPException(
                 status_code=400,
@@ -1807,9 +1824,43 @@ def _upload_suffix(file: UploadFile, file_format: str) -> str:
     return ".json"
 
 
-def _file_ingestion_response(report: Any, *, source: str | None = None) -> dict[str, Any]:
+def _ingestion_diagnostics_response(
+    report: Any,
+    *,
+    source: str | None = None,
+    include_source_material: bool = False,
+) -> dict[str, Any]:
     payload = report.as_dict()
-    payload["source"] = _clean(source) or payload.get("source") or ""
+    if source is not None:
+        payload["source"] = _clean(source) or payload.get("source") or ""
+    if include_source_material:
+        payload["source_material"] = [
+            dict(row)
+            for row in getattr(report, "opportunities", ())
+            if isinstance(row, Mapping)
+        ]
+    return payload
+
+
+def _flag_enabled(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _file_ingestion_response(
+    report: Any,
+    *,
+    source: str | None = None,
+    include_source_material: bool = False,
+) -> dict[str, Any]:
+    payload = _ingestion_diagnostics_response(
+        report,
+        source=source,
+        include_source_material=include_source_material,
+    )
     payload["ingestion_path"] = "file_upload"
     payload["limits"] = {
         "max_file_bytes": _MAX_INGESTION_FILE_BYTES,

--- a/plans/PR-Content-Ops-Upload-Source-Run-Handoff.md
+++ b/plans/PR-Content-Ops-Upload-Source-Run-Handoff.md
@@ -1,0 +1,132 @@
+# PR: Content Ops Upload Source Run Handoff
+
+## Why this slice exists
+
+The landing-page and generated-blog product path is now reviewable and public,
+but the New Run UI still leaves a gap between uploaded customer exports and the
+generation request. Operators can load/inspect/import a CSV, and the backend can
+normalize it, but execute still consumes `inputs.source_material`; the imported
+target IDs shown in the UI are not automatically usable by landing/blog
+generation. That makes the live path easy to false-green: the CSV import can
+succeed while the later page/blog run omits the uploaded data.
+
+This slice closes the smallest end-to-end handoff: the ingestion API can
+optionally return the full normalized source material, and the UI can apply that
+material to `inputs.source_material` after a successful upload/import before
+preview/plan/execute.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-source-run-handoff
+
+Slice phase: Vertical slice
+
+1. Add an opt-in `include_source_material` flag to ingestion inspect/import
+   requests, including multipart file uploads.
+2. When requested, return the bounded normalized opportunities as
+   `source_material` in ingestion diagnostics.
+3. Thread the optional field through the frontend API/domain adapters.
+4. In the New Run UI, request source material during import and provide a
+   guarded apply action that writes it into `inputs.source_material`.
+5. Add focused API/domain/UI source tests proving upload/import can feed the
+   generation request without using samples as a lossy substitute.
+
+### Files touched
+
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/domain/contentOps/types.ts`
+- `atlas-intel-ui/src/domain/contentOps/fromWire.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-ingestion-routing.test.mjs`
+- `atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs`
+- `atlas-intel-ui/package.json`
+- `plans/PR-Content-Ops-Upload-Source-Run-Handoff.md`
+
+## Mechanism
+
+`ContentOpsIngestionInspectModel` gains an optional boolean
+`include_source_material`, mirrored by file-upload form fields. The default is
+false, so ordinary inspect/import responses remain compact. When true,
+`_ingestion_diagnostics_response(...)` adds:
+
+```json
+{
+  "source_material": [{ "target_id": "ticket-1", "...": "..." }]
+}
+```
+
+The UI requests this on import, maps it through `fromWireIngestionDiagnostics`,
+and exposes an apply control on the successful import card. Applying the import
+updates `inputsJson` with `source_material` from the normalized response and
+marks preview/plan/execute stale. If the response omits source material or the
+current inputs JSON is invalid, the apply action fails closed with an inline
+message instead of mutating the request.
+
+## Intentional
+
+- No persisted-target execute path in this slice. Loading imported target IDs
+  back from Postgres into the provider is a larger backend orchestration slice;
+  this PR proves the UI upload to generation handoff without adding another DB
+  lookup surface.
+- The full source material is opt-in. Existing inspect/import callers keep the
+  compact diagnostics envelope.
+- The UI applies `source_material`, not `samples`; samples are capped and are
+  only for diagnostics.
+- No live LLM, database, or hosted browser run in CI. Tests use route/unit
+  fixtures and source-level UI checks.
+
+## Deferred
+
+- Future PR: persisted import target selection for execute, where imported
+  target IDs are read back from `campaign_opportunities` by tenant scope.
+- Future PR: browser E2E against a live uploaded support-ticket CSV producing
+  an approved public landing/blog asset.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  existing entries are blog content-quality issues, not this upload handoff.
+
+## Verification
+
+- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py
+  tests/test_extracted_content_control_surface_api.py` - passed.
+- `pytest tests/test_extracted_content_control_surface_api.py -k
+  'ingestion_inspect_route_can_include_full_source_material or
+  ingestion_file_inspect_route_can_include_full_source_material or
+  ingestion_file_import_route_dry_run_uses_file_parser or
+  ingestion_inspect_route_reports_source_rows or
+  ingestion_file_inspect_route_accepts_more_than_inline_row_cap' -q` - 5
+  passed, 121 deselected.
+- `pytest tests/test_extracted_content_control_surface_api.py -q` - 125
+  passed, 1 skipped.
+- `cd atlas-intel-ui && npm run test:content-ops-upload-source-run-handoff` -
+  3 passed.
+- `cd atlas-intel-ui && npm run test:content-ops-ingestion-routing` - 4
+  passed.
+- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4
+  passed.
+- `cd atlas-intel-ui && npm run build` - passed; generated 17 sitemap URLs and
+  prerendered 16 public routes.
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py
+  extracted_content_pipeline` - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
+- `bash scripts/check_ascii_python.sh` - passed.
+- `bash scripts/run_extracted_pipeline_checks.sh` - passed; extracted content
+  pytest reported 2879 passed, 10 skipped.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /tmp/content-ops-upload-source-run-handoff-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~130 |
+| Backend API + tests | ~120 |
+| Frontend API/domain | ~60 |
+| UI handoff + tests | ~150 |
+| **Total** | **~465** |
+
+This is slightly over the 400 LOC soft budget because the backend opt-in
+envelope, frontend wire mapping, and UI apply behavior need to ship together to
+prove the uploaded CSV reaches the run request.

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -1306,6 +1306,45 @@ async def test_ingestion_inspect_route_reports_source_rows():
     assert payload["opportunity_count"] == 1
     assert payload["source_type_counts"] == {"transcript": 1}
     assert payload["samples"][0]["source_type"] == "transcript"
+    assert "source_material" not in payload
+
+
+@pytest.mark.asyncio
+async def test_ingestion_inspect_route_can_include_full_source_material():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+
+    route = _route(router, "/ops/ingestion/inspect", "POST")
+    payload = await route.endpoint({
+        "source_rows": True,
+        "source": "fixture",
+        "sample_limit": 1,
+        "include_source_material": True,
+        "rows": [
+            {
+                "call_id": "call-1",
+                "company": "Acme",
+                "vendor": "HubSpot",
+                "transcript": "The renewal process is too manual.",
+                "contact_email": "ops@example.com",
+            },
+            {
+                "call_id": "call-2",
+                "company": "Acme",
+                "vendor": "HubSpot",
+                "transcript": "Setup needs a checklist.",
+                "contact_email": "ops@example.com",
+            },
+        ],
+    })
+
+    assert payload["ok"] is True
+    assert len(payload["samples"]) == 1
+    assert [row["target_id"] for row in payload["source_material"]] == [
+        "call-1",
+        "call-2",
+    ]
 
 
 @pytest.mark.asyncio
@@ -1430,6 +1469,40 @@ async def test_ingestion_file_inspect_route_accepts_more_than_inline_row_cap():
     assert payload["ok"] is True
     assert payload["opportunity_count"] == 1001
     assert payload["source_type_counts"] == {"support_ticket": 1001}
+    assert "source_material" not in payload
+
+
+@pytest.mark.asyncio
+async def test_ingestion_file_inspect_route_can_include_full_source_material():
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/ops", tags=("ops",)),
+    )
+    upload = _ticket_bundle_upload(3)
+
+    route = _route(router, "/ops/ingestion/files/inspect", "POST")
+    payload = await route.endpoint(
+        file=upload,
+        source_rows=True,
+        source="ticket-csv-upload",
+        target_mode="vendor_retention",
+        file_format="json",
+        max_source_text_chars=1200,
+        sample_limit=1,
+        default_fields=json.dumps({
+            "company_name": "Acme",
+            "vendor_name": "Atlas",
+            "contact_email": "support@example.com",
+        }),
+        include_source_material=True,
+    )
+
+    assert payload["ingestion_path"] == "file_upload"
+    assert len(payload["samples"]) == 1
+    assert [row["target_id"] for row in payload["source_material"]] == [
+        "ticket-0",
+        "ticket-1",
+        "ticket-2",
+    ]
 
 
 @pytest.mark.asyncio
@@ -1468,10 +1541,13 @@ async def test_ingestion_file_import_route_dry_run_uses_file_parser():
             "contact_email": "support@example.com",
         }),
         dry_run=True,
+        include_source_material=True,
     )
 
     assert payload["diagnostics"]["ingestion_path"] == "file_upload"
     assert payload["diagnostics"]["opportunity_count"] == 1001
+    assert len(payload["diagnostics"]["samples"]) == 3
+    assert len(payload["diagnostics"]["source_material"]) == 1001
     assert payload["import"]["dry_run"] is True
     assert payload["import"]["inserted"] == 1001
     assert payload["import"]["source"] == "ticket-csv-upload"


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Upload-Source-Run-Handoff.md
Slice phase: Vertical slice

This closes the smallest upload-to-generation handoff for Content Ops New Run: ingestion import can now return full normalized source material on request, and the UI can apply those rows into `inputs.source_material` before preview, plan, or execute. That prevents a false-green CSV import where landing/blog generation still runs without the uploaded customer data.

## Intentional
- No persisted-target execute path in this slice; reading imported target IDs back from Postgres by tenant scope is deferred.
- Full source material is opt-in so ordinary inspect/import diagnostics stay compact.
- The UI applies `source_material`, not capped `samples`; samples remain diagnostic only.
- No live LLM, database, or hosted browser run in CI.

## Deferred
- Persisted import target selection for execute via `campaign_opportunities` by tenant scope.
- Browser E2E against a live uploaded support-ticket CSV producing approved public landing/blog assets.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/api/control_surfaces.py tests/test_extracted_content_control_surface_api.py` - passed.
- `pytest tests/test_extracted_content_control_surface_api.py -k 'ingestion_inspect_route_can_include_full_source_material or ingestion_file_inspect_route_can_include_full_source_material or ingestion_file_import_route_dry_run_uses_file_parser or ingestion_inspect_route_reports_source_rows or ingestion_file_inspect_route_accepts_more_than_inline_row_cap' -q` - 5 passed, 121 deselected.
- `pytest tests/test_extracted_content_control_surface_api.py -q` - 125 passed, 1 skipped.
- `cd atlas-intel-ui && npm run test:content-ops-upload-source-run-handoff` - 3 passed.
- `cd atlas-intel-ui && npm run test:content-ops-ingestion-routing` - 4 passed.
- `cd atlas-intel-ui && npm run test:content-ops-landing-page-e2e-ui` - 4 passed.
- `cd atlas-intel-ui && npm run build` - passed; generated 17 sitemap URLs and prerendered 16 public routes.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - passed; extracted content pytest reported 2879 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-upload-source-run-handoff-pr-body.md` - passed.

## Diff size
10 files, +467 / -17.
