### PR TITLE
PR-Content-Ops-Persisted-Source-Execute

### DIFF
--- a/.github/workflows/atlas_content_ops_input_provider_checks.yml
+++ b/.github/workflows/atlas_content_ops_input_provider_checks.yml
@@ -1,0 +1,40 @@
+name: Atlas Content Ops Input Provider Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "atlas_brain/_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_input_provider.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
+      - "atlas_brain/_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_input_provider.py"
+
+jobs:
+  atlas-content-ops-input-provider-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops input provider tests
+        run: |
+          python -m pytest \
+            tests/test_atlas_content_ops_input_provider.py \
+            -q

--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
+from extracted_content_pipeline.campaign_postgres import PostgresIntelligenceRepository
 from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_input_provider import (
     ContentOpsInputPackage,
@@ -23,6 +24,7 @@ from extracted_content_pipeline.ticket_faq_postgres import PostgresTicketFAQRepo
 
 PoolProvider = Callable[[], Any | Awaitable[Any]]
 FAQRepositoryFactory = Callable[[Any], Any]
+OpportunityRepositoryFactory = Callable[[Any], Any]
 
 _SUPPORT_TICKET_BUNDLE_KEYS = frozenset({
     "support_tickets",
@@ -69,6 +71,11 @@ _SOURCE_FAQ_ID_KEYS = (
     "source_faq_draft_ids",
     "selected_faq_draft_ids",
 )
+_SOURCE_IMPORT_TARGET_ID_KEYS = (
+    "source_import_target_ids",
+    "source_target_ids",
+    "import_target_ids",
+)
 
 
 @dataclass(frozen=True)
@@ -78,6 +85,9 @@ class _AtlasSupportTicketInputProvider:
     provider_name: str = "atlas_support_ticket_request"
     pool_provider: PoolProvider | None = None
     faq_repository_factory: FAQRepositoryFactory = PostgresTicketFAQRepository
+    opportunity_repository_factory: OpportunityRepositoryFactory = (
+        PostgresIntelligenceRepository
+    )
 
     def build_content_ops_input_package(
         self,
@@ -87,9 +97,11 @@ class _AtlasSupportTicketInputProvider:
     ) -> ContentOpsInputPackage | Awaitable[ContentOpsInputPackage]:
         source_material = _request_source_material(request)
         source_faq_ids = _request_source_faq_ids(request)
-        if source_faq_ids:
-            return self._build_from_selected_faq_ids(
+        source_target_ids = _request_source_target_ids(request)
+        if source_faq_ids or source_target_ids:
+            return self._build_from_selected_sources(
                 source_faq_ids,
+                source_target_ids,
                 source_material=source_material,
                 scope=scope,
                 request=request,
@@ -106,30 +118,55 @@ class _AtlasSupportTicketInputProvider:
             request=request,
         )
 
-    async def _build_from_selected_faq_ids(
+    async def _build_from_selected_sources(
         self,
         source_faq_ids: Sequence[str],
+        source_target_ids: Sequence[str],
         *,
         source_material: Any,
         scope: TenantScope,
         request: RequestPayload | None,
     ) -> ContentOpsInputPackage:
         valid_faq_ids, invalid_faq_ids = _partition_source_faq_ids(source_faq_ids)
-        loaded, missing = await self._load_selected_faq_drafts(
+        loaded_faqs, missing_faqs = await self._load_selected_faq_drafts(
             valid_faq_ids,
             scope=scope,
         )
-        combined_source_material = _combine_source_material(source_material, loaded)
+        (
+            loaded_targets,
+            missing_targets,
+            ambiguous_targets,
+            target_skip_reason,
+        ) = await self._load_selected_import_targets(
+            source_target_ids,
+            scope=scope,
+            request=request,
+        )
+        combined_source_material = _combine_source_material(
+            source_material,
+            [*loaded_targets, *loaded_faqs],
+        )
         metadata = {
             "selected_faq_id_count": len(source_faq_ids),
-            "selected_faq_loaded_count": len(loaded),
-            "selected_faq_missing_id_count": len(missing),
+            "selected_faq_loaded_count": len(loaded_faqs),
+            "selected_faq_missing_id_count": len(missing_faqs),
             "selected_faq_invalid_id_count": len(invalid_faq_ids),
+            "source_target_id_count": len(source_target_ids),
+            "source_target_loaded_count": len(loaded_targets),
+            "source_target_missing_id_count": len(missing_targets),
+            "source_target_ambiguous_id_count": len(ambiguous_targets),
         }
-        warnings = _selected_faq_warnings(
-            invalid=invalid_faq_ids,
-            missing=missing,
-            repository_configured=self.pool_provider is not None,
+        warnings = (
+            *_selected_faq_warnings(
+                invalid=invalid_faq_ids,
+                missing=missing_faqs,
+                repository_configured=self.pool_provider is not None,
+            ),
+            *_selected_source_target_warnings(
+                missing=missing_targets,
+                ambiguous=ambiguous_targets,
+                skip_reason=target_skip_reason,
+            ),
         )
         if _is_empty_source_material(combined_source_material) or not _is_support_ticket_material(
             combined_source_material
@@ -183,17 +220,57 @@ class _AtlasSupportTicketInputProvider:
             loaded.append(draft.as_dict())
         return loaded, missing
 
+    async def _load_selected_import_targets(
+        self,
+        source_target_ids: Sequence[str],
+        *,
+        scope: TenantScope,
+        request: RequestPayload | None,
+    ) -> tuple[list[dict[str, Any]], list[str], list[str], str | None]:
+        if not source_target_ids:
+            return [], [], [], None
+        if not _clean(getattr(scope, "account_id", None)):
+            return [], list(source_target_ids), [], "missing_account_scope"
+        if self.pool_provider is None:
+            return [], list(source_target_ids), [], "repository_unconfigured"
+        pool = self.pool_provider()
+        if hasattr(pool, "__await__"):
+            pool = await pool
+        repository = self.opportunity_repository_factory(pool)
+        target_mode = _request_target_mode(request)
+        loaded: list[dict[str, Any]] = []
+        missing: list[str] = []
+        ambiguous: list[str] = []
+        for target_id in source_target_ids:
+            rows = await repository.read_campaign_opportunities(
+                scope=scope,
+                target_mode=target_mode,
+                limit=2,
+                filters={"target_id": target_id},
+            )
+            if len(rows) == 1:
+                loaded.append(dict(rows[0]))
+            elif len(rows) > 1:
+                ambiguous.append(target_id)
+            else:
+                missing.append(target_id)
+        return loaded, missing, ambiguous, None
+
 
 def build_content_ops_input_provider(
     *,
     pool_provider: PoolProvider | None = None,
     faq_repository_factory: FAQRepositoryFactory = PostgresTicketFAQRepository,
+    opportunity_repository_factory: OpportunityRepositoryFactory = (
+        PostgresIntelligenceRepository
+    ),
 ) -> _AtlasSupportTicketInputProvider:
     """Return the host's request-aware Content Ops input provider."""
 
     return _AtlasSupportTicketInputProvider(
         pool_provider=pool_provider,
         faq_repository_factory=faq_repository_factory,
+        opportunity_repository_factory=opportunity_repository_factory,
     )
 
 
@@ -217,6 +294,25 @@ def _request_source_faq_ids(request: RequestPayload | None) -> tuple[str, ...]:
         if values:
             return tuple(values)
     return ()
+
+
+def _request_source_target_ids(request: RequestPayload | None) -> tuple[str, ...]:
+    if not isinstance(request, Mapping):
+        return ()
+    inputs = request.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return ()
+    for key in _SOURCE_IMPORT_TARGET_ID_KEYS:
+        values = _string_values(inputs.get(key))
+        if values:
+            return tuple(values)
+    return ()
+
+
+def _request_target_mode(request: RequestPayload | None) -> str:
+    if not isinstance(request, Mapping):
+        return "vendor_retention"
+    return _clean(request.get("target_mode")) or "vendor_retention"
 
 
 def _string_values(value: Any) -> tuple[str, ...]:
@@ -356,6 +452,45 @@ def _selected_faq_warnings(
             "code": "source_faq_drafts_not_found",
             "message": "One or more selected FAQ reports were not found for this account.",
             "missing_count": len(missing),
+        })
+    return tuple(warnings)
+
+
+def _selected_source_target_warnings(
+    *,
+    missing: Sequence[str],
+    ambiguous: Sequence[str],
+    skip_reason: str | None,
+) -> tuple[dict[str, Any], ...]:
+    warnings: list[dict[str, Any]] = []
+    if skip_reason == "missing_account_scope":
+        warnings.append({
+            "code": "source_import_targets_unscoped",
+            "message": (
+                "Persisted import target IDs require an account-scoped Content "
+                "Ops request."
+            ),
+            "missing_count": len(missing),
+        })
+        return tuple(warnings)
+    if skip_reason == "repository_unconfigured":
+        warnings.append({
+            "code": "source_import_target_repository_unconfigured",
+            "message": "Persisted import target selection is not configured for this route.",
+            "missing_count": len(missing),
+        })
+        return tuple(warnings)
+    if missing:
+        warnings.append({
+            "code": "source_import_targets_not_found",
+            "message": "One or more persisted import target IDs were not found for this account.",
+            "missing_count": len(missing),
+        })
+    if ambiguous:
+        warnings.append({
+            "code": "source_import_targets_ambiguous",
+            "message": "One or more persisted import target IDs matched multiple rows.",
+            "ambiguous_count": len(ambiguous),
         })
     return tuple(warnings)
 

--- a/plans/PR-Content-Ops-Persisted-Source-Execute.md
+++ b/plans/PR-Content-Ops-Persisted-Source-Execute.md
@@ -1,0 +1,120 @@
+# PR: Content Ops Persisted Source Execute
+
+## Why this slice exists
+
+PR #1228 closed the immediate uploaded CSV handoff by letting the New Run UI
+apply full normalized rows to `inputs.source_material`. Its deferred backend
+item remains: when rows have already been imported into
+`campaign_opportunities`, execute should be able to load those persisted target
+IDs by tenant scope instead of requiring the operator to inline the full row
+payload again.
+
+This slice adds the smallest persisted-source execution path behind the
+existing Atlas input-provider seam. It lands slightly over the 400 LOC soft
+budget because the tenant-scope guard, ambiguity guard, missing-row warning, and
+route-level execute proof all need to ship with the new persisted lookup path;
+dropping any one of those would repeat the false-green shape from #1228.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-source-run-handoff
+
+Slice phase: Vertical slice
+
+1. Teach the Atlas Content Ops input provider to accept persisted import target
+   IDs from request inputs.
+2. Resolve those IDs through the existing tenant-scoped
+   `PostgresIntelligenceRepository.read_campaign_opportunities(...)`.
+3. Fail closed when no tenant account scope or no DB provider is available:
+   report warnings and do not load unscoped/global rows.
+4. Reuse `SupportTicketInputProvider` to convert loaded rows into the existing
+   FAQ/landing/blog `source_material` package.
+5. Add host-provider and route tests proving tenant-scoped lookup, missing-row
+   warnings, no-scope skip, and execute using persisted source rows.
+
+### Files touched
+
+- `atlas_brain/_content_ops_input_provider.py`
+- `.github/workflows/atlas_content_ops_input_provider_checks.yml`
+- `tests/test_atlas_content_ops_input_provider.py`
+- `plans/PR-Content-Ops-Persisted-Source-Execute.md`
+
+## Mechanism
+
+The request contract is intentionally small and provider-owned. The input
+provider recognizes these aliases under `inputs`:
+
+```json
+{
+  "source_import_target_ids": ["ticket-1", "ticket-2"]
+}
+```
+
+It also accepts `source_target_ids` and `import_target_ids` for compatibility
+with operator JSON. The provider deduplicates non-empty IDs, requires
+`scope.account_id`, then reads each ID with:
+
+```python
+repository.read_campaign_opportunities(
+    scope=scope,
+    target_mode=request.target_mode or "vendor_retention",
+    limit=2,
+    filters={"target_id": target_id},
+)
+```
+
+Exactly one returned row is loaded; zero rows are reported missing and more
+than one row is reported ambiguous so lookup fails closed instead of guessing.
+Loaded rows are combined with any inline `source_material` or selected FAQ
+outputs and handed to `SupportTicketInputProvider`. Missing IDs and skipped
+unscoped lookups are surfaced as input-provider warnings. No generation
+services or import SQL are reimplemented.
+
+## Intentional
+
+- No UI change in this slice. The backend execution contract lands first; the
+  next UI slice can choose whether to write target IDs instead of full
+  `source_material`.
+- No new database adapter. The existing `PostgresIntelligenceRepository`
+  already handles table identifiers, row normalization, and account filtering
+  when scoped.
+- No unscoped fallback. If `scope.account_id` is empty, persisted target IDs
+  are skipped and no repository call is made.
+- Reads are one target ID at a time. Request input arrays are already bounded,
+  and this keeps the slice within the current repository API.
+
+## Deferred
+
+- Future PR: New Run UI control that applies imported `targetIds` as
+  `source_import_target_ids` instead of applying full `source_material`.
+- Future PR: batch `target_id IN (...)` repository helper if persisted source
+  selection needs larger operator-managed batches.
+- Future PR: browser E2E against a live uploaded support-ticket CSV producing
+  an approved public landing/blog asset.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  existing entries are dependency audit and blog content-quality issues, not
+  this persisted-source execution path.
+
+## Verification
+
+- `python -m py_compile atlas_brain/_content_ops_input_provider.py
+  tests/test_atlas_content_ops_input_provider.py` - passed.
+- `pytest tests/test_atlas_content_ops_input_provider.py -k
+  'persisted or source_import_targets_unscoped or
+  source_import_targets_ambiguous' -q` - 4 passed, 19 deselected.
+- `pytest tests/test_atlas_content_ops_input_provider.py -q` - 23 passed, 1
+  warning from the existing optional `atlas_brain.api` import path.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py
+  --atlas-brain-tests-from origin/main` - passed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /tmp/content-ops-persisted-source-execute-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~100 |
+| Dedicated Atlas workflow enrollment | ~40 |
+| Host input provider | ~160 |
+| Host/provider and execute route tests | ~220 |
+| **Total** | **~520** |

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -112,6 +112,41 @@ class _FAQRepo:
         return self.pool["drafts"].get(faq_id)
 
 
+class _OpportunityRepo:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters=None,
+    ):
+        filters = dict(filters or {})
+        target_id = filters.get("target_id")
+        self.pool["opportunity_calls"].append({
+            "account_id": scope.account_id,
+            "target_mode": target_mode,
+            "limit": limit,
+            "target_id": target_id,
+        })
+        rows = self.pool["opportunities"].get(target_id, ())
+        return tuple(rows)[:limit]
+
+
+def _persisted_ticket_row(target_id: str, *, subject: str | None = None) -> dict[str, object]:
+    return {
+        "target_id": target_id,
+        "ticket_id": target_id,
+        "source_type": "support_ticket",
+        "subject": subject or "Billing renewal question",
+        "message": "How do I confirm my renewal invoice before payment?",
+        "pain_category": "billing",
+    }
+
+
 def test_atlas_content_ops_input_provider_noops_without_source_material() -> None:
     provider = build_content_ops_input_provider()
 
@@ -388,6 +423,133 @@ async def test_atlas_content_ops_input_provider_fetches_selected_faq_ids_by_scop
 
 
 @pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_fetches_persisted_source_targets_by_scope() -> None:
+    pool = {
+        "opportunities": {
+            "ticket-1": [_persisted_ticket_row("ticket-1")],
+            "ticket-2": [_persisted_ticket_row("ticket-2", subject="Login email change")],
+        },
+        "opportunity_calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        opportunity_repository_factory=_OpportunityRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "target_mode": "support_ticket_faq",
+            "inputs": {
+                "source_import_target_ids": ["ticket-1", "ticket-2", "ticket-1"],
+            },
+        },
+    )
+
+    assert pool["opportunity_calls"] == [
+        {
+            "account_id": "acct-1",
+            "target_mode": "support_ticket_faq",
+            "limit": 2,
+            "target_id": "ticket-1",
+        },
+        {
+            "account_id": "acct-1",
+            "target_mode": "support_ticket_faq",
+            "limit": 2,
+            "target_id": "ticket-2",
+        },
+    ]
+    assert package.provider == "atlas_support_ticket_request"
+    assert package.metadata["source_target_id_count"] == 2
+    assert package.metadata["source_target_loaded_count"] == 2
+    assert package.metadata["source_target_missing_id_count"] == 0
+    assert package.metadata["source_target_ambiguous_id_count"] == 0
+    assert package.warnings == ()
+    assert [row["source_id"] for row in package.inputs["source_material"]] == [
+        "ticket-1",
+        "ticket-2",
+    ]
+    assert package.inputs["faq_questions"] == [
+        "How do I confirm my renewal invoice before payment?"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_skips_persisted_targets_without_account_scope() -> None:
+    pool = {
+        "opportunities": {
+            "ticket-1": [_persisted_ticket_row("ticket-1")],
+        },
+        "opportunity_calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        opportunity_repository_factory=_OpportunityRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(),
+        request={"inputs": {"source_import_target_ids": ["ticket-1"]}},
+    )
+
+    assert pool["opportunity_calls"] == []
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["source_target_id_count"] == 1
+    assert package.metadata["source_target_loaded_count"] == 0
+    assert package.metadata["source_target_missing_id_count"] == 1
+    assert package.warnings == ({
+        "code": "source_import_targets_unscoped",
+        "message": (
+            "Persisted import target IDs require an account-scoped Content "
+            "Ops request."
+        ),
+        "missing_count": 1,
+    },)
+
+
+@pytest.mark.asyncio
+async def test_atlas_content_ops_input_provider_fails_safe_on_ambiguous_persisted_targets() -> None:
+    pool = {
+        "opportunities": {
+            "ticket-1": [
+                _persisted_ticket_row("ticket-1", subject="First duplicate"),
+                _persisted_ticket_row("ticket-1", subject="Second duplicate"),
+            ],
+        },
+        "opportunity_calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        opportunity_repository_factory=_OpportunityRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={"inputs": {"source_target_ids": ["ticket-1"]}},
+    )
+
+    assert pool["opportunity_calls"] == [
+        {
+            "account_id": "acct-1",
+            "target_mode": "vendor_retention",
+            "limit": 2,
+            "target_id": "ticket-1",
+        }
+    ]
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["source_target_loaded_count"] == 0
+    assert package.metadata["source_target_ambiguous_id_count"] == 1
+    assert package.warnings == ({
+        "code": "source_import_targets_ambiguous",
+        "message": "One or more persisted import target IDs matched multiple rows.",
+        "ambiguous_count": 1,
+    },)
+
+
+@pytest.mark.asyncio
 async def test_atlas_content_ops_input_provider_warns_for_missing_selected_faq_ids() -> None:
     pool = {"drafts": {}, "calls": []}
     provider = build_content_ops_input_provider(
@@ -582,6 +744,63 @@ async def test_execute_route_generates_support_ticket_faq_at_inline_cap() -> Non
     assert result["saved_ids"] == []
     assert result["items"][0]["ticket_count"] == 1000
     assert len(result["items"][0]["source_ids"]) == 1000
+
+
+@pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+@pytest.mark.asyncio
+async def test_execute_route_generates_faq_from_persisted_source_targets() -> None:
+    pool = {
+        "opportunities": {
+            "ticket-1": [_persisted_ticket_row("ticket-1")],
+            "ticket-2": [_persisted_ticket_row("ticket-2", subject="Login email change")],
+        },
+        "opportunity_calls": [],
+    }
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=build_content_ops_input_provider(
+            pool_provider=lambda: pool,
+            opportunity_repository_factory=_OpportunityRepo,
+        ),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_markdown=TicketFAQMarkdownService()
+        ),
+        scope_provider=lambda: TenantScope(
+            account_id="acct-persisted-source-execute",
+            user_id="user-persisted-source-execute",
+        ),
+    )
+    route = _router_route(router, "/content-ops/execute", "POST")
+
+    payload = await route.endpoint({
+        "outputs": ["faq_markdown"],
+        "limit": 2,
+        "require_quality_gates": False,
+        "inputs": {
+            "source_import_target_ids": ["ticket-1", "ticket-2"],
+        },
+    })
+
+    assert [call["target_id"] for call in pool["opportunity_calls"]] == [
+        "ticket-1",
+        "ticket-2",
+    ]
+    assert {call["account_id"] for call in pool["opportunity_calls"]} == {
+        "acct-persisted-source-execute"
+    }
+    assert payload["status"] == "completed"
+    assert payload["input_provider"]["provider"] == "atlas_support_ticket_request"
+    assert payload["input_provider"]["metadata"]["source_row_count"] == 2
+    assert payload["input_provider"]["metadata"]["included_row_count"] == 2
+    assert payload["input_provider"]["warnings"] == []
+    step = payload["steps"][0]
+    assert step["output"] == "faq_markdown"
+    assert step["status"] == "completed"
+    assert step["result"]["source_count"] == 2
+    assert step["result"]["ticket_source_count"] == 2
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Persisted-Source-Execute.md
Slice phase: Vertical slice

This closes the #1228 deferred backend path for persisted imported sources: Content Ops execute can now load tenant-scoped `campaign_opportunities` rows from request input target IDs, convert them through the existing support-ticket input provider, and run FAQ/landing/blog generation without requiring full row payloads to be inlined again.

## Intentional
- No UI change in this slice; the backend execution contract lands first.
- No new database adapter; this reuses `PostgresIntelligenceRepository`.
- No unscoped fallback; persisted target IDs are skipped without `scope.account_id`.
- Reads are one target ID at a time and use `limit=2` so ambiguous matches fail safe.

## Deferred
- New Run UI control that applies imported `targetIds` as `source_import_target_ids`.
- Batch `target_id IN (...)` repository helper if larger persisted batches need it.
- Browser E2E against a live uploaded support-ticket CSV producing an approved public landing/blog asset.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_input_provider.py` - passed.
- `pytest tests/test_atlas_content_ops_input_provider.py -k 'persisted or source_import_targets_unscoped or source_import_targets_ambiguous' -q` - 4 passed, 19 deselected.
- `pytest tests/test_atlas_content_ops_input_provider.py -q` - 23 passed, 1 warning from the existing optional `atlas_brain.api` import path.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-persisted-source-execute-pr-body.md` - passed.

## Diff size
4 files, +525 / -11.