### PR TITLE
PR-Content-Ops-Upload-Source-Target-Ids-UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs
@@ -87,11 +87,31 @@ test('domain import request can opt into full source material', () => {
   )
 })
 
-test('new run import handoff applies source material to the run inputs', () => {
+test('new run import handoff applies persisted target ids to the run inputs', () => {
   assert.ok(newRunSource.includes('include_source_material: true'))
   assert.ok(newRunSource.includes('includeSourceMaterial: true'))
-  assert.ok(newRunSource.includes('function updateSourceMaterialInputJson'))
-  assert.ok(newRunSource.includes('next.source_material = sourceMaterial.map'))
-  assert.ok(newRunSource.includes('Use rows for run'))
-  assert.ok(newRunSource.includes('onApplySourceMaterial(sourceMaterial)'))
+  assert.ok(
+    newRunSource.includes(
+      "const SOURCE_IMPORT_TARGET_IDS_INPUT = 'source_import_target_ids'",
+    ),
+  )
+  assert.ok(newRunSource.includes('function updateSourceImportTargetIdsInputJson'))
+  assert.ok(newRunSource.includes('next[SOURCE_IMPORT_TARGET_IDS_INPUT] = values'))
+  assert.ok(newRunSource.includes('delete next.source_material'))
+  assert.ok(newRunSource.includes('Use targets for run'))
+  assert.ok(
+    newRunSource.includes(
+      'onApplySourceTargetIds(result.targetIds, result.dryRun)',
+    ),
+  )
+  assert.ok(
+    newRunSource.includes(
+      'disabled={result.dryRun || result.targetIds.length === 0}',
+    ),
+  )
+  assert.ok(
+    newRunSource.includes('Dry-run import target IDs are not persisted.'),
+  )
+  assert.equal(newRunSource.includes('next.source_material = sourceMaterial.map'), false)
+  assert.equal(newRunSource.includes('onApplySourceMaterial(sourceMaterial)'), false)
 })

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -145,6 +145,7 @@ const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
+const SOURCE_IMPORT_TARGET_IDS_INPUT = 'source_import_target_ids'
 const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'blog_post',
   'report',
@@ -271,7 +272,7 @@ export default function ContentOpsNewRun() {
     useState<IngestionInspectState>({ kind: 'idle' })
   const [ingestionImportState, setIngestionImportState] =
     useState<IngestionImportState>({ kind: 'idle' })
-  const [sourceMaterialApplyError, setSourceMaterialApplyError] =
+  const [sourceImportTargetApplyError, setSourceImportTargetApplyError] =
     useState<string | null>(null)
   // Codex P2 fix: request-id ref so a stale in-flight preview/plan
   // response can't overwrite a result the user has since invalidated
@@ -375,7 +376,7 @@ export default function ContentOpsNewRun() {
     setSubmitState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
     setPlanState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
     setExecutionState((prev) => (prev.kind === 'idle' ? prev : { kind: 'idle' }))
-    setSourceMaterialApplyError(null)
+    setSourceImportTargetApplyError(null)
   }
 
   const markIngestionStale = () => {
@@ -388,7 +389,7 @@ export default function ContentOpsNewRun() {
     setIngestionImportState((prev) =>
       prev.kind === 'idle' ? prev : { kind: 'idle' },
     )
-    setSourceMaterialApplyError(null)
+    setSourceImportTargetApplyError(null)
   }
 
   const handleLandingPageRepairAttemptsChange = (value: string) => {
@@ -782,7 +783,7 @@ export default function ContentOpsNewRun() {
     const inlineRows = parsedRows?.ok ? parsedRows.rows : []
 
     setIngestionImportState({ kind: 'submitting' })
-    setSourceMaterialApplyError(null)
+    setSourceImportTargetApplyError(null)
     try {
       const outcome = selectedIngestionFile
         ? await importContentOpsIngestionFile({
@@ -850,16 +851,23 @@ export default function ContentOpsNewRun() {
     }
   }
 
-  const handleApplyImportedSourceMaterial = (
-    sourceMaterial: Array<Record<string, unknown>>,
+  const handleApplyImportedSourceTargetIds = (
+    targetIds: string[],
+    dryRun: boolean,
   ) => {
-    const updated = updateSourceMaterialInputJson(inputsJson, sourceMaterial)
+    if (dryRun) {
+      setSourceImportTargetApplyError(
+        'Dry-run import target IDs are not persisted.',
+      )
+      return
+    }
+    const updated = updateSourceImportTargetIdsInputJson(inputsJson, targetIds)
     if (!updated.ok) {
-      setSourceMaterialApplyError(updated.message)
+      setSourceImportTargetApplyError(updated.message)
       return
     }
     setInputsJson(updated.value)
-    setSourceMaterialApplyError(null)
+    setSourceImportTargetApplyError(null)
     markStale()
   }
 
@@ -1419,8 +1427,8 @@ export default function ContentOpsNewRun() {
           <IngestionInspectResult state={ingestionInspectState} />
           <IngestionImportResult
             state={ingestionImportState}
-            applyError={sourceMaterialApplyError}
-            onApplySourceMaterial={handleApplyImportedSourceMaterial}
+            applyError={sourceImportTargetApplyError}
+            onApplySourceTargetIds={handleApplyImportedSourceTargetIds}
           />
         </section>
 
@@ -2544,11 +2552,11 @@ function supportsAutoDetection(formats: string[]): boolean {
 function IngestionImportResult({
   state,
   applyError,
-  onApplySourceMaterial,
+  onApplySourceTargetIds,
 }: {
   state: IngestionImportState
   applyError: string | null
-  onApplySourceMaterial: (sourceMaterial: Array<Record<string, unknown>>) => void
+  onApplySourceTargetIds: (targetIds: string[], dryRun: boolean) => void
 }) {
   if (state.kind === 'idle' || state.kind === 'submitting') {
     return null
@@ -2595,7 +2603,6 @@ function IngestionImportResult({
   }
 
   const result = state.response.importResult
-  const sourceMaterial = state.response.diagnostics.sourceMaterial
   return (
     <div className="mt-3 rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs">
       <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -2611,21 +2618,20 @@ function IngestionImportResult({
         </div>
         <button
           type="button"
-          onClick={() => onApplySourceMaterial(sourceMaterial)}
-          disabled={sourceMaterial.length === 0}
+          onClick={() => onApplySourceTargetIds(result.targetIds, result.dryRun)}
+          disabled={result.dryRun || result.targetIds.length === 0}
           className="flex items-center justify-center gap-2 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-xs font-medium text-cyan-200 hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Upload className="h-3.5 w-3.5" />
-          Use rows for run
+          Use targets for run
         </button>
       </div>
       <div className="mb-2 text-slate-300">
-        Source material available: {sourceMaterial.length.toLocaleString('en-US')}{' '}
-        row{sourceMaterial.length === 1 ? '' : 's'}
+        Target IDs available: {result.targetIds.length.toLocaleString('en-US')}
       </div>
       {applyError && (
         <div className="mb-2 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-          Could not apply rows: {applyError}
+          Could not apply import: {applyError}
         </div>
       )}
       {result.targetIds.length > 0 && (
@@ -2857,21 +2863,23 @@ function updateSourceFaqIdsInputJson(
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
 }
 
-function updateSourceMaterialInputJson(
+function updateSourceImportTargetIdsInputJson(
   current: string,
-  sourceMaterial: Array<Record<string, unknown>>,
+  targetIds: string[],
 ): UpdatedInputsJson {
   const parsed = parseInputsJsonObject(current)
   if (!parsed.ok) return parsed
-  if (sourceMaterial.length === 0) {
+  const values = uniqueNonBlankStrings(targetIds)
+  if (values.length === 0) {
     return {
       ok: false,
-      message: 'Imported source material is empty.',
+      message: 'Imported target IDs are empty.',
     }
   }
 
   const next = { ...parsed.value }
-  next.source_material = sourceMaterial.map((row) => ({ ...row }))
+  next[SOURCE_IMPORT_TARGET_IDS_INPUT] = values
+  delete next.source_material
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
 }
 

--- a/plans/PR-Content-Ops-Upload-Source-Target-Ids-UI.md
+++ b/plans/PR-Content-Ops-Upload-Source-Target-Ids-UI.md
@@ -1,0 +1,93 @@
+# PR: Content Ops Upload Source Target IDs UI
+
+## Why this slice exists
+
+PR #1228 proved the upload/import to run handoff by inlining normalized rows
+into `inputs.source_material`. PR #1231 then landed the safer backend execution
+path: once imported rows exist in `campaign_opportunities`, execute can load
+selected `source_import_target_ids` by tenant scope. The UI still applies the
+old inline row payload, so operators can keep carrying large source material in
+the run request even though the persisted target-id contract now exists.
+
+This slice closes that handoff without changing ingestion or execute APIs: the
+New Run import result applies committed import `targetIds` into
+`inputs.source_import_target_ids` and clears stale inline `source_material`.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-source-run-handoff
+
+Slice phase: Vertical slice
+
+1. Replace the New Run import-result apply action so it writes imported
+   `targetIds` to `inputs.source_import_target_ids`.
+2. Fail closed for dry-run or empty target-id imports so the UI does not create
+   a run request that references rows which were not persisted.
+3. Remove stale `source_material` when target IDs are applied, so persisted
+   rows are the source of truth for execute.
+4. Extend the existing upload-source frontend test script, which is already
+   enrolled in `.github/workflows/atlas_intel_ui_checks.yml`.
+
+### Files touched
+
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-upload-source-run-handoff.test.mjs`
+- `plans/PR-Content-Ops-Upload-Source-Target-Ids-UI.md`
+
+## Mechanism
+
+`IngestionImportResult` already receives mapped `result.targetIds` and
+`result.dryRun`. The apply button will pass both to a new helper:
+
+```ts
+updateSourceImportTargetIdsInputJson(inputsJson, targetIds)
+```
+
+The helper parses the current inputs JSON, deduplicates non-empty target IDs,
+sets `source_import_target_ids`, and deletes `source_material`. The handler
+refuses to apply dry-run imports before calling the helper because those target
+IDs are not durable backend rows.
+
+No backend contract changes are needed; #1231 already made
+`source_import_target_ids` executable through the Atlas input provider.
+
+## Intentional
+
+- No backend change. The persisted-source execute path already landed in
+  #1231.
+- No live browser E2E in this slice. The existing source-level UI test already
+  covers the import-result wiring and is enrolled in Atlas Intel UI CI.
+- Keep `include_source_material` on import for now. It preserves the current
+  diagnostics envelope while the apply action switches to persisted target IDs.
+- Dry-run imports cannot be applied as persisted source IDs. They are useful for
+  diagnostics, not execute.
+
+## Deferred
+
+- Future PR: stop requesting full `source_material` during import once the UI
+  no longer needs it for diagnostics or fallback inspection.
+- Future PR: browser E2E against a live uploaded support-ticket CSV producing
+  an approved public landing/blog asset.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned;
+  existing entries are dependency audit and blog content-quality issues, not
+  this target-id UI handoff.
+
+## Verification
+
+- `cd atlas-intel-ui && npm run test:content-ops-upload-source-run-handoff`
+  - 3 passed.
+- `cd atlas-intel-ui && npm run test:content-ops-ingestion-routing` - 4
+  passed.
+- `cd atlas-intel-ui && npm run build` - passed; generated 17 sitemap URLs
+  and prerendered 16 public routes.
+- `bash scripts/local_pr_review.sh --current-pr-body-file
+  /tmp/content-ops-upload-source-target-ids-ui-pr-body.md` - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| UI target-id apply helper + result wiring | ~45 |
+| Frontend test updates | ~25 |
+| **Total** | **~160** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Upload-Source-Target-Ids-UI.md
Slice phase: Vertical slice

This closes the UI half of the persisted upload-source handoff: after a committed import, New Run now applies imported `targetIds` to `inputs.source_import_target_ids` and clears stale inline `source_material`, letting execute use the tenant-scoped backend path from #1231.

## Intentional
- No backend change; #1231 already made `source_import_target_ids` executable.
- Dry-run imports cannot be applied as persisted source IDs.
- `include_source_material` remains on import for the current diagnostics envelope.
- No live browser E2E in this slice; the existing enrolled source-level UI test covers the handoff.

## Deferred
- Stop requesting full `source_material` during import once the UI no longer needs it for diagnostics or fallback inspection.
- Browser E2E against a live uploaded support-ticket CSV producing an approved public landing/blog asset.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm run test:content-ops-upload-source-run-handoff` - 3 passed.
- `cd atlas-intel-ui && npm run test:content-ops-ingestion-routing` - 4 passed.
- `cd atlas-intel-ui && npm run build` - passed; generated 17 sitemap URLs and prerendered 16 public routes.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-upload-source-target-ids-ui-pr-body.md` - passed.

## Diff size
3 files, +151 / -30.