### PR TITLE
PR-Deflection-Question-Evidence-Scoping

### DIFF
--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -61,6 +61,7 @@ _GENERIC_QUESTION_PHRASES = (
     "our complaint is about",
     "this complaint is about",
 )
+_MIXED_EVIDENCE_REVIEW_QUESTION = "Which remaining support questions need manual review?"
 _REDACTION_TOKEN_RE = re.compile(r"\bX{2,}\b", re.IGNORECASE)
 _REDACTED_DATE_RE = re.compile(r"\bX{2}/X{2}/(?:X{2,4}|\d{2,4})\b", re.IGNORECASE)
 _REDACTED_MONEY_RE = re.compile(r"\{\$|\$\s*X{2,}", re.IGNORECASE)
@@ -415,7 +416,7 @@ def build_ticket_faq_markdown(
     date_window = _date_window(window_days=window_days, as_of_date=as_of_date)
     resolved_documentation_terms = _documentation_terms(opportunities, documentation_terms)
     resolved_vocabulary_gap_rules = _vocabulary_gap_rules(vocabulary_gap_rules)
-    groups: dict[str, list[dict[str, str]]] = defaultdict(list)
+    groups: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
     seen: set[tuple[str, str]] = set()
     source_keys: set[str] = set()
 
@@ -447,21 +448,29 @@ def build_ticket_faq_markdown(
                 continue
             seen.add(key)
             source_keys.add(source_key)
-            groups[_topic(opportunity, evidence, intent_rules=intent_rules)].append({
+            topic = _topic(opportunity, evidence, intent_rules=intent_rules)
+            resolution_text = _resolution_text(evidence, opportunity)
+            evidence_group_key = _evidence_group_key(resolution_text)
+            group_key = (topic, evidence_group_key or f"topic:{_compact_key(topic)}")
+            groups[group_key].append({
                 "text": text,
                 "source_id": source_id or "unknown",
                 "source_key": source_key,
                 "source_type": source_type,
                 "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
+                "evidence_group_key": evidence_group_key,
                 "results_count": _first_present(evidence, opportunity, key="results_count"),
                 "result_count": _first_present(evidence, opportunity, key="result_count"),
                 "zero_results": _first_present(evidence, opportunity, key="zero_results"),
                 "zero_result": _first_present(evidence, opportunity, key="zero_result"),
                 "source_weight": _source_weight(evidence, opportunity),
-                "resolution_text": _resolution_text(evidence, opportunity),
+                "resolution_text": resolution_text,
             })
 
-    sorted_groups = sorted(groups.items(), key=_group_sort_key)
+    sorted_groups = sorted(
+        ((topic, rows) for (topic, _scope), rows in groups.items()),
+        key=_group_sort_key,
+    )
     if len(sorted_groups) > max_items:
         visible_groups = tuple(sorted_groups[: max(1, max_items - 1)])
         overflow_rows: list[dict[str, str]] = []
@@ -529,6 +538,21 @@ def _topic(
             if text:
                 return text.lower()
     return (_compact(evidence.get("source_title") or opportunity.get("source_title")) or "customer support issues").lower()
+
+
+def _evidence_group_key(resolution_text: Any) -> str:
+    text = _compact(resolution_text)
+    return f"resolution:{_compact_key(text)}" if text else ""
+
+
+def _has_mixed_evidence_scopes(rows: Sequence[Mapping[str, Any]]) -> bool:
+    scopes = {
+        _clean(row.get("evidence_group_key"))
+        for row in rows
+        if _clean(row.get("evidence_group_key"))
+    }
+    has_unscoped_rows = any(not _clean(row.get("evidence_group_key")) for row in rows)
+    return len(scopes) > 1 or (bool(scopes) and has_unscoped_rows)
 
 
 def _group_sort_key(item: tuple[str, Sequence[Mapping[str, str]]]) -> tuple[int, int, int, str]:
@@ -606,7 +630,15 @@ def _item(
         snippets,
         " / ".join(_clean(row.get("source_title")) for row in display_rows if _clean(row.get("source_title"))),
     ))
-    question, question_source, question_row = _question(topic, display_rows)
+    has_mixed_evidence_scopes = _has_mixed_evidence_scopes(rows)
+    if has_mixed_evidence_scopes:
+        question, question_source, question_row = (
+            _MIXED_EVIDENCE_REVIEW_QUESTION,
+            "source_policy",
+            None,
+        )
+    else:
+        question, question_source, question_row = _question(topic, display_rows)
     summary_rows = _rows_with_question_source_first(display_rows, question_row)
     summary = _summary(
         topic=topic,
@@ -614,7 +646,12 @@ def _item(
         source_count=len(source_ids),
         question_source=question_source,
     )
-    resolution_texts = _resolution_texts(rows)
+    resolution_rows = (
+        ()
+        if has_mixed_evidence_scopes
+        else _resolution_rows_for_question(rows, question_row)
+    )
+    resolution_texts = _resolution_texts(resolution_rows)
     answer_evidence_status = (
         "resolution_evidence" if resolution_texts else "draft_needs_review"
     )
@@ -642,7 +679,7 @@ def _item(
         "summary": summary,
         "steps": steps,
         "answer_evidence_status": answer_evidence_status,
-        "resolution_source_count": _resolution_source_count(rows),
+        "resolution_source_count": _resolution_source_count(resolution_rows),
         "when_to_contact_support": escalation,
         "evidence_quotes": evidence_quotes,
         "term_mappings": term_mappings,
@@ -758,6 +795,21 @@ def _resolution_texts(rows: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
         if _compact(row.get("resolution_text"))
     )
     return tuple(dict.fromkeys(values))
+
+
+def _resolution_rows_for_question(
+    rows: Sequence[Mapping[str, Any]],
+    question_row: Mapping[str, Any] | None,
+) -> tuple[Mapping[str, Any], ...]:
+    evidence_group_key = _clean(
+        question_row.get("evidence_group_key") if question_row is not None else ""
+    )
+    if not evidence_group_key:
+        return tuple(rows)
+    scoped_rows = tuple(
+        row for row in rows if _clean(row.get("evidence_group_key")) == evidence_group_key
+    )
+    return scoped_rows or tuple(rows)
 
 
 def _resolution_source_count(rows: Sequence[Mapping[str, Any]]) -> int:

--- a/plans/PR-Deflection-Question-Evidence-Scoping.md
+++ b/plans/PR-Deflection-Question-Evidence-Scoping.md
@@ -1,0 +1,107 @@
+## Why this slice exists
+
+Large SaaS-only live validation proved the deflection funnel can ingest 420
+resolution-backed support-ticket rows, rank recurring questions, unlock through
+the paid webhook path, and render the full report. It also exposed a correctness
+bug in the FAQ draft pipeline: broad intent grouping can merge distinct
+customer questions, causing a draft for one question to include resolution
+steps from another question's source rows. Copy polish must wait until this
+evidence-scoping invariant is fixed, because polished prose over cross-question
+evidence would be confidently wrong.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Production hardening
+
+1. Split resolution-backed support-ticket FAQ groups by normalized resolution
+   evidence within the intent topic, so broad intent rules cannot merge
+   distinct SaaS resolutions into the same draft.
+2. Keep existing intent-topic clustering for rows that do not carry resolution
+   evidence.
+3. Add focused regression coverage proving resolutions from a dashboard-refresh
+   question cannot bleed into an SSO/SCIM question.
+4. Keep mixed-question overflow buckets review-needed instead of treating one
+   leftover question's resolution as a publishable answer for the whole bucket.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `plans/PR-Deflection-Question-Evidence-Scoping.md`
+
+## Mechanism
+
+`build_ticket_faq_markdown` currently keys `groups` by `_topic(...)`, which can
+collapse unrelated resolution-backed questions under broad rules such as
+`integration setup`. This slice introduces a grouping key that scopes
+resolution-backed rows by normalized resolution evidence:
+
+```python
+resolution_text = _resolution_text(evidence, opportunity)
+if resolution_text:
+    return f"resolution:{_compact_key(resolution_text)}"
+return f"topic:{_topic(...)}"
+```
+
+The user-facing item topic remains the intent topic for labels and scoring, but
+the grouping boundary is evidence-scoped when resolution evidence exists. That
+keeps repeated phrasings that share the same proven resolution together while
+preventing a draft from collecting a neighboring question's different
+resolution_text. Rows without resolution evidence retain the existing
+intent-topic grouping so non-drafted clustering behavior does not churn.
+
+## Intentional
+
+- This slice does not polish the visible step copy. The existing
+  "Use the uploaded resolution evidence:" phrasing is rough, but polishing it
+  before fixing evidence boundaries would hide the correctness bug.
+- This slice does not add LLM clustering or semantic similarity. The production
+  failure came from over-merging different resolutions, so the conservative fix
+  is stricter evidence-scoped grouping.
+- Mixed-question overflow still preserves source coverage for condensation, but
+  it now fails closed to `draft_needs_review` instead of claiming a publishable
+  answer from one leftover question's resolution.
+
+## Deferred
+
+- Follow-up slice: `PR-Deflection-Resolution-Copy-Polish` should turn
+  resolution_text into clean help-center prose once grouping is safe.
+- Follow-up slice: add a stricter artifact/eval gate that fails closed if an
+  item step cites resolution evidence outside that item's evidence scope.
+- Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py -k "resolution_evidence or sharing_resolutions or overflow_resolution or unresolved_overflow" -q`
+  - Passed: 5 passed, 146 deselected.
+- `pytest tests/test_extracted_ticket_faq_markdown.py -q`
+  - Passed: 151 passed.
+- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-local-after-scoping.json --summary-output /tmp/deflection-large-saas-local-after-scoping-summary.json --require-output-checks --json`
+  - Passed: generated 8; drafted_answer_count 7; no_proven_answer_count 1;
+    output checks all true; source_count 420.
+- `pytest tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q`
+  - Passed: 1 passed.
+- `env ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= EXTRACTED_DATABASE_URL= DATABASE_URL= pytest tests/test_smoke_content_ops_deflection_submit_handoff.py::test_validate_args_fails_closed_for_missing_and_unsafe_inputs tests/test_smoke_content_ops_deflection_submit_handoff.py::test_validate_args_defaults_to_checked_fixture_when_no_source_is_provided tests/test_smoke_content_ops_deflection_submit_handoff.py::test_run_success_posts_multipart_csv_and_probes_locked_artifact tests/test_smoke_content_ops_deflection_portfolio_result_page.py::test_preflight_only_writes_missing_inputs_without_network -q`
+  - Passed: 4 passed.
+- `bash scripts/run_extracted_pipeline_checks.sh`
+  - Local caveat: reached 2879 passed, 10 skipped, then failed on 6
+    deflection smoke/contract tests because the repo-root `.env` is loaded by
+    smoke helpers during tests. The code-caused contract-doc failure was fixed;
+    the env-sensitive deflection subset passes when deflection env defaults are
+    blanked. I did not move or edit the user's `.env` secret file to sanitize
+    the remaining subprocess preflight test.
+- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file /tmp/pr-deflection-question-evidence-scoping-body.md`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | ~65 |
+| `tests/test_extracted_ticket_faq_markdown.py` | ~127 |
+| Plan doc | ~92 |
+| **Total** | **~284** |
+
+Under the 400 LOC soft cap.

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -303,6 +303,133 @@ def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() 
     assert len([step for step in item["steps"] if step.startswith("Use the uploaded")]) == 1
 
 
+def test_build_ticket_faq_markdown_keeps_distinct_questions_from_sharing_resolutions() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "SCIM setup",
+                "evidence": [{
+                    "text": "Can we sync users before enforcing SSO?",
+                    "source_id": "ticket-scim-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Enable SSO first, confirm every existing user email matches "
+                        "the identity provider email, then enable SCIM in Preview mode."
+                    ),
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Warehouse sync",
+                "evidence": [{
+                    "text": "Why is my dashboard data not refreshing after the warehouse sync?",
+                    "source_id": "ticket-warehouse-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Check Data > Sync history for the warehouse job, then open "
+                        "Analytics > Model refresh."
+                    ),
+                }],
+            },
+        ]
+    )
+
+    by_question = {item["question"]: item for item in result.items}
+    scim = by_question["Can we sync users before enforcing SSO?"]
+    warehouse = by_question[
+        "Why is my dashboard data not refreshing after the warehouse sync?"
+    ]
+
+    assert scim["answer_evidence_status"] == "resolution_evidence"
+    assert warehouse["answer_evidence_status"] == "resolution_evidence"
+    assert scim["source_ids"] == ("ticket-scim-1",)
+    assert warehouse["source_ids"] == ("ticket-warehouse-1",)
+    assert "SCIM in Preview mode" in " ".join(scim["steps"])
+    assert "Analytics > Model refresh" not in " ".join(scim["steps"])
+    assert "Analytics > Model refresh" in " ".join(warehouse["steps"])
+    assert "SCIM in Preview mode" not in " ".join(warehouse["steps"])
+
+
+def test_build_ticket_faq_markdown_scopes_overflow_resolution_to_item_question() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "SCIM setup",
+                "evidence": [{
+                    "text": "Can we sync users before enforcing SSO?",
+                    "source_id": "ticket-scim-1",
+                    "source_type": "support_ticket",
+                    "source_weight": 10,
+                    "resolution_text": (
+                        "Enable SSO first, confirm existing user emails, then enable "
+                        "SCIM in Preview mode."
+                    ),
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "Warehouse sync",
+                "evidence": [{
+                    "text": "Why is my dashboard data not refreshing after the warehouse sync?",
+                    "source_id": "ticket-warehouse-1",
+                    "source_type": "support_ticket",
+                    "resolution_text": (
+                        "Check Data > Sync history for the warehouse job, then open "
+                        "Analytics > Model refresh."
+                    ),
+                }],
+            },
+        ],
+        max_items=1,
+    )
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item["question"] == "Which remaining support questions need manual review?"
+    assert item["source_ids"] == ("ticket-scim-1", "ticket-warehouse-1")
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_source_count"] == 0
+    assert "SCIM in Preview mode" not in " ".join(item["steps"])
+    assert "Analytics > Model refresh" not in " ".join(item["steps"])
+
+
+def test_build_ticket_faq_markdown_fails_closed_for_resolved_and_unresolved_overflow() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_type": "support_ticket",
+                "source_title": "CSV export",
+                "evidence": [{
+                    "text": "How do I export reports?",
+                    "source_id": "ticket-export-1",
+                    "source_type": "support_ticket",
+                    "source_weight": 10,
+                    "resolution_text": "Open Reports, choose Export, then select CSV.",
+                }],
+            },
+            {
+                "source_type": "support_ticket",
+                "source_title": "SSO setup",
+                "evidence": [{
+                    "text": "Can I turn on SSO for all users?",
+                    "source_id": "ticket-sso-1",
+                    "source_type": "support_ticket",
+                }],
+            },
+        ],
+        max_items=1,
+    )
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item["source_ids"] == ("ticket-export-1", "ticket-sso-1")
+    assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_source_count"] == 0
+    assert "Open Reports" not in " ".join(item["steps"])
+
+
 def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
     result = build_ticket_faq_markdown(
         [


### PR DESCRIPTION
Plan: plans/PR-Deflection-Question-Evidence-Scoping.md
Slice phase: Production hardening

Large SaaS-only validation proved the funnel works, but exposed cross-resolution evidence bleed: broad support-ticket intent groups could attach a neighboring question's resolution steps to the wrong draft. This slice scopes resolution-backed grouping by normalized resolution evidence inside the intent topic, while preserving existing topic clustering for rows without resolution evidence.

## Intentional
- This does not polish the visible "Use the uploaded resolution evidence" step copy; copy polish follows once evidence boundaries are safe.
- This does not add semantic clustering or LLM judgment; it uses deterministic evidence scoping to close the observed bleed.
- Mixed-evidence overflow preserves source coverage but fails closed to `draft_needs_review` instead of claiming a publishable answer.

## Deferred
- `PR-Deflection-Resolution-Copy-Polish` should turn resolution_text into clean help-center prose.
- Add a stricter artifact/eval gate that fails if an item cites evidence outside its evidence scope.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py -k "resolution_evidence or sharing_resolutions or overflow_resolution or unresolved_overflow" -q` - 5 passed, 146 deselected.
- `pytest tests/test_extracted_ticket_faq_markdown.py -q` - 151 passed.
- `pytest tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q` - 1 passed.
- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-local-after-scoping.json --summary-output /tmp/deflection-large-saas-local-after-scoping-summary.json --require-output-checks --json` - generated 8; drafted 7; review-needed 1; output checks true; source_count 420.
- Package guardrails passed: `bash scripts/validate_extracted_content_pipeline.sh`; `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`; `python scripts/audit_extracted_standalone.py --fail-on-debt`; `bash scripts/check_ascii_python.sh`.
- `bash scripts/run_extracted_pipeline_checks.sh` - local run reached 2879 passed / 10 skipped; failed only on repo-root `.env` leakage in deflection smoke preflight tests. The code-caused contract failure was fixed, and the env-sensitive subset passes when deflection envs are blanked.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file /tmp/pr-deflection-question-evidence-scoping-body.md` - passed.

## Diff size
3 files, +292 / -7
