### PR TITLE
PR-Deflection-Resolution-Copy-Polish

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -1,27 +1,74 @@
 {
+  "markdown": "# Support Ticket Deflection Report\n\n## Executive Summary\n\nThis report analyzed 4 source rows and produced 2 ranked FAQ opportunities from the supplied support data.\n\n- Drafted answers with proven solutions: 1\n- No proven answer yet: 1\n- Ticket sources represented: 4\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |\n|---:|---|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | 2 | drafted from resolution evidence | ticket-export-1, ticket-export-2 |\n| 2 | Can I turn on SSO for all users? | 2 | 2 | no proven answer yet | ticket-sso-2, ticket-sso-1 |\n\n## Drafted Answers With Proven Solutions\n\n### 1. How do I export attribution reports?\n\nUploaded resolution evidence supports this draft answer.\n\n**Draft answer steps:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Sources:** ticket-export-1, ticket-export-2\n\n## No Proven Answer Yet\n\n### 1. Can I turn on SSO for all users?\n\nCustomers repeatedly asked this question, but the uploaded data did not include verified resolution evidence for a publishable answer.\n\nNo verified support resolution was present in the uploaded data. Support should add the approved answer before this FAQ is published.\n\n**Sources:** ticket-sso-2, ticket-sso-1\n\n## Vocabulary Gaps\n\n| Customer wording | Documentation term | Suggested update | Source count |\n|---|---|---|---:|\n| export | Download report | Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| report download | Download report | Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| SSO | Single sign-on setup | Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. | 2 |\n\n## Evidence Appendix\n\n### 1. How do I export attribution reports?\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. Can I turn on SSO for all users?\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
+  "summary": {
+    "generated": 2,
+    "source_count": 4,
+    "ticket_source_count": 4,
+    "drafted_answer_count": 1,
+    "no_proven_answer_count": 1,
+    "output_checks": {
+      "uses_user_vocabulary": true,
+      "condensed": true,
+      "has_action_items": true
+    },
+    "top_question": "How do I export attribution reports?",
+    "top_opportunity_score": 2
+  },
   "faq_result": {
     "generated": 2,
+    "markdown": "# Support Ticket FAQ Source\n\n_Source rows analyzed: 4. Ticket sources used: 4._\n\n## 1. How do I export attribution reports?\n\nCustomers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n- Customers say \"report download\"; documentation says \"Download report\". Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n## 2. Can I turn on SSO for all users?\n\nCustomers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"SSO\"; documentation says \"Single sign-on setup\". Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.\n\n**Sources:**\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
     "items": [
       {
+        "topic": "reporting friction",
+        "question": "How do I export attribution reports?",
+        "question_source": "customer_wording",
+        "frequency": 2,
+        "weighted_frequency": 2,
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "opportunity_score": 2,
+        "answer": "Customers mention: \"How do I export attribution reports?\" Evidence comes from 2 ticket source(s).",
         "action_items": [
-          "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report",
+          "Open Analytics, choose Attribution, then click Download report",
           "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
           "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
         ],
-        "answer": "Customers mention: \"How do I export attribution reports?\" Evidence comes from 2 ticket source(s).",
+        "summary": "Customers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "steps": [
+          "Open Analytics, choose Attribution, then click Download report",
+          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
         "answer_evidence_status": "resolution_evidence",
-        "displayed_evidence_count": 1,
-        "evidence_count": 1,
+        "resolution_source_count": 2,
+        "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.",
         "evidence_quotes": [
           "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\""
         ],
-        "failure_risk_score": 0,
-        "failure_risk_signals": [],
-        "frequency": 2,
-        "opportunity_score": 2,
-        "question": "How do I export attribution reports?",
-        "question_source": "customer_wording",
-        "resolution_source_count": 2,
+        "term_mappings": [
+          {
+            "customer_term": "export",
+            "documentation_term": "Download report",
+            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "source_id_count": 2,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "opportunity_score": 2,
+            "first_source_id": "ticket-export-1"
+          },
+          {
+            "customer_term": "report download",
+            "documentation_term": "Download report",
+            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "source_id_count": 2,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "opportunity_score": 2,
+            "first_source_id": "ticket-export-1"
+          }
+        ],
         "source_ids": [
           "ticket-export-1",
           "ticket-export-2"
@@ -32,64 +79,53 @@
         "source_type_counts": {
           "support_ticket": 2
         },
-        "steps": [
-          "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report",
-          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
-          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-        ],
-        "summary": "Customers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
-        "term_mappings": [
-          {
-            "customer_term": "export",
-            "documentation_term": "Download report",
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "first_source_id": "ticket-export-1",
-            "opportunity_score": 2,
-            "source_id_count": 2,
-            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-            "zero_result_source_count": 0
-          },
-          {
-            "customer_term": "report download",
-            "documentation_term": "Download report",
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "first_source_id": "ticket-export-1",
-            "opportunity_score": 2,
-            "source_id_count": 2,
-            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-            "zero_result_source_count": 0
-          }
-        ],
-        "ticket_count": 2,
-        "topic": "reporting friction",
-        "weighted_frequency": 2,
         "weighted_source_volume_by_type": {
           "support_ticket": 2
         },
-        "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
+        "evidence_count": 1,
+        "displayed_evidence_count": 1,
+        "ticket_count": 2
       },
       {
+        "topic": "other support issues",
+        "question": "Can I turn on SSO for all users?",
+        "question_source": "customer_wording",
+        "frequency": 2,
+        "weighted_frequency": 2,
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "opportunity_score": 2,
+        "answer": "Customers mention: \"Can I turn on SSO for all users?\" Evidence comes from 2 ticket source(s).",
         "action_items": [
           "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
           "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
           "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
         ],
-        "answer": "Customers mention: \"Can I turn on SSO for all users?\" Evidence comes from 2 ticket source(s).",
+        "summary": "Customers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "steps": [
+          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
         "answer_evidence_status": "draft_needs_review",
-        "displayed_evidence_count": 1,
-        "evidence_count": 1,
+        "resolution_source_count": 0,
+        "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.",
         "evidence_quotes": [
           "`ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\""
         ],
-        "failure_risk_score": 0,
-        "failure_risk_signals": [],
-        "frequency": 2,
-        "opportunity_score": 2,
-        "question": "Can I turn on SSO for all users?",
-        "question_source": "customer_wording",
-        "resolution_source_count": 0,
+        "term_mappings": [
+          {
+            "customer_term": "SSO",
+            "documentation_term": "Single sign-on setup",
+            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
+            "source_id_count": 2,
+            "zero_result_source_count": 0,
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "opportunity_score": 2,
+            "first_source_id": "ticket-sso-2"
+          }
+        ],
         "source_ids": [
           "ticket-sso-2",
           "ticket-sso-1"
@@ -100,58 +136,22 @@
         "source_type_counts": {
           "support_ticket": 2
         },
-        "steps": [
-          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
-          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
-          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-        ],
-        "summary": "Customers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
-        "term_mappings": [
-          {
-            "customer_term": "SSO",
-            "documentation_term": "Single sign-on setup",
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "first_source_id": "ticket-sso-2",
-            "opportunity_score": 2,
-            "source_id_count": 2,
-            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
-            "zero_result_source_count": 0
-          }
-        ],
-        "ticket_count": 2,
-        "topic": "other support issues",
-        "weighted_frequency": 2,
         "weighted_source_volume_by_type": {
           "support_ticket": 2
         },
-        "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives."
+        "evidence_count": 1,
+        "displayed_evidence_count": 1,
+        "ticket_count": 2
       }
     ],
-    "markdown": "# Support Ticket FAQ Source\n\n_Source rows analyzed: 4. Ticket sources used: 4._\n\n## 1. How do I export attribution reports?\n\nCustomers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n- Customers say \"report download\"; documentation says \"Download report\". Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n## 2. Can I turn on SSO for all users?\n\nCustomers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"SSO\"; documentation says \"Single sign-on setup\". Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.\n\n**Sources:**\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
-    "output_checks": {
-      "condensed": true,
-      "has_action_items": true,
-      "uses_user_vocabulary": true
-    },
-    "saved_ids": [],
     "source_count": 4,
     "ticket_source_count": 4,
-    "warnings": []
-  },
-  "markdown": "# Support Ticket Deflection Report\n\n## Executive Summary\n\nThis report analyzed 4 source rows and produced 2 ranked FAQ opportunities from the supplied support data.\n\n- Drafted answers with proven solutions: 1\n- No proven answer yet: 1\n- Ticket sources represented: 4\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |\n|---:|---|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | 2 | drafted from resolution evidence | ticket-export-1, ticket-export-2 |\n| 2 | Can I turn on SSO for all users? | 2 | 2 | no proven answer yet | ticket-sso-2, ticket-sso-1 |\n\n## Drafted Answers With Proven Solutions\n\n### 1. How do I export attribution reports?\n\nUploaded resolution evidence supports this draft answer.\n\n**Draft answer steps:**\n\n1. Use the uploaded resolution evidence: Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Sources:** ticket-export-1, ticket-export-2\n\n## No Proven Answer Yet\n\n### 1. Can I turn on SSO for all users?\n\nCustomers repeatedly asked this question, but the uploaded data did not include verified resolution evidence for a publishable answer.\n\nNo verified support resolution was present in the uploaded data. Support should add the approved answer before this FAQ is published.\n\n**Sources:** ticket-sso-2, ticket-sso-1\n\n## Vocabulary Gaps\n\n| Customer wording | Documentation term | Suggested update | Source count |\n|---|---|---|---:|\n| export | Download report | Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| report download | Download report | Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| SSO | Single sign-on setup | Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. | 2 |\n\n## Evidence Appendix\n\n### 1. How do I export attribution reports?\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. Can I turn on SSO for all users?\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
-  "summary": {
-    "drafted_answer_count": 1,
-    "generated": 2,
-    "no_proven_answer_count": 1,
     "output_checks": {
+      "uses_user_vocabulary": true,
       "condensed": true,
-      "has_action_items": true,
-      "uses_user_vocabulary": true
+      "has_action_items": true
     },
-    "source_count": 4,
-    "ticket_source_count": 4,
-    "top_opportunity_score": 2,
-    "top_question": "How do I export attribution reports?"
+    "warnings": [],
+    "saved_ids": []
   }
 }

--- a/docs/frontend/content_ops_faq_report_example.json
+++ b/docs/frontend/content_ops_faq_report_example.json
@@ -1,122 +1,80 @@
 {
-  "generated": 2,
+  "generated": 1,
+  "markdown": "# Support Ticket FAQ Report\n\n_Source rows analyzed: 2. Ticket sources used: 2._\n\n## 1. Which remaining support questions need manual review?\n\nCustomers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); 1 zero-result search source(s); mapping score 42.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `search-export-1`: \"How do I export attribution report?\"\n- `ticket-email-1` - Email update: \"How do I change my email?\"\n",
   "items": [
     {
-      "action_items": [
-        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
-        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
-        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-      ],
-      "answer": "Customers mention: \"How do I export attribution report?\" Evidence comes from 1 ticket source(s).",
-      "answer_evidence_status": "draft_needs_review",
-      "displayed_evidence_count": 1,
-      "evidence_count": 1,
-      "evidence_quotes": [
-        "`search-export-1`: \"How do I export attribution report?\""
-      ],
+      "topic": "reporting friction",
+      "question": "Which remaining support questions need manual review?",
+      "question_source": "source_policy",
+      "frequency": 21,
+      "weighted_frequency": 21,
       "failure_risk_score": 1,
       "failure_risk_signals": [
         "zero_result_search"
       ],
-      "frequency": 20,
-      "opportunity_score": 40,
-      "question": "How do I export attribution report?",
-      "question_source": "customer_wording",
-      "resolution_source_count": 0,
-      "source_ids": [
-        "search-export-1"
+      "opportunity_score": 42,
+      "answer": "Customers mention: \"How do I export attribution report?\" / \"How do I change my email?\" Evidence comes from 2 ticket source(s).",
+      "action_items": [
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
       ],
-      "source_labels": [
-        "`search-export-1`"
-      ],
-      "source_type_counts": {
-        "search_log": 1
-      },
+      "summary": "Customers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.",
       "steps": [
         "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
         "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
         "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
       ],
-      "summary": "A customer asked about reporting friction: \"How do I export attribution report?\". This FAQ should answer the request directly and tell the user exactly what to try next.",
+      "answer_evidence_status": "draft_needs_review",
+      "resolution_source_count": 0,
+      "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.",
+      "evidence_quotes": [
+        "`search-export-1`: \"How do I export attribution report?\"",
+        "`ticket-email-1` - Email update: \"How do I change my email?\""
+      ],
       "term_mappings": [
         {
           "customer_term": "export",
           "documentation_term": "Download report",
+          "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+          "source_id_count": 2,
+          "zero_result_source_count": 1,
           "failure_risk_score": 1,
           "failure_risk_signals": [
             "zero_result_search"
           ],
-          "first_source_id": "search-export-1",
-          "opportunity_score": 40,
-          "source_id_count": 1,
-          "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-          "zero_result_source_count": 1
+          "opportunity_score": 42,
+          "first_source_id": "search-export-1"
         }
       ],
-      "ticket_count": 1,
-      "topic": "reporting friction",
-      "weighted_frequency": 20,
-      "weighted_source_volume_by_type": {
-        "search_log": 20
-      },
-      "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
-    },
-    {
-      "action_items": [
-        "Use the uploaded resolution evidence: Open account settings, choose Profile, update the email address, then confirm the verification email",
-        "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
-        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-      ],
-      "answer": "Customers mention: \"How do I change my email?\" / \"I need to update the email on my account.\" Evidence comes from 2 ticket source(s).",
-      "answer_evidence_status": "resolution_evidence",
-      "displayed_evidence_count": 2,
-      "evidence_count": 2,
-      "evidence_quotes": [
-        "`ticket-email-1` - Email update: \"How do I change my email?\"",
-        "`ticket-email-2` - Email settings: \"I need to update the email on my account.\""
-      ],
-      "failure_risk_score": 0,
-      "failure_risk_signals": [],
-      "frequency": 2,
-      "opportunity_score": 2,
-      "question": "How do I change my email?",
-      "question_source": "customer_wording",
-      "resolution_source_count": 2,
       "source_ids": [
-        "ticket-email-1",
-        "ticket-email-2"
+        "search-export-1",
+        "ticket-email-1"
       ],
       "source_labels": [
-        "`ticket-email-1` - Email update",
-        "`ticket-email-2` - Email settings"
+        "`search-export-1`",
+        "`ticket-email-1` - Email update"
       ],
       "source_type_counts": {
-        "support_ticket": 2
+        "search_log": 1,
+        "support_ticket": 1
       },
-      "steps": [
-        "Use the uploaded resolution evidence: Open account settings, choose Profile, update the email address, then confirm the verification email",
-        "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
-        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-      ],
-      "summary": "Customers are asking about email and profile updates across 2 ticket sources. The clearest customer wording is \"How do I change my email?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
-      "term_mappings": [],
-      "ticket_count": 2,
-      "topic": "email and profile updates",
-      "weighted_frequency": 2,
       "weighted_source_volume_by_type": {
-        "support_ticket": 2
+        "search_log": 20,
+        "support_ticket": 1
       },
-      "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives."
+      "evidence_count": 2,
+      "displayed_evidence_count": 2,
+      "ticket_count": 2
     }
   ],
-  "markdown": "# Support Ticket FAQ Report\n\n_Source rows analyzed: 5. Ticket sources used: 5._\n\n## 1. How do I export attribution report?\n\nA customer asked about reporting friction: \"How do I export attribution report?\". This FAQ should answer the request directly and tell the user exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 1 source(s); 1 zero-result search source(s); mapping score 40.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `search-export-1`: \"How do I export attribution report?\"\n\n## 2. How do I change my email?\n\nCustomers are asking about email and profile updates across 2 ticket sources. The clearest customer wording is \"How do I change my email?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+  "source_count": 2,
+  "ticket_source_count": 2,
   "output_checks": {
+    "uses_user_vocabulary": true,
     "condensed": true,
-    "has_action_items": true,
-    "uses_user_vocabulary": true
+    "has_action_items": true
   },
-  "saved_ids": [],
-  "source_count": 5,
-  "ticket_source_count": 5,
-  "warnings": []
+  "warnings": [],
+  "saved_ids": []
 }

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -1445,10 +1445,7 @@ def _resolution_article_steps(
             if (excerpt := _resolution_excerpt(text))
         )
     )
-    steps = tuple(
-        f"Use the uploaded resolution evidence: {excerpt}"
-        for excerpt in excerpts[:2]
-    )
+    steps = tuple(excerpts[:2])
     if len(steps) >= 2:
         return (*steps, _support_step(support_contact))
     if len(steps) == 1:

--- a/plans/PR-Deflection-Resolution-Copy-Polish.md
+++ b/plans/PR-Deflection-Resolution-Copy-Polish.md
@@ -1,0 +1,108 @@
+## Why this slice exists
+
+The large SaaS-only validation proved the paid report can rank recurring
+questions and produce resolution-backed drafts, and
+`PR-Deflection-Question-Evidence-Scoping` fixed the unsafe cross-resolution
+bleed. The remaining buyer-visible issue is copy quality: resolution-backed
+steps expose internal scaffolding such as "Use the uploaded resolution
+evidence:" instead of clean help-center prose. The full paid report page and
+macro writeback both render those steps directly, so this polish belongs in the
+backend draft generator.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Product polish
+
+1. Remove internal evidence-scaffold copy from resolution-backed FAQ steps.
+2. Preserve fail-closed behavior for review-needed drafts; only
+   `resolution_evidence` steps are polished.
+3. Update report and macro-writeback expectations so buyer-visible surfaces no
+   longer contain "Use the uploaded resolution evidence:".
+4. Refresh the frontend contract examples so docs fixtures match the polished
+   paid-report payload.
+
+### Files touched
+
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_example.json`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+- `tests/test_extracted_ticket_faq_macro_writeback.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_output_ingestion.py`
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `plans/PR-Deflection-Resolution-Copy-Polish.md`
+
+## Mechanism
+
+The resolution step builder in
+`extracted_content_pipeline/ticket_faq_markdown.py` already extracts the first
+sentence from each trusted `resolution_text`. This slice stops wrapping that
+trusted excerpt in internal provenance wording. A resolved step becomes:
+
+```text
+Open Reports, choose Export, then select CSV
+```
+
+instead of:
+
+```text
+Use the uploaded resolution evidence: Open Reports, choose Export, then select CSV
+```
+
+The evidence status, source IDs, resolution source count, and review-needed
+fallback stay unchanged.
+
+The frontend example payloads are regenerated from the producer fixtures after
+the generator change, and their contract tests now assert that the public JSON
+examples do not contain the internal scaffold phrase.
+
+## Intentional
+
+- This does not rewrite or synthesize new product instructions. It only removes
+  wrapper text around already-scoped `resolution_text` excerpts.
+- This does not change the `answer` field yet. The highest-friction buyer
+  surface is the ordered step list used by the paid page, Markdown report, and
+  macro writeback. A later slice can improve answer summaries separately.
+- This does not change overflow/yield behavior from #1235.
+
+## Deferred
+
+- Follow-up slice: improve `answer` summaries so the paid card paragraph no
+  longer starts with "Customers mention:".
+- Follow-up slice: add the stricter artifact/eval gate that fails if an item
+  cites evidence outside its evidence scope.
+- Considered hardening: the existing `HARDENING.md` FAQ UI dependency-audit
+  entry is unrelated to this backend copy surface and remains parked.
+- Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py -k "resolution_evidence" -q` -- 2 passed, 149 deselected.
+- `pytest tests/test_extracted_ticket_faq_macro_writeback.py::test_macro_writeback_preview_uses_real_faq_generator_resolution_steps tests/test_content_ops_deflection_report.py::test_deflection_report_partitions_proven_and_unproven_answers tests/test_extracted_ticket_faq_output_ingestion.py::test_source_material_to_source_rows_accepts_ticket_faq_result_dict tests/test_content_ops_faq_report_contract_docs.py -q` -- 8 passed.
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_macro_writeback.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 189 passed.
+- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-copy-polish.json --summary-output /tmp/deflection-large-saas-copy-polish-summary.json --require-output-checks --json` -- passed; generated 8 opportunities, 7 proven drafts, 1 review-needed bucket.
+- `rg -n "Use the uploaded resolution evidence" /tmp/deflection-large-saas-copy-polish.json /tmp/deflection-large-saas-copy-polish-summary.json` -- no matches.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= bash scripts/run_extracted_pipeline_checks.sh` -- local checkout caveat: 1 unrelated SaaS demo preflight subprocess test failed because it reloads this repo's `.env`; 2886 passed, 10 skipped.
+- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-resolution-copy-polish-body.md` -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | ~5 |
+| Tests | ~30 |
+| Frontend JSON examples | ~312 |
+| Plan doc | ~108 |
+| **Total** | **~452** |
+
+Over the 400 LOC soft cap because the contract examples are regenerated JSON
+fixtures. The behavioral diff is intentionally small: one generator line plus
+focused expectations that keep buyer-visible payloads free of internal
+scaffold copy.

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -47,7 +47,7 @@ def test_deflection_report_partitions_proven_and_unproven_answers() -> None:
                 "opportunity_score": 14,
                 "answer_evidence_status": "resolution_evidence",
                 "steps": [
-                    "Use the uploaded resolution evidence: Open Analytics, choose Attribution, then select Download report.",
+                    "Open Analytics, choose Attribution, then select Download report.",
                     "Confirm the answer matches the customer's support record before publishing it.",
                 ],
                 "source_ids": ("ticket-1", "ticket-2"),
@@ -87,7 +87,8 @@ def test_deflection_report_partitions_proven_and_unproven_answers() -> None:
     assert "## Ranked Question Opportunities" in artifact.markdown
     assert "## Drafted Answers With Proven Solutions" in artifact.markdown
     assert "How do I export attribution reports?" in artifact.markdown
-    assert "Use the uploaded resolution evidence: Open Analytics" in artifact.markdown
+    assert "Open Analytics, choose Attribution" in artifact.markdown
+    assert "Use the uploaded resolution evidence" not in artifact.markdown
     assert "## No Proven Answer Yet" in artifact.markdown
     assert "Why is the dashboard stale?" in artifact.markdown
     assert "Customers repeatedly asked this question" in artifact.markdown

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -107,6 +107,7 @@ def _producer_deflection_report_payload() -> dict[str, object]:
 def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
     payload = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
     producer_payload_keys, producer_item_keys = _producer_report_shape()
+    encoded = json.dumps(payload, sort_keys=True)
 
     assert set(payload) == producer_payload_keys
     assert payload["generated"] == len(payload["items"])
@@ -142,11 +143,13 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
         }
         assert item["steps"]
         assert item["source_ids"]
+    assert "Use the uploaded resolution evidence" not in encoded
 
 
 def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
     payload = json.loads(DEFLECTION_EXAMPLE_PATH.read_text(encoding="utf-8"))
     producer_payload = _producer_deflection_report_payload()
+    encoded = json.dumps(payload, sort_keys=True)
 
     assert set(payload) == set(producer_payload)
     assert set(payload["summary"]) == set(producer_payload["summary"])
@@ -162,6 +165,7 @@ def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
     assert all(payload["faq_result"]["output_checks"].values())
     assert "## Drafted Answers With Proven Solutions" in payload["markdown"]
     assert "## No Proven Answer Yet" in payload["markdown"]
+    assert "Use the uploaded resolution evidence" not in encoded
 
 
 def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback.py
@@ -190,9 +190,8 @@ def test_macro_writeback_preview_uses_real_faq_generator_resolution_steps() -> N
     macro = preview.macros[0]
     assert "Customers mention:" in generated.items[0]["answer"]
     assert "Customers mention:" not in macro.body
-    assert macro.body.startswith(
-        "1. Use the uploaded resolution evidence: Open Billing, review the invoice history"
-    )
+    assert macro.body.startswith("1. Open Billing, review the invoice history")
+    assert "Use the uploaded resolution evidence" not in macro.body
     assert "pending authorizations with settled charges" in macro.body
 
 

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -203,8 +203,7 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
     assert item["answer_evidence_status"] == "resolution_evidence"
     assert item["resolution_source_count"] == 1
     assert item["steps"][0] == (
-        "Use the uploaded resolution evidence: Open Analytics, choose the "
-        "attribution dashboard, and select Export CSV"
+        "Open Analytics, choose the attribution dashboard, and select Export CSV"
     )
     assert item["steps"][1] == (
         "Confirm the answer matches the customer's account, plan, policy, or "
@@ -267,7 +266,7 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_beyond_display_rows(
     assert item["answer_evidence_status"] == "resolution_evidence"
     assert item["resolution_source_count"] == 1
     assert item["steps"][0] == (
-        "Use the uploaded resolution evidence: Enable Report Downloads for the analyst role"
+        "Enable Report Downloads for the analyst role"
     )
 
 
@@ -300,7 +299,8 @@ def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() 
     item = result.items[0]
     assert item["answer_evidence_status"] == "resolution_evidence"
     assert item["resolution_source_count"] == 2
-    assert len([step for step in item["steps"] if step.startswith("Use the uploaded")]) == 1
+    assert item["steps"][0] == "Send the reset email from Account Settings"
+    assert all(not step.startswith("Use the uploaded") for step in item["steps"])
 
 
 def test_build_ticket_faq_markdown_keeps_distinct_questions_from_sharing_resolutions() -> None:

--- a/tests/test_extracted_ticket_faq_output_ingestion.py
+++ b/tests/test_extracted_ticket_faq_output_ingestion.py
@@ -123,9 +123,8 @@ def test_source_material_to_source_rows_accepts_ticket_faq_result_dict() -> None
     assert len(rows) == 1
     assert rows[0]["source_type"] == FAQ_OUTPUT_SOURCE_TYPE
     assert rows[0]["faq_answer_evidence_status"] == "resolution_evidence"
-    assert rows[0]["resolution_text"].startswith(
-        "Use the uploaded resolution evidence: Open Billing"
-    )
+    assert rows[0]["resolution_text"].startswith("Open Billing")
+    assert "Use the uploaded resolution evidence" not in rows[0]["resolution_text"]
     assert "Why was I charged twice this month?" in rows[0]["text"]
     warning_codes = [warning.code for warning in loaded.warnings]
     assert "missing_source_text" not in warning_codes


### PR DESCRIPTION
Plan: plans/PR-Deflection-Resolution-Copy-Polish.md
Slice phase: Product polish

The large SaaS-only validation proved resolution-backed drafts work after evidence scoping, but paid-report and macro-writeback steps still exposed the internal scaffold phrase "Use the uploaded resolution evidence:". This slice removes that wrapper from trusted `resolution_text` excerpts and refreshes the frontend contract examples so buyer-visible payloads stay clean.

## Intentional
- Only strips wrapper text around trusted `resolution_text` excerpts; it does not synthesize new instructions.
- Leaves `answer` summaries and overflow/review-needed behavior unchanged for follow-up slices.

## Deferred
- Improve answer summaries that still start with "Customers mention:".
- Add a stricter artifact/eval gate for evidence-scope citations.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py -k "resolution_evidence" -q` -- 2 passed, 149 deselected.
- `pytest tests/test_extracted_ticket_faq_macro_writeback.py::test_macro_writeback_preview_uses_real_faq_generator_resolution_steps tests/test_content_ops_deflection_report.py::test_deflection_report_partitions_proven_and_unproven_answers tests/test_extracted_ticket_faq_output_ingestion.py::test_source_material_to_source_rows_accepts_ticket_faq_result_dict tests/test_content_ops_faq_report_contract_docs.py -q` -- 8 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_macro_writeback.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 189 passed.
- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-copy-polish.json --summary-output /tmp/deflection-large-saas-copy-polish-summary.json --require-output-checks --json` -- passed; generated 8 opportunities, 7 proven drafts, 1 review-needed bucket.
- `rg -n "Use the uploaded resolution evidence" /tmp/deflection-large-saas-copy-polish.json /tmp/deflection-large-saas-copy-polish-summary.json` -- no matches.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= bash scripts/run_extracted_pipeline_checks.sh` -- local checkout caveat: 1 unrelated SaaS demo preflight subprocess test failed because it reloads this repo's `.env`; 2886 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-resolution-copy-polish-body.md` -- passed.

## Diff size
9 files, +259 / -193.
