### PR TITLE
PR-Content-Ops-Upload-Source-Deployed-Smoke

### DIFF
--- a/plans/PR-Content-Ops-Upload-Source-Deployed-Smoke.md
+++ b/plans/PR-Content-Ops-Upload-Source-Deployed-Smoke.md
@@ -1,0 +1,113 @@
+# PR: Content Ops Upload Source Deployed Smoke
+
+## Why this slice exists
+
+The upload-source handoff is now validated in deterministic route-level pieces:
+persisted import target IDs execute into landing/blog drafts (#1236), and the
+landing-page review route gates the unauthenticated public landing route
+(#1239). The remaining operator need is a live-deployment smoke harness that
+can run those seams against a preview or production API without hand-clicking
+every request.
+
+This PR adds that harness as an opt-in script plus transport-mocked tests. It
+does not run live network calls in CI; CI proves request shape, response
+contract checks, and fail-closed behavior.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/upload-source-run-handoff
+
+Slice phase: Functional validation
+
+1. Add a CLI smoke script that accepts explicit `--api-base-url`, `--token`,
+   and `--csv` arguments, then runs:
+   uploaded CSV import -> execute landing/blog -> approve landing draft ->
+   fetch public landing route.
+2. Require explicit `--allow-indexed-public-artifact` acknowledgement because
+   a successful smoke approves an indexable public landing page.
+3. Assert response-envelope drift fails closed: missing target IDs, missing
+   saved draft IDs, partial/failed execution, failed approval confirmation,
+   public ID mismatch, missing public slug, or non-public robots policy all
+   fail the smoke.
+4. Add focused tests that mock `urllib` transport and prove request shape and
+   negative envelope detection.
+5. Enroll the test in the extracted pipeline CI runner so the checker does not
+   become a local-only safety claim.
+
+### Files touched
+
+- `scripts/smoke_content_ops_upload_source_public_asset.py`
+- `tests/test_smoke_content_ops_upload_source_public_asset.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-Upload-Source-Deployed-Smoke.md`
+
+## Mechanism
+
+The script uses only standard-library HTTP utilities and explicit CLI
+arguments. It intentionally avoids reading secret tokens from environment
+variables; operators pass tokens at invocation time. Because a successful run
+approves an indexable public page, it refuses to run unless the operator passes
+`--allow-indexed-public-artifact`.
+
+The live sequence is:
+
+```text
+POST /api/v1/content-ops/ingestion/files/import
+POST /api/v1/content-ops/execute
+POST /api/v1/content-assets/landing_page/drafts/review
+GET  /api/v1/content-assets/landing_page/public/{landing_page_id}
+```
+
+It prints a JSON summary containing the imported target IDs, saved landing/blog
+IDs, approval status, public slug, and public robots policy. Any contract drift
+returns a non-zero exit status and a JSON error list.
+
+## Intentional
+
+- No Playwright dependency. The repository does not currently carry Playwright
+  in `atlas-intel-ui`, and adding it would turn this into a dependency slice.
+  This harness validates the deployed API/public seam; a separate manual
+  browser check can open `/lp/{id}/{slug}` using the returned URL.
+- No CI live calls. Tests mock the HTTP transport and prove the checker fails
+  closed on malformed or contradictory response envelopes, including execute,
+  approval, and public-route drift.
+- No env-var token reads. Tokens are provided as CLI arguments so this script
+  does not add another secret configuration surface.
+- No teardown in this slice. The script is intentionally guarded instead:
+  operators must acknowledge that success creates an indexable public artifact,
+  so preview deployments remain the recommended target for routine smoke runs.
+
+## Deferred
+
+- Future PR: optional browser-rendered verification if the repo adopts a
+  Playwright/browser dependency for Atlas Intel UI smoke tests.
+- Parked hardening: none. `HARDENING.md` and `ATLAS-HARDENING.md` were scanned
+  in the previous route-validation slice; no matching active entries apply to
+  this smoke-harness slice.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_upload_source_public_asset.py -q`
+  - 11 passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  - OK: 141 matching tests are enrolled.
+- `python scripts/smoke_content_ops_upload_source_public_asset.py --help`
+  - Printed CLI usage.
+- `bash scripts/run_extracted_pipeline_checks.sh`
+  - 2899 passed, 10 skipped, 1 warning; all extracted content pipeline checks completed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-upload-source-deployed-smoke-pr-body.md`
+  - local PR review passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~90 |
+| Smoke script | ~335 |
+| Transport-mocked tests | ~305 |
+| CI runner enrollment | ~1 |
+| **Total** | **~740** |
+
+This is over the 400 LOC soft cap because the live harness and the mocked
+negative-path tests need to ship together; otherwise the script would add a
+checker without proving its failure detection.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -57,6 +57,7 @@ pytest \
   tests/test_smoke_content_ops_ingestion_file_route_inprocess_load.py \
   tests/test_smoke_content_ops_ingestion_file_route_multiprocess_load.py \
   tests/test_smoke_content_ops_live_generation.py \
+  tests/test_smoke_content_ops_upload_source_public_asset.py \
   tests/test_smoke_content_ops_review_source_generation.py \
   tests/test_export_content_ops_review_sources.py \
   tests/test_export_content_ops_cfpb_sources.py \

--- a/scripts/smoke_content_ops_upload_source_public_asset.py
+++ b/scripts/smoke_content_ops_upload_source_public_asset.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Smoke-test deployed upload-source generation through the public asset seam."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+from uuid import uuid4
+
+
+DEFAULT_IMPORT_PATH = "/api/v1/content-ops/ingestion/files/import"
+DEFAULT_EXECUTE_PATH = "/api/v1/content-ops/execute"
+DEFAULT_REVIEW_PATH = "/api/v1/content-assets/landing_page/drafts/review"
+DEFAULT_PUBLIC_PATH_TEMPLATE = "/api/v1/content-assets/landing_page/public/{id}"
+LOCAL_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})
+
+OpenRequest = Callable[[urllib.request.Request, float], Any]
+
+
+@dataclass(frozen=True)
+class HttpResult:
+    status: int
+    text: str
+    payload: Any
+
+
+class SmokeFailure(RuntimeError):
+    def __init__(self, errors: Sequence[str], summary: Mapping[str, Any] | None = None) -> None:
+        self.errors = tuple(errors)
+        self.summary = dict(summary or {})
+        super().__init__("; ".join(self.errors))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Upload a support-ticket CSV to a deployed Content Ops API, execute "
+            "landing/blog generation, approve the landing page, and verify the "
+            "public landing-page route."
+        )
+    )
+    parser.add_argument("--api-base-url", required=True)
+    parser.add_argument("--token", required=True)
+    parser.add_argument("--csv", required=True, type=Path)
+    parser.add_argument("--target-mode", default="vendor_retention")
+    parser.add_argument("--source", default="upload-source-public-asset-smoke.csv")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--import-path", default=DEFAULT_IMPORT_PATH)
+    parser.add_argument("--execute-path", default=DEFAULT_EXECUTE_PATH)
+    parser.add_argument("--review-path", default=DEFAULT_REVIEW_PATH)
+    parser.add_argument("--public-path-template", default=DEFAULT_PUBLIC_PATH_TEMPLATE)
+    parser.add_argument(
+        "--allow-indexed-public-artifact",
+        action="store_true",
+        help=(
+            "Confirm that this smoke may create an approved, indexable public "
+            "landing-page artifact. Use preview deployments when possible; "
+            "production runs can leave crawlable smoke content until manually "
+            "reviewed or removed."
+        ),
+    )
+    parser.add_argument("--output-result", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def run_smoke(args: argparse.Namespace, *, opener: OpenRequest | None = None) -> dict[str, Any]:
+    errors = _validate_args(args)
+    if errors:
+        raise SmokeFailure(errors)
+    open_request = opener or _open_request
+    base_url = _clean(args.api_base_url).rstrip("/")
+    token = _clean(args.token)
+    timeout = float(args.timeout)
+
+    imported = _post_multipart(
+        _join_url(base_url, args.import_path),
+        token=token,
+        fields={
+            "source_rows": "true",
+            "source": _clean(args.source),
+            "target_mode": _clean(args.target_mode),
+            "file_format": "csv",
+            "include_source_material": "false",
+            "replace_existing": "false",
+            "dry_run": "false",
+        },
+        file_field="file",
+        file_path=args.csv,
+        timeout=timeout,
+        opener=open_request,
+    ).payload
+    target_ids = _import_target_ids(imported)
+    if not target_ids:
+        raise SmokeFailure(["import response did not include persisted target_ids"], {"import": imported})
+
+    executed = _post_json(
+        _join_url(base_url, args.execute_path),
+        token=token,
+        payload={
+            "target_mode": _clean(args.target_mode),
+            "outputs": ["landing_page", "blog_post"],
+            "limit": 1,
+            "require_quality_gates": True,
+            "inputs": {"source_import_target_ids": target_ids},
+        },
+        timeout=timeout,
+        opener=open_request,
+    ).payload
+    landing_id = _saved_id_for_output(executed, "landing_page")
+    blog_id = _saved_id_for_output(executed, "blog_post")
+    execute_errors: list[str] = []
+    if _mapping(executed).get("status") != "completed":
+        execute_errors.append("execute response status was not completed")
+    if not landing_id:
+        execute_errors.append("execute response did not include a landing_page saved id")
+    if not blog_id:
+        execute_errors.append("execute response did not include a blog_post saved id")
+    if execute_errors:
+        raise SmokeFailure(execute_errors, {"execute": executed, "target_ids": target_ids})
+
+    approval = _post_json(
+        _join_url(base_url, args.review_path),
+        token=token,
+        payload={"id": landing_id, "status": "approved"},
+        timeout=timeout,
+        opener=open_request,
+    ).payload
+    approval_map = _mapping(approval)
+    if approval_map.get("updated") is not True or approval_map.get("status") != "approved":
+        raise SmokeFailure(
+            ["landing_page review response did not confirm approval"],
+            {"approval": approval, "landing_page_id": landing_id},
+        )
+
+    public_path = str(args.public_path_template).format(id=urllib.parse.quote(landing_id))
+    public = _get_json(
+        _join_url(base_url, public_path),
+        timeout=timeout,
+        opener=open_request,
+    ).payload
+    public_map = _mapping(public)
+    public_errors: list[str] = []
+    if public_map.get("id") != landing_id:
+        public_errors.append("public landing response id did not match approved draft id")
+    if not _clean(public_map.get("slug")):
+        public_errors.append("public landing response did not include a slug")
+    if public_map.get("robots") != "index,follow":
+        public_errors.append("public landing response was not indexable")
+    if public_errors:
+        raise SmokeFailure(public_errors, {"public": public, "landing_page_id": landing_id})
+
+    slug = _clean(public_map.get("slug"))
+    return {
+        "ok": True,
+        "target_ids": target_ids,
+        "landing_page_id": landing_id,
+        "blog_post_id": blog_id,
+        "public_slug": slug,
+        "public_robots": public_map.get("robots"),
+        "public_url_path": f"/lp/{urllib.parse.quote(landing_id)}/{urllib.parse.quote(slug)}",
+    }
+
+
+def _validate_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    if not _hosted_https_url(_clean(args.api_base_url)):
+        errors.append("--api-base-url must be an absolute hosted HTTPS URL")
+    if not _clean(args.token):
+        errors.append("--token is required")
+    csv_path = Path(args.csv)
+    if not csv_path.exists() or not csv_path.is_file():
+        errors.append("--csv must point to an existing CSV file")
+    if float(args.timeout) <= 0:
+        errors.append("--timeout must be positive")
+    if not bool(getattr(args, "allow_indexed_public_artifact", False)):
+        errors.append(
+            "--allow-indexed-public-artifact is required because this smoke "
+            "approves an indexable public landing page"
+        )
+    for attr in ("import_path", "execute_path", "review_path", "public_path_template"):
+        value = _clean(getattr(args, attr))
+        if not value.startswith("/"):
+            errors.append(f"--{attr.replace('_', '-')} must start with /")
+    if "{id}" not in _clean(args.public_path_template):
+        errors.append("--public-path-template must include {id}")
+    return errors
+
+
+def _hosted_https_url(value: str) -> bool:
+    try:
+        parsed = urllib.parse.urlparse(value)
+    except ValueError:
+        return False
+    host = (parsed.hostname or "").lower()
+    return parsed.scheme == "https" and bool(host) and host not in LOCAL_HOSTS and not host.startswith("127.")
+
+
+def _post_json(
+    url: str,
+    *,
+    token: str,
+    payload: Mapping[str, Any],
+    timeout: float,
+    opener: OpenRequest,
+) -> HttpResult:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    return _read_json(request, timeout=timeout, opener=opener)
+
+
+def _get_json(url: str, *, timeout: float, opener: OpenRequest) -> HttpResult:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    return _read_json(request, timeout=timeout, opener=opener)
+
+
+def _post_multipart(
+    url: str,
+    *,
+    token: str,
+    fields: Mapping[str, str],
+    file_field: str,
+    file_path: Path,
+    timeout: float,
+    opener: OpenRequest,
+) -> HttpResult:
+    boundary = f"atlas-smoke-{uuid4().hex}"
+    body = _multipart_body(boundary=boundary, fields=fields, file_field=file_field, file_path=file_path)
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        },
+    )
+    return _read_json(request, timeout=timeout, opener=opener)
+
+
+def _multipart_body(
+    *,
+    boundary: str,
+    fields: Mapping[str, str],
+    file_field: str,
+    file_path: Path,
+) -> bytes:
+    chunks: list[bytes] = []
+    for key, value in fields.items():
+        chunks.extend([
+            f"--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode(),
+            str(value).encode("utf-8"),
+            b"\r\n",
+        ])
+    chunks.extend([
+        f"--{boundary}\r\n".encode(),
+        (
+            f'Content-Disposition: form-data; name="{file_field}"; '
+            f'filename="{file_path.name}"\r\n'
+        ).encode(),
+        b"Content-Type: text/csv\r\n\r\n",
+        file_path.read_bytes(),
+        b"\r\n",
+        f"--{boundary}--\r\n".encode(),
+    ])
+    return b"".join(chunks)
+
+
+def _read_json(request: urllib.request.Request, *, timeout: float, opener: OpenRequest) -> HttpResult:
+    try:
+        with opener(request, timeout) as response:
+            text = response.read().decode("utf-8", errors="replace")
+            payload = json.loads(text) if text else None
+            return HttpResult(status=int(response.getcode()), text=text, payload=payload)
+    except urllib.error.HTTPError as exc:
+        text = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        raise SmokeFailure([f"{request.full_url} returned HTTP {exc.code}"], {"body": text}) from None
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise SmokeFailure([f"{request.full_url} failed: {exc}"]) from None
+
+
+def _open_request(request: urllib.request.Request, timeout: float) -> Any:
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def _import_target_ids(payload: Any) -> list[str]:
+    target_ids = _mapping(_mapping(payload).get("import")).get("target_ids")
+    if not isinstance(target_ids, Sequence) or isinstance(target_ids, (str, bytes)):
+        return []
+    return [_clean(value) for value in target_ids if _clean(value)]
+
+
+def _saved_id_for_output(payload: Any, output: str) -> str:
+    for step in _mapping(payload).get("steps") or ():
+        step_map = _mapping(step)
+        if step_map.get("output") != output:
+            continue
+        saved_ids = _mapping(step_map.get("result")).get("saved_ids")
+        if isinstance(saved_ids, Sequence) and not isinstance(saved_ids, (str, bytes)):
+            for value in saved_ids:
+                text = _clean(value)
+                if text:
+                    return text
+    return ""
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _join_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{str(path).lstrip('/')}"
+
+
+def _clean(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = run_smoke(args)
+    except SmokeFailure as exc:
+        result = {"ok": False, "errors": list(exc.errors), **exc.summary}
+        if args.output_result:
+            args.output_result.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        print(json.dumps(result, indent=2, sort_keys=True) if args.json else "\n".join(exc.errors))
+        return 1
+    if args.output_result:
+        args.output_result.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True) if args.json else f"OK {result['public_url_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_content_ops_upload_source_public_asset.py
+++ b/tests/test_smoke_content_ops_upload_source_public_asset.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+import urllib.request
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import smoke_content_ops_upload_source_public_asset as smoke
+
+
+class _Response:
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def getcode(self) -> int:
+        return self.status
+
+
+class _Transport:
+    def __init__(self, *payloads: Any) -> None:
+        self.payloads = list(payloads)
+        self.requests: list[urllib.request.Request] = []
+
+    def __call__(self, request: urllib.request.Request, timeout: float) -> _Response:
+        assert timeout == 11.0
+        self.requests.append(request)
+        assert self.payloads, f"unexpected request: {request.full_url}"
+        return _Response(self.payloads.pop(0))
+
+
+def _args(csv_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        api_base_url="https://atlas-preview.example.com",
+        token="secret-token",
+        csv=csv_path,
+        target_mode="vendor_retention",
+        source="tickets.csv",
+        timeout=11.0,
+        import_path=smoke.DEFAULT_IMPORT_PATH,
+        execute_path=smoke.DEFAULT_EXECUTE_PATH,
+        review_path=smoke.DEFAULT_REVIEW_PATH,
+        public_path_template=smoke.DEFAULT_PUBLIC_PATH_TEMPLATE,
+        allow_indexed_public_artifact=True,
+        output_result=None,
+        json=False,
+    )
+
+
+def _csv(tmp_path: Path) -> Path:
+    path = tmp_path / "tickets.csv"
+    path.write_text(
+        "ticket_id,subject,message\n"
+        "ticket-1,Billing renewal,How do I confirm my renewal invoice?\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_upload_source_public_asset_smoke_request_sequence(tmp_path: Path) -> None:
+    transport = _Transport(
+        {
+            "diagnostics": {"ok": True},
+            "import": {
+                "dry_run": False,
+                "target_ids": ["ticket-1", "ticket-2"],
+                "warnings": [],
+            },
+        },
+        {
+            "status": "completed",
+            "steps": [
+                {
+                    "output": "landing_page",
+                    "status": "completed",
+                    "result": {"saved_ids": ["landing-1"]},
+                },
+                {
+                    "output": "blog_post",
+                    "status": "completed",
+                    "result": {"saved_ids": ["blog-1"]},
+                },
+            ],
+        },
+        {"asset": "landing_page", "id": "landing-1", "status": "approved", "updated": True},
+        {
+            "id": "landing-1",
+            "slug": "support-faq-report",
+            "robots": "index,follow",
+        },
+    )
+
+    result = smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert result == {
+        "ok": True,
+        "target_ids": ["ticket-1", "ticket-2"],
+        "landing_page_id": "landing-1",
+        "blog_post_id": "blog-1",
+        "public_slug": "support-faq-report",
+        "public_robots": "index,follow",
+        "public_url_path": "/lp/landing-1/support-faq-report",
+    }
+    assert [request.get_method() for request in transport.requests] == [
+        "POST",
+        "POST",
+        "POST",
+        "GET",
+    ]
+    assert [request.full_url for request in transport.requests] == [
+        "https://atlas-preview.example.com/api/v1/content-ops/ingestion/files/import",
+        "https://atlas-preview.example.com/api/v1/content-ops/execute",
+        "https://atlas-preview.example.com/api/v1/content-assets/landing_page/drafts/review",
+        "https://atlas-preview.example.com/api/v1/content-assets/landing_page/public/landing-1",
+    ]
+
+    import_request = transport.requests[0]
+    import_body = import_request.data or b""
+    assert import_request.headers["Authorization"] == "Bearer secret-token"
+    assert b'name="file"; filename="tickets.csv"' in import_body
+    assert b'name="source_rows"\r\n\r\ntrue' in import_body
+    assert b'name="include_source_material"\r\n\r\nfalse' in import_body
+    assert b'name="dry_run"\r\n\r\nfalse' in import_body
+
+    execute_body = json.loads((transport.requests[1].data or b"{}").decode("utf-8"))
+    assert execute_body == {
+        "target_mode": "vendor_retention",
+        "outputs": ["landing_page", "blog_post"],
+        "limit": 1,
+        "require_quality_gates": True,
+        "inputs": {"source_import_target_ids": ["ticket-1", "ticket-2"]},
+    }
+    review_body = json.loads((transport.requests[2].data or b"{}").decode("utf-8"))
+    assert review_body == {"id": "landing-1", "status": "approved"}
+
+
+def test_upload_source_public_asset_smoke_fails_without_target_ids(tmp_path: Path) -> None:
+    transport = _Transport({"diagnostics": {"ok": True}, "import": {"target_ids": []}})
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert exc.value.errors == ("import response did not include persisted target_ids",)
+    assert len(transport.requests) == 1
+
+
+def test_upload_source_public_asset_smoke_fails_when_public_route_is_noindex(
+    tmp_path: Path,
+) -> None:
+    transport = _Transport(
+        {"import": {"target_ids": ["ticket-1"]}},
+        {
+            "status": "completed",
+            "steps": [
+                {"output": "landing_page", "result": {"saved_ids": ["landing-1"]}},
+                {"output": "blog_post", "result": {"saved_ids": ["blog-1"]}},
+            ],
+        },
+        {"status": "approved", "updated": True},
+        {"id": "landing-1", "slug": "support-faq-report", "robots": "noindex,follow"},
+    )
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert exc.value.errors == ("public landing response was not indexable",)
+    assert exc.value.summary["landing_page_id"] == "landing-1"
+
+
+@pytest.mark.parametrize(
+    ("execute_payload", "expected_errors"),
+    (
+        (
+            {
+                "status": "partial",
+                "steps": [
+                    {"output": "landing_page", "result": {"saved_ids": ["landing-1"]}},
+                    {"output": "blog_post", "result": {"saved_ids": ["blog-1"]}},
+                ],
+            },
+            ("execute response status was not completed",),
+        ),
+        (
+            {
+                "status": "completed",
+                "steps": [
+                    {"output": "blog_post", "result": {"saved_ids": ["blog-1"]}},
+                ],
+            },
+            ("execute response did not include a landing_page saved id",),
+        ),
+        (
+            {
+                "status": "completed",
+                "steps": [
+                    {"output": "landing_page", "result": {"saved_ids": ["landing-1"]}},
+                ],
+            },
+            ("execute response did not include a blog_post saved id",),
+        ),
+    ),
+)
+def test_upload_source_public_asset_smoke_fails_on_execute_envelope_drift(
+    tmp_path: Path,
+    execute_payload: dict[str, Any],
+    expected_errors: tuple[str, ...],
+) -> None:
+    transport = _Transport(
+        {"import": {"target_ids": ["ticket-1"]}},
+        execute_payload,
+    )
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert exc.value.errors == expected_errors
+    assert exc.value.summary["target_ids"] == ["ticket-1"]
+    assert len(transport.requests) == 2
+
+
+def test_upload_source_public_asset_smoke_fails_when_approval_is_not_confirmed(
+    tmp_path: Path,
+) -> None:
+    transport = _Transport(
+        {"import": {"target_ids": ["ticket-1"]}},
+        {
+            "status": "completed",
+            "steps": [
+                {"output": "landing_page", "result": {"saved_ids": ["landing-1"]}},
+                {"output": "blog_post", "result": {"saved_ids": ["blog-1"]}},
+            ],
+        },
+        {"status": "draft", "updated": False},
+    )
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert exc.value.errors == ("landing_page review response did not confirm approval",)
+    assert exc.value.summary["landing_page_id"] == "landing-1"
+    assert len(transport.requests) == 3
+
+
+@pytest.mark.parametrize(
+    ("public_payload", "expected_errors"),
+    (
+        (
+            {"id": "other-landing", "slug": "support-faq-report", "robots": "index,follow"},
+            ("public landing response id did not match approved draft id",),
+        ),
+        (
+            {"id": "landing-1", "slug": "", "robots": "index,follow"},
+            ("public landing response did not include a slug",),
+        ),
+    ),
+)
+def test_upload_source_public_asset_smoke_fails_on_public_envelope_drift(
+    tmp_path: Path,
+    public_payload: dict[str, Any],
+    expected_errors: tuple[str, ...],
+) -> None:
+    transport = _Transport(
+        {"import": {"target_ids": ["ticket-1"]}},
+        {
+            "status": "completed",
+            "steps": [
+                {"output": "landing_page", "result": {"saved_ids": ["landing-1"]}},
+                {"output": "blog_post", "result": {"saved_ids": ["blog-1"]}},
+            ],
+        },
+        {"status": "approved", "updated": True},
+        public_payload,
+    )
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(_args(_csv(tmp_path)), opener=transport)
+
+    assert exc.value.errors == expected_errors
+    assert exc.value.summary["landing_page_id"] == "landing-1"
+    assert len(transport.requests) == 4
+
+
+def test_upload_source_public_asset_smoke_rejects_local_base_url(tmp_path: Path) -> None:
+    args = _args(_csv(tmp_path))
+    args.api_base_url = "http://localhost:8000"
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(args, opener=_Transport())
+
+    assert exc.value.errors == ("--api-base-url must be an absolute hosted HTTPS URL",)
+
+
+def test_upload_source_public_asset_smoke_requires_public_artifact_confirmation(
+    tmp_path: Path,
+) -> None:
+    args = _args(_csv(tmp_path))
+    args.allow_indexed_public_artifact = False
+
+    with pytest.raises(smoke.SmokeFailure) as exc:
+        smoke.run_smoke(args, opener=_Transport())
+
+    assert exc.value.errors == (
+        "--allow-indexed-public-artifact is required because this smoke "
+        "approves an indexable public landing page",
+    )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Upload-Source-Deployed-Smoke.md
Slice phase: Functional validation

This PR adds an opt-in deployed smoke harness for the uploaded-source public asset path. The script uploads a support-ticket CSV to a deployed Content Ops API, executes landing/blog generation from persisted target IDs, approves the generated landing page, and verifies the unauthenticated public landing-page route returns an indexable payload.

## Intentional
- No Playwright dependency; this validates the deployed API/public seam and returns the `/lp/{id}/{slug}` path for a manual browser check.
- No CI live calls; tests mock the HTTP transport and prove request shape plus fail-closed envelope detection.
- No env-var token reads; operators pass tokens explicitly via CLI arguments.
- Requires `--allow-indexed-public-artifact` because a successful run creates an approved, indexable public landing page; preview deployments are the recommended target.

## Deferred
- Future PR: optional browser-rendered verification if the repo adopts a Playwright/browser dependency for Atlas Intel UI smoke tests.

## Parked hardening
- None.

## Verification
- `pytest tests/test_smoke_content_ops_upload_source_public_asset.py -q` - 11 passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - OK: 141 matching tests are enrolled.
- `python scripts/smoke_content_ops_upload_source_public_asset.py --help` - printed CLI usage.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2899 passed, 10 skipped, 1 warning; all extracted content pipeline checks completed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-upload-source-deployed-smoke-pr-body.md` - local PR review passed.

## Diff size
4 files, ~740 LOC. Over the soft cap because the live harness and mocked failure-detection tests need to ship together.