### PR TITLE
PR-Deflection-Answer-Copy-Polish

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,6 +30,17 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
+## 2026-06-02
+
+### SaaS demo preflight subprocess reloads live repo dotenv
+- File/location: `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py::test_script_preflight_uses_atlas_db_settings_fallback` / `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py`
+- Description: The test removes required env vars before spawning the smoke script, but the subprocess reloads the repo-root `.env`, so local checkouts with live `ATLAS_API_BASE_URL` / token / account envs can return success instead of missing-inputs.
+- Why it matters: It makes `scripts/run_extracted_pipeline_checks.sh` fail locally in provisioned workspaces even when CI's clean environment should pass.
+- Effort: S
+- Category: tech-debt
+- Owner/session: Codex FAQ deflection answer copy polish slice
+- Found during: PR-Deflection-Answer-Copy-Polish
+
 ## 2026-05-29
 
 ### atlas-intel-ui npm audit vulnerabilities

--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -1,74 +1,26 @@
 {
-  "markdown": "# Support Ticket Deflection Report\n\n## Executive Summary\n\nThis report analyzed 4 source rows and produced 2 ranked FAQ opportunities from the supplied support data.\n\n- Drafted answers with proven solutions: 1\n- No proven answer yet: 1\n- Ticket sources represented: 4\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |\n|---:|---|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | 2 | drafted from resolution evidence | ticket-export-1, ticket-export-2 |\n| 2 | Can I turn on SSO for all users? | 2 | 2 | no proven answer yet | ticket-sso-2, ticket-sso-1 |\n\n## Drafted Answers With Proven Solutions\n\n### 1. How do I export attribution reports?\n\nUploaded resolution evidence supports this draft answer.\n\n**Draft answer steps:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Sources:** ticket-export-1, ticket-export-2\n\n## No Proven Answer Yet\n\n### 1. Can I turn on SSO for all users?\n\nCustomers repeatedly asked this question, but the uploaded data did not include verified resolution evidence for a publishable answer.\n\nNo verified support resolution was present in the uploaded data. Support should add the approved answer before this FAQ is published.\n\n**Sources:** ticket-sso-2, ticket-sso-1\n\n## Vocabulary Gaps\n\n| Customer wording | Documentation term | Suggested update | Source count |\n|---|---|---|---:|\n| export | Download report | Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| report download | Download report | Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| SSO | Single sign-on setup | Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. | 2 |\n\n## Evidence Appendix\n\n### 1. How do I export attribution reports?\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. Can I turn on SSO for all users?\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
-  "summary": {
-    "generated": 2,
-    "source_count": 4,
-    "ticket_source_count": 4,
-    "drafted_answer_count": 1,
-    "no_proven_answer_count": 1,
-    "output_checks": {
-      "uses_user_vocabulary": true,
-      "condensed": true,
-      "has_action_items": true
-    },
-    "top_question": "How do I export attribution reports?",
-    "top_opportunity_score": 2
-  },
   "faq_result": {
     "generated": 2,
-    "markdown": "# Support Ticket FAQ Source\n\n_Source rows analyzed: 4. Ticket sources used: 4._\n\n## 1. How do I export attribution reports?\n\nCustomers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n- Customers say \"report download\"; documentation says \"Download report\". Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n## 2. Can I turn on SSO for all users?\n\nCustomers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"SSO\"; documentation says \"Single sign-on setup\". Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.\n\n**Sources:**\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
     "items": [
       {
-        "topic": "reporting friction",
-        "question": "How do I export attribution reports?",
-        "question_source": "customer_wording",
-        "frequency": 2,
-        "weighted_frequency": 2,
-        "failure_risk_score": 0,
-        "failure_risk_signals": [],
-        "opportunity_score": 2,
-        "answer": "Customers mention: \"How do I export attribution reports?\" Evidence comes from 2 ticket source(s).",
         "action_items": [
           "Open Analytics, choose Attribution, then click Download report",
-          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
           "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
         ],
-        "summary": "Customers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
-        "steps": [
-          "Open Analytics, choose Attribution, then click Download report",
-          "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
-          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-        ],
+        "answer": "Verified resolution evidence from 2 ticket sources supports the draft answer for: How do I export attribution reports?",
         "answer_evidence_status": "resolution_evidence",
-        "resolution_source_count": 2,
-        "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.",
+        "displayed_evidence_count": 1,
+        "evidence_count": 1,
         "evidence_quotes": [
           "`ticket-export-1` - Export attribution: \"How do I export attribution reports?\""
         ],
-        "term_mappings": [
-          {
-            "customer_term": "export",
-            "documentation_term": "Download report",
-            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-            "source_id_count": 2,
-            "zero_result_source_count": 0,
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "opportunity_score": 2,
-            "first_source_id": "ticket-export-1"
-          },
-          {
-            "customer_term": "report download",
-            "documentation_term": "Download report",
-            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-            "source_id_count": 2,
-            "zero_result_source_count": 0,
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "opportunity_score": 2,
-            "first_source_id": "ticket-export-1"
-          }
-        ],
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "frequency": 2,
+        "opportunity_score": 2,
+        "question": "How do I export attribution reports?",
+        "question_source": "customer_wording",
+        "resolution_source_count": 2,
         "source_ids": [
           "ticket-export-1",
           "ticket-export-2"
@@ -79,53 +31,63 @@
         "source_type_counts": {
           "support_ticket": 2
         },
+        "steps": [
+          "Open Analytics, choose Attribution, then click Download report",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "summary": "Customers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "term_mappings": [
+          {
+            "customer_term": "export",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          },
+          {
+            "customer_term": "report download",
+            "documentation_term": "Download report",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-export-1",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "reporting friction",
+        "weighted_frequency": 2,
         "weighted_source_volume_by_type": {
           "support_ticket": 2
         },
-        "evidence_count": 1,
-        "displayed_evidence_count": 1,
-        "ticket_count": 2
+        "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
       },
       {
-        "topic": "other support issues",
-        "question": "Can I turn on SSO for all users?",
-        "question_source": "customer_wording",
-        "frequency": 2,
-        "weighted_frequency": 2,
-        "failure_risk_score": 0,
-        "failure_risk_signals": [],
-        "opportunity_score": 2,
-        "answer": "Customers mention: \"Can I turn on SSO for all users?\" Evidence comes from 2 ticket source(s).",
         "action_items": [
           "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
           "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
           "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
         ],
-        "summary": "Customers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
-        "steps": [
-          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
-          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
-          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-        ],
+        "answer": "No verified resolution evidence was found in 2 ticket sources; keep this FAQ in review before answering: Can I turn on SSO for all users?",
         "answer_evidence_status": "draft_needs_review",
-        "resolution_source_count": 0,
-        "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.",
+        "displayed_evidence_count": 1,
+        "evidence_count": 1,
         "evidence_quotes": [
           "`ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\""
         ],
-        "term_mappings": [
-          {
-            "customer_term": "SSO",
-            "documentation_term": "Single sign-on setup",
-            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
-            "source_id_count": 2,
-            "zero_result_source_count": 0,
-            "failure_risk_score": 0,
-            "failure_risk_signals": [],
-            "opportunity_score": 2,
-            "first_source_id": "ticket-sso-2"
-          }
-        ],
+        "failure_risk_score": 0,
+        "failure_risk_signals": [],
+        "frequency": 2,
+        "opportunity_score": 2,
+        "question": "Can I turn on SSO for all users?",
+        "question_source": "customer_wording",
+        "resolution_source_count": 0,
         "source_ids": [
           "ticket-sso-2",
           "ticket-sso-1"
@@ -136,22 +98,58 @@
         "source_type_counts": {
           "support_ticket": 2
         },
+        "steps": [
+          "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+          "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+          "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+        ],
+        "summary": "Customers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.",
+        "term_mappings": [
+          {
+            "customer_term": "SSO",
+            "documentation_term": "Single sign-on setup",
+            "failure_risk_score": 0,
+            "failure_risk_signals": [],
+            "first_source_id": "ticket-sso-2",
+            "opportunity_score": 2,
+            "source_id_count": 2,
+            "suggestion": "Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text.",
+            "zero_result_source_count": 0
+          }
+        ],
+        "ticket_count": 2,
+        "topic": "other support issues",
+        "weighted_frequency": 2,
         "weighted_source_volume_by_type": {
           "support_ticket": 2
         },
-        "evidence_count": 1,
-        "displayed_evidence_count": 1,
-        "ticket_count": 2
+        "when_to_contact_support": "Contact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives."
       }
     ],
+    "markdown": "# Support Ticket FAQ Source\n\n_Source rows analyzed: 4. Ticket sources used: 4._\n\n## 1. How do I export attribution reports?\n\nCustomers are asking about reporting friction across 2 ticket sources. The clearest customer wording is \"How do I export attribution reports?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n- Customers say \"report download\"; documentation says \"Download report\". Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n## 2. Can I turn on SSO for all users?\n\nCustomers are asking about other support issues across 2 ticket sources. The clearest customer wording is \"Can I turn on SSO for all users?\", so this FAQ should answer that request directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"SSO\"; documentation says \"Single sign-on setup\". Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. (Seen in 2 source(s); mapping score 2.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if you cannot access the account, the field is locked, or the confirmation message never arrives.\n\n**Sources:**\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
+    "output_checks": {
+      "condensed": true,
+      "has_action_items": true,
+      "uses_user_vocabulary": true
+    },
+    "saved_ids": [],
     "source_count": 4,
     "ticket_source_count": 4,
+    "warnings": []
+  },
+  "markdown": "# Support Ticket Deflection Report\n\n## Executive Summary\n\nThis report analyzed 4 source rows and produced 2 ranked FAQ opportunities from the supplied support data.\n\n- Drafted answers with proven solutions: 1\n- No proven answer yet: 1\n- Ticket sources represented: 4\n\n## Ranked Question Opportunities\n\n| Rank | Customer question | Frequency | Opportunity | Answer status | Source IDs |\n|---:|---|---:|---:|---|---|\n| 1 | How do I export attribution reports? | 2 | 2 | drafted from resolution evidence | ticket-export-1, ticket-export-2 |\n| 2 | Can I turn on SSO for all users? | 2 | 2 | no proven answer yet | ticket-sso-2, ticket-sso-1 |\n\n## Drafted Answers With Proven Solutions\n\n### 1. How do I export attribution reports?\n\nUploaded resolution evidence supports this draft answer.\n\n**Draft answer steps:**\n\n1. Open Analytics, choose Attribution, then click Download report\n2. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**Sources:** ticket-export-1, ticket-export-2\n\n## No Proven Answer Yet\n\n### 1. Can I turn on SSO for all users?\n\nCustomers repeatedly asked this question, but the uploaded data did not include verified resolution evidence for a publishable answer.\n\nNo verified support resolution was present in the uploaded data. Support should add the approved answer before this FAQ is published.\n\n**Sources:** ticket-sso-2, ticket-sso-1\n\n## Vocabulary Gaps\n\n| Customer wording | Documentation term | Suggested update | Source count |\n|---|---|---|---:|\n| export | Download report | Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| report download | Download report | Add \"report download\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. | 2 |\n| SSO | Single sign-on setup | Add \"SSO\" as alternate phrasing for \"Single sign-on setup\" in FAQ headings and answer text. | 2 |\n\n## Evidence Appendix\n\n### 1. How do I export attribution reports?\n\n- `ticket-export-1` - Export attribution: \"How do I export attribution reports?\"\n\n### 2. Can I turn on SSO for all users?\n\n- `ticket-sso-2` - Team login: \"Can I turn on SSO for all users?\"\n",
+  "summary": {
+    "drafted_answer_count": 1,
+    "generated": 2,
+    "no_proven_answer_count": 1,
     "output_checks": {
-      "uses_user_vocabulary": true,
       "condensed": true,
-      "has_action_items": true
+      "has_action_items": true,
+      "uses_user_vocabulary": true
     },
-    "warnings": [],
-    "saved_ids": []
+    "source_count": 4,
+    "ticket_source_count": 4,
+    "top_opportunity_score": 2,
+    "top_question": "How do I export attribution reports?"
   }
 }

--- a/docs/frontend/content_ops_faq_report_example.json
+++ b/docs/frontend/content_ops_faq_report_example.json
@@ -1,52 +1,29 @@
 {
   "generated": 1,
-  "markdown": "# Support Ticket FAQ Report\n\n_Source rows analyzed: 2. Ticket sources used: 2._\n\n## 1. Which remaining support questions need manual review?\n\nCustomers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); 1 zero-result search source(s); mapping score 42.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `search-export-1`: \"How do I export attribution report?\"\n- `ticket-email-1` - Email update: \"How do I change my email?\"\n",
   "items": [
     {
-      "topic": "reporting friction",
-      "question": "Which remaining support questions need manual review?",
-      "question_source": "source_policy",
-      "frequency": 21,
-      "weighted_frequency": 21,
-      "failure_risk_score": 1,
-      "failure_risk_signals": [
-        "zero_result_search"
-      ],
-      "opportunity_score": 42,
-      "answer": "Customers mention: \"How do I export attribution report?\" / \"How do I change my email?\" Evidence comes from 2 ticket source(s).",
       "action_items": [
         "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
         "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
         "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
       ],
-      "summary": "Customers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.",
-      "steps": [
-        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
-        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
-        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
-      ],
+      "answer": "No verified resolution evidence was found in 2 ticket sources; keep this FAQ in review before answering: Which remaining support questions need manual review?",
       "answer_evidence_status": "draft_needs_review",
-      "resolution_source_count": 0,
-      "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.",
+      "displayed_evidence_count": 2,
+      "evidence_count": 2,
       "evidence_quotes": [
         "`search-export-1`: \"How do I export attribution report?\"",
         "`ticket-email-1` - Email update: \"How do I change my email?\""
       ],
-      "term_mappings": [
-        {
-          "customer_term": "export",
-          "documentation_term": "Download report",
-          "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
-          "source_id_count": 2,
-          "zero_result_source_count": 1,
-          "failure_risk_score": 1,
-          "failure_risk_signals": [
-            "zero_result_search"
-          ],
-          "opportunity_score": 42,
-          "first_source_id": "search-export-1"
-        }
+      "failure_risk_score": 1,
+      "failure_risk_signals": [
+        "zero_result_search"
       ],
+      "frequency": 21,
+      "opportunity_score": 42,
+      "question": "Which remaining support questions need manual review?",
+      "question_source": "source_policy",
+      "resolution_source_count": 0,
       "source_ids": [
         "search-export-1",
         "ticket-email-1"
@@ -59,22 +36,45 @@
         "search_log": 1,
         "support_ticket": 1
       },
+      "steps": [
+        "Review the cited ticket evidence and confirm the policy-approved answer before publishing.",
+        "Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "summary": "Customers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.",
+      "term_mappings": [
+        {
+          "customer_term": "export",
+          "documentation_term": "Download report",
+          "failure_risk_score": 1,
+          "failure_risk_signals": [
+            "zero_result_search"
+          ],
+          "first_source_id": "search-export-1",
+          "opportunity_score": 42,
+          "source_id_count": 2,
+          "suggestion": "Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text.",
+          "zero_result_source_count": 1
+        }
+      ],
+      "ticket_count": 2,
+      "topic": "reporting friction",
+      "weighted_frequency": 21,
       "weighted_source_volume_by_type": {
         "search_log": 20,
         "support_ticket": 1
       },
-      "evidence_count": 2,
-      "displayed_evidence_count": 2,
-      "ticket_count": 2
+      "when_to_contact_support": "Contact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions."
     }
   ],
+  "markdown": "# Support Ticket FAQ Report\n\n_Source rows analyzed: 2. Ticket sources used: 2._\n\n## 1. Which remaining support questions need manual review?\n\nCustomers are asking about reporting friction across 2 ticket sources. Representative evidence includes \"How do I export attribution report?\", so this FAQ should answer the issue directly and tell users exactly what to try next.\n\n**Vocabulary gaps:**\n\n- Customers say \"export\"; documentation says \"Download report\". Add \"export\" as alternate phrasing for \"Download report\" in FAQ headings and answer text. (Seen in 2 source(s); 1 zero-result search source(s); mapping score 42.)\n\n**What to do next:**\n\n1. Review the cited ticket evidence and confirm the policy-approved answer before publishing.\n2. Draft the customer-facing steps from a verified help article, runbook, macro, or resolved ticket.\n3. If it still does not work, contact support at https://example.com/support and include the cited ticket details.\n\n**When to contact support:**\n\nContact support at https://example.com/support if the export is missing, locked by plan or role, or still unavailable after an admin checks permissions.\n\n**Sources:**\n\n- `search-export-1`: \"How do I export attribution report?\"\n- `ticket-email-1` - Email update: \"How do I change my email?\"\n",
+  "output_checks": {
+    "condensed": true,
+    "has_action_items": true,
+    "uses_user_vocabulary": true
+  },
+  "saved_ids": [],
   "source_count": 2,
   "ticket_source_count": 2,
-  "output_checks": {
-    "uses_user_vocabulary": true,
-    "condensed": true,
-    "has_action_items": true
-  },
-  "warnings": [],
-  "saved_ids": []
+  "warnings": []
 }

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -674,7 +674,11 @@ def _item(
         "failure_risk_score": opportunity["failure_risk_score"],
         "failure_risk_signals": opportunity["failure_risk_signals"],
         "opportunity_score": opportunity["opportunity_score"],
-        "answer": f"Customers mention: {snippets} Evidence comes from {len(source_ids)} ticket source(s).",
+        "answer": _answer_summary(
+            question=question,
+            source_count=len(source_ids),
+            answer_evidence_status=answer_evidence_status,
+        ),
         "action_items": steps,
         "summary": summary,
         "steps": steps,
@@ -823,7 +827,34 @@ def _resolution_excerpt(value: Any, *, limit: int = 180) -> str:
     text = sentence or _compact(value)
     if len(text) <= limit:
         return text
-    return f"{text[:limit].rstrip()}..."
+    excerpt = text[:limit].rstrip()
+    if " " in excerpt:
+        excerpt = excerpt.rsplit(" ", 1)[0].rstrip(" ,;:-")
+    return f"{excerpt or text[:limit].rstrip()}..."
+
+
+def _answer_summary(
+    *,
+    question: str,
+    source_count: int,
+    answer_evidence_status: str,
+) -> str:
+    source_label = _source_count_label(source_count)
+    if answer_evidence_status == "resolution_evidence":
+        return (
+            f"Verified resolution evidence from {source_label} supports the "
+            f"draft answer for: {question}"
+        )
+    return (
+        f"No verified resolution evidence was found in {source_label}; keep "
+        f"this FAQ in review before answering: {question}"
+    )
+
+
+def _source_count_label(source_count: int) -> str:
+    if source_count == 1:
+        return "1 ticket source"
+    return f"{source_count} ticket sources"
 
 
 def _term_mappings(
@@ -1451,7 +1482,6 @@ def _resolution_article_steps(
     if len(steps) == 1:
         return (
             steps[0],
-            "Confirm the answer matches the customer's account, plan, policy, or support record before publishing it.",
             _support_step(support_contact),
         )
     return _draft_review_steps(support_contact)

--- a/plans/PR-Deflection-Answer-Copy-Polish.md
+++ b/plans/PR-Deflection-Answer-Copy-Polish.md
@@ -1,0 +1,118 @@
+## Why this slice exists
+
+`PR-Deflection-Resolution-Copy-Polish` removed the internal
+"Use the uploaded resolution evidence:" scaffold from proven FAQ steps. The
+reviewer then flagged the next buyer-visible polish gaps: proven-answer
+summaries still start with "Customers mention:", single-resolution drafts add
+an internal reviewer instruction as step 2, and long resolution excerpts can
+truncate mid-word. Those issues make otherwise resolution-backed drafts look
+less publishable even though the underlying evidence scoping is correct.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Product polish
+
+1. Replace the proven FAQ item `answer` summary with clean, evidence-scoped
+   copy that does not start with "Customers mention:".
+2. Avoid mid-word truncation when long `resolution_text` excerpts are shortened
+   for draft steps.
+3. Remove the internal single-resolution "Confirm the answer..." reviewer step
+   from proven drafts; keep fail-closed review steps for unproven drafts.
+4. Refresh report/macro/docs expectations for the buyer-visible copy.
+5. Align the compact FAQ output proof with the new proven-draft minimum of one
+   verified resolution step plus the support fallback.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `scripts/smoke_content_ops_faq_output_proof.py`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_extracted_ticket_faq_macro_writeback.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+- `tests/test_smoke_content_ops_faq_output_proof.py`
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_example.json`
+- `HARDENING.md`
+- `plans/PR-Deflection-Answer-Copy-Polish.md`
+
+## Mechanism
+
+The item builder already knows the selected question, source count, and whether
+resolution evidence exists. This slice uses that state to emit a short
+evidence-scoped answer summary for proven drafts while leaving unproven drafts
+clearly marked as needing review.
+
+For resolution-backed steps, the existing first-sentence excerpt logic remains
+the source of truth. The shortening branch changes from a raw character slice
+to a word-boundary slice so generated steps do not end mid-word. When only one
+resolution excerpt exists, the proven draft now returns that excerpt plus the
+support step instead of inserting an internal reviewer instruction.
+
+The compact output proof checker now treats two steps as sufficient coverage:
+one verified resolution step and one support fallback. Its negative fixture
+still uses one step, so the `action_step_coverage` detection branch remains
+proven.
+
+## Intentional
+
+- This does not synthesize new troubleshooting instructions. Proven drafts
+  still use only uploaded `resolution_text` excerpts for action steps.
+- This does not polish unproven draft-review steps. Those are intentionally
+  internal because the item is not publishable without verified resolution
+  evidence.
+- This does not change grouping, evidence scoping, ranking, paywall behavior, or
+  macro approval gates.
+- Cross-layer caller hints were inspected: `faq_deflection_report.py` is covered
+  by the focused deflection-report tests, and `ticket_faq_search.py` references
+  its own answer-summary helper rather than the new ticket FAQ summary helper.
+
+## Deferred
+
+- Follow-up slice: add the stricter artifact/eval gate that fails if an item
+  cites evidence outside its evidence scope.
+- Follow-up slice: richer final help-center prose over verified resolution
+  evidence once the copy surface is clean and guarded.
+- Considered hardening: the existing `HARDENING.md` FAQ UI dependency-audit
+  entry is unrelated to this backend copy surface and remains parked.
+- Parked hardening: `SaaS demo preflight subprocess reloads live repo dotenv`
+  records the local `.env` isolation issue that still affects full local mirror
+  runs in provisioned checkouts.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_macro_writeback.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 190 passed.
+- `pytest tests/test_smoke_content_ops_faq_output_proof.py -q` -- 4 passed.
+- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-answer-copy-polish.json --summary-output /tmp/deflection-large-saas-answer-copy-polish-summary.json --require-output-checks --json` -- passed; generated 8 opportunities, 7 proven drafts, 1 review-needed bucket.
+- Direct 420-row generator check -- 0 occurrences of "Customers mention:",
+  "Confirm the answer matches", "Use the uploaded resolution evidence", and
+  the prior `for se...` mid-word truncation; all 7 proven answers start with
+  "Verified resolution evidence".
+- `scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `scripts/check_ascii_python.sh` -- passed.
+- Full extracted mirror with live deflection env vars blanked before
+  `scripts/run_extracted_pipeline_checks.sh` -- local checkout caveat: 1
+  unrelated SaaS demo preflight subprocess test failed because it reloads this
+  repo's `.env`; 2888 passed, 10 skipped.
+- `scripts/local_pr_review.sh` with `--allow-dirty` and the staged PR body file -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | ~35 |
+| Output proof checker | ~2 |
+| Tests | ~56 |
+| Frontend JSON examples | ~268 |
+| Hardening note | ~11 |
+| Plan doc | ~118 |
+| **Total** | **~491** |
+
+Over the 400 LOC soft cap because the frontend contract examples are
+regenerated JSON fixtures. The behavioral diff is intentionally narrow: answer
+summary phrasing, word-boundary excerpting, and removal of one internal
+single-resolution step.

--- a/scripts/smoke_content_ops_faq_output_proof.py
+++ b/scripts/smoke_content_ops_faq_output_proof.py
@@ -348,7 +348,7 @@ def _proof_failures(
         failures.append({"check": "generated_items", "detail": proof.get("generated")})
     if _integer(proof.get("min_source_id_count")) < 1:
         failures.append({"check": "source_id_coverage", "detail": proof.get("min_source_id_count")})
-    if _integer(proof.get("min_step_count")) < 3:
+    if _integer(proof.get("min_step_count")) < 2:
         failures.append({"check": "action_step_coverage", "detail": proof.get("min_step_count")})
     bridge = _mapping(proof.get("ingestion_bridge"))
     if _integer(bridge.get("adapted_source_row_count")) < _integer(proof.get("generated")):

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -48,7 +48,7 @@ def test_deflection_report_partitions_proven_and_unproven_answers() -> None:
                 "answer_evidence_status": "resolution_evidence",
                 "steps": [
                     "Open Analytics, choose Attribution, then select Download report.",
-                    "Confirm the answer matches the customer's support record before publishing it.",
+                    "If it still does not work, contact support and include the cited ticket details.",
                 ],
                 "source_ids": ("ticket-1", "ticket-2"),
                 "evidence_quotes": (

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -144,6 +144,8 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
         assert item["steps"]
         assert item["source_ids"]
     assert "Use the uploaded resolution evidence" not in encoded
+    assert "Customers mention:" not in encoded
+    assert "Confirm the answer matches" not in encoded
 
 
 def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
@@ -166,6 +168,8 @@ def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
     assert "## Drafted Answers With Proven Solutions" in payload["markdown"]
     assert "## No Proven Answer Yet" in payload["markdown"]
     assert "Use the uploaded resolution evidence" not in encoded
+    assert "Customers mention:" not in encoded
+    assert "Confirm the answer matches" not in encoded
 
 
 def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() -> None:

--- a/tests/test_extracted_ticket_faq_macro_writeback.py
+++ b/tests/test_extracted_ticket_faq_macro_writeback.py
@@ -188,7 +188,11 @@ def test_macro_writeback_preview_uses_real_faq_generator_resolution_steps() -> N
     ])
 
     macro = preview.macros[0]
-    assert "Customers mention:" in generated.items[0]["answer"]
+    assert "Customers mention:" not in generated.items[0]["answer"]
+    assert generated.items[0]["answer"] == (
+        "Verified resolution evidence from 1 ticket source supports the draft "
+        "answer for: Why was I charged twice this month?"
+    )
     assert "Customers mention:" not in macro.body
     assert macro.body.startswith("1. Open Billing, review the invoice history")
     assert "Use the uploaded resolution evidence" not in macro.body

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -206,11 +206,44 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
         "Open Analytics, choose the attribution dashboard, and select Export CSV"
     )
     assert item["steps"][1] == (
-        "Confirm the answer matches the customer's account, plan, policy, or "
-        "support record before publishing it."
+        "If it still does not work, contact support at support@example.com and "
+        "include the cited ticket details."
+    )
+    assert "Customers mention:" not in item["answer"]
+    assert item["answer"] == (
+        "Verified resolution evidence from 1 ticket source supports the draft "
+        "answer for: How do I export the attribution dashboard before renewal?"
     )
     assert "Draft the customer-facing steps" not in result.markdown
     assert "support@example.com" in result.markdown
+
+
+def test_build_ticket_faq_markdown_truncates_resolution_steps_at_word_boundary() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "SSO setup",
+            "evidence": [{
+                "text": "How do I enable SSO after my domain is verified?",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "resolution_text": (
+                    "Open Settings > Security > Single sign-on, confirm the "
+                    "verified domain badge is green, paste the IdP metadata URL, "
+                    "map email to NameID, click Test SSO, then Save and enforce "
+                    "for selected users before rollout."
+                ),
+            }],
+        }]
+    )
+
+    step = result.items[0]["steps"][0]
+    assert step == (
+        "Open Settings > Security > Single sign-on, confirm the verified domain "
+        "badge is green, paste the IdP metadata URL, map email to NameID, click "
+        "Test SSO, then Save and enforce for..."
+    )
+    assert "se..." not in step
 
 
 def test_build_ticket_faq_markdown_ignores_disposition_resolution_aliases() -> None:
@@ -1370,7 +1403,10 @@ def test_build_ticket_faq_markdown_keeps_total_volume_when_display_is_capped() -
     assert item["displayed_evidence_count"] == 2
     assert item["source_ids"] == ("ticket-1", "ticket-2", "ticket-3", "ticket-4")
     assert len(item["source_labels"]) == 2
-    assert "Evidence comes from 4 ticket source(s)." in item["answer"]
+    assert item["answer"] == (
+        "No verified resolution evidence was found in 4 ticket sources; keep "
+        "this FAQ in review before answering: What should I do about data freshness?"
+    )
     assert "ticket-3" not in result.markdown
 
 

--- a/tests/test_smoke_content_ops_faq_output_proof.py
+++ b/tests/test_smoke_content_ops_faq_output_proof.py
@@ -42,7 +42,7 @@ def test_faq_output_proof_writes_artifacts_and_passes(tmp_path: Path) -> None:
         "billing and payments",
     }
     assert summary["proof"]["min_source_id_count"] >= 1
-    assert summary["proof"]["min_step_count"] >= 3
+    assert summary["proof"]["min_step_count"] >= 2
     assert summary["proof"]["ingestion_bridge"]["adapted_source_row_count"] >= (
         summary["proof"]["generated"]
     )


### PR DESCRIPTION
Plan: plans/PR-Deflection-Answer-Copy-Polish.md
Slice phase: Product polish

The previous copy-polish slice removed the explicit resolution-evidence scaffold from steps, but the paid draft payload still had rough buyer-visible copy: `Customers mention:` answer summaries, mid-word excerpt truncation, and an internal reviewer step in proven single-resolution drafts. This slice keeps the evidence doctrine intact while making proven draft copy cleaner.

## Intentional
- Uses only existing question/source metadata and uploaded `resolution_text` excerpts; no new troubleshooting instructions are synthesized.
- Leaves unproven draft-review copy internal and fail-closed.
- Adjusts the output proof minimum from 3 steps to 2 because proven single-resolution drafts now contain one verified resolution step plus the support fallback.
- Cross-layer caller hints were inspected: `extracted_content_pipeline/faq_deflection_report.py` is covered by focused deflection-report tests, and `extracted_content_pipeline/ticket_faq_search.py` references its own answer-summary helper.

## Deferred
- Add the stricter artifact/eval gate for evidence-scope citations.
- Richer final help-center prose over verified resolution evidence.

## Parked hardening
- `SaaS demo preflight subprocess reloads live repo dotenv` records the local `.env` isolation issue that still affects full local mirror runs in provisioned checkouts.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_extracted_ticket_faq_macro_writeback.py tests/test_content_ops_deflection_report.py tests/test_extracted_ticket_faq_output_ingestion.py tests/test_content_ops_faq_report_contract_docs.py -q` -- 190 passed.
- `pytest tests/test_smoke_content_ops_faq_output_proof.py -q` -- 4 passed.
- `python scripts/build_content_ops_deflection_report.py /home/juan-canfield/Desktop/saas-deflection-large-sample.csv --source-format csv --max-items 8 --result-output /tmp/deflection-large-saas-answer-copy-polish.json --summary-output /tmp/deflection-large-saas-answer-copy-polish-summary.json --require-output-checks --json` -- passed; generated 8 opportunities, 7 proven drafts, 1 review-needed bucket.
- Direct 420-row generator check -- 0 occurrences of `Customers mention:`, `Confirm the answer matches`, `Use the uploaded resolution evidence`, and the prior `for se...` mid-word truncation; all 7 proven answers start with `Verified resolution evidence`.
- `scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `scripts/check_ascii_python.sh` -- passed.
- Full extracted mirror with live deflection env vars blanked before `scripts/run_extracted_pipeline_checks.sh` -- local checkout caveat: 1 unrelated SaaS demo preflight subprocess test failed because it reloads this repo's `.env`; 2888 passed, 10 skipped.
- `scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-answer-copy-polish-body.md` -- passed.

## Diff size
11 files, +341 / -145.
