### PR TITLE
PR-Content-Ops-Image-Provider-Unsplash

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -57,6 +57,11 @@ from extracted_content_pipeline.campaign_postgres import (
     PostgresCampaignRepository,
     PostgresIntelligenceRepository,
 )
+from extracted_content_pipeline.content_image_provider import (
+    ContentImageProvider,
+    UnsplashContentImageProvider,
+    UnsplashContentImageProviderConfig,
+)
 from extracted_content_pipeline.content_ops_execution import (
     ContentOpsExecutionServices,
 )
@@ -106,6 +111,7 @@ def _build_landing_page_service(
     llm: LLMClient | None,
     skills: SkillStore,
     pool: Any,
+    image_provider: ContentImageProvider | None = None,
 ) -> LandingPageGenerationService | None:
     """Build a wired `LandingPageGenerationService`, or `None` if
     no host LLM is currently active.
@@ -127,6 +133,7 @@ def _build_landing_page_service(
         landing_pages=PostgresLandingPageRepository(pool=pool),
         llm=llm,
         skills=skills,
+        image_provider=image_provider,
     )
 
 
@@ -193,6 +200,7 @@ def _build_blog_post_service(
     llm: LLMClient | None,
     skills: SkillStore,
     pool: Any,
+    image_provider: ContentImageProvider | None = None,
 ) -> BlogPostGenerationService | None:
     """E4: blog-post drafts.
 
@@ -212,6 +220,23 @@ def _build_blog_post_service(
         blog_posts=PostgresBlogPostRepository(pool=pool),
         llm=llm,
         skills=skills,
+        image_provider=image_provider,
+    )
+
+
+def _build_content_image_provider() -> ContentImageProvider | None:
+    from atlas_brain.config import settings
+
+    cfg = settings.b2b_campaign
+    if not bool(cfg.content_ops_image_provider_enabled):
+        return None
+    return UnsplashContentImageProvider(
+        UnsplashContentImageProviderConfig(
+            enabled=True,
+            access_key=cfg.content_ops_image_unsplash_access_key,
+            base_url=cfg.content_ops_image_unsplash_base_url,
+            timeout_seconds=cfg.content_ops_image_timeout_seconds,
+        )
     )
 
 
@@ -293,10 +318,12 @@ def build_content_ops_execution_services(
         intelligence: IntelligenceRepository | None = (
             PostgresIntelligenceRepository(pool=pool) if pool is not None else None
         )
+        image_provider = _build_content_image_provider()
         landing_page = _build_landing_page_service(
             llm=llm,
             skills=skills,
             pool=pool,
+            image_provider=image_provider,
         )
         campaign = _build_campaign_service(
             intelligence=intelligence,
@@ -320,6 +347,7 @@ def build_content_ops_execution_services(
             llm=llm,
             skills=skills,
             pool=pool,
+            image_provider=image_provider,
         )
         faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None

--- a/atlas_brain/config.py
+++ b/atlas_brain/config.py
@@ -4799,6 +4799,27 @@ class B2BCampaignConfig(BaseSettings):
         validation_alias=AliasChoices("ATLAS_CONTENT_OPS_FAQ_MACRO_WRITEBACK_SCHEDULED_INTERVAL_SECONDS"),
         description="Interval for autonomous Content Ops FAQ-to-Zendesk macro publishing.",
     )
+    content_ops_image_provider_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_IMAGE_PROVIDER_ENABLED"),
+        description="Enable server-side image enrichment for generated Content Ops landing/blog drafts.",
+    )
+    content_ops_image_unsplash_access_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_IMAGE_UNSPLASH_ACCESS_KEY"),
+        description="Unsplash access key for Content Ops image enrichment.",
+    )
+    content_ops_image_unsplash_base_url: str = Field(
+        default="https://api.unsplash.com",
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_IMAGE_UNSPLASH_BASE_URL"),
+        description="Unsplash API base URL for Content Ops image enrichment.",
+    )
+    content_ops_image_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        validation_alias=AliasChoices("ATLAS_CONTENT_OPS_IMAGE_TIMEOUT_SECONDS"),
+        description="HTTP timeout for Content Ops image provider requests.",
+    )
     personas: list[str] = Field(
         default=["executive", "technical", "operations", "evaluator", "champion"],
         description="Persona types to generate campaigns for (buying committee coverage)",

--- a/extracted_content_pipeline/blog_generation.py
+++ b/extracted_content_pipeline/blog_generation.py
@@ -16,6 +16,11 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .content_image_provider import (
+    ContentImageAsset,
+    ContentImageProvider,
+    ContentImageRequest,
+)
 from .services._parse_retry_helpers import (
     accumulate_usage,
     clip_invalid_response,
@@ -425,6 +430,7 @@ class BlogPostGenerationService:
         llm: LLMClient,
         skills: SkillStore,
         reasoning_context: CampaignReasoningContextProvider | None = None,
+        image_provider: ContentImageProvider | None = None,
         config: BlogPostGenerationConfig | None = None,
     ):
         self._blueprints = blueprints
@@ -436,6 +442,7 @@ class BlogPostGenerationService:
         # reasoning context is merged into each blueprint before the
         # LLM call -- additive enrichment, not replacement.
         self._reasoning_context = reasoning_context
+        self._image_provider = image_provider
         self._config = config or BlogPostGenerationConfig()
 
     def with_reasoning_context(
@@ -452,6 +459,7 @@ class BlogPostGenerationService:
             llm=self._llm,
             skills=self._skills,
             reasoning_context=provider,
+            image_provider=self._image_provider,
             config=self._config,
         )
 
@@ -624,7 +632,8 @@ class BlogPostGenerationService:
                 consumed_reasoning_contexts.extend(
                     consumed_campaign_reasoning_contexts(blueprint)
                 )
-            drafts.append(self._build_draft(parsed, blueprint=blueprint))
+            draft = self._build_draft(parsed, blueprint=blueprint)
+            drafts.append(await self._with_optional_image(draft, blueprint=blueprint))
 
         saved_ids: tuple[str, ...] = ()
         if drafts:
@@ -874,6 +883,33 @@ class BlogPostGenerationService:
             metadata=metadata,
         )
 
+    async def _with_optional_image(
+        self,
+        draft: BlogPostDraft,
+        *,
+        blueprint: Mapping[str, Any],
+    ) -> BlogPostDraft:
+        if self._image_provider is None or draft.metadata.get("cover_image"):
+            return draft
+        try:
+            asset = await self._image_provider.select_image(
+                ContentImageRequest(
+                    asset_type="blog_post",
+                    slot="cover",
+                    title=draft.title,
+                    query_terms=(
+                        str(blueprint.get("topic") or ""),
+                        str(blueprint.get("suggested_title") or ""),
+                        str(blueprint.get("topic_type") or ""),
+                    ),
+                )
+            )
+        except Exception:
+            return draft
+        if asset is None:
+            return draft
+        return _blog_post_with_image_asset(draft, asset)
+
 
 def _quality_context(
     parsed: Mapping[str, Any],
@@ -897,6 +933,27 @@ def _quality_context(
         "secondary_keywords": parsed.get("secondary_keywords"),
         "faq": parsed.get("faq"),
     }
+
+
+def _blog_post_with_image_asset(
+    draft: BlogPostDraft,
+    asset: ContentImageAsset,
+) -> BlogPostDraft:
+    metadata = dict(draft.metadata or {})
+    metadata["cover_image"] = asset.as_dict()
+    return BlogPostDraft(
+        slug=draft.slug,
+        title=draft.title,
+        description=draft.description,
+        tags=tuple(draft.tags),
+        topic_type=draft.topic_type,
+        content=draft.content,
+        charts=tuple(draft.charts),
+        data_context=dict(draft.data_context or {}),
+        metadata=metadata,
+        id=draft.id,
+        status=draft.status,
+    )
 
 
 def _quality_policy_for_context(

--- a/extracted_content_pipeline/content_image_provider.py
+++ b/extracted_content_pipeline/content_image_provider.py
@@ -1,0 +1,238 @@
+"""Content image provider ports and the Unsplash adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import ipaddress
+import json
+from typing import Any, Callable, Protocol
+from urllib.parse import urlencode, urljoin, urlparse
+import urllib.request
+
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ContentImageRequest:
+    """Trusted server-side context used to pick an image for a content asset."""
+
+    asset_type: str
+    slot: str
+    title: str = ""
+    query_terms: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def query(self) -> str:
+        parts = [self.title, *self.query_terms]
+        return " ".join(str(part).strip() for part in parts if str(part).strip())
+
+
+@dataclass(frozen=True)
+class ContentImageAsset:
+    """Selected image payload stored on generated drafts."""
+
+    url: str
+    provider: str
+    alt_text: str = ""
+    attribution_name: str = ""
+    attribution_url: str = ""
+    source_id: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "url": self.url,
+            "provider": self.provider,
+            "alt_text": self.alt_text,
+            "attribution_name": self.attribution_name,
+            "attribution_url": self.attribution_url,
+            "source_id": self.source_id,
+            "metadata": dict(self.metadata),
+        }
+
+
+class ContentImageProvider(Protocol):
+    async def select_image(
+        self,
+        request: ContentImageRequest,
+    ) -> ContentImageAsset | None:
+        """Return one image for a content asset, or None when unavailable."""
+
+
+@dataclass(frozen=True)
+class UnsplashContentImageProviderConfig:
+    enabled: bool = False
+    access_key: str = ""
+    base_url: str = "https://api.unsplash.com"
+    timeout_seconds: float = 10.0
+
+
+Opener = Callable[[urllib.request.Request, float], Any]
+
+
+class UnsplashContentImageProvider:
+    """Unsplash search adapter with required download tracking."""
+
+    def __init__(
+        self,
+        config: UnsplashContentImageProviderConfig,
+        *,
+        opener: Opener | None = None,
+    ) -> None:
+        self._config = config
+        self._opener = opener or _urlopen
+
+    async def select_image(
+        self,
+        request: ContentImageRequest,
+    ) -> ContentImageAsset | None:
+        return await asyncio.to_thread(self._select_image_sync, request)
+
+    def _select_image_sync(
+        self,
+        request: ContentImageRequest,
+    ) -> ContentImageAsset | None:
+        if not self._config.enabled or not self._config.access_key.strip():
+            return None
+        base_url = _safe_https_base_url(self._config.base_url)
+        if not base_url:
+            return None
+        query = request.query()
+        if not query:
+            return None
+        search_url = urljoin(base_url + "/", "search/photos")
+        params = {
+            'query': query,
+            'per_page': 1,
+            'orientation': 'landscape',
+            'content_filter': 'high',
+        }
+        search_url = f"{search_url}?{urlencode(params)}"
+        try:
+            payload = self._fetch_json(search_url)
+            asset, download_url = _asset_from_unsplash_payload(payload)
+            if asset is None or not _safe_https_url(download_url):
+                return None
+            if not self._track_download(download_url):
+                return None
+            return asset
+        except Exception:
+            return None
+
+    def _fetch_json(self, url: str) -> Mapping[str, Any]:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Client-ID {self._config.access_key.strip()}",
+                "Accept": "application/json",
+                "User-Agent": "Atlas-Content-Ops/1.0",
+            },
+        )
+        with self._opener(request, _timeout(self._config.timeout_seconds)) as response:
+            status = int(getattr(response, "status", 0) or response.getcode())
+            if status < 200 or status >= 300:
+                return {}
+            decoded = json.loads(response.read().decode("utf-8"))
+            return decoded if isinstance(decoded, Mapping) else {}
+
+    def _track_download(self, url: str) -> bool:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Client-ID {self._config.access_key.strip()}",
+                "Accept": "application/json",
+                "User-Agent": "Atlas-Content-Ops/1.0",
+            },
+        )
+        with self._opener(request, _timeout(self._config.timeout_seconds)) as response:
+            status = int(getattr(response, "status", 0) or response.getcode())
+            return 200 <= status < 300
+
+
+def _asset_from_unsplash_payload(
+    payload: Mapping[str, Any],
+) -> tuple[ContentImageAsset | None, str]:
+    results = payload.get("results")
+    if not isinstance(results, Sequence) or isinstance(results, (str, bytes)):
+        return None, ""
+    first = next((item for item in results if isinstance(item, Mapping)), None)
+    if first is None:
+        return None, ""
+    urls = first.get("urls") if isinstance(first.get("urls"), Mapping) else {}
+    image_url = _clean_text(urls.get("regular") or urls.get("full") or urls.get("small"))
+    links = first.get("links") if isinstance(first.get("links"), Mapping) else {}
+    download_url = _clean_text(links.get("download_location"))
+    if not image_url or not _safe_https_url(image_url):
+        return None, ""
+    user = first.get("user") if isinstance(first.get("user"), Mapping) else {}
+    user_links = user.get("links") if isinstance(user.get("links"), Mapping) else {}
+    asset = ContentImageAsset(
+        url=image_url,
+        provider="unsplash",
+        alt_text=_clean_text(first.get("alt_description") or first.get("description")),
+        attribution_name=_clean_text(user.get("name")),
+        attribution_url=_clean_text(user_links.get("html")),
+        source_id=_clean_text(first.get("id")),
+        metadata={"source": "unsplash"},
+    )
+    return asset, download_url
+
+
+def _urlopen(request: urllib.request.Request, timeout: float) -> Any:
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def _timeout(value: float) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return 10.0
+    return timeout if timeout > 0 else 10.0
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _safe_https_base_url(value: Any) -> str:
+    parsed = urlparse(_clean_text(value))
+    if parsed.path not in ("", "/"):
+        return ""
+    if not _safe_parsed_https_url(parsed):
+        return ""
+    return f"https://{parsed.netloc}"
+
+
+def _safe_https_url(value: Any) -> bool:
+    return _safe_parsed_https_url(urlparse(_clean_text(value)))
+
+
+def _safe_parsed_https_url(parsed: Any) -> bool:
+    if parsed.scheme != "https" or not parsed.netloc:
+        return False
+    host = parsed.hostname or ""
+    if host.lower() == "localhost" or host.endswith(".local"):
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return True
+    return not (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+    )
+
+
+__all__ = [
+    "ContentImageAsset",
+    "ContentImageProvider",
+    "ContentImageRequest",
+    "UnsplashContentImageProvider",
+    "UnsplashContentImageProviderConfig",
+]

--- a/extracted_content_pipeline/landing_page_generation.py
+++ b/extracted_content_pipeline/landing_page_generation.py
@@ -35,6 +35,11 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .content_image_provider import (
+    ContentImageAsset,
+    ContentImageProvider,
+    ContentImageRequest,
+)
 from .landing_page_ports import (
     LandingPageDraft,
     LandingPageRepository,
@@ -242,12 +247,14 @@ class LandingPageGenerationService:
         llm: LLMClient,
         skills: SkillStore,
         reasoning_context: CampaignReasoningContextProvider | None = None,
+        image_provider: ContentImageProvider | None = None,
         config: LandingPageGenerationConfig | None = None,
     ):
         self._landing_pages = landing_pages
         self._llm = llm
         self._skills = skills
         self._reasoning_context = reasoning_context
+        self._image_provider = image_provider
         self._config = config or LandingPageGenerationConfig()
 
     def with_reasoning_context(
@@ -260,6 +267,7 @@ class LandingPageGenerationService:
             llm=self._llm,
             skills=self._skills,
             reasoning_context=provider,
+            image_provider=self._image_provider,
             config=self._config,
         )
 
@@ -436,6 +444,7 @@ class LandingPageGenerationService:
             campaign=campaign,
             campaign_payload=campaign_payload,
         )
+        draft = await self._with_optional_image(draft, campaign=campaign)
         saved_ids = tuple(
             str(item) for item in await self._landing_pages.save_drafts([draft], scope=scope)
         )
@@ -890,6 +899,35 @@ class LandingPageGenerationService:
             metadata=metadata,
         )
 
+    async def _with_optional_image(
+        self,
+        draft: LandingPageDraft,
+        *,
+        campaign: MarketingCampaign,
+    ) -> LandingPageDraft:
+        if self._image_provider is None or str(draft.hero.get("image_url") or "").strip():
+            return draft
+        try:
+            asset = await self._image_provider.select_image(
+                ContentImageRequest(
+                    asset_type="landing_page",
+                    slot="hero",
+                    title=draft.title,
+                    query_terms=(
+                        campaign.name,
+                        campaign.persona,
+                        campaign.value_prop,
+                        *campaign.categories,
+                        *campaign.tags,
+                    ),
+                )
+            )
+        except Exception:
+            return draft
+        if asset is None:
+            return draft
+        return _landing_page_with_image_asset(draft, asset)
+
 
 def _landing_page_source_context(context: Mapping[str, Any]) -> dict[str, Any]:
     return {
@@ -897,6 +935,38 @@ def _landing_page_source_context(context: Mapping[str, Any]) -> dict[str, Any]:
         for key in LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS
         if key in context and context[key] not in (None, "", [], {})
     }
+
+
+def _landing_page_with_image_asset(
+    draft: LandingPageDraft,
+    asset: ContentImageAsset,
+) -> LandingPageDraft:
+    hero = dict(draft.hero or {})
+    meta = dict(draft.meta or {})
+    metadata = dict(draft.metadata or {})
+    if not str(hero.get("image_url") or "").strip():
+        hero["image_url"] = asset.url
+    if asset.alt_text:
+        if not str(hero.get("image_alt") or "").strip():
+            hero["image_alt"] = asset.alt_text
+    if not str(meta.get("og_image_url") or "").strip():
+        meta["og_image_url"] = asset.url
+    metadata["content_image"] = asset.as_dict()
+    return LandingPageDraft(
+        campaign_name=draft.campaign_name,
+        persona=draft.persona,
+        value_prop=draft.value_prop,
+        title=draft.title,
+        slug=draft.slug,
+        hero=hero,
+        sections=tuple(draft.sections),
+        cta=dict(draft.cta or {}),
+        meta=meta,
+        reference_ids=tuple(draft.reference_ids),
+        metadata=metadata,
+        id=draft.id,
+        status=draft.status,
+    )
 
 
 def _quality_repair_history_row(

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -189,6 +189,9 @@
       "target": "extracted_content_pipeline/content_ops_cache_policy.py"
     },
     {
+      "target": "extracted_content_pipeline/content_image_provider.py"
+    },
+    {
       "target": "extracted_content_pipeline/campaign_ports.py"
     },
     {

--- a/plans/PR-Content-Ops-Image-Provider-Unsplash.md
+++ b/plans/PR-Content-Ops-Image-Provider-Unsplash.md
@@ -1,0 +1,129 @@
+# PR: Content Ops Image Provider Unsplash
+
+## Why this slice exists
+
+Plan PR #1238 identified the next product gap after the landing/blog upload
+handoff: generated landing pages and blog posts have public review/publish
+paths, but no host-owned way to attach a real visual asset. Landing-page drafts
+already expose `hero.image_url` and `meta.og_image_url`, and blog drafts have
+flexible metadata, so the smallest shippable slice is a provider port plus one
+concrete free-first adapter that enriches drafts before persistence.
+
+This PR implements the Unsplash half of that plan. It keeps paid AI fallback
+behind the same port but defers the Flux/OpenRouter adapter until the free path
+is proven and reviewed.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/image-provider
+
+Slice phase: Vertical slice
+
+1. Add a package-owned content image provider port and Unsplash adapter that
+   searches one landscape image using a typed config object and mocked
+   transport in tests.
+2. Wire the optional provider into landing-page and blog-post generation so
+   successful image lookup enriches drafts before save:
+   - landing page: `hero.image_url`, `meta.og_image_url`, `metadata.content_image`
+   - blog post: `metadata.cover_image`
+3. Keep image lookup best-effort: missing config, no results, malformed
+   response, download-tracking failure, or provider exception yields the
+   original draft rather than failing content generation.
+4. Add typed host config fields under the existing Content Ops/B2B campaign
+   settings surface using `ATLAS_CONTENT_OPS_IMAGE_*` aliases; no direct
+   environment reads.
+5. Add focused tests for adapter request shape, Unsplash attribution/download
+   tracking, draft enrichment, and provider failure fallback.
+
+### Files touched
+
+- `extracted_content_pipeline/content_image_provider.py`
+- `extracted_content_pipeline/landing_page_generation.py`
+- `extracted_content_pipeline/blog_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `atlas_brain/config.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_content_image_provider.py`
+- `tests/test_extracted_landing_page_generation.py`
+- `tests/test_extracted_blog_generation.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-Image-Provider-Unsplash.md`
+
+## Mechanism
+
+`ContentImageProvider` exposes one async method:
+
+```python
+async def select_image(request: ContentImageRequest) -> ContentImageAsset | None: ...
+```
+
+`UnsplashContentImageProvider` uses the official public-auth shape
+(`Authorization: Client-ID <access-key>`) against `/search/photos`, selects the
+first result, then calls the returned `links.download_location` before returning
+the hotlinked URL and attribution. Tests mock the opener and assert both
+requests, so CI never calls Unsplash.
+
+Generation services accept `image_provider: ContentImageProvider | None`.
+When absent, behavior is unchanged. When present, the service builds a compact
+query from trusted draft/campaign/blueprint fields, calls the provider, and
+copies the returned asset into draft metadata. Provider errors are caught
+locally because visual enrichment must not fail an otherwise successful content
+generation run.
+
+## Intentional
+
+- Unsplash only in this slice. Flux/OpenRouter fallback remains deferred behind
+  the same port because OpenRouter image-generation request/response shape and
+  cost accounting need their own focused tests.
+- No schema migration. Landing pages already have image URL fields in JSONB
+  hero/meta, and blog posts already have JSONB metadata.
+- No client-side Unsplash key exposure. The provider runs server-side and is
+  wired only from typed host config.
+- No live API calls in CI. The adapter is transport-mocked.
+
+## Deferred
+
+- Future PR: Flux/OpenRouter fallback adapter with cost metadata and mocked
+  provider transport.
+- Future PR: UI rendering polish for blog cover images if the current public
+  template does not surface `metadata.cover_image`.
+- Parked hardening: none. `HARDENING.md` was scanned; the current entries do
+  not touch the content-ops/image-provider lane.
+
+## Verification
+
+- `pytest tests/test_extracted_content_image_provider.py tests/test_extracted_landing_page_generation.py tests/test_extracted_blog_generation.py -q`
+  - 124 passed.
+- `python -m py_compile extracted_content_pipeline/content_image_provider.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/blog_generation.py atlas_brain/_content_ops_services.py atlas_brain/config.py`
+  - passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  - OK: 142 matching tests are enrolled.
+- `bash scripts/validate_extracted_content_pipeline.sh`
+  - passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Atlas runtime import findings: 0.
+- `bash scripts/check_ascii_python.sh`
+  - ASCII check passed for extracted_content_pipeline Python files.
+- `bash scripts/run_extracted_pipeline_checks.sh`
+  - 2911 passed, 10 skipped, 1 warning; all extracted content pipeline checks completed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-image-provider-unsplash-pr-body.md`
+  - local PR review passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~129 |
+| Provider port + adapter | ~238 |
+| Generator integration | ~129 |
+| Host config/wiring | ~49 |
+| Tests + CI enrollment | ~323 |
+| **Total** | **~878** |
+
+This is above the soft cap because the provider, generation integration, host
+typed-config wiring, manifest enrollment, and failure-detection tests need to
+ship together; splitting the adapter from the draft enrichment would leave an
+unused provider or an untested generation hook. The Flux/OpenRouter fallback is
+deferred specifically to keep this already-over-budget vertical slice bounded.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -67,6 +67,7 @@ pytest \
   tests/test_smoke_content_ops_review_source_postgres.py \
   tests/test_smoke_content_ops_cfpb_source_postgres.py \
   tests/test_extracted_content_ingestion_diagnostics.py \
+  tests/test_extracted_content_image_provider.py \
   tests/test_extracted_blog_generation.py \
   tests/test_extracted_blog_blueprint_ingest.py \
   tests/test_extracted_blog_blueprint_postgres.py \

--- a/tests/test_extracted_blog_generation.py
+++ b/tests/test_extracted_blog_generation.py
@@ -21,6 +21,7 @@ from extracted_content_pipeline.campaign_ports import (
     LLMResponse,
     TenantScope,
 )
+from extracted_content_pipeline.content_image_provider import ContentImageAsset
 from extracted_quality_gate.types import QualityPolicy
 
 
@@ -272,6 +273,19 @@ class _ReasoningProvider:
         return self.context
 
 
+class _ImageProvider:
+    def __init__(self, asset=None, error: Exception | None = None):
+        self.asset = asset
+        self.error = error
+        self.calls = []
+
+    async def select_image(self, request):
+        self.calls.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.asset
+
+
 def _service(
     *,
     rows=None,
@@ -279,6 +293,7 @@ def _service(
     prompts=None,
     config=None,
     reasoning_context=None,
+    image_provider=None,
 ):
     blueprints = _Blueprints(rows or [_blueprint()])
     blog_posts = _BlogPosts()
@@ -292,6 +307,7 @@ def _service(
         llm=llm,
         skills=skills,
         reasoning_context=reasoning_context,
+        image_provider=image_provider,
         config=config or BlogPostGenerationConfig(
             quality_policy=QualityPolicy(
                 name="blog_post",
@@ -721,6 +737,54 @@ async def test_generate_persists_blog_drafts_via_ports() -> None:
     assert draft.slug == "hubspot-pricing-pressure"
     assert draft.metadata["target_keyword"] == "hubspot pricing pressure"
     assert draft.metadata["generation_model"] == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_generate_attaches_optional_blog_cover_image_before_save() -> None:
+    image_provider = _ImageProvider(
+        ContentImageAsset(
+            url="https://images.example.com/blog.jpg",
+            provider="unsplash",
+            alt_text="Pricing dashboard",
+            attribution_name="Ada Lens",
+            attribution_url="https://unsplash.example.com/@ada",
+            source_id="photo-1",
+        )
+    )
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        image_provider=image_provider
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert draft.metadata["cover_image"]["url"] == "https://images.example.com/blog.jpg"
+    assert draft.metadata["cover_image"]["provider"] == "unsplash"
+    assert image_provider.calls[0].asset_type == "blog_post"
+    assert image_provider.calls[0].slot == "cover"
+    assert "HubSpot" in image_provider.calls[0].title
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_blog_post_when_image_provider_fails() -> None:
+    service, _blueprints, blog_posts, _llm, _skills = _service(
+        image_provider=_ImageProvider(error=RuntimeError("image service unavailable"))
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        limit=1,
+    )
+
+    assert result.generated == 1
+    draft = blog_posts.saved[0]["drafts"][0]
+    assert "cover_image" not in draft.metadata
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_image_provider.py
+++ b/tests/test_extracted_content_image_provider.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+import urllib.request
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import extracted_content_pipeline.content_image_provider as image_provider_mod
+from extracted_content_pipeline.content_image_provider import (
+    ContentImageRequest,
+    UnsplashContentImageProvider,
+    UnsplashContentImageProviderConfig,
+)
+
+
+class _Response:
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def getcode(self) -> int:
+        return self.status
+
+
+class _Transport:
+    def __init__(self, *responses: _Response) -> None:
+        self.responses = list(responses)
+        self.requests: list[urllib.request.Request] = []
+
+    def __call__(self, request: urllib.request.Request, timeout: float) -> _Response:
+        assert timeout == 7.0
+        self.requests.append(request)
+        assert self.responses, f"unexpected request: {request.full_url}"
+        return self.responses.pop(0)
+
+
+def _provider(transport: _Transport, *, base_url: str = "https://api.unsplash.test"):
+    return UnsplashContentImageProvider(
+        UnsplashContentImageProviderConfig(
+            enabled=True,
+            access_key="unsplash-key",
+            base_url=base_url,
+            timeout_seconds=7.0,
+        ),
+        opener=transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsplash_provider_selects_first_landscape_and_tracks_download() -> None:
+    transport = _Transport(
+        _Response({
+            "results": [{
+                "id": "photo-1",
+                "alt_description": "Support team reviewing customer questions",
+                "urls": {"regular": "https://images.unsplash.test/photo-1.jpg"},
+                "links": {
+                    "html": "https://unsplash.test/photos/photo-1",
+                    "download_location": "https://api.unsplash.test/photos/photo-1/download",
+                },
+                "user": {
+                    "name": "Ada Lens",
+                    "links": {"html": "https://unsplash.test/@ada"},
+                },
+            }],
+        }),
+        _Response({"url": "https://images.unsplash.test/photo-1.jpg"}),
+    )
+    provider = _provider(transport)
+
+    asset = await provider.select_image(
+        ContentImageRequest(
+            asset_type="landing_page",
+            slot="hero",
+            title="Support FAQ gaps",
+            query_terms=("SaaS help desk", "customer support"),
+        )
+    )
+
+    assert asset is not None
+    assert asset.url == "https://images.unsplash.test/photo-1.jpg"
+    assert asset.provider == "unsplash"
+    assert asset.attribution_name == "Ada Lens"
+    assert asset.attribution_url == "https://unsplash.test/@ada"
+    assert asset.source_id == "photo-1"
+    assert [request.get_method() for request in transport.requests] == ["GET", "GET"]
+    assert [
+        request.get_header("Authorization") for request in transport.requests
+    ] == ["Client-ID unsplash-key", "Client-ID unsplash-key"]
+
+    search_url = urlparse(transport.requests[0].full_url)
+    assert search_url.path == "/search/photos"
+    params = parse_qs(search_url.query)
+    assert params["query"] == ["Support FAQ gaps SaaS help desk customer support"]
+    assert params["per_page"] == ["1"]
+    assert params["orientation"] == ["landscape"]
+    assert transport.requests[1].full_url == (
+        "https://api.unsplash.test/photos/photo-1/download"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsplash_provider_offloads_blocking_transport_to_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _Transport(_Response({"results": []}))
+    provider = _provider(transport)
+    calls = []
+
+    async def fake_to_thread(func, *args):
+        calls.append((func, args))
+        return func(*args)
+
+    monkeypatch.setattr(image_provider_mod.asyncio, "to_thread", fake_to_thread)
+
+    asset = await provider.select_image(
+        ContentImageRequest(asset_type="landing_page", slot="hero", title="FAQ gaps")
+    )
+
+    assert asset is None
+    assert len(calls) == 1
+    assert calls[0][0].__name__ == "_select_image_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"results": []},
+        {"results": [{"urls": {}, "links": {}}]},
+        {"results": [{"urls": {"regular": "http://images.test/photo.jpg"}, "links": {}}]},
+    ),
+)
+async def test_unsplash_provider_fails_closed_on_malformed_envelopes(
+    payload: dict[str, Any],
+) -> None:
+    transport = _Transport(_Response(payload))
+    provider = _provider(transport)
+
+    asset = await provider.select_image(
+        ContentImageRequest(asset_type="blog_post", slot="cover", title="Pricing pressure")
+    )
+
+    assert asset is None
+
+
+@pytest.mark.asyncio
+async def test_unsplash_provider_requires_download_tracking_success() -> None:
+    transport = _Transport(
+        _Response({
+            "results": [{
+                "id": "photo-1",
+                "urls": {"regular": "https://images.unsplash.test/photo-1.jpg"},
+                "links": {
+                    "download_location": "https://api.unsplash.test/photos/photo-1/download"
+                },
+            }],
+        }),
+        _Response({"error": "rate limited"}, status=429),
+    )
+    provider = _provider(transport)
+
+    asset = await provider.select_image(
+        ContentImageRequest(asset_type="landing_page", slot="hero", title="FAQ gaps")
+    )
+
+    assert asset is None
+    assert len(transport.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_unsplash_provider_rejects_unsafe_base_url_without_transport_call() -> None:
+    transport = _Transport()
+    provider = _provider(transport, base_url="http://localhost:9000")
+
+    asset = await provider.select_image(
+        ContentImageRequest(asset_type="landing_page", slot="hero", title="FAQ gaps")
+    )
+
+    assert asset is None
+    assert transport.requests == []

--- a/tests/test_extracted_landing_page_generation.py
+++ b/tests/test_extracted_landing_page_generation.py
@@ -9,6 +9,9 @@ from extracted_content_pipeline.campaign_ports import (
     LLMResponse,
     TenantScope,
 )
+from extracted_content_pipeline.content_image_provider import (
+    ContentImageAsset,
+)
 from extracted_content_pipeline.landing_page_generation import (
     LandingPageGenerationConfig,
     LandingPageGenerationService,
@@ -102,6 +105,19 @@ class _ReasoningProvider:
             "target_mode": target_mode,
         })
         return self.context
+
+
+class _ImageProvider:
+    def __init__(self, asset=None, error: Exception | None = None):
+        self.asset = asset
+        self.error = error
+        self.calls = []
+
+    async def select_image(self, request):
+        self.calls.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.asset
 
 
 def _campaign() -> MarketingCampaign:
@@ -224,7 +240,14 @@ def _draft_from_response(
     )
 
 
-def _service(*, responses=None, prompts=None, reasoning_context=None, config=None):
+def _service(
+    *,
+    responses=None,
+    prompts=None,
+    reasoning_context=None,
+    config=None,
+    image_provider=None,
+):
     landing_pages = _LandingPages()
     llm = _LLM(responses or [_valid_response()])
     if prompts is None:
@@ -238,6 +261,7 @@ def _service(*, responses=None, prompts=None, reasoning_context=None, config=Non
         llm=llm,
         skills=skills,
         reasoning_context=reasoning_provider,
+        image_provider=image_provider,
         config=config or LandingPageGenerationConfig(),
     )
     return service, landing_pages, llm, skills, reasoning_provider
@@ -420,6 +444,55 @@ async def test_generate_persists_one_landing_page_per_call_via_save_drafts() -> 
     )
     assert "preventable churn" in draft.sections[0].metadata["answer_summary"]
     assert draft.metadata["generation_model"] == "test-model"
+
+
+@pytest.mark.asyncio
+async def test_generate_attaches_optional_landing_page_image_before_save() -> None:
+    payload = json.loads(_valid_response())
+    payload["hero"]["image_url"] = ""
+    payload["hero"]["image_alt"] = ""
+    payload["meta"] = {"og_image_url": None}
+    image_provider = _ImageProvider(
+        ContentImageAsset(
+            url="https://images.example.com/landing.jpg",
+            provider="unsplash",
+            alt_text="Support team reviewing customer questions",
+            attribution_name="Ada Lens",
+            attribution_url="https://unsplash.example.com/@ada",
+            source_id="photo-1",
+        )
+    )
+    service, landing_pages, _llm, _skills, _rp = _service(
+        responses=[json.dumps(payload)],
+        config=LandingPageGenerationConfig(quality_gates_enabled=False),
+        image_provider=image_provider,
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 1
+    draft = landing_pages.saved[0]["drafts"][0]
+    assert draft.hero["image_url"] == "https://images.example.com/landing.jpg"
+    assert draft.hero["image_alt"] == "Support team reviewing customer questions"
+    assert draft.meta["og_image_url"] == "https://images.example.com/landing.jpg"
+    assert draft.metadata["content_image"]["provider"] == "unsplash"
+    assert image_provider.calls[0].asset_type == "landing_page"
+    assert image_provider.calls[0].slot == "hero"
+    assert "Acme Q3" in image_provider.calls[0].title
+
+
+@pytest.mark.asyncio
+async def test_generate_keeps_landing_page_when_image_provider_fails() -> None:
+    service, landing_pages, _llm, _skills, _rp = _service(
+        image_provider=_ImageProvider(error=RuntimeError("image service unavailable"))
+    )
+
+    result = await service.generate(scope=TenantScope(account_id="acct-1"), campaign=_campaign())
+
+    assert result.generated == 1
+    draft = landing_pages.saved[0]["drafts"][0]
+    assert "image_url" not in draft.hero
+    assert "content_image" not in draft.metadata
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Image-Provider-Unsplash.md
Slice phase: Vertical slice

This PR implements the first image-provider slice from the merged #1238 plan: a server-side Unsplash provider port plus optional draft enrichment for Content Ops landing pages and blog posts. It keeps image lookup best-effort and opt-in through typed `ATLAS_CONTENT_OPS_IMAGE_*` config, with all provider transport mocked in CI.

## Intentional
- Unsplash only in this slice; Flux/OpenRouter fallback is deferred behind the same port to keep this over-budget vertical slice bounded.
- No schema migration; landing pages already expose `hero.image_url` / `meta.og_image_url`, and blog posts use JSONB metadata for `cover_image`.
- No client-side key exposure; provider construction happens server-side from typed config.
- No live Unsplash calls in CI; tests mock search and download-tracking requests.

## Deferred
- Future PR: Flux/OpenRouter fallback adapter with cost metadata and mocked provider transport.
- Future PR: UI rendering polish for blog cover images if the public template does not surface `metadata.cover_image`.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_image_provider.py tests/test_extracted_landing_page_generation.py tests/test_extracted_blog_generation.py -q` - 124 passed.
- `python -m py_compile extracted_content_pipeline/content_image_provider.py extracted_content_pipeline/landing_page_generation.py extracted_content_pipeline/blog_generation.py atlas_brain/_content_ops_services.py atlas_brain/config.py` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - OK: 142 matching tests are enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - Atlas runtime import findings: 0.
- `bash scripts/check_ascii_python.sh` - passed.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2911 passed, 10 skipped, 1 warning; all extracted content pipeline checks completed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-image-provider-unsplash-pr-body.md` - local PR review passed.

## Diff size
11 files, +878 / -2. Over the soft cap because the provider, draft enrichment hooks, host config, manifest entry, and failure-detection tests need to ship together.