### PR TITLE
PR-Deflection-Evidence-Scope-Gate

### DIFF
--- a/docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md
+++ b/docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md
@@ -95,7 +95,8 @@ returns the persisted FAQ draft:
 Each detail `items[]` entry carries the full generated FAQ shape:
 
 - strings: `topic`, `question`, `question_source`, `summary`, `answer`,
-  `answer_evidence_status`, `when_to_contact_support`
+  `answer_evidence_status`, `resolution_evidence_scope`,
+  `when_to_contact_support`
 - integers: `frequency`, `weighted_frequency`, `ticket_count`,
   `opportunity_score`, `failure_risk_score`, `resolution_source_count`,
   `evidence_count`, `displayed_evidence_count`

--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -20,6 +20,7 @@
         "opportunity_score": 2,
         "question": "How do I export attribution reports?",
         "question_source": "customer_wording",
+        "resolution_evidence_scope": "scoped",
         "resolution_source_count": 2,
         "source_ids": [
           "ticket-export-1",
@@ -87,6 +88,7 @@
         "opportunity_score": 2,
         "question": "Can I turn on SSO for all users?",
         "question_source": "customer_wording",
+        "resolution_evidence_scope": "not_applicable",
         "resolution_source_count": 0,
         "source_ids": [
           "ticket-sso-2",
@@ -130,6 +132,7 @@
     "output_checks": {
       "condensed": true,
       "has_action_items": true,
+      "resolution_evidence_scoped": true,
       "uses_user_vocabulary": true
     },
     "saved_ids": [],
@@ -145,6 +148,7 @@
     "output_checks": {
       "condensed": true,
       "has_action_items": true,
+      "resolution_evidence_scoped": true,
       "uses_user_vocabulary": true
     },
     "source_count": 4,

--- a/docs/frontend/content_ops_faq_report_example.json
+++ b/docs/frontend/content_ops_faq_report_example.json
@@ -23,6 +23,7 @@
       "opportunity_score": 42,
       "question": "Which remaining support questions need manual review?",
       "question_source": "source_policy",
+      "resolution_evidence_scope": "not_applicable",
       "resolution_source_count": 0,
       "source_ids": [
         "search-export-1",
@@ -71,6 +72,7 @@
   "output_checks": {
     "condensed": true,
     "has_action_items": true,
+    "resolution_evidence_scoped": true,
     "uses_user_vocabulary": true
   },
   "saved_ids": [],

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -655,6 +655,12 @@ def _item(
     answer_evidence_status = (
         "resolution_evidence" if resolution_texts else "draft_needs_review"
     )
+    resolution_evidence_scope = _resolution_evidence_scope_status(
+        has_mixed_evidence_scopes=has_mixed_evidence_scopes,
+        question_row=question_row,
+        resolution_rows=resolution_rows,
+        resolution_texts=resolution_texts,
+    )
     steps = _article_steps(
         topic,
         action_context,
@@ -683,6 +689,7 @@ def _item(
         "summary": summary,
         "steps": steps,
         "answer_evidence_status": answer_evidence_status,
+        "resolution_evidence_scope": resolution_evidence_scope,
         "resolution_source_count": _resolution_source_count(resolution_rows),
         "when_to_contact_support": escalation,
         "evidence_quotes": evidence_quotes,
@@ -820,6 +827,34 @@ def _resolution_source_count(rows: Sequence[Mapping[str, Any]]) -> int:
     return len(_distinct_source_keys([
         row for row in rows if _compact(row.get("resolution_text"))
     ]))
+
+
+def _resolution_evidence_scope_status(
+    *,
+    has_mixed_evidence_scopes: bool,
+    question_row: Mapping[str, Any] | None,
+    resolution_rows: Sequence[Mapping[str, Any]],
+    resolution_texts: Sequence[str],
+) -> str:
+    if not resolution_texts:
+        return "not_applicable"
+    if has_mixed_evidence_scopes:
+        return "mixed_evidence_scope"
+    resolution_scopes = {
+        _clean(row.get("evidence_group_key"))
+        for row in resolution_rows
+        if _compact(row.get("resolution_text")) and _clean(row.get("evidence_group_key"))
+    }
+    if len(resolution_scopes) != 1:
+        return "missing_resolution_scope"
+    question_scope = _clean(
+        question_row.get("evidence_group_key") if question_row is not None else ""
+    )
+    if not question_scope:
+        return "missing_question_scope"
+    if question_scope and resolution_scopes != {question_scope}:
+        return "scope_mismatch"
+    return "scoped"
 
 
 def _resolution_excerpt(value: Any, *, limit: int = 180) -> str:
@@ -1726,7 +1761,15 @@ def _output_checks(
         and covers_all_sources
         and (ticket_source_count <= 1 or len(items) < ticket_source_count),
         "has_action_items": has_items and all(bool(item.get("action_items")) for item in items),
+        "resolution_evidence_scoped": has_items
+        and all(_resolution_evidence_is_scoped(item) for item in items),
     }
+
+
+def _resolution_evidence_is_scoped(item: Mapping[str, Any]) -> bool:
+    if item.get("answer_evidence_status") != "resolution_evidence":
+        return True
+    return item.get("resolution_evidence_scope") == "scoped"
 
 
 def _rendered_ticket_source_count(items: Sequence[Mapping[str, Any]]) -> int:

--- a/plans/PR-Deflection-Evidence-Scope-Gate.md
+++ b/plans/PR-Deflection-Evidence-Scope-Gate.md
@@ -1,0 +1,126 @@
+## Why this slice exists
+
+`PR-Deflection-Question-Evidence-Scoping` fixed the cross-resolution bleed that
+large SaaS validation exposed, and the follow-up copy slices made the proven
+drafts buyer-readable. The remaining safety gap is explicit enforcement: the
+generator now scopes resolution rows correctly, but the output checks do not
+fail closed if a future change marks an item as `resolution_evidence` while its
+resolution rows are outside the selected question scope.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Production hardening
+
+1. Add item-level resolution evidence scope metadata for generated FAQ items.
+2. Add an output check, `resolution_evidence_scoped`, that fails when a proven
+   item is not scoped to its own resolution evidence.
+3. Update CLI diagnostics and contract fixtures for the additional output
+   check.
+4. Add focused positive and negative tests, including a direct malformed-item
+   fixture proving the checker failure branch fires.
+5. Update FAQ search/detail contract fixtures so the route checker accepts the
+   producer's new item metadata.
+6. Address review feedback by failing closed when resolution evidence exists
+   but the selected question has no evidence scope to compare.
+
+### Files touched
+
+- `extracted_content_pipeline/ticket_faq_markdown.py`
+- `scripts/build_extracted_ticket_faq_markdown.py`
+- `scripts/check_content_ops_faq_search_route_contract.py`
+- `scripts/smoke_content_ops_faq_output_proof.py`
+- `scripts/smoke_content_ops_faq_search_concurrency.py`
+- `docs/extraction/validation/content_ops_faq_search_route_contract_handoff.md`
+- `tests/test_extracted_ticket_faq_markdown.py`
+- `tests/test_content_ops_faq_report_contract_docs.py`
+- `tests/test_content_ops_faq_saas_demo_corpus.py`
+- `tests/test_check_content_ops_faq_search_route_contract.py`
+- `tests/test_extracted_content_ops_execution_smoke.py`
+- `tests/test_atlas_content_ops_input_provider.py`
+- `tests/test_smoke_content_ops_cfpb_faq_markdown.py`
+- `tests/test_smoke_content_ops_faq_lifecycle.py`
+- `tests/test_smoke_content_ops_faq_output_proof.py`
+- `tests/test_smoke_content_ops_faq_scale_run.py`
+- `tests/test_smoke_content_ops_faq_search_route_concurrency.py`
+- `docs/frontend/content_ops_faq_deflection_report_example.json`
+- `docs/frontend/content_ops_faq_report_example.json`
+- `plans/PR-Deflection-Evidence-Scope-Gate.md`
+
+## Mechanism
+
+The item builder already computes the selected question row, mixed-scope state,
+and scoped resolution rows before producing steps. This slice records a compact
+`resolution_evidence_scope` status on each item:
+
+- `scoped` for resolution-backed drafts whose resolution rows match the selected
+  question scope.
+- `not_applicable` for review-needed drafts without resolution evidence.
+- fail-closed statuses such as `mixed_evidence_scope`, `missing_question_scope`,
+  or `scope_mismatch` for malformed proven states.
+
+The output-check builder then adds `resolution_evidence_scoped`, which requires every
+`resolution_evidence` item to carry the `scoped` status. The CLI and output
+proof smoke include the new check in their fail-closed checks, and
+`_output_check_hint()` gets a specific message for the new check.
+
+Because item detail payloads now expose a new compact status field, the FAQ
+search route contract checker admits `resolution_evidence_scope` as an expected
+string field and the handoff doc names it in the detail item shape.
+
+## Intentional
+
+- This does not change grouping, ranking, answer copy, paywall behavior, or
+  macro writeback. It adds an explicit detector for a safety invariant that the
+  current generator already satisfies.
+- The negative fixture tests the checker directly with a malformed item instead
+  of weakening the generator to create an invalid state.
+- A generator-level negative fixture covers the source-policy fallback case:
+  resolution evidence without a scoped selected question now yields
+  `missing_question_scope` and fails `resolution_evidence_scoped`.
+- The new item metadata is compact status-only data; it does not expose
+  resolution text, raw evidence, or Markdown in snapshot payloads.
+- The broader fixture updates are shape synchronization only; they keep
+  existing support-ticket, CFPB, execution, lifecycle, and search-route tests on
+  the same output-check contract.
+
+## Deferred
+
+- Follow-up slice: richer final help-center prose over verified resolution
+  evidence.
+- Considered hardening: the existing SaaS demo preflight dotenv entry in
+  `HARDENING.md` is unrelated to this detector and remains parked.
+- Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_ticket_faq_markdown.py -q` -- 154 passed.
+- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 184 passed.
+- `pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_lifecycle.py tests/test_smoke_content_ops_cfpb_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_ticket_faq_markdown.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 379 passed, 1 warning.
+- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py tests/test_extracted_ticket_faq_markdown.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 342 passed.
+- Direct 420-row SaaS sample generator check -- 8 items, 7 proven,
+  `resolution_evidence_scoped=True`, no unscoped proven answers.
+- `scripts/validate_extracted_content_pipeline.sh` run with bash -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `scripts/check_ascii_python.sh` run with bash -- passed.
+- Full extracted mirror with live deflection env vars blanked before
+  `scripts/run_extracted_pipeline_checks.sh` -- 2900 passed, 10 skipped, 1
+  known local failure in
+  `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py::test_script_preflight_uses_atlas_db_settings_fallback`
+  from the parked SaaS demo preflight dotenv hardening entry.
+- `scripts/local_pr_review.sh` with the current PR body -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| `extracted_content_pipeline/ticket_faq_markdown.py` | ~45 |
+| CLI/search contract scripts | ~15 |
+| Tests and contract docs | ~100 |
+| Frontend JSON examples | ~10 |
+| Plan doc | ~100 |
+| **Total** | **~285** |
+
+Under the 400 LOC soft cap.

--- a/scripts/build_extracted_ticket_faq_markdown.py
+++ b/scripts/build_extracted_ticket_faq_markdown.py
@@ -560,6 +560,8 @@ def _output_check_hint(name: str, result: Any, rendered_ticket_source_count: int
         return "One or more FAQ questions did not come from customer wording or source policy."
     if name == "has_action_items":
         return "One or more FAQ items did not include actionable next steps."
+    if name == "resolution_evidence_scoped":
+        return "One or more proven answers used resolution evidence outside its selected question scope."
     return "Output check failed."
 
 

--- a/scripts/check_content_ops_faq_search_route_contract.py
+++ b/scripts/check_content_ops_faq_search_route_contract.py
@@ -49,6 +49,7 @@ DETAIL_ITEM_STRING_FIELDS = (
     "summary",
     "answer",
     "answer_evidence_status",
+    "resolution_evidence_scope",
     "when_to_contact_support",
 )
 DETAIL_ITEM_INT_FIELDS = (

--- a/scripts/smoke_content_ops_faq_output_proof.py
+++ b/scripts/smoke_content_ops_faq_output_proof.py
@@ -54,7 +54,7 @@ DEFAULT_ROWS: tuple[dict[str, str], ...] = (
         "source_type": "support_ticket",
         "source_id": "ticket-export-2",
         "source_title": "Reporting dashboard missing export",
-        "text": "The reporting dashboard export is missing for my analyst role.",
+        "text": "How do I export the reporting dashboard for my analyst role?",
         "resolution_text": "Enable Report Downloads for the analyst role before exporting.",
         "pain_category": "reporting friction",
     },
@@ -337,7 +337,12 @@ def _proof_failures(
             "detail": failed_output_checks,
         })
     output_checks = _mapping(proof.get("output_checks"))
-    for name in ("uses_user_vocabulary", "condensed", "has_action_items"):
+    for name in (
+        "uses_user_vocabulary",
+        "condensed",
+        "has_action_items",
+        "resolution_evidence_scoped",
+    ):
         if output_checks.get(name) is not True:
             failures.append({"check": f"output_check_{name}", "detail": output_checks.get(name)})
     topics = set(str(topic) for topic in _sequence(proof.get("topics")))

--- a/scripts/smoke_content_ops_faq_search_concurrency.py
+++ b/scripts/smoke_content_ops_faq_search_concurrency.py
@@ -290,6 +290,7 @@ def _items_for_case(case: SearchCase, *, documents_per_corpus: int) -> list[dict
                 "Contact support if the CSV is missing.",
             ],
             "answer_evidence_status": "draft_needs_review",
+            "resolution_evidence_scope": "not_applicable",
             "resolution_source_count": 0,
             "when_to_contact_support": "Contact support if the exported CSV is missing.",
             "evidence_quotes": [

--- a/tests/test_atlas_content_ops_input_provider.py
+++ b/tests/test_atlas_content_ops_input_provider.py
@@ -838,6 +838,7 @@ async def test_execute_route_generates_support_ticket_faq_at_inline_cap() -> Non
     assert result["output_checks"] == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
     assert result["saved_ids"] == []
@@ -1189,6 +1190,7 @@ async def test_execute_route_generates_faq_from_support_ticket_input_provider() 
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert "FAQ Report" in result["markdown"]
     assert result["items"][0]["source_ids"] == (

--- a/tests/test_check_content_ops_faq_search_route_contract.py
+++ b/tests/test_check_content_ops_faq_search_route_contract.py
@@ -93,6 +93,7 @@ def _valid_detail_item():
         "steps": ["Review the statement.", "Contact support with records."],
         "action_items": ["Review the statement.", "Contact support with records."],
         "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
         "resolution_source_count": 1,
         "when_to_contact_support": "Contact support if the payment still looks wrong.",
         "evidence_quotes": ["`CFPB-1`: payment dispute"],

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -116,6 +116,7 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
     assert payload["output_checks"] == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
 
@@ -126,6 +127,7 @@ def test_content_ops_faq_report_example_matches_documented_core_shape() -> None:
         "opportunity_score",
         "question",
         "question_source",
+        "resolution_evidence_scope",
         "source_ids",
         "steps",
         "summary",
@@ -162,6 +164,7 @@ def test_content_ops_faq_deflection_example_matches_producer_shape() -> None:
     assert payload["summary"]["output_checks"] == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
     assert all(payload["faq_result"]["output_checks"].values())

--- a/tests/test_content_ops_faq_saas_demo_corpus.py
+++ b/tests/test_content_ops_faq_saas_demo_corpus.py
@@ -160,6 +160,7 @@ def test_saas_demo_corpus_generates_valid_faq_output() -> None:
     assert result.output_checks == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
     assert result.items

--- a/tests/test_extracted_content_ops_execution_smoke.py
+++ b/tests/test_extracted_content_ops_execution_smoke.py
@@ -253,6 +253,7 @@ def test_content_ops_execution_smoke_cli_runs_faq_markdown_json() -> None:
     assert result["output_checks"] == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
     assert "What to do next" in result["markdown"]

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -17,6 +17,7 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownConfig,
     TicketFAQMarkdownService,
+    _output_checks,
     build_ticket_faq_markdown,
     normalize_intent_rules,
     weighted_source_volume_by_group,
@@ -168,6 +169,7 @@ def test_build_ticket_faq_markdown_groups_grounded_ticket_evidence() -> None:
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
 
 
@@ -201,6 +203,7 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
 
     item = result.items[0]
     assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
     assert item["resolution_source_count"] == 1
     assert item["steps"][0] == (
         "Open Analytics, choose the attribution dashboard, and select Export CSV"
@@ -216,6 +219,32 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_for_steps() -> None:
     )
     assert "Draft the customer-facing steps" not in result.markdown
     assert "support@example.com" in result.markdown
+
+
+def test_build_ticket_faq_markdown_fails_closed_when_resolution_has_no_question_scope() -> None:
+    result = build_ticket_faq_markdown(
+        [{
+            "source_type": "support_ticket",
+            "source_title": "Export issue",
+            "evidence": [{
+                "text": "The export button disappears for analysts.",
+                "source_id": "ticket-1",
+                "source_type": "support_ticket",
+                "resolution_text": "Enable Report Downloads for the analyst role.",
+            }],
+        }]
+    )
+
+    item = result.items[0]
+    assert item["question_source"] == "source_policy"
+    assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "missing_question_scope"
+    assert result.output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+        "resolution_evidence_scoped": False,
+    }
 
 
 def test_build_ticket_faq_markdown_truncates_resolution_steps_at_word_boundary() -> None:
@@ -264,12 +293,13 @@ def test_build_ticket_faq_markdown_ignores_disposition_resolution_aliases() -> N
 
     item = result.items[0]
     assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
     assert item["resolution_source_count"] == 0
     assert item["steps"][0].startswith("Review the cited ticket evidence")
     assert "Use the uploaded resolution evidence: Closed" not in result.markdown
 
 
-def test_build_ticket_faq_markdown_uses_resolution_evidence_beyond_display_rows() -> None:
+def test_build_ticket_faq_markdown_fails_closed_for_unscoped_resolution_beyond_display_rows() -> None:
     result = build_ticket_faq_markdown(
         [
             {
@@ -296,11 +326,14 @@ def test_build_ticket_faq_markdown_uses_resolution_evidence_beyond_display_rows(
     )
 
     item = result.items[0]
+    assert item["question_source"] == "source_policy"
     assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "missing_question_scope"
     assert item["resolution_source_count"] == 1
     assert item["steps"][0] == (
         "Enable Report Downloads for the analyst role"
     )
+    assert result.output_checks["resolution_evidence_scoped"] is False
 
 
 def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() -> None:
@@ -331,6 +364,7 @@ def test_build_ticket_faq_markdown_counts_resolution_sources_not_unique_texts() 
 
     item = result.items[0]
     assert item["answer_evidence_status"] == "resolution_evidence"
+    assert item["resolution_evidence_scope"] == "scoped"
     assert item["resolution_source_count"] == 2
     assert item["steps"][0] == "Send the reset email from Account Settings"
     assert all(not step.startswith("Use the uploaded") for step in item["steps"])
@@ -376,6 +410,8 @@ def test_build_ticket_faq_markdown_keeps_distinct_questions_from_sharing_resolut
 
     assert scim["answer_evidence_status"] == "resolution_evidence"
     assert warehouse["answer_evidence_status"] == "resolution_evidence"
+    assert scim["resolution_evidence_scope"] == "scoped"
+    assert warehouse["resolution_evidence_scope"] == "scoped"
     assert scim["source_ids"] == ("ticket-scim-1",)
     assert warehouse["source_ids"] == ("ticket-warehouse-1",)
     assert "SCIM in Preview mode" in " ".join(scim["steps"])
@@ -423,6 +459,7 @@ def test_build_ticket_faq_markdown_scopes_overflow_resolution_to_item_question()
     assert item["question"] == "Which remaining support questions need manual review?"
     assert item["source_ids"] == ("ticket-scim-1", "ticket-warehouse-1")
     assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
     assert item["resolution_source_count"] == 0
     assert "SCIM in Preview mode" not in " ".join(item["steps"])
     assert "Analytics > Model refresh" not in " ".join(item["steps"])
@@ -459,6 +496,7 @@ def test_build_ticket_faq_markdown_fails_closed_for_resolved_and_unresolved_over
     item = result.items[0]
     assert item["source_ids"] == ("ticket-export-1", "ticket-sso-1")
     assert item["answer_evidence_status"] == "draft_needs_review"
+    assert item["resolution_evidence_scope"] == "not_applicable"
     assert item["resolution_source_count"] == 0
     assert "Open Reports" not in " ".join(item["steps"])
 
@@ -496,6 +534,27 @@ def test_build_ticket_faq_markdown_clusters_repeated_user_intent() -> None:
     assert "I need to update the email on my account." in result.markdown
     assert result.output_checks["uses_user_vocabulary"] is True
     assert result.output_checks["condensed"] is True
+
+
+def test_ticket_faq_output_check_fails_unscoped_resolution_evidence() -> None:
+    output_checks = _output_checks(
+        items=({
+            "question_source": "customer_wording",
+            "action_items": ("Open Reports.",),
+            "answer_evidence_status": "resolution_evidence",
+            "resolution_evidence_scope": "scope_mismatch",
+            "source_ids": ("ticket-1",),
+        },),
+        ticket_source_count=1,
+        rendered_ticket_source_count=1,
+    )
+
+    assert output_checks == {
+        "uses_user_vocabulary": True,
+        "condensed": True,
+        "has_action_items": True,
+        "resolution_evidence_scoped": False,
+    }
 
 
 def test_build_ticket_faq_markdown_ranks_by_frequency_times_failure_risk() -> None:
@@ -1058,6 +1117,7 @@ def test_build_ticket_faq_markdown_derives_question_from_complaint_narrative() -
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert "Review the cited ticket evidence and confirm the policy-approved answer" in result.markdown
     assert result.items[0]["answer_evidence_status"] == "draft_needs_review"
@@ -1455,6 +1515,7 @@ def test_build_ticket_faq_markdown_condenses_tail_groups_when_item_cap_is_lower_
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
 
 
@@ -1492,6 +1553,7 @@ def test_build_ticket_faq_markdown_preserves_top_group_when_single_item_cap_over
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
 
 
@@ -1605,6 +1667,7 @@ def test_build_ticket_faq_markdown_handles_1000_cfpb_style_rows_without_archive(
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert all(item["question_source"] != "topic_fallback" for item in result.items)
     assert all("XX/XX/2019" not in question for question in questions)
@@ -1722,6 +1785,7 @@ def test_ticket_faq_markdown_renders_action_and_source_lists_from_packaged_rows(
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
 
 
@@ -2141,6 +2205,7 @@ def test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits
         "uses_user_vocabulary": False,
         "condensed": False,
         "has_action_items": False,
+        "resolution_evidence_scoped": False,
     }
     with pytest.raises(ValueError, match="max_items must be positive"):
         build_ticket_faq_markdown([], max_items=0)
@@ -2341,6 +2406,7 @@ def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_credit_report_r
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "Open the reporting or analytics area" not in result.markdown
@@ -2397,6 +2463,7 @@ def test_build_ticket_faq_markdown_uses_cfpb_product_context_for_mortgage_rows(t
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert "Draft the customer-facing steps from a verified help article" in result.markdown
     assert "Open the bill, statement, payment history, or dispute record" not in result.markdown
@@ -2731,9 +2798,9 @@ def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:
         "source_channel_counts": {"support_tickets": 4},
         "zero_result_search_source_count": 0,
         "output_checks": {
-            "passed": 3,
+            "passed": 4,
             "failed": 0,
-            "total": 3,
+            "total": 4,
             "failed_checks": [],
         },
         "vocabulary_gaps": {
@@ -3998,13 +4065,14 @@ def test_ticket_faq_cli_fails_required_output_checks_for_weak_rows(tmp_path: Pat
             ),
         },
         {"check": "has_action_items", "passed": True},
+        {"check": "resolution_evidence_scoped", "passed": True},
         {"check": "uses_user_vocabulary", "passed": True},
     ]
     assert result["diagnostics"]["run_summary"]["status"] == "failed_output_checks"
     assert result["diagnostics"]["run_summary"]["output_checks"] == {
-        "passed": 2,
+        "passed": 3,
         "failed": 1,
-        "total": 3,
+        "total": 4,
         "failed_checks": ["condensed"],
     }
     assert result["diagnostics"]["run_summary"]["generated"] == 2

--- a/tests/test_smoke_content_ops_cfpb_faq_markdown.py
+++ b/tests/test_smoke_content_ops_cfpb_faq_markdown.py
@@ -100,6 +100,7 @@ def test_cfpb_faq_smoke_builds_grounded_markdown(monkeypatch, tmp_path: Path) ->
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert calls[0]["require_narrative"] is True
     assert payload["source_profile"]["raw_row_count"] == 4
@@ -154,6 +155,7 @@ def test_cfpb_faq_smoke_accepts_source_policy_questions_for_weak_rows(
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert payload["faq"]["items"][0]["question_source"] == "source_policy"
     assert payload["errors"] == []

--- a/tests/test_smoke_content_ops_faq_lifecycle.py
+++ b/tests/test_smoke_content_ops_faq_lifecycle.py
@@ -143,6 +143,7 @@ async def test_faq_lifecycle_smoke_generates_exports_reviews_and_reexports(monke
         "uses_user_vocabulary": True,
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
     }
     assert payload["normalization_warnings"] == {
         "warning_count": 0,
@@ -233,6 +234,7 @@ async def test_faq_lifecycle_smoke_persists_1000_row_json_bundle(monkeypatch, tm
             "uses_user_vocabulary": True,
             "condensed": True,
             "has_action_items": True,
+            "resolution_evidence_scoped": True,
         },
         "saved_faq_count": 1,
         "draft_export_count": 1,

--- a/tests/test_smoke_content_ops_faq_output_proof.py
+++ b/tests/test_smoke_content_ops_faq_output_proof.py
@@ -69,6 +69,7 @@ def test_faq_output_proof_writes_artifacts_and_passes(tmp_path: Path) -> None:
     assert result["output_checks"] == {
         "condensed": True,
         "has_action_items": True,
+        "resolution_evidence_scoped": True,
         "uses_user_vocabulary": True,
     }
     assert "ticket-export-1" in markdown
@@ -117,6 +118,7 @@ def test_faq_output_proof_reports_failed_predicates() -> None:
                 "uses_user_vocabulary": True,
                 "condensed": False,
                 "has_action_items": False,
+                "resolution_evidence_scoped": False,
             },
             "topics": ["reporting friction"],
             "min_source_id_count": 0,
@@ -146,6 +148,7 @@ def test_faq_output_proof_reports_failed_predicates() -> None:
         "output_checks_pass",
         "output_check_condensed",
         "output_check_has_action_items",
+        "output_check_resolution_evidence_scoped",
         "topic_present",
         "generated_items",
         "source_id_coverage",

--- a/tests/test_smoke_content_ops_faq_scale_run.py
+++ b/tests/test_smoke_content_ops_faq_scale_run.py
@@ -426,7 +426,7 @@ def test_faq_scale_smoke_main_uses_cli_defaults(tmp_path: Path, capsys) -> None:
     assert "faq=available" in captured.out
     assert "generated=2" in captured.out
     assert "weighted_volume=4" in captured.out
-    assert "checks_failed=0/3" in captured.out
+    assert "checks_failed=0/4" in captured.out
     assert "score_max=4" in captured.out
     assert "summary=" in captured.out
     assert captured.err == ""
@@ -451,7 +451,7 @@ def test_faq_scale_smoke_main_prints_profile_on_failure(tmp_path: Path, capsys) 
     assert "source_rows=2/3" in captured.err
     assert "faq=available" in captured.err
     assert "generated=2" in captured.err
-    assert "checks_failed=1/3" in captured.err
+    assert "checks_failed=1/4" in captured.err
     assert "skipped_rows=1" in captured.err
     assert "missing_source_text=1" in captured.err
     assert "failure=output_checks" in captured.err

--- a/tests/test_smoke_content_ops_faq_search_route_concurrency.py
+++ b/tests/test_smoke_content_ops_faq_search_route_concurrency.py
@@ -105,6 +105,7 @@ def _valid_detail_payload(faq_id="11111111-1111-1111-1111-111111111111"):
             "steps": ["Review the statement.", "Contact support with records."],
             "action_items": ["Review the statement.", "Contact support with records."],
             "answer_evidence_status": "draft_needs_review",
+            "resolution_evidence_scope": "not_applicable",
             "resolution_source_count": 0,
             "when_to_contact_support": "Contact support if the payment still looks wrong.",
             "evidence_quotes": ["`CFPB-1`: payment dispute"],


### PR DESCRIPTION
Plan: plans/PR-Deflection-Evidence-Scope-Gate.md
Slice phase: Production hardening

Add a fail-closed resolution evidence scope gate for FAQ deflection output. The generator now emits compact `resolution_evidence_scope` metadata for each item, and output/proof checks fail if a proven `resolution_evidence` answer is not scoped to the selected question's own resolution evidence. Search/detail contract fixtures and docs are synchronized so downstream route validation accepts the producer's new item shape.

## Intentional
- Status-only metadata: no raw resolution text, raw evidence, or Markdown is exposed in snapshot payloads.
- No grouping, ranking, answer-copy, paywall, or macro-writeback behavior changes.
- The broader fixture updates are contract-shape synchronization for existing support-ticket, CFPB, execution, lifecycle, and search-route tests.
- Review feedback addressed: resolution-backed source-policy fallback items with no selected-question evidence scope now fail closed as `missing_question_scope`.

## Deferred
- Richer final help-center prose over verified resolution evidence remains a follow-up slice.

## Parked hardening
- None. The existing SaaS demo preflight dotenv entry in `HARDENING.md` remains parked and unrelated to this detector.

## Verification
- `pytest tests/test_extracted_ticket_faq_markdown.py -q` -- 154 passed.
- `pytest tests/test_extracted_ticket_faq_markdown.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 184 passed.
- `pytest tests/test_content_ops_faq_saas_demo_corpus.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_scale_run.py tests/test_smoke_content_ops_faq_lifecycle.py tests/test_smoke_content_ops_cfpb_faq_markdown.py tests/test_extracted_content_ops_execution_smoke.py tests/test_atlas_content_ops_input_provider.py tests/test_extracted_ticket_faq_markdown.py tests/test_content_ops_faq_report_contract_docs.py tests/test_content_ops_deflection_report.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 379 passed, 1 warning.
- `pytest tests/test_smoke_content_ops_faq_search_concurrency.py tests/test_smoke_content_ops_faq_search_route_concurrency.py tests/test_extracted_ticket_faq_markdown.py tests/test_check_content_ops_faq_search_route_contract.py tests/test_smoke_content_ops_faq_output_proof.py -q` -- 342 passed.
- Direct 420-row SaaS sample generator check -- 8 items, 7 proven, `resolution_evidence_scoped=True`, no unscoped proven answers.
- `scripts/validate_extracted_content_pipeline.sh` run with bash -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `scripts/check_ascii_python.sh` run with bash -- passed.
- Full extracted mirror with live deflection env vars blanked before `scripts/run_extracted_pipeline_checks.sh` -- 2900 passed, 10 skipped, 1 known local failure in `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py::test_script_preflight_uses_atlas_db_settings_fallback` from the parked SaaS demo preflight dotenv hardening entry.
- `scripts/local_pr_review.sh` with this PR body -- passed.

## Diff size
20 files, +279 / -10.
