### PR TITLE
PR-Content-Ops-Reviews-Input-Provider

### DIFF
--- a/.github/workflows/atlas_content_ops_input_provider_checks.yml
+++ b/.github/workflows/atlas_content_ops_input_provider_checks.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
       - "atlas_brain/_content_ops_input_provider.py"
       - "tests/test_atlas_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_review_input_provider.py"
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
       - "atlas_brain/_content_ops_input_provider.py"
       - "tests/test_atlas_content_ops_input_provider.py"
+      - "tests/test_atlas_content_ops_review_input_provider.py"
 
 jobs:
   atlas-content-ops-input-provider-checks:
@@ -37,4 +39,5 @@ jobs:
         run: |
           python -m pytest \
             tests/test_atlas_content_ops_input_provider.py \
+            tests/test_atlas_content_ops_review_input_provider.py \
             -q

--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test Content Ops blog review public link
         run: npm run test:content-ops-blog-review-public-link
 
+      - name: Test Content Ops review source selection
+        run: npm run test:content-ops-review-source-selection
+
       - name: Build
         run: npm run build
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -22,6 +22,7 @@
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
     "test:content-ops-upload-source-run-handoff": "node --test scripts/content-ops-upload-source-run-handoff.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
+    "test:content-ops-review-source-selection": "node --test scripts/content-ops-review-source-selection.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",
     "test:landing-page-prerender": "node --test scripts/verify-landing-page-geo-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+async function loadSourceModeModule() {
+  const source = readFileSync(
+    new URL('../src/pages/contentOpsSourceMode.ts', import.meta.url),
+    'utf8',
+  )
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  parseInputsJsonObject,
+  sourceModeDraftValue,
+  updateSourceModeInputJson,
+} = await loadSourceModeModule()
+
+test('new run page exposes review source selection', () => {
+  assert.ok(newRunSource.includes('sourceModeDraftValue(parsedInputsForControls)'))
+  assert.ok(newRunSource.includes('updateSourceModeInputJson(inputsJson, mode)'))
+  assert.ok(newRunSource.includes('Support tickets'))
+  assert.ok(newRunSource.includes('Reviews'))
+})
+
+test('review source mode writes source type into inputs JSON', () => {
+  const updated = updateSourceModeInputJson(
+    JSON.stringify({
+      source_material_type: 'support_ticket',
+      source_faq_ids: ['faq-1'],
+      target_account: 'Acme',
+    }),
+    'reviews',
+  )
+
+  assert.equal(updated.ok, true)
+  const parsed = JSON.parse(updated.value)
+  assert.deepEqual(parsed, {
+    source_type: 'reviews',
+    target_account: 'Acme',
+  })
+  assert.equal(sourceModeDraftValue(parseInputsJsonObject(updated.value)), 'reviews')
+})
+
+test('support-ticket source mode removes explicit source type but preserves FAQ selection', () => {
+  const updated = updateSourceModeInputJson(
+    JSON.stringify({
+      source_type: 'reviews',
+      source_faq_ids: ['faq-1'],
+      target_account: 'Acme',
+    }),
+    'support_ticket',
+  )
+
+  assert.equal(updated.ok, true)
+  const parsed = JSON.parse(updated.value)
+  assert.deepEqual(parsed, {
+    source_faq_ids: ['faq-1'],
+    target_account: 'Acme',
+  })
+  assert.equal(sourceModeDraftValue(parseInputsJsonObject(updated.value)), 'support_ticket')
+})
+
+test('review source mode disables support-ticket FAQ source selection in the page', () => {
+  assert.ok(newRunSource.includes("sourceMode !== 'reviews'"))
+})

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -81,6 +81,15 @@ import type {
 } from '../api/contentOps'
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
+import {
+  parseInputsJsonObject,
+  sourceModeDraftValue,
+  updateSourceModeInputJson,
+  SOURCE_FAQ_IDS_INPUT,
+  type ContentOpsSourceMode,
+  type ParsedInputsJsonObject,
+  type UpdatedInputsJson,
+} from './contentOpsSourceMode'
 
 type SubmitState =
   | { kind: 'idle' }
@@ -144,7 +153,6 @@ const LANDING_PAGE_QUALITY_REPAIR_INPUT =
 const LANDING_PAGE_INPUT_ASSET = 'landing_page'
 const LANDING_PAGE_SEO_GEO_AEO_INPUT_GROUP = 'seo_geo_aeo'
 const BLOG_POST_OUTPUT = 'blog_post'
-const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
 const SOURCE_IMPORT_TARGET_IDS_INPUT = 'source_import_target_ids'
 const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'blog_post',
@@ -304,10 +312,12 @@ export default function ContentOpsNewRun() {
   const reasoningCapabilityHint = reasoningConfigured
     ? reasoningStatusHint(catalog.reasoning)
     : ''
+  const sourceMode = sourceModeDraftValue(parsedInputsForControls)
   const landingPageOutputSelected = request.outputs.includes('landing_page')
   const blogPostOutputSelected = request.outputs.includes(BLOG_POST_OUTPUT)
   const faqSourceSelectionVisible =
-    landingPageOutputSelected || blogPostOutputSelected
+    (landingPageOutputSelected || blogPostOutputSelected) &&
+    sourceMode !== 'reviews'
   const faqConfigurationOutputSelected = faqConfigurationInputsSelected(
     request.outputs,
   )
@@ -439,6 +449,13 @@ export default function ContentOpsNewRun() {
       ? [...selectedFaqSourceIds, draftId]
       : selectedFaqSourceIds.filter((id) => id !== draftId)
     const updated = updateSourceFaqIdsInputJson(inputsJson, nextIds)
+    if (!updated.ok) return
+    setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleSourceModeChange = (mode: ContentOpsSourceMode) => {
+    const updated = updateSourceModeInputJson(inputsJson, mode)
     if (!updated.ok) return
     setInputsJson(updated.value)
     markStale()
@@ -1060,6 +1077,30 @@ export default function ContentOpsNewRun() {
           <h2 className="mb-2 text-sm font-medium uppercase tracking-wide text-slate-400">
             Inputs (JSON)
           </h2>
+          <div className="mb-3 flex flex-wrap gap-2">
+            {[
+              ['support_ticket', 'Support tickets'],
+              ['reviews', 'Reviews'],
+            ].map(([mode, label]) => {
+              const selected = sourceMode === mode
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => handleSourceModeChange(mode as ContentOpsSourceMode)}
+                  disabled={!parsedInputsForControls.ok}
+                  className={clsx(
+                    'rounded-md border px-3 py-1.5 text-sm transition disabled:cursor-not-allowed disabled:opacity-60',
+                    selected
+                      ? 'border-cyan-500 bg-cyan-500/10 text-cyan-100'
+                      : 'border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500',
+                  )}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
           <p className="mb-2 text-xs text-slate-500">
             Required keys depend on the selected outputs (see chip list
             above). Type a JSON object or use the per-output fields below.
@@ -2675,30 +2716,6 @@ type ParsedIngestionRows =
 type ParsedIngestionDefaultFields =
   | { ok: true; fields: Record<string, unknown> }
   | { ok: false; message: string }
-
-type ParsedInputsJsonObject =
-  | { ok: true; value: Record<string, unknown> }
-  | { ok: false; message: string }
-
-type UpdatedInputsJson =
-  | { ok: true; value: string }
-  | { ok: false; message: string }
-
-function parseInputsJsonObject(value: string): ParsedInputsJsonObject {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(value.trim() || '{}')
-  } catch (err) {
-    return {
-      ok: false,
-      message: err instanceof Error ? err.message : String(err),
-    }
-  }
-  if (!isRecord(parsed)) {
-    return { ok: false, message: 'Inputs JSON must be an object.' }
-  }
-  return { ok: true, value: { ...parsed } }
-}
 
 function landingPageSeoGeoAeoInputContracts(
   catalog: ContentOpsCatalog,

--- a/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
+++ b/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
@@ -1,0 +1,68 @@
+const SOURCE_TYPE_INPUT = 'source_type'
+const SOURCE_MATERIAL_TYPE_INPUT = 'source_material_type'
+const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
+
+export type ContentOpsSourceMode = 'support_ticket' | 'reviews'
+
+export type ParsedInputsJsonObject =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; message: string }
+
+export type UpdatedInputsJson =
+  | { ok: true; value: string }
+  | { ok: false; message: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseInputsJsonObject(value: string): ParsedInputsJsonObject {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value.trim() || '{}')
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+    }
+  }
+  if (!isRecord(parsed)) {
+    return { ok: false, message: 'Inputs JSON must be an object.' }
+  }
+  return { ok: true, value: { ...parsed } }
+}
+
+export function sourceModeDraftValue(
+  parsed: ParsedInputsJsonObject,
+): ContentOpsSourceMode {
+  if (!parsed.ok) return 'support_ticket'
+  const raw =
+    parsed.value[SOURCE_TYPE_INPUT] ?? parsed.value[SOURCE_MATERIAL_TYPE_INPUT]
+  const value = String(raw ?? '').trim().toLowerCase().replace(/-/g, '_')
+  if (value === 'review' || value === 'reviews') return 'reviews'
+  return 'support_ticket'
+}
+
+export function updateSourceModeInputJson(
+  current: string,
+  mode: ContentOpsSourceMode,
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+
+  const next = { ...parsed.value }
+  delete next[SOURCE_MATERIAL_TYPE_INPUT]
+  if (mode === 'reviews') {
+    next[SOURCE_TYPE_INPUT] = 'reviews'
+    delete next[SOURCE_FAQ_IDS_INPUT]
+  } else {
+    delete next[SOURCE_TYPE_INPUT]
+  }
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+export {
+  SOURCE_FAQ_IDS_INPUT,
+  SOURCE_MATERIAL_TYPE_INPUT,
+  SOURCE_TYPE_INPUT,
+}

--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -8,6 +8,10 @@ from uuid import UUID
 
 from extracted_content_pipeline.campaign_postgres import PostgresIntelligenceRepository
 from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.campaign_source_adapters import (
+    source_material_to_source_rows,
+    source_rows_to_campaign_opportunities,
+)
 from extracted_content_pipeline.content_ops_input_provider import (
     ContentOpsInputPackage,
     RequestPayload,
@@ -76,6 +80,26 @@ _SOURCE_IMPORT_TARGET_ID_KEYS = (
     "source_target_ids",
     "import_target_ids",
 )
+_SOURCE_TYPE_KEYS = ("source_type", "source_material_type")
+_SUPPORT_TICKET_SOURCE_TYPE_ALIASES = frozenset({
+    "support",
+    "support_ticket",
+    "support_tickets",
+    "ticket",
+    "tickets",
+})
+_REVIEW_SOURCE_TYPE_ALIASES = frozenset({
+    "review",
+    "reviews",
+    "complaint",
+    "complaints",
+})
+_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post")
+_REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
+_REVIEW_TOPIC = "Customer review themes worth turning into content"
+_REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
+_REVIEW_OFFER = "Turn customer review themes into buyer-facing landing pages and blog posts"
+_REVIEW_TARGET_KEYWORD = "customer review content marketing"
 
 
 @dataclass(frozen=True)
@@ -96,8 +120,41 @@ class _AtlasSupportTicketInputProvider:
         request: RequestPayload | None = None,
     ) -> ContentOpsInputPackage | Awaitable[ContentOpsInputPackage]:
         source_material = _request_source_material(request)
+        source_type = _request_source_type(request)
         source_faq_ids = _request_source_faq_ids(request)
         source_target_ids = _request_source_target_ids(request)
+        if source_type in _REVIEW_SOURCE_TYPE_ALIASES:
+            if source_faq_ids:
+                return _noop_package(
+                    "atlas_review_request",
+                    metadata={"requested_source_type": source_type},
+                    warnings=({
+                        "code": "review_source_faq_ids_unsupported",
+                        "message": "Saved FAQ source selection is only supported for support-ticket runs.",
+                    },),
+                )
+            if source_target_ids:
+                return self._build_reviews_from_selected_sources(
+                    source_target_ids,
+                    source_material=source_material,
+                    scope=scope,
+                    request=request,
+                )
+            return _build_review_input_package(
+                source_material,
+                metadata={"requested_source_type": source_type},
+                default_source_type=source_type,
+            )
+        if source_type and source_type not in _SUPPORT_TICKET_SOURCE_TYPE_ALIASES:
+            return _noop_package(
+                self.provider_name,
+                metadata={"requested_source_type": source_type},
+                warnings=({
+                    "code": "content_ops_source_type_unsupported",
+                    "message": "Unsupported Content Ops source type.",
+                    "source_type": source_type,
+                },),
+            )
         if source_faq_ids or source_target_ids:
             return self._build_from_selected_sources(
                 source_faq_ids,
@@ -198,6 +255,48 @@ class _AtlasSupportTicketInputProvider:
             warnings=tuple(package.warnings) + tuple(warnings),
         )
 
+    async def _build_reviews_from_selected_sources(
+        self,
+        source_target_ids: Sequence[str],
+        *,
+        source_material: Any,
+        scope: TenantScope,
+        request: RequestPayload | None,
+    ) -> ContentOpsInputPackage:
+        (
+            loaded_targets,
+            missing_targets,
+            ambiguous_targets,
+            target_skip_reason,
+        ) = await self._load_selected_import_targets(
+            source_target_ids,
+            scope=scope,
+            request=request,
+        )
+        combined_source_material = _combine_source_material(
+            source_material,
+            loaded_targets,
+        )
+        requested_source_type = _request_source_type(request) or "reviews"
+        metadata = {
+            "requested_source_type": requested_source_type,
+            "source_target_id_count": len(source_target_ids),
+            "source_target_loaded_count": len(loaded_targets),
+            "source_target_missing_id_count": len(missing_targets),
+            "source_target_ambiguous_id_count": len(ambiguous_targets),
+        }
+        warnings = _selected_source_target_warnings(
+            missing=missing_targets,
+            ambiguous=ambiguous_targets,
+            skip_reason=target_skip_reason,
+        )
+        return _build_review_input_package(
+            combined_source_material,
+            metadata=metadata,
+            warnings=warnings,
+            default_source_type=requested_source_type,
+        )
+
     async def _load_selected_faq_drafts(
         self,
         source_faq_ids: Sequence[str],
@@ -281,6 +380,19 @@ def _request_source_material(request: RequestPayload | None) -> Any:
     if not isinstance(inputs, Mapping):
         return None
     return inputs.get("source_material")
+
+
+def _request_source_type(request: RequestPayload | None) -> str:
+    if not isinstance(request, Mapping):
+        return ""
+    inputs = request.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return ""
+    for key in _SOURCE_TYPE_KEYS:
+        value = _key(inputs.get(key))
+        if value:
+            return value
+    return ""
 
 
 def _request_source_faq_ids(request: RequestPayload | None) -> tuple[str, ...]:
@@ -427,6 +539,121 @@ def _key(value: Any) -> str:
 
 def _clean(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _build_review_input_package(
+    source_material: Any,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+    warnings: Sequence[Mapping[str, Any]] = (),
+    default_source_type: str = "reviews",
+) -> ContentOpsInputPackage:
+    source_rows = source_material_to_source_rows(source_material)
+    load_result = source_rows_to_campaign_opportunities(
+        source_rows,
+        default_fields={"source_type": default_source_type},
+    )
+    review_opportunities = [
+        dict(row)
+        for row in load_result.opportunities
+        if _key(row.get("source_type")) in _REVIEW_SOURCE_TYPE_ALIASES
+    ]
+    adapter_warnings = [
+        {
+            "code": warning.code,
+            "message": warning.message,
+            **({"row_index": warning.row_index} if warning.row_index is not None else {}),
+            **({"field": warning.field} if warning.field else {}),
+        }
+        for warning in load_result.warnings
+    ]
+    package_metadata = {
+        "source": "review_input_package",
+        "source_row_count": len(source_rows),
+        "opportunity_count": len(load_result.opportunities),
+        "included_row_count": len(review_opportunities),
+        "skipped_row_count": max(0, len(source_rows) - len(review_opportunities)),
+        **dict(metadata or {}),
+    }
+    package_warnings = [dict(warning) for warning in warnings]
+    package_warnings.extend(adapter_warnings)
+    if not review_opportunities:
+        warning_code = (
+            "review_source_rows_unrecognized"
+            if source_rows
+            else "review_source_material_empty"
+        )
+        warning_message = (
+            "Review source rows were provided, but none were recognized as review or complaint rows."
+            if source_rows
+            else "No review or complaint source rows were provided."
+        )
+        package_warnings.append({
+            "code": warning_code,
+            "message": warning_message,
+        })
+        return _noop_package(
+            "atlas_review_request",
+            metadata=package_metadata,
+            warnings=package_warnings,
+        )
+    primary_entity = _review_primary_entity(review_opportunities)
+    inputs = {
+        "source_material": review_opportunities,
+        "review_source_material": review_opportunities,
+        "source_type": "reviews",
+        "campaign_name": _REVIEW_CAMPAIGN_NAME,
+        "target_account": primary_entity,
+        "topic": _REVIEW_TOPIC,
+        "offer": _REVIEW_OFFER,
+        "audience": _REVIEW_AUDIENCE,
+        "target_keyword": _REVIEW_TARGET_KEYWORD,
+        "search_intent": (
+            "Marketing teams looking for review-grounded themes for landing "
+            "pages and blog posts."
+        ),
+        "primary_entity": primary_entity,
+        "audience_entity": _REVIEW_AUDIENCE,
+        "competitors": _review_competitors(review_opportunities),
+        "objections": [
+            "Will this sound generic?",
+            "Can we trace the claims back to customer language?",
+        ],
+        "source_period": "Recent customer reviews",
+        "review_source_count": len(review_opportunities),
+        "internal_links": ["/systems/ai-content-ops/intake"],
+        "cta_label": "Turn Reviews Into Content",
+        "cta_url": "/systems/ai-content-ops/intake",
+    }
+    return ContentOpsInputPackage(
+        provider="atlas_review_request",
+        inputs=inputs,
+        outputs=_REVIEW_CAMPAIGN_OUTPUTS,
+        target_mode="vendor_retention",
+        ingestion_profile="existing_evidence",
+        metadata=package_metadata,
+        warnings=tuple(package_warnings),
+    )
+
+
+def _review_primary_entity(rows: Sequence[Mapping[str, Any]]) -> str:
+    for row in rows:
+        for key in ("vendor_name", "product_name", "company_name"):
+            value = _clean(row.get(key))
+            if value:
+                return value
+    return _REVIEW_CAMPAIGN_NAME
+
+
+def _review_competitors(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    values: list[str] = []
+    for row in rows:
+        value = _clean(row.get("vendor_name") or row.get("product_name"))
+        if value and value not in values:
+            values.append(value)
+        if len(values) == 3:
+            break
+    return values or ["generic AI copy", "manual review mining"]
 
 
 def _selected_faq_warnings(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -581,7 +581,10 @@ async def _dispatch_blog_post(
         "quality_repair_attempts": _step_config_int(step.config, "quality_repair_attempts"),
         "topic": _step_config_text(step.config, "topic"),
     }
-    data_context = _support_ticket_blog_data_context_from_inputs(request.inputs)
+    data_context = (
+        _review_blog_data_context_from_inputs(request.inputs)
+        or _support_ticket_blog_data_context_from_inputs(request.inputs)
+    )
     if data_context:
         kwargs["data_context"] = data_context
     return await service.generate(
@@ -883,6 +886,38 @@ def _support_ticket_blog_data_context_from_inputs(
     }
 
 
+def _review_blog_data_context_from_inputs(
+    inputs: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    source_type = _source_type_input(inputs)
+    review_rows = _mapping_list_input(inputs.get("review_source_material"))
+    if not review_rows and source_type in {"review", "reviews"}:
+        review_rows = _mapping_list_input(inputs.get("source_material"))
+    if not review_rows:
+        return None
+    context: dict[str, Any] = {
+        "source": "review_input_provider",
+        "source_type": "reviews",
+        "source_period": _clean(inputs.get("source_period"))
+        or "Recent customer reviews",
+        "review_period": _clean(inputs.get("source_period"))
+        or "Recent customer reviews",
+        "source_row_count": _positive_int_context(inputs.get("review_source_count"))
+        or len(review_rows),
+        "review_source_count": _positive_int_context(inputs.get("review_source_count"))
+        or len(review_rows),
+        "source_material": review_rows,
+        "review_source_material": review_rows,
+        "customer_wording_examples": review_rows[:5],
+        "topic": _clean(inputs.get("topic")),
+    }
+    return {
+        key: value
+        for key, value in context.items()
+        if value not in (None, "", [], {})
+    }
+
+
 def _inputs_use_support_ticket_source(inputs: Mapping[str, Any]) -> bool:
     filters = _filters_from_inputs(inputs) or {}
     if is_support_ticket_topic_type(filters.get("topic_type")):
@@ -890,6 +925,15 @@ def _inputs_use_support_ticket_source(inputs: Mapping[str, Any]) -> bool:
     if is_support_ticket_context(inputs):
         return True
     return _value_contains_support_ticket_source(inputs.get("source_material"))
+
+
+def _source_type_input(inputs: Mapping[str, Any]) -> str:
+    return (
+        str(inputs.get("source_type") or inputs.get("source_material_type") or "")
+        .strip()
+        .lower()
+        .replace("-", "_")
+    )
 
 
 def _value_contains_support_ticket_source(value: Any) -> bool:

--- a/extracted_content_pipeline/landing_page_input_contract.py
+++ b/extracted_content_pipeline/landing_page_input_contract.py
@@ -44,6 +44,11 @@ LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS: tuple[str, ...] = (
     "measured_outcome_examples",
 )
 
+LANDING_PAGE_REVIEW_SOURCE_INPUT_KEYS: tuple[str, ...] = (
+    "review_source_material",
+    "review_source_count",
+)
+
 LANDING_PAGE_EXISTING_CONTEXT_KEYS: tuple[str, ...] = (
     "industry",
     "pain_points",
@@ -58,6 +63,7 @@ LANDING_PAGE_CONTEXT_INPUT_KEYS: frozenset[str] = frozenset((
     *LANDING_PAGE_EXISTING_CONTEXT_KEYS,
     *LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS,
     *LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS,
+    *LANDING_PAGE_REVIEW_SOURCE_INPUT_KEYS,
 ))
 
 

--- a/plans/PR-Content-Ops-Reviews-Input-Provider.md
+++ b/plans/PR-Content-Ops-Reviews-Input-Provider.md
@@ -1,0 +1,115 @@
+# PR: Content Ops Reviews Input Provider
+
+## Why this slice exists
+
+PR #1237 landed the scoping plan for marketer-facing review inputs. The
+generation engine already understands review-shaped source rows through
+`campaign_source_adapters.py`, but the host Content Ops input provider still
+routes only support-ticket source material. This vertical slice makes the
+existing New Run path explicit about source type so review rows can drive the
+already-built landing-page and blog generators without creating a second
+pipeline. The diff is over the preferred 400 LOC budget because the slice is
+only useful if the backend provider, operator-facing selector, and required
+negative fixtures land together; splitting any one of those would leave either
+an unselectable backend path or an untested source-type gate.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add explicit source-type selection to the Atlas host input provider.
+2. Add a review input package path that reuses existing source-row adapters.
+3. Add a New Run source selector that writes the source type into inputs JSON.
+4. Add focused backend and frontend tests for review routing and support-ticket
+   preservation.
+5. Enroll the new Atlas-host test file in the dedicated input-provider workflow.
+6. Review-fix pass: seed request-level review type into adapter defaults,
+   carry review evidence into landing/blog generation contexts, and enroll the
+   frontend selector test in the explicit intel-ui CI workflow.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Reviews-Input-Provider.md`
+- `.github/workflows/atlas_content_ops_input_provider_checks.yml`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `atlas_brain/_content_ops_input_provider.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/landing_page_input_contract.py`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/contentOpsSourceMode.ts`
+- `atlas-intel-ui/package.json`
+- `atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host provider reads `inputs.source_type` with `inputs.source_material_type`
+as a compatibility alias. Missing source type preserves the current
+support-ticket autodetect behavior. Explicit `support_ticket` keeps the existing
+support-ticket provider. Explicit `reviews` / `review` routes source material
+through `source_material_to_source_rows` and
+`source_rows_to_campaign_opportunities`, accepts only review or complaint rows,
+and returns a Content Ops input package for `landing_page` and `blog_post`.
+Unsupported explicit source types fail closed with a noop package and warning.
+
+The New Run UI adds a compact source selector beside the raw inputs controls.
+The support-ticket option removes the explicit key for backward compatibility;
+the review option writes `"source_type": "reviews"` and hides saved FAQ source
+selection because saved FAQ drafts are support-ticket-specific.
+
+Review rows are also copied to `review_source_material` so the executor can
+place the evidence in landing-page campaign context and blog `data_context`.
+This keeps the operator-selected review source visible to the generators rather
+than only to the input-provider diagnostics.
+
+## Intentional
+
+- No new endpoint: preview, plan, and execute already call the host input
+  provider.
+- No new review parser: reuse `campaign_source_adapters.py`.
+- No image-provider work in this slice; PR #1244 is separate.
+- Missing source type remains backward-compatible support-ticket autodetection.
+
+## Deferred
+
+- Competitive/displacement-as-input remains parked for a later marketer slice.
+- Social/ad/stat-card outputs remain separate output work.
+- Image generation and image attachment remain in the image-provider lane.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- pytest for review input provider plus support-ticket provider regressions --
+  35 passed, 1 warning.
+- Focused review-input pytest (`tests/test_atlas_content_ops_review_input_provider.py`) -- 11
+  passed.
+- Frontend review source-selection npm script -- 4 passed.
+- `npm run lint` -- passed.
+- `npm run build` -- passed.
+- py_compile for changed Python files -- passed.
+- Extracted CI enrollment audit
+  -- OK: 143 matching tests are enrolled.
+- Full extracted pipeline mirror (`scripts/run_extracted_pipeline_checks.sh`) -- 2924 passed, 10
+  skipped, 1 warning; all extracted content pipeline checks completed.
+- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-reviews-input-provider-pr-body.md`
+  -- local PR review passed.
+
+## Estimated diff size
+
+Estimated: 982 LOC (12 files, +955 / -27 actual). This intentionally exceeds the preferred 400 LOC budget to
+keep the review provider, New Run selector, same-PR frontend enrollment, and
+source-type negative fixtures in one vertical slice.
+
+| Area | Estimated LOC |
+|---|---:|
+| Backend provider + executor context | ~278 |
+| Backend tests | ~362 |
+| Frontend selector helper and test enrollment | ~153 |
+| Workflow and runner enrollment | ~8 |
+| Plan doc | ~115 |
+| **Total** | **982** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -94,6 +94,7 @@ pytest \
   tests/test_atlas_content_ops_generated_assets_api.py \
   tests/test_atlas_content_ops_import_admission.py \
   tests/test_atlas_content_ops_input_provider.py \
+  tests/test_atlas_content_ops_review_input_provider.py \
   tests/test_atlas_content_ops_macro_writeback.py \
   tests/test_content_ops_faq_macro_writeback_flow.py \
   tests/test_content_ops_zendesk_credentials.py \

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import extracted_content_pipeline.api.control_surfaces as api_module
+from atlas_brain._content_ops_input_provider import build_content_ops_input_provider
+from extracted_content_pipeline.api.control_surfaces import (
+    ContentOpsControlSurfaceApiConfig,
+    create_content_ops_control_surface_router,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.content_ops_execution import ContentOpsExecutionServices
+from extracted_content_pipeline.content_ops_execution import execute_content_ops_request
+from extracted_content_pipeline.content_ops_input_provider import (
+    merge_content_ops_input_package,
+)
+from extracted_content_pipeline.control_surfaces import (
+    preview_control_surface,
+    request_from_mapping,
+)
+
+
+class _OpportunityRepo:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def read_campaign_opportunities(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        limit: int,
+        filters=None,
+    ):
+        target_id = dict(filters or {}).get("target_id")
+        self.pool["opportunity_calls"].append({
+            "account_id": scope.account_id,
+            "target_mode": target_mode,
+            "limit": limit,
+            "target_id": target_id,
+        })
+        return tuple(self.pool["opportunities"].get(target_id, ()))[:limit]
+
+
+class _RunnableService:
+    async def generate(self, **kwargs):  # pragma: no cover - plan route only.
+        return {"kwargs": kwargs}
+
+
+def _route(router, path: str, method: str):
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method.upper() in getattr(
+            route,
+            "methods",
+            set(),
+        ):
+            return route
+    raise AssertionError(f"Route {method.upper()} {path!r} not mounted")
+
+
+def _review_row(
+    target_id: str = "review-1",
+    *,
+    vendor_name: str = "Slack",
+) -> dict[str, Any]:
+    return {
+        "target_id": target_id,
+        "review_id": target_id,
+        "source_type": "review",
+        "reviewer_company": "Acme Logistics",
+        "vendor_name": vendor_name,
+        "review_text": "Search gets slow once message history grows.",
+        "pain_category": "performance",
+    }
+
+
+def _generic_review_row(target_id: str = "review-1") -> dict[str, Any]:
+    return {
+        "target_id": target_id,
+        "review_id": target_id,
+        "vendor_name": "Slack",
+        "reviewer_company": "Acme Logistics",
+        "content": "Search gets slow once message history grows.",
+        "pain_category": "performance",
+    }
+
+
+def _support_ticket_row() -> dict[str, Any]:
+    return {
+        "ticket_id": "ticket-1",
+        "subject": "Billing question",
+        "message": "Why was I charged twice this month?",
+    }
+
+
+def test_review_source_material_builds_landing_and_blog_inputs() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "reviews",
+                "source_material": [_review_row()],
+            }
+        },
+    )
+    payload = merge_content_ops_input_package({"inputs": {}}, package)
+    request = request_from_mapping(payload)
+    preview = preview_control_surface(request)
+
+    assert package.provider == "atlas_review_request"
+    assert request.outputs == ("landing_page", "blog_post")
+    assert request.ingestion_profile == "existing_evidence"
+    assert request.inputs["source_type"] == "reviews"
+    assert request.inputs["source_material"][0]["source_type"] == "review"
+    assert request.inputs["review_source_material"][0]["source_type"] == "review"
+    assert request.inputs["source_material"][0]["target_id"] == "review-1"
+    assert request.inputs["target_account"] == "Slack"
+    assert request.inputs["topic"] == "Customer review themes worth turning into content"
+    assert package.metadata["included_row_count"] == 1
+    assert preview.can_run is True
+
+
+def test_review_mode_defaults_generic_rows_to_requested_review_type() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "reviews",
+                "source_material": [_generic_review_row()],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_review_request"
+    assert package.inputs["source_material"][0]["source_type"] == "reviews"
+    assert package.inputs["source_material"][0]["target_id"] == "review-1"
+    assert package.metadata["source_row_count"] == 1
+    assert package.metadata["included_row_count"] == 1
+
+
+def test_review_source_material_accepts_review_bundle_alias() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_material_type": "review",
+                "source_material": {"reviews": [_review_row()]},
+            }
+        },
+    )
+
+    assert package.provider == "atlas_review_request"
+    assert package.outputs == ("landing_page", "blog_post")
+    assert package.inputs["source_material"][0]["source_type"] == "review"
+    assert package.metadata["included_row_count"] == 1
+
+
+def test_missing_source_type_keeps_review_rows_out_of_support_ticket_provider() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "outputs": ["signal_extraction"],
+            "inputs": {"source_material": [_review_row()]},
+        },
+    )
+    payload = merge_content_ops_input_package(
+        {"outputs": ["signal_extraction"], "inputs": {"source_material": [_review_row()]}},
+        package,
+    )
+    request = request_from_mapping(payload)
+
+    assert package.metadata["mode"] == "noop"
+    assert request.outputs == ("signal_extraction",)
+    assert request.inputs["source_material"][0]["source_type"] == "review"
+
+
+def test_explicit_support_ticket_source_type_keeps_support_ticket_provider() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "outputs": ["faq_markdown"],
+            "inputs": {
+                "source_type": "support_ticket",
+                "source_material": [_support_ticket_row()],
+            },
+        },
+    )
+
+    assert package.provider == "atlas_support_ticket_request"
+    assert package.inputs["source_material"][0]["source_type"] == "support_ticket"
+    assert "faq_markdown" in package.outputs
+    assert package.metadata["included_row_count"] == 1
+
+
+def test_review_mode_rejects_non_review_rows() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "reviews",
+                "source_material": [{
+                    "source_type": "document",
+                    "target_id": "doc-1",
+                    "content": "General implementation notes.",
+                }],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_review_request"
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["included_row_count"] == 0
+    assert package.warnings[-1]["code"] == "review_source_rows_unrecognized"
+
+
+def test_review_mode_rejects_saved_faq_selection() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "reviews",
+                "source_faq_ids": ["11111111-1111-1111-1111-111111111111"],
+                "source_material": [_review_row()],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_review_request"
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.warnings == ({
+        "code": "review_source_faq_ids_unsupported",
+        "message": "Saved FAQ source selection is only supported for support-ticket runs.",
+    },)
+
+
+def test_unknown_explicit_source_type_fails_closed() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "call_recordings",
+                "source_material": [_review_row()],
+            }
+        },
+    )
+
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["requested_source_type"] == "call_recordings"
+    assert package.warnings == ({
+        "code": "content_ops_source_type_unsupported",
+        "message": "Unsupported Content Ops source type.",
+        "source_type": "call_recordings",
+    },)
+
+
+@pytest.mark.asyncio
+async def test_review_mode_fetches_persisted_targets_by_tenant_scope() -> None:
+    pool = {
+        "opportunities": {
+            "review-1": [_generic_review_row("review-1")],
+            "review-2": [{**_generic_review_row("review-2"), "vendor_name": "Teams"}],
+        },
+        "opportunity_calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        opportunity_repository_factory=_OpportunityRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "target_mode": "vendor_retention",
+            "inputs": {
+                "source_type": "reviews",
+                "source_import_target_ids": ["review-1", "review-2"],
+            },
+        },
+    )
+
+    assert [call["target_id"] for call in pool["opportunity_calls"]] == [
+        "review-1",
+        "review-2",
+    ]
+    assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
+    assert package.provider == "atlas_review_request"
+    assert package.outputs == ("landing_page", "blog_post")
+    assert package.metadata["source_target_loaded_count"] == 2
+    assert package.metadata["included_row_count"] == 2
+    assert {row["source_type"] for row in package.inputs["source_material"]} == {
+        "reviews",
+    }
+
+
+@pytest.mark.asyncio
+async def test_review_input_evidence_reaches_landing_and_blog_generators() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "reviews",
+                "source_material": [_generic_review_row()],
+            }
+        },
+    )
+    payload = merge_content_ops_input_package({"inputs": {}}, package)
+    request = request_from_mapping(payload)
+
+    result = await execute_content_ops_request(
+        request,
+        services=ContentOpsExecutionServices(
+            blog_post=_RunnableService(),
+            landing_page=_RunnableService(),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    landing_step = next(step for step in result.steps if step.output == "landing_page")
+    landing_campaign = landing_step.result["kwargs"]["campaign"]
+    assert landing_campaign.context["review_source_material"][0]["target_id"] == "review-1"
+
+    blog_step = next(step for step in result.steps if step.output == "blog_post")
+    blog_context = blog_step.result["kwargs"]["data_context"]
+    assert blog_context["source"] == "review_input_provider"
+    assert blog_context["review_source_material"][0]["target_id"] == "review-1"
+
+
+@pytest.mark.skipif(
+    api_module.APIRouter is None,
+    reason="fastapi is not installed in this test environment",
+)
+@pytest.mark.asyncio
+async def test_plan_route_applies_review_input_provider() -> None:
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(prefix="/content-ops"),
+        input_provider=build_content_ops_input_provider(),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            blog_post=_RunnableService(),
+            landing_page=_RunnableService(),
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-review-route"),
+    )
+    route = _route(router, "/content-ops/plan", "POST")
+
+    payload = await route.endpoint({
+        "inputs": {
+            "source_type": "reviews",
+            "source_material": [_review_row()],
+        },
+    })
+
+    assert payload["can_execute"] is True
+    assert [step["output"] for step in payload["steps"]] == [
+        "landing_page",
+        "blog_post",
+    ]
+    assert payload["preview"]["outputs"] == ["landing_page", "blog_post"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Reviews-Input-Provider.md
Slice phase: Vertical slice

This PR implements the marketer reviews-as-input vertical slice from #1237: the host Content Ops input provider can now route explicit review source material into landing-page and blog generation, and the New Run UI exposes the source selector that writes the source type into inputs JSON.

## Intentional
- No new endpoint: preview, plan, and execute already call the host input provider.
- No new review parser: the slice reuses `campaign_source_adapters.py`.
- No image-provider work in this slice; PR #1244 is separate.
- Missing source type remains backward-compatible support-ticket autodetection.

## Deferred
- Competitive/displacement-as-input remains parked for a later marketer slice.
- Social/ad/stat-card outputs remain separate output work.
- Image generation and image attachment remain in the image-provider lane.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` - 11 passed.
- `pytest tests/test_atlas_content_ops_review_input_provider.py tests/test_atlas_content_ops_input_provider.py -q` - 35 passed, 1 warning.
- `npm run test:content-ops-review-source-selection` - 4 passed.
- `npm run lint` - passed.
- `npm run build` - passed.
- `python -m py_compile atlas_brain/_content_ops_input_provider.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/landing_page_input_contract.py` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - OK: 143 matching tests are enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2924 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-reviews-input-provider-pr-body.md` - local PR review passed.

## Diff size
12 files, +955 / -27. Over the soft cap because the provider, New Run selector, same-PR workflow enrollment, review-fix context wiring, and negative fixtures need to ship together.