### PR TITLE
PR-Deflection-SaaS-Demo-Dotenv-Preflight

### DIFF
--- a/HARDENING.md
+++ b/HARDENING.md
@@ -30,21 +30,6 @@ register under `docs/technical-debt/`.
 
 ## Parked Items
 
-## 2026-06-02
-
-### SaaS demo preflight subprocess reloads live repo dotenv
-- File/location: `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py::test_script_preflight_uses_atlas_db_settings_fallback` / `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py`
-- Description: The test removes required env vars before spawning the smoke script, but the subprocess reloads the repo-root `.env`, so local checkouts with live `ATLAS_API_BASE_URL` / token / account envs can return success instead of missing-inputs.
-- Why it matters: It makes `scripts/run_extracted_pipeline_checks.sh` fail locally in provisioned workspaces even when CI's clean environment should pass.
-- Effort: S
-- Category: tech-debt
-- Owner/session: Codex FAQ deflection answer copy polish slice
-- Found during: PR-Deflection-Answer-Copy-Polish
-- Root cause (verified 2026-06-01, independent review): `_load_dotenv_files()` (called from `_build_parser`) runs `load_dotenv(ROOT / ".env")` then `load_dotenv(ROOT / ".env.local", override=True)`, repopulating the exact vars the test popped from the subprocess env. This workspace's `.env` carries 3 of them (`ATLAS_API_BASE_URL` / token / account), so preflight finds all required inputs present and exits 0 instead of 2. Reproduced locally as `assert 0 == 2`; passes in CI's clean checkout. `cwd=tmp_path` does not help because the script loads `ROOT/.env` by absolute path.
-- Proposed fix: gate `_load_dotenv_files()` on an opt-out (`ATLAS_DISABLE_DOTENV=1`, or a `--no-dotenv` flag parsed before the load) and set it in `test_script_preflight_uses_atlas_db_settings_fallback`, so the popped vars cannot be reloaded from the on-disk dotenv. Real runs still load `.env` / `.env.local` unchanged.
-- Acceptance criteria: (1) the test passes both in CI (clean env) and locally with a populated `ROOT/.env`; (2) with the opt-out set and required inputs absent, the script still exits 2 and emits the missing-input preflight errors (do not relax the assertion to accept 0, which would defeat the test); (3) without the opt-out, dotenv loading is byte-for-byte unchanged for real runs.
-- Not-a-bug note: the 10 co-reported mirror skips are unrelated Postgres integration tests that skip on `EXTRACTED_DATABASE_URL or DATABASE_URL is required`; verified they pass when `EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas` is set (those 6 files: 197 passed). No code change needed for the skips.
-
 ## 2026-05-29
 
 ### atlas-intel-ui npm audit vulnerabilities

--- a/plans/PR-Deflection-SaaS-Demo-Dotenv-Preflight.md
+++ b/plans/PR-Deflection-SaaS-Demo-Dotenv-Preflight.md
@@ -1,0 +1,97 @@
+## Why this slice exists
+
+`HARDENING.md` has a parked FAQ-deflection local verification bug:
+`test_script_preflight_uses_atlas_db_settings_fallback` removes required hosted
+route env vars before spawning the SaaS demo smoke, but the subprocess reloads
+repo-root `.env` and can silently repopulate them. In provisioned workspaces,
+that makes the local extracted mirror fail even though CI's clean environment
+passes.
+
+The local database is also available at
+`postgresql://atlas@localhost:5433/atlas`, so full local mirrors can run
+DB-backed tests instead of skipping them.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Production hardening
+
+1. Add an explicit dotenv opt-out for the SaaS demo route smoke.
+2. Use that opt-out in the subprocess preflight regression so popped env vars
+   cannot be reloaded from repo-local dotenv files.
+3. Keep normal smoke runs unchanged: `.env` and `.env.local` still load by
+   default.
+4. Drain the fixed `HARDENING.md` entry.
+
+### Files touched
+
+- `scripts/smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py`
+- `HARDENING.md`
+- `plans/PR-Deflection-SaaS-Demo-Dotenv-Preflight.md`
+
+## Mechanism
+
+`_load_dotenv_files()` will return early when `ATLAS_DISABLE_DOTENV=1` is set.
+The smoke continues to load repo `.env` and `.env.local` by default for real
+operator runs. The failing preflight test sets only this opt-out in the
+subprocess env, then keeps the existing strict assertion that missing hosted
+inputs produce exit code 2 while Atlas DB settings still provide a database DSN.
+
+For verification in a live-provisioned checkout, the full extracted mirror
+should be run with a local database URL and blank hosted smoke envs:
+
+```bash
+EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas \
+ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= \
+ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= \
+ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= \
+ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= \
+ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= \
+bash scripts/run_extracted_pipeline_checks.sh
+```
+
+That exercises the local DB-backed tests rather than skipping them.
+
+## Intentional
+
+- This does not change hosted route validation, seeding, cleanup, or live smoke
+  behavior.
+- The opt-out is env-only rather than a CLI flag because the bug happens before
+  normal argument defaults are safe to compute.
+- This slice does not alter the seed script dotenv behavior; the failing
+  preflight path is in the route smoke subprocess.
+
+## Deferred
+
+- Parked hardening: none; this drains the SaaS demo preflight dotenv item.
+
+## Verification
+
+- `pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q`
+  - 26 passed in 0.99s.
+- `bash scripts/validate_extracted_content_pipeline.sh`
+  - Passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+  - Passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt`
+  - Passed.
+- `bash scripts/check_ascii_python.sh`
+  - Passed.
+- `EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= bash scripts/run_extracted_pipeline_checks.sh`
+  - 2924 passed, 1 warning in 52.13s.
+- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-saas-demo-dotenv-preflight-body.md`
+  - Passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| SaaS demo smoke | ~5 |
+| Tests | ~5 |
+| `HARDENING.md` | ~20 removed |
+| Plan doc | ~75 |
+| **Total** | **~105** |
+
+Under the 400 LOC soft cap.

--- a/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/scripts/smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -34,6 +34,8 @@ except ImportError:  # pragma: no cover - optional host dependency
 
 
 def _load_dotenv_files() -> None:
+    if os.getenv("ATLAS_DISABLE_DOTENV") == "1":
+        return
     if load_dotenv is not None:
         load_dotenv(ROOT / ".env")
         load_dotenv(ROOT / ".env.local", override=True)

--- a/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
+++ b/tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py
@@ -178,6 +178,30 @@ def test_default_database_url_prefers_url_env(monkeypatch) -> None:
     assert smoke._default_database_url() == "postgresql://env/atlas"
 
 
+def test_load_dotenv_files_can_be_disabled(monkeypatch) -> None:
+    calls = []
+
+    def fake_load_dotenv(path, *, override=False):
+        calls.append((path, override))
+
+    monkeypatch.setattr(smoke, "load_dotenv", fake_load_dotenv)
+    monkeypatch.delenv("ATLAS_DISABLE_DOTENV", raising=False)
+
+    smoke._load_dotenv_files()
+
+    assert calls == [
+        (ROOT / ".env", False),
+        (ROOT / ".env.local", True),
+    ]
+
+    calls.clear()
+    monkeypatch.setenv("ATLAS_DISABLE_DOTENV", "1")
+
+    smoke._load_dotenv_files()
+
+    assert calls == []
+
+
 def test_default_database_url_falls_back_to_atlas_db_settings(monkeypatch) -> None:
     monkeypatch.delenv("EXTRACTED_DATABASE_URL", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
@@ -246,6 +270,7 @@ def test_script_preflight_uses_atlas_db_settings_fallback(tmp_path) -> None:
             "ATLAS_DB_DATABASE": "atlas_settings",
             "ATLAS_DB_USER": "atlas_settings_user",
             "ATLAS_DB_PASSWORD": "atlas_settings_password",
+            "ATLAS_DISABLE_DOTENV": "1",
         }
     )
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-SaaS-Demo-Dotenv-Preflight.md
Slice phase: Production hardening

This drains the parked SaaS demo route smoke hardening item: local provisioned checkouts could repopulate hosted route env vars from repo-root dotenv files inside the subprocess preflight test, causing the test to miss its intended fail-closed missing-input path. The smoke now has an explicit env-only dotenv opt-out for test isolation while real operator runs still load `.env` and `.env.local` by default.

## Intentional
- This does not change hosted route validation, seeding, cleanup, or live smoke behavior.
- The opt-out is env-only rather than a CLI flag because the bug happens before normal argument defaults are safe to compute.
- This slice leaves the seed script dotenv behavior unchanged; the failing preflight path is in the route smoke subprocess.

## Deferred
- None.

## Parked hardening
- None; this drains the SaaS demo preflight dotenv item from `HARDENING.md`.

## Verification
- `pytest tests/test_smoke_content_ops_faq_saas_demo_route_e2e.py -q` - 26 passed in 0.99s.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= bash scripts/run_extracted_pipeline_checks.sh` - 2924 passed, 1 warning in 52.13s.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-saas-demo-dotenv-preflight-body.md` - passed.

## Diff size
4 files, +102 / -15.
