### PR TITLE
PR-Deflection-Delivery-Email-Metadata

### DIFF
--- a/atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql
+++ b/atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql
@@ -1,0 +1,4 @@
+-- Persist the delivery address captured during FAQ deflection report submit.
+
+ALTER TABLE content_ops_deflection_reports
+    ADD COLUMN IF NOT EXISTS delivery_email TEXT;

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -1111,6 +1111,7 @@ def create_content_ops_control_surface_router(
                 scope=scope,
                 request_id=request_id,
                 top_n=resolved_config.deflection_snapshot_top_n,
+                delivery_email=_delivery_email_from_payload(payload_mapping),
             )
             result = _with_input_provider_diagnostics(result, payload_mapping)
             result["request_id"] = request_id
@@ -2436,6 +2437,7 @@ async def _gate_deflection_report_artifacts(
     scope: TenantScope | None,
     request_id: str,
     top_n: int,
+    delivery_email: str | None = None,
 ) -> dict[str, Any]:
     gated = dict(result)
     steps = list(gated.get("steps", ()) or ())
@@ -2462,6 +2464,7 @@ async def _gate_deflection_report_artifacts(
                 request_id=request_id,
                 snapshot=snapshot,
                 artifact=dict(artifact),
+                delivery_email=delivery_email,
             )
         except ValueError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -2486,6 +2489,13 @@ async def _gate_deflection_report_artifacts(
         gated_steps.append(step_dict)
     gated["steps"] = gated_steps
     return gated
+
+
+def _delivery_email_from_payload(payload: Mapping[str, Any]) -> str | None:
+    inputs = payload.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return None
+    return _clean(inputs.get("contact_email")) or None
 
 
 def _is_completed_deflection_report_step(step: Any) -> bool:

--- a/extracted_content_pipeline/deflection_report_access.py
+++ b/extracted_content_pipeline/deflection_report_access.py
@@ -24,6 +24,7 @@ class DeflectionReportAccessRecord:
     artifact: dict[str, Any] | None
     paid: bool
     payment_reference: str | None = None
+    delivery_email: str | None = None
 
 
 class DeflectionReportArtifactStore(Protocol):
@@ -36,6 +37,7 @@ class DeflectionReportArtifactStore(Protocol):
         request_id: str,
         snapshot: Mapping[str, Any],
         artifact: Mapping[str, Any],
+        delivery_email: str | None = None,
     ) -> None:
         """Persist a generated report while keeping it locked by default."""
 
@@ -78,9 +80,11 @@ class InMemoryDeflectionReportArtifactStore:
         request_id: str,
         snapshot: Mapping[str, Any],
         artifact: Mapping[str, Any],
+        delivery_email: str | None = None,
     ) -> None:
         key = (_required_text(account_id, "account_id"), _required_text(request_id, "request_id"))
         existing = self._rows.get(key)
+        cleaned_delivery_email = _clean(delivery_email)
         self._rows[key] = DeflectionReportAccessRecord(
             account_id=key[0],
             request_id=key[1],
@@ -88,6 +92,8 @@ class InMemoryDeflectionReportArtifactStore:
             artifact=dict(artifact),
             paid=bool(existing.paid) if existing else False,
             payment_reference=existing.payment_reference if existing else None,
+            delivery_email=cleaned_delivery_email
+            or (existing.delivery_email if existing else None),
         )
 
     async def get_snapshot(
@@ -115,6 +121,7 @@ class InMemoryDeflectionReportArtifactStore:
             artifact=dict(row.artifact or {}) if row.artifact is not None else None,
             paid=row.paid,
             payment_reference=row.payment_reference,
+            delivery_email=row.delivery_email,
         )
 
     async def mark_paid(
@@ -135,6 +142,7 @@ class InMemoryDeflectionReportArtifactStore:
             artifact=dict(row.artifact or {}) if row.artifact is not None else None,
             paid=True,
             payment_reference=_clean(payment_reference) or row.payment_reference,
+            delivery_email=row.delivery_email,
         )
         return True
 
@@ -152,24 +160,30 @@ class PostgresDeflectionReportArtifactStore:
         request_id: str,
         snapshot: Mapping[str, Any],
         artifact: Mapping[str, Any],
+        delivery_email: str | None = None,
     ) -> None:
         await self.pool.execute(
             """
             INSERT INTO content_ops_deflection_reports (
-                account_id, request_id, snapshot, artifact, paid, updated_at
+                account_id, request_id, snapshot, artifact, paid, delivery_email, updated_at
             )
-            VALUES ($1, $2, $3::jsonb, $4::jsonb, false, NOW())
+            VALUES ($1, $2, $3::jsonb, $4::jsonb, false, $5, NOW())
             ON CONFLICT (account_id, request_id) DO UPDATE
             SET snapshot = EXCLUDED.snapshot,
                 artifact = EXCLUDED.artifact,
                 paid = content_ops_deflection_reports.paid,
                 payment_reference = content_ops_deflection_reports.payment_reference,
+                delivery_email = COALESCE(
+                    EXCLUDED.delivery_email,
+                    content_ops_deflection_reports.delivery_email
+                ),
                 updated_at = NOW()
             """,
             _required_text(account_id, "account_id"),
             _required_text(request_id, "request_id"),
             json_dump_jsonb(dict(snapshot)),
             json_dump_jsonb(dict(artifact)),
+            _clean(delivery_email) or None,
         )
 
     async def get_snapshot(
@@ -200,7 +214,7 @@ class PostgresDeflectionReportArtifactStore:
     ) -> DeflectionReportAccessRecord | None:
         row = await self.pool.fetchrow(
             """
-            SELECT account_id, request_id, snapshot, artifact, paid, payment_reference
+            SELECT account_id, request_id, snapshot, artifact, paid, payment_reference, delivery_email
             FROM content_ops_deflection_reports
             WHERE account_id = $1 AND request_id = $2
             """,
@@ -244,6 +258,7 @@ def _record_from_row(row: Mapping[str, Any]) -> DeflectionReportAccessRecord:
         artifact=dict(artifact) if isinstance(artifact, Mapping) else None,
         paid=bool(row.get("paid")),
         payment_reference=_clean(row.get("payment_reference")),
+        delivery_email=_clean(row.get("delivery_email")) or None,
     )
 
 

--- a/plans/PR-Deflection-Delivery-Email-Metadata.md
+++ b/plans/PR-Deflection-Delivery-Email-Metadata.md
@@ -1,0 +1,100 @@
+## Why this slice exists
+
+The live FAQ deflection flow collects `contact_email` during report submission,
+but the paid-gated report row only persists snapshot/artifact/paid state. That
+blocks the next delivery step: after a buyer unlocks the report, ATLAS needs a
+durable delivery address to send the report link or follow-up conversion email.
+
+This slice adds the durable metadata only. It does not send email, expose the
+address in the free snapshot, or change the Stripe/paywall trust boundary.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Production hardening
+
+1. Add a nullable delivery email column for persisted deflection report rows.
+2. Thread a cleaned `contact_email` from Content Ops execute inputs into the
+   deflection report store when the gated report artifact is saved.
+3. Preserve existing paid/payment state across report regenerations.
+4. Keep snapshots and customer-facing result payloads free of delivery email.
+5. Add focused tests for in-memory submit persistence and Postgres store
+   round-trip behavior.
+
+### Files touched
+
+- `atlas_brain/storage/migrations/331_content_ops_deflection_report_delivery_email.sql`
+- `extracted_content_pipeline/deflection_report_access.py`
+- `extracted_content_pipeline/api/control_surfaces.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_deflection_submit.py`
+- `plans/PR-Deflection-Delivery-Email-Metadata.md`
+
+## Mechanism
+
+`DeflectionReportArtifactStore.save_report(...)` accepts an optional
+`delivery_email`. The control-surface execution path extracts
+`inputs.contact_email`, cleans it, and passes it only at the storage boundary
+when a `faq_deflection_report` artifact is gated.
+
+The Postgres adapter persists the value in `content_ops_deflection_reports` via
+a new nullable `delivery_email` column. On conflict, a non-empty new delivery
+email replaces the prior value; a missing/blank value leaves the prior value in
+place, so regenerating a report without delivery metadata does not erase the
+address needed for later delivery.
+
+The free snapshot route still returns only the stored snapshot JSON. The paid
+artifact route still returns only the full artifact after the verified paid
+gate. The new delivery email is store metadata for future delivery workers, not
+a customer payload field.
+
+## Intentional
+
+- No email is sent in this slice. Delivery requires a separate worker/template
+  slice after the persistence contract exists.
+- The delivery email is not added to `DeflectionSnapshot`,
+  `FAQDeflectionReportArtifact`, or the portfolio result page response.
+- This does not alter Stripe metadata, payment verification, paid unlock, or
+  checkout behavior.
+- The field is named `delivery_email`, not `contact_email`, because it records
+  the address ATLAS may use for post-purchase delivery and follow-up workflows.
+
+## Deferred
+
+- Future slice: post-webhook report delivery email using the persisted
+  `delivery_email` and canonical result URL.
+- Future slice: abandoned/checkout-cancel follow-up capture policy and opt-out
+  rules.
+- Parked hardening: none.
+
+## Verification
+
+- Py compile for `extracted_content_pipeline/deflection_report_access.py`,
+  `extracted_content_pipeline/api/control_surfaces.py`,
+  `tests/test_content_ops_deflection_report.py`, and
+  `tests/test_extracted_content_deflection_submit.py` - passed.
+- Focused pytest for `tests/test_content_ops_deflection_report.py` and
+  `tests/test_extracted_content_deflection_submit.py` - 39 passed in 0.61s;
+  rechecked after rebase, 39 passed in 0.60s.
+- Extracted package guardrails - passed:
+  `scripts/validate_extracted_content_pipeline.sh`,
+  `extracted/_shared/scripts/forbid_atlas_reasoning_imports.py`,
+  `scripts/audit_extracted_standalone.py`, and
+  `scripts/check_ascii_python.sh`.
+- Full extracted mirror with
+  `EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas` and hosted
+  deflection smoke env vars blanked - 2924 passed, 1 warning in 53.91s.
+- Local PR review bundle with the current PR body - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Store + API threading | ~45 |
+| Migration | ~10 |
+| Tests | ~35 |
+| Plan doc | ~85 |
+| **Total** | **~175** |
+
+Under the 400 LOC soft cap.

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -210,7 +210,7 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
 
         async def execute(self, query: str, *args: object) -> str:
             if "INSERT INTO content_ops_deflection_reports" in query:
-                account_id, request_id, snapshot, artifact = args
+                account_id, request_id, snapshot, artifact, delivery_email = args
                 key = (str(account_id), str(request_id))
                 existing = self.rows.get(key, {})
                 self.rows[key] = {
@@ -220,6 +220,7 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
                     "artifact": artifact,
                     "paid": bool(existing.get("paid")),
                     "payment_reference": existing.get("payment_reference"),
+                    "delivery_email": delivery_email or existing.get("delivery_email"),
                 }
                 return "INSERT 0 1"
             if "UPDATE content_ops_deflection_reports" in query:
@@ -268,12 +269,14 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
         request_id="request-1",
         snapshot=snapshot,
         artifact=artifact,
+        delivery_email=" buyer@example.com ",
     )
 
     assert await store.get_snapshot(
         account_id="acct-1",
         request_id="request-1",
     ) == snapshot
+    assert "buyer@example.com" not in str(snapshot)
     locked = await store.get_artifact_record(
         account_id="acct-1",
         request_id="request-1",
@@ -281,6 +284,7 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
     assert locked is not None
     assert locked.paid is False
     assert locked.artifact == artifact
+    assert locked.delivery_email == "buyer@example.com"
     assert await store.mark_paid(
         account_id="acct-1",
         request_id="request-1",
@@ -293,6 +297,21 @@ async def test_postgres_deflection_report_store_round_trips_paid_gate() -> None:
     assert unlocked is not None
     assert unlocked.paid is True
     assert unlocked.payment_reference == "checkout-session:test"
+    assert unlocked.delivery_email == "buyer@example.com"
+    await store.save_report(
+        account_id="acct-1",
+        request_id="request-1",
+        snapshot=snapshot,
+        artifact=artifact,
+    )
+    preserved = await store.get_artifact_record(
+        account_id="acct-1",
+        request_id="request-1",
+    )
+    assert preserved is not None
+    assert preserved.delivery_email == "buyer@example.com"
+    assert preserved.paid is True
+    assert preserved.payment_reference == "checkout-session:test"
     assert await store.mark_paid(
         account_id="acct-1",
         request_id="missing",

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -192,6 +192,14 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+    assert "lead@acme.example" not in str(gated_result["snapshot"])
+
+    record = await store.get_artifact_record(
+        account_id="acct-portfolio-submit",
+        request_id=payload["request_id"],
+    )
+    assert record is not None
+    assert record.delivery_email == "lead@acme.example"
 
     artifact = _route(router, "/ops/deflection-reports/{request_id}/artifact", "GET")
     with pytest.raises(api_module.HTTPException) as locked:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Email-Metadata.md
Slice phase: Production hardening

The FAQ deflection submit flow already collects `contact_email`, but the paid-gated report row did not persist a delivery address. This PR stores that cleaned address as report-row metadata so a later post-purchase delivery worker has a durable destination, while keeping snapshots, artifacts, Checkout, and paid unlock behavior unchanged.

## Intentional
- No email is sent in this slice.
- Delivery email is store metadata only; it is not added to `DeflectionSnapshot`, `FAQDeflectionReportArtifact`, or the portfolio result page payload.
- Stripe metadata, payment verification, paid unlock, and checkout behavior are unchanged.
- The field is named `delivery_email` because it records the address ATLAS may use for post-purchase delivery and follow-up workflows.

## Deferred
- Post-webhook report delivery email using the persisted `delivery_email` and canonical result URL.
- Abandoned/checkout-cancel follow-up capture policy and opt-out rules.

## Parked hardening
- None.

## Verification
- `python -m py_compile extracted_content_pipeline/deflection_report_access.py extracted_content_pipeline/api/control_surfaces.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py` - passed.
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_deflection_submit.py -q` - 39 passed in 0.61s; rechecked after rebase, 39 passed in 0.60s.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed.
- `bash scripts/check_ascii_python.sh` - passed.
- `EXTRACTED_DATABASE_URL=postgresql://atlas@localhost:5433/atlas ATLAS_API_BASE_URL= ATLAS_B2B_JWT= ATLAS_TOKEN= ATLAS_ACCOUNT_ID= ATLAS_FAQ_SEARCH_ACCOUNT_ID= ATLAS_DEFLECTION_SUBMIT_BLOB_URL= ATLAS_DEFLECTION_SUBMIT_CSV_FILE= ATLAS_DEFLECTION_COMPANY_NAME= ATLAS_DEFLECTION_CONTACT_EMAIL= ATLAS_DEFLECTION_SUPPORT_PLATFORM= ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL= ATLAS_DEFLECTION_REQUEST_ID= bash scripts/run_extracted_pipeline_checks.sh` - 2924 passed, 1 warning in 53.91s.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-delivery-email-metadata-body.md` - passed.

## Diff size
6 files, +160 / -4.
