### PR TITLE
PR-Deflection-Delivery-Privacy-Regressions

### DIFF
--- a/plans/PR-Deflection-Delivery-Privacy-Regressions.md
+++ b/plans/PR-Deflection-Delivery-Privacy-Regressions.md
@@ -1,0 +1,76 @@
+## Why this slice exists
+
+PR-Deflection-Delivery-Email-Metadata persisted `delivery_email` as store-only
+metadata for future post-purchase report delivery. The reviewer verified by
+trace that the address does not leak through customer payloads, but flagged a
+non-blocking privacy hardening gap: there is no direct regression test proving
+future projections cannot accidentally expose the buyer email.
+
+This slice locks that privacy boundary before adding any delivery worker.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-backend
+
+Slice phase: Production hardening
+
+1. Add negative regression coverage proving `delivery_email` is absent from the
+   free snapshot response.
+2. Add negative regression coverage proving `delivery_email` is absent from the
+   paid artifact response after unlock.
+3. Add negative regression coverage proving the gated execute/result payload
+   does not expose `delivery_email`.
+4. Leave storage, checkout, paid unlock, and email sending unchanged.
+
+### Files touched
+
+- `tests/test_extracted_content_deflection_submit.py`
+- `plans/PR-Deflection-Delivery-Privacy-Regressions.md`
+
+## Mechanism
+
+The existing submit-route regression already creates a report with
+`contact_email`, verifies the locked gated payload, and checks the stored
+metadata. This slice extends that path to assert the same email is absent from:
+
+- the immediate gated submit payload,
+- `GET /deflection-reports/{request_id}/snapshot`, and
+- `GET /deflection-reports/{request_id}/artifact` after the trusted paid route
+  unlocks the report.
+
+The test uses the existing in-memory store and route helpers, so it exercises
+the same projection boundaries that customer routes use without adding new
+infrastructure.
+
+## Intentional
+
+- This is test-only hardening. The prior slice already added the storage
+  behavior; this slice locks the privacy invariant the reviewer requested.
+- No email is sent and no delivery worker/template is introduced.
+- No changes to Stripe metadata, checkout, paid unlock, snapshot shape, or
+  artifact shape.
+
+## Deferred
+
+- Future slice: post-webhook report delivery email using the persisted
+  `delivery_email` and canonical result URL.
+- Future slice: abandoned/checkout-cancel follow-up capture policy and opt-out
+  rules before any non-buyer nurture email is sent.
+- Parked hardening: none.
+
+## Verification
+
+- Py compile for `tests/test_extracted_content_deflection_submit.py` - passed.
+- Focused pytest for `tests/test_extracted_content_deflection_submit.py` - 18
+  passed in 0.47s.
+- Local PR review bundle with the current PR body - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Tests | ~20 |
+| Plan doc | ~70 |
+| **Total** | **~90** |
+
+Under the 400 LOC soft cap.

--- a/tests/test_extracted_content_deflection_submit.py
+++ b/tests/test_extracted_content_deflection_submit.py
@@ -170,6 +170,7 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     }
     assert "markdown" not in str(gated_result)
     assert "ticket-export-1" not in str(gated_result)
+    assert "lead@acme.example" not in str(payload)
     assert payload["input_provider"]["metadata"] == {
         "blob_bytes": len(csv_data),
         "included_row_count": 2,
@@ -191,7 +192,9 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     }]
 
     snapshot = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
-    assert await snapshot.endpoint(request_id=payload["request_id"]) == gated_result["snapshot"]
+    snapshot_payload = await snapshot.endpoint(request_id=payload["request_id"])
+    assert snapshot_payload == gated_result["snapshot"]
+    assert "lead@acme.example" not in str(snapshot_payload)
     assert "lead@acme.example" not in str(gated_result["snapshot"])
 
     record = await store.get_artifact_record(
@@ -205,6 +208,16 @@ async def test_deflection_submit_fetches_blob_and_returns_locked_report(
     with pytest.raises(api_module.HTTPException) as locked:
         await artifact.endpoint(request_id=payload["request_id"])
     assert locked.value.status_code == 403
+
+    paid = _route(router, "/ops/deflection-reports/{request_id}/paid", "POST")
+    assert await paid.endpoint(
+        payload=api_module.DeflectionReportPaidModel(
+            payment_reference="checkout-session:test"
+        ),
+        request_id=payload["request_id"],
+    ) == {"request_id": payload["request_id"], "paid": True}
+    artifact_payload = await artifact.endpoint(request_id=payload["request_id"])
+    assert "lead@acme.example" not in str(artifact_payload)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Privacy-Regressions.md
Slice phase: Production hardening

This follows up the delivery-email metadata slice with route-level privacy regressions. The persisted `delivery_email` stays server-side, and the tests now prove it is absent from the gated submit payload, free snapshot response, and paid artifact response after unlock.

## Intentional
- Test-only hardening; no delivery worker or email sending is introduced.
- Storage, checkout, paid unlock, snapshot shape, and artifact shape are unchanged.
- This locks the reviewer-requested privacy invariant before building post-purchase delivery.

## Deferred
- Post-webhook report delivery email using the persisted `delivery_email` and canonical result URL.
- Abandoned/checkout-cancel follow-up capture policy and opt-out rules before any non-buyer nurture email is sent.

## Parked hardening
- None.

## Verification
- `python -m py_compile tests/test_extracted_content_deflection_submit.py` - passed.
- `pytest tests/test_extracted_content_deflection_submit.py -q` - 18 passed in 0.47s.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-delivery-privacy-regressions-body.md` - passed.

## Diff size
2 files, +90 / -1.
