### PR TITLE
PR-Content-Ops-Competitive-Input-Provider

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
@@ -36,6 +36,7 @@ test('new run page exposes review source selection', () => {
   assert.ok(newRunSource.includes('updateSourceModeInputJson(inputsJson, mode)'))
   assert.ok(newRunSource.includes('Support tickets'))
   assert.ok(newRunSource.includes('Reviews'))
+  assert.ok(newRunSource.includes('Competitive'))
 })
 
 test('review source mode writes source type into inputs JSON', () => {
@@ -76,6 +77,32 @@ test('support-ticket source mode removes explicit source type but preserves FAQ 
   assert.equal(sourceModeDraftValue(parseInputsJsonObject(updated.value)), 'support_ticket')
 })
 
-test('review source mode disables support-ticket FAQ source selection in the page', () => {
-  assert.ok(newRunSource.includes("sourceMode !== 'reviews'"))
+test('competitive source mode writes source type and removes FAQ selection', () => {
+  const updated = updateSourceModeInputJson(
+    JSON.stringify({
+      source_material_type: 'support_ticket',
+      source_faq_ids: ['faq-1'],
+      target_account: 'Acme',
+    }),
+    'competitive',
+  )
+
+  assert.equal(updated.ok, true)
+  const parsed = JSON.parse(updated.value)
+  assert.deepEqual(parsed, {
+    source_type: 'competitive',
+    target_account: 'Acme',
+  })
+  assert.equal(
+    sourceModeDraftValue(parseInputsJsonObject('{"source_material_type":"displacement"}')),
+    'competitive',
+  )
+  assert.equal(
+    sourceModeDraftValue(parseInputsJsonObject('{"source_type":"competitors"}')),
+    'competitive',
+  )
+})
+
+test('non-support source modes disable support-ticket FAQ source selection in the page', () => {
+  assert.ok(newRunSource.includes("sourceMode === 'support_ticket'"))
 })

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -317,7 +317,7 @@ export default function ContentOpsNewRun() {
   const blogPostOutputSelected = request.outputs.includes(BLOG_POST_OUTPUT)
   const faqSourceSelectionVisible =
     (landingPageOutputSelected || blogPostOutputSelected) &&
-    sourceMode !== 'reviews'
+    sourceMode === 'support_ticket'
   const faqConfigurationOutputSelected = faqConfigurationInputsSelected(
     request.outputs,
   )
@@ -1081,6 +1081,7 @@ export default function ContentOpsNewRun() {
             {[
               ['support_ticket', 'Support tickets'],
               ['reviews', 'Reviews'],
+              ['competitive', 'Competitive'],
             ].map(([mode, label]) => {
               const selected = sourceMode === mode
               return (

--- a/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
+++ b/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
@@ -2,7 +2,7 @@ const SOURCE_TYPE_INPUT = 'source_type'
 const SOURCE_MATERIAL_TYPE_INPUT = 'source_material_type'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
 
-export type ContentOpsSourceMode = 'support_ticket' | 'reviews'
+export type ContentOpsSourceMode = 'support_ticket' | 'reviews' | 'competitive'
 
 export type ParsedInputsJsonObject =
   | { ok: true; value: Record<string, unknown> }
@@ -40,6 +40,20 @@ export function sourceModeDraftValue(
     parsed.value[SOURCE_TYPE_INPUT] ?? parsed.value[SOURCE_MATERIAL_TYPE_INPUT]
   const value = String(raw ?? '').trim().toLowerCase().replace(/-/g, '_')
   if (value === 'review' || value === 'reviews') return 'reviews'
+  if (
+    value === 'competitive' ||
+    value === 'competition' ||
+    value === 'competitor' ||
+    value === 'competitors' ||
+    value === 'competitive_displacement' ||
+    value === 'competitive_signal' ||
+    value === 'competitive_signals' ||
+    value === 'displacement' ||
+    value === 'displacement_edge' ||
+    value === 'displacement_edges'
+  ) {
+    return 'competitive'
+  }
   return 'support_ticket'
 }
 
@@ -54,6 +68,9 @@ export function updateSourceModeInputJson(
   delete next[SOURCE_MATERIAL_TYPE_INPUT]
   if (mode === 'reviews') {
     next[SOURCE_TYPE_INPUT] = 'reviews'
+    delete next[SOURCE_FAQ_IDS_INPUT]
+  } else if (mode === 'competitive') {
+    next[SOURCE_TYPE_INPUT] = 'competitive'
     delete next[SOURCE_FAQ_IDS_INPUT]
   } else {
     delete next[SOURCE_TYPE_INPUT]

--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -94,12 +94,75 @@ _REVIEW_SOURCE_TYPE_ALIASES = frozenset({
     "complaint",
     "complaints",
 })
+_COMPETITIVE_SOURCE_TYPE_ALIASES = frozenset({
+    "competitive",
+    "competition",
+    "competitor",
+    "competitors",
+    "competitive_displacement",
+    "competitive_signal",
+    "competitive_signals",
+    "displacement",
+    "displacement_edge",
+    "displacement_edges",
+})
+_COMPETITIVE_BUNDLE_KEYS = frozenset({
+    "competitive_inputs",
+    "competitive_rows",
+    "competitive_signal",
+    "competitive_signals",
+    "displacement_edge",
+    "displacement_edges",
+    "displacements",
+    "switching_evidence",
+})
+_COMPETITIVE_MARKER_KEYS = frozenset({
+    "alternative",
+    "alternative_name",
+    "alternative_product",
+    "alternative_vendor",
+    "alternatives",
+    "competitive_alternative",
+    "competitive_alternatives",
+    "competitive_displacement",
+    "competitor",
+    "competitor_name",
+    "competitor_overlap",
+    "competitor_vendor",
+    "competitor_vendor_name",
+    "competitors",
+    "competitors_mentioned",
+    "displacement_confidence",
+    "displacement_direction",
+    "displacement_map",
+    "displacement_mention_count",
+    "from_vendor",
+    "losing_vendor",
+    "new_vendor",
+    "switched_from",
+    "switched_to",
+    "switching_from",
+    "switching_to",
+    "to_vendor",
+    "top_displacement_targets",
+    "winning_vendor",
+})
 _REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post")
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
 _REVIEW_OFFER = "Turn customer review themes into buyer-facing landing pages and blog posts"
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
+_COMPETITIVE_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post")
+_COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
+_COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
+_COMPETITIVE_AUDIENCE = (
+    "Marketing teams turning competitive evidence into grounded content"
+)
+_COMPETITIVE_OFFER = (
+    "Turn competitor and switching evidence into buyer-facing landing pages and blog posts"
+)
+_COMPETITIVE_TARGET_KEYWORD = "competitive displacement content marketing"
 
 
 @dataclass(frozen=True)
@@ -141,6 +204,28 @@ class _AtlasSupportTicketInputProvider:
                     request=request,
                 )
             return _build_review_input_package(
+                source_material,
+                metadata={"requested_source_type": source_type},
+                default_source_type=source_type,
+            )
+        if source_type in _COMPETITIVE_SOURCE_TYPE_ALIASES:
+            if source_faq_ids:
+                return _noop_package(
+                    "atlas_competitive_request",
+                    metadata={"requested_source_type": source_type},
+                    warnings=({
+                        "code": "competitive_source_faq_ids_unsupported",
+                        "message": "Saved FAQ source selection is only supported for support-ticket runs.",
+                    },),
+                )
+            if source_target_ids:
+                return self._build_competitive_from_selected_sources(
+                    source_target_ids,
+                    source_material=source_material,
+                    scope=scope,
+                    request=request,
+                )
+            return _build_competitive_input_package(
                 source_material,
                 metadata={"requested_source_type": source_type},
                 default_source_type=source_type,
@@ -291,6 +376,48 @@ class _AtlasSupportTicketInputProvider:
             skip_reason=target_skip_reason,
         )
         return _build_review_input_package(
+            combined_source_material,
+            metadata=metadata,
+            warnings=warnings,
+            default_source_type=requested_source_type,
+        )
+
+    async def _build_competitive_from_selected_sources(
+        self,
+        source_target_ids: Sequence[str],
+        *,
+        source_material: Any,
+        scope: TenantScope,
+        request: RequestPayload | None,
+    ) -> ContentOpsInputPackage:
+        (
+            loaded_targets,
+            missing_targets,
+            ambiguous_targets,
+            target_skip_reason,
+        ) = await self._load_selected_import_targets(
+            source_target_ids,
+            scope=scope,
+            request=request,
+        )
+        combined_source_material = _combine_source_material(
+            source_material,
+            loaded_targets,
+        )
+        requested_source_type = _request_source_type(request) or "competitive"
+        metadata = {
+            "requested_source_type": requested_source_type,
+            "source_target_id_count": len(source_target_ids),
+            "source_target_loaded_count": len(loaded_targets),
+            "source_target_missing_id_count": len(missing_targets),
+            "source_target_ambiguous_id_count": len(ambiguous_targets),
+        }
+        warnings = _selected_source_target_warnings(
+            missing=missing_targets,
+            ambiguous=ambiguous_targets,
+            skip_reason=target_skip_reason,
+        )
+        return _build_competitive_input_package(
             combined_source_material,
             metadata=metadata,
             warnings=warnings,
@@ -534,7 +661,7 @@ def _has_any_text(value: Mapping[str, Any], keys: frozenset[str]) -> bool:
 
 
 def _key(value: Any) -> str:
-    return str(value or "").strip().lower().replace(" ", "_")
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
 
 
 def _clean(value: Any) -> str:
@@ -654,6 +781,203 @@ def _review_competitors(rows: Sequence[Mapping[str, Any]]) -> list[str]:
         if len(values) == 3:
             break
     return values or ["generic AI copy", "manual review mining"]
+
+
+def _build_competitive_input_package(
+    source_material: Any,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+    warnings: Sequence[Mapping[str, Any]] = (),
+    default_source_type: str = "competitive",
+) -> ContentOpsInputPackage:
+    source_rows = source_material_to_source_rows(
+        _competitive_source_material_rows(source_material)
+    )
+    load_result = source_rows_to_campaign_opportunities(
+        source_rows,
+        default_fields={"source_type": default_source_type},
+    )
+    competitive_opportunities = [
+        dict(row)
+        for row in load_result.opportunities
+        if _is_competitive_opportunity(row)
+    ]
+    adapter_warnings = [
+        {
+            "code": warning.code,
+            "message": warning.message,
+            **({"row_index": warning.row_index} if warning.row_index is not None else {}),
+            **({"field": warning.field} if warning.field else {}),
+        }
+        for warning in load_result.warnings
+    ]
+    package_metadata = {
+        "source": "competitive_input_package",
+        "source_row_count": len(source_rows),
+        "opportunity_count": len(load_result.opportunities),
+        "included_row_count": len(competitive_opportunities),
+        "skipped_row_count": max(0, len(source_rows) - len(competitive_opportunities)),
+        **dict(metadata or {}),
+    }
+    package_warnings = [dict(warning) for warning in warnings]
+    package_warnings.extend(adapter_warnings)
+    if not competitive_opportunities:
+        warning_code = (
+            "competitive_source_rows_unrecognized"
+            if source_rows
+            else "competitive_source_material_empty"
+        )
+        warning_message = (
+            "Competitive source rows were provided, but none carried competitor or displacement markers."
+            if source_rows
+            else "No competitive or displacement source rows were provided."
+        )
+        package_warnings.append({
+            "code": warning_code,
+            "message": warning_message,
+        })
+        return _noop_package(
+            "atlas_competitive_request",
+            metadata=package_metadata,
+            warnings=package_warnings,
+        )
+    primary_entity = _competitive_primary_entity(competitive_opportunities)
+    competitors = _competitive_competitors(competitive_opportunities)
+    inputs = {
+        "source_material": competitive_opportunities,
+        "competitive_source_material": competitive_opportunities,
+        "source_type": "competitive",
+        "campaign_name": _COMPETITIVE_CAMPAIGN_NAME,
+        "target_account": primary_entity,
+        "topic": _COMPETITIVE_TOPIC,
+        "offer": _COMPETITIVE_OFFER,
+        "audience": _COMPETITIVE_AUDIENCE,
+        "target_keyword": _COMPETITIVE_TARGET_KEYWORD,
+        "search_intent": (
+            "Marketing teams looking for competitor and switching evidence "
+            "they can turn into grounded buyer-facing content."
+        ),
+        "primary_entity": primary_entity,
+        "audience_entity": _COMPETITIVE_AUDIENCE,
+        "competitors": competitors,
+        "competitive_alternatives": competitors,
+        "objections": [
+            "Will this make unsupported competitive claims?",
+            "Can we trace switching claims back to source evidence?",
+        ],
+        "source_period": "Recent competitive and displacement evidence",
+        "competitive_source_count": len(competitive_opportunities),
+        "displacement_source_count": len(competitive_opportunities),
+        "internal_links": ["/systems/ai-content-ops/intake"],
+        "cta_label": "Turn Competitive Evidence Into Content",
+        "cta_url": "/systems/ai-content-ops/intake",
+    }
+    return ContentOpsInputPackage(
+        provider="atlas_competitive_request",
+        inputs=inputs,
+        outputs=_COMPETITIVE_CAMPAIGN_OUTPUTS,
+        target_mode="vendor_retention",
+        ingestion_profile="existing_evidence",
+        metadata=package_metadata,
+        warnings=tuple(package_warnings),
+    )
+
+
+def _is_competitive_opportunity(row: Mapping[str, Any]) -> bool:
+    if _key(row.get("source_type")) in _COMPETITIVE_SOURCE_TYPE_ALIASES:
+        return _has_competitive_marker(row)
+    return _has_competitive_marker(row)
+
+
+def _has_competitive_marker(row: Mapping[str, Any]) -> bool:
+    return any(
+        _key(key) in _COMPETITIVE_MARKER_KEYS and value not in (None, "", [], {})
+        for key, value in row.items()
+    )
+
+
+def _competitive_primary_entity(rows: Sequence[Mapping[str, Any]]) -> str:
+    for row in rows:
+        for key in (
+            "from_vendor",
+            "vendor_name",
+            "current_vendor",
+            "incumbent_vendor",
+            "product_name",
+            "company_name",
+        ):
+            value = _clean(row.get(key))
+            if value:
+                return value
+    return _COMPETITIVE_CAMPAIGN_NAME
+
+
+def _competitive_competitors(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    values: list[str] = []
+    for row in rows:
+        for key in (
+            "to_vendor",
+            "competitor",
+            "competitor_name",
+            "competitor_vendor",
+            "alternative_name",
+            "alternative_vendor",
+            "winning_vendor",
+            "new_vendor",
+            "competitive_alternatives",
+            "alternatives",
+            "competitors",
+            "competitors_mentioned",
+            "top_displacement_targets",
+            "competitor_overlap",
+        ):
+            _append_competitive_names(values, row.get(key))
+            if len(values) >= 5:
+                return values[:5]
+    return values[:5] or ["manual competitive research", "generic AI copy"]
+
+
+def _competitive_source_material_rows(source_material: Any) -> Any:
+    if not isinstance(source_material, Mapping):
+        return source_material
+    rows: list[Any] = []
+    for key, value in source_material.items():
+        if _key(key) not in _COMPETITIVE_BUNDLE_KEYS:
+            continue
+        if _is_empty_source_material(value):
+            continue
+        if isinstance(value, (list, tuple)):
+            rows.extend(value)
+        else:
+            rows.append(value)
+    return rows if rows else source_material
+
+
+def _append_competitive_names(values: list[str], raw: Any) -> None:
+    if raw in (None, "", [], {}):
+        return
+    if isinstance(raw, str):
+        items: Sequence[Any] = raw.split(",")
+    elif isinstance(raw, Mapping):
+        items = (
+            raw.get("name")
+            or raw.get("competitor")
+            or raw.get("vendor")
+            or raw.get("to_vendor")
+            or raw.get("alternative")
+            or raw.get("alternative_name"),
+        )
+    elif isinstance(raw, Sequence) and not isinstance(raw, (bytes, bytearray)):
+        items = raw
+    else:
+        items = (raw,)
+    for item in items:
+        if isinstance(item, Mapping):
+            _append_competitive_names(values, item)
+            continue
+        value = _clean(item)
+        if value and value not in values:
+            values.append(value)
 
 
 def _selected_faq_warnings(

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -45,6 +45,18 @@ _REASONING_OUTPUT_TO_ATTR: Mapping[str, str] = MappingProxyType({
     "sales_brief": "sales_brief",
 })
 _REASONING_AWARE_OUTPUTS = tuple(_REASONING_OUTPUT_TO_ATTR)
+_COMPETITIVE_SOURCE_TYPES = frozenset({
+    "competitive",
+    "competition",
+    "competitor",
+    "competitors",
+    "competitive_displacement",
+    "competitive_signal",
+    "competitive_signals",
+    "displacement",
+    "displacement_edge",
+    "displacement_edges",
+})
 
 
 @dataclass(frozen=True)
@@ -582,7 +594,8 @@ async def _dispatch_blog_post(
         "topic": _step_config_text(step.config, "topic"),
     }
     data_context = (
-        _review_blog_data_context_from_inputs(request.inputs)
+        _competitive_blog_data_context_from_inputs(request.inputs)
+        or _review_blog_data_context_from_inputs(request.inputs)
         or _support_ticket_blog_data_context_from_inputs(request.inputs)
     )
     if data_context:
@@ -909,6 +922,52 @@ def _review_blog_data_context_from_inputs(
         "source_material": review_rows,
         "review_source_material": review_rows,
         "customer_wording_examples": review_rows[:5],
+        "topic": _clean(inputs.get("topic")),
+    }
+    return {
+        key: value
+        for key, value in context.items()
+        if value not in (None, "", [], {})
+    }
+
+
+def _competitive_blog_data_context_from_inputs(
+    inputs: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    source_type = _source_type_input(inputs)
+    rows = _mapping_list_input(inputs.get("competitive_source_material"))
+    if not rows and source_type in _COMPETITIVE_SOURCE_TYPES:
+        rows = _mapping_list_input(inputs.get("source_material"))
+    if not rows:
+        return None
+    competitors = (
+        _text_list_input(inputs.get("competitive_alternatives"))
+        or _text_list_input(inputs.get("competitors"))
+    )
+    context: dict[str, Any] = {
+        "source": "competitive_input_provider",
+        "source_type": "competitive",
+        "source_period": _clean(inputs.get("source_period"))
+        or "Recent competitive and displacement evidence",
+        "review_period": _clean(inputs.get("source_period"))
+        or "Recent competitive and displacement evidence",
+        "source_row_count": _positive_int_context(
+            inputs.get("competitive_source_count")
+        )
+        or len(rows),
+        "competitive_source_count": _positive_int_context(
+            inputs.get("competitive_source_count")
+        )
+        or len(rows),
+        "displacement_source_count": _positive_int_context(
+            inputs.get("displacement_source_count")
+        )
+        or len(rows),
+        "source_material": rows,
+        "competitive_source_material": rows,
+        "competitive_alternatives": competitors,
+        "competitors": competitors,
+        "customer_wording_examples": rows[:5],
         "topic": _clean(inputs.get("topic")),
     }
     return {

--- a/extracted_content_pipeline/landing_page_input_contract.py
+++ b/extracted_content_pipeline/landing_page_input_contract.py
@@ -49,6 +49,12 @@ LANDING_PAGE_REVIEW_SOURCE_INPUT_KEYS: tuple[str, ...] = (
     "review_source_count",
 )
 
+LANDING_PAGE_COMPETITIVE_SOURCE_INPUT_KEYS: tuple[str, ...] = (
+    "competitive_source_material",
+    "competitive_source_count",
+    "displacement_source_count",
+)
+
 LANDING_PAGE_EXISTING_CONTEXT_KEYS: tuple[str, ...] = (
     "industry",
     "pain_points",
@@ -64,6 +70,7 @@ LANDING_PAGE_CONTEXT_INPUT_KEYS: frozenset[str] = frozenset((
     *LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS,
     *LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS,
     *LANDING_PAGE_REVIEW_SOURCE_INPUT_KEYS,
+    *LANDING_PAGE_COMPETITIVE_SOURCE_INPUT_KEYS,
 ))
 
 
@@ -158,8 +165,10 @@ def landing_page_seo_geo_aeo_input_contracts() -> dict[str, dict[str, Any]]:
 
 __all__ = [
     "LANDING_PAGE_CONTEXT_INPUT_KEYS",
+    "LANDING_PAGE_COMPETITIVE_SOURCE_INPUT_KEYS",
     "LANDING_PAGE_EXISTING_CONTEXT_KEYS",
     "LANDING_PAGE_INPUT_ASSET",
+    "LANDING_PAGE_REVIEW_SOURCE_INPUT_KEYS",
     "LANDING_PAGE_SEO_GEO_AEO_INPUT_KEYS",
     "LANDING_PAGE_SUPPORT_TICKET_SOURCE_INPUT_KEYS",
     "landing_page_seo_geo_aeo_input_contracts",

--- a/plans/PR-Content-Ops-Competitive-Input-Provider.md
+++ b/plans/PR-Content-Ops-Competitive-Input-Provider.md
@@ -1,0 +1,119 @@
+# PR: Content Ops Competitive Input Provider
+
+## Why this slice exists
+
+PR #1247 made review-shaped source rows usable from the operator-facing New Run
+path. Its deferred marketer follow-up is competitive/displacement-as-input:
+marketers also need to turn switching, competitor, and alternative evidence into
+landing-page and blog drafts without waiting for the autonomous B2B report path.
+The campaign source adapter already preserves competitive fields on normalized
+opportunities, and the generators already accept source-grounded context; the
+missing product seam is explicit host routing and generator handoff for
+operator-supplied competitive evidence.
+
+The diff is over the 400 LOC soft cap because the vertical slice needs the host
+source-mode package, generator context handoff, UI selector behavior, and
+negative fixtures together; splitting any one of those would leave either an
+unselectable source mode or a source package that does not actually reach the
+generators.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add an explicit `competitive` / `displacement` source mode beside support
+   tickets and reviews.
+2. Package operator-supplied competitive/displacement rows through the existing
+   source-row adapter, with a fail-closed filter for rows that do not carry
+   competitive markers.
+3. Carry the packaged competitive evidence into landing-page campaign context
+   and blog `data_context`.
+4. Extend the New Run source selector and behavioral selector test.
+5. Add focused host tests for competitive routing, selected-target tenant
+   loading, non-competitive rejection, and generator handoff.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Competitive-Input-Provider.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/landing_page_input_contract.py`
+- `atlas-intel-ui/src/pages/contentOpsSourceMode.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host provider recognizes competitive aliases (`competitive`,
+`competitive_displacement`, `competitive-signal`, `displacement`, etc.) from
+`inputs.source_type` or `inputs.source_material_type`. Hyphenated aliases are
+normalized server-side the same way the UI normalizes them. That path expands
+competitive bundle keys such as `competitive_signals` and `displacement_edges`
+before reusing
+`source_material_to_source_rows(...)` and
+`source_rows_to_campaign_opportunities(...)`, then keeps only opportunities with
+competitive/displacement markers such as competitor, alternative, `from_vendor`,
+`to_vendor`, or displacement counts. Rows that only contain generic text fail
+closed with a noop warning rather than becoming customer-facing content.
+
+Accepted rows are packaged as `source_material` plus
+`competitive_source_material`, with marketer-facing campaign defaults for
+landing-page and blog generation. The executor allowlist exposes
+`competitive_source_material` to landing pages, and a sibling blog data-context
+helper passes the same evidence into blog generation.
+
+## Intentional
+
+- No autonomous B2B Postgres fetcher in this PR. This slice handles
+  operator-supplied or selected imported rows; live B2B displacement-table
+  sourcing is a later data-selection slice.
+- No adapter fork. The host package path reuses the existing source-row adapter
+  and applies only host-level source-mode filtering plus competitive-specific
+  bundle-key expansion.
+- The UI keeps the existing `test:content-ops-review-source-selection` script
+  rather than adding a new script, so no new intel-ui workflow enrollment is
+  needed.
+
+## Deferred
+
+- Pulling canonical B2B displacement dynamics directly from the B2B tables.
+- Competitive-specific output skills beyond blog and landing page, such as ad
+  copy, social posts, or stat/quote cards.
+- Product packaging/pricing for the competitive marketer offer.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Command: pytest tests/test_atlas_content_ops_review_input_provider.py -q -- 16 passed.
+- Review follow-up command: pytest tests/test_atlas_content_ops_review_input_provider.py -q -- 18 passed.
+- Command: pytest tests/test_atlas_content_ops_review_input_provider.py tests/test_atlas_content_ops_input_provider.py -q -- 40 passed, 1 warning.
+- Review follow-up command: pytest tests/test_atlas_content_ops_review_input_provider.py tests/test_atlas_content_ops_input_provider.py -q -- 42 passed, 1 warning.
+- Command: cd atlas-intel-ui && npm run test:content-ops-review-source-selection -- 5 passed.
+- Command: cd atlas-intel-ui && npm run lint -- passed.
+- Command: cd atlas-intel-ui && npm run build -- passed.
+- Command: python -m py_compile atlas_brain/_content_ops_input_provider.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/landing_page_input_contract.py -- passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main -- OK: 143 matching tests are enrolled.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- passed.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- 2935 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-competitive-input-provider-pr-body.md -- passed.
+
+## Estimated diff size
+
+Estimated: 762 LOC actual (8 files, +756 / -6). This is over the 400 LOC soft
+cap for the vertical-slice reason named in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider + executor context | ~409 |
+| Backend tests | ~194 |
+| Frontend selector + test updates | ~51 |
+| Plan doc | ~119 |
+| **Total** | **~762** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -87,6 +87,20 @@ def _generic_review_row(target_id: str = "review-1") -> dict[str, Any]:
     }
 
 
+def _competitive_row(target_id: str = "competitive-1") -> dict[str, Any]:
+    return {
+        "target_id": target_id,
+        "source_id": target_id,
+        "source_type": "competitive_displacement",
+        "from_vendor": "Slack",
+        "to_vendor": "Teams",
+        "competitor": "Teams",
+        "content": "Admins are switching to Teams because calendar handoff is simpler.",
+        "displacement_mention_count": 4,
+        "primary_driver": "workflow friction",
+    }
+
+
 def _support_ticket_row() -> dict[str, Any]:
     return {
         "ticket_id": "ticket-1",
@@ -137,6 +151,72 @@ def test_review_mode_defaults_generic_rows_to_requested_review_type() -> None:
     assert package.inputs["source_material"][0]["source_type"] == "reviews"
     assert package.inputs["source_material"][0]["target_id"] == "review-1"
     assert package.metadata["source_row_count"] == 1
+    assert package.metadata["included_row_count"] == 1
+
+
+def test_competitive_source_material_builds_landing_and_blog_inputs() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "competitive",
+                "source_material": [_competitive_row()],
+            }
+        },
+    )
+    payload = merge_content_ops_input_package({"inputs": {}}, package)
+    request = request_from_mapping(payload)
+    preview = preview_control_surface(request)
+
+    assert package.provider == "atlas_competitive_request"
+    assert request.outputs == ("landing_page", "blog_post")
+    assert request.ingestion_profile == "existing_evidence"
+    assert request.inputs["source_type"] == "competitive"
+    assert request.inputs["competitive_source_material"][0]["target_id"] == "competitive-1"
+    assert request.inputs["target_account"] == "Slack"
+    assert request.inputs["competitive_alternatives"] == ["Teams"]
+    assert package.metadata["included_row_count"] == 1
+    assert preview.can_run is True
+
+
+def test_competitive_source_material_accepts_competitive_bundle_alias() -> None:
+    row = _competitive_row()
+    row.pop("source_type")
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_material_type": "competitive",
+                "source_material": {"competitive_signals": [row]},
+            }
+        },
+    )
+
+    assert package.provider == "atlas_competitive_request"
+    assert package.outputs == ("landing_page", "blog_post")
+    assert package.inputs["source_material"][0]["source_type"] == "competitive"
+    assert package.inputs["source_material"][0]["target_id"] == "competitive-1"
+    assert package.metadata["source_row_count"] == 1
+    assert package.metadata["included_row_count"] == 1
+
+
+def test_hyphenated_competitive_source_type_routes_to_competitive_provider() -> None:
+    row = _competitive_row()
+    row.pop("source_type")
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "competitive-signal",
+                "source_material": [row],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_competitive_request"
+    assert package.inputs["source_type"] == "competitive"
+    assert package.inputs["source_material"][0]["source_type"] == "competitive_signal"
+    assert package.metadata["requested_source_type"] == "competitive_signal"
     assert package.metadata["included_row_count"] == 1
 
 
@@ -216,6 +296,24 @@ def test_review_mode_rejects_non_review_rows() -> None:
     assert package.warnings[-1]["code"] == "review_source_rows_unrecognized"
 
 
+def test_competitive_mode_rejects_non_competitive_rows() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "competitive",
+                "source_material": [_generic_review_row()],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_competitive_request"
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.metadata["included_row_count"] == 0
+    assert package.warnings[-1]["code"] == "competitive_source_rows_unrecognized"
+
+
 def test_review_mode_rejects_saved_faq_selection() -> None:
     package = build_content_ops_input_provider().build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
@@ -233,6 +331,27 @@ def test_review_mode_rejects_saved_faq_selection() -> None:
     assert package.metadata["mode"] == "noop"
     assert package.warnings == ({
         "code": "review_source_faq_ids_unsupported",
+        "message": "Saved FAQ source selection is only supported for support-ticket runs.",
+    },)
+
+
+def test_competitive_mode_rejects_saved_faq_selection() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "competitive",
+                "source_faq_ids": ["11111111-1111-1111-1111-111111111111"],
+                "source_material": [_competitive_row()],
+            }
+        },
+    )
+
+    assert package.provider == "atlas_competitive_request"
+    assert package.inputs == {}
+    assert package.metadata["mode"] == "noop"
+    assert package.warnings == ({
+        "code": "competitive_source_faq_ids_unsupported",
         "message": "Saved FAQ source selection is only supported for support-ticket runs.",
     },)
 
@@ -298,6 +417,48 @@ async def test_review_mode_fetches_persisted_targets_by_tenant_scope() -> None:
 
 
 @pytest.mark.asyncio
+async def test_competitive_mode_fetches_persisted_targets_by_tenant_scope() -> None:
+    pool = {
+        "opportunities": {
+            "competitive-1": [_competitive_row("competitive-1")],
+            "competitive-2": [{
+                **_competitive_row("competitive-2"),
+                "from_vendor": "Notion",
+                "to_vendor": "Confluence",
+                "competitor": "Confluence",
+            }],
+        },
+        "opportunity_calls": [],
+    }
+    provider = build_content_ops_input_provider(
+        pool_provider=lambda: pool,
+        opportunity_repository_factory=_OpportunityRepo,
+    )
+
+    package = await provider.build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "target_mode": "vendor_retention",
+            "inputs": {
+                "source_type": "competitive",
+                "source_import_target_ids": ["competitive-1", "competitive-2"],
+            },
+        },
+    )
+
+    assert [call["target_id"] for call in pool["opportunity_calls"]] == [
+        "competitive-1",
+        "competitive-2",
+    ]
+    assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
+    assert package.provider == "atlas_competitive_request"
+    assert package.outputs == ("landing_page", "blog_post")
+    assert package.metadata["source_target_loaded_count"] == 2
+    assert package.metadata["included_row_count"] == 2
+    assert package.inputs["competitive_alternatives"] == ["Teams", "Confluence"]
+
+
+@pytest.mark.asyncio
 async def test_review_input_evidence_reaches_landing_and_blog_generators() -> None:
     package = build_content_ops_input_provider().build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
@@ -328,6 +489,39 @@ async def test_review_input_evidence_reaches_landing_and_blog_generators() -> No
     blog_context = blog_step.result["kwargs"]["data_context"]
     assert blog_context["source"] == "review_input_provider"
     assert blog_context["review_source_material"][0]["target_id"] == "review-1"
+
+
+@pytest.mark.asyncio
+async def test_competitive_input_evidence_reaches_landing_and_blog_generators() -> None:
+    package = build_content_ops_input_provider().build_content_ops_input_package(
+        scope=TenantScope(account_id="acct-1"),
+        request={
+            "inputs": {
+                "source_type": "competitive",
+                "source_material": [_competitive_row()],
+            }
+        },
+    )
+    payload = merge_content_ops_input_package({"inputs": {}}, package)
+    request = request_from_mapping(payload)
+
+    result = await execute_content_ops_request(
+        request,
+        services=ContentOpsExecutionServices(
+            blog_post=_RunnableService(),
+            landing_page=_RunnableService(),
+        ),
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    landing_step = next(step for step in result.steps if step.output == "landing_page")
+    landing_campaign = landing_step.result["kwargs"]["campaign"]
+    assert landing_campaign.context["competitive_source_material"][0]["target_id"] == "competitive-1"
+
+    blog_step = next(step for step in result.steps if step.output == "blog_post")
+    blog_context = blog_step.result["kwargs"]["data_context"]
+    assert blog_context["source"] == "competitive_input_provider"
+    assert blog_context["competitive_source_material"][0]["target_id"] == "competitive-1"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Competitive-Input-Provider.md
Slice phase: Vertical slice

This slice adds the competitive/displacement source mode deferred from the marketer input-provider path: operator-supplied competitive evidence can now be packaged through the existing source-row adapter and handed to landing-page and blog generation without using the autonomous B2B report path.

## Review follow-up
- Expanded competitive bundle payloads such as `competitive_signals` and `displacement_edges` before the existing source-row adapter runs, with a regression for request-level competitive defaults.
- Normalized hyphenated server-side aliases such as `competitive-signal` the same way the UI does, with a regression proving they route to the competitive provider.

## Intentional
- No autonomous B2B Postgres fetcher in this PR. This slice handles operator-supplied or selected imported rows; live B2B displacement-table sourcing is a later data-selection slice.
- No adapter fork. The host package path reuses the existing source-row adapter and applies only host-level source-mode filtering plus competitive-specific bundle-key expansion.
- The UI keeps the existing `test:content-ops-review-source-selection` script rather than adding a new script, so no new intel-ui workflow enrollment is needed.

## Deferred
- Pulling canonical B2B displacement dynamics directly from the B2B tables.
- Competitive-specific output skills beyond blog and landing page, such as ad copy, social posts, or stat/quote cards.
- Product packaging/pricing for the competitive marketer offer.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` -- 18 passed.
- `pytest tests/test_atlas_content_ops_review_input_provider.py tests/test_atlas_content_ops_input_provider.py -q` -- 42 passed, 1 warning.
- `cd atlas-intel-ui && npm run test:content-ops-review-source-selection` -- 5 passed.
- `cd atlas-intel-ui && npm run lint` -- passed.
- `cd atlas-intel-ui && npm run build` -- passed.
- `python -m py_compile atlas_brain/_content_ops_input_provider.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/landing_page_input_contract.py` -- passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` -- OK: 143 matching tests are enrolled.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 2935 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-competitive-input-provider-pr-body.md` -- passed.

## Diff size
8 files, +756 / -6.