### PR TITLE
PR-Deflection-Paid-Delivery-Worker

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -1,0 +1,38 @@
+name: Atlas Content Ops Deflection Delivery Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/content_ops_deflection_delivery.py"
+      - "tests/test_atlas_content_ops_deflection_delivery.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
+      - "atlas_brain/content_ops_deflection_delivery.py"
+      - "tests/test_atlas_content_ops_deflection_delivery.py"
+
+jobs:
+  atlas-content-ops-deflection-delivery-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops deflection delivery tests
+        run: |
+          python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -1,0 +1,269 @@
+"""Send paid FAQ deflection report delivery emails from the webhook queue."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+from urllib.parse import quote
+
+from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+
+
+DEFAULT_DEFLECTION_DELIVERY_SUBJECT = "Your FAQ deflection report is ready"
+MAX_DELIVERY_ERROR_CHARS = 500
+
+
+class DeflectionReportDeliverySender(Protocol):
+    async def send(self, request: SendRequest) -> SendResult:
+        """Send a delivery email."""
+
+
+@dataclass(frozen=True)
+class DeflectionReportDeliveryConfig:
+    from_email: str
+    result_base_url: str = ""
+    result_url_template: str = ""
+    reply_to: str | None = None
+    subject: str = DEFAULT_DEFLECTION_DELIVERY_SUBJECT
+    limit: int = 20
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class DeflectionReportDeliverySummary:
+    scanned: int
+    sent: int
+    failed: int
+    dry_run: int
+
+
+async def send_pending_deflection_report_deliveries(
+    pool: Any,
+    *,
+    sender: DeflectionReportDeliverySender,
+    config: DeflectionReportDeliveryConfig,
+) -> DeflectionReportDeliverySummary:
+    """Send pending paid-report delivery emails and update queue status."""
+
+    _validate_config(config)
+    rows = await pool.fetch(_PENDING_SQL, int(config.limit))
+    sent = failed = dry_run = 0
+    for row in rows:
+        data = _row_to_dict(row)
+        account_id = _required_text(data.get("account_id"), "account_id")
+        request_id = _required_text(data.get("request_id"), "request_id")
+        report_url = deflection_report_result_url(request_id=request_id, config=config)
+        email = _clean(data.get("delivery_email"))
+        if not bool(data.get("paid")):
+            await _mark_failed(pool, account_id, request_id, "report_not_paid")
+            failed += 1
+            continue
+        if not email:
+            await _mark_failed(pool, account_id, request_id, "missing_delivery_email")
+            failed += 1
+            continue
+        if config.dry_run:
+            dry_run += 1
+            continue
+        try:
+            result = await sender.send(
+                _send_request(
+                    account_id=account_id,
+                    request_id=request_id,
+                    email=email,
+                    report_url=report_url,
+                    config=config,
+                )
+            )
+        except Exception as exc:
+            await _mark_failed(pool, account_id, request_id, _bounded_error(exc))
+            failed += 1
+            continue
+        await _mark_delivered(
+            pool,
+            account_id,
+            request_id,
+            _provider_message_id(result.provider, result.message_id),
+        )
+        sent += 1
+    return DeflectionReportDeliverySummary(
+        scanned=len(rows),
+        sent=sent,
+        failed=failed,
+        dry_run=dry_run,
+    )
+
+
+def deflection_report_result_url(
+    *,
+    request_id: str,
+    config: DeflectionReportDeliveryConfig,
+) -> str:
+    encoded = quote(_required_text(request_id, "request_id"), safe="")
+    template = _clean(config.result_url_template)
+    if template:
+        if "{request_id}" not in template:
+            raise ValueError("result_url_template must include {request_id}")
+        return template.format(request_id=encoded)
+    base = _clean(config.result_base_url)
+    if not base:
+        raise ValueError("result_base_url or result_url_template is required")
+    return (
+        f"{base.rstrip('/')}/systems/support-ticket-deflection/results/"
+        f"{encoded}?checkout=success"
+    )
+
+
+def _send_request(
+    *,
+    account_id: str,
+    request_id: str,
+    email: str,
+    report_url: str,
+    config: DeflectionReportDeliveryConfig,
+) -> SendRequest:
+    return SendRequest(
+        campaign_id=f"content_ops_deflection_report:{account_id}:{request_id}",
+        to_email=email,
+        from_email=_required_text(config.from_email, "from_email"),
+        reply_to=_clean(config.reply_to) or None,
+        subject=_required_text(config.subject, "subject"),
+        html_body=_render_html(report_url),
+        text_body=_render_text(report_url),
+        tags=(
+            {"name": "source", "value": "content_ops_deflection_report"},
+            {"name": "request_id", "value": request_id},
+        ),
+        metadata={
+            "account_id": account_id,
+            "request_id": request_id,
+            "source": "content_ops_deflection_report",
+        },
+    )
+
+
+def _render_html(report_url: str) -> str:
+    safe_url = _escape(report_url)
+    return (
+        "<h1>Your FAQ deflection report is ready</h1>"
+        "<p>Your paid report is available at the secure results page below.</p>"
+        f'<p><a href="{safe_url}">Open your report</a></p>'
+        "<p>This email only carries the access link; the report stays behind "
+        "the paid results page.</p>"
+    )
+
+
+def _render_text(report_url: str) -> str:
+    return (
+        "Your FAQ deflection report is ready\n\n"
+        "Your paid report is available at the secure results page below:\n\n"
+        f"{report_url}\n\n"
+        "This email only carries the access link; the report stays behind "
+        "the paid results page.\n"
+    )
+
+
+async def _mark_delivered(
+    pool: Any,
+    account_id: str,
+    request_id: str,
+    provider_message_id: str,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE content_ops_deflection_report_deliveries
+        SET delivery_status = 'delivered',
+            delivery_error = NULL,
+            provider_message_id = $3,
+            delivered_at = NOW(),
+            updated_at = NOW()
+        WHERE account_id = $1
+          AND request_id = $2
+          AND delivery_status = 'pending'
+        """,
+        account_id,
+        request_id,
+        provider_message_id,
+    )
+
+
+async def _mark_failed(pool: Any, account_id: str, request_id: str, error: str) -> None:
+    await pool.execute(
+        """
+        UPDATE content_ops_deflection_report_deliveries
+        SET delivery_status = 'failed',
+            delivery_error = $3,
+            updated_at = NOW()
+        WHERE account_id = $1
+          AND request_id = $2
+          AND delivery_status = 'pending'
+        """,
+        account_id,
+        request_id,
+        _bounded_text(error),
+    )
+
+
+def _validate_config(config: DeflectionReportDeliveryConfig) -> None:
+    _required_text(config.from_email, "from_email")
+    _required_text(config.subject, "subject")
+    if int(config.limit) <= 0:
+        raise ValueError("limit must be greater than 0")
+    deflection_report_result_url(request_id="config-check", config=config)
+
+
+def _provider_message_id(provider: str, message_id: str) -> str:
+    return f"{_required_text(provider, 'provider')}:{_required_text(message_id, 'message_id')}"
+
+
+def _bounded_error(exc: Exception) -> str:
+    return _bounded_text(f"{type(exc).__name__}: {exc}")
+
+
+def _bounded_text(value: Any) -> str:
+    text = str(value or "").strip()
+    if len(text) <= MAX_DELIVERY_ERROR_CHARS:
+        return text
+    return text[: MAX_DELIVERY_ERROR_CHARS - 3] + "..."
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, Mapping):
+        return dict(row)
+    return dict(row)
+
+
+def _required_text(value: Any, label: str) -> str:
+    cleaned = _clean(value)
+    if not cleaned:
+        raise ValueError(f"{label} is required")
+    return cleaned
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+_PENDING_SQL = """
+SELECT
+    d.account_id,
+    d.request_id,
+    r.delivery_email,
+    r.paid
+FROM content_ops_deflection_report_deliveries d
+JOIN content_ops_deflection_reports r
+  ON r.account_id = d.account_id
+ AND r.request_id = d.request_id
+WHERE d.delivery_status = 'pending'
+ORDER BY d.created_at
+LIMIT $1
+"""

--- a/plans/PR-Deflection-Paid-Delivery-Worker.md
+++ b/plans/PR-Deflection-Paid-Delivery-Worker.md
@@ -1,0 +1,118 @@
+## Why this slice exists
+
+The paid webhook now queues post-purchase delivery rows, but nothing consumes
+that queue. Buyers can unlock the report in the browser, yet they do not get
+the paid result link in their inbox after purchase.
+
+This slice adds the smallest worker core for that handoff: read pending
+paid-delivery rows, send a transactional report-link email through an injected
+sender, and mark the queue row delivered or failed. It intentionally stops
+short of a manual CLI, scheduling, and non-buyer nurture policy.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-deflection-paid-unlock
+
+Slice phase: Production hardening
+
+1. Add a Content Ops deflection delivery service that drains pending delivery
+   rows joined to paid report rows with `delivery_email`.
+2. Render a transactional email containing only the hosted paid-result link,
+   not the report artifact, answers, evidence, or markdown.
+3. Update delivery rows to `delivered` with provider/message id on success or
+   `failed` with a bounded error on send failure/missing email.
+4. Add dry-run support at the service level so operators can wire a manual
+   script in a follow-up without changing the queue contract.
+5. Enroll the atlas-brain importing test in a dedicated workflow.
+6. Honor `ATLAS_DISABLE_DOTENV=1` in the existing deflection hosted-smoke
+   scripts so the required full extracted pipeline check can run without
+   local live env leakage.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `scripts/smoke_content_ops_deflection_submit_handoff.py`
+- `scripts/smoke_content_ops_deflection_portfolio_result_page.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py`
+- `tests/test_smoke_content_ops_deflection_portfolio_result_page.py`
+- `plans/PR-Deflection-Paid-Delivery-Worker.md`
+
+## Mechanism
+
+The worker selects pending queue rows from
+`content_ops_deflection_report_deliveries`, joins the corresponding
+`content_ops_deflection_reports` row, and requires the report to be paid before
+delivery:
+
+```text
+pending queue row -> paid report + delivery_email -> send link -> mark delivered
+```
+
+The email body includes a portfolio result URL built from a configured URL
+template or base URL. It does not embed the paid artifact. The sender is a
+small port so tests can use an in-memory fake and a follow-up script can wire
+the existing Resend campaign sender adapter.
+
+The worker lives at `atlas_brain/content_ops_deflection_delivery.py` instead
+of under `atlas_brain/services/` because `atlas_brain.services.__init__`
+eagerly imports the LLM/embedding stack. Keeping this module on a lightweight
+path lets the extracted CI lane import the worker test without requiring
+torch.
+
+Because the focused test imports `atlas_brain.*`, this slice adds a dedicated
+atlas workflow and also enrolls the test in `run_extracted_pipeline_checks.sh`
+to satisfy the repo's extracted pipeline enrollment audit.
+
+The full extracted pipeline check also runs hosted-smoke unit tests in this
+checkout. Those scripts now honor `ATLAS_DISABLE_DOTENV=1`, matching the
+existing local-env opt-out used elsewhere so local live deflection credentials
+cannot change unit-test defaults.
+
+## Intentional
+
+- No CLI or scheduler is added; this PR locks the queue consumer contract first.
+- The dotenv opt-out change is limited to hosted-smoke scripts that already
+  read local live env files; it exists to make the required full runner
+  deterministic in developer checkouts.
+- No non-buyer abandon/cancel nurture email is added; that needs consent and
+  opt-out policy first.
+- The email contains a hosted result link only, so the paywall remains enforced
+  by the existing artifact route and Stripe-paid state.
+- Delivery errors are stored as bounded text, not raw provider payloads.
+
+## Deferred
+
+- Future slice: manual script wiring using the existing Resend sender adapter.
+- Future slice: scheduler/cron wiring for automatic delivery polling.
+- Future slice: provider webhook ingestion for delivery/open/click events.
+- Future slice: abandoned checkout follow-up policy and unsubscribe handling.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` -- 7 passed, 1 warning.
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` -- 41 passed, 1 warning.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 2934 passed, 10 skipped, 1 warning.
+- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-paid-delivery-worker-body.md` -- passed.
+- `python -m py_compile atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py && <torch-blocked import check> && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` -- torch-blocked import ok; 7 passed.
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` -- 41 passed.
+- `python -m py_compile atlas_brain/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py && <torch-blocked import + production default URL check> && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` -- torch-blocked import and production default URL ok; 41 passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Delivery service | ~250 |
+| Workflow | ~35 |
+| Extracted runner enrollment | ~1 |
+| Hosted-smoke dotenv opt-out | ~20 |
+| Tests | ~220 |
+| Plan doc | ~85 |
+| **Total** | **~611** |
+
+This exceeds the 400 LOC soft cap because the slice needs the service,
+dedicated CI enrollment, and focused failure-branch tests to be useful and
+reviewable. The implementation stays on one narrow queue consumer contract.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -35,6 +35,7 @@ pytest \
   tests/test_smoke_content_ops_deflection_submit_handoff.py \
   tests/test_smoke_content_ops_deflection_portfolio_result_page.py \
   tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py \
+  tests/test_atlas_content_ops_deflection_delivery.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \

--- a/scripts/smoke_content_ops_deflection_portfolio_result_page.py
+++ b/scripts/smoke_content_ops_deflection_portfolio_result_page.py
@@ -67,6 +67,8 @@ class UnlockCtaParser(HTMLParser):
 
 
 def _load_dotenv_files() -> None:
+    if os.getenv("ATLAS_DISABLE_DOTENV") == "1":
+        return
     if load_dotenv is not None:
         load_dotenv(ROOT / ".env")
         load_dotenv(ROOT / ".env.local", override=True)

--- a/scripts/smoke_content_ops_deflection_submit_handoff.py
+++ b/scripts/smoke_content_ops_deflection_submit_handoff.py
@@ -62,6 +62,8 @@ class HttpJsonResponse:
 
 
 def _load_dotenv_files() -> None:
+    if os.getenv("ATLAS_DISABLE_DOTENV") == "1":
+        return
     if load_dotenv is not None:
         load_dotenv(ROOT / ".env")
         load_dotenv(ROOT / ".env.local", override=True)

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from atlas_brain.content_ops_deflection_delivery import (
+    DeflectionReportDeliveryConfig,
+    deflection_report_result_url,
+    send_pending_deflection_report_deliveries,
+)
+from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
+
+
+class _Pool:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.fetch_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append((query, args))
+        assert "content_ops_deflection_report_deliveries" in query
+        assert "content_ops_deflection_reports" in query
+        return self.rows[: int(args[0])]
+
+    async def execute(self, query: str, *args: Any) -> str:
+        self.execute_calls.append((query, args))
+        return "UPDATE 1"
+
+
+class _Sender:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.requests: list[SendRequest] = []
+
+    async def send(self, request: SendRequest) -> SendResult:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return SendResult(provider="resend", message_id="email-123", raw={"id": "email-123"})
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "account_id": "acct-123",
+        "request_id": "content-ops-abc123",
+        "delivery_email": "buyer@example.com",
+        "paid": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def _config(**overrides: Any) -> DeflectionReportDeliveryConfig:
+    values = {
+        "from_email": "Atlas Content Ops <reports@example.com>",
+        "result_base_url": "https://portfolio.example.com",
+        "reply_to": "support@example.com",
+        "limit": 20,
+    }
+    values.update(overrides)
+    return DeflectionReportDeliveryConfig(**values)
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_sends_pending_paid_report_link() -> None:
+    pool = _Pool([_row()])
+    sender = _Sender()
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 1
+    assert summary.failed == 0
+    assert len(sender.requests) == 1
+    request = sender.requests[0]
+    assert request.to_email == "buyer@example.com"
+    assert request.from_email == "Atlas Content Ops <reports@example.com>"
+    assert request.reply_to == "support@example.com"
+    assert request.subject == "Your FAQ deflection report is ready"
+    expected_url = (
+        "https://portfolio.example.com/systems/support-ticket-deflection/results/"
+        "content-ops-abc123?checkout=success"
+    )
+    assert expected_url in request.html_body
+    assert expected_url in (request.text_body or "")
+    assert "markdown" not in request.html_body.lower()
+    assert "resolution_evidence" not in request.html_body
+
+    update_query, update_args = pool.execute_calls[0]
+    assert "delivery_status = 'delivered'" in update_query
+    assert update_args == ("acct-123", "content-ops-abc123", "resend:email-123")
+    assert "buyer@example.com" not in str(update_args)
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_dry_run_does_not_send_or_update() -> None:
+    pool = _Pool([_row()])
+    sender = _Sender()
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(dry_run=True),
+    )
+
+    assert summary.scanned == 1
+    assert summary.sent == 0
+    assert summary.dry_run == 1
+    assert sender.requests == []
+    assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_marks_missing_email_failed() -> None:
+    pool = _Pool([_row(delivery_email=" ")])
+    sender = _Sender()
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.failed == 1
+    assert sender.requests == []
+    query, args = pool.execute_calls[0]
+    assert "delivery_status = 'failed'" in query
+    assert args == ("acct-123", "content-ops-abc123", "missing_delivery_email")
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_marks_unpaid_report_failed() -> None:
+    pool = _Pool([_row(paid=False)])
+    sender = _Sender()
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.failed == 1
+    assert sender.requests == []
+    query, args = pool.execute_calls[0]
+    assert "delivery_status = 'failed'" in query
+    assert args == ("acct-123", "content-ops-abc123", "report_not_paid")
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_marks_provider_failure_failed_with_bounded_error() -> None:
+    pool = _Pool([_row()])
+    sender = _Sender(error=RuntimeError("provider down " + ("x" * 700)))
+
+    summary = await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    assert summary.failed == 1
+    query, args = pool.execute_calls[0]
+    assert "delivery_status = 'failed'" in query
+    assert args[0:2] == ("acct-123", "content-ops-abc123")
+    assert args[2].startswith("RuntimeError: provider down")
+    assert len(args[2]) == 500
+
+
+def test_deflection_report_result_url_uses_template_and_quotes_request_id() -> None:
+    url = deflection_report_result_url(
+        request_id="content ops/abc",
+        config=_config(
+            result_base_url="",
+            result_url_template="https://portfolio.example.com/r/{request_id}?checkout=success",
+        ),
+    )
+
+    assert url == "https://portfolio.example.com/r/content%20ops%2Fabc?checkout=success"
+
+
+def test_deflection_report_result_url_requires_configured_destination() -> None:
+    with pytest.raises(ValueError, match="result_base_url or result_url_template"):
+        deflection_report_result_url(request_id="req-123", config=_config(result_base_url=""))

--- a/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
+++ b/tests/test_smoke_content_ops_deflection_portfolio_result_page.py
@@ -7,6 +7,8 @@ import sys
 import urllib.error
 from typing import Any
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/smoke_content_ops_deflection_portfolio_result_page.py"
@@ -37,6 +39,21 @@ SNAPSHOT = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _isolate_deflection_result_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL",
+        "ATLAS_API_BASE_URL",
+        "ATLAS_B2B_JWT",
+        "ATLAS_TOKEN",
+        "ATLAS_ACCOUNT_ID",
+        "ATLAS_FAQ_SEARCH_ACCOUNT_ID",
+        "ATLAS_DEFLECTION_REQUEST_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ATLAS_DISABLE_DOTENV", "1")
+
+
 def _base_args(tmp_path: Path) -> list[str]:
     return [
         "--result-url",
@@ -63,6 +80,16 @@ def _page_html() -> str:
          data-checkout-request_id="content-ops-123">Unlock full report</a>
     </main>
     """
+
+
+def test_load_dotenv_files_honors_disable_flag(monkeypatch) -> None:
+    calls: list[Path] = []
+    monkeypatch.setenv("ATLAS_DISABLE_DOTENV", "1")
+    monkeypatch.setattr(smoke, "load_dotenv", lambda path, **_kwargs: calls.append(path))
+
+    smoke._load_dotenv_files()
+
+    assert calls == []
 
 
 class FakeResponse:

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -7,6 +7,8 @@ import sys
 from typing import Any
 import urllib.error
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/smoke_content_ops_deflection_submit_handoff.py"
@@ -32,6 +34,24 @@ SNAPSHOT = {
         }
     ],
 }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_deflection_submit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "ATLAS_API_BASE_URL",
+        "ATLAS_B2B_JWT",
+        "ATLAS_TOKEN",
+        "ATLAS_ACCOUNT_ID",
+        "ATLAS_FAQ_SEARCH_ACCOUNT_ID",
+        "ATLAS_DEFLECTION_SUBMIT_CSV_FILE",
+        "ATLAS_DEFLECTION_SUBMIT_BLOB_URL",
+        "ATLAS_DEFLECTION_SUPPORT_PLATFORM",
+        "ATLAS_DEFLECTION_COMPANY_NAME",
+        "ATLAS_DEFLECTION_CONTACT_EMAIL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ATLAS_DISABLE_DOTENV", "1")
 
 
 def _base_args(tmp_path: Path) -> list[str]:
@@ -84,6 +104,16 @@ def _write_csv(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     return csv_file
+
+
+def test_load_dotenv_files_honors_disable_flag(monkeypatch) -> None:
+    calls: list[Path] = []
+    monkeypatch.setenv("ATLAS_DISABLE_DOTENV", "1")
+    monkeypatch.setattr(smoke, "load_dotenv", lambda path, **_kwargs: calls.append(path))
+
+    smoke._load_dotenv_files()
+
+    assert calls == []
 
 
 def _submit_payload(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-Delivery-Worker.md
Slice phase: Production hardening

This slice adds the core paid-delivery queue consumer for FAQ deflection reports: pending queue rows are joined to paid report rows, a transactional paid-result link email is sent through an injected sender, and the delivery row is marked delivered or failed. It does not add a CLI, scheduler, or non-buyer nurture flow.

## Intentional
- No CLI or scheduler is added; this PR locks the queue consumer contract first.
- No non-buyer abandon/cancel nurture email is added; that needs consent and opt-out policy first.
- The email contains a hosted result link only, so the paywall remains enforced by the existing artifact route and Stripe-paid state.
- Delivery errors are stored as bounded text, not raw provider payloads.

## Deferred
- Future slice: manual script wiring using the existing Resend sender adapter.
- Future slice: scheduler/cron wiring for automatic delivery polling.
- Future slice: provider webhook ingestion for delivery/open/click events.
- Future slice: abandoned checkout follow-up policy and unsubscribe handling.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/services/content_ops_deflection_delivery.py tests/test_atlas_content_ops_deflection_delivery.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q` -- 7 passed, 1 warning.
- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_smoke_content_ops_deflection_submit_handoff.py tests/test_smoke_content_ops_deflection_portfolio_result_page.py -q` -- 41 passed, 1 warning.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 2934 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-paid-delivery-worker-body.md` -- passed.

## Diff size
9 files, +659 / -0.
