### PR TITLE
PR-Deflection-Paid-Delivery-Script

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_delivery_checks.yml
@@ -5,14 +5,18 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
       - "atlas_brain/content_ops_deflection_delivery.py"
+      - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_send_content_ops_deflection_report_deliveries.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_deflection_delivery_checks.yml"
       - "atlas_brain/content_ops_deflection_delivery.py"
+      - "scripts/send_content_ops_deflection_report_deliveries.py"
       - "tests/test_atlas_content_ops_deflection_delivery.py"
+      - "tests/test_send_content_ops_deflection_report_deliveries.py"
 
 jobs:
   atlas-content-ops-deflection-delivery-checks:
@@ -35,4 +39,7 @@ jobs:
 
       - name: Run Content Ops deflection delivery tests
         run: |
-          python -m pytest tests/test_atlas_content_ops_deflection_delivery.py -q
+          python -m pytest \
+            tests/test_atlas_content_ops_deflection_delivery.py \
+            tests/test_send_content_ops_deflection_report_deliveries.py \
+            -q

--- a/plans/PR-Deflection-Paid-Delivery-Script.md
+++ b/plans/PR-Deflection-Paid-Delivery-Script.md
@@ -1,0 +1,80 @@
+## Why this slice exists
+
+The paid-delivery worker can now consume pending FAQ deflection delivery rows,
+but there is no operator entrypoint to run it against Postgres. The next useful
+step is a manual script that wires the worker to the existing Resend sender
+adapter without adding scheduler semantics yet.
+
+This slice is over the 400 LOC soft cap because the runnable script needs
+fail-closed preflight branches, mocked transport tests, dedicated workflow
+enrollment, and extracted runner enrollment in the same PR to be safe to use.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-deflection-paid-unlock
+
+Slice phase: Production hardening
+
+1. Add a manual script for sending pending paid FAQ deflection report delivery
+   emails from Postgres.
+2. Default the script to dry-run mode and require explicit `--send` for live
+   Resend sends.
+3. Read database, sender, and result-link config from args/env with fail-closed
+   validation.
+4. Reuse the existing delivery worker and Resend campaign sender adapter.
+5. Add focused CLI/preflight tests and enroll them in the dedicated atlas
+   delivery workflow plus extracted runner.
+
+### Files touched
+
+- `scripts/send_content_ops_deflection_report_deliveries.py`
+- `.github/workflows/atlas_content_ops_deflection_delivery_checks.yml`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `tests/test_send_content_ops_deflection_report_deliveries.py`
+- `plans/PR-Deflection-Paid-Delivery-Script.md`
+
+## Mechanism
+
+The script validates operator inputs, creates an asyncpg pool, constructs a
+`DeflectionReportDeliveryConfig`, and calls
+`send_pending_deflection_report_deliveries(...)`.
+
+Dry-run is the default. Live sends require `--send`, a configured Resend API
+key, a From address, and a result URL destination. The destination may be a
+`result_base_url` using the production default path or an explicit
+`result_url_template`.
+
+## Intentional
+
+- No cron/scheduler is added; this is a manual operator entrypoint.
+- No abandoned checkout or non-buyer nurture flow is added.
+- Live sending is opt-in via `--send`; missing Resend config fails before any
+  DB connection or send attempt.
+- The script reuses the existing Resend adapter instead of adding a new email
+  provider integration.
+
+## Deferred
+
+- Future slice: scheduler/cron wiring and row-claiming for concurrent pollers.
+- Future slice: provider webhook ingestion for delivered/open/click events.
+- Future slice: abandoned checkout follow-up policy and unsubscribe handling.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile scripts/send_content_ops_deflection_report_deliveries.py tests/test_send_content_ops_deflection_report_deliveries.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py -q` -- 13 passed.
+- `scripts/run_extracted_pipeline_checks.sh` -- run with bash; 2950 passed, 10 skipped.
+- Local PR review bundle with the prepared PR body -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Manual script | ~250 |
+| Tests | ~185 |
+| Workflow/enrollment | ~10 |
+| Plan doc | ~80 |
+| **Total** | **~525** |
+
+Over the 400 LOC soft cap; justified above because the script, tests, and CI
+enrollment are the smallest reviewable operational entrypoint.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -36,6 +36,7 @@ pytest \
   tests/test_smoke_content_ops_deflection_portfolio_result_page.py \
   tests/test_smoke_content_ops_deflection_stripe_paid_unlock.py \
   tests/test_atlas_content_ops_deflection_delivery.py \
+  tests/test_send_content_ops_deflection_report_deliveries.py \
   tests/test_extracted_ticket_faq_markdown.py \
   tests/test_extracted_ticket_faq_macro_writeback.py \
   tests/test_extracted_ticket_faq_macro_writeback_postgres.py \

--- a/scripts/send_content_ops_deflection_report_deliveries.py
+++ b/scripts/send_content_ops_deflection_report_deliveries.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Send pending paid FAQ deflection report delivery emails."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atlas_brain.content_ops_deflection_delivery import (  # noqa: E402
+    DEFAULT_DEFLECTION_DELIVERY_SUBJECT,
+    DeflectionReportDeliveryConfig,
+    send_pending_deflection_report_deliveries,
+)
+from extracted_content_pipeline.campaign_ports import SendRequest, SendResult  # noqa: E402
+from extracted_content_pipeline.campaign_sender import (  # noqa: E402
+    DEFAULT_RESEND_TIMEOUT_SECONDS,
+    RESEND_API_URL,
+    create_campaign_sender,
+)
+
+
+DATABASE_URL_ENV = ("EXTRACTED_DATABASE_URL", "DATABASE_URL")
+FROM_EMAIL_ENV = (
+    "ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL",
+    "EXTRACTED_CAMPAIGN_FROM_EMAIL",
+    "EXTRACTED_RESEND_FROM_EMAIL",
+    "EXTRACTED_CAMPAIGN_RESEND_FROM_EMAIL",
+)
+RESEND_API_KEY_ENV = (
+    "ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY",
+    "EXTRACTED_RESEND_API_KEY",
+    "EXTRACTED_CAMPAIGN_RESEND_API_KEY",
+    "EXTRACTED_CAMPAIGN_SEQ_RESEND_API_KEY",
+)
+
+
+class _DryRunSender:
+    async def send(self, _request: SendRequest) -> SendResult:
+        raise RuntimeError("dry-run sender should not be called")
+
+
+def _env(*names: str, default: str | None = None) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid integer for {name}: {raw!r}") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid float for {name}: {raw!r}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Send pending paid FAQ deflection report delivery emails."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=_env(*DATABASE_URL_ENV),
+        help="Postgres DSN. Defaults to EXTRACTED_DATABASE_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=_env_int("ATLAS_DEFLECTION_DELIVERY_LIMIT", 20),
+        help="Maximum pending delivery rows to process.",
+    )
+    parser.add_argument(
+        "--from-email",
+        default=_env(*FROM_EMAIL_ENV),
+        help="Transactional From email.",
+    )
+    parser.add_argument(
+        "--reply-to",
+        default=_env("ATLAS_DEFLECTION_DELIVERY_REPLY_TO"),
+        help="Optional Reply-To email.",
+    )
+    parser.add_argument(
+        "--result-base-url",
+        default=_env("ATLAS_DEFLECTION_PORTFOLIO_BASE_URL"),
+        help="Portfolio origin; production result path is appended.",
+    )
+    parser.add_argument(
+        "--result-url-template",
+        default=_env("ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE"),
+        help="Full result URL template containing {request_id}.",
+    )
+    parser.add_argument(
+        "--subject",
+        default=_env(
+            "ATLAS_DEFLECTION_DELIVERY_SUBJECT",
+            default=DEFAULT_DEFLECTION_DELIVERY_SUBJECT,
+        ),
+        help="Email subject line.",
+    )
+    parser.add_argument(
+        "--resend-api-key",
+        default=_env(*RESEND_API_KEY_ENV),
+        help="Resend API key. Required only with --send.",
+    )
+    parser.add_argument(
+        "--resend-api-url",
+        default=_env("ATLAS_DEFLECTION_DELIVERY_RESEND_API_URL", default=RESEND_API_URL),
+        help="Resend email API URL.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=_env_float(
+            "ATLAS_DEFLECTION_DELIVERY_RESEND_TIMEOUT_SECONDS",
+            DEFAULT_RESEND_TIMEOUT_SECONDS,
+        ),
+        help="HTTP timeout for Resend calls.",
+    )
+    parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Perform live sends. Omit for dry-run mode.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON summary.")
+    return parser
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return _build_parser().parse_args(argv)
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    if not _configured(args.database_url):
+        raise SystemExit("Missing --database-url, EXTRACTED_DATABASE_URL, or DATABASE_URL")
+    if not _configured(args.from_email):
+        raise SystemExit("Missing --from-email or ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL")
+    if not _configured(args.result_base_url) and not _configured(args.result_url_template):
+        raise SystemExit(
+            "Missing --result-base-url, --result-url-template, "
+            "ATLAS_DEFLECTION_PORTFOLIO_BASE_URL, or "
+            "ATLAS_DEFLECTION_PORTFOLIO_RESULT_URL_TEMPLATE"
+        )
+    if int(args.limit) <= 0:
+        raise SystemExit("Invalid --limit: must be greater than 0")
+    if args.send and not _configured(args.resend_api_key):
+        raise SystemExit("Missing --resend-api-key or ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY")
+
+
+def _delivery_config(args: argparse.Namespace) -> DeflectionReportDeliveryConfig:
+    return DeflectionReportDeliveryConfig(
+        from_email=str(args.from_email or ""),
+        result_base_url=str(args.result_base_url or ""),
+        result_url_template=str(args.result_url_template or ""),
+        reply_to=args.reply_to,
+        subject=str(args.subject or DEFAULT_DEFLECTION_DELIVERY_SUBJECT),
+        limit=int(args.limit),
+        dry_run=not bool(args.send),
+    )
+
+
+def _sender(args: argparse.Namespace) -> Any:
+    if not args.send:
+        return _DryRunSender()
+    return create_campaign_sender(
+        "resend",
+        {
+            "api_key": args.resend_api_key,
+            "api_url": args.resend_api_url,
+            "timeout_seconds": args.timeout_seconds,
+        },
+    )
+
+
+async def _create_pool(database_url: str) -> Any:
+    try:
+        import asyncpg  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency
+        raise RuntimeError(
+            "asyncpg is required to send deflection report deliveries"
+        ) from exc
+    return await asyncpg.create_pool(dsn=database_url, min_size=1, max_size=2)
+
+
+def _summary_payload(summary: Any) -> dict[str, int]:
+    return {
+        "scanned": int(summary.scanned),
+        "sent": int(summary.sent),
+        "failed": int(summary.failed),
+        "dry_run": int(summary.dry_run),
+    }
+
+
+async def _main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _validate_args(args)
+    pool = await _create_pool(str(args.database_url))
+    try:
+        summary = await send_pending_deflection_report_deliveries(
+            pool,
+            sender=_sender(args),
+            config=_delivery_config(args),
+        )
+    finally:
+        await pool.close()
+
+    payload = _summary_payload(summary)
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        mode = "send" if args.send else "dry-run"
+        print(
+            "FAQ deflection deliveries "
+            f"mode={mode} scanned={summary.scanned} sent={summary.sent} "
+            f"failed={summary.failed} dry_run={summary.dry_run}"
+        )
+    return 0 if summary.failed == 0 else 1
+
+
+def _configured(value: Any) -> bool:
+    return bool(str(value or "").strip())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_send_content_ops_deflection_report_deliveries.py
+++ b/tests/test_send_content_ops_deflection_report_deliveries.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "send_content_ops_deflection_report_deliveries.py"
+SPEC = importlib.util.spec_from_file_location("send_deflection_deliveries", SCRIPT)
+assert SPEC and SPEC.loader
+send_cli = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(send_cli)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _base_args(*extra: str) -> list[str]:
+    return [
+        "--database-url",
+        "postgresql://atlas@example/db",
+        "--from-email",
+        "reports@example.com",
+        "--result-base-url",
+        "https://juancanfield.com",
+        *extra,
+    ]
+
+
+def test_parse_defaults_to_dry_run_and_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXTRACTED_DATABASE_URL", "postgresql://env/db")
+    monkeypatch.setenv("ATLAS_DEFLECTION_DELIVERY_FROM_EMAIL", "reports@env.example")
+    monkeypatch.setenv("ATLAS_DEFLECTION_PORTFOLIO_BASE_URL", "https://juancanfield.com")
+
+    args = send_cli._parse_args([])
+
+    assert args.database_url == "postgresql://env/db"
+    assert args.from_email == "reports@env.example"
+    assert args.result_base_url == "https://juancanfield.com"
+    assert args.send is False
+
+
+def test_validate_allows_dry_run_without_resend_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY", raising=False)
+    args = send_cli._parse_args(_base_args())
+
+    send_cli._validate_args(args)
+    config = send_cli._delivery_config(args)
+
+    assert config.dry_run is True
+
+
+def test_validate_requires_resend_key_for_live_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_DEFLECTION_DELIVERY_RESEND_API_KEY", raising=False)
+    args = send_cli._parse_args(_base_args("--send"))
+
+    with pytest.raises(SystemExit, match="Missing --resend-api-key"):
+        send_cli._validate_args(args)
+
+
+def test_validate_fails_closed_before_pool_for_missing_destination() -> None:
+    args = send_cli._parse_args(
+        [
+            "--database-url",
+            "postgresql://atlas@example/db",
+            "--from-email",
+            "reports@example.com",
+        ]
+    )
+
+    with pytest.raises(SystemExit, match="Missing --result-base-url"):
+        send_cli._validate_args(args)
+
+
+@pytest.mark.asyncio
+async def test_main_dry_run_wires_worker_without_resend(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pool = _Pool()
+    calls: list[dict[str, Any]] = []
+
+    async def _create_pool(database_url: str) -> _Pool:
+        calls.append({"database_url": database_url})
+        return pool
+
+    async def _send_pending(pool_arg: Any, *, sender: Any, config: Any) -> Any:
+        calls.append(
+            {
+                "pool": pool_arg,
+                "sender_type": type(sender).__name__,
+                "dry_run": config.dry_run,
+                "result_base_url": config.result_base_url,
+            }
+        )
+        return SimpleNamespace(scanned=2, sent=0, failed=0, dry_run=2)
+
+    monkeypatch.setattr(send_cli, "_create_pool", _create_pool)
+    monkeypatch.setattr(send_cli, "send_pending_deflection_report_deliveries", _send_pending)
+
+    code = await send_cli._main([*_base_args(), "--json"])
+
+    assert code == 0
+    assert pool.closed is True
+    assert calls == [
+        {"database_url": "postgresql://atlas@example/db"},
+        {
+            "pool": pool,
+            "sender_type": "_DryRunSender",
+            "dry_run": True,
+            "result_base_url": "https://juancanfield.com",
+        },
+    ]
+    assert json.loads(capsys.readouterr().out) == {
+        "dry_run": 2,
+        "failed": 0,
+        "scanned": 2,
+        "sent": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_main_live_send_uses_resend_sender_and_returns_failed_status(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pool = _Pool()
+    sender = object()
+    calls: list[dict[str, Any]] = []
+
+    async def _create_pool(_database_url: str) -> _Pool:
+        return pool
+
+    def _create_sender(provider: str, config: dict[str, Any]) -> object:
+        calls.append({"provider": provider, "config": config})
+        return sender
+
+    async def _send_pending(_pool: Any, *, sender: Any, config: Any) -> Any:
+        calls.append({"sender": sender, "dry_run": config.dry_run})
+        return SimpleNamespace(scanned=1, sent=0, failed=1, dry_run=0)
+
+    monkeypatch.setattr(send_cli, "_create_pool", _create_pool)
+    monkeypatch.setattr(send_cli, "create_campaign_sender", _create_sender)
+    monkeypatch.setattr(send_cli, "send_pending_deflection_report_deliveries", _send_pending)
+
+    code = await send_cli._main(
+        [
+            *_base_args(
+                "--send",
+                "--resend-api-key",
+                "re_test",
+                "--resend-api-url",
+                "https://resend.example.test/emails",
+                "--timeout-seconds",
+                "3",
+            )
+        ]
+    )
+
+    assert code == 1
+    assert pool.closed is True
+    assert calls == [
+        {
+            "provider": "resend",
+            "config": {
+                "api_key": "re_test",
+                "api_url": "https://resend.example.test/emails",
+                "timeout_seconds": 3.0,
+            },
+        },
+        {"sender": sender, "dry_run": False},
+    ]
+    assert "mode=send scanned=1 sent=0 failed=1 dry_run=0" in capsys.readouterr().out


### PR DESCRIPTION
Plan: plans/PR-Deflection-Paid-Delivery-Script.md
Slice phase: Production hardening

This slice adds a manual operator script for pending paid FAQ deflection report deliveries. The script wires the existing worker to Postgres and the existing Resend sender adapter, defaults to dry-run, and requires explicit `--send` plus Resend config for live sends.

## Intentional
- No cron/scheduler is added; this is a manual operator entrypoint.
- No abandoned checkout or non-buyer nurture flow is added.
- Live sending is opt-in via `--send`; missing Resend config fails before any DB connection or send attempt.
- The script reuses the existing Resend adapter instead of adding a new email provider integration.

## Deferred
- Future slice: scheduler/cron wiring and row-claiming for concurrent pollers.
- Future slice: provider webhook ingestion for delivered/open/click events.
- Future slice: abandoned checkout follow-up policy and unsubscribe handling.

## Parked hardening
- None.

## Verification
- `python -m py_compile scripts/send_content_ops_deflection_report_deliveries.py tests/test_send_content_ops_deflection_report_deliveries.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py -q` -- 13 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 2950 passed, 10 skipped.
- `bash scripts/local_pr_review.sh --allow-dirty --current-pr-body-file .git/pr-deflection-paid-delivery-script-body.md` -- passed.

## Diff size
5 files, +519 / -1.
