### PR TITLE
PR-Deflection-Delivery-Row-Claim

### DIFF
--- a/atlas_brain/api/billing.py
+++ b/atlas_brain/api/billing.py
@@ -678,7 +678,7 @@ async def _queue_content_ops_deflection_report_delivery(
         ON CONFLICT (account_id, request_id) DO UPDATE
         SET payment_reference = COALESCE(EXCLUDED.payment_reference, content_ops_deflection_report_deliveries.payment_reference),
             delivery_status = CASE
-                WHEN content_ops_deflection_report_deliveries.delivery_status = 'delivered'
+                WHEN content_ops_deflection_report_deliveries.delivery_status IN ('delivered', 'sending')
                     THEN content_ops_deflection_report_deliveries.delivery_status
                 ELSE 'pending'
             END,

--- a/atlas_brain/content_ops_deflection_delivery.py
+++ b/atlas_brain/content_ops_deflection_delivery.py
@@ -10,6 +10,7 @@ from extracted_content_pipeline.campaign_ports import SendRequest, SendResult
 
 
 DEFAULT_DEFLECTION_DELIVERY_SUBJECT = "Your FAQ deflection report is ready"
+DELIVERY_CLAIM_STALE_AFTER = "15 minutes"
 MAX_DELIVERY_ERROR_CHARS = 500
 
 
@@ -46,7 +47,10 @@ async def send_pending_deflection_report_deliveries(
     """Send pending paid-report delivery emails and update queue status."""
 
     _validate_config(config)
-    rows = await pool.fetch(_PENDING_SQL, int(config.limit))
+    rows = await pool.fetch(
+        _PENDING_SQL if config.dry_run else _CLAIM_PENDING_SQL,
+        int(config.limit),
+    )
     sent = failed = dry_run = 0
     for row in rows:
         data = _row_to_dict(row)
@@ -179,7 +183,7 @@ async def _mark_delivered(
             updated_at = NOW()
         WHERE account_id = $1
           AND request_id = $2
-          AND delivery_status = 'pending'
+          AND delivery_status = 'sending'
         """,
         account_id,
         request_id,
@@ -196,7 +200,7 @@ async def _mark_failed(pool: Any, account_id: str, request_id: str, error: str) 
             updated_at = NOW()
         WHERE account_id = $1
           AND request_id = $2
-          AND delivery_status = 'pending'
+          AND delivery_status = 'sending'
         """,
         account_id,
         request_id,
@@ -266,4 +270,37 @@ JOIN content_ops_deflection_reports r
 WHERE d.delivery_status = 'pending'
 ORDER BY d.created_at
 LIMIT $1
+"""
+
+_CLAIM_PENDING_SQL = f"""
+WITH claimed AS (
+    SELECT
+        d.account_id,
+        d.request_id,
+        d.created_at
+    FROM content_ops_deflection_report_deliveries d
+    WHERE d.delivery_status = 'pending'
+       OR (
+            d.delivery_status = 'sending'
+            AND d.updated_at < NOW() - INTERVAL '{DELIVERY_CLAIM_STALE_AFTER}'
+       )
+    ORDER BY d.created_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+)
+UPDATE content_ops_deflection_report_deliveries d
+SET delivery_status = 'sending',
+    delivery_error = NULL,
+    updated_at = NOW()
+FROM claimed c
+JOIN content_ops_deflection_reports r
+  ON r.account_id = c.account_id
+ AND r.request_id = c.request_id
+WHERE d.account_id = c.account_id
+  AND d.request_id = c.request_id
+RETURNING
+    d.account_id,
+    d.request_id,
+    r.delivery_email,
+    r.paid
 """

--- a/plans/PR-Deflection-Delivery-Row-Claim.md
+++ b/plans/PR-Deflection-Delivery-Row-Claim.md
@@ -1,0 +1,89 @@
+## Why this slice exists
+
+The paid FAQ deflection delivery loop is now operator-runnable, but the worker
+still reads pending rows with a plain `SELECT`. Two operator runs, or an
+operator run plus a future scheduler, can therefore observe the same pending
+row and send the same paid report link twice. This production-hardening slice
+closes that double-send risk before scheduler automation.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-deflection-paid-unlock
+Slice phase: Production hardening
+
+1. Claim live delivery rows atomically before sending by moving them from
+   `pending` to `sending` with `FOR UPDATE SKIP LOCKED`.
+2. Keep dry-run read-only; dry-run still scans pending rows but does not claim,
+   send, or update.
+3. Preserve `sending` rows when duplicate Stripe webhooks requeue the same paid
+   report, so a webhook race cannot reopen an in-flight delivery.
+4. Add focused tests proving live claim SQL, dry-run read-only behavior, stale
+   `sending` retry eligibility, and duplicate-webhook status preservation.
+
+### Files touched
+
+- `atlas_brain/content_ops_deflection_delivery.py`
+- `atlas_brain/api/billing.py`
+- `tests/test_atlas_content_ops_deflection_delivery.py`
+- `tests/test_atlas_billing_content_ops_deflection_stripe_paid.py`
+- `plans/PR-Deflection-Delivery-Row-Claim.md`
+
+## Mechanism
+
+Live delivery fetches use a writable CTE:
+
+```sql
+WITH claimed AS (
+  SELECT account_id, request_id
+  FROM content_ops_deflection_report_deliveries
+  WHERE delivery_status = 'pending'
+  FOR UPDATE SKIP LOCKED
+  LIMIT $1
+)
+UPDATE content_ops_deflection_report_deliveries ...
+RETURNING ...
+```
+
+The worker only sends rows returned by that claim statement. Success moves a
+claimed row from `sending` to `delivered`; validation/provider failures move it
+to `failed`. Rows left in `sending` by a crashed worker become eligible after a
+bounded stale-claim interval. Dry-run keeps using the existing read-only pending
+query.
+
+The Stripe delivery queue upsert preserves both `delivered` and `sending`.
+Other statuses can still be reset to `pending` by a verified paid webhook.
+
+## Intentional
+
+- No scheduler/cron is added; the manual script remains the only operator
+  entrypoint.
+- No new migration is added; `delivery_status` is already `TEXT`, and the
+  pending partial index still serves the normal queue path.
+- Stale `sending` retry uses a conservative fixed interval rather than a new
+  CLI/config field; operational tuning can wait until scheduler automation.
+
+## Deferred
+
+- Future slice: scheduler/cron wiring for the claimed worker.
+- Future slice: provider webhook ingestion for delivered/open/click events.
+- Future slice: abandoned checkout follow-up policy and unsubscribe handling.
+- Parked hardening: none.
+
+## Verification
+
+- `python -m py_compile atlas_brain/content_ops_deflection_delivery.py atlas_brain/api/billing.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 27 passed.
+- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 34 passed.
+- `scripts/run_extracted_pipeline_checks.sh` -- run with bash; 2955 passed, 10 skipped.
+- Cross-layer caller hint for `send_pending_deflection_report_deliveries` is
+  covered by `tests/test_send_content_ops_deflection_report_deliveries.py` in
+  the combined focused run.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Worker claim SQL | ~45 |
+| Billing queue guard | ~5 |
+| Tests | ~95 |
+| Plan doc | ~80 |
+| **Total** | **~225** |

--- a/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
+++ b/tests/test_atlas_billing_content_ops_deflection_stripe_paid.py
@@ -132,6 +132,7 @@ async def test_deflection_checkout_completion_marks_report_paid() -> None:
     assert args == (account_id, "req-123", "cs_test_deflection")
     delivery_query, delivery_args = pool.execute_calls[1]
     assert "INSERT INTO content_ops_deflection_report_deliveries" in delivery_query
+    assert "delivery_status IN ('delivered', 'sending')" in delivery_query
     assert delivery_args == (account_id, "req-123", "cs_test_deflection")
     assert "buyer@example.com" not in str(pool.delivery_rows)
 

--- a/tests/test_atlas_content_ops_deflection_delivery.py
+++ b/tests/test_atlas_content_ops_deflection_delivery.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from atlas_brain.content_ops_deflection_delivery import (
+    DELIVERY_CLAIM_STALE_AFTER,
     DeflectionReportDeliveryConfig,
     deflection_report_result_url,
     send_pending_deflection_report_deliveries,
@@ -77,6 +78,10 @@ async def test_delivery_worker_sends_pending_paid_report_link() -> None:
     assert summary.scanned == 1
     assert summary.sent == 1
     assert summary.failed == 0
+    claim_query, claim_args = pool.fetch_calls[0]
+    assert "FOR UPDATE SKIP LOCKED" in claim_query
+    assert "SET delivery_status = 'sending'" in claim_query
+    assert claim_args == (20,)
     assert len(sender.requests) == 1
     request = sender.requests[0]
     assert request.to_email == "buyer@example.com"
@@ -94,6 +99,7 @@ async def test_delivery_worker_sends_pending_paid_report_link() -> None:
 
     update_query, update_args = pool.execute_calls[0]
     assert "delivery_status = 'delivered'" in update_query
+    assert "delivery_status = 'sending'" in update_query
     assert update_args == ("acct-123", "content-ops-abc123", "resend:email-123")
     assert "buyer@example.com" not in str(update_args)
 
@@ -112,8 +118,29 @@ async def test_delivery_worker_dry_run_does_not_send_or_update() -> None:
     assert summary.scanned == 1
     assert summary.sent == 0
     assert summary.dry_run == 1
+    pending_query, pending_args = pool.fetch_calls[0]
+    assert "FOR UPDATE SKIP LOCKED" not in pending_query
+    assert "WHERE d.delivery_status = 'pending'" in pending_query
+    assert pending_args == (20,)
     assert sender.requests == []
     assert pool.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_claim_query_retries_stale_sending_rows() -> None:
+    pool = _Pool([_row()])
+    sender = _Sender()
+
+    await send_pending_deflection_report_deliveries(
+        pool,
+        sender=sender,
+        config=_config(),
+    )
+
+    claim_query, _claim_args = pool.fetch_calls[0]
+    assert "d.delivery_status = 'pending'" in claim_query
+    assert "d.delivery_status = 'sending'" in claim_query
+    assert f"INTERVAL '{DELIVERY_CLAIM_STALE_AFTER}'" in claim_query
 
 
 @pytest.mark.asyncio
@@ -131,6 +158,7 @@ async def test_delivery_worker_marks_missing_email_failed() -> None:
     assert sender.requests == []
     query, args = pool.execute_calls[0]
     assert "delivery_status = 'failed'" in query
+    assert "delivery_status = 'sending'" in query
     assert args == ("acct-123", "content-ops-abc123", "missing_delivery_email")
 
 
@@ -149,6 +177,7 @@ async def test_delivery_worker_marks_unpaid_report_failed() -> None:
     assert sender.requests == []
     query, args = pool.execute_calls[0]
     assert "delivery_status = 'failed'" in query
+    assert "delivery_status = 'sending'" in query
     assert args == ("acct-123", "content-ops-abc123", "report_not_paid")
 
 
@@ -166,6 +195,7 @@ async def test_delivery_worker_marks_provider_failure_failed_with_bounded_error(
     assert summary.failed == 1
     query, args = pool.execute_calls[0]
     assert "delivery_status = 'failed'" in query
+    assert "delivery_status = 'sending'" in query
     assert args[0:2] == ("acct-123", "content-ops-abc123")
     assert args[2].startswith("RuntimeError: provider down")
     assert len(args[2]) == 500


### PR DESCRIPTION
Plan: plans/PR-Deflection-Delivery-Row-Claim.md
Slice phase: Production hardening

This slice prevents duplicate paid FAQ deflection report emails by atomically claiming live delivery rows before send, while keeping dry-run read-only and preserving in-flight `sending` rows across duplicate Stripe webhooks.

## Intentional
- No scheduler/cron is added; the manual script remains the only operator entrypoint.
- No new migration is added; `delivery_status` is already `TEXT`, and the pending partial index still serves the normal queue path.
- Stale `sending` retry uses a conservative fixed interval rather than a new CLI/config field.

## Deferred
- Future slice: scheduler/cron wiring for the claimed worker.
- Future slice: provider webhook ingestion for delivered/open/click events.
- Future slice: abandoned checkout follow-up policy and unsubscribe handling.

## Parked hardening
- None.

## Verification
- `python -m py_compile atlas_brain/content_ops_deflection_delivery.py atlas_brain/api/billing.py tests/test_atlas_content_ops_deflection_delivery.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py && python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py -q` -- 27 passed.
- `python -m pytest tests/test_atlas_content_ops_deflection_delivery.py tests/test_send_content_ops_deflection_report_deliveries.py tests/test_atlas_billing_content_ops_deflection_stripe_paid.py tests/test_atlas_billing_content_ops_deflection_paid_flow.py -q` -- 34 passed.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 2955 passed, 10 skipped.
- Cross-layer caller hint for `send_pending_deflection_report_deliveries` is covered by `tests/test_send_content_ops_deflection_report_deliveries.py` in the combined focused run.

## Diff size
5 files, +161 / -4.
