### PR TITLE
PR-Content-Ops-B2B-Displacement-Vendor-UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs
@@ -26,8 +26,10 @@ async function loadSourceModeModule() {
 }
 
 const {
+  b2bDisplacementVendorsDraftValue,
   parseInputsJsonObject,
   sourceModeDraftValue,
+  updateB2BDisplacementVendorsInputJson,
   updateSourceModeInputJson,
 } = await loadSourceModeModule()
 
@@ -39,10 +41,18 @@ test('new run page exposes review source selection', () => {
   assert.ok(newRunSource.includes('Competitive'))
 })
 
+test('new run page exposes B2B displacement vendor selection for competitive mode', () => {
+  assert.ok(newRunSource.includes('fetchTrackedVendors()'))
+  assert.ok(newRunSource.includes('B2BDisplacementVendorSelector'))
+  assert.ok(newRunSource.includes("sourceMode === 'competitive'"))
+  assert.ok(newRunSource.includes('SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT'))
+})
+
 test('review source mode writes source type into inputs JSON', () => {
   const updated = updateSourceModeInputJson(
     JSON.stringify({
       source_material_type: 'support_ticket',
+      b2b_displacement_vendors: ['Zendesk'],
       source_faq_ids: ['faq-1'],
       target_account: 'Acme',
     }),
@@ -62,6 +72,7 @@ test('support-ticket source mode removes explicit source type but preserves FAQ 
   const updated = updateSourceModeInputJson(
     JSON.stringify({
       source_type: 'reviews',
+      b2b_displacement_vendors: ['Zendesk'],
       source_faq_ids: ['faq-1'],
       target_account: 'Acme',
     }),
@@ -101,6 +112,47 @@ test('competitive source mode writes source type and removes FAQ selection', () 
     sourceModeDraftValue(parseInputsJsonObject('{"source_type":"competitors"}')),
     'competitive',
   )
+})
+
+test('B2B displacement vendor helper writes deduped vendor names into inputs JSON', () => {
+  const updated = updateB2BDisplacementVendorsInputJson(
+    JSON.stringify({
+      source_type: 'competitive',
+      b2b_displacement_vendors: ['Legacy'],
+      target_account: 'Acme',
+    }),
+    [' Zendesk ', '', 'Freshdesk', 'Zendesk'],
+  )
+
+  assert.equal(updated.ok, true)
+  const parsed = JSON.parse(updated.value)
+  assert.deepEqual(parsed, {
+    source_type: 'competitive',
+    b2b_displacement_vendors: ['Zendesk', 'Freshdesk'],
+    target_account: 'Acme',
+  })
+  assert.deepEqual(
+    b2bDisplacementVendorsDraftValue(parseInputsJsonObject(updated.value)),
+    ['Zendesk', 'Freshdesk'],
+  )
+})
+
+test('B2B displacement vendor helper removes the key when selection is empty', () => {
+  const updated = updateB2BDisplacementVendorsInputJson(
+    JSON.stringify({
+      source_type: 'competitive',
+      b2b_displacement_vendors: ['Zendesk'],
+      target_account: 'Acme',
+    }),
+    [],
+  )
+
+  assert.equal(updated.ok, true)
+  const parsed = JSON.parse(updated.value)
+  assert.deepEqual(parsed, {
+    source_type: 'competitive',
+    target_account: 'Acme',
+  })
 })
 
 test('non-support source modes disable support-ticket FAQ source selection in the page', () => {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -27,6 +27,7 @@ import {
   revokeContentOpsZendeskCredential,
   saveContentOpsZendeskCredential,
 } from '../api/contentOps'
+import { fetchTrackedVendors, type TrackedVendor } from '../api/b2bClient'
 import {
   contentOpsIngestionFilePreflightError,
   contentOpsInlineRowsPreflightError,
@@ -82,9 +83,12 @@ import type {
 import useApiData from '../hooks/useApiData'
 import { PageError } from '../components/ErrorBoundary'
 import {
+  b2bDisplacementVendorsDraftValue,
   parseInputsJsonObject,
   sourceModeDraftValue,
+  updateB2BDisplacementVendorsInputJson,
   updateSourceModeInputJson,
+  SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT,
   SOURCE_FAQ_IDS_INPUT,
   type ContentOpsSourceMode,
   type ParsedInputsJsonObject,
@@ -235,6 +239,13 @@ export default function ContentOpsNewRun() {
     () => fetchGeneratedAssetDrafts('faq_markdown', { status: 'draft', limit: 10 }),
     [],
   )
+  const {
+    data: trackedVendors,
+    loading: trackedVendorsLoading,
+    error: trackedVendorsError,
+    refresh: refreshTrackedVendors,
+    refreshing: trackedVendorsRefreshing,
+  } = useApiData(() => fetchTrackedVendors(), [])
 
   const catalog = useMemo<ContentOpsCatalog | null>(
     () => (wireCatalog ? fromWireCatalog(wireCatalog) : null),
@@ -318,6 +329,7 @@ export default function ContentOpsNewRun() {
   const faqSourceSelectionVisible =
     (landingPageOutputSelected || blogPostOutputSelected) &&
     sourceMode === 'support_ticket'
+  const b2bDisplacementVendorSelectionVisible = sourceMode === 'competitive'
   const faqConfigurationOutputSelected = faqConfigurationInputsSelected(
     request.outputs,
   )
@@ -373,6 +385,10 @@ export default function ContentOpsNewRun() {
   const faqInputsDisabled = !parsedInputsForControls.ok
   const selectedFaqSourceIds = sourceFaqIdsDraftValue(parsedInputsForControls)
   const faqSourceSelectionDisabled = !parsedInputsForControls.ok
+  const selectedB2BDisplacementVendors = b2bDisplacementVendorsDraftValue(
+    parsedInputsForControls,
+  )
+  const b2bDisplacementVendorSelectionDisabled = !parsedInputsForControls.ok
   const landingPageRepairAttemptDisabled =
     !parsedInputsForControls.ok || !landingPageRepairAttemptContract
 
@@ -449,6 +465,22 @@ export default function ContentOpsNewRun() {
       ? [...selectedFaqSourceIds, draftId]
       : selectedFaqSourceIds.filter((id) => id !== draftId)
     const updated = updateSourceFaqIdsInputJson(inputsJson, nextIds)
+    if (!updated.ok) return
+    setInputsJson(updated.value)
+    markStale()
+  }
+
+  const handleB2BDisplacementVendorChange = (
+    vendorName: string,
+    checked: boolean,
+  ) => {
+    const nextVendorNames = checked
+      ? [...selectedB2BDisplacementVendors, vendorName]
+      : selectedB2BDisplacementVendors.filter((name) => name !== vendorName)
+    const updated = updateB2BDisplacementVendorsInputJson(
+      inputsJson,
+      nextVendorNames,
+    )
     if (!updated.ok) return
     setInputsJson(updated.value)
     markStale()
@@ -1185,6 +1217,18 @@ export default function ContentOpsNewRun() {
               disabled={faqSourceSelectionDisabled}
               onRefresh={refreshFaqDrafts}
               onToggle={handleFaqSourceSelectionChange}
+            />
+          )}
+          {b2bDisplacementVendorSelectionVisible && (
+            <B2BDisplacementVendorSelector
+              vendors={trackedVendors?.vendors ?? []}
+              selectedVendorNames={selectedB2BDisplacementVendors}
+              loading={trackedVendorsLoading}
+              refreshing={trackedVendorsRefreshing}
+              error={trackedVendorsError}
+              disabled={b2bDisplacementVendorSelectionDisabled}
+              onRefresh={refreshTrackedVendors}
+              onToggle={handleB2BDisplacementVendorChange}
             />
           )}
           {landingPageOutputSelected && (
@@ -2026,6 +2070,172 @@ function ZendeskCredentialCard({
       </p>
     </section>
   )
+}
+
+function B2BDisplacementVendorSelector({
+  vendors,
+  selectedVendorNames,
+  loading,
+  refreshing,
+  error,
+  disabled,
+  onRefresh,
+  onToggle,
+}: {
+  vendors: TrackedVendor[]
+  selectedVendorNames: string[]
+  loading: boolean
+  refreshing: boolean
+  error: Error | null
+  disabled: boolean
+  onRefresh: () => void
+  onToggle: (vendorName: string, checked: boolean) => void
+}) {
+  const visibleVendors = uniqueTrackedVendorRows(vendors)
+  const visibleVendorNames = new Set(
+    visibleVendors.map((vendor) => trackedVendorName(vendor)),
+  )
+  const missingSelectedVendorNames = selectedVendorNames.filter(
+    (vendorName) => !visibleVendorNames.has(vendorName),
+  )
+
+  return (
+    <div className="mt-3 rounded-md border border-slate-800 bg-slate-900/70 p-3">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-medium text-slate-200">
+            B2B displacement vendors
+          </h3>
+          <p className="mt-1 text-xs text-slate-500">
+            Writes to{' '}
+            <span className="font-mono">{SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT}</span>.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading || refreshing}
+          className="flex items-center justify-center gap-2 rounded-md border border-slate-700 px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+        >
+          <RefreshCw className={clsx('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+          Refresh
+        </button>
+      </div>
+
+      {disabled && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          Fix inputs JSON before selecting B2B displacement vendors.
+        </div>
+      )}
+
+      {!disabled && loading && (
+        <div className="flex items-center gap-2 rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-300">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading tracked vendors...
+        </div>
+      )}
+
+      {!disabled && error && !loading && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+          B2B tracked vendors unavailable: {error.message}
+        </div>
+      )}
+
+      {!disabled && !loading && missingSelectedVendorNames.length > 0 && (
+        <div className="mb-3 grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {missingSelectedVendorNames.map((vendorName) => (
+            <label
+              key={vendorName}
+              className="flex cursor-pointer items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 transition hover:border-amber-400/70"
+            >
+              <input
+                type="checkbox"
+                checked
+                onChange={(event) => onToggle(vendorName, event.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-800 accent-amber-500"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-amber-100">
+                  Selected vendor not in tracked list
+                </span>
+                <span className="mt-0.5 block break-all font-mono text-xs text-amber-200/80">
+                  {vendorName}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      {!disabled &&
+        !loading &&
+        !error &&
+        visibleVendors.length === 0 &&
+        missingSelectedVendorNames.length === 0 && (
+          <div className="rounded-md border border-slate-800 bg-slate-950/50 px-3 py-2 text-xs text-slate-400">
+            No tracked vendors found yet.
+          </div>
+        )}
+
+      {!disabled && !loading && !error && visibleVendors.length > 0 && (
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {visibleVendors.map((vendor) => {
+            const vendorName = trackedVendorName(vendor)
+            const checked = selectedVendorNames.includes(vendorName)
+            return (
+              <label
+                key={vendorName}
+                className={clsx(
+                  'flex cursor-pointer items-start gap-3 rounded-md border px-3 py-2 transition',
+                  checked
+                    ? 'border-cyan-500 bg-cyan-500/10'
+                    : 'border-slate-800 bg-slate-950/50 hover:border-slate-600',
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(event) => onToggle(vendorName, event.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-800 accent-cyan-500"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-slate-200">
+                    {vendorName}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-slate-500">
+                    {trackedVendorSubtitle(vendor)}
+                  </span>
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function uniqueTrackedVendorRows(vendors: TrackedVendor[]): TrackedVendor[] {
+  const seen = new Set<string>()
+  const rows: TrackedVendor[] = []
+  for (const vendor of vendors) {
+    const name = trackedVendorName(vendor)
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    rows.push(vendor)
+  }
+  return rows
+}
+
+function trackedVendorName(vendor: TrackedVendor): string {
+  return String(vendor.vendor_name ?? '').trim()
+}
+
+function trackedVendorSubtitle(vendor: TrackedVendor): string {
+  const facts = [vendor.track_mode, vendor.label].filter(
+    (fact): fact is string => Boolean(fact),
+  )
+  return facts.join(' · ') || 'Tracked vendor'
 }
 
 function FaqSourceSelector({

--- a/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
+++ b/atlas-intel-ui/src/pages/contentOpsSourceMode.ts
@@ -1,6 +1,7 @@
 const SOURCE_TYPE_INPUT = 'source_type'
 const SOURCE_MATERIAL_TYPE_INPUT = 'source_material_type'
 const SOURCE_FAQ_IDS_INPUT = 'source_faq_ids'
+const SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT = 'b2b_displacement_vendors'
 
 export type ContentOpsSourceMode = 'support_ticket' | 'reviews' | 'competitive'
 
@@ -69,16 +70,60 @@ export function updateSourceModeInputJson(
   if (mode === 'reviews') {
     next[SOURCE_TYPE_INPUT] = 'reviews'
     delete next[SOURCE_FAQ_IDS_INPUT]
+    delete next[SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT]
   } else if (mode === 'competitive') {
     next[SOURCE_TYPE_INPUT] = 'competitive'
     delete next[SOURCE_FAQ_IDS_INPUT]
   } else {
     delete next[SOURCE_TYPE_INPUT]
+    delete next[SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT]
   }
   return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
 }
 
+export function b2bDisplacementVendorsDraftValue(
+  parsed: ParsedInputsJsonObject,
+): string[] {
+  if (!parsed.ok) return []
+  const value = parsed.value[SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT]
+  if (Array.isArray(value)) return uniqueNonBlankStrings(value)
+  if (typeof value === 'string') return uniqueNonBlankStrings([value])
+  return []
+}
+
+export function updateB2BDisplacementVendorsInputJson(
+  current: string,
+  vendorNames: string[],
+): UpdatedInputsJson {
+  const parsed = parseInputsJsonObject(current)
+  if (!parsed.ok) return parsed
+
+  const next = { ...parsed.value }
+  const values = uniqueNonBlankStrings(vendorNames)
+  if (values.length === 0) {
+    delete next[SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT]
+  } else {
+    next[SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT] = values
+  }
+
+  return { ok: true, value: `${JSON.stringify(next, null, 2)}\n` }
+}
+
+function uniqueNonBlankStrings(values: unknown[]): string[] {
+  const seen = new Set<string>()
+  const items: string[] = []
+  for (const item of values) {
+    if (typeof item === 'undefined' || item === null) continue
+    const trimmed = String(item).trim()
+    if (trimmed === '' || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    items.push(trimmed)
+  }
+  return items
+}
+
 export {
+  SOURCE_B2B_DISPLACEMENT_VENDORS_INPUT,
   SOURCE_FAQ_IDS_INPUT,
   SOURCE_MATERIAL_TYPE_INPUT,
   SOURCE_TYPE_INPUT,

--- a/plans/PR-Content-Ops-B2B-Displacement-Vendor-UI.md
+++ b/plans/PR-Content-Ops-B2B-Displacement-Vendor-UI.md
@@ -1,0 +1,92 @@
+# PR: Content Ops B2B Displacement Vendor UI
+
+## Why this slice exists
+
+PR #1258 made canonical B2B displacement dynamics selectable through request
+JSON for competitive Content Ops runs, but the operator-facing New Run screen
+still has no control for choosing the tracked vendors. That leaves the product
+flow technically wired but manually keyed, which is easy to mistype and hard to
+use during live landing-page/blog generation.
+
+This slice closes the first deferred gap from #1258 by adding a thin New Run UI
+selector over the existing tenant tracked-vendor client. It does not add a new
+backend endpoint: `fetchTrackedVendors()` already reads the tenant's tracked
+vendors, and #1258 already consumes `b2b_displacement_vendors` in the request
+inputs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Fetch tenant tracked vendors on the New Run page through the existing B2B
+   client.
+2. Show a competitive-mode vendor selector that writes selected vendor names to
+   `inputs.b2b_displacement_vendors`.
+3. Preserve already-selected vendor names that are not in the current fetched
+   list until the operator unchecks them.
+4. Add focused frontend helper/page tests by extending the already-enrolled
+   source-selection test script.
+
+### Files touched
+
+- `plans/PR-Content-Ops-B2B-Displacement-Vendor-UI.md`
+- `atlas-intel-ui/src/pages/contentOpsSourceMode.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/scripts/content-ops-review-source-selection.test.mjs`
+
+## Mechanism
+
+The source-mode helper will own the JSON contract helpers for
+`b2b_displacement_vendors`. `ContentOpsNewRun` will import
+`fetchTrackedVendors()` from the existing B2B client, render a selector when
+`sourceMode === 'competitive'`, and call the helper whenever the operator
+toggles a vendor. The selector mirrors the existing FAQ source selector shape:
+loading, refresh, unavailable, empty, and missing-selected rows are all local UI
+states.
+
+The existing `test:content-ops-review-source-selection` script is already run by
+the UI checks workflow, so this slice extends it instead of adding an unenrolled
+test script.
+
+## Intentional
+
+- No backend route or SQL changes. #1258 already added the tenant-scoped B2B
+  displacement loader; this PR only makes the request key easy to populate.
+- No search/add tracked-vendor workflow inside New Run. Operators manage tracked
+  vendors through the B2B tenant surface; this selector only chooses from that
+  tenant-owned list.
+- No new workflow step. The changed test lives in the already-enrolled
+  `test:content-ops-review-source-selection` step.
+
+## Deferred
+
+- Competitive-specific output skills beyond blog and landing page, such as ad
+  copy, social posts, or stat/quote cards.
+- Product packaging/pricing for the marketer competitive offer.
+- Inline tracked-vendor add/search from New Run, if operators need that instead
+  of using the B2B tenant page.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Command: `cd atlas-intel-ui && npm run test:content-ops-review-source-selection` -- 8 passed.
+- Command: `cd atlas-intel-ui && npm run lint` -- passed.
+- Command: `cd atlas-intel-ui && npm run build` -- passed.
+- Command: `git diff --check` -- passed.
+- Command: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-b2b-displacement-vendor-ui-pr-body.md` -- passed.
+
+## Estimated diff size
+
+Estimated: 399 LOC actual (4 files, +399 / -0).
+
+| Area | Estimated LOC |
+|---|---:|
+| New Run selector + state | ~210 |
+| Source-mode JSON helpers | ~45 |
+| Frontend tests | ~52 |
+| Plan doc | ~92 |
+| **Total** | **~399** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-B2B-Displacement-Vendor-UI.md
Slice phase: Vertical slice

Adds the New Run UI control for the #1258 B2B displacement request key: competitive-mode runs can now fetch tenant tracked vendors and write selected names into `inputs.b2b_displacement_vendors` without hand-editing JSON.

## Intentional
- No backend route or SQL changes; #1258 already added the scoped loader.
- No tracked-vendor add/search workflow in New Run; this selector chooses from the existing tenant-owned list.
- No new workflow step; coverage extends the already-enrolled `test:content-ops-review-source-selection` script.

## Deferred
- Competitive-specific output skills beyond blog and landing page, such as ad copy, social posts, or stat/quote cards.
- Product packaging/pricing for the marketer competitive offer.
- Inline tracked-vendor add/search from New Run, if operators need it.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm run test:content-ops-review-source-selection` -- 8 passed.
- `cd atlas-intel-ui && npm run lint` -- passed.
- `cd atlas-intel-ui && npm run build` -- passed.
- `git diff --check` -- passed.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-b2b-displacement-vendor-ui-pr-body.md` -- passed.

## Diff size
4 files, +399 / -0