### PR TITLE
PR-Content-Ops-Competitive-Sales-Brief-Handoff

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -166,7 +166,7 @@ _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
 _REVIEW_OFFER = "Turn customer review themes into buyer-facing landing pages and blog posts"
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
-_COMPETITIVE_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief")
 _COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
 _COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
 _COMPETITIVE_AUDIENCE = (
@@ -998,6 +998,7 @@ def _build_competitive_input_package(
         "offer": _COMPETITIVE_OFFER,
         "audience": _COMPETITIVE_AUDIENCE,
         "target_keyword": _COMPETITIVE_TARGET_KEYWORD,
+        "brief_type": "displacement",
         "search_intent": (
             "Marketing teams looking for competitor and switching evidence "
             "they can turn into grounded buyer-facing content."

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -528,20 +528,23 @@ async def _dispatch_sales_brief(
     scope: TenantScope,
     filters: Mapping[str, Any] | None,
 ) -> Any:
-    return await service.generate(
-        scope=scope,
-        target_mode=request.target_mode,
-        limit=request.limit,
-        filters=filters,
-        default_brief_type=_step_config_text(step.config, "default_brief_type"),
-        temperature=_step_config_float(step.config, "temperature"),
-        max_tokens=_step_config_int(step.config, "max_tokens"),
-        parse_retry_attempts=_step_config_int(step.config, "parse_retry_attempts"),
-        parse_retry_response_excerpt_chars=_step_config_int(
+    kwargs: dict[str, Any] = {
+        "scope": scope,
+        "target_mode": request.target_mode,
+        "limit": request.limit,
+        "filters": filters,
+        "default_brief_type": _step_config_text(step.config, "default_brief_type"),
+        "temperature": _step_config_float(step.config, "temperature"),
+        "max_tokens": _step_config_int(step.config, "max_tokens"),
+        "parse_retry_attempts": _step_config_int(step.config, "parse_retry_attempts"),
+        "parse_retry_response_excerpt_chars": _step_config_int(
             step.config, "parse_retry_response_excerpt_chars"
         ),
-        quality_gates_enabled=_step_config_bool(step.config, "quality_gates_enabled"),
-    )
+        "quality_gates_enabled": _step_config_bool(step.config, "quality_gates_enabled"),
+    }
+    if "source_material" in request.inputs:
+        kwargs["source_material"] = request.inputs.get("source_material")
+    return await service.generate(**kwargs)
 
 
 async def _dispatch_landing_page(

--- a/extracted_content_pipeline/sales_brief_generation.py
+++ b/extracted_content_pipeline/sales_brief_generation.py
@@ -47,6 +47,10 @@ from .campaign_ports import (
     SkillStore,
     TenantScope,
 )
+from .campaign_source_adapters import (
+    source_material_to_source_rows,
+    source_rows_to_campaign_opportunities,
+)
 from .sales_brief_ports import (
     SalesBriefDraft,
     SalesBriefRepository,
@@ -107,6 +111,22 @@ class SalesBriefGenerationResult:
                 dict(item) for item in self.consumed_reasoning_contexts
             ]
         return data
+
+
+def _opportunities_from_source_material(
+    source_material: Any,
+    *,
+    target_mode: str,
+    limit: int,
+) -> list[dict[str, Any]] | None:
+    rows = source_material_to_source_rows(source_material)
+    if not rows:
+        return None
+    loaded = source_rows_to_campaign_opportunities(rows, target_mode=target_mode)
+    return [
+        normalize_campaign_opportunity(row, target_mode=target_mode)
+        for row in loaded.opportunities[: max(0, int(limit))]
+    ]
 
 
 def parse_sales_brief_response(text: str) -> dict[str, Any] | None:
@@ -233,6 +253,7 @@ class SalesBriefGenerationService:
         parse_retry_attempts: int | None = None,
         parse_retry_response_excerpt_chars: int | None = None,
         quality_gates_enabled: bool | None = None,
+        source_material: Any = None,
     ) -> SalesBriefGenerationResult:
         prompt_template = self._skills.get_prompt(self._config.skill_name)
         if not prompt_template:
@@ -265,15 +286,23 @@ class SalesBriefGenerationService:
         )
 
         requested = int(limit or self._config.limit)
-        opportunities = [
-            normalize_campaign_opportunity(row, target_mode=target_mode)
-            for row in await self._intelligence.read_campaign_opportunities(
-                scope=scope,
-                target_mode=target_mode,
-                limit=requested,
-                filters=filters,
-            )
-        ]
+        source_opportunities = _opportunities_from_source_material(
+            source_material,
+            target_mode=target_mode,
+            limit=requested,
+        )
+        if source_opportunities is None:
+            opportunities = [
+                normalize_campaign_opportunity(row, target_mode=target_mode)
+                for row in await self._intelligence.read_campaign_opportunities(
+                    scope=scope,
+                    target_mode=target_mode,
+                    limit=requested,
+                    filters=filters,
+                )
+            ]
+        else:
+            opportunities = source_opportunities
 
         drafts: list[SalesBriefDraft] = []
         errors: list[dict[str, Any]] = []

--- a/plans/PR-Content-Ops-Competitive-Sales-Brief-Handoff.md
+++ b/plans/PR-Content-Ops-Competitive-Sales-Brief-Handoff.md
@@ -1,0 +1,95 @@
+# PR: Content Ops Competitive Sales Brief Handoff
+
+## Why this slice exists
+
+PR #1253 made competitive/displacement evidence usable for landing pages and
+blog posts. PR #1258 and #1260 then made canonical B2B displacement rows
+selectable from the operator UI. The remaining marketer-output gap is that the
+same competitive evidence still cannot produce a sales-facing generated asset:
+`sales_brief` reads repository opportunities and ignores the source material
+package the competitive input provider already prepares.
+
+This slice is the thinnest competitive-specific output follow-up. It does not
+invent a new asset type; it reuses the existing `SalesBriefGenerationService`
+and its `displacement` brief shape, but lets the Content Ops executor hand it
+packaged source-material opportunities for competitive runs.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Let `SalesBriefGenerationService.generate(...)` accept optional
+   `source_material` and build normalized campaign opportunities from it before
+   falling back to the repository.
+2. Thread `request.inputs.source_material` through the sales-brief dispatcher.
+3. Add `sales_brief` to the competitive input package defaults and set
+   `brief_type=displacement`.
+4. Add focused tests proving competitive source material reaches the sales brief
+   path and defaults to the displacement brief type.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Competitive-Sales-Brief-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/sales_brief_generation.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_sales_brief_generation.py`
+
+## Mechanism
+
+`SalesBriefGenerationService.generate` will gain a `source_material` keyword.
+When it is supplied, the service will use the existing source-row adapter to
+normalize the material into campaign opportunities and skip the repository read.
+When it is omitted, the current repository-backed behavior stays unchanged.
+
+The Content Ops sales-brief dispatcher will pass `request.inputs.source_material`
+to the service. The competitive input package already stores the filtered
+competitive opportunities under that key, so adding `sales_brief` to the package
+outputs plus `brief_type=displacement` gives the existing generated asset a real
+competitive path.
+
+## Intentional
+
+- No new generated asset table, router, UI review screen, or output id. Sales
+  briefs already exist and already support `displacement` copy framing.
+- No live B2B SQL change. The canonical B2B displacement loader landed in
+  #1258 and the UI selector landed in #1260.
+- Source-material mode is opt-in: repository-backed sales briefs still use the
+  current `read_campaign_opportunities` path when no source material is present.
+
+## Deferred
+
+- Social posts, ad copy, and stat/quote card outputs remain future slices.
+- Product packaging/pricing for the marketer competitive offer remains
+  deferred.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_sales_brief_generation.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_review_input_provider.py -q (107 passed)
+- Passed: python -m py_compile extracted_content_pipeline/sales_brief_generation.py extracted_content_pipeline/content_ops_execution.py atlas_brain/_content_ops_input_provider.py
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2957 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-competitive-sales-brief-handoff-pr-body.md
+
+## Estimated diff size
+
+Actual: 7 files, +242 / -26.
+
+| Area | Estimated LOC |
+|---|---:|
+| Sales-brief source-material handoff | ~75 |
+| Executor + provider defaults | ~25 |
+| Focused tests | ~140 |
+| Plan doc | ~90 |
+| **Total** | **~330** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -207,10 +207,11 @@ def test_competitive_source_material_builds_landing_and_blog_inputs() -> None:
     preview = preview_control_surface(request)
 
     assert package.provider == "atlas_competitive_request"
-    assert request.outputs == ("landing_page", "blog_post")
+    assert request.outputs == ("landing_page", "blog_post", "sales_brief")
     assert request.ingestion_profile == "existing_evidence"
     assert request.inputs["source_type"] == "competitive"
     assert request.inputs["competitive_source_material"][0]["target_id"] == "competitive-1"
+    assert request.inputs["brief_type"] == "displacement"
     assert request.inputs["target_account"] == "Slack"
     assert request.inputs["competitive_alternatives"] == ["Teams"]
     assert package.metadata["included_row_count"] == 1
@@ -231,7 +232,7 @@ def test_competitive_source_material_accepts_competitive_bundle_alias() -> None:
     )
 
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post")
+    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
     assert package.inputs["source_material"][0]["source_type"] == "competitive"
     assert package.inputs["source_material"][0]["target_id"] == "competitive-1"
     assert package.metadata["source_row_count"] == 1
@@ -490,7 +491,7 @@ async def test_competitive_mode_fetches_persisted_targets_by_tenant_scope() -> N
     ]
     assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post")
+    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
     assert package.metadata["source_target_loaded_count"] == 2
     assert package.metadata["included_row_count"] == 2
     assert package.inputs["competitive_alternatives"] == ["Teams", "Confluence"]
@@ -512,7 +513,7 @@ async def test_competitive_mode_fetches_b2b_displacement_dynamics_by_tracked_ven
     )
 
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post")
+    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
     assert package.metadata["b2b_displacement_vendor_count"] == 2
     assert package.metadata["b2b_displacement_loaded_count"] == 1
     assert package.metadata["b2b_displacement_missing_vendor_count"] == 1
@@ -656,6 +657,7 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
         services=ContentOpsExecutionServices(
             blog_post=_RunnableService(),
             landing_page=_RunnableService(),
+            sales_brief=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -668,6 +670,11 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
     blog_context = blog_step.result["kwargs"]["data_context"]
     assert blog_context["source"] == "competitive_input_provider"
     assert blog_context["competitive_source_material"][0]["target_id"] == "competitive-1"
+
+    sales_brief_step = next(step for step in result.steps if step.output == "sales_brief")
+    sales_brief_kwargs = sales_brief_step.result["kwargs"]
+    assert sales_brief_kwargs["default_brief_type"] == "displacement"
+    assert sales_brief_kwargs["source_material"][0]["target_id"] == "competitive-1"
 
 
 @pytest.mark.skipif(

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -73,6 +73,7 @@ class _OpportunityService:
         quality_gates_enabled: bool | None = None,
         topic: str | None = None,
         opportunity_defaults: Mapping[str, Any] | None = None,
+        source_material: Any | None = None,
         **extras: Any,
     ) -> _Result:
         self.calls.append({
@@ -93,6 +94,7 @@ class _OpportunityService:
             "quality_gates_enabled": quality_gates_enabled,
             "topic": topic,
             "opportunity_defaults": dict(opportunity_defaults or {}),
+            "source_material": source_material,
             "extras": dict(extras),
         })
         return _Result()
@@ -992,6 +994,39 @@ async def test_execute_threads_user_selected_brief_type_into_sales_brief_service
     assert result["status"] == "completed"
     assert sales_brief.calls[0]["default_brief_type"] == "renewal"
     assert sales_brief.calls[0]["extras"] == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_source_material_into_sales_brief_service() -> None:
+    source_material = [{
+        "target_id": "competitive-1",
+        "source_id": "competitive-1",
+        "source_type": "competitive",
+        "vendor_name": "Slack",
+        "competitor": "Teams",
+        "text": "Slack buyers cite Teams as the replacement alternative.",
+    }]
+    sales_brief = _OpportunityService()
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["sales_brief"],
+            "inputs": {
+                "target_account": "Slack",
+                "offer": "Competitive displacement audit",
+                "opportunity_id": "competitive-1",
+                "brief_type": "displacement",
+                "source_material": source_material,
+            },
+        },
+        services=ContentOpsExecutionServices(sales_brief=sales_brief),
+    )
+
+    assert result["status"] == "completed"
+    call = sales_brief.calls[0]
+    assert call["default_brief_type"] == "displacement"
+    assert call["source_material"] == source_material
+    assert call["extras"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_sales_brief_generation.py
+++ b/tests/test_extracted_sales_brief_generation.py
@@ -288,6 +288,52 @@ async def test_generate_persists_one_brief_per_opportunity_via_save_drafts() -> 
 
 
 @pytest.mark.asyncio
+async def test_generate_uses_source_material_before_repository_fallback() -> None:
+    response = json.dumps({
+        "title": "Competitive displacement brief",
+        "headline": "Slack risk: Teams is showing up in replacement evidence",
+        "sections": [
+            {
+                "id": "competitive_context",
+                "title": "Competitive Context",
+                "body_markdown": "Lead with the Teams replacement signal.",
+                "evidence_ids": ["competitive-1"],
+            }
+        ],
+        "reference_ids": ["competitive-1"],
+    })
+    service, intelligence, sales_briefs, llm, _skills, _rp = _service(
+        opportunities=[_opportunity()],
+        responses=[response],
+    )
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[{
+            "target_id": "competitive-1",
+            "source_id": "competitive-1",
+            "source_type": "competitive_displacement",
+            "vendor_name": "Slack",
+            "competitor": "Teams",
+            "text": "Slack buyers cite Teams as the replacement alternative.",
+        }],
+        default_brief_type="displacement",
+    )
+
+    assert intelligence.calls == []
+    assert result.requested == 1
+    assert result.generated == 1
+    system_msg = llm.calls[0]["messages"][0].content
+    assert '"target_id":"competitive-1"' in system_msg
+    assert "Teams" in system_msg
+    draft = sales_briefs.saved[0]["drafts"][0]
+    assert draft.target_id == "competitive-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.brief_type == "displacement"
+
+
+@pytest.mark.asyncio
 async def test_generate_substitutes_opportunity_json_into_system_prompt_only() -> None:
     """Opportunity payload appears in system content and NOT in user content."""
     service, _intel, _sb, llm, _skills, _rp = _service(


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Competitive-Sales-Brief-Handoff.md
Slice phase: Vertical slice

Competitive/displacement source material can already feed landing pages and blog posts, but `sales_brief` still read repository opportunities and ignored the packaged competitive evidence. This slice reuses the existing sales-brief generator and displacement brief type so the same competitive input package can produce a sales-facing asset.

## Intentional
- No new generated asset table, router, UI review screen, or output id. Sales briefs already exist and already support displacement copy framing.
- No live B2B SQL change. The canonical B2B displacement loader landed in #1258 and the UI selector landed in #1260.
- Source-material mode is opt-in: repository-backed sales briefs still use `read_campaign_opportunities` when no source material rows are present.

## Deferred
- Social posts, ad copy, and stat/quote card outputs remain future slices.
- Product packaging/pricing for the marketer competitive offer remains deferred.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_sales_brief_generation.py tests/test_extracted_content_ops_execution.py tests/test_atlas_content_ops_review_input_provider.py -q` (107 passed)
- `python -m py_compile extracted_content_pipeline/sales_brief_generation.py extracted_content_pipeline/content_ops_execution.py atlas_brain/_content_ops_input_provider.py`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (`OK: 144 matching tests are enrolled.`)
- `bash scripts/run_extracted_pipeline_checks.sh` (2957 passed, 10 skipped, 1 warning)
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-competitive-sales-brief-handoff-pr-body.md`

## Diff size
7 files, +242 / -26