### PR TITLE
PR-Content-Ops-Review-Sales-Brief-Handoff

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -160,7 +160,7 @@ _COMPETITIVE_MARKER_KEYS = frozenset({
     "top_displacement_targets",
     "winning_vendor",
 })
-_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post")
+_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief")
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
@@ -880,6 +880,7 @@ def _build_review_input_package(
         "offer": _REVIEW_OFFER,
         "audience": _REVIEW_AUDIENCE,
         "target_keyword": _REVIEW_TARGET_KEYWORD,
+        "brief_type": "discovery",
         "search_intent": (
             "Marketing teams looking for review-grounded themes for landing "
             "pages and blog posts."

--- a/plans/PR-Content-Ops-Review-Sales-Brief-Handoff.md
+++ b/plans/PR-Content-Ops-Review-Sales-Brief-Handoff.md
@@ -1,0 +1,83 @@
+# PR: Content Ops Review Sales Brief Handoff
+
+## Why this slice exists
+
+PR #1247 made customer review/source evidence usable as input for landing pages
+and blog posts. PR #1261 then added the missing service-side source-material
+path for `sales_brief`, but only competitive packages were enrolled as a
+sales-brief output. That leaves the review marketer path uneven: the same
+review-grounded source rows can produce public landing/blog assets, but not the
+internal sales-facing brief that a rep can use from those review themes.
+
+This slice reuses the existing `sales_brief` output and the source-material
+handoff that already landed. It only enrolls review-source packages in that
+output set and proves the review evidence reaches the sales-brief dispatcher.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add `sales_brief` to the review-source input package output defaults.
+2. Set review-source packages to use `brief_type=discovery`, which matches a
+   review-grounded sales enablement brief better than renewal or displacement.
+3. Update focused provider/execution tests so review source material reaches
+   landing, blog, and sales-brief services from the same package.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Review-Sales-Brief-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The review input provider already normalizes raw review/source rows into flat
+campaign opportunities and stores them under both `source_material` and
+`review_source_material`. PR #1261 made the sales-brief executor pass
+`request.inputs.source_material` into `SalesBriefGenerationService.generate`.
+
+This PR therefore only changes the review package defaults:
+
+- `_REVIEW_CAMPAIGN_OUTPUTS` becomes `("landing_page", "blog_post", "sales_brief")`.
+- The review input payload gains `brief_type: "discovery"` so the existing plan
+  builder emits that as the sales-brief `default_brief_type`.
+
+## Intentional
+
+- No generator, prompt, router, DB, or UI review-screen change. The sales-brief
+  generator already accepts source material after #1261.
+- No competitive-path change. Competitive packages already use
+  `brief_type=displacement`.
+- Review sales briefs use `discovery`, not `pre_call`, because the source rows
+  are third-party review themes rather than account-specific meeting notes.
+
+## Deferred
+
+- Social posts, ad copy, and stat/quote card outputs remain future slices.
+- Product packaging/pricing for the review/competitive marketer offer remains
+  deferred.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_atlas_content_ops_review_input_provider.py -q (22 passed)
+- Passed: python -m py_compile atlas_brain/_content_ops_input_provider.py
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: git diff --check
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2957 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-review-sales-brief-handoff-pr-body.md
+
+## Estimated diff size
+
+Actual: 3 files, +99 / -7.
+
+| Area | Estimated LOC |
+|---|---:|
+| Review provider defaults | ~5 |
+| Focused tests | ~60 |
+| Plan doc | ~85 |
+| **Total** | **~150** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -147,7 +147,7 @@ def _support_ticket_row() -> dict[str, Any]:
     }
 
 
-def test_review_source_material_builds_landing_and_blog_inputs() -> None:
+def test_review_source_material_builds_landing_blog_and_sales_brief_inputs() -> None:
     package = build_content_ops_input_provider().build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
         request={
@@ -162,9 +162,10 @@ def test_review_source_material_builds_landing_and_blog_inputs() -> None:
     preview = preview_control_surface(request)
 
     assert package.provider == "atlas_review_request"
-    assert request.outputs == ("landing_page", "blog_post")
+    assert request.outputs == ("landing_page", "blog_post", "sales_brief")
     assert request.ingestion_profile == "existing_evidence"
     assert request.inputs["source_type"] == "reviews"
+    assert request.inputs["brief_type"] == "discovery"
     assert request.inputs["source_material"][0]["source_type"] == "review"
     assert request.inputs["review_source_material"][0]["source_type"] == "review"
     assert request.inputs["source_material"][0]["target_id"] == "review-1"
@@ -271,7 +272,7 @@ def test_review_source_material_accepts_review_bundle_alias() -> None:
     )
 
     assert package.provider == "atlas_review_request"
-    assert package.outputs == ("landing_page", "blog_post")
+    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
     assert package.inputs["source_material"][0]["source_type"] == "review"
     assert package.metadata["included_row_count"] == 1
 
@@ -447,7 +448,7 @@ async def test_review_mode_fetches_persisted_targets_by_tenant_scope() -> None:
     ]
     assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
     assert package.provider == "atlas_review_request"
-    assert package.outputs == ("landing_page", "blog_post")
+    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
     assert package.metadata["source_target_loaded_count"] == 2
     assert package.metadata["included_row_count"] == 2
     assert {row["source_type"] for row in package.inputs["source_material"]} == {
@@ -606,7 +607,7 @@ async def test_competitive_b2b_displacement_selection_reports_missing_vendor() -
 
 
 @pytest.mark.asyncio
-async def test_review_input_evidence_reaches_landing_and_blog_generators() -> None:
+async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_generators() -> None:
     package = build_content_ops_input_provider().build_content_ops_input_package(
         scope=TenantScope(account_id="acct-1"),
         request={
@@ -624,6 +625,7 @@ async def test_review_input_evidence_reaches_landing_and_blog_generators() -> No
         services=ContentOpsExecutionServices(
             blog_post=_RunnableService(),
             landing_page=_RunnableService(),
+            sales_brief=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -636,6 +638,11 @@ async def test_review_input_evidence_reaches_landing_and_blog_generators() -> No
     blog_context = blog_step.result["kwargs"]["data_context"]
     assert blog_context["source"] == "review_input_provider"
     assert blog_context["review_source_material"][0]["target_id"] == "review-1"
+
+    sales_brief_step = next(step for step in result.steps if step.output == "sales_brief")
+    sales_brief_kwargs = sales_brief_step.result["kwargs"]
+    assert sales_brief_kwargs["default_brief_type"] == "discovery"
+    assert sales_brief_kwargs["source_material"][0]["target_id"] == "review-1"
 
 
 @pytest.mark.asyncio
@@ -705,5 +712,6 @@ async def test_plan_route_applies_review_input_provider() -> None:
     assert [step["output"] for step in payload["steps"]] == [
         "landing_page",
         "blog_post",
+        "sales_brief",
     ]
-    assert payload["preview"]["outputs"] == ["landing_page", "blog_post"]
+    assert payload["preview"]["outputs"] == ["landing_page", "blog_post", "sales_brief"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Review-Sales-Brief-Handoff.md
Slice phase: Vertical slice

Review-source packages already feed landing pages and blog posts. Now that #1261 added the source-material path for sales briefs, this slice enrolls review packages in `sales_brief` too and defaults that brief to `discovery` so customer-review themes can produce a rep-facing enablement brief.

## Intentional
- No generator, prompt, router, DB, or UI review-screen change. The sales-brief generator already accepts source material after #1261.
- No competitive-path change. Competitive packages already use `brief_type=displacement`.
- Review sales briefs use `discovery`, not `pre_call`, because the source rows are third-party review themes rather than account-specific meeting notes.

## Deferred
- Social posts, ad copy, and stat/quote card outputs remain future slices.
- Product packaging/pricing for the review/competitive marketer offer remains deferred.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
- `python -m py_compile atlas_brain/_content_ops_input_provider.py`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (`OK: 144 matching tests are enrolled.`)
- `git diff --check`
- `bash scripts/run_extracted_pipeline_checks.sh` (2957 passed, 10 skipped, 1 warning)
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-review-sales-brief-handoff-pr-body.md`

## Diff size
3 files, +99 / -7