### PR TITLE
PR-Content-Ops-Marketer-Evidence-Preset

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -132,6 +132,16 @@
       ]
     },
     {
+      "id": "marketer_evidence_bundle",
+      "label": "Marketer Evidence Bundle",
+      "description": "Landing page, blog post, and sales brief from review or competitive evidence.",
+      "outputs": [
+        "landing_page",
+        "blog_post",
+        "sales_brief"
+      ]
+    },
+    {
       "id": "lead_gen_campaign",
       "label": "Lead Gen Campaign",
       "description": "Outreach plus landing page.",

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -240,6 +240,15 @@ PRESETS: Mapping[str, ControlSurfacePreset] = MappingProxyType({
         outputs=("blog_post", "report"),
         description="Blog plus report using the same evidence base.",
     ),
+    "marketer_evidence_bundle": ControlSurfacePreset(
+        id="marketer_evidence_bundle",
+        label="Marketer Evidence Bundle",
+        outputs=("landing_page", "blog_post", "sales_brief"),
+        description=(
+            "Landing page, blog post, and sales brief from review or "
+            "competitive evidence."
+        ),
+    ),
     "lead_gen_campaign": ControlSurfacePreset(
         id="lead_gen_campaign",
         label="Lead Gen Campaign",

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -94,6 +94,7 @@ Current preset ids:
 | `email_only` | `email_campaign` | Lowest-cost outreach draft run. |
 | `intelligence_report` | `report` | Reference-backed report generation. |
 | `content_marketing` | `blog_post`, `report` | Blog plus report from the same evidence base. |
+| `marketer_evidence_bundle` | `landing_page`, `blog_post`, `sales_brief` | Landing page, blog post, and sales brief from review or competitive evidence. |
 | `lead_gen_campaign` | `email_campaign`, `landing_page` | Outreach plus landing page. |
 | `full_campaign` | `email_campaign`, `blog_post`, `report`, `landing_page`, `sales_brief` | Full generated-content bundle. |
 

--- a/plans/PR-Content-Ops-Marketer-Evidence-Preset.md
+++ b/plans/PR-Content-Ops-Marketer-Evidence-Preset.md
@@ -1,0 +1,96 @@
+# PR: Content Ops Marketer Evidence Preset
+
+## Why this slice exists
+
+PR #1261 and PR #1263 completed output parity for review and competitive
+source-material packages: both can now hand their evidence to `landing_page`,
+`blog_post`, and `sales_brief`. The operator can still only select those assets
+manually or use broader presets that include unrelated outputs, so the product
+bundle is not exposed as a named control-surface option.
+
+This slice productizes the completed marketer evidence path without adding a
+new generator. It gives the UI/API a stable preset for the landing page, blog
+post, and sales brief bundle that review and competitive source-material runs
+now support end to end.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Product polish
+
+1. Add a `marketer_evidence_bundle` control-surface preset for
+   `landing_page`, `blog_post`, and `sales_brief`.
+2. Prove the preset resolves through the pure preview path and is exposed by
+   the control-surfaces API catalog.
+3. Keep docs and the UI catalog fixture aligned with the producer output.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Marketer-Evidence-Preset.md`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+
+## Mechanism
+
+`PRESETS` is the single source for named output bundles. Adding
+`marketer_evidence_bundle` there makes the existing preview, plan, API catalog,
+and UI preset rendering paths pick up the bundle automatically.
+
+The preset intentionally references only already-implemented outputs:
+
+```python
+outputs=("landing_page", "blog_post", "sales_brief")
+```
+
+The focused tests cover both the pure extracted resolver and the API catalog
+serialization so a future preset rename, missing catalog exposure, or wrong
+output list fails locally.
+
+## Intentional
+
+- No new generated asset type. Social posts, ad copy, and stat/quote cards are
+  still separate future outputs.
+- No UI component change. `ContentOpsNewRun` already renders
+  `catalog.presets`, so changing the producer catalog is the narrowest path.
+- No provider-default change. Review and competitive input packages already
+  default to this output set after #1261 and #1263; this PR names the same set
+  for manual/API control-surface selection.
+
+## Deferred
+
+- Social posts, ad copy, and stat/quote card outputs remain future slices.
+- Pricing/packaging copy outside the control-surface preset remains deferred to
+  the marketer offer packaging slice.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q (160 passed, 1 skipped)
+- Passed: python -m py_compile extracted_content_pipeline/control_surfaces.py
+- Passed: git diff --check
+- Passed: npm run lint, from atlas-intel-ui
+- Passed: npm run build, from atlas-intel-ui
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2958 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-evidence-preset-pr-body.md
+
+## Estimated diff size
+
+Actual: 6 files, +146 / -0.
+
+| Area | Estimated LOC |
+|---|---:|
+| Preset catalog + docs/fixture | ~35 |
+| Focused tests | ~25 |
+| Plan doc | ~80 |
+| **Total** | **~140** |

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -399,6 +399,16 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert payload["reasoning"] == {"configured": False}
     assert "email_only" in preset_ids
     assert "lead_gen_campaign" in preset_ids
+    presets = {item["id"]: item for item in payload["presets"]}
+    assert presets["marketer_evidence_bundle"] == {
+        "id": "marketer_evidence_bundle",
+        "label": "Marketer Evidence Bundle",
+        "outputs": ["landing_page", "blog_post", "sales_brief"],
+        "description": (
+            "Landing page, blog post, and sales brief from review or "
+            "competitive evidence."
+        ),
+    }
     assert payload["ingestion_profiles"] == [
         "domain_specific",
         "manual",

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -1,6 +1,7 @@
 import pytest
 
 from extracted_content_pipeline.control_surfaces import (
+    PRESETS,
     evaluate_usage_budget,
     normalize_outputs,
     preview_from_mapping,
@@ -108,6 +109,27 @@ def test_preview_warns_when_outputs_override_preset():
         "Preset ignored because explicit outputs were provided: full_campaign"
         in preview["warnings"]
     )
+
+
+def test_marketer_evidence_bundle_preset_selects_review_competitive_outputs():
+    preset = PRESETS["marketer_evidence_bundle"]
+    preview = preview_from_mapping(
+        {
+            "preset": preset.id,
+            "inputs": {
+                "audience": "SaaS operators",
+                "offer": "Review-backed churn audit",
+                "target_account": "Acme",
+                "topic": "Competitor switching signals",
+            },
+        }
+    )
+
+    assert preset.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["landing_page", "blog_post", "sales_brief"]
+    assert preview["estimated_cost_usd"] == 4.2
+    assert preview["missing_inputs"] == []
 
 
 def test_missing_required_inputs_treats_empty_tuple_as_missing():


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Marketer-Evidence-Preset.md
Slice phase: Product polish

Adds a marketer evidence bundle preset for the review/competitive source-material outputs now that landing page, blog post, and sales brief handoffs are merged. The UI already renders server-provided presets, so this names the completed bundle without adding another generator or control surface.

## Intentional
- No new generated asset type; social posts, ad copy, and stat/quote cards remain future outputs.
- No UI component change; ContentOpsNewRun already renders catalog.presets from the API.
- No provider-default change; review and competitive input packages already default to this output set after #1261 and #1263.

## Deferred
- Social posts, ad copy, and stat/quote card outputs remain future slices.
- Pricing/packaging copy outside the control-surface preset remains deferred to the marketer offer packaging slice.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_control_surface_api.py -q` (160 passed, 1 skipped)
- `python -m py_compile extracted_content_pipeline/control_surfaces.py`
- `git diff --check`
- `npm run lint` from `atlas-intel-ui`
- `npm run build` from `atlas-intel-ui`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- `bash scripts/run_extracted_pipeline_checks.sh` (2958 passed, 10 skipped, 1 warning)
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-evidence-preset-pr-body.md`

## Diff size
6 files, +148 / -0