### PR TITLE
PR-Content-Ops-Marketer-Social-Post-Output

### DIFF
--- a/.github/workflows/atlas_content_ops_input_provider_checks.yml
+++ b/.github/workflows/atlas_content_ops_input_provider_checks.yml
@@ -5,16 +5,20 @@ on:
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
       - "atlas_brain/_content_ops_input_provider.py"
+      - "atlas_brain/_content_ops_services.py"
       - "tests/test_atlas_content_ops_input_provider.py"
       - "tests/test_atlas_content_ops_review_input_provider.py"
+      - "tests/test_atlas_content_ops_execution_services.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/atlas_content_ops_input_provider_checks.yml"
       - "atlas_brain/_content_ops_input_provider.py"
+      - "atlas_brain/_content_ops_services.py"
       - "tests/test_atlas_content_ops_input_provider.py"
       - "tests/test_atlas_content_ops_review_input_provider.py"
+      - "tests/test_atlas_content_ops_execution_services.py"
 
 jobs:
   atlas-content-ops-input-provider-checks:
@@ -40,4 +44,5 @@ jobs:
           python -m pytest \
             tests/test_atlas_content_ops_input_provider.py \
             tests/test_atlas_content_ops_review_input_provider.py \
+            tests/test_atlas_content_ops_execution_services.py \
             -q

--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -88,6 +88,23 @@
       "can_execute": false
     },
     {
+      "id": "social_post",
+      "label": "Social Posts",
+      "description": "Short social post drafts from source evidence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.0,
+      "default_parse_retry_attempts": 0,
+      "default_quality_repair_attempts": 0,
+      "estimated_retry_adjusted_unit_cost_usd": 0.0,
+      "required_inputs": [
+        "source_material"
+      ],
+      "default_max_items": 3,
+      "reasoning_requirement": "absent",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
       "id": "signal_extraction",
       "label": "Signal Extraction",
       "description": "Extracted opportunity or churn signals from source evidence.",

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -9,6 +9,8 @@ route layer maps to a per-step error the UI can render.
 Currently wired:
 - `signal_extraction` (E1, PR #452): deterministic generator
   with no external dependencies.
+- `social_post`: deterministic source-evidence social post drafts
+  with no external dependencies.
 - `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
   host LLM + Skill adapters from PR #453 +
   `PostgresLandingPageRepository` backed by the host's
@@ -89,6 +91,9 @@ from extracted_content_pipeline.sales_brief_postgres import (
 from extracted_content_pipeline.signal_extraction import (
     SignalExtractionService,
 )
+from extracted_content_pipeline.social_post_generation import (
+    SocialPostGenerationService,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownService,
 )
@@ -100,6 +105,7 @@ from extracted_content_pipeline.ticket_faq_postgres import (
 # Module-level singleton: SignalExtractionService is stateless, so
 # re-creating it per request would just churn allocations.
 _SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
+_SOCIAL_POST_SERVICE: SocialPostGenerationService = SocialPostGenerationService()
 _FAQ_MARKDOWN_SERVICE: TicketFAQMarkdownService = TicketFAQMarkdownService()
 _FAQ_DEFLECTION_REPORT_SERVICE: FAQDeflectionReportService = FAQDeflectionReportService(
     faq_markdown=_FAQ_MARKDOWN_SERVICE
@@ -357,6 +363,7 @@ def build_content_ops_execution_services(
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
+        social_post=_SOCIAL_POST_SERVICE,
         landing_page=landing_page,
         campaign=campaign,
         report=report,

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -77,6 +77,7 @@ class ContentOpsExecutionServices:
     report: Any | None = None
     landing_page: Any | None = None
     sales_brief: Any | None = None
+    social_post: Any | None = None
     signal_extraction: Any | None = None
     faq_markdown: Any | None = None
     faq_deflection_report: Any | None = None
@@ -100,6 +101,8 @@ class ContentOpsExecutionServices:
             return self.landing_page
         if output == "sales_brief":
             return self.sales_brief
+        if output == "social_post":
+            return self.social_post
         if output == "signal_extraction":
             return self.signal_extraction
         if output == "faq_markdown":
@@ -116,6 +119,7 @@ class ContentOpsExecutionServices:
             "report",
             "landing_page",
             "sales_brief",
+            "social_post",
             "signal_extraction",
             "faq_markdown",
             "faq_deflection_report",
@@ -185,6 +189,7 @@ class ContentOpsExecutionServices:
             report=services["report"],
             landing_page=services["landing_page"],
             sales_brief=services["sales_brief"],
+            social_post=self.social_post,
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
             # faq_markdown stays as-is; it does not consume reasoning.
@@ -630,6 +635,24 @@ async def _dispatch_signal_extraction(
     )
 
 
+async def _dispatch_social_post(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del filters
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        source_material=request.inputs.get("source_material"),
+        limit=request.limit,
+        max_text_chars=_step_config_int(step.config, "max_text_chars"),
+    )
+
+
 async def _dispatch_faq_markdown(
     *,
     step: GenerationPlanStep,
@@ -719,6 +742,7 @@ _DISPATCH: Mapping[str, Any] = {
     "sales_brief": _dispatch_sales_brief,
     "landing_page": _dispatch_landing_page,
     "blog_post": _dispatch_blog_post,
+    "social_post": _dispatch_social_post,
     "signal_extraction": _dispatch_signal_extraction,
     "faq_markdown": _dispatch_faq_markdown,
     "faq_deflection_report": _dispatch_faq_deflection_report,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -187,6 +187,17 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         required_inputs=("target_account",),
         reasoning_requirement="optional_host_context",
     ),
+    "social_post": OutputDefinition(
+        id="social_post",
+        label="Social Posts",
+        description="Short social post drafts from source evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.0,
+        required_inputs=("source_material",),
+        default_max_items=3,
+        reasoning_requirement="absent",
+        default_parse_retry_attempts=0,
+    ),
     "signal_extraction": OutputDefinition(
         id="signal_extraction",
         label="Signal Extraction",

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -70,6 +70,7 @@ Current output ids:
 | `report` | Implemented | `optional_host_context` | Structured report draft path. |
 | `landing_page` | Implemented | `optional_host_context` | Landing page generation service path. |
 | `sales_brief` | Implemented | `optional_host_context` | Sales brief generation service path. |
+| `social_post` | Implemented | `absent` | Deterministic source-evidence social post drafts; no LLM call. |
 | `signal_extraction` | Implemented | `absent` | Deterministic source-row normalization into campaign opportunities; no LLM call. |
 
 Future outputs should be added to the catalog first, then exposed through
@@ -374,6 +375,7 @@ Runnable outputs dispatch to:
 | `report` | `ReportGenerationService.generate(...)` |
 | `landing_page` | `LandingPageGenerationService.generate(...)` |
 | `sales_brief` | `SalesBriefGenerationService.generate(...)` |
+| `social_post` | `SocialPostGenerationService.generate(...)` |
 | `signal_extraction` | `SignalExtractionService.generate(...)` |
 
 Non-executable plans return HTTP 400 with the blocked execution result. Missing

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -33,6 +33,7 @@ from .reasoning_policy import (
 from .report_generation import ReportGenerationConfig
 from .sales_brief_generation import SalesBriefGenerationConfig
 from .signal_extraction import SignalExtractionConfig
+from .social_post_generation import SocialPostGenerationConfig
 from .ticket_faq_markdown import (
     DEFAULT_INTENT_RULES,
     TicketFAQMarkdownConfig,
@@ -204,6 +205,17 @@ def _signal_extraction_config_for_request(
     if max_text_chars is None:
         return config
     return SignalExtractionConfig(
+        limit=config.limit,
+        max_text_chars=max_text_chars,
+    )
+
+
+def _social_post_config_for_request(request: ContentOpsRequest) -> SocialPostGenerationConfig:
+    config = SocialPostGenerationConfig(limit=request.limit)
+    max_text_chars = _positive_int_input(request.inputs, "source_max_text_chars")
+    if max_text_chars is None:
+        return config
+    return SocialPostGenerationConfig(
         limit=config.limit,
         max_text_chars=max_text_chars,
     )
@@ -404,6 +416,17 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
         return GenerationPlanStep(
             output=output,
             runner="SignalExtractionService.generate",
+            status="runnable",
+            config={
+                "limit": config.limit,
+                "max_text_chars": config.max_text_chars,
+            },
+        )
+    if output == "social_post":
+        config = _social_post_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="SocialPostGenerationService.generate",
             status="runnable",
             config={
                 "limit": config.limit,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -303,6 +303,9 @@
       "target": "extracted_content_pipeline/signal_extraction.py"
     },
     {
+      "target": "extracted_content_pipeline/social_post_generation.py"
+    },
+    {
       "target": "extracted_content_pipeline/blog_ports.py"
     },
     {

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -160,6 +160,11 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
         default_preset="none",
         supported_presets=("none",),
     ),
+    "social_post": OutputReasoningPolicy(
+        output="social_post",
+        default_preset="none",
+        supported_presets=("none",),
+    ),
     "faq_markdown": OutputReasoningPolicy(
         output="faq_markdown",
         default_preset="none",

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -1,0 +1,224 @@
+"""Deterministic social-post drafts from Content Ops source material."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .campaign_customer_data import CampaignOpportunityWarning
+from .campaign_ports import TenantScope
+from .campaign_source_adapters import source_row_to_campaign_opportunity
+
+_ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
+
+
+@dataclass(frozen=True)
+class SocialPostGenerationConfig:
+    """Config for deterministic source-material social posts."""
+
+    limit: int = 3
+    max_text_chars: int = 600
+    max_post_chars: int = 420
+
+
+@dataclass(frozen=True)
+class SocialPostGenerationResult:
+    """Generated social posts plus non-fatal source-material warnings."""
+
+    posts: tuple[dict[str, Any], ...]
+    warnings: tuple[CampaignOpportunityWarning, ...] = ()
+    target_mode: str = "vendor_retention"
+
+    @property
+    def generated(self) -> int:
+        return len(self.posts)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "generated": self.generated,
+            "target_mode": self.target_mode,
+            "posts": [dict(post) for post in self.posts],
+            "warnings": [warning.as_dict() for warning in self.warnings],
+        }
+
+
+class SocialPostGenerationService:
+    """Build short, evidence-backed social posts from source material."""
+
+    def __init__(self, config: SocialPostGenerationConfig | None = None) -> None:
+        self.config = config or SocialPostGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        source_material: Any,
+        limit: int | None = None,
+        max_text_chars: int | None = None,
+        **kwargs: Any,
+    ) -> SocialPostGenerationResult:
+        del scope
+        del kwargs
+        resolved_limit = int(limit) if limit is not None else self.config.limit
+        if resolved_limit < 1:
+            raise ValueError("limit must be at least 1")
+        resolved_max_text_chars = (
+            int(max_text_chars)
+            if max_text_chars is not None
+            else self.config.max_text_chars
+        )
+        if resolved_max_text_chars < 1:
+            raise ValueError("max_text_chars must be at least 1")
+        return _generate_social_posts(
+            _rows_from_source_material(source_material),
+            target_mode=target_mode,
+            limit=resolved_limit,
+            max_text_chars=resolved_max_text_chars,
+            max_post_chars=self.config.max_post_chars,
+        )
+
+
+def _generate_social_posts(
+    rows: Sequence[Any],
+    *,
+    target_mode: str,
+    limit: int,
+    max_text_chars: int,
+    max_post_chars: int,
+) -> SocialPostGenerationResult:
+    posts: list[dict[str, Any]] = []
+    warnings: list[CampaignOpportunityWarning] = []
+    for index, row in enumerate(rows, start=1):
+        if len(posts) >= limit:
+            break
+        if not isinstance(row, Mapping):
+            warnings.append(CampaignOpportunityWarning(
+                code="row_not_object",
+                row_index=index,
+                message="Skipped source row because it is not an object.",
+            ))
+            continue
+        opportunity, row_warnings = source_row_to_campaign_opportunity(
+            row,
+            row_index=index,
+            max_text_chars=max_text_chars,
+        )
+        warnings.extend(row_warnings)
+        post = _post_from_opportunity(
+            opportunity,
+            index=len(posts) + 1,
+            max_post_chars=max_post_chars,
+        )
+        if post is None:
+            warnings.append(CampaignOpportunityWarning(
+                code="missing_social_post_evidence",
+                row_index=index,
+                message="Skipped source row because it did not contain usable evidence.",
+            ))
+            continue
+        posts.append(post)
+    return SocialPostGenerationResult(
+        posts=tuple(posts),
+        warnings=tuple(warnings),
+        target_mode=target_mode,
+    )
+
+
+def _post_from_opportunity(
+    opportunity: Mapping[str, Any],
+    *,
+    index: int,
+    max_post_chars: int,
+) -> dict[str, Any] | None:
+    if not opportunity:
+        return None
+    evidence = _first_evidence(opportunity)
+    if not evidence:
+        return None
+    vendor = _clean(opportunity.get("vendor_name") or opportunity.get("vendor"))
+    pain = _first_text(opportunity.get("pain_points"))
+    hook_parts = ["Customer evidence"]
+    if vendor:
+        hook_parts.append(f"for {vendor}")
+    if pain:
+        hook_parts.append(f"flags {pain}")
+    hook = " ".join(hook_parts) + "."
+    body = (
+        f'{hook} Source note: "{evidence}" Use this proof point to sharpen '
+        "the next landing page, blog post, or sales brief."
+    )
+    source_id = _clean(opportunity.get("source_id") or opportunity.get("target_id"))
+    return {
+        "id": source_id or f"social-post-{index}",
+        "channel": "linkedin",
+        "text": _truncate(body, max_post_chars),
+        "source_id": source_id,
+        "source_type": _clean(opportunity.get("source_type")),
+        "target_id": _clean(opportunity.get("target_id")),
+        "company_name": _clean(opportunity.get("company_name")),
+        "vendor_name": vendor,
+        "pain_points": list(opportunity.get("pain_points") or ()),
+    }
+
+
+def _first_evidence(opportunity: Mapping[str, Any]) -> str:
+    raw = opportunity.get("evidence")
+    if isinstance(raw, Mapping):
+        return _clean(raw.get("text"))
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        for item in raw:
+            if isinstance(item, Mapping):
+                text = _clean(item.get("text"))
+                if text:
+                    return text
+            else:
+                text = _clean(item)
+                if text:
+                    return text
+    return _clean(raw)
+
+
+def _first_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            text = _clean(item)
+            if text:
+                return text
+    return _clean(value)
+
+
+def _rows_from_source_material(source_material: Any) -> list[Any]:
+    if isinstance(source_material, str):
+        text = source_material.strip()
+        return [{"text": text}] if text else []
+    if isinstance(source_material, Mapping):
+        for key in _ROW_LIST_KEYS:
+            value = source_material.get(key)
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                return list(value)
+        return [dict(source_material)]
+    if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
+        return list(source_material)
+    return []
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 3)].rstrip() + "..."
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "SocialPostGenerationConfig",
+    "SocialPostGenerationResult",
+    "SocialPostGenerationService",
+]

--- a/plans/PR-Content-Ops-Marketer-Social-Post-Output.md
+++ b/plans/PR-Content-Ops-Marketer-Social-Post-Output.md
@@ -1,0 +1,124 @@
+# PR: Content Ops Marketer Social Post Output
+
+## Why this slice exists
+
+PR #1264 productized the completed marketer evidence bundle for landing pages,
+blog posts, and sales briefs. The same plan deliberately deferred the next
+marketer asset types: social posts, ad copy, and stat/quote cards. None of
+those outputs exists in the Content Ops catalog today, so operators cannot turn
+review or competitive source material into short-form share copy through the
+same execution path.
+
+This slice adds the first new marketer asset type as a deterministic vertical
+slice: `social_post` runs from uploaded/source-material evidence and returns
+bounded, evidence-backed post drafts. It does not add LLM prompting, storage, or
+UI controls beyond the existing catalog-driven output list.
+
+This PR exceeds the 400 LOC soft cap because the first executable output type
+cannot be split cleanly: the service, manifest entry, catalog exposure,
+generation plan, executor dispatch, host wiring, UI fixture, reasoning no-op
+policy, and tests all have to land together or the output is either invisible or
+not runnable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a pure `SocialPostGenerationService` that turns source material into
+   bounded social post drafts with source ids and non-fatal warnings.
+2. Register `social_post` in the control-surface catalog, generation plan, and
+   executor service bundle.
+3. Wire the always-safe deterministic service into the host execution-service
+   factory.
+4. Add focused tests for the service, preview/plan mapping, executor dispatch,
+   and API catalog readiness.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Marketer-Social-Post-Output.md`
+- `.github/workflows/atlas_content_ops_input_provider_checks.yml`
+- `extracted_content_pipeline/social_post_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_social_post_generation.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+
+## Mechanism
+
+`SocialPostGenerationService.generate(...)` accepts `source_material`, normalizes
+rows through the existing source-row-to-campaign-opportunity adapter, then emits
+one short post per usable opportunity up to `limit`.
+
+The output is intentionally deterministic:
+
+- `source_material` is required by the control surface.
+- `source_max_text_chars` controls the adapter text cap, matching
+  `signal_extraction`.
+- The service returns `{generated, posts, warnings, target_mode}` and does not
+  persist or call an LLM.
+
+The host factory wires one reusable deterministic service, so
+`GET /content-ops/control-surfaces` reports `social_post` as executable when
+normal execution services are configured.
+
+## Intentional
+
+- No LLM social-copy prompt yet. The first slice proves the asset path and keeps
+  copy evidence-bounded; richer channel/style variants can layer on later.
+- No DB migration or generated-asset review screen. The executor response is
+  enough to prove the new output can run from source material.
+- No default review/competitive package enrollment yet. This PR exposes the
+  output and proves execution; the follow-up can add it to package defaults once
+  the reviewer has accepted the output shape.
+
+## Deferred
+
+- Add `social_post` to review and competitive input-package defaults in the next
+  marketer-output handoff slice.
+- Ad copy and stat/quote card outputs remain future slices.
+- LLM/style/channel variants for social posts remain future product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_social_post_generation.py -q (4 passed)
+- Passed: pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q (308 passed, 1 skipped)
+- Passed: python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py
+- Passed: git diff --check
+- Passed: npm run lint, from atlas-intel-ui
+- Passed: npm run build, from atlas-intel-ui
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2964 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-social-post-output-pr-body.md
+
+## Estimated diff size
+
+Actual: 18 files, +715 / -5. This is over the soft cap for the indivisible
+first-output wiring reason described in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Social-post service | 224 |
+| Catalog/plan/executor/host/reasoning/workflow wiring | ~74 |
+| Focused tests + fixture/docs alignment | ~385 |
+| Plan doc | 122 |
+| **Total** | **~705** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -256,6 +256,7 @@ async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None
     assert services.faq_markdown is None
     assert services.faq_deflection_report is not None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_deflection_report",
     )
@@ -304,6 +305,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
         "report",
         "landing_page",
         "sales_brief",
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -325,6 +327,7 @@ def test_landing_page_slot_stays_none_when_no_active_llm() -> None:
 
     assert services.landing_page is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -350,6 +353,7 @@ def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
     )
     assert services.landing_page is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -373,6 +377,7 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
 
     assert services.landing_page is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -421,6 +426,19 @@ def test_sales_brief_wired_when_llm_active_and_db_enabled() -> None:
     assert services.for_output("sales_brief") is services.sales_brief
 
 
+def test_social_post_is_always_wired() -> None:
+    """Deterministic social posts run without LLM or DB services."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=False,
+    )
+    assert services.social_post is not None
+    assert services.for_output("social_post") is services.social_post
+
+
 def test_e3_services_skip_together_when_no_active_llm() -> None:
     """E3 fallback: campaign / report / sales_brief slots all
     stay `None` when no LLM is active. Same short-circuit shape
@@ -437,6 +455,7 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
     assert services.report is None
     assert services.sales_brief is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -462,6 +481,7 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.sales_brief is None
     assert services.blog_post is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -498,6 +518,7 @@ def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
     )
     assert services.blog_post is None
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -522,6 +543,7 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         "report",
         "landing_page",
         "sales_brief",
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -539,6 +561,7 @@ def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
         enable_db_services=True,
     )
     assert services.configured_outputs() == (
+        "social_post",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -329,7 +329,9 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert "email_campaign" in output_ids
     assert "landing_page" in output_ids
     assert "faq_markdown" in output_ids
+    assert "social_post" in output_ids
     assert outputs["signal_extraction"]["implemented"] is True
+    assert outputs["social_post"]["implemented"] is True
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
     assert outputs["email_campaign"]["estimated_unit_cost_usd"] == 0.18
@@ -389,6 +391,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     }
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
+    assert outputs["social_post"]["reasoning_requirement"] == "absent"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert outputs["faq_markdown"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {
@@ -528,6 +531,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
         execution_services_provider=lambda: ContentOpsExecutionServices(
             campaign=_CampaignService(),
             report=_CampaignService(),
+            social_post=_CampaignService(),
             signal_extraction=_CampaignService(),
             faq_markdown=_CampaignService(),
         )
@@ -540,17 +544,20 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     assert payload["execution"] == {
         "configured": True,
         "configured_outputs": [
-            "email_campaign",
-            "faq_markdown",
-            "report",
-            "signal_extraction",
-        ],
+                "email_campaign",
+                "faq_markdown",
+                "report",
+                "signal_extraction",
+                "social_post",
+            ],
         "limits": dict(_DEFAULT_EXECUTION_LIMITS),
     }
     assert outputs["email_campaign"]["execution_configured"] is True
     assert outputs["email_campaign"]["can_execute"] is True
     assert outputs["report"]["execution_configured"] is True
     assert outputs["report"]["can_execute"] is True
+    assert outputs["social_post"]["execution_configured"] is True
+    assert outputs["social_post"]["can_execute"] is True
     assert outputs["signal_extraction"]["execution_configured"] is True
     assert outputs["signal_extraction"]["can_execute"] is True
     assert outputs["faq_markdown"]["execution_configured"] is True

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -162,6 +162,24 @@ def test_preview_allows_signal_extraction_when_source_material_present():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_allows_social_post_when_source_material_present():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["social_post"]
+    assert preview["missing_inputs"] == []
+    assert preview["blocked_outputs"] == []
+    assert preview["estimated_cost_usd"] == 0.0
+
+
 def test_preview_allows_faq_markdown_when_source_material_present():
     preview = preview_from_mapping(
         {
@@ -367,6 +385,19 @@ def test_preview_keeps_signal_extraction_blocked_without_source_material():
     assert preview["missing_inputs"] == ["source_material"]
 
 
+def test_preview_keeps_social_post_blocked_without_source_material():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "inputs": {},
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["outputs"] == ["social_post"]
+    assert preview["missing_inputs"] == ["source_material"]
+
+
 def test_output_catalog_states_reasoning_requirement():
     from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
 
@@ -375,6 +406,7 @@ def test_output_catalog_states_reasoning_requirement():
     assert OUTPUT_CATALOG["landing_page"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["sales_brief"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "optional_host_context"
+    assert OUTPUT_CATALOG["social_post"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["faq_markdown"].reasoning_requirement == "absent"
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -472,6 +472,33 @@ def test_plan_maps_signal_extraction_to_signal_extraction_service():
     }
 
 
+def test_plan_maps_social_post_to_social_post_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing pressure came up at renewal.",
+                    }
+                ],
+                "source_max_text_chars": 300,
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "SocialPostGenerationService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "limit": 3,
+        "max_text_chars": 300,
+    }
+
+
 def test_plan_maps_faq_markdown_to_ticket_faq_service():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -20,6 +20,7 @@ from extracted_content_pipeline.content_ops_execution import (
 )
 from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
 from extracted_content_pipeline.signal_extraction import SignalExtractionService
+from extracted_content_pipeline.social_post_generation import SocialPostGenerationService
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
 
 
@@ -574,6 +575,45 @@ async def test_execute_runs_signal_extraction_service_from_source_material() -> 
     assert opportunity["target_id"] == "review-1"
     assert opportunity["evidence"][0]["text"] == "Pricing"
     assert step["result"]["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_social_post_service_from_source_material() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "limit": 1,
+            "inputs": {
+                "source_max_text_chars": 20,
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "company": "Acme",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing is a problem after renewal.",
+                        "pain_category": "pricing pressure",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            social_post=SocialPostGenerationService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["output"] == "social_post"
+    assert step["runner"] == "SocialPostGenerationService.generate"
+    assert step["result"]["generated"] == 1
+    post = step["result"]["posts"][0]
+    assert post["source_id"] == "review-1"
+    assert post["vendor_name"] == "HubSpot"
+    assert "Pricing is a problem" in post["text"]
+    assert result["plan"]["steps"][0]["config"] == {
+        "limit": 1,
+        "max_text_chars": 20,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -49,6 +49,7 @@ def test_output_policy_defaults_match_audit_recommendations() -> None:
     }
     assert defaults == {
         "signal_extraction": "none",
+        "social_post": "none",
         "faq_markdown": "none",
         "faq_deflection_report": "none",
         "email_campaign": "single_pass",
@@ -97,6 +98,12 @@ def test_signal_extraction_only_supports_no_reasoning() -> None:
     assert supported_reasoning_presets("signal_extraction") == ("none",)
     with pytest.raises(ValueError, match="not supported"):
         resolve_reasoning_policy("signal_extraction", "single_pass")
+
+
+def test_social_post_only_supports_no_reasoning() -> None:
+    assert supported_reasoning_presets("social_post") == ("none",)
+    with pytest.raises(ValueError, match="not supported"):
+        resolve_reasoning_policy("social_post", "single_pass")
 
 
 def test_faq_markdown_only_supports_no_reasoning() -> None:

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.social_post_generation import (
+    SocialPostGenerationConfig,
+    SocialPostGenerationService,
+)
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_generates_evidence_backed_posts() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["target_mode"] == "vendor_retention"
+    assert payload["warnings"] == []
+    assert payload["posts"] == [
+        {
+            "id": "review-1",
+            "channel": "linkedin",
+            "text": (
+                "Customer evidence for HubSpot flags pricing pressure. "
+                "Source note: \"Pricing became hard to justify after renewal.\" "
+                "Use this proof point to sharpen the next landing page, blog "
+                "post, or sales brief."
+            ),
+            "source_id": "review-1",
+            "source_type": "review",
+            "target_id": "review-1",
+            "company_name": "Acme Logistics",
+            "vendor_name": "HubSpot",
+            "pain_points": ["pricing pressure"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_skips_unusable_rows_with_warnings() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=["not a row", {"review_id": "missing-text"}],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 0
+    assert [warning["code"] for warning in payload["warnings"]] == [
+        "row_not_object",
+        "missing_source_text",
+        "missing_social_post_evidence",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_keeps_truncated_posts_within_configured_bound() -> None:
+    config = SocialPostGenerationConfig(max_post_chars=120)
+    service = SocialPostGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "vendor": "HubSpot",
+                "review_text": " ".join(["renewal pressure"] * 80),
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert len(payload["posts"][0]["text"]) <= config.max_post_chars
+    assert payload["posts"][0]["text"].endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_applies_limit_to_usable_rows() -> None:
+    service = SocialPostGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=2,
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify.",
+                "pain_category": "pricing pressure",
+            },
+            {
+                "review_id": "review-2",
+                "vendor": "Zendesk",
+                "review_text": "Support queues took too long to triage.",
+                "pain_category": "slow support",
+            },
+            {
+                "review_id": "review-3",
+                "vendor": "Intercom",
+                "review_text": "Reporting did not explain where leads came from.",
+                "pain_category": "unclear reporting",
+            },
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 2
+    assert [post["source_id"] for post in payload["posts"]] == ["review-1", "review-2"]


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Marketer-Social-Post-Output.md
Slice phase: Vertical slice

Adds the first marketer social-post output as a deterministic source-material execution path. The output is catalog-visible, plan-mapped, executable through ContentOpsExecutionServices, wired in the host factory, and covered by service/preview/plan/execution/API/reasoning-policy tests.

## Intentional
- No LLM social-copy prompt yet; copy is deterministic and source-evidence bounded.
- No DB migration, generated-asset review screen, or default review/competitive package enrollment in this slice.
- Diff exceeds the 400 LOC soft cap because this first executable output requires service, manifest, catalog, planner, executor, host wiring, UI fixture, reasoning policy, workflow enrollment, and tests together.

## Deferred
- Add `social_post` to review and competitive input-package defaults in the next marketer-output handoff slice.
- Ad copy and stat/quote card outputs remain future slices.
- LLM/style/channel variants remain future product polish.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_social_post_generation.py -q` (4 passed)
- `pytest tests/test_extracted_content_reasoning_policy.py tests/test_extracted_social_post_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q` (308 passed, 1 skipped)
- `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py`
- `git diff --check`
- `npm run lint` from `atlas-intel-ui`
- `npm run build` from `atlas-intel-ui`
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- `bash scripts/run_extracted_pipeline_checks.sh` (2964 passed, 10 skipped, 1 warning)
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-social-post-output-pr-body.md` (passed)

## Diff size
18 files, +715 / -5