### PR TITLE
PR-Deflection-Uncap-Paid-Report

### DIFF
--- a/.github/workflows/atlas_content_ops_deflection_report_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_report_checks.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
       - "extracted_content_pipeline/faq_deflection_report.py"
       - "extracted_content_pipeline/ticket_faq_markdown.py"
+      - "scripts/build_content_ops_deflection_report.py"
+      - "tests/test_content_ops_deflection_report.py"
       - "tests/test_extracted_content_ops_live_execute_harness.py"
       - "tests/test_extracted_ticket_faq_markdown.py"
   push:
@@ -15,6 +17,8 @@ on:
       - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
       - "extracted_content_pipeline/faq_deflection_report.py"
       - "extracted_content_pipeline/ticket_faq_markdown.py"
+      - "scripts/build_content_ops_deflection_report.py"
+      - "tests/test_content_ops_deflection_report.py"
       - "tests/test_extracted_content_ops_live_execute_harness.py"
       - "tests/test_extracted_ticket_faq_markdown.py"
 
@@ -44,4 +48,5 @@ jobs:
             tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited \
             tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating \
             tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n \
+            tests/test_content_ops_deflection_report.py::test_deflection_report_cli_ignores_legacy_max_items_cap \
             -q

--- a/.github/workflows/atlas_content_ops_deflection_report_checks.yml
+++ b/.github/workflows/atlas_content_ops_deflection_report_checks.yml
@@ -1,0 +1,47 @@
+name: Atlas Content Ops Deflection Report Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
+      - "extracted_content_pipeline/faq_deflection_report.py"
+      - "extracted_content_pipeline/ticket_faq_markdown.py"
+      - "tests/test_extracted_content_ops_live_execute_harness.py"
+      - "tests/test_extracted_ticket_faq_markdown.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/atlas_content_ops_deflection_report_checks.yml"
+      - "extracted_content_pipeline/faq_deflection_report.py"
+      - "extracted_content_pipeline/ticket_faq_markdown.py"
+      - "tests/test_extracted_content_ops_live_execute_harness.py"
+      - "tests/test_extracted_ticket_faq_markdown.py"
+
+jobs:
+  atlas-content-ops-deflection-report-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run Content Ops deflection report tests
+        run: |
+          python -m pytest \
+            tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits \
+            tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited \
+            tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating \
+            tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n \
+            -q

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -13,6 +13,7 @@ from .ticket_faq_markdown import TicketFAQMarkdownResult, TicketFAQMarkdownServi
 _RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
 _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
 DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
+_UNCAPPED_REPORT_MAX_ITEMS = 0
 
 
 @dataclass(frozen=True)
@@ -74,13 +75,13 @@ class FAQDeflectionReportService:
         vocabulary_gap_rules: Sequence[Sequence[str]] | None = None,
         **kwargs: Any,
     ) -> DeflectionReportArtifact:
-        del kwargs
+        del kwargs, max_items
         faq_result = await self._faq_markdown.generate(
             scope=scope,
             target_mode=target_mode,
             source_material=source_material,
             title=faq_title,
-            max_items=max_items,
+            max_items=_UNCAPPED_REPORT_MAX_ITEMS,
             max_evidence_per_item=max_evidence_per_item,
             source_types=source_types,
             max_text_chars=max_text_chars,

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -249,7 +249,7 @@ class TicketFAQMarkdownConfig:
     """Config for service-shaped FAQ Markdown generation."""
 
     title: str = DEFAULT_TITLE
-    max_items: int = 8
+    max_items: int | None = 8
     max_evidence_per_item: int = 3
     source_types: tuple[str, ...] = DEFAULT_TICKET_SOURCE_TYPES
     max_text_chars: int = 1200
@@ -293,7 +293,9 @@ class TicketFAQMarkdownService:
         **kwargs: Any,
     ) -> TicketFAQMarkdownResult:
         del kwargs
-        resolved_max_items = int(max_items) if max_items is not None else self.config.max_items
+        resolved_max_items = _normalize_max_items(
+            max_items if max_items is not None else self.config.max_items
+        )
         resolved_max_evidence = (
             int(max_evidence_per_item)
             if max_evidence_per_item is not None
@@ -395,7 +397,7 @@ def build_ticket_faq_markdown(
     opportunities: Sequence[Mapping[str, Any]],
     *,
     title: str = DEFAULT_TITLE,
-    max_items: int = 8,
+    max_items: int | None = 8,
     max_evidence_per_item: int = 3,
     source_types: Sequence[str] = DEFAULT_TICKET_SOURCE_TYPES,
     window_days: int | None = None,
@@ -407,8 +409,7 @@ def build_ticket_faq_markdown(
 ) -> TicketFAQMarkdownResult:
     """Render an extractive FAQ from normalized source-row opportunities."""
 
-    if max_items < 1:
-        raise ValueError("max_items must be positive")
+    resolved_max_items = _normalize_max_items(max_items)
     if max_evidence_per_item < 1:
         raise ValueError("max_evidence_per_item must be positive")
 
@@ -471,12 +472,12 @@ def build_ticket_faq_markdown(
         ((topic, rows) for (topic, _scope), rows in groups.items()),
         key=_group_sort_key,
     )
-    if len(sorted_groups) > max_items:
-        visible_groups = tuple(sorted_groups[: max(1, max_items - 1)])
+    if resolved_max_items is not None and len(sorted_groups) > resolved_max_items:
+        visible_groups = tuple(sorted_groups[: max(1, resolved_max_items - 1)])
         overflow_rows: list[dict[str, str]] = []
         for _topic_name, rows in sorted_groups[len(visible_groups):]:
             overflow_rows.extend(rows)
-        if len(visible_groups) == max_items:
+        if len(visible_groups) == resolved_max_items:
             topic, rows = visible_groups[0]
             selected_groups = ((topic, [*rows, *overflow_rows]),)
         else:
@@ -506,6 +507,17 @@ def build_ticket_faq_markdown(
             rendered_ticket_source_count=_rendered_ticket_source_count(items),
         ),
     )
+
+
+def _normalize_max_items(max_items: int | None) -> int | None:
+    if max_items is None:
+        return None
+    value = int(max_items)
+    if value < 0:
+        raise ValueError("max_items must be positive or 0 for unlimited")
+    if value == 0:
+        return None
+    return value
 
 
 def _evidence_rows(opportunity: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:

--- a/plans/PR-Deflection-Uncap-Paid-Report.md
+++ b/plans/PR-Deflection-Uncap-Paid-Report.md
@@ -1,0 +1,69 @@
+# PR-Deflection-Uncap-Paid-Report
+
+## Why this slice exists
+
+Issue #1265 identifies a product-truth gap in the paid FAQ deflection report: the offer says the paid report lists every recurring question, but the report build still uses the generic FAQ Markdown `max_items` cap. When distinct questions exceed that cap, the tail is collapsed into a single overflow item, and the free snapshot inherits capped totals. This slice makes the paid report uncapped so the full artifact and snapshot summary counts reflect the true ranked question set.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+
+Slice phase: Production hardening
+
+1. Add a real unlimited mode to the FAQ Markdown grouping cap so callers can request no display cap without losing the existing finite-cap overflow behavior.
+2. Make the customer-facing deflection report use unlimited mode for the paid artifact.
+3. Preserve the free snapshot projection: top questions remain governed by `deflection_snapshot_top_n`, and paid answer/evidence fields remain absent from the snapshot.
+4. Add regression coverage for uncapped report generation, truthful snapshot counts, and finite-cap compatibility.
+
+### Files touched
+
+- `plans/PR-Deflection-Uncap-Paid-Report.md` - Plan doc for this slice.
+- `.github/workflows/atlas_content_ops_deflection_report_checks.yml` - Dedicated atlas workflow enrollment for the atlas_brain-importing harness test.
+- `extracted_content_pipeline/ticket_faq_markdown.py` - Add unlimited max-items normalization while preserving finite caps.
+- `extracted_content_pipeline/faq_deflection_report.py` - Force the paid deflection artifact through uncapped FAQ Markdown generation.
+- `tests/test_extracted_ticket_faq_markdown.py` - Pin unlimited sentinel and finite-cap compatibility.
+- `tests/test_extracted_content_ops_live_execute_harness.py` - Prove the paid artifact is uncapped while the free snapshot remains top-N.
+
+## Mechanism
+
+`build_ticket_faq_markdown(..., max_items=0)` becomes the explicit unlimited sentinel. Positive caps keep the existing overflow condensation behavior, and negative values remain invalid. `TicketFAQMarkdownService` normalizes explicit/configured values through the same helper so a configured `0` or `None` can mean uncapped.
+
+`FAQDeflectionReportService.generate()` passes the unlimited sentinel to the FAQ Markdown service instead of forwarding the execution/request cap. That keeps upload row limits separate from paid-report display limits: row ingestion may still be bounded, but every distinct recurring question found in the ingested rows is listed in the paid artifact.
+
+The snapshot already slices the artifact items by `top_n` and strips paid fields. Once the artifact is uncapped, the deflection report summary remains truthful because it counts the full item tuple.
+
+## Intentional
+
+- Generic finite-cap FAQ Markdown output is retained for non-deflection callers and for existing tests that prove overflow condensation.
+- The deflection report intentionally ignores `max_items` as a display cap. In this product lane, request limits govern input volume, not how many paid report questions are shown.
+- No separate `questions_found` summary field is added because the uncapped paid artifact makes `generated`, drafted, and no-proven counts truthful.
+
+## Deferred
+
+- Frontend copy or layout changes for larger paid reports are deferred to the atlas-portfolio snapshot/results work tracked separately.
+- Live redeploy and customer re-verification are operational follow-ups after this PR merges.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q -- 4 passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- 0 findings.
+- Command: bash scripts/check_ascii_python.sh -- passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main -- passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- passed; 2960 passed, 10 skipped, 1 warning in the extracted content pipeline pytest suite, plus extracted reasoning core checks passed.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-uncap-paid-report-pr-body.md -- passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Workflow enrollment | 47 |
+| Product code | 33 |
+| Plan doc | 69 |
+| Tests | 148 |
+| **Total** | **297** |
+
+Actual diff: 6 files, +285 / -12. Under the 400 LOC soft cap.

--- a/plans/PR-Deflection-Uncap-Paid-Report.md
+++ b/plans/PR-Deflection-Uncap-Paid-Report.md
@@ -7,13 +7,13 @@ Issue #1265 identifies a product-truth gap in the paid FAQ deflection report: th
 ## Scope (this PR)
 
 Ownership lane: content-ops/faq-deflection
-
 Slice phase: Production hardening
 
-1. Add a real unlimited mode to the FAQ Markdown grouping cap so callers can request no display cap without losing the existing finite-cap overflow behavior.
+1. Add a real unlimited mode to the FAQ Markdown grouping cap without losing existing finite-cap overflow behavior.
 2. Make the customer-facing deflection report use unlimited mode for the paid artifact.
-3. Preserve the free snapshot projection: top questions remain governed by `deflection_snapshot_top_n`, and paid answer/evidence fields remain absent from the snapshot.
-4. Add regression coverage for uncapped report generation, truthful snapshot counts, and finite-cap compatibility.
+3. Align the local deflection report CLI with the same uncapped behavior so verification does not show stale capped output.
+4. Preserve the free snapshot projection: top questions remain governed by `deflection_snapshot_top_n`, and paid answer/evidence fields remain absent from the snapshot.
+5. Add regression coverage for uncapped generation, truthful snapshot counts, script parity, and finite-cap compatibility.
 
 ### Files touched
 
@@ -21,8 +21,10 @@ Slice phase: Production hardening
 - `.github/workflows/atlas_content_ops_deflection_report_checks.yml` - Dedicated atlas workflow enrollment for the atlas_brain-importing harness test.
 - `extracted_content_pipeline/ticket_faq_markdown.py` - Add unlimited max-items normalization while preserving finite caps.
 - `extracted_content_pipeline/faq_deflection_report.py` - Force the paid deflection artifact through uncapped FAQ Markdown generation.
+- `scripts/build_content_ops_deflection_report.py` - Force the local deflection report CLI through uncapped FAQ Markdown generation.
 - `tests/test_extracted_ticket_faq_markdown.py` - Pin unlimited sentinel and finite-cap compatibility.
 - `tests/test_extracted_content_ops_live_execute_harness.py` - Prove the paid artifact is uncapped while the free snapshot remains top-N.
+- `tests/test_content_ops_deflection_report.py` - Prove the CLI cannot verify the deflection report with a stale finite cap.
 
 ## Mechanism
 
@@ -30,12 +32,15 @@ Slice phase: Production hardening
 
 `FAQDeflectionReportService.generate()` passes the unlimited sentinel to the FAQ Markdown service instead of forwarding the execution/request cap. That keeps upload row limits separate from paid-report display limits: row ingestion may still be bounded, but every distinct recurring question found in the ingested rows is listed in the paid artifact.
 
+`scripts/build_content_ops_deflection_report.py` uses the same unlimited sentinel for local artifacts. Its legacy `--max-items` flag is retained for compatibility and recorded in result JSON as `requested_max_items`, but it no longer caps the deflection report display.
+
 The snapshot already slices the artifact items by `top_n` and strips paid fields. Once the artifact is uncapped, the deflection report summary remains truthful because it counts the full item tuple.
 
 ## Intentional
 
 - Generic finite-cap FAQ Markdown output is retained for non-deflection callers and for existing tests that prove overflow condensation.
 - The deflection report intentionally ignores `max_items` as a display cap. In this product lane, request limits govern input volume, not how many paid report questions are shown.
+- The deflection CLI keeps `--max-items` as a compatibility flag but records it as requested-only because capped local artifacts are now misleading for this product.
 - No separate `questions_found` summary field is added because the uncapped paid artifact makes `generated`, drafted, and no-proven counts truthful.
 
 ## Deferred
@@ -47,23 +52,21 @@ Parked hardening: none.
 
 ## Verification
 
-- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q -- 4 passed.
+- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_content_ops_deflection_report.py::test_deflection_report_cli_ignores_legacy_max_items_cap -q -- 5 passed.
 - Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
 - Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
 - Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- 0 findings.
 - Command: bash scripts/check_ascii_python.sh -- passed.
 - Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main -- passed.
-- Command: bash scripts/run_extracted_pipeline_checks.sh -- passed; 2960 passed, 10 skipped, 1 warning in the extracted content pipeline pytest suite, plus extracted reasoning core checks passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh -- passed; 2961 passed, 10 skipped, 1 warning in the extracted content pipeline pytest suite, plus extracted reasoning core checks passed.
 - Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-uncap-paid-report-pr-body.md -- passed.
 
 ## Estimated diff size
 
 | Area | Estimated LOC |
 |---|---:|
-| Workflow enrollment | 47 |
-| Product code | 33 |
-| Plan doc | 69 |
-| Tests | 148 |
-| **Total** | **297** |
-
-Actual diff: 6 files, +285 / -12. Under the 400 LOC soft cap.
+| Workflow enrollment | 52 |
+| Product code | 56 |
+| Plan doc | 72 |
+| Tests | 218 |
+| **Total** | **398** |

--- a/scripts/build_content_ops_deflection_report.py
+++ b/scripts/build_content_ops_deflection_report.py
@@ -40,10 +40,13 @@ from content_ops_faq_cli_rules import (  # noqa: E402
 )
 
 
+UNCAPPED_REPORT_MAX_ITEMS = 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    if args.max_items < 1:
-        raise SystemExit("--max-items must be positive")
+    if args.max_items < 0:
+        raise SystemExit("--max-items must be 0 or positive; deflection reports are uncapped")
     if args.max_evidence_per_item < 1:
         raise SystemExit("--max-evidence-per-item must be positive")
     if args.max_text_chars < 1:
@@ -99,7 +102,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--title", default="Support Ticket Deflection Report")
     parser.add_argument("--faq-title", default=DEFAULT_TITLE)
-    parser.add_argument("--max-items", type=int, default=20)
+    parser.add_argument(
+        "--max-items",
+        type=int,
+        default=UNCAPPED_REPORT_MAX_ITEMS,
+        help=(
+            "Deprecated compatibility flag. Deflection reports are uncapped; "
+            "0 means unlimited and positive values are recorded but not used "
+            "as a display cap."
+        ),
+    )
     parser.add_argument("--max-evidence-per-item", type=int, default=3)
     parser.add_argument("--max-text-chars", type=int, default=1200)
     parser.add_argument("--window-days", type=int)
@@ -189,7 +201,7 @@ def build_report(args: argparse.Namespace):
     faq_result = build_ticket_faq_markdown(
         loaded.opportunities,
         title=args.faq_title,
-        max_items=args.max_items,
+        max_items=UNCAPPED_REPORT_MAX_ITEMS,
         max_evidence_per_item=args.max_evidence_per_item,
         window_days=args.window_days,
         as_of_date=args.as_of_date,
@@ -230,7 +242,8 @@ def _result_payload(
         "config": {
             "title": args.title,
             "faq_title": args.faq_title,
-            "max_items": args.max_items,
+            "max_items": UNCAPPED_REPORT_MAX_ITEMS,
+            "requested_max_items": args.max_items,
             "max_evidence_per_item": args.max_evidence_per_item,
             "max_text_chars": args.max_text_chars,
             "window_days": args.window_days,

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -495,6 +495,76 @@ def test_deflection_report_cli_builds_saas_demo_artifact(tmp_path: Path) -> None
     assert "tell users exactly what to try next" not in markdown
 
 
+def test_deflection_report_cli_ignores_legacy_max_items_cap(tmp_path: Path) -> None:
+    source = tmp_path / "uncapped-support-tickets.json"
+    result_output = tmp_path / "deflection-report-result.json"
+    rows = [
+        {
+            "ticket_id": "ticket-sso-1",
+            "source_type": "support_ticket",
+            "subject": "SSO setup",
+            "message": "Can we sync users before enforcing SSO?",
+            "pain_category": "single sign-on rollout",
+            "resolution_text": "Enable SSO, verify emails, then enable SCIM.",
+        },
+        {
+            "ticket_id": "ticket-dashboard-1",
+            "source_type": "support_ticket",
+            "subject": "Dashboard refresh",
+            "message": "Why is the executive dashboard not refreshing?",
+            "pain_category": "warehouse refresh status",
+            "resolution_text": "Rerun the failed warehouse job, then refresh the model.",
+        },
+        {
+            "ticket_id": "ticket-billing-1",
+            "source_type": "support_ticket",
+            "subject": "Renewal invoice",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "renewal billing review",
+            "resolution_text": "Open Billing > Invoices, then download the PDF.",
+        },
+        {
+            "ticket_id": "ticket-token-1",
+            "source_type": "support_ticket",
+            "subject": "API token rotation",
+            "message": "How do we rotate API tokens without downtime?",
+            "pain_category": "api token rotation",
+            "resolution_text": "Deploy the replacement token, then revoke the old token.",
+        },
+    ]
+    source.write_text(json.dumps(rows), encoding="utf-8")
+
+    exit_code = MODULE.main([
+        str(source),
+        "--source-format",
+        "json",
+        "--max-items",
+        "2",
+        "--result-output",
+        str(result_output),
+        "--json",
+    ])
+
+    assert exit_code == 0
+    result = json.loads(result_output.read_text(encoding="utf-8"))
+    assert result["generated"] == 4
+    assert result["summary"]["generated"] == 4
+    assert result["config"]["max_items"] == 0
+    assert result["config"]["requested_max_items"] == 2
+    assert result["diagnostics"]["item_count"] == 4
+    assert "other support issues" not in {
+        item["topic"] for item in result["diagnostics"]["items"]
+    }
+    assert {
+        item["first_source_id"] for item in result["diagnostics"]["items"]
+    } == {
+        "ticket-sso-1",
+        "ticket-dashboard-1",
+        "ticket-billing-1",
+        "ticket-token-1",
+    }
+
+
 def test_deflection_report_cli_splits_backed_and_unproven_answers(tmp_path: Path) -> None:
     source = tmp_path / "mixed-support-tickets.json"
     output = tmp_path / "deflection-report.md"

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -928,6 +928,128 @@ async def test_live_execute_route_handles_bulk_faq_deflection_report() -> None:
     )
 
 
+async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n() -> None:
+    store = InMemoryDeflectionReportArtifactStore()
+    router = create_content_ops_control_surface_router(
+        config=ContentOpsControlSurfaceApiConfig(deflection_snapshot_top_n=2),
+        execution_services_provider=lambda: ContentOpsExecutionServices(
+            faq_deflection_report=FAQDeflectionReportService(),
+        ),
+        scope_provider=lambda: TenantScope(account_id="acct-faq", user_id="user-faq"),
+        deflection_report_store_provider=lambda: store,
+    )
+    support_tickets = [
+        {
+            "ticket_id": "ticket-sso-1",
+            "source_type": "support_ticket",
+            "subject": "SSO setup",
+            "message": "Can we sync users before enforcing SSO?",
+            "pain_category": "single sign-on rollout",
+            "resolution_text": (
+                "Enable SSO first, verify matching user emails, then enable SCIM."
+            ),
+        },
+        {
+            "ticket_id": "ticket-dashboard-1",
+            "source_type": "support_ticket",
+            "subject": "Dashboard refresh",
+            "message": "Why is the executive dashboard not refreshing?",
+            "pain_category": "warehouse refresh status",
+            "resolution_text": (
+                "Open Data > Sync history, rerun the failed warehouse job, "
+                "then refresh the model."
+            ),
+        },
+        {
+            "ticket_id": "ticket-billing-1",
+            "source_type": "support_ticket",
+            "subject": "Renewal invoice",
+            "message": "How do I confirm my renewal invoice before payment?",
+            "pain_category": "renewal billing review",
+            "resolution_text": (
+                "Open Billing > Invoices, compare the renewal line items, "
+                "then download the PDF."
+            ),
+        },
+        {
+            "ticket_id": "ticket-token-1",
+            "source_type": "support_ticket",
+            "subject": "API token rotation",
+            "message": "How do we rotate API tokens without downtime?",
+            "pain_category": "api token rotation",
+            "resolution_text": (
+                "Create the replacement token, deploy it alongside the old "
+                "token, then revoke the old token."
+            ),
+        },
+    ]
+
+    route = _route(router, "/content-ops/execute", "POST")
+    payload = await route.endpoint({
+        "target_mode": "vendor_retention",
+        "outputs": ["faq_deflection_report"],
+        "limit": 2,
+        "require_quality_gates": False,
+        "inputs": {
+            "deflection_report_title": "Hosted FAQ Deflection Uncapped",
+            "faq_title": "Hosted FAQ Deflection Source",
+            "source_material": {"support_tickets": support_tickets},
+        },
+    })
+
+    assert payload["status"] == "completed"
+    assert payload["plan"]["steps"][0]["config"]["max_items"] == 2
+
+    step = payload["steps"][0]
+    assert step["output"] == "faq_deflection_report"
+    assert step["status"] == "completed"
+
+    snapshot = step["result"]["snapshot"]
+    assert snapshot["summary"] == {
+        "generated": 4,
+        "drafted_answer_count": 4,
+        "no_proven_answer_count": 0,
+    }
+    assert len(snapshot["top_questions"]) == 2
+    snapshot_payload = json.dumps(snapshot, sort_keys=True)
+    assert "resolution_text" not in snapshot_payload
+    assert "Open Billing" not in snapshot_payload
+    assert "ticket-token-1" not in snapshot_payload
+    assert step["result"]["full_report"]["status"] == "locked"
+
+    await _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/paid",
+        "POST",
+    ).endpoint(
+        payload=api_module.DeflectionReportPaidModel(),
+        request_id=payload["request_id"],
+    )
+    artifact = await _route(
+        router,
+        "/content-ops/deflection-reports/{request_id}/artifact",
+        "GET",
+    ).endpoint(request_id=payload["request_id"])
+
+    faq_result = artifact["faq_result"]
+    assert artifact["summary"]["generated"] == 4
+    assert artifact["summary"]["drafted_answer_count"] == 4
+    assert len(faq_result["items"]) == 4
+    assert "other support issues" not in {item["topic"] for item in faq_result["items"]}
+    source_ids = {
+        source_id
+        for item in faq_result["items"]
+        for source_id in item["source_ids"]
+    }
+    assert source_ids == {
+        "ticket-sso-1",
+        "ticket-dashboard-1",
+        "ticket-billing-1",
+        "ticket-token-1",
+    }
+    assert "Create the replacement token" in artifact["markdown"]
+
+
 async def test_live_execute_route_handles_concurrent_faq_deflection_reports() -> None:
     class _BarrierFAQDeflectionReportService:
         def __init__(self, *, expected: int) -> None:

--- a/tests/test_extracted_ticket_faq_markdown.py
+++ b/tests/test_extracted_ticket_faq_markdown.py
@@ -2213,8 +2213,8 @@ def test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits
         "has_action_items": False,
         "resolution_evidence_scoped": False,
     }
-    with pytest.raises(ValueError, match="max_items must be positive"):
-        build_ticket_faq_markdown([], max_items=0)
+    with pytest.raises(ValueError, match="max_items must be positive or 0 for unlimited"):
+        build_ticket_faq_markdown([], max_items=-1)
     with pytest.raises(ValueError, match="max_evidence_per_item must be positive"):
         build_ticket_faq_markdown([], max_evidence_per_item=0)
 
@@ -2745,6 +2745,28 @@ def test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncat
     assert result.output_checks["condensed"] is True
     assert result.items[-1]["topic"] == "other support issues"
     assert result.items[-1]["source_ids"] == ("ticket-8", "ticket-9")
+
+
+def test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited() -> None:
+    opportunities = [
+        {
+            "source_type": "support_ticket",
+            "source_title": f"Unique issue {index}",
+            "evidence": [{
+                "text": f"How do I handle unique issue {index}?",
+                "source_id": f"ticket-{index}",
+                "source_type": "support_ticket",
+            }],
+        }
+        for index in range(1, 10)
+    ]
+
+    result = build_ticket_faq_markdown(opportunities, max_items=0)
+
+    assert len(result.items) == 9
+    assert result.ticket_source_count == 9
+    assert "other support issues" not in {item["topic"] for item in result.items}
+    assert result.items[-1]["source_ids"] == ("ticket-9",)
 
 
 def test_ticket_faq_cli_writes_markdown_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Plan: plans/PR-Deflection-Uncap-Paid-Report.md
Slice phase: Production hardening

Uncap the paid FAQ deflection report so every distinct recurring question found in the ingested ticket rows becomes its own ranked item, and align the local deflection report CLI so verification cannot accidentally use a stale finite cap. The free snapshot remains a top-N projection with truthful full-report counts.

## Intentional
- Keep finite `max_items` overflow condensation for generic FAQ Markdown callers.
- Treat deflection request limits as input-volume controls, not paid-report display caps.
- Keep the deflection CLI `--max-items` flag as compatibility-only; result JSON records it as `requested_max_items`.
- Do not add a separate `questions_found` field because `generated` is truthful once the artifact is uncapped.

## Deferred
- Frontend copy/layout work for larger reports remains in atlas-portfolio follow-up work.
- Live redeploy and customer re-verification follow after merge.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_skips_non_ticket_sources_and_validates_limits tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_treats_zero_max_items_as_unlimited tests/test_extracted_ticket_faq_markdown.py::test_build_ticket_faq_markdown_condenses_overflow_sources_instead_of_truncating tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_content_ops_deflection_report.py::test_deflection_report_cli_ignores_legacy_max_items_cap -q -- 5 passed.
- Command: bash scripts/validate_extracted_content_pipeline.sh -- passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline -- clean.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt -- 0 findings.
- Command: bash scripts/check_ascii_python.sh -- passed.
- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main -- passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh -- passed; 2961 passed, 10 skipped, 1 warning in the extracted content pipeline pytest suite, plus extracted reasoning core checks passed.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-uncap-paid-report-pr-body.md -- passed.

## Diff size
8 files, +381 / -17.
