### PR TITLE
PR-Deflection-Snapshot-Teaser

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -34,8 +34,11 @@ type GatedDeflectionExecuteResult = {
 };
 ```
 
-Render `snapshot` on the free page. Do not derive answer text, evidence, source
-IDs, or Markdown from this object.
+Render `snapshot` on the free page. The only answer body available before
+payment is `snapshot.teaser.full_answer`, when present. Teaser previews are
+body-withheld (`body_withheld: true`) and exist only to show answer structure.
+Do not derive other answer text, evidence, source IDs, or Markdown from this
+object.
 
 ## Portfolio Submit Endpoint
 
@@ -88,6 +91,11 @@ Responses:
 
 - `200`: `DeflectionSnapshot`
 - `404`: no report exists for this `request_id` in the authenticated account
+
+The snapshot teaser is bounded and fail-closed: at most one full scoped
+resolution-backed answer plus configured body-withheld previews. When no item
+has scoped resolution evidence, `teaser.full_answer` is `null` and previews are
+empty.
 
 The authenticated ATLAS scope supplies `account_id`; do not put `account_id` in
 the path or query string.

--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -4,6 +4,22 @@
     "generated": 2,
     "no_proven_answer_count": 1
   },
+  "teaser": {
+    "full_answer": {
+      "answer": "To resolve this, open Analytics, choose Attribution, then click Download report.",
+      "answer_evidence_status": "resolution_evidence",
+      "question": "How do I export attribution reports?",
+      "rank": 1,
+      "resolution_evidence_scope": "scoped",
+      "source_count": 2,
+      "steps": [
+        "Open Analytics, choose Attribution, then click Download report.",
+        "If it still does not work, contact support at https://example.com/support and include the cited ticket details."
+      ],
+      "weighted_frequency": 2
+    },
+    "previews": []
+  },
   "top_questions": [
     {
       "customer_wording": "How do I export attribution reports?",

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -86,6 +86,7 @@ type DeflectionSnapshot = {
     no_proven_answer_count: number;
   };
   top_questions: DeflectionSnapshotQuestion[];
+  teaser: DeflectionSnapshotTeaser;
 };
 
 type DeflectionSnapshotQuestion = {
@@ -94,16 +95,46 @@ type DeflectionSnapshotQuestion = {
   weighted_frequency: number;
   customer_wording: string;
 };
+
+type DeflectionSnapshotTeaser = {
+  full_answer: DeflectionSnapshotFullAnswer | null;
+  previews: DeflectionSnapshotAnswerPreview[];
+};
+
+type DeflectionSnapshotFullAnswer = {
+  rank: number;
+  question: string;
+  answer: string;
+  steps: string[];
+  answer_evidence_status: "resolution_evidence";
+  resolution_evidence_scope: "scoped";
+  weighted_frequency: number;
+  source_count: number;
+};
+
+type DeflectionSnapshotAnswerPreview = {
+  rank: number;
+  question: string;
+  answer_evidence_status: "resolution_evidence";
+  resolution_evidence_scope: "scoped";
+  weighted_frequency: number;
+  step_count: number;
+  source_count: number;
+  body_withheld: true;
+};
 ```
 
 This shape intentionally excludes paid deliverable fields:
 
 - no `markdown`
 - no `faq_result`
-- no answer text or `steps`
+- no answer text or `steps` outside `teaser.full_answer`
 - no `evidence_quotes`
 - no `source_ids`
 - no vocabulary term mappings
+
+The teaser is fail-closed: only scoped `resolution_evidence` FAQ items are
+eligible. Preview entries never include answer body text.
 
 ## FAQ Item
 

--- a/extracted_content_pipeline/api/control_surfaces.py
+++ b/extracted_content_pipeline/api/control_surfaces.py
@@ -69,6 +69,7 @@ from ..control_surfaces import (
 from ..generation_plan import build_generation_plan, build_generation_plan_from_mapping
 from ..faq_deflection_report import (
     DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
+    DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT,
     build_deflection_snapshot,
 )
 from ..landing_page_input_contract import landing_page_seo_geo_aeo_input_contracts
@@ -339,6 +340,9 @@ class ContentOpsControlSurfaceApiConfig:
     execute_max_concurrency: int = 8
     faq_execute_max_source_material_rows: int = _MAX_INGESTION_ROWS
     deflection_snapshot_top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N
+    deflection_snapshot_teaser_preview_count: int = (
+        DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT
+    )
     ingestion_import_max_concurrency: int = 8
 
     def __post_init__(self) -> None:
@@ -388,6 +392,10 @@ class ContentOpsControlSurfaceApiConfig:
             )
         if self.deflection_snapshot_top_n <= 0:
             raise ValueError("deflection_snapshot_top_n must be positive")
+        if self.deflection_snapshot_teaser_preview_count < 0:
+            raise ValueError(
+                "deflection_snapshot_teaser_preview_count must be non-negative"
+            )
         if self.ingestion_import_max_concurrency <= 0:
             raise ValueError("ingestion_import_max_concurrency must be positive")
         if not isinstance(
@@ -1111,6 +1119,9 @@ def create_content_ops_control_surface_router(
                 scope=scope,
                 request_id=request_id,
                 top_n=resolved_config.deflection_snapshot_top_n,
+                teaser_preview_count=(
+                    resolved_config.deflection_snapshot_teaser_preview_count
+                ),
                 delivery_email=_delivery_email_from_payload(payload_mapping),
             )
             result = _with_input_provider_diagnostics(result, payload_mapping)
@@ -2437,6 +2448,7 @@ async def _gate_deflection_report_artifacts(
     scope: TenantScope | None,
     request_id: str,
     top_n: int,
+    teaser_preview_count: int,
     delivery_email: str | None = None,
 ) -> dict[str, Any]:
     gated = dict(result)
@@ -2458,7 +2470,11 @@ async def _gate_deflection_report_artifacts(
                 detail="Deflection report artifact is malformed.",
             )
         try:
-            snapshot = build_deflection_snapshot(artifact, top_n=top_n).as_dict()
+            snapshot = build_deflection_snapshot(
+                artifact,
+                top_n=top_n,
+                teaser_preview_count=teaser_preview_count,
+            ).as_dict()
             await store.save_report(
                 account_id=account_id,
                 request_id=request_id,

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -11,8 +11,10 @@ from .ticket_faq_markdown import TicketFAQMarkdownResult, TicketFAQMarkdownServi
 
 
 _RESOLUTION_EVIDENCE_STATUS = "resolution_evidence"
+_RESOLUTION_EVIDENCE_SCOPE_SCOPED = "scoped"
 _DRAFT_NEEDS_REVIEW_STATUS = "draft_needs_review"
 DEFAULT_DEFLECTION_SNAPSHOT_TOP_N = 5
+DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT = 3
 _UNCAPPED_REPORT_MAX_ITEMS = 0
 
 
@@ -22,11 +24,24 @@ class DeflectionSnapshot:
 
     summary: dict[str, int]
     top_questions: tuple[dict[str, Any], ...]
+    teaser: dict[str, Any]
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "summary": dict(self.summary),
             "top_questions": [dict(question) for question in self.top_questions],
+            "teaser": {
+                "full_answer": (
+                    dict(self.teaser["full_answer"])
+                    if isinstance(self.teaser.get("full_answer"), Mapping)
+                    else None
+                ),
+                "previews": [
+                    dict(preview)
+                    for preview in self.teaser.get("previews", ())
+                    if isinstance(preview, Mapping)
+                ],
+            },
         }
 
 
@@ -124,6 +139,7 @@ def build_deflection_snapshot(
     artifact: DeflectionReportArtifact | Mapping[str, Any],
     *,
     top_n: int = DEFAULT_DEFLECTION_SNAPSHOT_TOP_N,
+    teaser_preview_count: int = DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT,
 ) -> DeflectionSnapshot:
     """Project a report into the free snapshot shape.
 
@@ -133,6 +149,8 @@ def build_deflection_snapshot(
 
     if top_n <= 0:
         raise ValueError("top_n must be positive")
+    if teaser_preview_count < 0:
+        raise ValueError("teaser_preview_count must be non-negative")
     summary = _artifact_summary(artifact)
     items = _artifact_items(artifact)
     snapshot_summary = {
@@ -154,6 +172,7 @@ def build_deflection_snapshot(
     return DeflectionSnapshot(
         summary=snapshot_summary,
         top_questions=tuple(top_questions),
+        teaser=_snapshot_teaser(items, preview_count=teaser_preview_count),
     )
 
 
@@ -436,6 +455,78 @@ def _snapshot_customer_wording(item: Mapping[str, Any], question: str) -> str:
     return ""
 
 
+def _snapshot_teaser(
+    items: Sequence[Mapping[str, Any]],
+    *,
+    preview_count: int,
+) -> dict[str, Any]:
+    eligible = tuple(
+        (rank, item)
+        for rank, item in enumerate(items, start=1)
+        if _is_teaser_eligible(item)
+    )
+    if not eligible:
+        return {"full_answer": None, "previews": []}
+    full_rank, full_item = _select_full_teaser_item(eligible)
+    previews = [
+        _teaser_preview(rank, item)
+        for rank, item in eligible
+        if rank != full_rank
+    ][:preview_count]
+    return {
+        "full_answer": _teaser_full_answer(full_rank, full_item),
+        "previews": previews,
+    }
+
+
+def _is_teaser_eligible(item: Mapping[str, Any]) -> bool:
+    return (
+        _text(item.get("answer_evidence_status")) == _RESOLUTION_EVIDENCE_STATUS
+        and _text(item.get("resolution_evidence_scope")) == _RESOLUTION_EVIDENCE_SCOPE_SCOPED
+        and bool(_text(item.get("answer")))
+    )
+
+
+def _select_full_teaser_item(
+    eligible: Sequence[tuple[int, Mapping[str, Any]]],
+) -> tuple[int, Mapping[str, Any]]:
+    for rank, item in eligible:
+        if rank >= 4:
+            return rank, item
+    return eligible[-1]
+
+
+def _teaser_full_answer(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "rank": rank,
+        "question": _text(item.get("question")),
+        "answer": _text(item.get("answer")),
+        "steps": _texts(item.get("steps")),
+        "answer_evidence_status": _RESOLUTION_EVIDENCE_STATUS,
+        "resolution_evidence_scope": _RESOLUTION_EVIDENCE_SCOPE_SCOPED,
+        "weighted_frequency": _int(item.get("weighted_frequency") or item.get("frequency")),
+        "source_count": _source_count(item),
+    }
+
+
+def _teaser_preview(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "rank": rank,
+        "question": _text(item.get("question")),
+        "answer_evidence_status": _RESOLUTION_EVIDENCE_STATUS,
+        "resolution_evidence_scope": _RESOLUTION_EVIDENCE_SCOPE_SCOPED,
+        "weighted_frequency": _int(item.get("weighted_frequency") or item.get("frequency")),
+        "step_count": len(_texts(item.get("steps"))),
+        "source_count": _source_count(item),
+        "body_withheld": True,
+    }
+
+
+def _source_count(item: Mapping[str, Any]) -> int:
+    source_count = len(_texts(item.get("source_ids")))
+    return source_count or _int(item.get("ticket_count"))
+
+
 def _texts(value: Any) -> list[str]:
     if value in (None, "", [], {}):
         return []
@@ -483,6 +574,7 @@ def _md(value: Any) -> str:
 
 __all__ = [
     "DEFAULT_DEFLECTION_SNAPSHOT_TOP_N",
+    "DEFAULT_DEFLECTION_TEASER_PREVIEW_COUNT",
     "DeflectionSnapshot",
     "DeflectionReportArtifact",
     "FAQDeflectionReportService",

--- a/plans/PR-Deflection-Snapshot-Teaser.md
+++ b/plans/PR-Deflection-Snapshot-Teaser.md
@@ -1,0 +1,75 @@
+# PR-Deflection-Snapshot-Teaser
+
+## Why this slice exists
+
+Issue #1262 identifies a conversion gap in the unpaid FAQ deflection results page: the snapshot proves volume and ranking, but it shows no answer quality. The paid gate should not expose the report, evidence, source IDs, or the full drafted-answer set, but the free snapshot can safely expose one bounded, scoped, resolution-backed drafted answer plus a few body-withheld previews. This slice adds that backend projection so atlas-portfolio can render a real teaser instead of mocks.
+
+The diff is slightly over the 400 LOC target because the contract is only safe when the producer, execute-route config, frontend docs, canonical example, and regression tests land together. Splitting those pieces would leave either an undocumented payload or docs/examples that are not producer-pinned.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Product polish
+
+1. Add a `teaser` block to `DeflectionSnapshot` with one full scoped drafted answer and at most a configured number of body-withheld previews.
+2. Select teaser candidates deterministically from items whose `answer_evidence_status` is `resolution_evidence` and `resolution_evidence_scope` is `scoped`.
+3. Keep snapshot privacy fail-closed: no evidence quotes, source IDs, Markdown, term mappings, or non-teaser answer bodies leak.
+4. Thread a default teaser preview-count config through the execute route snapshot gate.
+5. Update frontend contract docs and the canonical snapshot example.
+
+### Files touched
+
+- `plans/PR-Deflection-Snapshot-Teaser.md` - Plan doc for this slice.
+- `extracted_content_pipeline/faq_deflection_report.py` - Build and serialize the bounded teaser projection.
+- `extracted_content_pipeline/api/control_surfaces.py` - Add route config for teaser preview count.
+- `tests/test_content_ops_deflection_report.py` - Pin teaser selection, privacy, and fail-closed behavior.
+- `tests/test_extracted_content_control_surface_api.py` - Pin the teaser preview-count config validation branch.
+- `tests/test_extracted_content_ops_live_execute_harness.py` - Prove execute-route snapshots include the bounded teaser.
+- `tests/test_content_ops_faq_report_contract_docs.py` - Keep producer docs/examples in sync.
+- `docs/frontend/content_ops_faq_report_contract.md` - Document the snapshot teaser type.
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md` - Document the unpaid teaser contract.
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json` - Canonical example payload.
+
+## Mechanism
+
+The snapshot builder keeps summary/top questions unchanged and adds `teaser`. Eligible teaser items must have `answer_evidence_status == "resolution_evidence"`, `resolution_evidence_scope == "scoped"`, and a real drafted answer body. The full answer chooses the first eligible mid-rank item when possible, preferring rank 4+ so the highest-frequency answers stay locked; smaller reports fall back to the last eligible item so a one-answer report can still show a teaser. Previews are deterministic eligible items excluding the full answer, capped by config.
+
+The full teaser answer includes only unpaid-safe render fields: rank, question, answer, steps, status/scope, weighted frequency, and source count. Preview entries include rank, question, status/scope, weighted frequency, step count, source count, and `body_withheld: true`. No evidence, source IDs, term mappings, nested FAQ item payloads, or Markdown are projected.
+
+## Intentional
+
+- This is a backend payload slice only. Portfolio rendering, blur treatment, and landing-page demo placement remain in atlas-portfolio.
+- The teaser is omitted as an empty block when no item passes the scoped resolution-evidence plus drafted-answer gate.
+- The source count is structural metadata, not source identity; it lets the frontend show proof shape without leaking source IDs.
+- Cross-layer caller hints were inspected. Existing router/config callers remain compatible because the new preview count has a default, and the execute-route snapshot path is covered here; portfolio-ui is a deferred consumer and its contract docs are updated.
+
+## Deferred
+
+- atlas-portfolio rendering for the snapshot teaser and landing-page before/after demo.
+- Live customer validation after this backend payload lands and the portfolio consumes it.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_includes_bounded_fail_closed_teaser tests/test_content_ops_deflection_report.py::test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence tests/test_content_ops_deflection_report.py::test_deflection_snapshot_rejects_negative_teaser_preview_count tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_extracted_content_control_surface_api.py::test_content_ops_config_rejects_negative_deflection_teaser_preview_count tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q - 6 passed.
+- Command: pytest tests/test_content_ops_faq_report_contract_docs.py -q - 5 passed.
+- Command: pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_extracted_content_control_surface_api.py::test_content_ops_config_rejects_negative_deflection_teaser_preview_count tests/test_extracted_content_ops_live_execute_harness.py::test_live_execute_route_returns_faq_deflection_report_artifact tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q - 32 passed.
+- Command: bash scripts/validate_extracted_content_pipeline.sh - passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 findings.
+- Command: bash scripts/check_ascii_python.sh - passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main - passed, 144 matching tests enrolled.
+- Command: bash scripts/run_extracted_pipeline_checks.sh - 2965 passed, 10 skipped, 1 warning.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-snapshot-teaser-pr-body.md - passed.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 75 |
+| Snapshot projection | 92 |
+| API config | 17 |
+| Tests | 202 |
+| Docs/examples | 58 |
+| **Total** | **444** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -206,10 +206,104 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
                 "customer_wording": "How do I export attribution reports?",
             }
         ],
+        "teaser": {"full_answer": None, "previews": []},
     }
     assert "Open Analytics" not in encoded
     assert "ticket-export-1" not in encoded
     assert "evidence" not in encoded
+
+
+def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=6,
+        ticket_source_count=6,
+        output_checks={"condensed": True},
+        items=(
+            _scoped_answer_item(1, "How do I export reports?", "Locked top answer one"),
+            _scoped_answer_item(2, "How do I update billing?", "Locked top answer two"),
+            _scoped_answer_item(3, "How do I enable SSO?", "Locked top answer three"),
+            _scoped_answer_item(
+                4,
+                "How do we rotate API tokens?",
+                "Create the replacement token, deploy it, then revoke the old token.",
+                step="Create the replacement token before revoking the old one.",
+            ),
+            {
+                **_scoped_answer_item(
+                    5,
+                    "Why is the dashboard stale?",
+                    "Mismatched answer must stay locked.",
+                ),
+                "resolution_evidence_scope": "scope_mismatch",
+            },
+            _scoped_answer_item(6, "How do I add a teammate?", "Tail answer locked"),
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(
+        build_deflection_report_artifact(result),
+        top_n=3,
+        teaser_preview_count=2,
+    ).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot["summary"]["generated"] == 6
+    assert len(snapshot["top_questions"]) == 3
+    assert snapshot["teaser"]["full_answer"] == {
+        "rank": 4,
+        "question": "How do we rotate API tokens?",
+        "answer": "Create the replacement token, deploy it, then revoke the old token.",
+        "steps": ["Create the replacement token before revoking the old one."],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "weighted_frequency": 4,
+        "source_count": 1,
+    }
+    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [1, 2]
+    for preview in snapshot["teaser"]["previews"]:
+        assert preview["body_withheld"] is True
+        assert preview["answer_evidence_status"] == "resolution_evidence"
+        assert preview["resolution_evidence_scope"] == "scoped"
+        assert "answer" not in preview
+        assert "steps" not in preview
+
+    assert "Locked top answer" not in encoded
+    assert "Mismatched answer must stay locked" not in encoded
+    assert "Tail answer locked" not in encoded
+    assert "ticket-" not in encoded
+    assert "evidence_quotes" not in encoded
+    assert "source_ids" not in encoded
+
+
+def test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=2,
+        ticket_source_count=2,
+        output_checks={"condensed": True},
+        items=(
+            {
+                **_scoped_answer_item(1, "How do I export reports?", "Locked answer"),
+                "resolution_evidence_scope": "scope_mismatch",
+            },
+            {
+                "question": "Scoped status without answer body stays hidden",
+                "weighted_frequency": 1,
+                "answer": "",
+                "answer_evidence_status": "resolution_evidence",
+                "resolution_evidence_scope": "scoped",
+                "source_ids": ("ticket-2",),
+            },
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(build_deflection_report_artifact(result)).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot["teaser"] == {"full_answer": None, "previews": []}
+    assert "Locked answer" not in encoded
+    assert "ticket-1" not in encoded
 
 
 def test_deflection_snapshot_rejects_non_positive_top_n() -> None:
@@ -223,6 +317,41 @@ def test_deflection_snapshot_rejects_non_positive_top_n() -> None:
 
     with pytest.raises(ValueError, match="top_n must be positive"):
         build_deflection_snapshot(build_deflection_report_artifact(result), top_n=0)
+
+
+def test_deflection_snapshot_rejects_negative_teaser_preview_count() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=0,
+        ticket_source_count=0,
+        output_checks={},
+        items=(),
+    )
+
+    with pytest.raises(ValueError, match="teaser_preview_count must be non-negative"):
+        build_deflection_snapshot(
+            build_deflection_report_artifact(result),
+            teaser_preview_count=-1,
+        )
+
+
+def _scoped_answer_item(
+    rank: int,
+    question: str,
+    answer: str,
+    *,
+    step: str | None = None,
+) -> dict[str, object]:
+    return {
+        "question": question,
+        "weighted_frequency": rank,
+        "answer": answer,
+        "steps": [step or f"Step for {question}"],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "source_ids": (f"ticket-{rank}",),
+        "evidence_quotes": (f"`ticket-{rank}` - {question}",),
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -184,7 +184,7 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
     encoded = json.dumps(payload, sort_keys=True)
 
     assert payload == producer_payload
-    assert set(payload) == {"summary", "top_questions"}
+    assert set(payload) == {"summary", "top_questions", "teaser"}
     assert set(payload["summary"]) == {
         "generated",
         "drafted_answer_count",
@@ -197,10 +197,39 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
             "weighted_frequency",
             "customer_wording",
         }
+    assert set(payload["teaser"]) == {"full_answer", "previews"}
+    if payload["teaser"]["full_answer"] is not None:
+        assert set(payload["teaser"]["full_answer"]) == {
+            "rank",
+            "question",
+            "answer",
+            "steps",
+            "answer_evidence_status",
+            "resolution_evidence_scope",
+            "weighted_frequency",
+            "source_count",
+        }
+        assert (
+            payload["teaser"]["full_answer"]["answer_evidence_status"]
+            == "resolution_evidence"
+        )
+        assert payload["teaser"]["full_answer"]["resolution_evidence_scope"] == "scoped"
+    for preview in payload["teaser"]["previews"]:
+        assert set(preview) == {
+            "rank",
+            "question",
+            "answer_evidence_status",
+            "resolution_evidence_scope",
+            "weighted_frequency",
+            "step_count",
+            "source_count",
+            "body_withheld",
+        }
+        assert preview["body_withheld"] is True
     assert "markdown" not in encoded
     assert "faq_result" not in encoded
-    assert "steps" not in encoded
-    assert "evidence" not in encoded
+    assert "steps" not in json.dumps(payload["top_questions"], sort_keys=True)
+    assert "evidence_quotes" not in encoded
     assert "source_ids" not in encoded
 
 
@@ -227,6 +256,8 @@ def test_content_ops_faq_deflection_checkout_contract_pins_paid_handoff() -> Non
         "account_id: string;",
         "request_id: string;",
         "GET /content-ops/deflection-reports/{request_id}/snapshot",
+        "snapshot.teaser.full_answer",
+        "body_withheld: true",
         "GET /content-ops/deflection-reports/{request_id}/artifact",
         "csv_file: File;",
         "do not expose raw support-ticket CSVs through a",

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2562,10 +2562,13 @@ async def test_execute_generation_route_returns_snapshot_for_unpaid_deflection_r
     assert result["snapshot"]["summary"]["drafted_answer_count"] == 1
     assert result["snapshot"]["summary"]["no_proven_answer_count"] == 1
     assert result["snapshot"]["top_questions"][0]["rank"] == 1
+    assert result["snapshot"]["teaser"]["full_answer"]["answer"] == (
+        "To resolve this, open Analytics and download the report."
+    )
     assert "markdown" not in result
     assert "faq_result" not in result
-    assert "Open Analytics" not in encoded
     assert "ticket-export-1" not in encoded
+    assert "evidence_quotes" not in encoded
 
     snapshot_route = _route(router, "/ops/deflection-reports/{request_id}/snapshot", "GET")
     assert await snapshot_route.endpoint(request_id=request_id) == result["snapshot"]
@@ -4017,6 +4020,14 @@ def test_content_ops_config_rejects_invalid_faq_execute_row_limit():
 def test_content_ops_config_rejects_invalid_ingestion_import_concurrency():
     with pytest.raises(ValueError, match="ingestion_import_max_concurrency must be positive"):
         ContentOpsControlSurfaceApiConfig(ingestion_import_max_concurrency=0)
+
+
+def test_content_ops_config_rejects_negative_deflection_teaser_preview_count():
+    with pytest.raises(
+        ValueError,
+        match="deflection_snapshot_teaser_preview_count must be non-negative",
+    ):
+        ContentOpsControlSurfaceApiConfig(deflection_snapshot_teaser_preview_count=-1)
 
 
 def test_content_ops_config_rejects_invalid_falsification_rules_shape():

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -809,7 +809,10 @@ async def test_live_execute_route_returns_faq_deflection_report_artifact() -> No
     assert step["result"]["full_report"]["status"] == "locked"
     assert "markdown" not in step["result"]
     assert "faq_result" not in step["result"]
-    assert "Open Analytics" not in json.dumps(step["result"], sort_keys=True)
+    gated_payload = json.dumps(step["result"], sort_keys=True)
+    assert "Open Analytics" in gated_payload
+    assert "ticket-export-1" not in gated_payload
+    assert "evidence_quotes" not in gated_payload
 
     request_id = payload["request_id"]
     artifact_route = _route(
@@ -931,7 +934,10 @@ async def test_live_execute_route_handles_bulk_faq_deflection_report() -> None:
 async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n() -> None:
     store = InMemoryDeflectionReportArtifactStore()
     router = create_content_ops_control_surface_router(
-        config=ContentOpsControlSurfaceApiConfig(deflection_snapshot_top_n=2),
+        config=ContentOpsControlSurfaceApiConfig(
+            deflection_snapshot_top_n=2,
+            deflection_snapshot_teaser_preview_count=1,
+        ),
         execution_services_provider=lambda: ContentOpsExecutionServices(
             faq_deflection_report=FAQDeflectionReportService(),
         ),
@@ -1011,10 +1017,28 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
         "no_proven_answer_count": 0,
     }
     assert len(snapshot["top_questions"]) == 2
+    assert snapshot["teaser"]["full_answer"]["answer_evidence_status"] == (
+        "resolution_evidence"
+    )
+    assert snapshot["teaser"]["full_answer"]["resolution_evidence_scope"] == "scoped"
+    assert len(snapshot["teaser"]["previews"]) == 1
+    assert snapshot["teaser"]["previews"][0]["body_withheld"] is True
+    assert "answer" not in snapshot["teaser"]["previews"][0]
+    assert "steps" not in snapshot["teaser"]["previews"][0]
     snapshot_payload = json.dumps(snapshot, sort_keys=True)
+    visible_answer_count = sum(
+        answer in snapshot_payload
+        for answer in (
+            "Enable SSO first",
+            "Open Data > Sync history",
+            "Open Billing > Invoices",
+            "Create the replacement token",
+        )
+    )
+    assert visible_answer_count == 1
     assert "resolution_text" not in snapshot_payload
-    assert "Open Billing" not in snapshot_payload
     assert "ticket-token-1" not in snapshot_payload
+    assert "source_ids" not in snapshot_payload
     assert step["result"]["full_report"]["status"] == "locked"
 
     await _route(


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Teaser.md
Slice phase: Product polish

Issue #1262 identified that the unpaid FAQ deflection snapshot proves ranking and volume but gives buyers no real answer-quality sample. This adds a fail-closed `snapshot.teaser` projection: one scoped, resolution-backed full drafted answer plus a bounded set of body-withheld previews, with evidence/source IDs/Markdown/full report content still locked behind paid access.

## Intentional
- Backend payload only; atlas-portfolio rendering and landing-page demo placement are deferred.
- Empty teaser block when no item passes the scoped resolution-evidence plus drafted-answer gate.
- `source_count` is structural metadata only; source identities remain stripped from the snapshot.
- Cross-layer caller hints were inspected. Existing router/config callers remain compatible because the new preview count has a default, and the execute-route snapshot path is covered here; portfolio-ui is a deferred consumer and its contract docs are updated.

## Deferred
- atlas-portfolio rendering for the snapshot teaser and landing-page before/after demo.
- Live customer validation after this backend payload lands and the portfolio consumes it.

## Parked hardening
- None.

## Verification
- `pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_includes_bounded_fail_closed_teaser tests/test_content_ops_deflection_report.py::test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence tests/test_content_ops_deflection_report.py::test_deflection_snapshot_rejects_negative_teaser_preview_count tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_extracted_content_control_surface_api.py::test_content_ops_config_rejects_negative_deflection_teaser_preview_count tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q` - 6 passed.
- `pytest tests/test_content_ops_faq_report_contract_docs.py -q` - 5 passed.
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_extracted_content_control_surface_api.py::test_content_ops_config_rejects_negative_deflection_teaser_preview_count tests/test_extracted_content_ops_live_execute_harness.py::test_live_execute_route_returns_faq_deflection_report_artifact tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q` - 32 passed.
- `bash scripts/validate_extracted_content_pipeline.sh` - passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed, 0 findings.
- `bash scripts/check_ascii_python.sh` - passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` - passed, 144 matching tests enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` - 2965 passed, 10 skipped, 1 warning.
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-snapshot-teaser-pr-body.md` - passed.

## Diff size
10 files, +444 / -11. Slightly over the 400 LOC target because the producer, execute-route config, frontend docs, canonical example, and regression tests need to land together to keep the teaser contract pinned.
