### PR TITLE
PR-Content-Ops-Social-Post-Package-Handoff

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -160,20 +160,29 @@ _COMPETITIVE_MARKER_KEYS = frozenset({
     "top_displacement_targets",
     "winning_vendor",
 })
-_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief")
+_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief", "social_post")
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
-_REVIEW_OFFER = "Turn customer review themes into buyer-facing landing pages and blog posts"
+_REVIEW_OFFER = (
+    "Turn customer review themes into buyer-facing landing pages, blog posts, "
+    "sales briefs, and social posts"
+)
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
-_COMPETITIVE_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = (
+    "landing_page",
+    "blog_post",
+    "sales_brief",
+    "social_post",
+)
 _COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
 _COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
 _COMPETITIVE_AUDIENCE = (
     "Marketing teams turning competitive evidence into grounded content"
 )
 _COMPETITIVE_OFFER = (
-    "Turn competitor and switching evidence into buyer-facing landing pages and blog posts"
+    "Turn competitor and switching evidence into buyer-facing landing pages, "
+    "blog posts, sales briefs, and social posts"
 )
 _COMPETITIVE_TARGET_KEYWORD = "competitive displacement content marketing"
 

--- a/plans/PR-Content-Ops-Social-Post-Package-Handoff.md
+++ b/plans/PR-Content-Ops-Social-Post-Package-Handoff.md
@@ -1,0 +1,86 @@
+# PR: Content Ops Social Post Package Handoff
+
+## Why this slice exists
+
+PR #1266 added the deterministic `social_post` output and deliberately deferred
+putting it into the review and competitive input-package defaults. Until this
+handoff lands, operators can run `social_post` explicitly, but the productized
+review/competitive source modes still default only to landing pages, blog posts,
+and sales briefs.
+
+This slice completes that handoff by making review and competitive source
+packages request social posts by default, using the same normalized
+`source_material` already proven by #1266. It does not overlap #1268, which is a
+plan-doc-only output-variations lane.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add `social_post` to the review source-mode default outputs.
+2. Add `social_post` to the competitive source-mode default outputs.
+3. Align the package offer copy with the expanded output set.
+4. Extend the existing host-provider tests to prove the default package outputs
+   and execution handoff include `social_post`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Social-Post-Package-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host input provider already builds normalized `source_material` for review
+and competitive source modes. `social_post` consumes that same field, so this
+slice only expands the two output tuples:
+
+```python
+_REVIEW_CAMPAIGN_OUTPUTS = (..., "social_post")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = (..., "social_post")
+```
+
+The execution tests use the existing `_RunnableService` fake in the
+`social_post` service slot. If the output is present but the dispatcher fails to
+handoff `source_material`, the tests fail on the social-post step kwargs.
+
+## Intentional
+
+- No new source adapter or generator logic. #1266 already proved
+  `social_post` runs from normalized source material.
+- No UI selector changes. The New Run source-mode path consumes these package
+  defaults automatically.
+- No changes to #1268 output variations; that open PR is a separate
+  workflow/process lane and remains untouched.
+
+## Deferred
+
+- Ad copy and stat/quote card package defaults remain future output slices.
+- Persisting generated social posts into the generated-asset review queue
+  remains future productization.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_atlas_content_ops_review_input_provider.py -q (22 passed)
+- Passed: pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q (46 passed, 1 warning)
+- Passed: python -m py_compile atlas_brain/_content_ops_input_provider.py
+- Passed: git diff --check
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-package-handoff-pr-body.md
+
+## Estimated diff size
+
+Actual: 3 files, +125 / -17. This stays under the 400 LOC soft cap because it
+reuses the existing source-mode package and #1266's social-post dispatcher.
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider defaults and copy | ~17 |
+| Host provider tests | ~39 |
+| Plan doc | ~86 |
+| **Total** | **~142** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -59,6 +59,9 @@ class _RunnableService:
         return {"kwargs": kwargs}
 
 
+_MARKETER_OUTPUTS = ("landing_page", "blog_post", "sales_brief", "social_post")
+
+
 def _route(router, path: str, method: str):
     for route in router.routes:
         if getattr(route, "path", None) == path and method.upper() in getattr(
@@ -162,7 +165,7 @@ def test_review_source_material_builds_landing_blog_and_sales_brief_inputs() -> 
     preview = preview_control_surface(request)
 
     assert package.provider == "atlas_review_request"
-    assert request.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert request.outputs == _MARKETER_OUTPUTS
     assert request.ingestion_profile == "existing_evidence"
     assert request.inputs["source_type"] == "reviews"
     assert request.inputs["brief_type"] == "discovery"
@@ -208,7 +211,7 @@ def test_competitive_source_material_builds_landing_and_blog_inputs() -> None:
     preview = preview_control_surface(request)
 
     assert package.provider == "atlas_competitive_request"
-    assert request.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert request.outputs == _MARKETER_OUTPUTS
     assert request.ingestion_profile == "existing_evidence"
     assert request.inputs["source_type"] == "competitive"
     assert request.inputs["competitive_source_material"][0]["target_id"] == "competitive-1"
@@ -233,7 +236,7 @@ def test_competitive_source_material_accepts_competitive_bundle_alias() -> None:
     )
 
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert package.outputs == _MARKETER_OUTPUTS
     assert package.inputs["source_material"][0]["source_type"] == "competitive"
     assert package.inputs["source_material"][0]["target_id"] == "competitive-1"
     assert package.metadata["source_row_count"] == 1
@@ -272,7 +275,7 @@ def test_review_source_material_accepts_review_bundle_alias() -> None:
     )
 
     assert package.provider == "atlas_review_request"
-    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert package.outputs == _MARKETER_OUTPUTS
     assert package.inputs["source_material"][0]["source_type"] == "review"
     assert package.metadata["included_row_count"] == 1
 
@@ -448,7 +451,7 @@ async def test_review_mode_fetches_persisted_targets_by_tenant_scope() -> None:
     ]
     assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
     assert package.provider == "atlas_review_request"
-    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert package.outputs == _MARKETER_OUTPUTS
     assert package.metadata["source_target_loaded_count"] == 2
     assert package.metadata["included_row_count"] == 2
     assert {row["source_type"] for row in package.inputs["source_material"]} == {
@@ -492,7 +495,7 @@ async def test_competitive_mode_fetches_persisted_targets_by_tenant_scope() -> N
     ]
     assert {call["account_id"] for call in pool["opportunity_calls"]} == {"acct-1"}
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert package.outputs == _MARKETER_OUTPUTS
     assert package.metadata["source_target_loaded_count"] == 2
     assert package.metadata["included_row_count"] == 2
     assert package.inputs["competitive_alternatives"] == ["Teams", "Confluence"]
@@ -514,7 +517,7 @@ async def test_competitive_mode_fetches_b2b_displacement_dynamics_by_tracked_ven
     )
 
     assert package.provider == "atlas_competitive_request"
-    assert package.outputs == ("landing_page", "blog_post", "sales_brief")
+    assert package.outputs == _MARKETER_OUTPUTS
     assert package.metadata["b2b_displacement_vendor_count"] == 2
     assert package.metadata["b2b_displacement_loaded_count"] == 1
     assert package.metadata["b2b_displacement_missing_vendor_count"] == 1
@@ -626,6 +629,7 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
             blog_post=_RunnableService(),
             landing_page=_RunnableService(),
             sales_brief=_RunnableService(),
+            social_post=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -643,6 +647,11 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
     sales_brief_kwargs = sales_brief_step.result["kwargs"]
     assert sales_brief_kwargs["default_brief_type"] == "discovery"
     assert sales_brief_kwargs["source_material"][0]["target_id"] == "review-1"
+
+    social_post_step = next(step for step in result.steps if step.output == "social_post")
+    social_post_kwargs = social_post_step.result["kwargs"]
+    assert social_post_kwargs["source_material"][0]["target_id"] == "review-1"
+    assert social_post_kwargs["target_mode"] == "vendor_retention"
 
 
 @pytest.mark.asyncio
@@ -665,6 +674,7 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
             blog_post=_RunnableService(),
             landing_page=_RunnableService(),
             sales_brief=_RunnableService(),
+            social_post=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -683,6 +693,11 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
     assert sales_brief_kwargs["default_brief_type"] == "displacement"
     assert sales_brief_kwargs["source_material"][0]["target_id"] == "competitive-1"
 
+    social_post_step = next(step for step in result.steps if step.output == "social_post")
+    social_post_kwargs = social_post_step.result["kwargs"]
+    assert social_post_kwargs["source_material"][0]["target_id"] == "competitive-1"
+    assert social_post_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.skipif(
     api_module.APIRouter is None,
@@ -696,6 +711,8 @@ async def test_plan_route_applies_review_input_provider() -> None:
         execution_services_provider=lambda: ContentOpsExecutionServices(
             blog_post=_RunnableService(),
             landing_page=_RunnableService(),
+            sales_brief=_RunnableService(),
+            social_post=_RunnableService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-review-route"),
     )
@@ -709,9 +726,5 @@ async def test_plan_route_applies_review_input_provider() -> None:
     })
 
     assert payload["can_execute"] is True
-    assert [step["output"] for step in payload["steps"]] == [
-        "landing_page",
-        "blog_post",
-        "sales_brief",
-    ]
-    assert payload["preview"]["outputs"] == ["landing_page", "blog_post", "sales_brief"]
+    assert [step["output"] for step in payload["steps"]] == list(_MARKETER_OUTPUTS)
+    assert payload["preview"]["outputs"] == list(_MARKETER_OUTPUTS)


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Package-Handoff.md
Slice phase: Vertical slice

Adds `social_post` to the review and competitive source-mode input-package defaults now that #1266 made the deterministic social-post output executable from normalized source material.

## Intentional
- No new source adapter or generator logic; this reuses #1266's `social_post` dispatcher and the existing review/competitive source packages.
- No UI selector changes; New Run source modes consume these package defaults automatically.
- No changes to #1268 output variations; that open PR is a separate workflow/process lane.

## Deferred
- Ad copy and stat/quote card package defaults remain future output slices.
- Persisting generated social posts into the generated-asset review queue remains future productization.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
- `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
- `python -m py_compile atlas_brain/_content_ops_input_provider.py`
- `git diff --check`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-package-handoff-pr-body.md` (passed)

## Diff size
3 files, +125 / -17