### PR TITLE
PR-Content-Ops-Social-Post-Review-Assets

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -94,6 +94,9 @@ from extracted_content_pipeline.signal_extraction import (
 from extracted_content_pipeline.social_post_generation import (
     SocialPostGenerationService,
 )
+from extracted_content_pipeline.social_post_postgres import (
+    PostgresSocialPostRepository,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownService,
 )
@@ -254,6 +257,16 @@ def _build_ticket_faq_service(*, pool: Any) -> TicketFAQMarkdownService | None:
     return TicketFAQMarkdownService(ticket_faqs=PostgresTicketFAQRepository(pool=pool))
 
 
+def _build_social_post_service(*, pool: Any) -> SocialPostGenerationService:
+    """Build social-post generation with optional draft persistence."""
+
+    if pool is None:
+        return _SOCIAL_POST_SERVICE
+    return SocialPostGenerationService(
+        social_posts=PostgresSocialPostRepository(pool=pool)
+    )
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -311,6 +324,7 @@ def build_content_ops_execution_services(
     report = None
     sales_brief = None
     blog_post = None
+    social_post = _SOCIAL_POST_SERVICE
     faq_markdown_service = _FAQ_MARKDOWN_SERVICE
     faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
     faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
@@ -355,6 +369,7 @@ def build_content_ops_execution_services(
             pool=pool,
             image_provider=image_provider,
         )
+        social_post = _build_social_post_service(pool=pool)
         faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
         faq_deflection_report = FAQDeflectionReportService(
@@ -363,7 +378,7 @@ def build_content_ops_execution_services(
 
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
-        social_post=_SOCIAL_POST_SERVICE,
+        social_post=social_post,
         landing_page=landing_page,
         campaign=campaign,
         report=report,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -306,6 +306,15 @@
       "target": "extracted_content_pipeline/social_post_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/social_post_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/social_post_postgres.py"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/331_social_posts.sql"
+    },
+    {
       "target": "extracted_content_pipeline/blog_ports.py"
     },
     {

--- a/extracted_content_pipeline/social_post_generation.py
+++ b/extracted_content_pipeline/social_post_generation.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from .campaign_customer_data import CampaignOpportunityWarning
 from .campaign_ports import TenantScope
 from .campaign_source_adapters import source_row_to_campaign_opportunity
+from .social_post_ports import SocialPostDraft, SocialPostRepository
 
 _ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
 
@@ -29,6 +30,7 @@ class SocialPostGenerationResult:
     posts: tuple[dict[str, Any], ...]
     warnings: tuple[CampaignOpportunityWarning, ...] = ()
     target_mode: str = "vendor_retention"
+    saved_ids: tuple[str, ...] = ()
 
     @property
     def generated(self) -> int:
@@ -40,14 +42,21 @@ class SocialPostGenerationResult:
             "target_mode": self.target_mode,
             "posts": [dict(post) for post in self.posts],
             "warnings": [warning.as_dict() for warning in self.warnings],
+            "saved_ids": list(self.saved_ids),
         }
 
 
 class SocialPostGenerationService:
     """Build short, evidence-backed social posts from source material."""
 
-    def __init__(self, config: SocialPostGenerationConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: SocialPostGenerationConfig | None = None,
+        *,
+        social_posts: SocialPostRepository | None = None,
+    ) -> None:
         self.config = config or SocialPostGenerationConfig()
+        self._social_posts = social_posts
 
     async def generate(
         self,
@@ -59,7 +68,6 @@ class SocialPostGenerationService:
         max_text_chars: int | None = None,
         **kwargs: Any,
     ) -> SocialPostGenerationResult:
-        del scope
         del kwargs
         resolved_limit = int(limit) if limit is not None else self.config.limit
         if resolved_limit < 1:
@@ -71,13 +79,23 @@ class SocialPostGenerationService:
         )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be at least 1")
-        return _generate_social_posts(
+        result = _generate_social_posts(
             _rows_from_source_material(source_material),
             target_mode=target_mode,
             limit=resolved_limit,
             max_text_chars=resolved_max_text_chars,
             max_post_chars=self.config.max_post_chars,
         )
+        if self._social_posts is None or not result.posts:
+            return result
+        saved_ids = tuple(
+            str(item)
+            for item in await self._social_posts.save_drafts(
+                _drafts_from_posts(result.posts, target_mode=target_mode),
+                scope=scope,
+            )
+        )
+        return replace(result, saved_ids=saved_ids)
 
 
 def _generate_social_posts(
@@ -163,6 +181,41 @@ def _post_from_opportunity(
     }
 
 
+def _drafts_from_posts(
+    posts: Sequence[Mapping[str, Any]],
+    *,
+    target_mode: str,
+) -> tuple[SocialPostDraft, ...]:
+    drafts: list[SocialPostDraft] = []
+    for post in posts:
+        source_id = _clean(post.get("source_id") or post.get("id"))
+        target_id = _clean(post.get("target_id")) or source_id
+        drafts.append(
+            SocialPostDraft(
+                target_id=target_id,
+                target_mode=target_mode,
+                channel=_clean(post.get("channel")) or "linkedin",
+                text=_clean(post.get("text")),
+                source_id=source_id,
+                source_type=_clean(post.get("source_type")),
+                company_name=_clean(post.get("company_name")),
+                vendor_name=_clean(post.get("vendor_name")),
+                pain_points=_pain_points_from_post(post.get("pain_points")),
+                metadata={"source_post": dict(post)},
+            )
+        )
+    return tuple(drafts)
+
+
+def _pain_points_from_post(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
+
+
 def _first_evidence(opportunity: Mapping[str, Any]) -> str:
     raw = opportunity.get("evidence")
     if isinstance(raw, Mapping):
@@ -221,4 +274,6 @@ __all__ = [
     "SocialPostGenerationConfig",
     "SocialPostGenerationResult",
     "SocialPostGenerationService",
+    "SocialPostDraft",
+    "SocialPostRepository",
 ]

--- a/extracted_content_pipeline/social_post_ports.py
+++ b/extracted_content_pipeline/social_post_ports.py
@@ -1,0 +1,89 @@
+"""Standalone ports for persisted social-post drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class SocialPostDraft:
+    """A generated, not-yet-approved social post."""
+
+    target_id: str
+    target_mode: str
+    channel: str
+    text: str
+    source_id: str = ""
+    source_type: str = ""
+    company_name: str = ""
+    vendor_name: str = ""
+    pain_points: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "channel": self.channel,
+            "text": self.text,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "company_name": self.company_name,
+            "vendor_name": self.vendor_name,
+            "pain_points": list(self.pain_points),
+            "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
+        }
+
+
+class SocialPostRepository(Protocol):
+    """Persistence contract for generated social-post drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SocialPostDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return assigned social-post ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        channel: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SocialPostDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft status and return True on hit."""
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched scope."""
+
+
+__all__ = [
+    "SocialPostDraft",
+    "SocialPostRepository",
+]

--- a/extracted_content_pipeline/social_post_postgres.py
+++ b/extracted_content_pipeline/social_post_postgres.py
@@ -1,0 +1,189 @@
+"""Postgres repository adapter for generated social-post drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .social_post_ports import SocialPostDraft
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_SOCIAL_POST_COLUMNS = (
+    "id, target_id, target_mode, channel, text, source_id, source_type, "
+    "company_name, vendor_name, pain_points, metadata, status"
+)
+
+
+def _draft_metadata(draft: SocialPostDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_string_sequence(value: Any) -> tuple[str, ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in decoded if str(item).strip())
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> SocialPostDraft:
+    return SocialPostDraft(
+        id=str(row.get("id") or ""),
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        channel=str(row.get("channel") or ""),
+        text=str(row.get("text") or ""),
+        source_id=str(row.get("source_id") or ""),
+        source_type=str(row.get("source_type") or ""),
+        company_name=str(row.get("company_name") or ""),
+        vendor_name=str(row.get("vendor_name") or ""),
+        pain_points=_json_string_sequence(row.get("pain_points")),
+        metadata=_json_mapping(row.get("metadata")),
+        status=str(row.get("status") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresSocialPostRepository:
+    """Async Postgres adapter for generated social posts."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[SocialPostDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            draft_id = await self.pool.fetchval(
+                """
+                INSERT INTO social_posts (
+                    account_id, target_id, target_mode, channel, text,
+                    source_id, source_type, company_name, vendor_name,
+                    pain_points, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6, $7, $8, $9,
+                    $10::jsonb, $11::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.channel,
+                draft.text,
+                draft.source_id,
+                draft.source_type,
+                draft.company_name,
+                draft.vendor_name,
+                json_dump_jsonb([str(item) for item in draft.pain_points]),
+                json_dump_jsonb(_draft_metadata(draft, scope)),
+            )
+            saved.append(str(draft_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        channel: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[SocialPostDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if channel is not None:
+            params.append(channel)
+            clauses.append(f"channel = ${len(params)}")
+        sql = (
+            f"SELECT {_SOCIAL_POST_COLUMNS} "
+            "FROM social_posts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE social_posts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1::uuid
+               AND account_id = $3
+            """,
+            draft_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in draft_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE social_posts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+__all__ = [
+    "PostgresSocialPostRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/331_social_posts.sql
+++ b/extracted_content_pipeline/storage/migrations/331_social_posts.sql
@@ -1,0 +1,33 @@
+-- Social posts: deterministic, evidence-backed social copy generated from
+-- Content Ops source material. One row is one reviewable social-post draft.
+--
+-- The status lifecycle mirrors the other generated assets: drafts start at
+-- 'draft' and host workflows can move them through 'approved', 'rejected', or
+-- custom intermediate states without a CHECK constraint.
+
+CREATE TABLE IF NOT EXISTS social_posts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    channel TEXT NOT NULL DEFAULT 'linkedin',
+    text TEXT NOT NULL,
+    source_id TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT '',
+    company_name TEXT NOT NULL DEFAULT '',
+    vendor_name TEXT NOT NULL DEFAULT '',
+    pain_points JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_posts_target
+    ON social_posts (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_posts_status
+    ON social_posts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_social_posts_channel
+    ON social_posts (account_id, channel, created_at DESC);

--- a/plans/PR-Content-Ops-Social-Post-Review-Assets.md
+++ b/plans/PR-Content-Ops-Social-Post-Review-Assets.md
@@ -1,0 +1,114 @@
+# PR: Content Ops Social Post Review Assets
+
+## Why this slice exists
+
+PR #1266 made `social_post` executable and PR #1270 put it into the review and
+competitive input-package defaults. The remaining productization gap is that a
+run returns social posts in the execution payload, but those drafts are not
+persisted anywhere. Operators cannot review, approve, or export them later.
+
+This slice is the persistence prerequisite for the review queue: generated
+social posts are saved as tenant-scoped draft rows when DB-backed Content Ops
+services are enabled. Keeping the API/UI switchboard for a follow-up preserves
+the thin-slice boundary while making the next route slice mechanical.
+
+The diff is over the 400 LOC soft cap because the persistence boundary is not
+safe to split below the table/contract/adapter/save-hook/host-wiring/tests set.
+A table without a save hook is dead schema; a save hook without the tenant
+adapter is not reviewable; and host wiring without focused tests risks another
+"declared but not exercised" generated-output gap.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a package-owned `SocialPostDraft` persistence contract and Postgres
+   adapter.
+2. Add the package migration for `social_posts` draft rows.
+3. Teach `SocialPostGenerationService` to persist generated posts when a
+   repository is injected, returning `saved_ids` in the result.
+4. Wire the host DB-backed service bundle to use the Postgres social-post
+   repository when `enable_db_services=True`.
+5. Add focused package and host tests proving tenant-scoped persistence and the
+   non-persistent fallback.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Social-Post-Review-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/social_post_ports.py`
+- `extracted_content_pipeline/social_post_postgres.py`
+- `extracted_content_pipeline/social_post_generation.py`
+- `extracted_content_pipeline/storage/migrations/331_social_posts.sql`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_social_post_generation.py`
+- `tests/test_extracted_social_post_postgres.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+
+## Mechanism
+
+`SocialPostGenerationService` already produces a tuple of post dictionaries from
+normalized source material. This slice converts those dictionaries into
+`SocialPostDraft` values and calls:
+
+```python
+await social_posts.save_drafts(drafts, scope=scope)
+```
+
+only when a repository is injected. The default constructor keeps today's
+deterministic in-memory behavior, so dependency-light extracted tests and hosts
+without DB services still receive the same `posts` payload.
+
+The Postgres adapter mirrors the existing generated-asset adapters: tenant scope
+is written to `account_id`, original source metadata remains in JSONB
+`metadata`, drafts start as `status = 'draft'`, and update/list helpers scope by
+`account_id`.
+
+## Intentional
+
+- No generated-assets API or frontend tab in this PR. The table and repository
+  must exist before the route switchboard can list/review/export social posts.
+- No LLM or quality-gate changes. `social_post` remains deterministic and uses
+  the same source-material checks from #1266.
+- No fallback to unscoped/global persistence. Host persistence only happens when
+  `enable_db_services=True` supplies the tenant-aware DB-backed service bundle.
+
+## Deferred
+
+- Next PR: add `social_post` to generated-assets API list/export/review/batch
+  switchboards and expose it to the asset review UI.
+- Ad copy and stat/quote card package defaults remain future output slices.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_social_post_generation.py tests/test_extracted_social_post_postgres.py -q (9 passed)
+- Passed: pytest tests/test_atlas_content_ops_execution_services.py -q (20 passed)
+- Passed: python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/social_post_postgres.py extracted_content_pipeline/social_post_ports.py atlas_brain/_content_ops_services.py
+- Passed: git diff --check
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2972 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-review-assets-pr-body.md
+
+## Estimated diff size
+
+Actual: 10 files, +783 / -12. This is above the 400 LOC soft cap because the
+persistence prerequisite is indivisible: the table, port, adapter, service save
+hook, host wiring, and focused tests have to land together or the next
+generated-assets route slice has no durable draft source to read.
+
+| Area | Estimated LOC |
+|---|---:|
+| Social-post contract, adapter, migration, and manifest | ~320 |
+| Generator save hook and host wiring | ~80 |
+| Focused package and host tests | ~278 |
+| Plan doc | ~94 |
+| **Total** | **~795** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -17,6 +17,7 @@ the host has wired. Currently:
 - `faq_markdown`: wired by default, but host callers can hide it from
   customer-executable output lists while keeping it as the internal
   deflection-report source.
+- `social_post`: deterministic; persists when DB services are enabled.
 - `faq_deflection_report` (this slice): always wired (stateless wrapper over
   `faq_markdown`).
 
@@ -26,7 +27,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (18 tests):
+Test inventory (20 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -45,18 +46,20 @@ Test inventory (18 tests):
 12. `blog_post` skips when no LLM (E4 fallback).
 13. `faq_markdown` runs through the full executor.
 14. `faq_markdown` persists when DB services are enabled.
-15. `faq_deflection_report` runs through the full executor.
-16. `configured_outputs()` with LLM + db enabled advertises
+15. `social_post` persists when DB services are enabled.
+16. `faq_deflection_report` runs through the full executor.
+17. `social_post` is always wired.
+18. `configured_outputs()` with LLM + db enabled advertises
     all 8 outputs: `(email_campaign, blog_post, report,
     landing_page, sales_brief, signal_extraction, faq_markdown,
     faq_deflection_report)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-17. `configured_outputs()` without an active LLM (even with
+19. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     deterministic outputs.
-18. The hosted paywall mode can hide `faq_markdown` while
+20. The hosted paywall mode can hide `faq_markdown` while
     retaining a runnable `faq_deflection_report`.
 """
 
@@ -70,6 +73,7 @@ import pytest
 from atlas_brain._content_ops_services import (
     build_content_ops_execution_services,
 )
+from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
@@ -101,12 +105,13 @@ def _make_pool_stub() -> Any:
 
 
 class _FAQPoolStub:
-    def __init__(self) -> None:
+    def __init__(self, return_id: str = "faq-uuid-1") -> None:
         self.fetchval_calls: list[dict[str, Any]] = []
+        self.return_id = return_id
 
     async def fetchval(self, query: str, *args: Any) -> str:
         self.fetchval_calls.append({"query": query, "args": args})
-        return "faq-uuid-1"
+        return self.return_id
 
 
 def _no_llm() -> None:
@@ -207,6 +212,49 @@ async def test_faq_markdown_persists_when_db_services_enabled() -> None:
     assert step["status"] == "completed"
     assert step["result"]["saved_ids"] == ["faq-uuid-1"]
     assert "INSERT INTO ticket_faq_markdown" in pool.fetchval_calls[0]["query"]
+
+
+@pytest.mark.asyncio
+async def test_social_post_persists_when_db_services_enabled() -> None:
+    pool = _FAQPoolStub(return_id="social-post-uuid-1")
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["social_post"],
+            "inputs": {
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "reviewer_company": "Acme Logistics",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                    "pain_category": "pricing pressure",
+                }]
+            },
+        },
+        services=services,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "social_post"
+    assert step["status"] == "completed"
+    assert step["result"]["saved_ids"] == ["social-post-uuid-1"]
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO social_posts" in call["query"]
+    assert call["args"][:5] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "linkedin",
+        step["result"]["posts"][0]["text"],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_social_post_generation.py
+++ b/tests/test_extracted_social_post_generation.py
@@ -7,6 +7,21 @@ from extracted_content_pipeline.social_post_generation import (
     SocialPostGenerationConfig,
     SocialPostGenerationService,
 )
+from extracted_content_pipeline.social_post_ports import SocialPostDraft
+
+
+class _SocialPostRepository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def save_drafts(
+        self,
+        drafts: list[SocialPostDraft] | tuple[SocialPostDraft, ...],
+        *,
+        scope: TenantScope,
+    ) -> tuple[str, ...]:
+        self.calls.append({"drafts": tuple(drafts), "scope": scope})
+        return ("social-post-db-id-1",)
 
 
 @pytest.mark.asyncio
@@ -49,6 +64,45 @@ async def test_social_post_service_generates_evidence_backed_posts() -> None:
             "pain_points": ["pricing pressure"],
         }
     ]
+    assert payload["saved_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_social_post_service_persists_generated_drafts_when_repository_is_configured() -> None:
+    repository = _SocialPostRepository()
+    service = SocialPostGenerationService(social_posts=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    assert result.saved_ids == ("social-post-db-id-1",)
+    assert result.as_dict()["saved_ids"] == ["social-post-db-id-1"]
+    assert len(repository.calls) == 1
+    call = repository.calls[0]
+    assert call["scope"] == TenantScope(account_id="acct-1", user_id="user-1")
+    drafts = call["drafts"]
+    assert isinstance(drafts, tuple)
+    draft = drafts[0]
+    assert draft.target_id == "review-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.channel == "linkedin"
+    assert draft.source_id == "review-1"
+    assert draft.source_type == "review"
+    assert draft.company_name == "Acme Logistics"
+    assert draft.vendor_name == "HubSpot"
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata["source_post"]["id"] == "review-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_social_post_postgres.py
+++ b/tests/test_extracted_social_post_postgres.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.social_post_ports import SocialPostDraft
+from extracted_content_pipeline.social_post_postgres import (
+    PostgresSocialPostRepository,
+)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.fetchval_calls: list[dict[str, object]] = []
+        self.fetch_calls: list[dict[str, object]] = []
+        self.execute_calls: list[dict[str, object]] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return self.execute_result
+
+
+def _compact_sql(query: object) -> str:
+    return " ".join(str(query).split())
+
+
+def _draft() -> SocialPostDraft:
+    return SocialPostDraft(
+        target_id="review-1",
+        target_mode="vendor_retention",
+        channel="linkedin",
+        text="Customer evidence for HubSpot flags pricing pressure.",
+        source_id="review-1",
+        source_type="review",
+        company_name="Acme Logistics",
+        vendor_name="HubSpot",
+        pain_points=("pricing pressure",),
+        metadata={"confidence": 0.88},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_social_posts_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["social-post-uuid-1"]
+    repo = PostgresSocialPostRepository(pool)
+
+    saved = await repo.save_drafts(
+        [_draft()],
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert saved == ("social-post-uuid-1",)
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO social_posts" in call["query"]
+    args = call["args"]
+    assert args[:9] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "linkedin",
+        "Customer evidence for HubSpot flags pricing pressure.",
+        "review-1",
+        "review",
+        "Acme Logistics",
+        "HubSpot",
+    )
+    assert json.loads(args[9]) == ["pricing pressure"]
+    metadata = json.loads(args[10])
+    assert metadata["target_id"] == "review-1"
+    assert metadata["target_mode"] == "vendor_retention"
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert metadata["confidence"] == 0.88
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_scope_status_target_mode_and_channel() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{
+        "id": "social-post-uuid-1",
+        "target_id": "review-1",
+        "target_mode": "vendor_retention",
+        "channel": "linkedin",
+        "text": "Customer evidence for HubSpot flags pricing pressure.",
+        "source_id": "review-1",
+        "source_type": "review",
+        "company_name": "Acme Logistics",
+        "vendor_name": "HubSpot",
+        "pain_points": json.dumps(["pricing pressure"]),
+        "metadata": json.dumps({"confidence": 0.88}),
+        "status": "draft",
+    }]
+    repo = PostgresSocialPostRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor_retention",
+        channel="linkedin",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.id == "social-post-uuid-1"
+    assert draft.channel == "linkedin"
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata == {"confidence": 0.88}
+    call = pool.fetch_calls[0]
+    assert "FROM social_posts" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert call["args"] == ("acct-1", "draft", "vendor_retention", "linkedin", 10)
+
+
+@pytest.mark.asyncio
+async def test_update_status_is_tenant_scoped_and_reports_misses() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresSocialPostRepository(pool)
+
+    updated = await repo.update_status(
+        "social-post-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is False
+    call = pool.execute_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE social_posts" in sql
+    assert "WHERE id = $1::uuid AND account_id = $3" in sql
+    assert call["args"] == ("social-post-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_returns_scoped_matches() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "social-post-uuid-1"}]
+    repo = PostgresSocialPostRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["social-post-uuid-1", ""],
+        "rejected",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ("social-post-uuid-1",)
+    call = pool.fetch_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE social_posts" in sql
+    assert "WHERE id = ANY($1::uuid[]) AND account_id = $3" in sql
+    assert call["args"] == (["social-post-uuid-1"], "rejected", "acct-1")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Review-Assets.md
Slice phase: Vertical slice

PR #1266 made `social_post` executable and PR #1270 added it to the review and competitive source packages. This slice adds the persistence prerequisite for the generated-asset review queue: social-post runs now save tenant-scoped draft rows when DB-backed Content Ops services are enabled.

## Intentional
- No generated-assets API or frontend tab in this PR; the route/UI switchboard is the next slice once the table and repository exist.
- No LLM or quality-gate changes. `social_post` remains deterministic and uses the same source-material checks from #1266.
- No fallback to unscoped/global persistence. Host persistence only happens when `enable_db_services=True` supplies the tenant-aware DB-backed service bundle.

## Deferred
- Next PR: add `social_post` to generated-assets API list/export/review/batch switchboards and expose it to the asset review UI.
- Ad copy and stat/quote card package defaults remain future output slices.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_extracted_social_post_generation.py tests/test_extracted_social_post_postgres.py -q` (9 passed)
- Passed: `pytest tests/test_atlas_content_ops_execution_services.py -q` (20 passed)
- Passed: `python -m py_compile extracted_content_pipeline/social_post_generation.py extracted_content_pipeline/social_post_postgres.py extracted_content_pipeline/social_post_ports.py atlas_brain/_content_ops_services.py`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
- Passed: `bash scripts/check_ascii_python.sh`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (2972 passed, 10 skipped, 1 warning)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-review-assets-pr-body.md`

## Diff size
10 files, +783 / -12. Above the 400 LOC soft cap because the persistence prerequisite needs the table, contract, adapter, migration manifest entry, save hook, host wiring, and focused tests together.
