### PR TITLE
Plan: plans/PR-Content-Ops-Social-Post-Generated-Assets.md

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Test Content Ops blog review public link
         run: npm run test:content-ops-blog-review-public-link
 
+      - name: Test Content Ops social post review assets
+        run: npm run test:content-ops-social-post-review-assets
+
       - name: Test Content Ops review source selection
         run: npm run test:content-ops-review-source-selection
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -22,6 +22,7 @@
     "test:content-ops-landing-page-e2e-ui": "node --test scripts/content-ops-landing-page-e2e-ui.test.mjs",
     "test:content-ops-upload-source-run-handoff": "node --test scripts/content-ops-upload-source-run-handoff.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
+    "test:content-ops-social-post-review-assets": "node --test scripts/content-ops-social-post-review-assets.test.mjs",
     "test:content-ops-review-source-selection": "node --test scripts/content-ops-review-source-selection.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-social-post-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-social-post-review-assets.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fetchGeneratedAssetDrafts,
+  reviewGeneratedAssetDraft,
+  reviewGeneratedAssetDrafts,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('social-post generated asset list fetches the typed content-assets route', async () => {
+  const payload = {
+    count: 1,
+    limit: 5,
+    filters: { status: 'draft', channel: 'linkedin' },
+    rows: [{
+      id: 'social-post-1',
+      status: 'draft',
+      channel: 'linkedin',
+      text: 'Acme support teams can spot churn risk before renewal.',
+    }],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchGeneratedAssetDrafts('social_post', {
+    status: 'draft',
+    channel: 'linkedin',
+    limit: 5,
+  })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/social_post/drafts?status=draft&channel=linkedin&limit=5`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('social-post generated asset review actions post to typed routes', async () => {
+  const calls = installFetchResponder({
+    account_id: 'acct-1',
+    asset: 'social_post',
+    id: 'social-post-1',
+    status: 'approved',
+    updated: true,
+  })
+
+  await reviewGeneratedAssetDraft('social_post', 'social-post-1', 'approved')
+  await reviewGeneratedAssetDrafts('social_post', ['social-post-1'], 'rejected')
+
+  assert.equal(calls.length, 2)
+  assert.equal(
+    calls[0].url,
+    `${API_ORIGIN}/api/v1/content-assets/social_post/drafts/review`,
+  )
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    id: 'social-post-1',
+    status: 'approved',
+  })
+  assert.equal(
+    calls[1].url,
+    `${API_ORIGIN}/api/v1/content-assets/social_post/drafts/review-batch`,
+  )
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    ids: ['social-post-1'],
+    status: 'rejected',
+  })
+})
+
+test('asset review UI exposes social-post tab and text preview branches', () => {
+  assert.ok(reviewSource.includes("id: 'social_post'"))
+  assert.ok(reviewSource.includes("label: 'Social Posts'"))
+  assert.ok(reviewSource.includes("asset === 'social_post'"))
+  assert.ok(reviewSource.includes('textValue(row.text)'))
+  assert.ok(reviewSource.includes('socialPostPainPointCount(row)'))
+  assert.ok(reviewSource.includes("pain: ${item}"))
+})
+
+test('completed social-post runs link into generated asset review', () => {
+  assert.match(
+    newRunSource,
+    /const GENERATED_ASSET_OUTPUTS:[\s\S]*'social_post'[\s\S]*\]/,
+  )
+  assert.ok(newRunSource.includes('function generatedAssetReviewHref'))
+  assert.ok(newRunSource.includes("params.set('asset', output)"))
+  assert.ok(newRunSource.includes('Review generated drafts'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -431,6 +431,7 @@ export type GeneratedAssetType =
   | 'report'
   | 'landing_page'
   | 'sales_brief'
+  | 'social_post'
   | 'faq_markdown'
 
 export interface GeneratedAssetRepairHistoryEntry {
@@ -468,6 +469,14 @@ export interface GeneratedAssetDraft {
   topic_type?: string
   campaign_name?: string
   brief_type?: string
+  channel?: string
+  text?: string
+  source_id?: string
+  source_type?: string
+  company_name?: string
+  vendor_name?: string
+  pain_points?: string[] | string
+  pain_point_count?: number
   description?: string
   summary?: string
   headline?: string
@@ -525,6 +534,7 @@ export interface GeneratedAssetListParams {
   slug?: string
   topic_type?: string
   brief_type?: string
+  channel?: string
   id?: string | string[]
   format?: string
   limit?: number

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -173,6 +173,11 @@ const ASSETS: Array<{
     description: 'Pre-call and account-facing sales enablement assets.',
   },
   {
+    id: 'social_post',
+    label: 'Social Posts',
+    description: 'Short-form posts generated from review and source evidence.',
+  },
+  {
     id: 'faq_markdown',
     label: 'FAQ Markdown',
     description: 'Grounded FAQ documents generated from support-ticket evidence.',
@@ -522,7 +527,7 @@ export default function ContentOpsAssetsReview() {
         </div>
       </header>
 
-      <section className="grid gap-3 md:grid-cols-5">
+      <section className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
         {ASSETS.map((item) => (
           <button
             key={item.id}
@@ -2084,6 +2089,15 @@ function publicAssetUrlPending(
 }
 
 function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string {
+  if (asset === 'social_post') {
+    return (
+      textValue(row.company_name) ||
+      textValue(row.vendor_name) ||
+      textValue(row.target_id) ||
+      excerpt(textValue(row.text), 72) ||
+      'social_post draft'
+    )
+  }
   return (
     textValue(row.title) ||
     textValue(row.headline) ||
@@ -2116,6 +2130,15 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
       .map(textValue)
       .filter(Boolean)
       .join(' | ')
+  }
+  if (asset === 'social_post') {
+    return [
+      row.channel,
+      row.company_name,
+      row.vendor_name,
+      row.source_type,
+      row.source_id,
+    ].map(textValue).filter(Boolean).join(' | ')
   }
   if (asset === 'faq_markdown') {
     return [
@@ -2172,6 +2195,14 @@ function addAssetSpecificFacts(
     addFact(facts, 'source rows', row.source_count)
     addFact(facts, 'checks passed', row.passed_output_checks)
     addFact(facts, 'vocab gaps', faqVocabularyGapCount(row.items))
+    return
+  }
+  if (asset === 'social_post') {
+    addFact(facts, 'channel', row.channel)
+    addFact(facts, 'company', row.company_name)
+    addFact(facts, 'vendor', row.vendor_name)
+    addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
+    addFact(facts, 'pain points', socialPostPainPointCount(row))
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -2241,6 +2272,17 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
         vocabularyGapCount ? `vocab gaps: ${vocabularyGapCount}` : '',
         ...checks.slice(0, 3).map((check) => `check: ${check}`),
       ].filter(Boolean),
+    })
+  }
+  if (asset === 'social_post') {
+    const painPoints = valueList(row.pain_points).slice(0, 3)
+    return previewOrNull({
+      heading: [
+        textValue(row.channel),
+        textValue(row.company_name) || textValue(row.vendor_name),
+      ].filter(Boolean).join(' | '),
+      body: excerpt(textValue(row.text), 280),
+      meta: painPoints.map((item) => `pain: ${item}`),
     })
   }
   const section = firstSection(row.sections)
@@ -2396,6 +2438,13 @@ function readinessMeta(row: GeneratedAssetDraft): string[] {
     readinessLabel(row.seo_aeo_readiness, 'SEO/AEO'),
     readinessLabel(row.geo_readiness, 'GEO'),
   ].filter(Boolean)
+}
+
+function socialPostPainPointCount(row: GeneratedAssetDraft): number | string {
+  if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
+    return row.pain_point_count
+  }
+  return valueList(row.pain_points).length || ''
 }
 
 function readinessLabel(value: unknown, prefix?: string): string {

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -164,6 +164,7 @@ const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'landing_page',
   'sales_brief',
   'faq_markdown',
+  'social_post',
 ]
 const ID_FILTERED_REVIEW_OUTPUTS = new Set<string>([
   'blog_post',

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -45,6 +45,8 @@ from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
 from ..sales_brief_export import export_sales_brief_drafts
 from ..sales_brief_postgres import PostgresSalesBriefRepository
+from ..social_post_export import export_social_post_drafts
+from ..social_post_postgres import PostgresSocialPostRepository
 from ..ticket_faq_export import export_ticket_faq_drafts
 from ..ticket_faq_postgres import PostgresTicketFAQRepository
 
@@ -58,7 +60,14 @@ MacroPublishProviderFactory = Callable[
     MacroPublishProvider | Awaitable[MacroPublishProvider],
 ]
 
-ASSET_CHOICES = ("blog_post", "report", "landing_page", "sales_brief", "faq_markdown")
+ASSET_CHOICES = (
+    "blog_post",
+    "report",
+    "landing_page",
+    "sales_brief",
+    "social_post",
+    "faq_markdown",
+)
 logger = logging.getLogger(__name__)
 
 
@@ -280,6 +289,7 @@ def create_generated_asset_router(
         slug: str | None = Query(None),
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
+        channel: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
@@ -297,6 +307,7 @@ def create_generated_asset_router(
             slug=slug,
             topic_type=topic_type,
             brief_type=brief_type,
+            channel=channel,
             ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
@@ -312,6 +323,7 @@ def create_generated_asset_router(
         slug: str | None = Query(None),
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
+        channel: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
@@ -330,6 +342,7 @@ def create_generated_asset_router(
             slug=slug,
             topic_type=topic_type,
             brief_type=brief_type,
+            channel=channel,
             ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
@@ -713,6 +726,7 @@ async def _export_for_asset(
     slug: str | None,
     topic_type: str | None,
     brief_type: str | None,
+    channel: str | None,
     ids: Sequence[str] | None,
     limit: int,
 ) -> Any:
@@ -758,6 +772,15 @@ async def _export_for_asset(
             brief_type=brief_type,
             limit=limit,
         )
+    if asset == "social_post":
+        return await export_social_post_drafts(
+            PostgresSocialPostRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            channel=channel,
+            limit=limit,
+        )
     if asset == "faq_markdown":
         return await export_ticket_faq_drafts(
             PostgresTicketFAQRepository(pool),
@@ -785,6 +808,8 @@ async def _update_asset_status(
         return await PostgresLandingPageRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "social_post":
+        return await PostgresSocialPostRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_status(asset_id, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
@@ -806,6 +831,8 @@ async def _update_asset_statuses(
         return await PostgresLandingPageRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "sales_brief":
         return await PostgresSalesBriefRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "social_post":
+        return await PostgresSocialPostRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -306,6 +306,9 @@
       "target": "extracted_content_pipeline/social_post_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/social_post_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/social_post_ports.py"
     },
     {

--- a/extracted_content_pipeline/social_post_export.py
+++ b/extracted_content_pipeline/social_post_export.py
@@ -1,0 +1,131 @@
+"""Read-only social-post draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .campaign_ports import TenantScope
+from .social_post_ports import SocialPostDraft, SocialPostRepository
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "channel",
+    "company_name",
+    "vendor_name",
+    "source_id",
+    "source_type",
+    "pain_point_count",
+    "text",
+    "pain_points",
+    "metadata",
+    "id",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class SocialPostDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_social_post_drafts(
+    repository: SocialPostRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    channel: str | None = None,
+    limit: int = 20,
+) -> SocialPostDraftExportResult:
+    """Return generated social-post drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    if channel:
+        filters["channel"] = channel
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        channel=channel,
+        limit=normalized_limit,
+    )
+    return SocialPostDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: SocialPostDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["pain_point_count"] = len(draft.pain_points)
+    return row
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "SocialPostDraftExportResult",
+    "export_social_post_drafts",
+]

--- a/plans/PR-Content-Ops-Social-Post-Generated-Assets.md
+++ b/plans/PR-Content-Ops-Social-Post-Generated-Assets.md
@@ -1,0 +1,126 @@
+# PR: Content Ops Social Post Generated Assets
+
+## Why this slice exists
+
+PR #1271 persisted generated `social_post` drafts into tenant-scoped
+`social_posts` rows, but the generated-asset review API and UI still only know
+how to list, export, approve, and reject reports, blog posts, landing pages,
+sales briefs, and FAQ Markdown. That leaves the new durable social-post table
+invisible to operators.
+
+This slice completes the review-queue handoff from #1271: persisted social
+posts become a first-class generated asset in the existing review API and
+`atlas-intel-ui` generated-asset review screen.
+
+The diff is over the 400 LOC soft cap because this is the smallest safe
+end-to-end handoff: the backend export/review branches, frontend type/UI
+branches, CI-enrolled frontend test, and extracted API tests need to land
+together or `social_post` would be only partially reviewable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a package-owned social-post export helper that returns the same
+   `count`/`limit`/`filters`/`rows` envelope and CSV behavior as the sibling
+   generated assets.
+2. Add `social_post` to the generated-assets backend switchboards for list,
+   CSV/JSON export, single review, and batch review.
+3. Add `social_post` to the atlas-intel-ui API type surface and generated-asset
+   review asset registry.
+4. Render social-post rows with channel, company/vendor/source facts and the
+   post text as the preview body.
+5. Add `social_post` to the completed-run review CTA allowlist so saved social
+   post IDs hand off to the review tab without id filtering.
+6. Add backend and frontend tests proving the route/UI wiring, and enroll the
+   new frontend test in CI.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Social-Post-Generated-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/social_post_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-social-post-review-assets.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+
+## Mechanism
+
+`export_social_post_drafts(...)` wraps `PostgresSocialPostRepository.list_drafts`
+and maps each `SocialPostDraft` into a flat review/export row. The generated
+asset router then treats `social_post` like the other non-public generated
+assets:
+
+```python
+if asset == "social_post":
+    return await export_social_post_drafts(PostgresSocialPostRepository(pool), ...)
+```
+
+The same `_update_asset_status` and `_update_asset_statuses` helpers call the
+repository added in #1271, so review and batch review retain tenant-scoped
+`account_id` predicates from the adapter instead of duplicating SQL in the API
+layer.
+
+On the frontend, `GeneratedAssetType` and the review screen `ASSETS` registry
+include `social_post`. Existing fetch/review/export helpers already build URLs
+from the asset type, so the UI work is limited to rendering meaningful social
+post labels, facts, and preview text. `ContentOpsNewRun.tsx` also includes
+`social_post` in the generated-output allowlist used by
+`generatedAssetReviewHref(...)`; because the backend intentionally does not add
+id-filter repository support in this slice, the CTA links to the
+`social_post` draft review tab with no repeated `id` query keys.
+
+## Intentional
+
+- No public social-post URL support. Social posts are review/export assets, not
+  hosted public pages in this slice.
+- No edit/repair flow for social posts. The existing landing-page edit/repair
+  controls remain landing-page-only.
+- No ID deep-link filter for `social_post`. The #1271 repository lists by
+  status, target mode, and channel; adding id-filter repository support can be a
+  follow-up if run-result deep links need it.
+
+## Deferred
+
+- Ad-copy and stat/quote-card package defaults remain future output slices.
+- Optional social-post id deep links can be added after a product path actually
+  needs direct review links from generation results.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_content_asset_api.py -q` (70 passed)
+- Passed: `python -m py_compile extracted_content_pipeline/social_post_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-social-post-review-assets` (4 passed)
+- Passed: `cd atlas-intel-ui && npm run lint`
+- Passed: `cd atlas-intel-ui && npm run build`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
+- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
+- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- Passed: `bash scripts/check_ascii_python.sh`
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (2976 passed, 10 skipped, 1 warning)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-generated-assets-pr-body.md`
+
+## Estimated diff size
+
+Actual: 11 files, +619 / -2. Above the 400 LOC soft cap for the end-to-end
+handoff reasons named in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Social-post export helper + manifest | ~135 |
+| Backend switchboard + tests | ~135 |
+| Frontend type/UI/test/workflow enrollment | ~232 |
+| Plan doc | ~119 |
+| **Total** | **~621** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -426,6 +426,23 @@ def _sales_brief_row():
     }
 
 
+def _social_post_row():
+    return {
+        "id": "social-post-uuid-1",
+        "status": "draft",
+        "target_id": "review-1",
+        "target_mode": "review",
+        "channel": "linkedin",
+        "text": "Acme support teams can spot churn risk before renewal.",
+        "source_id": "source-1",
+        "source_type": "review",
+        "company_name": "Acme",
+        "vendor_name": "Zendesk",
+        "pain_points": ["slow response", "renewal pressure"],
+        "metadata": {"source_url": "https://example.test/reviews/1"},
+    }
+
+
 def _ticket_faq_row():
     return {
         "id": "faq-uuid-1",
@@ -1434,6 +1451,49 @@ def test_generated_asset_router_exports_ticket_faq_csv() -> None:
     assert args == ("", "draft", "support_account", 20)
 
 
+def test_generated_asset_router_lists_social_post_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_social_post_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/social_post/drafts"
+        "?target_mode=review&channel=linkedin&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    row = body["rows"][0]
+    assert row["id"] == "social-post-uuid-1"
+    assert row["channel"] == "linkedin"
+    assert row["text"] == "Acme support teams can spot churn risk before renewal."
+    assert row["pain_point_count"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM social_posts" in query
+    assert args == ("acct_1", "draft", "review", "linkedin", 5)
+
+
+def test_generated_asset_router_exports_social_post_csv() -> None:
+    pool = _Pool(rows=[_social_post_row()])
+
+    response = _client(pool).get(
+        "/content-assets/social_post/drafts/export"
+        "?format=csv&status=&target_mode=review&channel=linkedin"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_social_post.csv" in response.headers["content-disposition"]
+    assert "target_id,target_mode,channel" in response.text
+    assert "Acme support teams can spot churn risk before renewal." in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM social_posts" in query
+    assert "status = " not in query
+    assert args == ("", "review", "linkedin", 20)
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 
@@ -1457,6 +1517,27 @@ def test_generated_asset_router_reviews_report_with_host_defined_status() -> Non
     query, args = pool.execute_calls[0]
     assert "UPDATE reports" in query
     assert args == ("report-uuid-1", "published", "acct_1")
+
+
+def test_generated_asset_router_reviews_social_post() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/social_post/drafts/review",
+        json={"id": "social-post-uuid-1", "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct_1",
+        "asset": "social_post",
+        "id": "social-post-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE social_posts" in query
+    assert args == ("social-post-uuid-1", "approved", "acct_1")
 
 
 def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
@@ -1795,6 +1876,31 @@ def test_generated_asset_router_batch_reviews_reports() -> None:
     assert "UPDATE reports" in query
     assert "RETURNING id" in query
     assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "approved", "acct_1")
+
+
+def test_generated_asset_router_batch_reviews_social_posts() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/social_post/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
+            "status": "rejected",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset"] == "social_post"
+    assert response.json()["updated"] == 2
+    assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE social_posts" in query
+    assert "RETURNING id" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
+    assert pool.execute_calls == []
 
 
 def test_generated_asset_router_batch_reviews_reports_misses() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Social-Post-Generated-Assets.md
Slice phase: Vertical slice

PR #1271 persisted generated `social_post` drafts into tenant-scoped `social_posts` rows, but the generated-asset review API and UI still only knew how to list, export, approve, and reject reports, blog posts, landing pages, sales briefs, and FAQ Markdown. This slice completes the review-queue handoff: persisted social posts become a first-class generated asset in the existing review API, `atlas-intel-ui` generated-asset review screen, and completed-run review CTA.

## Intentional
- No public social-post URL support. Social posts are review/export assets, not hosted public pages in this slice.
- No edit/repair flow for social posts. The existing landing-page edit/repair controls remain landing-page-only.
- No ID deep-link filter for `social_post`. The #1271 repository lists by status, target mode, and channel; the completed-run CTA links to the social-post draft tab without repeated id query keys.

## Deferred
- Ad-copy and stat/quote-card package defaults remain future output slices.
- Optional social-post id deep links can be added after a product path actually needs direct review links from generation results.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_extracted_content_asset_api.py -q` (70 passed)
- Passed: `python -m py_compile extracted_content_pipeline/social_post_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
- Passed: `cd atlas-intel-ui && npm run test:content-ops-social-post-review-assets` (4 passed)
- Passed: `cd atlas-intel-ui && npm run lint`
- Passed: `cd atlas-intel-ui && npm run build`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
- Passed: `bash scripts/check_ascii_python.sh`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (2976 passed, 10 skipped, 1 warning)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-social-post-generated-assets-pr-body.md`

## Diff size
11 files, +619 / -2. Above the 400 LOC soft cap for the end-to-end handoff reasons named in the plan.
