### PR TITLE
Plan: plans/PR-Deflection-Snapshot-Counts.md

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -40,6 +40,14 @@ body-withheld (`body_withheld: true`) and exist only to show answer structure.
 Do not derive other answer text, evidence, source IDs, or Markdown from this
 object.
 
+For Support Tax or FOMO copy, use only raw measured count fields:
+`snapshot.summary.repeat_ticket_count`, visible
+`snapshot.top_questions[].ticket_count`, and locked
+`snapshot.locked_questions[].ticket_count`. `weighted_frequency` is a ranking
+score, not a customer-specific ticket count; do not use it for spend
+calculations or projections. `locked_questions` intentionally exposes only
+rank and ticket count, with question text withheld until paid unlock.
+
 ## Portfolio Submit Endpoint
 
 The production PII-safe submit path is an authenticated server-to-server

--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -1,8 +1,10 @@
 {
+  "locked_questions": [],
   "summary": {
     "drafted_answer_count": 1,
     "generated": 2,
-    "no_proven_answer_count": 1
+    "no_proven_answer_count": 1,
+    "repeat_ticket_count": 4
   },
   "teaser": {
     "full_answer": {
@@ -25,12 +27,14 @@
       "customer_wording": "How do I export attribution reports?",
       "question": "How do I export attribution reports?",
       "rank": 1,
+      "ticket_count": 2,
       "weighted_frequency": 2
     },
     {
       "customer_wording": "Can I turn on SSO for all users?",
       "question": "Can I turn on SSO for all users?",
       "rank": 2,
+      "ticket_count": 2,
       "weighted_frequency": 2
     }
   ]

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -84,16 +84,24 @@ type DeflectionSnapshot = {
     generated: number;
     drafted_answer_count: number;
     no_proven_answer_count: number;
+    repeat_ticket_count: number;
   };
   top_questions: DeflectionSnapshotQuestion[];
+  locked_questions: DeflectionSnapshotLockedQuestion[];
   teaser: DeflectionSnapshotTeaser;
 };
 
 type DeflectionSnapshotQuestion = {
   rank: number;
   question: string;
+  ticket_count: number;
   weighted_frequency: number;
   customer_wording: string;
+};
+
+type DeflectionSnapshotLockedQuestion = {
+  rank: number;
+  ticket_count: number;
 };
 
 type DeflectionSnapshotTeaser = {
@@ -132,9 +140,17 @@ This shape intentionally excludes paid deliverable fields:
 - no `evidence_quotes`
 - no `source_ids`
 - no vocabulary term mappings
+- no locked question text; `locked_questions` contains only rank and raw
+  ticket count
 
 The teaser is fail-closed: only scoped `resolution_evidence` FAQ items are
 eligible. Preview entries never include answer body text.
+
+`ticket_count` and `summary.repeat_ticket_count` are raw measured counts from
+the report items/source rows. `weighted_frequency` is ranking metadata only and
+must not feed spend or cost copy. If raw counts are unavailable, count-dependent
+frontend projections should stay hidden rather than fall back to the ranking
+score.
 
 ## FAQ Item
 
@@ -239,8 +255,9 @@ type TicketFAQSearchResponse = {
 - Use `items` for ranked cards or sections, and `markdown` for the full report.
 - For `faq_deflection_report`, render top-level `markdown` as the deliverable.
   Use `summary` for proof badges and `faq_result` for drill-down cards.
-- For unpaid deflection results, render only `DeflectionSnapshot.summary` and
-  `DeflectionSnapshot.top_questions`. Do not infer answer text, evidence, or
+- For unpaid deflection results, render only `DeflectionSnapshot.summary`,
+  `DeflectionSnapshot.top_questions`, `DeflectionSnapshot.locked_questions`,
+  and `DeflectionSnapshot.teaser`. Do not infer answer text, evidence, or
   source IDs from the snapshot.
 - Show `source_count`, `ticket_source_count`, and `output_checks` as proof badges.
 - Show `answer_evidence_status` near steps. `draft_needs_review` means the

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -24,12 +24,16 @@ class DeflectionSnapshot:
 
     summary: dict[str, int]
     top_questions: tuple[dict[str, Any], ...]
+    locked_questions: tuple[dict[str, int], ...]
     teaser: dict[str, Any]
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "summary": dict(self.summary),
             "top_questions": [dict(question) for question in self.top_questions],
+            "locked_questions": [
+                dict(question) for question in self.locked_questions
+            ],
             "teaser": {
                 "full_answer": (
                     dict(self.teaser["full_answer"])
@@ -157,6 +161,7 @@ def build_deflection_snapshot(
         "generated": _int(summary.get("generated")),
         "drafted_answer_count": _int(summary.get("drafted_answer_count")),
         "no_proven_answer_count": _int(summary.get("no_proven_answer_count")),
+        "repeat_ticket_count": sum(_ticket_count(item) for item in items),
     }
     top_questions: list[dict[str, Any]] = []
     for rank, item in enumerate(items[:top_n], start=1):
@@ -164,14 +169,23 @@ def build_deflection_snapshot(
         top_questions.append({
             "rank": rank,
             "question": question,
+            "ticket_count": _ticket_count(item),
             "weighted_frequency": _int(
                 item.get("weighted_frequency") or item.get("frequency")
             ),
             "customer_wording": _snapshot_customer_wording(item, question),
         })
+    locked_questions = tuple(
+        {
+            "rank": rank,
+            "ticket_count": _ticket_count(item),
+        }
+        for rank, item in enumerate(items[top_n:], start=top_n + 1)
+    )
     return DeflectionSnapshot(
         summary=snapshot_summary,
         top_questions=tuple(top_questions),
+        locked_questions=locked_questions,
         teaser=_snapshot_teaser(items, preview_count=teaser_preview_count),
     )
 
@@ -205,6 +219,7 @@ def deflection_snapshot_content_opportunities(
             {
                 "rank": rank,
                 "question": question,
+                "ticket_count": _int(raw.get("ticket_count")),
                 "weighted_frequency": frequency,
                 "customer_wording": _text(raw.get("customer_wording")),
                 "opportunity_score": _int(raw.get("opportunity_score")) or frequency,
@@ -525,6 +540,14 @@ def _teaser_preview(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:
 def _source_count(item: Mapping[str, Any]) -> int:
     source_count = len(_texts(item.get("source_ids")))
     return source_count or _int(item.get("ticket_count"))
+
+
+def _ticket_count(item: Mapping[str, Any]) -> int:
+    ticket_count = _int(item.get("ticket_count"))
+    if ticket_count > 0:
+        return ticket_count
+    source_count = len(_texts(item.get("source_ids")))
+    return source_count if source_count > 0 else 0
 
 
 def _texts(value: Any) -> list[str]:

--- a/plans/PR-Deflection-Snapshot-Counts.md
+++ b/plans/PR-Deflection-Snapshot-Counts.md
@@ -1,0 +1,76 @@
+# PR-Deflection-Snapshot-Counts
+
+## Why this slice exists
+
+ATLAS issue #1272 is the backend prerequisite for atlas-portfolio#196 after the results-page teaser landed in atlas-portfolio#199. The portfolio needs real measured inputs for the inline Support Tax projection and locked 6-N rows, but the current unpaid snapshot exposes only question text, weighted ranking score, and teaser metadata. `weighted_frequency` is not a customer-specific ticket count, so using it for spend copy would violate the derived-number doctrine.
+
+This slice exposes raw ticket counts from the FAQ item/source evidence already used by the report generator, and keeps the paid trust boundary intact by publishing only rank and count for rows beyond the free top-N.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection
+Slice phase: Functional validation
+
+1. Add raw `ticket_count` to each free `top_questions` row using real item counts or source-row cardinality, never `weighted_frequency`.
+2. Add `summary.repeat_ticket_count` as the real total repeat-ticket volume available to the frontend projection.
+3. Add `locked_questions` for ranks beyond the free top-N with only `{ rank, ticket_count }`.
+4. Keep snapshot privacy fail-closed: no locked question text, answers, steps, evidence, source IDs, Markdown, FAQ result payloads, or term mappings leak through the new fields.
+5. Update frontend contract docs and the canonical snapshot example.
+
+### Files touched
+
+- `plans/PR-Deflection-Snapshot-Counts.md` - Plan doc for this slice.
+- `extracted_content_pipeline/faq_deflection_report.py` - Build and serialize raw-count and locked-row snapshot fields.
+- `scripts/smoke_content_ops_deflection_paid_postgres.py` - Keep the paid-gate smoke fixture on the current snapshot shape.
+- `tests/test_content_ops_deflection_report.py` - Pin raw count selection, locked-row withholding, and weighted-score non-fallback behavior.
+- `tests/test_extracted_content_control_surface_api.py` - Pin execute-route snapshot counts on the unpaid gated response.
+- `tests/test_extracted_content_ops_live_execute_harness.py` - Pin uncapped paid artifact snapshots with locked rank/count rows.
+- `tests/test_faq_deflection_paid_postgres_smoke.py` - Keep the paid-gate smoke assertions and Postgres fake aligned with the current snapshot/store contract.
+- `tests/test_smoke_content_ops_deflection_submit_handoff.py` - Keep the submit-handoff smoke fixture aligned with the current snapshot shape.
+- `tests/test_content_ops_faq_report_contract_docs.py` - Keep producer docs/examples in sync and reject paid-field leaks.
+- `docs/frontend/content_ops_faq_report_contract.md` - Document raw counts and locked rows.
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md` - Document count-dependent projection rules.
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json` - Canonical example payload.
+
+## Mechanism
+
+`build_deflection_snapshot` computes a raw count per FAQ item from `ticket_count` when present, otherwise from the real `source_ids` cardinality. If neither exists, the count is zero and the summary projection does not invent a replacement from `weighted_frequency`.
+
+Visible top questions keep the existing fields and add `ticket_count`. The snapshot summary adds `repeat_ticket_count` as the sum of raw item counts across the artifact. Rows after `top_n` are projected into a new `locked_questions` tuple containing only rank and raw ticket count.
+
+## Intentional
+
+- This is an ATLAS producer slice only. atlas-portfolio will consume the fields in a follow-up PR under atlas-portfolio#196.
+- `weighted_frequency` remains in the payload as ranking metadata, but it is deliberately not used as a fallback count.
+- `source_ids` are counted server-side only. The IDs themselves remain stripped from the free snapshot.
+- Locked rows publish every post-top-N rank with count metadata only. This supports 6-N FOMO rows without exposing customer wording before payment.
+- Cross-layer caller hints were inspected. The execute-route caller is covered by `test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report` and the live execute harness; the readonly opportunity helper is covered by `test_deflection_snapshot_content_opportunities_are_unpaid_safe`; `portfolio-ui` is a legacy/non-canonical consumer and the active atlas-portfolio handoff is covered by docs/examples; broad `as_dict` and `_Pool` hints are name-only false positives outside this slice's call path.
+
+## Deferred
+
+- atlas-portfolio rendering for the Support Tax projection, locked 6-N rows, and cost-per-ticket benchmark citation.
+- Live report validation after ATLAS deploys this producer change and the portfolio consumes it.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources tests/test_content_ops_deflection_report.py::test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions tests/test_content_ops_deflection_report.py::test_deflection_snapshot_content_opportunities_are_unpaid_safe tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q - 5 passed.
+- Command: pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_faq_deflection_paid_postgres_smoke.py::test_deflection_paid_postgres_smoke_seeds_locks_marks_paid_and_rereads tests/test_smoke_content_ops_deflection_submit_handoff.py -q - 60 passed, 1 warning.
+- Command: bash scripts/validate_extracted_content_pipeline.sh - passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 findings.
+- Command: bash scripts/check_ascii_python.sh - passed.
+- Command: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main - passed, 144 matching tests enrolled.
+- Command: bash scripts/run_extracted_pipeline_checks.sh - 2973 passed, 10 skipped, 1 warning.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | 72 |
+| Snapshot projection | 23 |
+| Smoke fixture | 3 |
+| Tests | 115 |
+| Docs/examples | 29 |
+| **Total** | **242** |

--- a/scripts/smoke_content_ops_deflection_paid_postgres.py
+++ b/scripts/smoke_content_ops_deflection_paid_postgres.py
@@ -263,15 +263,18 @@ def _smoke_payload(request_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
             "generated": 1,
             "drafted_answer_count": 1,
             "no_proven_answer_count": 0,
+            "repeat_ticket_count": 1,
         },
         "top_questions": [
             {
                 "rank": 1,
                 "question": "How do customers export attribution reports?",
+                "ticket_count": 1,
                 "weighted_frequency": 2,
                 "customer_wording": "How do I export attribution reports?",
             }
         ],
+        "locked_questions": [],
     }
     artifact = {
         "markdown": "# Smoke FAQ Deflection Report\n\nOpen Analytics and export.",

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -170,6 +170,7 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
                 "question": "How do I export attribution reports?",
                 "question_source": "customer_wording",
                 "weighted_frequency": 8,
+                "ticket_count": 4,
                 "answer": "Customers mention export trouble.",
                 "steps": ["Open Analytics and download the report."],
                 "evidence_quotes": ("ticket-export-1 said export failed",),
@@ -197,13 +198,21 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
             "generated": 2,
             "drafted_answer_count": 1,
             "no_proven_answer_count": 1,
+            "repeat_ticket_count": 5,
         },
         "top_questions": [
             {
                 "rank": 1,
                 "question": "How do I export attribution reports?",
+                "ticket_count": 4,
                 "weighted_frequency": 8,
                 "customer_wording": "How do I export attribution reports?",
+            }
+        ],
+        "locked_questions": [
+            {
+                "rank": 2,
+                "ticket_count": 1,
             }
         ],
         "teaser": {"full_answer": None, "previews": []},
@@ -211,6 +220,59 @@ def test_deflection_snapshot_strips_answers_evidence_and_sources() -> None:
     assert "Open Analytics" not in encoded
     assert "ticket-export-1" not in encoded
     assert "evidence" not in encoded
+
+
+def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=10,
+        ticket_source_count=10,
+        output_checks={"condensed": True},
+        items=(
+            {
+                "question": "How do I export attribution reports?",
+                "weighted_frequency": 99,
+                "ticket_count": 7,
+                "source_ids": ("ticket-export-1",),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            {
+                "question": "Can I enable SSO?",
+                "weighted_frequency": 88,
+                "source_ids": ("ticket-sso-1", "ticket-sso-2"),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            {
+                "question": "Weighted score is not a ticket count",
+                "weighted_frequency": 77,
+                "answer_evidence_status": "draft_needs_review",
+            },
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(
+        build_deflection_report_artifact(result),
+        top_n=1,
+    ).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot["summary"]["repeat_ticket_count"] == 9
+    assert snapshot["top_questions"] == [
+        {
+            "rank": 1,
+            "question": "How do I export attribution reports?",
+            "ticket_count": 7,
+            "weighted_frequency": 99,
+            "customer_wording": "",
+        }
+    ]
+    assert snapshot["locked_questions"] == [
+        {"rank": 2, "ticket_count": 2},
+        {"rank": 3, "ticket_count": 0},
+    ]
+    assert "Can I enable SSO?" not in encoded
+    assert "Weighted score is not a ticket count" not in encoded
+    assert "ticket-sso-1" not in encoded
 
 
 def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:
@@ -555,6 +617,7 @@ def test_deflection_snapshot_content_opportunities_are_unpaid_safe() -> None:
                 {
                     "rank": 1,
                     "question": "How do I export reports?",
+                    "ticket_count": 3,
                     "weighted_frequency": 5,
                     "customer_wording": "export reports",
                     "answer": "Open Analytics.",
@@ -573,6 +636,7 @@ def test_deflection_snapshot_content_opportunities_are_unpaid_safe() -> None:
         {
             "rank": 1,
             "question": "How do I export reports?",
+            "ticket_count": 3,
             "weighted_frequency": 5,
             "customer_wording": "export reports",
             "opportunity_score": 5,

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -184,19 +184,28 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
     encoded = json.dumps(payload, sort_keys=True)
 
     assert payload == producer_payload
-    assert set(payload) == {"summary", "top_questions", "teaser"}
+    assert set(payload) == {
+        "summary",
+        "top_questions",
+        "locked_questions",
+        "teaser",
+    }
     assert set(payload["summary"]) == {
         "generated",
         "drafted_answer_count",
         "no_proven_answer_count",
+        "repeat_ticket_count",
     }
     for question in payload["top_questions"]:
         assert set(question) == {
             "rank",
             "question",
+            "ticket_count",
             "weighted_frequency",
             "customer_wording",
         }
+    for question in payload["locked_questions"]:
+        assert set(question) == {"rank", "ticket_count"}
     assert set(payload["teaser"]) == {"full_answer", "previews"}
     if payload["teaser"]["full_answer"] is not None:
         assert set(payload["teaser"]["full_answer"]) == {
@@ -228,9 +237,9 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
         assert preview["body_withheld"] is True
     assert "markdown" not in encoded
     assert "faq_result" not in encoded
-    assert "steps" not in json.dumps(payload["top_questions"], sort_keys=True)
-    assert "evidence_quotes" not in encoded
     assert "source_ids" not in encoded
+    assert "evidence_quotes" not in encoded
+    assert "steps" not in json.dumps(payload["top_questions"], sort_keys=True)
 
 
 def test_content_ops_faq_report_contract_links_example() -> None:

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -2568,7 +2568,10 @@ async def test_execute_generation_route_returns_snapshot_for_unpaid_deflection_r
     assert result["snapshot"]["summary"]["generated"] == 2
     assert result["snapshot"]["summary"]["drafted_answer_count"] == 1
     assert result["snapshot"]["summary"]["no_proven_answer_count"] == 1
+    assert result["snapshot"]["summary"]["repeat_ticket_count"] == 2
     assert result["snapshot"]["top_questions"][0]["rank"] == 1
+    assert result["snapshot"]["top_questions"][0]["ticket_count"] == 1
+    assert result["snapshot"]["locked_questions"] == []
     assert result["snapshot"]["teaser"]["full_answer"]["answer"] == (
         "To resolve this, open Analytics and download the report."
     )

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -1015,8 +1015,14 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
         "generated": 4,
         "drafted_answer_count": 4,
         "no_proven_answer_count": 0,
+        "repeat_ticket_count": 4,
     }
     assert len(snapshot["top_questions"]) == 2
+    assert [question["ticket_count"] for question in snapshot["top_questions"]] == [1, 1]
+    assert snapshot["locked_questions"] == [
+        {"rank": 3, "ticket_count": 1},
+        {"rank": 4, "ticket_count": 1},
+    ]
     assert snapshot["teaser"]["full_answer"]["answer_evidence_status"] == (
         "resolution_evidence"
     )

--- a/tests/test_faq_deflection_paid_postgres_smoke.py
+++ b/tests/test_faq_deflection_paid_postgres_smoke.py
@@ -30,7 +30,7 @@ class _Pool:
     async def execute(self, query: str, *args: Any) -> str:
         self.execute_calls.append((query, args))
         if "INSERT INTO content_ops_deflection_reports" in query:
-            account_id, request_id, snapshot, artifact = args
+            account_id, request_id, snapshot, artifact, delivery_email = args
             key = (str(account_id), str(request_id))
             existing = self.rows.get(key, {})
             self.rows[key] = {
@@ -40,6 +40,7 @@ class _Pool:
                 "artifact": artifact,
                 "paid": bool(existing.get("paid")),
                 "payment_reference": existing.get("payment_reference"),
+                "delivery_email": delivery_email,
             }
             return "INSERT 0 1"
         if "UPDATE content_ops_deflection_reports" in query:
@@ -165,6 +166,7 @@ async def test_deflection_paid_postgres_smoke_seeds_locks_marks_paid_and_rereads
         "drafted_answer_count": 1,
         "generated": 1,
         "no_proven_answer_count": 0,
+        "repeat_ticket_count": 1,
     }
     assert payload["artifact_summary"] == payload["snapshot_summary"]
     assert len(pool.execute_calls) == 2

--- a/tests/test_smoke_content_ops_deflection_submit_handoff.py
+++ b/tests/test_smoke_content_ops_deflection_submit_handoff.py
@@ -24,15 +24,18 @@ SNAPSHOT = {
         "generated": 2,
         "drafted_answer_count": 1,
         "no_proven_answer_count": 1,
+        "repeat_ticket_count": 4,
     },
     "top_questions": [
         {
             "rank": 1,
             "question": "How do I export reports?",
+            "ticket_count": 3,
             "weighted_frequency": 3,
             "customer_wording": "How do I export reports?",
         }
     ],
+    "locked_questions": [{"rank": 2, "ticket_count": 1}],
 }
 
 


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Counts.md
Slice phase: Functional validation

Expose raw measured ticket counts and locked rank/count rows in the unpaid FAQ deflection snapshot so atlas-portfolio#196 can render Support Tax and FOMO copy without treating `weighted_frequency` as a cost input. Closes #1272.

## Intentional
- This is an ATLAS producer slice only. atlas-portfolio will consume the fields in a follow-up PR under atlas-portfolio#196.
- `weighted_frequency` remains ranking metadata and is deliberately not used as a fallback count.
- `source_ids` are counted server-side only; IDs remain stripped from the free snapshot.
- Locked rows publish every post-top-N rank with count metadata only, no customer wording before payment.
- Cross-layer caller hints were inspected: execute-route callers are covered by router/live harness tests, the readonly opportunity helper is covered by its unpaid-safe regression, `portfolio-ui` is legacy/non-canonical, and broad `as_dict`/`_Pool` hints are name-only false positives outside this call path.

## Deferred
- atlas-portfolio rendering for the Support Tax projection, locked 6-N rows, and cost-per-ticket benchmark citation.
- Live report validation after ATLAS deploys this producer change and the portfolio consumes it.

## Parked hardening
- None.

## Verification
- pytest tests/test_content_ops_deflection_report.py::test_deflection_snapshot_strips_answers_evidence_and_sources tests/test_content_ops_deflection_report.py::test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions tests/test_content_ops_deflection_report.py::test_deflection_snapshot_content_opportunities_are_unpaid_safe tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_content_ops_faq_report_contract_docs.py::test_content_ops_faq_deflection_snapshot_example_matches_producer_shape -q - 5 passed.
- pytest tests/test_content_ops_deflection_report.py tests/test_content_ops_faq_report_contract_docs.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n tests/test_faq_deflection_paid_postgres_smoke.py::test_deflection_paid_postgres_smoke_seeds_locks_marks_paid_and_rereads tests/test_smoke_content_ops_deflection_submit_handoff.py -q - 60 passed, 1 warning.
- bash scripts/validate_extracted_content_pipeline.sh - passed.
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- python scripts/audit_extracted_standalone.py --fail-on-debt - passed, 0 findings.
- bash scripts/check_ascii_python.sh - passed.
- python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main - passed, 144 matching tests enrolled.
- bash scripts/run_extracted_pipeline_checks.sh - 2973 passed, 10 skipped, 1 warning.
- bash scripts/local_pr_review.sh --current-pr-body-file /tmp/deflection-snapshot-counts-pr-body.md - passed.

## Diff size
12 files, +225 / -7
