### PR TITLE
Plan: plans/PR-Content-Ops-Marketer-Ad-Copy-Output.md

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -105,6 +105,23 @@
       "can_execute": false
     },
     {
+      "id": "ad_copy",
+      "label": "Ad Copy",
+      "description": "Short paid-media copy drafts from source evidence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.0,
+      "default_parse_retry_attempts": 0,
+      "default_quality_repair_attempts": 0,
+      "estimated_retry_adjusted_unit_cost_usd": 0.0,
+      "required_inputs": [
+        "source_material"
+      ],
+      "default_max_items": 3,
+      "reasoning_requirement": "absent",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
       "id": "signal_extraction",
       "label": "Signal Extraction",
       "description": "Extracted opportunity or churn signals from source evidence.",

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -11,6 +11,8 @@ Currently wired:
   with no external dependencies.
 - `social_post`: deterministic source-evidence social post drafts
   with no external dependencies.
+- `ad_copy`: deterministic source-evidence ad-copy drafts with no
+  external dependencies.
 - `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
   host LLM + Skill adapters from PR #453 +
   `PostgresLandingPageRepository` backed by the host's
@@ -38,6 +40,9 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from extracted_content_pipeline.ad_copy_generation import (
+    AdCopyGenerationService,
+)
 from extracted_content_pipeline.blog_blueprint_postgres import (
     PostgresBlogBlueprintRepository,
 )
@@ -109,6 +114,7 @@ from extracted_content_pipeline.ticket_faq_postgres import (
 # re-creating it per request would just churn allocations.
 _SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
 _SOCIAL_POST_SERVICE: SocialPostGenerationService = SocialPostGenerationService()
+_AD_COPY_SERVICE: AdCopyGenerationService = AdCopyGenerationService()
 _FAQ_MARKDOWN_SERVICE: TicketFAQMarkdownService = TicketFAQMarkdownService()
 _FAQ_DEFLECTION_REPORT_SERVICE: FAQDeflectionReportService = FAQDeflectionReportService(
     faq_markdown=_FAQ_MARKDOWN_SERVICE
@@ -325,6 +331,7 @@ def build_content_ops_execution_services(
     sales_brief = None
     blog_post = None
     social_post = _SOCIAL_POST_SERVICE
+    ad_copy = _AD_COPY_SERVICE
     faq_markdown_service = _FAQ_MARKDOWN_SERVICE
     faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
     faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
@@ -379,6 +386,7 @@ def build_content_ops_execution_services(
     return ContentOpsExecutionServices(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
         social_post=social_post,
+        ad_copy=ad_copy,
         landing_page=landing_page,
         campaign=campaign,
         report=report,

--- a/extracted_content_pipeline/ad_copy_generation.py
+++ b/extracted_content_pipeline/ad_copy_generation.py
@@ -1,0 +1,239 @@
+"""Deterministic ad-copy drafts from Content Ops source material."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .campaign_customer_data import CampaignOpportunityWarning
+from .campaign_ports import TenantScope
+from .campaign_source_adapters import source_row_to_campaign_opportunity
+
+_ROW_LIST_KEYS = ("sources", "opportunities", "reviews", "documents", "rows", "data")
+
+
+@dataclass(frozen=True)
+class AdCopyGenerationConfig:
+    """Config for deterministic source-material ad copy."""
+
+    limit: int = 3
+    max_text_chars: int = 600
+    max_headline_chars: int = 90
+    max_primary_text_chars: int = 240
+
+
+@dataclass(frozen=True)
+class AdCopyGenerationResult:
+    """Generated ad copy plus non-fatal source-material warnings."""
+
+    ads: tuple[dict[str, Any], ...]
+    warnings: tuple[CampaignOpportunityWarning, ...] = ()
+    target_mode: str = "vendor_retention"
+
+    @property
+    def generated(self) -> int:
+        return len(self.ads)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "generated": self.generated,
+            "target_mode": self.target_mode,
+            "ads": [dict(ad) for ad in self.ads],
+            "warnings": [warning.as_dict() for warning in self.warnings],
+        }
+
+
+class AdCopyGenerationService:
+    """Build short, evidence-backed ad copy from source material."""
+
+    def __init__(self, config: AdCopyGenerationConfig | None = None) -> None:
+        self.config = config or AdCopyGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        source_material: Any,
+        limit: int | None = None,
+        max_text_chars: int | None = None,
+        **kwargs: Any,
+    ) -> AdCopyGenerationResult:
+        del scope
+        del kwargs
+        resolved_limit = int(limit) if limit is not None else self.config.limit
+        if resolved_limit < 1:
+            raise ValueError("limit must be at least 1")
+        resolved_max_text_chars = (
+            int(max_text_chars)
+            if max_text_chars is not None
+            else self.config.max_text_chars
+        )
+        if resolved_max_text_chars < 1:
+            raise ValueError("max_text_chars must be at least 1")
+        return _generate_ad_copy(
+            _rows_from_source_material(source_material),
+            target_mode=target_mode,
+            limit=resolved_limit,
+            max_text_chars=resolved_max_text_chars,
+            max_headline_chars=self.config.max_headline_chars,
+            max_primary_text_chars=self.config.max_primary_text_chars,
+        )
+
+
+def _generate_ad_copy(
+    rows: Sequence[Any],
+    *,
+    target_mode: str,
+    limit: int,
+    max_text_chars: int,
+    max_headline_chars: int,
+    max_primary_text_chars: int,
+) -> AdCopyGenerationResult:
+    ads: list[dict[str, Any]] = []
+    warnings: list[CampaignOpportunityWarning] = []
+    for index, row in enumerate(rows, start=1):
+        if len(ads) >= limit:
+            break
+        if not isinstance(row, Mapping):
+            warnings.append(CampaignOpportunityWarning(
+                code="row_not_object",
+                row_index=index,
+                message="Skipped source row because it is not an object.",
+            ))
+            continue
+        opportunity, row_warnings = source_row_to_campaign_opportunity(
+            row,
+            row_index=index,
+            max_text_chars=max_text_chars,
+        )
+        warnings.extend(row_warnings)
+        ad = _ad_from_opportunity(
+            opportunity,
+            index=len(ads) + 1,
+            max_headline_chars=max_headline_chars,
+            max_primary_text_chars=max_primary_text_chars,
+        )
+        if ad is None:
+            warnings.append(CampaignOpportunityWarning(
+                code="missing_ad_copy_evidence",
+                row_index=index,
+                message="Skipped source row because it did not contain usable evidence.",
+            ))
+            continue
+        ads.append(ad)
+    return AdCopyGenerationResult(
+        ads=tuple(ads),
+        warnings=tuple(warnings),
+        target_mode=target_mode,
+    )
+
+
+def _ad_from_opportunity(
+    opportunity: Mapping[str, Any],
+    *,
+    index: int,
+    max_headline_chars: int,
+    max_primary_text_chars: int,
+) -> dict[str, Any] | None:
+    if not opportunity:
+        return None
+    evidence = _first_evidence(opportunity)
+    if not evidence:
+        return None
+    vendor = _clean(opportunity.get("vendor_name") or opportunity.get("vendor"))
+    pain = _first_text(opportunity.get("pain_points"))
+    source_id = _clean(opportunity.get("source_id") or opportunity.get("target_id"))
+    headline_subject = pain or "customer proof"
+    headline = (
+        f"{vendor} proof: {headline_subject}"
+        if vendor
+        else f"Customer proof: {headline_subject}"
+    )
+    primary_parts = []
+    if vendor and pain:
+        primary_parts.append(f"When {vendor} buyers mention {pain}, use the proof.")
+    elif vendor:
+        primary_parts.append(f"Use real buyer evidence for {vendor}.")
+    elif pain:
+        primary_parts.append(f"Use real buyer evidence about {pain}.")
+    else:
+        primary_parts.append("Use real buyer evidence.")
+    primary_parts.append(f'"{evidence}"')
+    primary_parts.append("Turn review signal into the next campaign.")
+    return {
+        "id": source_id or f"ad-copy-{index}",
+        "channel": "paid_social",
+        "format": "single_image",
+        "headline": _truncate(headline, max_headline_chars),
+        "primary_text": _truncate(" ".join(primary_parts), max_primary_text_chars),
+        "cta": "See the proof",
+        "source_id": source_id,
+        "source_type": _clean(opportunity.get("source_type")),
+        "target_id": _clean(opportunity.get("target_id")),
+        "company_name": _clean(opportunity.get("company_name")),
+        "vendor_name": vendor,
+        "pain_points": list(opportunity.get("pain_points") or ()),
+    }
+
+
+def _first_evidence(opportunity: Mapping[str, Any]) -> str:
+    raw = opportunity.get("evidence")
+    if isinstance(raw, Mapping):
+        return _clean(raw.get("text"))
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        for item in raw:
+            if isinstance(item, Mapping):
+                text = _clean(item.get("text"))
+                if text:
+                    return text
+            else:
+                text = _clean(item)
+                if text:
+                    return text
+    return _clean(raw)
+
+
+def _first_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            text = _clean(item)
+            if text:
+                return text
+    return _clean(value)
+
+
+def _rows_from_source_material(source_material: Any) -> list[Any]:
+    if isinstance(source_material, str):
+        text = source_material.strip()
+        return [{"text": text}] if text else []
+    if isinstance(source_material, Mapping):
+        for key in _ROW_LIST_KEYS:
+            value = source_material.get(key)
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                return list(value)
+        return [dict(source_material)]
+    if isinstance(source_material, Sequence) and not isinstance(source_material, (bytes, bytearray)):
+        return list(source_material)
+    return []
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 3)].rstrip() + "..."
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "AdCopyGenerationConfig",
+    "AdCopyGenerationResult",
+    "AdCopyGenerationService",
+]

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -78,6 +78,7 @@ class ContentOpsExecutionServices:
     landing_page: Any | None = None
     sales_brief: Any | None = None
     social_post: Any | None = None
+    ad_copy: Any | None = None
     signal_extraction: Any | None = None
     faq_markdown: Any | None = None
     faq_deflection_report: Any | None = None
@@ -103,6 +104,8 @@ class ContentOpsExecutionServices:
             return self.sales_brief
         if output == "social_post":
             return self.social_post
+        if output == "ad_copy":
+            return self.ad_copy
         if output == "signal_extraction":
             return self.signal_extraction
         if output == "faq_markdown":
@@ -120,6 +123,7 @@ class ContentOpsExecutionServices:
             "landing_page",
             "sales_brief",
             "social_post",
+            "ad_copy",
             "signal_extraction",
             "faq_markdown",
             "faq_deflection_report",
@@ -190,6 +194,8 @@ class ContentOpsExecutionServices:
             landing_page=services["landing_page"],
             sales_brief=services["sales_brief"],
             social_post=self.social_post,
+            # ad_copy stays as-is; it does not consume reasoning.
+            ad_copy=self.ad_copy,
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
             # faq_markdown stays as-is; it does not consume reasoning.
@@ -653,6 +659,24 @@ async def _dispatch_social_post(
     )
 
 
+async def _dispatch_ad_copy(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del filters
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        source_material=request.inputs.get("source_material"),
+        limit=request.limit,
+        max_text_chars=_step_config_int(step.config, "max_text_chars"),
+    )
+
+
 async def _dispatch_faq_markdown(
     *,
     step: GenerationPlanStep,
@@ -743,6 +767,7 @@ _DISPATCH: Mapping[str, Any] = {
     "landing_page": _dispatch_landing_page,
     "blog_post": _dispatch_blog_post,
     "social_post": _dispatch_social_post,
+    "ad_copy": _dispatch_ad_copy,
     "signal_extraction": _dispatch_signal_extraction,
     "faq_markdown": _dispatch_faq_markdown,
     "faq_deflection_report": _dispatch_faq_deflection_report,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -198,6 +198,17 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         reasoning_requirement="absent",
         default_parse_retry_attempts=0,
     ),
+    "ad_copy": OutputDefinition(
+        id="ad_copy",
+        label="Ad Copy",
+        description="Short paid-media copy drafts from source evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.0,
+        required_inputs=("source_material",),
+        default_max_items=3,
+        reasoning_requirement="absent",
+        default_parse_retry_attempts=0,
+    ),
     "signal_extraction": OutputDefinition(
         id="signal_extraction",
         label="Signal Extraction",

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -71,6 +71,7 @@ Current output ids:
 | `landing_page` | Implemented | `optional_host_context` | Landing page generation service path. |
 | `sales_brief` | Implemented | `optional_host_context` | Sales brief generation service path. |
 | `social_post` | Implemented | `absent` | Deterministic source-evidence social post drafts; no LLM call. |
+| `ad_copy` | Implemented | `absent` | Deterministic source-evidence ad-copy drafts; no LLM call. |
 | `signal_extraction` | Implemented | `absent` | Deterministic source-row normalization into campaign opportunities; no LLM call. |
 
 Future outputs should be added to the catalog first, then exposed through
@@ -376,6 +377,7 @@ Runnable outputs dispatch to:
 | `landing_page` | `LandingPageGenerationService.generate(...)` |
 | `sales_brief` | `SalesBriefGenerationService.generate(...)` |
 | `social_post` | `SocialPostGenerationService.generate(...)` |
+| `ad_copy` | `AdCopyGenerationService.generate(...)` |
 | `signal_extraction` | `SignalExtractionService.generate(...)` |
 
 Non-executable plans return HTTP 400 with the blocked execution result. Missing

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field, replace
 from datetime import date
 from typing import Any, Mapping, Sequence
 
+from .ad_copy_generation import AdCopyGenerationConfig
 from .blog_generation import BlogPostGenerationConfig
 from .campaign_generation import CampaignGenerationConfig
 from .control_surfaces import (
@@ -216,6 +217,17 @@ def _social_post_config_for_request(request: ContentOpsRequest) -> SocialPostGen
     if max_text_chars is None:
         return config
     return SocialPostGenerationConfig(
+        limit=config.limit,
+        max_text_chars=max_text_chars,
+    )
+
+
+def _ad_copy_config_for_request(request: ContentOpsRequest) -> AdCopyGenerationConfig:
+    config = AdCopyGenerationConfig(limit=request.limit)
+    max_text_chars = _positive_int_input(request.inputs, "source_max_text_chars")
+    if max_text_chars is None:
+        return config
+    return AdCopyGenerationConfig(
         limit=config.limit,
         max_text_chars=max_text_chars,
     )
@@ -427,6 +439,17 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
         return GenerationPlanStep(
             output=output,
             runner="SocialPostGenerationService.generate",
+            status="runnable",
+            config={
+                "limit": config.limit,
+                "max_text_chars": config.max_text_chars,
+            },
+        )
+    if output == "ad_copy":
+        config = _ad_copy_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="AdCopyGenerationService.generate",
             status="runnable",
             config={
                 "limit": config.limit,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -306,6 +306,9 @@
       "target": "extracted_content_pipeline/social_post_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/ad_copy_generation.py"
+    },
+    {
       "target": "extracted_content_pipeline/social_post_export.py"
     },
     {

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -165,6 +165,11 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
         default_preset="none",
         supported_presets=("none",),
     ),
+    "ad_copy": OutputReasoningPolicy(
+        output="ad_copy",
+        default_preset="none",
+        supported_presets=("none",),
+    ),
     "faq_markdown": OutputReasoningPolicy(
         output="faq_markdown",
         default_preset="none",

--- a/plans/PR-Content-Ops-Marketer-Ad-Copy-Output.md
+++ b/plans/PR-Content-Ops-Marketer-Ad-Copy-Output.md
@@ -1,0 +1,143 @@
+# PR: Content Ops Marketer Ad Copy Output
+
+## Why this slice exists
+
+The marketer reviews-as-input lane has now productized one new short-form
+output, `social_post`, end to end through execution, package defaults,
+persistence, and generated-asset review. The same lane still has two deferred
+marketer asset families: ad copy and stat/quote cards. Operators can turn review
+or competitive source material into landing pages, blog posts, sales briefs,
+and social posts, but not short paid-media copy.
+
+This slice adds the first ad-copy vertical slice as a deterministic
+source-evidence generator. It mirrors the first `social_post` output slice:
+register an executable `ad_copy` output, generate bounded evidence-backed ad
+drafts from `source_material`, wire host execution, and prove preview/plan/run
+behavior. It does not touch #1268's plan-only output-variations lane.
+
+This PR may exceed the 400 LOC soft cap for the same indivisible first-output
+reason as `social_post`: the service, manifest entry, catalog exposure,
+generation plan, executor dispatch, host wiring, reasoning no-op policy, UI
+fixture, and tests need to land together or `ad_copy` is either invisible or not
+runnable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a package-owned deterministic `AdCopyGenerationService` that turns
+   source material into bounded ad-copy drafts with channel/format metadata and
+   non-fatal source-material warnings.
+2. Register `ad_copy` in the control-surface catalog, generation plan, executor
+   service bundle, host service factory, and no-op reasoning policy.
+3. Keep ad-copy generation source-evidence-only: no LLM prompt, persistence,
+   generated-asset review API/UI branch, or package-default enrollment in this
+   slice.
+4. Add focused tests for service output/warnings/limits, preview/plan mapping,
+   executor dispatch, host factory wiring, and catalog readiness.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Marketer-Ad-Copy-Output.md`
+- `extracted_content_pipeline/ad_copy_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_ad_copy_generation.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+
+## Mechanism
+
+`AdCopyGenerationService.generate(...)` accepts `source_material`, normalizes
+each row through the existing `source_row_to_campaign_opportunity(...)` adapter,
+and emits one ad draft per usable opportunity up to `limit`. Each draft carries:
+
+```python
+{
+    "id": source_id,
+    "format": "search_headline",
+    "headline": "...",
+    "primary_text": "...",
+    "cta": "See the proof",
+    "source_id": source_id,
+    "source_type": "review",
+    "company_name": "...",
+    "vendor_name": "...",
+    "pain_points": [...],
+}
+```
+
+The generator is deterministic and no-cost. `source_max_text_chars` controls the
+existing source-row adapter text cap, matching `signal_extraction` and
+`social_post`. `ContentOpsExecutionServices` gets an `ad_copy` slot and dispatch
+handler that passes `scope`, `target_mode`, `source_material`, `limit`, and
+`max_text_chars` to the service.
+
+## Intentional
+
+- No persistence or generated-asset review branch. This first slice proves the
+  output can run from source evidence; durable review/export handoff should
+  follow only after the reviewer accepts the output shape.
+- No package-default enrollment yet. Review/competitive package defaults remain
+  unchanged until the `ad_copy` output is executable and tested.
+- No #1268 output-variations work. `variant_count` and prompt-angle fan-out are
+  a separate plan-only lane and remain untouched.
+- No LLM ad-writing prompt. This slice keeps copy bounded to real review/source
+  evidence and avoids paid-media hallucination risk.
+
+## Deferred
+
+- Add `ad_copy` to review and competitive input-package defaults in the next
+  ad-copy handoff slice.
+- Persist generated ad-copy drafts into the generated-assets review queue after
+  the output shape is accepted.
+- Stat/quote card output remains the next marketer asset family after ad copy.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_ad_copy_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q` (316 passed, 1 skipped)
+- Passed: `pytest tests/test_extracted_content_ops_execution.py::test_services_with_reasoning_context_preserves_ad_copy_service tests/test_extracted_content_ops_execution.py::test_execute_runs_ad_copy_service_from_source_material tests/test_extracted_ad_copy_generation.py -q` (6 passed)
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-ingestion-limits` (10 passed)
+- Passed: `python -m json.tool atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json >/dev/null`
+- Passed: `python -m py_compile extracted_content_pipeline/ad_copy_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_ad_copy_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
+- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
+- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- Passed: `bash scripts/check_ascii_python.sh`
+- Passed: `cd atlas-intel-ui && npm run lint`
+- Passed: `cd atlas-intel-ui && npm run build`
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (2983 passed, 10 skipped, 1 warning)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-ad-copy-output-pr-body.md`
+
+## Estimated diff size
+
+Actual: 17 files, +763 / -2. This is above the 400 LOC soft cap because the
+first executable ad-copy output is not reviewable unless the service, catalog,
+planning, dispatch, host wiring, fixture, and tests land together.
+
+| Area | Estimated LOC |
+|---|---:|
+| Ad-copy service | ~239 |
+| Catalog/plan/executor/host/reasoning/docs/fixture wiring | ~86 |
+| Focused tests | ~291 |
+| Plan doc | ~143 |
+| **Total** | **~765** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -5,6 +5,7 @@
 the host has wired. Currently:
 
 - `signal_extraction` (E1, PR #452): always wired (stateless).
+- `ad_copy`: deterministic; always wired.
 - `landing_page` (E2 + E2.5, PRs #454/#455): wired when an
   LLM + pool are active; slot stays `None` otherwise.
 - `campaign` / `report` / `sales_brief` (E3, PR #456):
@@ -51,8 +52,8 @@ Test inventory (20 tests):
 17. `social_post` is always wired.
 18. `configured_outputs()` with LLM + db enabled advertises
     all 8 outputs: `(email_campaign, blog_post, report,
-    landing_page, sales_brief, signal_extraction, faq_markdown,
-    faq_deflection_report)` -- order
+    landing_page, sales_brief, social_post, ad_copy,
+    signal_extraction, faq_markdown, faq_deflection_report)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
@@ -305,6 +306,7 @@ async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None
     assert services.faq_deflection_report is not None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_deflection_report",
     )
@@ -354,6 +356,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
         "landing_page",
         "sales_brief",
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -376,6 +379,7 @@ def test_landing_page_slot_stays_none_when_no_active_llm() -> None:
     assert services.landing_page is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -402,6 +406,7 @@ def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
     assert services.landing_page is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -426,6 +431,7 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
     assert services.landing_page is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -487,6 +493,19 @@ def test_social_post_is_always_wired() -> None:
     assert services.for_output("social_post") is services.social_post
 
 
+def test_ad_copy_is_always_wired() -> None:
+    """Deterministic ad copy runs without LLM or DB services."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=False,
+    )
+    assert services.ad_copy is not None
+    assert services.for_output("ad_copy") is services.ad_copy
+
+
 def test_e3_services_skip_together_when_no_active_llm() -> None:
     """E3 fallback: campaign / report / sales_brief slots all
     stay `None` when no LLM is active. Same short-circuit shape
@@ -504,6 +523,7 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
     assert services.sales_brief is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -530,6 +550,7 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.blog_post is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -567,6 +588,7 @@ def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
     assert services.blog_post is None
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -592,6 +614,7 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         "landing_page",
         "sales_brief",
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -610,6 +633,7 @@ def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
     )
     assert services.configured_outputs() == (
         "social_post",
+        "ad_copy",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",

--- a/tests/test_extracted_ad_copy_generation.py
+++ b/tests/test_extracted_ad_copy_generation.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.ad_copy_generation import (
+    AdCopyGenerationConfig,
+    AdCopyGenerationService,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_service_generates_evidence_backed_ads() -> None:
+    service = AdCopyGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["target_mode"] == "vendor_retention"
+    assert payload["warnings"] == []
+    assert payload["ads"] == [
+        {
+            "id": "review-1",
+            "channel": "paid_social",
+            "format": "single_image",
+            "headline": "HubSpot proof: pricing pressure",
+            "primary_text": (
+                "When HubSpot buyers mention pricing pressure, use the proof. "
+                '"Pricing became hard to justify after renewal." Turn review '
+                "signal into the next campaign."
+            ),
+            "cta": "See the proof",
+            "source_id": "review-1",
+            "source_type": "review",
+            "target_id": "review-1",
+            "company_name": "Acme Logistics",
+            "vendor_name": "HubSpot",
+            "pain_points": ["pricing pressure"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_service_skips_unusable_rows_with_warnings() -> None:
+    service = AdCopyGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=["not a row", {"review_id": "missing-text"}],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 0
+    assert [warning["code"] for warning in payload["warnings"]] == [
+        "row_not_object",
+        "missing_source_text",
+        "missing_ad_copy_evidence",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_service_keeps_fields_within_configured_bounds() -> None:
+    config = AdCopyGenerationConfig(
+        max_headline_chars=28,
+        max_primary_text_chars=110,
+    )
+    service = AdCopyGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "vendor": "HubSpot",
+                "review_text": " ".join(["renewal pressure"] * 80),
+                "pain_category": "pricing pressure from enterprise renewals",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    ad = payload["ads"][0]
+    assert len(ad["headline"]) <= config.max_headline_chars
+    assert ad["headline"].endswith("...")
+    assert len(ad["primary_text"]) <= config.max_primary_text_chars
+    assert ad["primary_text"].endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_service_applies_limit_to_usable_rows() -> None:
+    service = AdCopyGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=2,
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify.",
+                "pain_category": "pricing pressure",
+            },
+            {
+                "review_id": "review-2",
+                "vendor": "Zendesk",
+                "review_text": "Support queues took too long to triage.",
+                "pain_category": "slow support",
+            },
+            {
+                "review_id": "review-3",
+                "vendor": "Intercom",
+                "review_text": "Reporting did not explain where leads came from.",
+                "pain_category": "unclear reporting",
+            },
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 2
+    assert [ad["source_id"] for ad in payload["ads"]] == ["review-1", "review-2"]

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -330,8 +330,10 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert "landing_page" in output_ids
     assert "faq_markdown" in output_ids
     assert "social_post" in output_ids
+    assert "ad_copy" in output_ids
     assert outputs["signal_extraction"]["implemented"] is True
     assert outputs["social_post"]["implemented"] is True
+    assert outputs["ad_copy"]["implemented"] is True
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
     assert outputs["email_campaign"]["estimated_unit_cost_usd"] == 0.18
@@ -392,6 +394,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["email_campaign"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["social_post"]["reasoning_requirement"] == "absent"
+    assert outputs["ad_copy"]["reasoning_requirement"] == "absent"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert outputs["faq_markdown"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {
@@ -532,6 +535,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
             campaign=_CampaignService(),
             report=_CampaignService(),
             social_post=_CampaignService(),
+            ad_copy=_CampaignService(),
             signal_extraction=_CampaignService(),
             faq_markdown=_CampaignService(),
         )
@@ -544,6 +548,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     assert payload["execution"] == {
         "configured": True,
         "configured_outputs": [
+                "ad_copy",
                 "email_campaign",
                 "faq_markdown",
                 "report",
@@ -558,6 +563,8 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     assert outputs["report"]["can_execute"] is True
     assert outputs["social_post"]["execution_configured"] is True
     assert outputs["social_post"]["can_execute"] is True
+    assert outputs["ad_copy"]["execution_configured"] is True
+    assert outputs["ad_copy"]["can_execute"] is True
     assert outputs["signal_extraction"]["execution_configured"] is True
     assert outputs["signal_extraction"]["can_execute"] is True
     assert outputs["faq_markdown"]["execution_configured"] is True

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -180,6 +180,24 @@ def test_preview_allows_social_post_when_source_material_present():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_allows_ad_copy_when_source_material_present():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["ad_copy"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["ad_copy"]
+    assert preview["missing_inputs"] == []
+    assert preview["blocked_outputs"] == []
+    assert preview["estimated_cost_usd"] == 0.0
+
+
 def test_preview_allows_faq_markdown_when_source_material_present():
     preview = preview_from_mapping(
         {
@@ -398,6 +416,19 @@ def test_preview_keeps_social_post_blocked_without_source_material():
     assert preview["missing_inputs"] == ["source_material"]
 
 
+def test_preview_keeps_ad_copy_blocked_without_source_material():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["ad_copy"],
+            "inputs": {},
+        }
+    )
+
+    assert preview["can_run"] is False
+    assert preview["outputs"] == ["ad_copy"]
+    assert preview["missing_inputs"] == ["source_material"]
+
+
 def test_output_catalog_states_reasoning_requirement():
     from extracted_content_pipeline.control_surfaces import OUTPUT_CATALOG
 
@@ -407,6 +438,7 @@ def test_output_catalog_states_reasoning_requirement():
     assert OUTPUT_CATALOG["sales_brief"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["social_post"].reasoning_requirement == "absent"
+    assert OUTPUT_CATALOG["ad_copy"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["faq_markdown"].reasoning_requirement == "absent"
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -499,6 +499,33 @@ def test_plan_maps_social_post_to_social_post_service():
     }
 
 
+def test_plan_maps_ad_copy_to_ad_copy_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["ad_copy"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing pressure came up at renewal.",
+                    }
+                ],
+                "source_max_text_chars": 300,
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "AdCopyGenerationService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "limit": 3,
+        "max_text_chars": 300,
+    }
+
+
 def test_plan_maps_faq_markdown_to_ticket_faq_service():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -11,6 +11,7 @@ from extracted_content_pipeline.campaign_ports import TenantScope
 from extracted_content_pipeline.campaign_llm_client import (
     current_content_ops_llm_trace_context,
 )
+from extracted_content_pipeline.ad_copy_generation import AdCopyGenerationService
 from extracted_content_pipeline.content_ops_cache_policy import (
     ContentOpsExactCachePolicy,
 )
@@ -167,6 +168,17 @@ def test_services_with_reasoning_context_can_target_specific_outputs() -> None:
     assert derived.report._reasoning_context is provider
     assert derived.reasoning_provider_active_for("report") is True
     assert derived.reasoning_provider_active_for("email_campaign") is False
+
+
+def test_services_with_reasoning_context_preserves_ad_copy_service() -> None:
+    ad_copy = AdCopyGenerationService()
+    derived = ContentOpsExecutionServices(ad_copy=ad_copy).with_reasoning_context(
+        object()
+    )
+
+    assert derived.ad_copy is ad_copy
+    assert derived.for_output("ad_copy") is ad_copy
+    assert "ad_copy" in derived.configured_outputs()
 
 
 def test_services_with_reasoning_context_accumulates_targeted_outputs() -> None:
@@ -610,6 +622,45 @@ async def test_execute_runs_social_post_service_from_source_material() -> None:
     assert post["source_id"] == "review-1"
     assert post["vendor_name"] == "HubSpot"
     assert "Pricing is a problem" in post["text"]
+    assert result["plan"]["steps"][0]["config"] == {
+        "limit": 1,
+        "max_text_chars": 20,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_ad_copy_service_from_source_material() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["ad_copy"],
+            "limit": 1,
+            "inputs": {
+                "source_max_text_chars": 20,
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "company": "Acme",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing is a problem after renewal.",
+                        "pain_category": "pricing pressure",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            ad_copy=AdCopyGenerationService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["output"] == "ad_copy"
+    assert step["runner"] == "AdCopyGenerationService.generate"
+    assert step["result"]["generated"] == 1
+    ad = step["result"]["ads"][0]
+    assert ad["source_id"] == "review-1"
+    assert ad["vendor_name"] == "HubSpot"
+    assert "Pricing is a problem" in ad["primary_text"]
     assert result["plan"]["steps"][0]["config"] == {
         "limit": 1,
         "max_text_chars": 20,

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -50,6 +50,7 @@ def test_output_policy_defaults_match_audit_recommendations() -> None:
     assert defaults == {
         "signal_extraction": "none",
         "social_post": "none",
+        "ad_copy": "none",
         "faq_markdown": "none",
         "faq_deflection_report": "none",
         "email_campaign": "single_pass",
@@ -104,6 +105,12 @@ def test_social_post_only_supports_no_reasoning() -> None:
     assert supported_reasoning_presets("social_post") == ("none",)
     with pytest.raises(ValueError, match="not supported"):
         resolve_reasoning_policy("social_post", "single_pass")
+
+
+def test_ad_copy_only_supports_no_reasoning() -> None:
+    assert supported_reasoning_presets("ad_copy") == ("none",)
+    with pytest.raises(ValueError, match="not supported"):
+        resolve_reasoning_policy("ad_copy", "single_pass")
 
 
 def test_faq_markdown_only_supports_no_reasoning() -> None:


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Marketer-Ad-Copy-Output.md
Slice phase: Vertical slice

The marketer reviews-as-input lane still lacks short paid-media copy. This slice adds a deterministic, evidence-backed `ad_copy` output that runs from `source_material`, appears in the control-surface catalog, plans and executes through the host service bundle, and stays separate from #1268's output-variations plan-only lane.

## Intentional
- No persistence or generated-asset review branch. This first slice proves the output can run from source evidence; durable review/export handoff should follow after the output shape is accepted.
- No package-default enrollment yet. Review/competitive package defaults remain unchanged until `ad_copy` is executable and tested.
- No #1268 output-variations work. `variant_count` and prompt-angle fan-out are a separate plan-only lane and remain untouched.
- No LLM ad-writing prompt. This slice keeps copy bounded to real review/source evidence and avoids paid-media hallucination risk.

## Deferred
- Add `ad_copy` to review and competitive input-package defaults in the next ad-copy handoff slice.
- Persist generated ad-copy drafts into the generated-assets review queue after the output shape is accepted.
- Stat/quote card output remains the next marketer asset family after ad copy.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_extracted_ad_copy_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q` (316 passed, 1 skipped)
- Passed: `pytest tests/test_extracted_content_ops_execution.py::test_services_with_reasoning_context_preserves_ad_copy_service tests/test_extracted_content_ops_execution.py::test_execute_runs_ad_copy_service_from_source_material tests/test_extracted_ad_copy_generation.py -q` (6 passed)
- Passed: `cd atlas-intel-ui && npm run test:content-ops-ingestion-limits` (10 passed)
- Passed: `python -m json.tool atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json >/dev/null`
- Passed: `python -m py_compile extracted_content_pipeline/ad_copy_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_ad_copy_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
- Passed: `bash scripts/check_ascii_python.sh`
- Passed: `cd atlas-intel-ui && npm run lint`
- Passed: `cd atlas-intel-ui && npm run build`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (2984 passed, 10 skipped, 1 warning)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-marketer-ad-copy-output-pr-body.md`

## Diff size
17 files, +763 / -2. Above the 400 LOC soft cap for the first executable ad-copy output wiring reasons named in the plan.
