### PR TITLE
PR-Deflection-Snapshot-Date-Window

### DIFF
--- a/docs/frontend/content_ops_faq_deflection_checkout_contract.md
+++ b/docs/frontend/content_ops_faq_deflection_checkout_contract.md
@@ -48,6 +48,13 @@ score, not a customer-specific ticket count; do not use it for spend
 calculations or projections. `locked_questions` intentionally exposes only
 rank and ticket count, with question text withheld until paid unlock.
 
+For period-normalized Support Tax copy, use
+`snapshot.summary.source_date_start`, `snapshot.summary.source_date_end`, and
+`snapshot.summary.source_window_days` only when all three are present. ATLAS
+omits them unless every contributing ticket source has a parseable date; the
+portfolio must not infer a date window, monthly pace, or annual run-rate from
+undated uploads.
+
 ## Portfolio Submit Endpoint
 
 The production PII-safe submit path is an authenticated server-to-server

--- a/docs/frontend/content_ops_faq_deflection_report_example.json
+++ b/docs/frontend/content_ops_faq_deflection_report_example.json
@@ -22,6 +22,13 @@
         "question_source": "customer_wording",
         "resolution_evidence_scope": "scoped",
         "resolution_source_count": 2,
+        "source_date_span": {
+          "dated_source_count": 2,
+          "end": "2026-05-03",
+          "missing_source_count": 0,
+          "start": "2026-05-01",
+          "window_days": 3
+        },
         "source_ids": [
           "ticket-export-1",
           "ticket-export-2"
@@ -90,6 +97,13 @@
         "question_source": "customer_wording",
         "resolution_evidence_scope": "not_applicable",
         "resolution_source_count": 0,
+        "source_date_span": {
+          "dated_source_count": 2,
+          "end": "2026-05-15",
+          "missing_source_count": 0,
+          "start": "2026-05-10",
+          "window_days": 6
+        },
         "source_ids": [
           "ticket-sso-2",
           "ticket-sso-1"
@@ -152,6 +166,9 @@
       "uses_user_vocabulary": true
     },
     "source_count": 4,
+    "source_date_end": "2026-05-15",
+    "source_date_start": "2026-05-01",
+    "source_window_days": 15,
     "ticket_source_count": 4,
     "top_opportunity_score": 2,
     "top_question": "How do I export attribution reports?"

--- a/docs/frontend/content_ops_faq_deflection_snapshot_example.json
+++ b/docs/frontend/content_ops_faq_deflection_snapshot_example.json
@@ -4,7 +4,10 @@
     "drafted_answer_count": 1,
     "generated": 2,
     "no_proven_answer_count": 1,
-    "repeat_ticket_count": 4
+    "repeat_ticket_count": 4,
+    "source_date_end": "2026-05-15",
+    "source_date_start": "2026-05-01",
+    "source_window_days": 15
   },
   "teaser": {
     "full_answer": {

--- a/docs/frontend/content_ops_faq_report_contract.md
+++ b/docs/frontend/content_ops_faq_report_contract.md
@@ -85,6 +85,9 @@ type DeflectionSnapshot = {
     drafted_answer_count: number;
     no_proven_answer_count: number;
     repeat_ticket_count: number;
+    source_date_start?: string; // ISO date, only when source-date coverage is complete
+    source_date_end?: string; // ISO date, only when source-date coverage is complete
+    source_window_days?: number; // inclusive day count, only when coverage is complete
   };
   top_questions: DeflectionSnapshotQuestion[];
   locked_questions: DeflectionSnapshotLockedQuestion[];
@@ -152,6 +155,12 @@ must not feed spend or cost copy. If raw counts are unavailable, count-dependent
 frontend projections should stay hidden rather than fall back to the ranking
 score.
 
+`summary.source_date_start`, `summary.source_date_end`, and
+`summary.source_window_days` are optional and fail closed. ATLAS emits them only
+when every contributing ticket source has a parseable date. If any of the three
+fields is absent, the frontend must not normalize Support Tax copy to a source
+window or infer a monthly pace from the upload.
+
 ## FAQ Item
 
 ```ts
@@ -180,6 +189,13 @@ type TicketFAQItem = {
   source_labels: string[];
   source_type_counts: Record<string, number>;
   weighted_source_volume_by_type: Record<string, number>;
+  source_date_span?: {
+    start: string;
+    end: string;
+    window_days: number;
+    dated_source_count: number;
+    missing_source_count: number;
+  };
 
   term_mappings: FAQTermMapping[];
 

--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 
 from .campaign_ports import TenantScope
@@ -22,7 +23,7 @@ _UNCAPPED_REPORT_MAX_ITEMS = 0
 class DeflectionSnapshot:
     """Free preview projection that excludes paid answer/evidence fields."""
 
-    summary: dict[str, int]
+    summary: dict[str, Any]
     top_questions: tuple[dict[str, Any], ...]
     locked_questions: tuple[dict[str, int], ...]
     teaser: dict[str, Any]
@@ -157,12 +158,15 @@ def build_deflection_snapshot(
         raise ValueError("teaser_preview_count must be non-negative")
     summary = _artifact_summary(artifact)
     items = _artifact_items(artifact)
-    snapshot_summary = {
+    snapshot_summary: dict[str, Any] = {
         "generated": _int(summary.get("generated")),
         "drafted_answer_count": _int(summary.get("drafted_answer_count")),
         "no_proven_answer_count": _int(summary.get("no_proven_answer_count")),
         "repeat_ticket_count": sum(_ticket_count(item) for item in items),
     }
+    source_date_window = _complete_source_date_window(summary, items)
+    if source_date_window:
+        snapshot_summary.update(source_date_window)
     top_questions: list[dict[str, Any]] = []
     for rank, item in enumerate(items[:top_n], start=1):
         question = _text(item.get("question"))
@@ -243,7 +247,7 @@ def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, 
         item for item in items
         if _text(item.get("answer_evidence_status")) != _RESOLUTION_EVIDENCE_STATUS
     )
-    return {
+    summary = {
         "generated": len(items),
         "source_count": int(faq_result.source_count),
         "ticket_source_count": int(faq_result.ticket_source_count),
@@ -253,6 +257,10 @@ def deflection_report_summary(faq_result: TicketFAQMarkdownResult) -> dict[str, 
         "top_question": _text(items[0].get("question")) if items else "",
         "top_opportunity_score": _int(items[0].get("opportunity_score")) if items else 0,
     }
+    source_date_window = _complete_source_date_window({}, items)
+    if source_date_window:
+        summary.update(source_date_window)
+    return summary
 
 
 def render_deflection_report(
@@ -548,6 +556,82 @@ def _ticket_count(item: Mapping[str, Any]) -> int:
         return ticket_count
     source_count = len(_texts(item.get("source_ids")))
     return source_count if source_count > 0 else 0
+
+
+def _complete_source_date_window(
+    summary: Mapping[str, Any],
+    items: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    summary_window = _summary_source_date_window(summary)
+    if summary_window:
+        return summary_window
+    return _items_source_date_window(items)
+
+
+def _summary_source_date_window(summary: Mapping[str, Any]) -> dict[str, Any]:
+    start = _iso_date_text(summary.get("source_date_start"))
+    end = _iso_date_text(summary.get("source_date_end"))
+    days = _int(summary.get("source_window_days"))
+    if not start or not end or days < 1:
+        return {}
+    parsed_start = date.fromisoformat(start)
+    parsed_end = date.fromisoformat(end)
+    if parsed_end < parsed_start:
+        return {}
+    expected_days = (parsed_end - parsed_start).days + 1
+    if days != expected_days:
+        return {}
+    return {
+        "source_date_start": start,
+        "source_date_end": end,
+        "source_window_days": days,
+    }
+
+
+def _items_source_date_window(items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    starts: list[date] = []
+    ends: list[date] = []
+    missing_source_count = 0
+    saw_dated_span = False
+    for item in items:
+        raw_span = item.get("source_date_span")
+        if not isinstance(raw_span, Mapping):
+            if _ticket_count(item) > 0:
+                missing_source_count += _ticket_count(item)
+            continue
+        start = _iso_date(raw_span.get("start"))
+        end = _iso_date(raw_span.get("end"))
+        if start is None or end is None or end < start:
+            missing_source_count += 1
+            continue
+        saw_dated_span = True
+        starts.append(start)
+        ends.append(end)
+        missing_source_count += _int(raw_span.get("missing_source_count"))
+    if not saw_dated_span or missing_source_count > 0 or not starts or not ends:
+        return {}
+    start = min(starts)
+    end = max(ends)
+    return {
+        "source_date_start": start.isoformat(),
+        "source_date_end": end.isoformat(),
+        "source_window_days": (end - start).days + 1,
+    }
+
+
+def _iso_date_text(value: Any) -> str:
+    parsed = _iso_date(value)
+    return parsed.isoformat() if parsed is not None else ""
+
+
+def _iso_date(value: Any) -> date | None:
+    text = _text(value)
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _texts(value: Any) -> list[str]:

--- a/extracted_content_pipeline/ticket_faq_markdown.py
+++ b/extracted_content_pipeline/ticket_faq_markdown.py
@@ -149,6 +149,7 @@ DEFAULT_INTENT_RULES = (
     ("renewal and cancellation", ("renewal", "cancel", "cancellation", "contract")),
 )
 _DATE_KEYS = (
+    "source_date",
     "created_at",
     "created",
     "ticket_created_at",
@@ -453,12 +454,14 @@ def build_ticket_faq_markdown(
             resolution_text = _resolution_text(evidence, opportunity)
             evidence_group_key = _evidence_group_key(resolution_text)
             group_key = (topic, evidence_group_key or f"topic:{_compact_key(topic)}")
+            source_date = _source_date(evidence) or _source_date(opportunity)
             groups[group_key].append({
                 "text": text,
                 "source_id": source_id or "unknown",
                 "source_key": source_key,
                 "source_type": source_type,
                 "source_title": _clean(evidence.get("source_title") or opportunity.get("source_title")),
+                "source_date": source_date.isoformat() if source_date is not None else "",
                 "evidence_group_key": evidence_group_key,
                 "results_count": _first_present(evidence, opportunity, key="results_count"),
                 "result_count": _first_present(evidence, opportunity, key="result_count"),
@@ -683,7 +686,7 @@ def _item(
     evidence_quotes = tuple(_evidence_quote(row) for row in display_rows)
     opportunity = _opportunity_score(topic, rows)
     term_mappings = _term_mappings(rows, documentation_terms, vocabulary_gap_rules)
-    return {
+    item = {
         "topic": topic,
         "question": question,
         "question_source": question_source,
@@ -714,6 +717,34 @@ def _item(
         "evidence_count": len(display_rows),
         "displayed_evidence_count": len(display_rows),
         "ticket_count": len(source_ids),
+    }
+    source_date_span = _source_date_span(rows)
+    if source_date_span is not None:
+        item["source_date_span"] = source_date_span
+    return item
+
+
+def _source_date_span(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    date_by_source: dict[str, date] = {}
+    missing_sources: set[str] = set()
+    for index, row in enumerate(rows, start=1):
+        source_key = _clean(row.get("source_key") or row.get("source_id")) or f"row:{index}"
+        parsed = _source_date(row)
+        if parsed is None:
+            missing_sources.add(source_key)
+            continue
+        date_by_source[source_key] = parsed
+    missing_sources.difference_update(date_by_source)
+    if not date_by_source:
+        return None
+    start = min(date_by_source.values())
+    end = max(date_by_source.values())
+    return {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "window_days": (end - start).days + 1,
+        "dated_source_count": len(date_by_source),
+        "missing_source_count": len(missing_sources),
     }
 
 

--- a/plans/PR-Deflection-Snapshot-Date-Window.md
+++ b/plans/PR-Deflection-Snapshot-Date-Window.md
@@ -1,0 +1,74 @@
+## Why this slice exists
+
+The portfolio #196 redesign now sizes Support Tax from real repeat-ticket counts, but its remaining period-honesty gap is that the results page cannot normalize the projection to the upload's actual source date window. ATLAS already parses support-ticket date fields for explicit `window_days` filtering, but the deflection artifact and free snapshot do not preserve a safe aggregate date span for the frontend to consume. This slice exposes only fail-closed aggregate date-window fields, so later portfolio copy can say "at the rate in your data" without assuming a monthly batch.
+
+## Scope (this PR)
+
+Ownership lane: ai-content-ops/faq-support-ticket-deflection
+
+Slice phase: Production hardening
+
+1. Preserve aggregate source-date coverage on generated FAQ deflection items without exposing source IDs in the free snapshot.
+2. Add optional `source_date_start`, `source_date_end`, and `source_window_days` fields to `DeflectionSnapshot.summary` only when every contributing ticket source has a parseable date.
+3. Keep date-window fields absent when source dates are missing or partial, so frontend normalized projections fail closed.
+4. Update the frontend contract docs, generated examples, and focused tests for the new optional summary fields.
+
+### Files touched
+
+- `plans/PR-Deflection-Snapshot-Date-Window.md` - plan doc for this slice.
+- `extracted_content_pipeline/ticket_faq_markdown.py` - carry per-item aggregate source-date coverage from contributing rows.
+- `extracted_content_pipeline/faq_deflection_report.py` - expose complete date-window fields in report and snapshot summaries.
+- `docs/frontend/content_ops_faq_report_contract.md` - document the optional fail-closed snapshot summary fields.
+- `docs/frontend/content_ops_faq_deflection_checkout_contract.md` - tell the portfolio to use date-window fields only when present.
+- `docs/frontend/content_ops_faq_deflection_report_example.json` - refreshed producer example.
+- `docs/frontend/content_ops_faq_deflection_snapshot_example.json` - refreshed snapshot example.
+- `tests/test_content_ops_deflection_report.py` - focused summary/snapshot date-window tests.
+- `tests/test_content_ops_faq_report_contract_docs.py` - contract-shape assertions for the optional fields.
+- `tests/test_extracted_content_ops_live_execute_harness.py` - execute-path snapshot expectation.
+
+## Mechanism
+
+`ticket_faq_markdown` already knows how to parse source dates from the accepted support-ticket aliases. This PR carries an ISO `source_date` on each normalized row that enters a FAQ item, then records an item-level `source_date_span` summary with start, end, inclusive day count, dated source count, and missing source count.
+
+`faq_deflection_report` folds item-level spans into report and snapshot summaries. The public snapshot only gets `source_date_start`, `source_date_end`, and `source_window_days` when the aggregate span is complete. If any contributing source lacks a parseable date, those fields are omitted instead of partially normalizing the upload.
+
+## Intentional
+
+- The free snapshot still strips Markdown, source IDs, evidence, answers outside the bounded teaser, and locked question text.
+- Date fields are aggregate and optional. Missing/partial dates do not produce fallback windows or synthetic assumptions.
+- This does not change grouping, ranking, answer drafting, paid unlock, Stripe, or portfolio rendering.
+
+## Deferred
+
+- Portfolio consumption is deferred to the follow-up atlas-portfolio slice after this contract lands and deploys.
+- Live production verification is deferred until ATLAS main is redeployed and a fresh report is generated from a dated CSV.
+
+Parked hardening: none.
+
+## Verification
+
+- Command: pytest tests/test_content_ops_deflection_report.py -q - passed, 32 tests.
+- Command: pytest tests/test_content_ops_faq_report_contract_docs.py -q - passed, 5 tests.
+- Command: pytest tests/test_extracted_content_ops_live_execute_harness.py -q - passed, 13 tests.
+- Command: bash scripts/validate_extracted_content_pipeline.sh - passed.
+- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
+- Command: python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
+- Command: bash scripts/check_ascii_python.sh - passed.
+- Command: bash scripts/run_extracted_pipeline_checks.sh - passed, 2980 passed / 10 skipped.
+- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-bodies/deflection-snapshot-date-window.md - passed.
+
+## Estimated diff size
+
+| File | Estimated LOC |
+|---|---:|
+| `plans/PR-Deflection-Snapshot-Date-Window.md` | ~65 |
+| `extracted_content_pipeline/ticket_faq_markdown.py` | ~60 |
+| `extracted_content_pipeline/faq_deflection_report.py` | ~65 |
+| `docs/frontend/content_ops_faq_report_contract.md` | ~20 |
+| `docs/frontend/content_ops_faq_deflection_checkout_contract.md` | ~15 |
+| `docs/frontend/content_ops_faq_deflection_report_example.json` | ~25 |
+| `docs/frontend/content_ops_faq_deflection_snapshot_example.json` | ~15 |
+| `tests/test_content_ops_deflection_report.py` | ~70 |
+| `tests/test_content_ops_faq_report_contract_docs.py` | ~20 |
+| `tests/test_extracted_content_ops_live_execute_harness.py` | ~10 |
+| Total | ~365 |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -15,7 +15,10 @@ from extracted_content_pipeline.deflection_report_access import (
     InMemoryDeflectionReportArtifactStore,
     PostgresDeflectionReportArtifactStore,
 )
-from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownResult
+from extracted_content_pipeline.ticket_faq_markdown import (
+    TicketFAQMarkdownResult,
+    build_ticket_faq_markdown,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -273,6 +276,100 @@ def test_deflection_snapshot_counts_are_raw_and_locked_rows_hide_questions() -> 
     assert "Can I enable SSO?" not in encoded
     assert "Weighted score is not a ticket count" not in encoded
     assert "ticket-sso-1" not in encoded
+
+
+def test_deflection_snapshot_exposes_complete_source_date_window() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "source_title": "Export report",
+                "text": "How do I export attribution reports?",
+                "created_at": "2026-05-01T13:00:00Z",
+                "resolution_text": "Open Analytics and download the report.",
+            },
+            {
+                "source_id": "ticket-sso-1",
+                "source_type": "support_ticket",
+                "source_title": "SSO setup",
+                "text": "Can I enable SSO for my workspace?",
+                "created_at": "2026-05-15",
+            },
+        ],
+        max_items=2,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    snapshot = build_deflection_snapshot(artifact).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert artifact.summary["source_date_start"] == "2026-05-01"
+    assert artifact.summary["source_date_end"] == "2026-05-15"
+    assert artifact.summary["source_window_days"] == 15
+    assert snapshot["summary"]["source_date_start"] == "2026-05-01"
+    assert snapshot["summary"]["source_date_end"] == "2026-05-15"
+    assert snapshot["summary"]["source_window_days"] == 15
+    assert "ticket-export-1" not in encoded
+    assert "source_date_span" not in encoded
+
+
+def test_deflection_snapshot_omits_date_window_when_source_dates_are_partial() -> None:
+    result = build_ticket_faq_markdown(
+        [
+            {
+                "source_id": "ticket-export-1",
+                "source_type": "support_ticket",
+                "source_title": "Export report",
+                "text": "How do I export attribution reports?",
+                "created_at": "2026-05-01",
+            },
+            {
+                "source_id": "ticket-sso-1",
+                "source_type": "support_ticket",
+                "source_title": "SSO setup",
+                "text": "Can I enable SSO for my workspace?",
+            },
+        ],
+        max_items=2,
+    )
+
+    artifact = build_deflection_report_artifact(result)
+    snapshot = build_deflection_snapshot(artifact).as_dict()
+
+    assert "source_date_start" not in artifact.summary
+    assert "source_date_end" not in artifact.summary
+    assert "source_window_days" not in artifact.summary
+    assert "source_date_start" not in snapshot["summary"]
+    assert "source_date_end" not in snapshot["summary"]
+    assert "source_window_days" not in snapshot["summary"]
+
+
+def test_deflection_snapshot_omits_contradictory_summary_date_window() -> None:
+    snapshot = build_deflection_snapshot(
+        {
+            "summary": {
+                "generated": 1,
+                "drafted_answer_count": 0,
+                "no_proven_answer_count": 1,
+                "source_date_start": "2026-05-01",
+                "source_date_end": "2026-05-15",
+                "source_window_days": 30,
+            },
+            "faq_result": {
+                "items": [
+                    {
+                        "question": "Can I enable SSO?",
+                        "source_ids": ["ticket-sso-1"],
+                    }
+                ],
+            },
+        }
+    ).as_dict()
+
+    assert "source_date_start" not in snapshot["summary"]
+    assert "source_date_end" not in snapshot["summary"]
+    assert "source_window_days" not in snapshot["summary"]
 
 
 def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:

--- a/tests/test_content_ops_faq_report_contract_docs.py
+++ b/tests/test_content_ops_faq_report_contract_docs.py
@@ -63,6 +63,7 @@ def _producer_deflection_report_payload() -> dict[str, object]:
                 "source_type": "support_ticket",
                 "source_title": "Export attribution",
                 "text": "How do I export attribution reports?",
+                "created_at": "2026-05-01T12:00:00Z",
                 "resolution_text": (
                     "Open Analytics, choose Attribution, then click Download report"
                 ),
@@ -72,6 +73,7 @@ def _producer_deflection_report_payload() -> dict[str, object]:
                 "source_type": "support_ticket",
                 "source_title": "Report download",
                 "text": "Where is the report download for attribution exports?",
+                "created_at": "2026-05-03",
                 "resolution_text": (
                     "Open Analytics, choose Attribution, then click Download report"
                 ),
@@ -81,12 +83,14 @@ def _producer_deflection_report_payload() -> dict[str, object]:
                 "source_type": "support_ticket",
                 "source_title": "SSO setup",
                 "text": "How do I enable SSO for my team?",
+                "created_at": "2026-05-10",
             },
             {
                 "source_id": "ticket-sso-2",
                 "source_type": "support_ticket",
                 "source_title": "Team login",
                 "text": "Can I turn on SSO for all users?",
+                "created_at": "2026-05-15",
             },
         ],
         title="Support Ticket FAQ Source",
@@ -195,6 +199,9 @@ def test_content_ops_faq_deflection_snapshot_example_matches_producer_shape() ->
         "drafted_answer_count",
         "no_proven_answer_count",
         "repeat_ticket_count",
+        "source_date_start",
+        "source_date_end",
+        "source_window_days",
     }
     for question in payload["top_questions"]:
         assert set(question) == {

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -951,6 +951,7 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
             "subject": "SSO setup",
             "message": "Can we sync users before enforcing SSO?",
             "pain_category": "single sign-on rollout",
+            "created_at": "2026-05-01T09:00:00Z",
             "resolution_text": (
                 "Enable SSO first, verify matching user emails, then enable SCIM."
             ),
@@ -961,6 +962,7 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
             "subject": "Dashboard refresh",
             "message": "Why is the executive dashboard not refreshing?",
             "pain_category": "warehouse refresh status",
+            "created_at": "2026-05-07",
             "resolution_text": (
                 "Open Data > Sync history, rerun the failed warehouse job, "
                 "then refresh the model."
@@ -972,6 +974,7 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
             "subject": "Renewal invoice",
             "message": "How do I confirm my renewal invoice before payment?",
             "pain_category": "renewal billing review",
+            "created_at": "2026-05-14",
             "resolution_text": (
                 "Open Billing > Invoices, compare the renewal line items, "
                 "then download the PDF."
@@ -983,6 +986,7 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
             "subject": "API token rotation",
             "message": "How do we rotate API tokens without downtime?",
             "pain_category": "api token rotation",
+            "created_at": "2026-05-20",
             "resolution_text": (
                 "Create the replacement token, deploy it alongside the old "
                 "token, then revoke the old token."
@@ -1016,6 +1020,9 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
         "drafted_answer_count": 4,
         "no_proven_answer_count": 0,
         "repeat_ticket_count": 4,
+        "source_date_start": "2026-05-01",
+        "source_date_end": "2026-05-20",
+        "source_window_days": 20,
     }
     assert len(snapshot["top_questions"]) == 2
     assert [question["ticket_count"] for question in snapshot["top_questions"]] == [1, 1]


### PR DESCRIPTION
Plan: plans/PR-Deflection-Snapshot-Date-Window.md
Slice phase: Production hardening

The portfolio #196 redesign can now size Support Tax from real repeat-ticket counts, but it still cannot normalize the projection to the upload's actual source date window. This PR exposes optional, fail-closed ATLAS snapshot summary fields (`source_date_start`, `source_date_end`, `source_window_days`) only when every contributing ticket source has a parseable date, so the portfolio can avoid monthly assumptions and omit normalized copy on undated/partial uploads.

## Intentional
- Snapshot still strips Markdown, source IDs, evidence, non-teaser answers, and locked question text.
- Date-window fields are optional and omitted when source dates are missing, partial, or contradictory.
- No grouping, ranking, answer drafting, paid unlock, Stripe, or portfolio rendering change.

## Deferred
- Portfolio consumption follows in atlas-portfolio after this contract lands and deploys.
- Live production verification waits for ATLAS redeploy and a fresh dated report.

## Parked hardening
- None.

## Verification
- Command: pytest tests/test_content_ops_deflection_report.py -q - passed, 32 tests.
- Command: pytest tests/test_content_ops_faq_report_contract_docs.py -q - passed, 5 tests.
- Command: pytest tests/test_extracted_content_ops_live_execute_harness.py -q - passed, 13 tests.
- Command: bash scripts/validate_extracted_content_pipeline.sh - passed.
- Command: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline - passed.
- Command: python scripts/audit_extracted_standalone.py --fail-on-debt - passed.
- Command: bash scripts/check_ascii_python.sh - passed.
- Command: bash scripts/run_extracted_pipeline_checks.sh - passed, 2980 passed / 10 skipped.
- Command: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/atlas-pr-bodies/deflection-snapshot-date-window.md - passed.

## Diff size
10 files, +349 / -6
