### PR TITLE
Plan: plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -160,13 +160,19 @@ _COMPETITIVE_MARKER_KEYS = frozenset({
     "top_displacement_targets",
     "winning_vendor",
 })
-_REVIEW_CAMPAIGN_OUTPUTS = ("landing_page", "blog_post", "sales_brief", "social_post")
+_REVIEW_CAMPAIGN_OUTPUTS = (
+    "landing_page",
+    "blog_post",
+    "sales_brief",
+    "social_post",
+    "ad_copy",
+)
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
 _REVIEW_OFFER = (
     "Turn customer review themes into buyer-facing landing pages, blog posts, "
-    "sales briefs, and social posts"
+    "sales briefs, social posts, and ad copy"
 )
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
 _COMPETITIVE_CAMPAIGN_OUTPUTS = (
@@ -174,6 +180,7 @@ _COMPETITIVE_CAMPAIGN_OUTPUTS = (
     "blog_post",
     "sales_brief",
     "social_post",
+    "ad_copy",
 )
 _COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
 _COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
@@ -182,7 +189,7 @@ _COMPETITIVE_AUDIENCE = (
 )
 _COMPETITIVE_OFFER = (
     "Turn competitor and switching evidence into buyer-facing landing pages, "
-    "blog posts, sales briefs, and social posts"
+    "blog posts, sales briefs, social posts, and ad copy"
 )
 _COMPETITIVE_TARGET_KEYWORD = "competitive displacement content marketing"
 

--- a/plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md
+++ b/plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md
@@ -1,0 +1,91 @@
+# PR: Content Ops Ad Copy Package Handoff
+
+## Why this slice exists
+
+PR #1275 added the deterministic `ad_copy` output and deliberately deferred
+putting it into the review and competitive input-package defaults. Until this
+handoff lands, operators can run `ad_copy` explicitly, but the productized
+review/competitive source modes still default only to landing pages, blog posts,
+sales briefs, and social posts.
+
+This slice completes that handoff by making review and competitive source
+packages request ad copy by default, using the same normalized
+`source_material` already proven by #1275. It mirrors
+`plans/PR-Content-Ops-Social-Post-Package-Handoff.md` and does not overlap
+#1268, which is a separate plan-doc-only output-variations lane.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add `ad_copy` to the review source-mode default outputs.
+2. Add `ad_copy` to the competitive source-mode default outputs.
+3. Align the package offer copy with the expanded output set.
+4. Extend the existing host-provider tests to prove the default package outputs
+   and execution handoff include `ad_copy`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host input provider already builds normalized `source_material` for review
+and competitive source modes. `ad_copy` consumes that same field, so this slice
+only expands the two output tuples:
+
+```python
+_REVIEW_CAMPAIGN_OUTPUTS = (..., "social_post", "ad_copy")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = (..., "social_post", "ad_copy")
+```
+
+The execution tests use the existing `_RunnableService` fake in the `ad_copy`
+service slot. If the output is present but the dispatcher fails to hand off
+`source_material`, the tests fail on the ad-copy step kwargs.
+
+## Intentional
+
+- No new source adapter or generator logic. #1275 already proved `ad_copy` runs
+  from normalized source material.
+- No UI selector changes. The New Run source-mode path consumes these package
+  defaults automatically.
+- No persistence or generated-asset review branch. Durable ad-copy review is a
+  separate productization slice after this default handoff.
+- No changes to #1268 output variations; that open PR is a separate
+  workflow/process lane and remains untouched.
+
+## Deferred
+
+- Persist generated ad-copy drafts into the generated-assets review queue after
+  the package-default handoff is accepted.
+- Stat/quote card output remains the next marketer asset family after ad copy.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
+- Passed: `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
+- Passed: `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-package-handoff-pr-body.md`
+
+## Estimated diff size
+
+Actual: 3 files, +121 / -4. This stays under the 400 LOC soft cap because it
+reuses the existing source-mode package and #1275's ad-copy dispatcher.
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider defaults and copy | ~13 |
+| Host provider tests | ~21 |
+| Plan doc | ~91 |
+| **Total** | **~125** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -59,7 +59,13 @@ class _RunnableService:
         return {"kwargs": kwargs}
 
 
-_MARKETER_OUTPUTS = ("landing_page", "blog_post", "sales_brief", "social_post")
+_MARKETER_OUTPUTS = (
+    "landing_page",
+    "blog_post",
+    "sales_brief",
+    "social_post",
+    "ad_copy",
+)
 
 
 def _route(router, path: str, method: str):
@@ -630,6 +636,7 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
             landing_page=_RunnableService(),
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
+            ad_copy=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -653,6 +660,11 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
     assert social_post_kwargs["source_material"][0]["target_id"] == "review-1"
     assert social_post_kwargs["target_mode"] == "vendor_retention"
 
+    ad_copy_step = next(step for step in result.steps if step.output == "ad_copy")
+    ad_copy_kwargs = ad_copy_step.result["kwargs"]
+    assert ad_copy_kwargs["source_material"][0]["target_id"] == "review-1"
+    assert ad_copy_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.asyncio
 async def test_competitive_input_evidence_reaches_landing_and_blog_generators() -> None:
@@ -675,6 +687,7 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
             landing_page=_RunnableService(),
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
+            ad_copy=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -698,6 +711,11 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
     assert social_post_kwargs["source_material"][0]["target_id"] == "competitive-1"
     assert social_post_kwargs["target_mode"] == "vendor_retention"
 
+    ad_copy_step = next(step for step in result.steps if step.output == "ad_copy")
+    ad_copy_kwargs = ad_copy_step.result["kwargs"]
+    assert ad_copy_kwargs["source_material"][0]["target_id"] == "competitive-1"
+    assert ad_copy_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.skipif(
     api_module.APIRouter is None,
@@ -713,6 +731,7 @@ async def test_plan_route_applies_review_input_provider() -> None:
             landing_page=_RunnableService(),
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
+            ad_copy=_RunnableService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-review-route"),
     )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md
Slice phase: Vertical slice

The ad-copy output from #1275 is executable, but the productized review and competitive source modes still do not request it by default. This slice adds `ad_copy` to those package defaults, aligns the package offer copy, and extends the host-provider handoff tests so source material reaches the ad-copy dispatcher.

## Intentional
- No new source adapter or generator logic. #1275 already proved `ad_copy` runs from normalized source material.
- No UI selector changes. The New Run source-mode path consumes these package defaults automatically.
- No persistence or generated-asset review branch. Durable ad-copy review is a separate productization slice after this default handoff.
- No changes to #1268 output variations; that open PR is a separate workflow/process lane and remains untouched.

## Deferred
- Persist generated ad-copy drafts into the generated-assets review queue after the package-default handoff is accepted.
- Stat/quote card output remains the next marketer asset family after ad copy.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
- Passed: `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
- Passed: `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-package-handoff-pr-body.md`

## Diff size
3 files, +121 / -4.
