### PR TITLE
Use Juan Canfield sign-off block on invoice cover emails

### DIFF
--- a/atlas_brain/autonomous/tasks/monthly_invoice_generation.py
+++ b/atlas_brain/autonomous/tasks/monthly_invoice_generation.py
@@ -382,7 +382,7 @@ async def run(task: ScheduledTask) -> dict:
             try:
                 from ...services.email_provider import get_email_provider
                 from ...templates.email.invoice import (
-                    BUSINESS_NAME, BUSINESS_PHONE, BUSINESS_EMAIL,
+                    BUSINESS_NAME, BUSINESS_SIGNATURE,
                 )
 
                 email_provider = get_email_provider()
@@ -393,9 +393,7 @@ async def run(task: ScheduledTask) -> dict:
                     f"Due Date: {due_date.strftime('%m/%d/%Y')}\n\n"
                     f"Make all checks payable to {BUSINESS_NAME}.\n\n"
                     f"Thank you for your business!\n\n"
-                    f"{BUSINESS_NAME}\n"
-                    f"{BUSINESS_PHONE}\n"
-                    f"{BUSINESS_EMAIL}"
+                    f"{BUSINESS_SIGNATURE}"
                 )
 
                 attachments = []

--- a/atlas_brain/templates/email/invoice.py
+++ b/atlas_brain/templates/email/invoice.py
@@ -14,6 +14,15 @@ BUSINESS_PHONE = "(217) 207-3097"
 BUSINESS_EMAIL = "info@effinghamofficemaids.com"
 BUSINESS_WEBSITE = "effinghamofficemaids.com"
 
+# Sign-off block for invoice cover emails (operator: Juan Canfield).
+BUSINESS_SIGNATURE = (
+    "Juan Canfield | Office Manager\n"
+    "Effingham Office Maids.\n"
+    "1901 S. 4th St. STE 1 | Effingham IL, 62401\n"
+    "T: (217) 207-3097\n"
+    "Canfieldjuan24@gmail.com"
+)
+
 
 def _fmt(val, fallback: str = "") -> str:
     """Return string value or fallback for None/empty."""

--- a/plans/PR-Invoice-Email-Signature.md
+++ b/plans/PR-Invoice-Email-Signature.md
@@ -1,0 +1,71 @@
+# PR-Invoice-Email-Signature
+
+## Why this slice exists
+
+Invoice cover emails -- both the message the monthly auto-invoice task sends and
+the body the operator reviews as a Gmail draft -- signed off with only the bare
+business name, phone, and email. The operator wants a fuller, consistent
+sign-off that includes the sender name and title and uses the operator's contact
+address.
+
+This slice replaces the cover-email sign-off with a single shared signature
+constant so every invoice email, current and future, carries the same block. It
+does not change invoice amounts, the formal invoice document, or any send
+behavior.
+
+## Scope (this PR)
+
+Ownership lane: invoicing/cover-email-signature
+Slice phase: Product polish
+
+1. Add a BUSINESS_SIGNATURE constant to the invoice email template module.
+2. Use it as the sign-off in the monthly auto-invoice cover email, replacing the
+   bare name/phone/email lines.
+
+### Files touched
+
+- `atlas_brain/templates/email/invoice.py`
+- `atlas_brain/autonomous/tasks/monthly_invoice_generation.py`
+- `plans/PR-Invoice-Email-Signature.md`
+
+## Mechanism
+
+`atlas_brain/templates/email/invoice.py` gains a BUSINESS_SIGNATURE string
+constant holding the operator sign-off block (name and title, business name,
+address, phone, contact email).
+`atlas_brain/autonomous/tasks/monthly_invoice_generation.py` imports
+BUSINESS_SIGNATURE and interpolates it into the plain-text cover-email body in
+place of the previous BUSINESS_NAME / BUSINESS_PHONE / BUSINESS_EMAIL sign-off
+lines. The "Make all checks payable to" line still uses BUSINESS_NAME.
+
+## Intentional
+
+- Email cover-note sign-off only. The formal invoice document footer rendered by
+  render_invoice_html / render_invoice_text is unchanged and still shows the
+  business contact block.
+- No change to invoice amounts, due dates, line items, or send/review behavior.
+- The signature uses the operator Gmail as the contact address by request; the
+  business email constant stays in place for the formal invoice document.
+
+## Deferred
+
+- Future PR: apply the same signature to the formal invoice document footer if
+  the operator wants the PDF/document to match.
+- Parked hardening: none.
+
+## Verification
+
+- pytest for `tests/test_monthly_invoice_generation.py` -- 43 passed.
+- python import of `atlas_brain/autonomous/tasks/monthly_invoice_generation.py`
+  and `atlas_brain/templates/email/invoice.py` -- resolves; signature renders as
+  specified.
+- check_ascii_python.sh -- added lines are ASCII-only.
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan | ~75 |
+| Template constant | ~8 |
+| Task body | ~6 |
+| **Total** | **~89** |


### PR DESCRIPTION
Plan: plans/PR-Invoice-Email-Signature.md

Slice phase: `Product polish`

## What

Adds a `BUSINESS_SIGNATURE` constant to `atlas_brain/templates/email/invoice.py` and uses it as the sign-off in the `monthly_invoice_generation` cover email, replacing the bare `BUSINESS_NAME / BUSINESS_PHONE / BUSINESS_EMAIL` block.

New sign-off:

```
Juan Canfield | Office Manager
Effingham Office Maids.
1901 S. 4th St. STE 1 | Effingham IL, 62401
T: (217) 207-3097
Canfieldjuan24@gmail.com
```

## Why

Operator-requested signature for outgoing invoice emails (adds name + title and uses the operator's Gmail as the contact address).

## Intentional

- Email cover-note sign-off only. The formal invoice PDF/document footer (`render_invoice_html` / `render_invoice_text`) is unchanged and still shows the business block.
- No change to invoice amounts, due dates, line items, or send/review behavior.

## Verification

- `pytest tests/test_monthly_invoice_generation.py` -> 43 passed.
- Import resolves; signature renders exactly as specified; added lines are ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
