### PR TITLE
Plan: Content Ops Ad Copy Review Assets

### DIFF
--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -11,8 +11,8 @@ Currently wired:
   with no external dependencies.
 - `social_post`: deterministic source-evidence social post drafts
   with no external dependencies.
-- `ad_copy`: deterministic source-evidence ad-copy drafts with no
-  external dependencies.
+- `ad_copy`: deterministic source-evidence ad-copy drafts
+  with no external dependencies; persists when DB services are enabled.
 - `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
   host LLM + Skill adapters from PR #453 +
   `PostgresLandingPageRepository` backed by the host's
@@ -42,6 +42,9 @@ from typing import Any, Callable
 
 from extracted_content_pipeline.ad_copy_generation import (
     AdCopyGenerationService,
+)
+from extracted_content_pipeline.ad_copy_postgres import (
+    PostgresAdCopyRepository,
 )
 from extracted_content_pipeline.blog_blueprint_postgres import (
     PostgresBlogBlueprintRepository,
@@ -273,6 +276,16 @@ def _build_social_post_service(*, pool: Any) -> SocialPostGenerationService:
     )
 
 
+def _build_ad_copy_service(*, pool: Any) -> AdCopyGenerationService:
+    """Build ad-copy generation with optional draft persistence."""
+
+    if pool is None:
+        return _AD_COPY_SERVICE
+    return AdCopyGenerationService(
+        ad_copy_drafts=PostgresAdCopyRepository(pool=pool)
+    )
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -377,6 +390,7 @@ def build_content_ops_execution_services(
             image_provider=image_provider,
         )
         social_post = _build_social_post_service(pool=pool)
+        ad_copy = _build_ad_copy_service(pool=pool)
         faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
         faq_deflection_report = FAQDeflectionReportService(

--- a/extracted_content_pipeline/ad_copy_generation.py
+++ b/extracted_content_pipeline/ad_copy_generation.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
+from .ad_copy_ports import AdCopyDraft, AdCopyRepository
 from .campaign_customer_data import CampaignOpportunityWarning
 from .campaign_ports import TenantScope
 from .campaign_source_adapters import source_row_to_campaign_opportunity
@@ -30,6 +31,7 @@ class AdCopyGenerationResult:
     ads: tuple[dict[str, Any], ...]
     warnings: tuple[CampaignOpportunityWarning, ...] = ()
     target_mode: str = "vendor_retention"
+    saved_ids: tuple[str, ...] = ()
 
     @property
     def generated(self) -> int:
@@ -41,14 +43,21 @@ class AdCopyGenerationResult:
             "target_mode": self.target_mode,
             "ads": [dict(ad) for ad in self.ads],
             "warnings": [warning.as_dict() for warning in self.warnings],
+            "saved_ids": list(self.saved_ids),
         }
 
 
 class AdCopyGenerationService:
     """Build short, evidence-backed ad copy from source material."""
 
-    def __init__(self, config: AdCopyGenerationConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: AdCopyGenerationConfig | None = None,
+        *,
+        ad_copy_drafts: AdCopyRepository | None = None,
+    ) -> None:
         self.config = config or AdCopyGenerationConfig()
+        self._ad_copy_drafts = ad_copy_drafts
 
     async def generate(
         self,
@@ -60,7 +69,6 @@ class AdCopyGenerationService:
         max_text_chars: int | None = None,
         **kwargs: Any,
     ) -> AdCopyGenerationResult:
-        del scope
         del kwargs
         resolved_limit = int(limit) if limit is not None else self.config.limit
         if resolved_limit < 1:
@@ -72,7 +80,7 @@ class AdCopyGenerationService:
         )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be at least 1")
-        return _generate_ad_copy(
+        result = _generate_ad_copy(
             _rows_from_source_material(source_material),
             target_mode=target_mode,
             limit=resolved_limit,
@@ -80,6 +88,16 @@ class AdCopyGenerationService:
             max_headline_chars=self.config.max_headline_chars,
             max_primary_text_chars=self.config.max_primary_text_chars,
         )
+        if self._ad_copy_drafts is None or not result.ads:
+            return result
+        saved_ids = tuple(
+            str(item)
+            for item in await self._ad_copy_drafts.save_drafts(
+                _drafts_from_ads(result.ads, target_mode=target_mode),
+                scope=scope,
+            )
+        )
+        return replace(result, saved_ids=saved_ids)
 
 
 def _generate_ad_copy(
@@ -178,6 +196,44 @@ def _ad_from_opportunity(
     }
 
 
+def _drafts_from_ads(
+    ads: Sequence[Mapping[str, Any]],
+    *,
+    target_mode: str,
+) -> tuple[AdCopyDraft, ...]:
+    drafts: list[AdCopyDraft] = []
+    for ad in ads:
+        source_id = _clean(ad.get("source_id") or ad.get("id"))
+        target_id = _clean(ad.get("target_id")) or source_id
+        drafts.append(
+            AdCopyDraft(
+                target_id=target_id,
+                target_mode=target_mode,
+                channel=_clean(ad.get("channel")) or "paid_social",
+                format=_clean(ad.get("format")) or "single_image",
+                headline=_clean(ad.get("headline")),
+                primary_text=_clean(ad.get("primary_text")),
+                cta=_clean(ad.get("cta")),
+                source_id=source_id,
+                source_type=_clean(ad.get("source_type")),
+                company_name=_clean(ad.get("company_name")),
+                vendor_name=_clean(ad.get("vendor_name")),
+                pain_points=_pain_points_from_ad(ad.get("pain_points")),
+                metadata={"source_ad": dict(ad)},
+            )
+        )
+    return tuple(drafts)
+
+
+def _pain_points_from_ad(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
+
+
 def _first_evidence(opportunity: Mapping[str, Any]) -> str:
     raw = opportunity.get("evidence")
     if isinstance(raw, Mapping):
@@ -236,4 +292,6 @@ __all__ = [
     "AdCopyGenerationConfig",
     "AdCopyGenerationResult",
     "AdCopyGenerationService",
+    "AdCopyDraft",
+    "AdCopyRepository",
 ]

--- a/extracted_content_pipeline/ad_copy_ports.py
+++ b/extracted_content_pipeline/ad_copy_ports.py
@@ -1,0 +1,95 @@
+"""Standalone ports for persisted ad-copy drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class AdCopyDraft:
+    """A generated, not-yet-approved ad-copy draft."""
+
+    target_id: str
+    target_mode: str
+    channel: str
+    format: str
+    headline: str
+    primary_text: str
+    cta: str
+    source_id: str = ""
+    source_type: str = ""
+    company_name: str = ""
+    vendor_name: str = ""
+    pain_points: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "channel": self.channel,
+            "format": self.format,
+            "headline": self.headline,
+            "primary_text": self.primary_text,
+            "cta": self.cta,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "company_name": self.company_name,
+            "vendor_name": self.vendor_name,
+            "pain_points": list(self.pain_points),
+            "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
+        }
+
+
+class AdCopyRepository(Protocol):
+    """Persistence contract for generated ad-copy drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[AdCopyDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return assigned ad-copy ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        channel: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[AdCopyDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft status and return True on hit."""
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched scope."""
+
+
+__all__ = [
+    "AdCopyDraft",
+    "AdCopyRepository",
+]

--- a/extracted_content_pipeline/ad_copy_postgres.py
+++ b/extracted_content_pipeline/ad_copy_postgres.py
@@ -1,0 +1,196 @@
+"""Postgres repository adapter for generated ad-copy drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .ad_copy_ports import AdCopyDraft
+from .campaign_ports import JsonDict, TenantScope
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_AD_COPY_COLUMNS = (
+    "id, target_id, target_mode, channel, format, headline, primary_text, cta, "
+    "source_id, source_type, company_name, vendor_name, pain_points, metadata, "
+    "status"
+)
+
+
+def _draft_metadata(draft: AdCopyDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_string_sequence(value: Any) -> tuple[str, ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in decoded if str(item).strip())
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> AdCopyDraft:
+    return AdCopyDraft(
+        id=str(row.get("id") or ""),
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        channel=str(row.get("channel") or ""),
+        format=str(row.get("format") or ""),
+        headline=str(row.get("headline") or ""),
+        primary_text=str(row.get("primary_text") or ""),
+        cta=str(row.get("cta") or ""),
+        source_id=str(row.get("source_id") or ""),
+        source_type=str(row.get("source_type") or ""),
+        company_name=str(row.get("company_name") or ""),
+        vendor_name=str(row.get("vendor_name") or ""),
+        pain_points=_json_string_sequence(row.get("pain_points")),
+        metadata=_json_mapping(row.get("metadata")),
+        status=str(row.get("status") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresAdCopyRepository:
+    """Async Postgres adapter for generated ad copy."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[AdCopyDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            draft_id = await self.pool.fetchval(
+                """
+                INSERT INTO ad_copy_drafts (
+                    account_id, target_id, target_mode, channel, format,
+                    headline, primary_text, cta, source_id, source_type,
+                    company_name, vendor_name, pain_points, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6, $7, $8, $9, $10,
+                    $11, $12, $13::jsonb, $14::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.channel,
+                draft.format,
+                draft.headline,
+                draft.primary_text,
+                draft.cta,
+                draft.source_id,
+                draft.source_type,
+                draft.company_name,
+                draft.vendor_name,
+                json_dump_jsonb([str(item) for item in draft.pain_points]),
+                json_dump_jsonb(_draft_metadata(draft, scope)),
+            )
+            saved.append(str(draft_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        channel: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[AdCopyDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if channel is not None:
+            params.append(channel)
+            clauses.append(f"channel = ${len(params)}")
+        sql = (
+            f"SELECT {_AD_COPY_COLUMNS} "
+            "FROM ad_copy_drafts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE ad_copy_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1::uuid
+               AND account_id = $3
+            """,
+            draft_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in draft_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE ad_copy_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+__all__ = [
+    "PostgresAdCopyRepository",
+]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -321,6 +321,15 @@
       "target": "extracted_content_pipeline/storage/migrations/331_social_posts.sql"
     },
     {
+      "target": "extracted_content_pipeline/ad_copy_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/ad_copy_postgres.py"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/332_ad_copy_drafts.sql"
+    },
+    {
       "target": "extracted_content_pipeline/blog_ports.py"
     },
     {

--- a/extracted_content_pipeline/storage/migrations/332_ad_copy_drafts.sql
+++ b/extracted_content_pipeline/storage/migrations/332_ad_copy_drafts.sql
@@ -1,0 +1,36 @@
+-- Ad-copy drafts: deterministic, evidence-backed paid-social copy generated
+-- from Content Ops source material. One row is one reviewable ad-copy draft.
+--
+-- The status lifecycle mirrors the other generated assets: drafts start at
+-- 'draft' and host workflows can move them through 'approved', 'rejected', or
+-- custom intermediate states without a CHECK constraint.
+
+CREATE TABLE IF NOT EXISTS ad_copy_drafts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    channel TEXT NOT NULL DEFAULT 'paid_social',
+    format TEXT NOT NULL DEFAULT 'single_image',
+    headline TEXT NOT NULL,
+    primary_text TEXT NOT NULL,
+    cta TEXT NOT NULL DEFAULT '',
+    source_id TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT '',
+    company_name TEXT NOT NULL DEFAULT '',
+    vendor_name TEXT NOT NULL DEFAULT '',
+    pain_points JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ad_copy_drafts_target
+    ON ad_copy_drafts (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_ad_copy_drafts_status
+    ON ad_copy_drafts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ad_copy_drafts_channel
+    ON ad_copy_drafts (account_id, channel, created_at DESC);

--- a/plans/PR-Content-Ops-Ad-Copy-Review-Assets.md
+++ b/plans/PR-Content-Ops-Ad-Copy-Review-Assets.md
@@ -1,0 +1,113 @@
+# PR: Content Ops Ad Copy Review Assets
+
+## Why this slice exists
+
+PR #1275 made `ad_copy` executable for marketer review inputs and PR #1278
+threaded ad-copy into the review and competitive package defaults. The product
+gap now matches the social-post gap closed by PR #1271: a run returns ad-copy
+drafts in the execution payload, but those drafts are not persisted anywhere.
+Operators cannot review, approve, reject, export, or revisit them later.
+
+This slice is the persistence prerequisite for the generated-asset review
+queue. It saves generated ad-copy drafts as tenant-scoped rows when DB-backed
+Content Ops services are enabled, while leaving the default deterministic
+service dependency-free. The generated-assets route and UI switchboard can then
+be added in the next slice without inventing storage in the API layer.
+
+The diff is expected to exceed the 400 LOC soft cap for the same reason as the
+social-post persistence slice: schema, package port, adapter, generator save
+hook, host wiring, and focused tests need to land together or the persistence
+boundary is either dead schema or unexercised wiring.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a package-owned `AdCopyDraft` persistence contract and Postgres adapter.
+2. Add the package migration for `ad_copy_drafts` review rows.
+3. Teach `AdCopyGenerationService` to persist generated ads when a repository
+   is injected, returning `saved_ids` in the result.
+4. Wire the host DB-backed service bundle to use the Postgres ad-copy
+   repository when `enable_db_services=True`.
+5. Add focused package and host tests proving tenant-scoped persistence and the
+   non-persistent fallback.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Ad-Copy-Review-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/ad_copy_ports.py`
+- `extracted_content_pipeline/ad_copy_postgres.py`
+- `extracted_content_pipeline/ad_copy_generation.py`
+- `extracted_content_pipeline/storage/migrations/332_ad_copy_drafts.sql`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_ad_copy_generation.py`
+- `tests/test_extracted_ad_copy_postgres.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+
+## Mechanism
+
+`AdCopyGenerationService` already turns normalized source material into ad
+dictionaries. This slice mirrors the social-post pattern: convert those
+dictionaries into `AdCopyDraft` values and call:
+
+```python
+await ad_copy_drafts.save_drafts(drafts, scope=scope)
+```
+
+only when a repository is injected. The default constructor keeps today's
+dependency-light extracted behavior, so hosts without DB services still receive
+the same `ads` payload, now with an empty `saved_ids` list.
+
+The Postgres adapter stores tenant scope in `account_id`, keeps the original
+source ad in JSONB metadata, starts rows at `status = 'draft'`, and exposes the
+same save/list/status update shape as the social-post adapter. Host wiring
+injects the adapter only inside the existing `enable_db_services=True` branch.
+
+## Intentional
+
+- No generated-assets API or frontend tab in this PR. The storage source must
+  exist before list/review/export routes can read ad-copy drafts.
+- No LLM or quality-gate changes. `ad_copy` remains deterministic and uses the
+  same source-material evidence parsing from #1275.
+- No persistence when DB services are disabled. The default service remains
+  dependency-free and returns empty `saved_ids`.
+
+## Deferred
+
+- Next PR: add `ad_copy` to generated-assets API list/export/review/batch
+  switchboards and expose it to the asset review UI.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_ad_copy_generation.py tests/test_extracted_ad_copy_postgres.py -q (9 passed)
+- Passed: pytest tests/test_atlas_content_ops_execution_services.py -q (22 passed)
+- Passed: python -m py_compile extracted_content_pipeline/ad_copy_generation.py extracted_content_pipeline/ad_copy_postgres.py extracted_content_pipeline/ad_copy_ports.py atlas_brain/_content_ops_services.py
+- Passed: git diff --check
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2988 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-review-assets-pr-body.md
+
+## Estimated diff size
+
+Actual: 10 files, +815 / -14. This is above the 400 LOC soft cap because the
+ad-copy persistence prerequisite is indivisible: the table, port, adapter,
+service save hook, host wiring, and focused tests have to land together or the
+next generated-assets route slice has no durable draft source to read.
+
+| Area | Estimated LOC |
+|---|---:|
+| Ad-copy contract, adapter, migration, and manifest | ~320 |
+| Generator save hook and host wiring | ~85 |
+| Focused package and host tests | ~260 |
+| Plan doc | ~85 |
+| **Total** | **~815** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -5,7 +5,7 @@
 the host has wired. Currently:
 
 - `signal_extraction` (E1, PR #452): always wired (stateless).
-- `ad_copy`: deterministic; always wired.
+- `ad_copy`: deterministic; persists when DB services are enabled.
 - `landing_page` (E2 + E2.5, PRs #454/#455): wired when an
   LLM + pool are active; slot stays `None` otherwise.
 - `campaign` / `report` / `sales_brief` (E3, PR #456):
@@ -28,7 +28,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (20 tests):
+Test inventory (22 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -48,19 +48,21 @@ Test inventory (20 tests):
 13. `faq_markdown` runs through the full executor.
 14. `faq_markdown` persists when DB services are enabled.
 15. `social_post` persists when DB services are enabled.
-16. `faq_deflection_report` runs through the full executor.
-17. `social_post` is always wired.
-18. `configured_outputs()` with LLM + db enabled advertises
-    all 8 outputs: `(email_campaign, blog_post, report,
+16. `ad_copy` persists when DB services are enabled.
+17. `faq_deflection_report` runs through the full executor.
+18. `social_post` is always wired.
+19. `ad_copy` is always wired.
+20. `configured_outputs()` with LLM + db enabled advertises
+    every wired output: `(email_campaign, blog_post, report,
     landing_page, sales_brief, social_post, ad_copy,
     signal_extraction, faq_markdown, faq_deflection_report)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-19. `configured_outputs()` without an active LLM (even with
+21. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     deterministic outputs.
-20. The hosted paywall mode can hide `faq_markdown` while
+22. The hosted paywall mode can hide `faq_markdown` while
     retaining a runnable `faq_deflection_report`.
 """
 
@@ -255,6 +257,51 @@ async def test_social_post_persists_when_db_services_enabled() -> None:
         "vendor_retention",
         "linkedin",
         step["result"]["posts"][0]["text"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_persists_when_db_services_enabled() -> None:
+    pool = _FAQPoolStub(return_id="ad-copy-uuid-1")
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["ad_copy"],
+            "inputs": {
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "reviewer_company": "Acme Logistics",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                    "pain_category": "pricing pressure",
+                }]
+            },
+        },
+        services=services,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "ad_copy"
+    assert step["status"] == "completed"
+    assert step["result"]["saved_ids"] == ["ad-copy-uuid-1"]
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO ad_copy_drafts" in call["query"]
+    assert call["args"][:7] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "paid_social",
+        "single_image",
+        step["result"]["ads"][0]["headline"],
+        step["result"]["ads"][0]["primary_text"],
     )
 
 

--- a/tests/test_extracted_ad_copy_generation.py
+++ b/tests/test_extracted_ad_copy_generation.py
@@ -6,7 +6,22 @@ from extracted_content_pipeline.ad_copy_generation import (
     AdCopyGenerationConfig,
     AdCopyGenerationService,
 )
+from extracted_content_pipeline.ad_copy_ports import AdCopyDraft
 from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _AdCopyRepository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def save_drafts(
+        self,
+        drafts: list[AdCopyDraft] | tuple[AdCopyDraft, ...],
+        *,
+        scope: TenantScope,
+    ) -> tuple[str, ...]:
+        self.calls.append({"drafts": tuple(drafts), "scope": scope})
+        return ("ad-copy-db-id-1",)
 
 
 @pytest.mark.asyncio
@@ -31,6 +46,7 @@ async def test_ad_copy_service_generates_evidence_backed_ads() -> None:
     assert payload["generated"] == 1
     assert payload["target_mode"] == "vendor_retention"
     assert payload["warnings"] == []
+    assert payload["saved_ids"] == []
     assert payload["ads"] == [
         {
             "id": "review-1",
@@ -51,6 +67,47 @@ async def test_ad_copy_service_generates_evidence_backed_ads() -> None:
             "pain_points": ["pricing pressure"],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_ad_copy_service_persists_generated_drafts_when_repository_is_configured() -> None:
+    repository = _AdCopyRepository()
+    service = AdCopyGenerationService(ad_copy_drafts=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    assert result.saved_ids == ("ad-copy-db-id-1",)
+    assert result.as_dict()["saved_ids"] == ["ad-copy-db-id-1"]
+    assert len(repository.calls) == 1
+    call = repository.calls[0]
+    assert call["scope"] == TenantScope(account_id="acct-1", user_id="user-1")
+    drafts = call["drafts"]
+    assert isinstance(drafts, tuple)
+    draft = drafts[0]
+    assert draft.target_id == "review-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.channel == "paid_social"
+    assert draft.format == "single_image"
+    assert draft.headline == "HubSpot proof: pricing pressure"
+    assert draft.cta == "See the proof"
+    assert draft.source_id == "review-1"
+    assert draft.source_type == "review"
+    assert draft.company_name == "Acme Logistics"
+    assert draft.vendor_name == "HubSpot"
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata["source_ad"]["id"] == "review-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_ad_copy_postgres.py
+++ b/tests/test_extracted_ad_copy_postgres.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.ad_copy_ports import AdCopyDraft
+from extracted_content_pipeline.ad_copy_postgres import (
+    PostgresAdCopyRepository,
+)
+from extracted_content_pipeline.campaign_ports import TenantScope
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.fetchval_calls: list[dict[str, object]] = []
+        self.fetch_calls: list[dict[str, object]] = []
+        self.execute_calls: list[dict[str, object]] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return self.execute_result
+
+
+def _compact_sql(query: object) -> str:
+    return " ".join(str(query).split())
+
+
+def _draft() -> AdCopyDraft:
+    return AdCopyDraft(
+        target_id="review-1",
+        target_mode="vendor_retention",
+        channel="paid_social",
+        format="single_image",
+        headline="HubSpot proof: pricing pressure",
+        primary_text="When HubSpot buyers mention pricing pressure, use the proof.",
+        cta="See the proof",
+        source_id="review-1",
+        source_type="review",
+        company_name="Acme Logistics",
+        vendor_name="HubSpot",
+        pain_points=("pricing pressure",),
+        metadata={"confidence": 0.88},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_ad_copy_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["ad-copy-uuid-1"]
+    repo = PostgresAdCopyRepository(pool)
+
+    saved = await repo.save_drafts(
+        [_draft()],
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert saved == ("ad-copy-uuid-1",)
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO ad_copy_drafts" in call["query"]
+    args = call["args"]
+    assert args[:12] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "paid_social",
+        "single_image",
+        "HubSpot proof: pricing pressure",
+        "When HubSpot buyers mention pricing pressure, use the proof.",
+        "See the proof",
+        "review-1",
+        "review",
+        "Acme Logistics",
+        "HubSpot",
+    )
+    assert json.loads(args[12]) == ["pricing pressure"]
+    metadata = json.loads(args[13])
+    assert metadata["target_id"] == "review-1"
+    assert metadata["target_mode"] == "vendor_retention"
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert metadata["confidence"] == 0.88
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_scope_status_target_mode_and_channel() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{
+        "id": "ad-copy-uuid-1",
+        "target_id": "review-1",
+        "target_mode": "vendor_retention",
+        "channel": "paid_social",
+        "format": "single_image",
+        "headline": "HubSpot proof: pricing pressure",
+        "primary_text": "When HubSpot buyers mention pricing pressure, use the proof.",
+        "cta": "See the proof",
+        "source_id": "review-1",
+        "source_type": "review",
+        "company_name": "Acme Logistics",
+        "vendor_name": "HubSpot",
+        "pain_points": json.dumps(["pricing pressure"]),
+        "metadata": json.dumps({"confidence": 0.88}),
+        "status": "draft",
+    }]
+    repo = PostgresAdCopyRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor_retention",
+        channel="paid_social",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.id == "ad-copy-uuid-1"
+    assert draft.channel == "paid_social"
+    assert draft.format == "single_image"
+    assert draft.headline == "HubSpot proof: pricing pressure"
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata == {"confidence": 0.88}
+    call = pool.fetch_calls[0]
+    assert "FROM ad_copy_drafts" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert call["args"] == ("acct-1", "draft", "vendor_retention", "paid_social", 10)
+
+
+@pytest.mark.asyncio
+async def test_update_status_is_tenant_scoped_and_reports_misses() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresAdCopyRepository(pool)
+
+    updated = await repo.update_status(
+        "ad-copy-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is False
+    call = pool.execute_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE ad_copy_drafts" in sql
+    assert "WHERE id = $1::uuid AND account_id = $3" in sql
+    assert call["args"] == ("ad-copy-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_returns_scoped_matches() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "ad-copy-uuid-1"}]
+    repo = PostgresAdCopyRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["ad-copy-uuid-1", ""],
+        "rejected",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ("ad-copy-uuid-1",)
+    call = pool.fetch_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE ad_copy_drafts" in sql
+    assert "WHERE id = ANY($1::uuid[]) AND account_id = $3" in sql
+    assert call["args"] == (["ad-copy-uuid-1"], "rejected", "acct-1")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ad-Copy-Review-Assets.md
Slice phase: Vertical slice

Generated `ad_copy` runs now return executable ad drafts for marketer review inputs, but those drafts disappear after the execution payload. This slice mirrors the social-post persistence boundary so DB-backed Content Ops services save ad-copy drafts into tenant-scoped review rows, while the default deterministic service remains dependency-free.

## Intentional

- No generated-assets API or frontend tab in this PR. The storage source must exist before list/review/export routes can read ad-copy drafts.
- No LLM or quality-gate changes. `ad_copy` remains deterministic and uses the same source-material evidence parsing from #1275.
- No persistence when DB services are disabled. The default service remains dependency-free and returns empty `saved_ids`.

## Deferred

- Next PR: add `ad_copy` to generated-assets API list/export/review/batch switchboards and expose it to the asset review UI.

## Parked hardening

- None.

## Verification

- Passed: pytest tests/test_extracted_ad_copy_generation.py tests/test_extracted_ad_copy_postgres.py -q (9 passed)
- Passed: pytest tests/test_atlas_content_ops_execution_services.py -q (22 passed)
- Passed: python -m py_compile extracted_content_pipeline/ad_copy_generation.py extracted_content_pipeline/ad_copy_postgres.py extracted_content_pipeline/ad_copy_ports.py atlas_brain/_content_ops_services.py
- Passed: git diff --check
- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
- Passed: bash scripts/validate_extracted_content_pipeline.sh
- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
- Passed: bash scripts/check_ascii_python.sh
- Passed: bash scripts/run_extracted_pipeline_checks.sh (2988 passed, 10 skipped, 1 warning)
- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-review-assets-pr-body.md

## Diff size

10 files, +815 / -14
