### PR TITLE
Plan: Content Ops Ad Copy Generated Assets

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test Content Ops social post review assets
         run: npm run test:content-ops-social-post-review-assets
 
+      - name: Test Content Ops ad copy review assets
+        run: npm run test:content-ops-ad-copy-review-assets
+
       - name: Test Content Ops review source selection
         run: npm run test:content-ops-review-source-selection
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -23,6 +23,7 @@
     "test:content-ops-upload-source-run-handoff": "node --test scripts/content-ops-upload-source-run-handoff.test.mjs",
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:content-ops-social-post-review-assets": "node --test scripts/content-ops-social-post-review-assets.test.mjs",
+    "test:content-ops-ad-copy-review-assets": "node --test scripts/content-ops-ad-copy-review-assets.test.mjs",
     "test:content-ops-review-source-selection": "node --test scripts/content-ops-review-source-selection.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-ad-copy-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-ad-copy-review-assets.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fetchGeneratedAssetDrafts,
+  reviewGeneratedAssetDraft,
+  reviewGeneratedAssetDrafts,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('ad-copy generated asset list fetches the typed content-assets route', async () => {
+  const payload = {
+    count: 1,
+    limit: 5,
+    filters: { status: 'draft', channel: 'paid_social' },
+    rows: [{
+      id: 'ad-copy-1',
+      status: 'draft',
+      channel: 'paid_social',
+      format: 'single_image',
+      headline: 'Zendesk proof: slow response',
+      primary_text: 'When Zendesk buyers mention slow response, use the proof.',
+      cta: 'See the proof',
+    }],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchGeneratedAssetDrafts('ad_copy', {
+    status: 'draft',
+    channel: 'paid_social',
+    limit: 5,
+  })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/ad_copy/drafts?status=draft&channel=paid_social&limit=5`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('ad-copy generated asset review actions post to typed routes', async () => {
+  const calls = installFetchResponder({
+    account_id: 'acct-1',
+    asset: 'ad_copy',
+    id: 'ad-copy-1',
+    status: 'approved',
+    updated: true,
+  })
+
+  await reviewGeneratedAssetDraft('ad_copy', 'ad-copy-1', 'approved')
+  await reviewGeneratedAssetDrafts('ad_copy', ['ad-copy-1'], 'rejected')
+
+  assert.equal(calls.length, 2)
+  assert.equal(
+    calls[0].url,
+    `${API_ORIGIN}/api/v1/content-assets/ad_copy/drafts/review`,
+  )
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    id: 'ad-copy-1',
+    status: 'approved',
+  })
+  assert.equal(
+    calls[1].url,
+    `${API_ORIGIN}/api/v1/content-assets/ad_copy/drafts/review-batch`,
+  )
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    ids: ['ad-copy-1'],
+    status: 'rejected',
+  })
+})
+
+test('asset review UI exposes ad-copy tab and preview branches', () => {
+  assert.ok(reviewSource.includes("id: 'ad_copy'"))
+  assert.ok(reviewSource.includes("label: 'Ad Copy'"))
+  assert.ok(reviewSource.includes("asset === 'ad_copy'"))
+  assert.ok(reviewSource.includes('textValue(row.primary_text)'))
+  assert.ok(reviewSource.includes('adCopyPainPointCount(row)'))
+  assert.ok(reviewSource.includes('CTA: ${cta}'))
+})
+
+test('completed ad-copy runs link into generated asset review', () => {
+  assert.match(
+    newRunSource,
+    /const GENERATED_ASSET_OUTPUTS:[\s\S]*'ad_copy'[\s\S]*\]/,
+  )
+  assert.ok(newRunSource.includes('function generatedAssetReviewHref'))
+  assert.ok(newRunSource.includes("params.set('asset', output)"))
+  assert.ok(newRunSource.includes('Review generated drafts'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -432,6 +432,7 @@ export type GeneratedAssetType =
   | 'landing_page'
   | 'sales_brief'
   | 'social_post'
+  | 'ad_copy'
   | 'faq_markdown'
 
 export interface GeneratedAssetRepairHistoryEntry {
@@ -470,7 +471,9 @@ export interface GeneratedAssetDraft {
   campaign_name?: string
   brief_type?: string
   channel?: string
+  format?: string
   text?: string
+  primary_text?: string
   source_id?: string
   source_type?: string
   company_name?: string
@@ -486,7 +489,7 @@ export interface GeneratedAssetDraft {
   tags?: string[] | string
   hero?: Record<string, unknown>
   sections?: Array<Record<string, unknown>> | string
-  cta?: Record<string, unknown>
+  cta?: Record<string, unknown> | string
   metadata?: GeneratedAssetDraftMetadata | string
   reference_ids?: string[] | string
   generation_total_tokens?: number

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -178,6 +178,11 @@ const ASSETS: Array<{
     description: 'Short-form posts generated from review and source evidence.',
   },
   {
+    id: 'ad_copy',
+    label: 'Ad Copy',
+    description: 'Paid-social ad drafts generated from review and source evidence.',
+  },
+  {
     id: 'faq_markdown',
     label: 'FAQ Markdown',
     description: 'Grounded FAQ documents generated from support-ticket evidence.',
@@ -2098,6 +2103,15 @@ function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string
       'social_post draft'
     )
   }
+  if (asset === 'ad_copy') {
+    return (
+      textValue(row.headline) ||
+      textValue(row.company_name) ||
+      textValue(row.vendor_name) ||
+      textValue(row.target_id) ||
+      'ad_copy draft'
+    )
+  }
   return (
     textValue(row.title) ||
     textValue(row.headline) ||
@@ -2134,6 +2148,16 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
   if (asset === 'social_post') {
     return [
       row.channel,
+      row.company_name,
+      row.vendor_name,
+      row.source_type,
+      row.source_id,
+    ].map(textValue).filter(Boolean).join(' | ')
+  }
+  if (asset === 'ad_copy') {
+    return [
+      row.channel,
+      row.format,
       row.company_name,
       row.vendor_name,
       row.source_type,
@@ -2203,6 +2227,15 @@ function addAssetSpecificFacts(
     addFact(facts, 'vendor', row.vendor_name)
     addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
     addFact(facts, 'pain points', socialPostPainPointCount(row))
+    return
+  }
+  if (asset === 'ad_copy') {
+    addFact(facts, 'channel', row.channel)
+    addFact(facts, 'format', row.format)
+    addFact(facts, 'company', row.company_name)
+    addFact(facts, 'vendor', row.vendor_name)
+    addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
+    addFact(facts, 'pain points', adCopyPainPointCount(row))
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -2283,6 +2316,20 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
       ].filter(Boolean).join(' | '),
       body: excerpt(textValue(row.text), 280),
       meta: painPoints.map((item) => `pain: ${item}`),
+    })
+  }
+  if (asset === 'ad_copy') {
+    const painPoints = valueList(row.pain_points).slice(0, 3)
+    const cta = textValue(row.cta)
+    return previewOrNull({
+      heading: textValue(row.headline),
+      body: excerpt(textValue(row.primary_text), 280),
+      meta: [
+        textValue(row.channel),
+        textValue(row.format),
+        cta ? `CTA: ${cta}` : '',
+        ...painPoints.map((item) => `pain: ${item}`),
+      ].filter(Boolean),
     })
   }
   const section = firstSection(row.sections)
@@ -2441,6 +2488,13 @@ function readinessMeta(row: GeneratedAssetDraft): string[] {
 }
 
 function socialPostPainPointCount(row: GeneratedAssetDraft): number | string {
+  if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
+    return row.pain_point_count
+  }
+  return valueList(row.pain_points).length || ''
+}
+
+function adCopyPainPointCount(row: GeneratedAssetDraft): number | string {
   if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
     return row.pain_point_count
   }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -165,6 +165,7 @@ const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'sales_brief',
   'faq_markdown',
   'social_post',
+  'ad_copy',
 ]
 const ID_FILTERED_REVIEW_OUTPUTS = new Set<string>([
   'blog_post',

--- a/extracted_content_pipeline/ad_copy_export.py
+++ b/extracted_content_pipeline/ad_copy_export.py
@@ -1,0 +1,134 @@
+"""Read-only ad-copy draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+import json
+from typing import Any
+
+from .ad_copy_ports import AdCopyDraft, AdCopyRepository
+from .campaign_ports import TenantScope
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "channel",
+    "format",
+    "company_name",
+    "vendor_name",
+    "source_id",
+    "source_type",
+    "pain_point_count",
+    "headline",
+    "primary_text",
+    "cta",
+    "pain_points",
+    "metadata",
+    "id",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class AdCopyDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_ad_copy_drafts(
+    repository: AdCopyRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    channel: str | None = None,
+    limit: int = 20,
+) -> AdCopyDraftExportResult:
+    """Return generated ad-copy drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    if channel:
+        filters["channel"] = channel
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        channel=channel,
+        limit=normalized_limit,
+    )
+    return AdCopyDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: AdCopyDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["pain_point_count"] = len(draft.pain_points)
+    return row
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, default=str, separators=(",", ":"))
+    return "" if value is None else value
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "AdCopyDraftExportResult",
+    "export_ad_copy_drafts",
+]

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -24,6 +24,8 @@ else:
     _FASTAPI_IMPORT_ERROR = None
 
 from ..campaign_ports import LLMClient, SkillStore, TenantScope
+from ..ad_copy_export import export_ad_copy_drafts
+from ..ad_copy_postgres import PostgresAdCopyRepository
 from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
 from ..landing_page_export import (
@@ -66,6 +68,7 @@ ASSET_CHOICES = (
     "landing_page",
     "sales_brief",
     "social_post",
+    "ad_copy",
     "faq_markdown",
 )
 logger = logging.getLogger(__name__)
@@ -781,6 +784,15 @@ async def _export_for_asset(
             channel=channel,
             limit=limit,
         )
+    if asset == "ad_copy":
+        return await export_ad_copy_drafts(
+            PostgresAdCopyRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            channel=channel,
+            limit=limit,
+        )
     if asset == "faq_markdown":
         return await export_ticket_faq_drafts(
             PostgresTicketFAQRepository(pool),
@@ -810,6 +822,8 @@ async def _update_asset_status(
         return await PostgresSalesBriefRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "social_post":
         return await PostgresSocialPostRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "ad_copy":
+        return await PostgresAdCopyRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_status(asset_id, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
@@ -833,6 +847,8 @@ async def _update_asset_statuses(
         return await PostgresSalesBriefRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "social_post":
         return await PostgresSocialPostRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "ad_copy":
+        return await PostgresAdCopyRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -312,6 +312,9 @@
       "target": "extracted_content_pipeline/social_post_export.py"
     },
     {
+      "target": "extracted_content_pipeline/ad_copy_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/social_post_ports.py"
     },
     {

--- a/plans/PR-Content-Ops-Ad-Copy-Generated-Assets.md
+++ b/plans/PR-Content-Ops-Ad-Copy-Generated-Assets.md
@@ -1,0 +1,125 @@
+# PR: Content Ops Ad Copy Generated Assets
+
+## Why this slice exists
+
+PR #1282 persisted generated `ad_copy` drafts into tenant-scoped
+`ad_copy_drafts` rows, but the generated-asset review API and UI still only know
+how to list, export, approve, and reject reports, blog posts, landing pages,
+sales briefs, social posts, and FAQ Markdown. That leaves the new durable
+ad-copy table invisible to operators.
+
+This slice completes the review-queue handoff from #1282: persisted ad-copy
+drafts become a first-class generated asset in the existing review API and
+`atlas-intel-ui` generated-asset review screen.
+
+The diff is expected to exceed the 400 LOC soft cap for the same reason as the
+social-post generated-assets slice: the backend export/review branches,
+frontend type/UI branches, CI-enrolled frontend test, and extracted API tests
+need to land together or `ad_copy` would be only partially reviewable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add a package-owned ad-copy export helper that returns the same
+   `count`/`limit`/`filters`/`rows` envelope and CSV behavior as sibling
+   generated assets.
+2. Add `ad_copy` to the generated-assets backend switchboards for list,
+   CSV/JSON export, single review, and batch review.
+3. Add `ad_copy` to the atlas-intel-ui API type surface and generated-asset
+   review asset registry.
+4. Render ad-copy rows with channel, format, company/vendor/source facts,
+   headline, primary text, CTA, and pain-point metadata.
+5. Add `ad_copy` to the completed-run review CTA allowlist so saved ad-copy IDs
+   hand off to the review tab without id filtering.
+6. Add backend and frontend tests proving the route/UI wiring, and enroll the
+   new frontend test in CI.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Ad-Copy-Generated-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/ad_copy_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-ad-copy-review-assets.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+
+## Mechanism
+
+`export_ad_copy_drafts(...)` wraps `PostgresAdCopyRepository.list_drafts` and
+maps each `AdCopyDraft` into a flat review/export row. The generated asset
+router then treats `ad_copy` like the other non-public generated assets:
+
+```python
+if asset == "ad_copy":
+    return await export_ad_copy_drafts(PostgresAdCopyRepository(pool), ...)
+```
+
+The same `_update_asset_status` and `_update_asset_statuses` helpers call the
+repository added in #1282, so review and batch review retain tenant-scoped
+`account_id` predicates from the adapter instead of duplicating SQL in the API
+layer.
+
+On the frontend, `GeneratedAssetType` and the review screen `ASSETS` registry
+include `ad_copy`. Existing fetch/review/export helpers already build URLs from
+the asset type, so the UI work is limited to rendering meaningful ad-copy
+labels, facts, and preview text. `ContentOpsNewRun.tsx` also includes `ad_copy`
+in the generated-output allowlist used by `generatedAssetReviewHref(...)`;
+because the backend intentionally does not add id-filter repository support in
+this slice, the CTA links to the `ad_copy` draft review tab with no repeated
+`id` query keys.
+
+## Intentional
+
+- No public ad-copy URL support. Ad copy is a review/export asset, not a hosted
+  public page in this slice.
+- No edit/repair flow for ad copy. The existing landing-page edit/repair
+  controls remain landing-page-only.
+- No ID deep-link filter for `ad_copy`. The #1282 repository lists by status,
+  target mode, and channel; adding id-filter repository support can be a
+  follow-up if run-result deep links need it.
+
+## Deferred
+
+- Optional ad-copy id deep links can be added after a product path actually
+  needs direct review links from generation results.
+- Stat/quote-card package defaults remain a future output slice.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: pytest tests/test_extracted_content_asset_api.py -q (74 passed)
+- Passed: python -m py_compile extracted_content_pipeline/ad_copy_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py
+- Passed: cd atlas-intel-ui && npm run test:content-ops-ad-copy-review-assets (4 passed)
+- Passed: cd atlas-intel-ui && npm run lint
+- Passed: cd atlas-intel-ui && npm run build
+- Passed: git diff --check
+- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
+- Passed: bash scripts/validate_extracted_content_pipeline.sh
+- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
+- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
+- Passed: bash scripts/check_ascii_python.sh
+- Passed: bash scripts/run_extracted_pipeline_checks.sh (2992 passed, 10 skipped, 1 warning)
+- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-generated-assets-pr-body.md
+
+## Estimated diff size
+
+Actual: 11 files, +617 / -1. This is above the 400 LOC soft cap for the
+end-to-end handoff reasons named in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Ad-copy export helper + manifest | ~135 |
+| Backend switchboard + tests | ~135 |
+| Frontend type/UI/test/workflow enrollment | ~230 |
+| Plan doc | ~115 |
+| **Total** | **~620** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -443,6 +443,28 @@ def _social_post_row():
     }
 
 
+def _ad_copy_row():
+    return {
+        "id": "ad-copy-uuid-1",
+        "status": "draft",
+        "target_id": "review-1",
+        "target_mode": "review",
+        "channel": "paid_social",
+        "format": "single_image",
+        "headline": "Zendesk proof: slow response",
+        "primary_text": (
+            "When Zendesk buyers mention slow response, use the proof."
+        ),
+        "cta": "See the proof",
+        "source_id": "source-1",
+        "source_type": "review",
+        "company_name": "Acme",
+        "vendor_name": "Zendesk",
+        "pain_points": ["slow response", "renewal pressure"],
+        "metadata": {"source_url": "https://example.test/reviews/1"},
+    }
+
+
 def _ticket_faq_row():
     return {
         "id": "faq-uuid-1",
@@ -1494,6 +1516,51 @@ def test_generated_asset_router_exports_social_post_csv() -> None:
     assert args == ("", "review", "linkedin", 20)
 
 
+def test_generated_asset_router_lists_ad_copy_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_ad_copy_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/ad_copy/drafts"
+        "?target_mode=review&channel=paid_social&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    row = body["rows"][0]
+    assert row["id"] == "ad-copy-uuid-1"
+    assert row["channel"] == "paid_social"
+    assert row["format"] == "single_image"
+    assert row["headline"] == "Zendesk proof: slow response"
+    assert row["cta"] == "See the proof"
+    assert row["pain_point_count"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM ad_copy_drafts" in query
+    assert args == ("acct_1", "draft", "review", "paid_social", 5)
+
+
+def test_generated_asset_router_exports_ad_copy_csv() -> None:
+    pool = _Pool(rows=[_ad_copy_row()])
+
+    response = _client(pool).get(
+        "/content-assets/ad_copy/drafts/export"
+        "?format=csv&status=&target_mode=review&channel=paid_social"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_ad_copy.csv" in response.headers["content-disposition"]
+    assert "target_id,target_mode,channel,format" in response.text
+    assert "Zendesk proof: slow response" in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM ad_copy_drafts" in query
+    assert "status = " not in query
+    assert args == ("", "review", "paid_social", 20)
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 
@@ -1538,6 +1605,27 @@ def test_generated_asset_router_reviews_social_post() -> None:
     query, args = pool.execute_calls[0]
     assert "UPDATE social_posts" in query
     assert args == ("social-post-uuid-1", "approved", "acct_1")
+
+
+def test_generated_asset_router_reviews_ad_copy() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/ad_copy/drafts/review",
+        json={"id": "ad-copy-uuid-1", "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct_1",
+        "asset": "ad_copy",
+        "id": "ad-copy-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE ad_copy_drafts" in query
+    assert args == ("ad-copy-uuid-1", "approved", "acct_1")
 
 
 def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
@@ -1898,6 +1986,31 @@ def test_generated_asset_router_batch_reviews_social_posts() -> None:
     assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
     query, args = pool.fetch_calls[0]
     assert "UPDATE social_posts" in query
+    assert "RETURNING id" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_reviews_ad_copy() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/ad_copy/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
+            "status": "rejected",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset"] == "ad_copy"
+    assert response.json()["updated"] == 2
+    assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE ad_copy_drafts" in query
     assert "RETURNING id" in query
     assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
     assert pool.execute_calls == []


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Ad-Copy-Generated-Assets.md
Slice phase: Vertical slice

Persisted `ad_copy` drafts now need the same generated-asset review handoff as social posts: list/export/review/batch-review backend routes plus atlas-intel-ui review tab and completed-run CTA wiring. This slice makes ad-copy drafts first-class review assets without adding public URL or edit/repair flows.

## Intentional

- No public ad-copy URL support. Ad copy is a review/export asset, not a hosted public page in this slice.
- No edit/repair flow for ad copy. The existing landing-page edit/repair controls remain landing-page-only.
- No ID deep-link filter for `ad_copy`. The #1282 repository lists by status, target mode, and channel; adding id-filter repository support can be a follow-up if run-result deep links need it.

## Deferred

- Optional ad-copy id deep links can be added after a product path actually needs direct review links from generation results.
- Stat/quote-card package defaults remain a future output slice.

## Parked hardening

- None.

## Verification

- Passed: pytest tests/test_extracted_content_asset_api.py -q (74 passed)
- Passed: python -m py_compile extracted_content_pipeline/ad_copy_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py
- Passed: cd atlas-intel-ui && npm run test:content-ops-ad-copy-review-assets (4 passed)
- Passed: cd atlas-intel-ui && npm run lint
- Passed: cd atlas-intel-ui && npm run build
- Passed: git diff --check
- Passed: python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
- Passed: bash scripts/validate_extracted_content_pipeline.sh
- Passed: python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline
- Passed: python scripts/audit_extracted_standalone.py --fail-on-debt
- Passed: bash scripts/check_ascii_python.sh
- Passed: bash scripts/run_extracted_pipeline_checks.sh (2992 passed, 10 skipped, 1 warning)
- Passed: bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-ad-copy-generated-assets-pr-body.md

## Diff size

11 files, +617 / -1
