### PR TITLE
Plan: Content Ops CSV Export Formula Hardening

### DIFF
--- a/extracted_content_pipeline/ad_copy_export.py
+++ b/extracted_content_pipeline/ad_copy_export.py
@@ -6,11 +6,11 @@ from collections.abc import Mapping
 import csv
 from dataclasses import dataclass
 from io import StringIO
-import json
 from typing import Any
 
 from .ad_copy_ports import AdCopyDraft, AdCopyRepository
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 
 
 JsonDict = dict[str, Any]
@@ -102,12 +102,6 @@ def _draft_row(draft: AdCopyDraft) -> JsonDict:
     row = draft.as_dict()
     row["pain_point_count"] = len(draft.pain_points)
     return row
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/blog_post_export.py
+++ b/extracted_content_pipeline/blog_post_export.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .blog_ports import BlogPostDraft, BlogPostRepository
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 
 
 JsonDict = dict[str, Any]
@@ -446,12 +447,6 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/campaign_postgres_export.py
+++ b/extracted_content_pipeline/campaign_postgres_export.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from .campaign_ports import TenantScope
 from .campaign_postgres_generation import tenant_scope_from_mapping
+from .csv_export import csv_cell_value as _csv_value
 from .storage._jsonb_helpers import row_to_dict as _row_dict
 
 
@@ -198,12 +199,6 @@ def _json_ready(value: Any) -> Any:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     return str(value)
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _clean(value: Any) -> str:

--- a/extracted_content_pipeline/campaign_reasoning_postgres.py
+++ b/extracted_content_pipeline/campaign_reasoning_postgres.py
@@ -31,13 +31,13 @@ from __future__ import annotations
 
 import csv
 import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from io import StringIO
 from typing import Any
 
 from .campaign_ports import CampaignReasoningContext, JsonDict, TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .services.campaign_reasoning_context import (
     campaign_reasoning_context_metadata,
     normalize_campaign_reasoning_context,
@@ -139,12 +139,6 @@ def _json_ready(value: Any) -> Any:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     return str(value)
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _serializable_context_row(row: Mapping[str, Any]) -> JsonDict:

--- a/extracted_content_pipeline/csv_export.py
+++ b/extracted_content_pipeline/csv_export.py
@@ -1,0 +1,32 @@
+"""CSV cell serialization helpers for Content Ops exports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Any
+
+
+_SPREADSHEET_FORMULA_PREFIXES = ("=", "+", "-", "@")
+
+
+def csv_cell_value(value: Any) -> Any:
+    """Return a CSV-safe cell value while preserving export row contracts."""
+
+    if isinstance(value, (Mapping, list, tuple)):
+        text: Any = json.dumps(value, default=str, separators=(",", ":"))
+    elif value is None:
+        text = ""
+    else:
+        text = value
+
+    if (
+        isinstance(text, str)
+        and text
+        and text.lstrip().startswith(_SPREADSHEET_FORMULA_PREFIXES)
+    ):
+        return "'" + text
+    return text
+
+
+__all__ = ["csv_cell_value"]

--- a/extracted_content_pipeline/landing_page_export.py
+++ b/extracted_content_pipeline/landing_page_export.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .landing_page_ports import LandingPageDraft, LandingPageRepository
 from .landing_page_readiness import (
     landing_page_geo_readiness,
@@ -239,12 +240,6 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -222,6 +222,9 @@
       "target": "extracted_content_pipeline/campaign_postgres_export.py"
     },
     {
+      "target": "extracted_content_pipeline/csv_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/report_export.py"
     },
     {

--- a/extracted_content_pipeline/report_export.py
+++ b/extracted_content_pipeline/report_export.py
@@ -10,6 +10,7 @@ import json
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .report_ports import ReportDraft, ReportRepository
 
 
@@ -137,12 +138,6 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/sales_brief_export.py
+++ b/extracted_content_pipeline/sales_brief_export.py
@@ -10,6 +10,7 @@ import json
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .sales_brief_ports import SalesBriefDraft, SalesBriefRepository
 
 
@@ -135,12 +136,6 @@ def _metadata_mapping(value: Any) -> JsonDict:
         if isinstance(parsed, Mapping):
             return {str(key): item for key, item in parsed.items()}
     return {}
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/social_post_export.py
+++ b/extracted_content_pipeline/social_post_export.py
@@ -6,10 +6,10 @@ from collections.abc import Mapping
 import csv
 from dataclasses import dataclass
 from io import StringIO
-import json
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .social_post_ports import SocialPostDraft, SocialPostRepository
 
 
@@ -99,12 +99,6 @@ def _draft_row(draft: SocialPostDraft) -> JsonDict:
     row = draft.as_dict()
     row["pain_point_count"] = len(draft.pain_points)
     return row
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/extracted_content_pipeline/ticket_faq_export.py
+++ b/extracted_content_pipeline/ticket_faq_export.py
@@ -6,10 +6,10 @@ from collections.abc import Mapping
 import csv
 from dataclasses import dataclass
 from io import StringIO
-import json
 from typing import Any
 
 from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
 from .ticket_faq_ports import TicketFAQDraft, TicketFAQRepository
 
 
@@ -103,12 +103,6 @@ def _passed_output_checks(value: Any) -> int:
     if not isinstance(value, Mapping):
         return 0
     return sum(1 for item in value.values() if item is True)
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (Mapping, list, tuple)):
-        return json.dumps(value, default=str, separators=(",", ":"))
-    return "" if value is None else value
 
 
 def _normalize_limit(value: Any) -> int:

--- a/plans/PR-Content-Ops-CSV-Export-Formula-Hardening.md
+++ b/plans/PR-Content-Ops-CSV-Export-Formula-Hardening.md
@@ -1,0 +1,110 @@
+# PR-Content-Ops-CSV-Export-Formula-Hardening
+
+## Why this slice exists
+
+PR #1283's review surfaced a recurring Content Ops CSV export hardening gap:
+the duplicated `_csv_value` helpers serialize customer/scraped/generated text
+directly into CSV cells. If an operator opens an exported CSV in a spreadsheet,
+cells beginning with `=`, `+`, `-`, or `@` can be interpreted as formulas.
+The generated-assets export path now includes marketer-provided review input and
+LLM-shaped copy, so this belongs as a small production-hardening follow-up
+before building more output variants.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input-hardening
+
+Slice phase: Production hardening
+
+1. Add one package-owned CSV cell serialization helper for
+   `extracted_content_pipeline` exports.
+2. Replace the duplicated `_csv_value` helpers in the Content Ops export
+   result classes with the shared helper.
+3. Keep existing JSON serialization and `None` handling stable while escaping
+   formula-leading string cells.
+4. Add focused tests for all risky prefixes, leading-whitespace formulas,
+   normal strings, non-string numerics, and JSON/list cells.
+5. Enroll the new helper test in the extracted pipeline CI wrapper.
+
+### Files touched
+
+- `extracted_content_pipeline/csv_export.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/campaign_postgres_export.py`
+- `extracted_content_pipeline/campaign_reasoning_postgres.py`
+- `extracted_content_pipeline/report_export.py`
+- `extracted_content_pipeline/blog_post_export.py`
+- `extracted_content_pipeline/landing_page_export.py`
+- `extracted_content_pipeline/sales_brief_export.py`
+- `extracted_content_pipeline/ticket_faq_export.py`
+- `extracted_content_pipeline/social_post_export.py`
+- `extracted_content_pipeline/ad_copy_export.py`
+- `tests/test_extracted_csv_export.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `plans/PR-Content-Ops-CSV-Export-Formula-Hardening.md`
+
+## Mechanism
+
+The helper keeps the previous export contract first, then applies the
+spreadsheet guard only to string cells:
+
+```python
+def csv_cell_value(value):
+    if isinstance(value, (Mapping, list, tuple)):
+        text = json.dumps(value, default=str, separators=(",", ":"))
+    elif value is None:
+        text = ""
+    else:
+        text = value
+    if isinstance(text, str) and text.lstrip().startswith(("=", "+", "-", "@")):
+        return "'" + text
+    return text
+```
+
+Each export module imports `csv_cell_value` as its local `_csv_value`, so the
+row-writing loops stay unchanged while the guard applies uniformly to generated
+asset exports, legacy campaign draft exports, and campaign reasoning context
+CSV inventory.
+
+## Intentional
+
+- CSV import parsers (`campaign_customer_data.py` and
+  `podcast_transcript_data.py`) are not in scope. They parse operator-supplied
+  input into structured rows; the risk here is exported cells being opened by a
+  spreadsheet.
+- Numeric values remain numeric. The guard applies to strings only, so an actual
+  integer or float does not become text; a string value such as `"-SUM(A1:A2)"`
+  is escaped.
+- Nested JSON values are not individually walked. Existing exports already
+  serialize mappings/lists into JSON text cells; the cell is escaped only when
+  the serialized cell itself starts with a formula prefix.
+
+## Deferred
+
+Parked hardening: none.
+
+Atlas-wide CSV surfaces outside `extracted_content_pipeline` are not audited in
+this slice. This PR drains the exact Content Ops export family raised by the
+#1283 review NIT; a future repo-wide CSV hardening audit can cover unrelated
+B2B/prospect exports if needed.
+
+## Verification
+
+- `pytest tests/test_extracted_csv_export.py -q` (8 passed)
+- `pytest tests/test_extracted_campaign_postgres_export.py tests/test_extracted_campaign_reasoning_list_cli.py tests/test_extracted_report_export.py tests/test_extracted_blog_post_export.py tests/test_extracted_landing_page_export.py tests/test_extracted_sales_brief_export.py tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_asset_api.py -q` (140 passed)
+- `bash scripts/validate_extracted_content_pipeline.sh` (passed)
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` (passed)
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` (passed; findings: 0)
+- `bash scripts/check_ascii_python.sh` (passed)
+- `bash scripts/run_extracted_pipeline_checks.sh` (3000 passed, 10 skipped)
+- `bash scripts/local_pr_review.sh --current-pr-body-file <process-substitution>` (passed)
+
+## Estimated diff size
+
+| Metric | LOC |
+|---|---:|
+| Added | 227 |
+| Deleted | 58 |
+| Total | 285 |
+
+Under the 400 LOC soft cap.

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -120,6 +120,7 @@ pytest \
   tests/test_extracted_storage_jsonb_helpers.py \
   tests/test_extracted_campaign_postgres_generation.py \
   tests/test_extracted_campaign_postgres_export.py \
+  tests/test_extracted_csv_export.py \
   tests/test_extracted_content_asset_export_cli.py \
   tests/test_extracted_content_asset_review_cli.py \
   tests/test_extracted_report_export.py \

--- a/tests/test_extracted_csv_export.py
+++ b/tests/test_extracted_csv_export.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import csv
+from io import StringIO
+
+import pytest
+
+from extracted_content_pipeline.ad_copy_export import AdCopyDraftExportResult
+from extracted_content_pipeline.csv_export import csv_cell_value
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "=HYPERLINK(\"https://example.invalid\")",
+        "+SUM(A1:A2)",
+        "-IMPORTXML(\"https://example.invalid\", \"//a\")",
+        "@NOW()",
+        " \t=HYPERLINK(\"https://example.invalid\")",
+    ),
+)
+def test_csv_cell_value_neutralizes_formula_like_strings(value: str) -> None:
+    escaped = csv_cell_value(value)
+
+    assert escaped == "'" + value
+
+
+def test_csv_cell_value_preserves_normal_cells() -> None:
+    assert csv_cell_value("normal copy") == "normal copy"
+    assert csv_cell_value("") == ""
+    assert csv_cell_value(None) == ""
+    assert csv_cell_value(-42) == -42
+    assert csv_cell_value(3.5) == 3.5
+
+
+def test_csv_cell_value_preserves_json_serialization_contract() -> None:
+    assert csv_cell_value({"scope": {"account_id": "acct_1"}}) == (
+        '{"scope":{"account_id":"acct_1"}}'
+    )
+    assert csv_cell_value(["slow support", "renewal risk"]) == (
+        '["slow support","renewal risk"]'
+    )
+
+
+def test_ad_copy_csv_export_applies_formula_guard_to_cells() -> None:
+    result = AdCopyDraftExportResult(
+        rows=({
+            "target_id": "target-1",
+            "target_mode": "review",
+            "channel": "paid_social",
+            "format": "single_image",
+            "company_name": "Acme",
+            "vendor_name": "Zendesk",
+            "source_id": "review-1",
+            "source_type": "review",
+            "pain_point_count": 1,
+            "headline": "=HYPERLINK(\"https://example.invalid\")",
+            "primary_text": "Open the proof.",
+            "cta": "+SUM(A1:A2)",
+            "pain_points": ["slow support"],
+            "metadata": {"scope": {"account_id": "acct_1"}},
+            "id": "ad-copy-1",
+            "status": "draft",
+        },),
+        limit=1,
+        filters={"status": "draft"},
+    )
+
+    row = next(csv.DictReader(StringIO(result.as_csv())))
+
+    assert row["headline"] == "'=HYPERLINK(\"https://example.invalid\")"
+    assert row["cta"] == "'+SUM(A1:A2)"
+    assert row["pain_points"] == '["slow support"]'
+    assert row["metadata"] == '{"scope":{"account_id":"acct_1"}}'


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-CSV-Export-Formula-Hardening.md
Slice phase: Production hardening

Harden Content Ops CSV exports by moving duplicated cell serialization into a shared package helper that neutralizes spreadsheet formula-leading strings while preserving existing JSON and None handling.

## Intentional
- CSV import parsers are not changed; this slice targets exported cells opened by operators in spreadsheets.
- Numeric values remain numeric; formula neutralization applies to string cells only.

## Deferred
- Atlas-wide CSV surfaces outside extracted_content_pipeline are deferred to a future audit if needed.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_csv_export.py -q (8 passed)
- pytest tests/test_extracted_campaign_postgres_export.py tests/test_extracted_campaign_reasoning_list_cli.py tests/test_extracted_report_export.py tests/test_extracted_blog_post_export.py tests/test_extracted_landing_page_export.py tests/test_extracted_sales_brief_export.py tests/test_extracted_ticket_faq_export.py tests/test_extracted_content_asset_api.py -q (140 passed)
- bash scripts/validate_extracted_content_pipeline.sh (passed)
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline (passed)
- python scripts/audit_extracted_standalone.py --fail-on-debt (passed; findings: 0)
- bash scripts/check_ascii_python.sh (passed)
- bash scripts/run_extracted_pipeline_checks.sh (3000 passed, 10 skipped)
- bash scripts/local_pr_review.sh --current-pr-body-file <process-substitution> (passed)
- pre-push hook local_pr_review.sh with ATLAS_CURRENT_PR_BODY_FILE (passed)

## Diff size
14 files, +229 / -58