### PR TITLE
PR-Deflection-Teaser-Top-Answer

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -609,10 +609,7 @@ def _is_teaser_eligible(item: Mapping[str, Any]) -> bool:
 def _select_full_teaser_item(
     eligible: Sequence[tuple[int, Mapping[str, Any]]],
 ) -> tuple[int, Mapping[str, Any]]:
-    for rank, item in eligible:
-        if rank >= 4:
-            return rank, item
-    return eligible[-1]
+    return eligible[0]
 
 
 def _teaser_full_answer(rank: int, item: Mapping[str, Any]) -> dict[str, Any]:

--- a/plans/PR-Deflection-Teaser-Top-Answer.md
+++ b/plans/PR-Deflection-Teaser-Top-Answer.md
@@ -1,0 +1,97 @@
+# PR-Deflection-Teaser-Top-Answer
+
+## Why this slice exists
+
+Issue #1286 revises the snapshot teaser selection rule. The shipped backend
+keeps the top three eligible drafted answers locked by selecting the first
+eligible answer at rank 4 or later, falling back to the last eligible answer
+when fewer than four exist. The operator decision in #1286 supersedes that:
+show the first eligible drafted answer by rank, intentionally exposing the
+most-asked answer when it has scoped resolution evidence.
+
+The reason is product clarity. The free sample should be the most relevant
+answer, not the first answer outside a top-N paywall rule. The buyer already
+sees the cost/bleed story; scarcity of one drafted answer is less persuasive
+than a directly relevant sample.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-teaser
+Slice phase: Product polish
+
+1. Change `_select_full_teaser_item` to return the first eligible teaser item
+   by rank.
+2. Preserve the existing fail-closed eligibility gate: only scoped
+   `resolution_evidence` items with an answer body can become the full teaser.
+3. Preserve the existing body-withheld preview shape and preview count.
+4. Update focused snapshot tests for the new rank-first behavior and the
+   fallback when rank 1 has no eligible answer.
+
+### Files touched
+
+- `plans/PR-Deflection-Teaser-Top-Answer.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `tests/test_content_ops_deflection_report.py`
+- `tests/test_extracted_content_ops_live_execute_harness.py`
+
+## Mechanism
+
+`_snapshot_teaser(...)` already builds `eligible` in ranked item order:
+
+```python
+eligible = tuple(
+    (rank, item)
+    for rank, item in enumerate(items, start=1)
+    if _is_teaser_eligible(item)
+)
+```
+
+This slice makes `_select_full_teaser_item(eligible)` return `eligible[0]`.
+That means:
+
+- rank 1 is exposed when it has scoped resolution evidence and answer text;
+- if rank 1 is not eligible, the next eligible ranked answer is exposed;
+- if no item is eligible, the existing empty teaser path remains unchanged.
+
+## Intentional
+
+- No "most-resolved" or "confidence" payload is added. The operator explicitly
+  chose rank-first selection, and adding a new explanation signal would imply a
+  different selection basis.
+- The snapshot still exposes at most one full answer; previews remain
+  body-withheld.
+- This is ATLAS backend selection only. Portfolio article formatting and copy
+  can consume the unchanged teaser payload in a separate frontend slice.
+
+## Deferred
+
+- Portfolio copy such as "Sample answer for your #1 most-asked question" is
+  deferred to the portfolio renderer because this PR does not touch
+  atlas-portfolio.
+- Help-center article card styling is deferred to the frontend renderer; the
+  backend already emits verbatim question, answer, and structured steps.
+- Parked hardening: none. `HARDENING.md` has no current entry touching this
+  ownership lane or files.
+
+## Verification
+
+Ran before push:
+
+- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_ops_live_execute_harness.py` - passed
+- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q` - 36 passed
+- `pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report -q` - 6 passed
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
+- `bash scripts/check_ascii_python.sh` - passed
+- `bash scripts/run_extracted_pipeline_checks.sh` - reasoning core 295 passed; extracted content pipeline 3003 passed, 10 skipped, 1 warning
+- `bash scripts/local_pr_review.sh --current-pr-body-file "$PR_BODY_FILE"` - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Teaser selector | ~5 |
+| Focused tests | ~45 |
+| **Total** | **~135** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -548,16 +548,16 @@ def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:
     assert snapshot["summary"]["generated"] == 6
     assert len(snapshot["top_questions"]) == 3
     assert snapshot["teaser"]["full_answer"] == {
-        "rank": 4,
-        "question": "How do we rotate API tokens?",
-        "answer": "Create the replacement token, deploy it, then revoke the old token.",
-        "steps": ["Create the replacement token before revoking the old one."],
+        "rank": 1,
+        "question": "How do I export reports?",
+        "answer": "Locked top answer one",
+        "steps": ["Step for How do I export reports?"],
         "answer_evidence_status": "resolution_evidence",
         "resolution_evidence_scope": "scoped",
-        "weighted_frequency": 4,
+        "weighted_frequency": 1,
         "source_count": 1,
     }
-    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [1, 2]
+    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [2, 3]
     for preview in snapshot["teaser"]["previews"]:
         assert preview["body_withheld"] is True
         assert preview["answer_evidence_status"] == "resolution_evidence"
@@ -565,12 +565,56 @@ def test_deflection_snapshot_includes_bounded_fail_closed_teaser() -> None:
         assert "answer" not in preview
         assert "steps" not in preview
 
-    assert "Locked top answer" not in encoded
+    assert "Locked top answer one" in encoded
+    assert "Locked top answer two" not in encoded
+    assert "Locked top answer three" not in encoded
     assert "Mismatched answer must stay locked" not in encoded
     assert "Tail answer locked" not in encoded
     assert "ticket-" not in encoded
     assert "evidence_quotes" not in encoded
     assert "source_ids" not in encoded
+
+
+def test_deflection_snapshot_teaser_falls_through_to_next_eligible_rank() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=3,
+        ticket_source_count=3,
+        output_checks={"condensed": True},
+        items=(
+            {
+                **_scoped_answer_item(
+                    1,
+                    "How do I export reports?",
+                    "Blocked top answer must not leak.",
+                ),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            _scoped_answer_item(2, "How do I update billing?", "Second answer"),
+            _scoped_answer_item(3, "How do I enable SSO?", "Third answer"),
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(
+        build_deflection_report_artifact(result),
+        top_n=2,
+        teaser_preview_count=1,
+    ).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot["teaser"]["full_answer"] == {
+        "rank": 2,
+        "question": "How do I update billing?",
+        "answer": "Second answer",
+        "steps": ["Step for How do I update billing?"],
+        "answer_evidence_status": "resolution_evidence",
+        "resolution_evidence_scope": "scoped",
+        "weighted_frequency": 2,
+        "source_count": 1,
+    }
+    assert [preview["rank"] for preview in snapshot["teaser"]["previews"]] == [3]
+    assert "Blocked top answer must not leak" not in encoded
+    assert "Third answer" not in encoded
 
 
 def test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence() -> None:

--- a/tests/test_extracted_content_ops_live_execute_harness.py
+++ b/tests/test_extracted_content_ops_live_execute_harness.py
@@ -1034,7 +1034,9 @@ async def test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot
         "resolution_evidence"
     )
     assert snapshot["teaser"]["full_answer"]["resolution_evidence_scope"] == "scoped"
+    assert snapshot["teaser"]["full_answer"]["rank"] == 1
     assert len(snapshot["teaser"]["previews"]) == 1
+    assert snapshot["teaser"]["previews"][0]["rank"] == 2
     assert snapshot["teaser"]["previews"][0]["body_withheld"] is True
     assert "answer" not in snapshot["teaser"]["previews"][0]
     assert "steps" not in snapshot["teaser"]["previews"][0]


### PR DESCRIPTION
Plan: plans/PR-Deflection-Teaser-Top-Answer.md
Slice phase: Product polish

Issue #1286 superseded the earlier most-resolved teaser idea with a simpler operator decision: expose the first eligible drafted answer by rank. This PR changes the ATLAS snapshot selector to show the #1 most-asked answer when it has scoped resolution evidence, while preserving the fail-closed eligibility gate and body-withheld previews.

## Intentional
- No "most-resolved" or "confidence" payload is added; rank-first selection is the chosen basis.
- The snapshot still exposes at most one full answer, and preview answers remain body-withheld.
- Portfolio copy and article-card rendering are left to the frontend because this PR only changes ATLAS backend selection.

## Deferred
- Portfolio copy such as "Sample answer for your #1 most-asked question" is deferred to the portfolio renderer.
- Help-center article card styling is deferred to the frontend renderer; the backend already emits verbatim question, answer, and structured steps.

## Parked hardening
- None. `HARDENING.md` has no current entry touching this ownership lane or files.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py tests/test_extracted_content_ops_live_execute_harness.py` - passed
- `pytest tests/test_content_ops_deflection_report.py tests/test_extracted_content_ops_live_execute_harness.py::test_deflection_report_execute_uncaps_paid_artifact_and_keeps_snapshot_top_n -q` - 36 passed
- `pytest tests/test_content_ops_faq_report_contract_docs.py tests/test_extracted_content_control_surface_api.py::test_execute_generation_route_returns_snapshot_for_unpaid_deflection_report -q` - 6 passed
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
- `bash scripts/check_ascii_python.sh` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - reasoning core 295 passed; extracted content pipeline 3003 passed, 10 skipped, 1 warning
- `bash scripts/local_pr_review.sh --current-pr-body-file "$PR_BODY_FILE"` - passed

## Diff size
4 files, +151 / -11
