### PR TITLE
Plan: Content Ops Marketer Quote Card Output

### DIFF
--- a/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
+++ b/atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json
@@ -122,6 +122,23 @@
       "can_execute": false
     },
     {
+      "id": "quote_card",
+      "label": "Quote Cards",
+      "description": "Short quote-card drafts from source evidence.",
+      "implemented": true,
+      "estimated_unit_cost_usd": 0.0,
+      "default_parse_retry_attempts": 0,
+      "default_quality_repair_attempts": 0,
+      "estimated_retry_adjusted_unit_cost_usd": 0.0,
+      "required_inputs": [
+        "source_material"
+      ],
+      "default_max_items": 3,
+      "reasoning_requirement": "absent",
+      "execution_configured": false,
+      "can_execute": false
+    },
+    {
       "id": "signal_extraction",
       "label": "Signal Extraction",
       "description": "Extracted opportunity or churn signals from source evidence.",

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -13,6 +13,8 @@ Currently wired:
   with no external dependencies.
 - `ad_copy`: deterministic source-evidence ad-copy drafts
   with no external dependencies; persists when DB services are enabled.
+- `quote_card`: deterministic source-evidence quote-card drafts
+  with no external dependencies.
 - `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
   host LLM + Skill adapters from PR #453 +
   `PostgresLandingPageRepository` backed by the host's
@@ -84,6 +86,9 @@ from extracted_content_pipeline.landing_page_generation import (
 from extracted_content_pipeline.landing_page_postgres import (
     PostgresLandingPageRepository,
 )
+from extracted_content_pipeline.quote_card_generation import (
+    QuoteCardGenerationService,
+)
 from extracted_content_pipeline.report_generation import (
     ReportGenerationService,
 )
@@ -118,6 +123,7 @@ from extracted_content_pipeline.ticket_faq_postgres import (
 _SIGNAL_EXTRACTION_SERVICE: SignalExtractionService = SignalExtractionService()
 _SOCIAL_POST_SERVICE: SocialPostGenerationService = SocialPostGenerationService()
 _AD_COPY_SERVICE: AdCopyGenerationService = AdCopyGenerationService()
+_QUOTE_CARD_SERVICE: QuoteCardGenerationService = QuoteCardGenerationService()
 _FAQ_MARKDOWN_SERVICE: TicketFAQMarkdownService = TicketFAQMarkdownService()
 _FAQ_DEFLECTION_REPORT_SERVICE: FAQDeflectionReportService = FAQDeflectionReportService(
     faq_markdown=_FAQ_MARKDOWN_SERVICE
@@ -345,6 +351,7 @@ def build_content_ops_execution_services(
     blog_post = None
     social_post = _SOCIAL_POST_SERVICE
     ad_copy = _AD_COPY_SERVICE
+    quote_card = _QUOTE_CARD_SERVICE
     faq_markdown_service = _FAQ_MARKDOWN_SERVICE
     faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
     faq_deflection_report = _FAQ_DEFLECTION_REPORT_SERVICE
@@ -401,6 +408,7 @@ def build_content_ops_execution_services(
         signal_extraction=_SIGNAL_EXTRACTION_SERVICE,
         social_post=social_post,
         ad_copy=ad_copy,
+        quote_card=quote_card,
         landing_page=landing_page,
         campaign=campaign,
         report=report,

--- a/extracted_content_pipeline/content_ops_execution.py
+++ b/extracted_content_pipeline/content_ops_execution.py
@@ -79,6 +79,7 @@ class ContentOpsExecutionServices:
     sales_brief: Any | None = None
     social_post: Any | None = None
     ad_copy: Any | None = None
+    quote_card: Any | None = None
     signal_extraction: Any | None = None
     faq_markdown: Any | None = None
     faq_deflection_report: Any | None = None
@@ -106,6 +107,8 @@ class ContentOpsExecutionServices:
             return self.social_post
         if output == "ad_copy":
             return self.ad_copy
+        if output == "quote_card":
+            return self.quote_card
         if output == "signal_extraction":
             return self.signal_extraction
         if output == "faq_markdown":
@@ -124,6 +127,7 @@ class ContentOpsExecutionServices:
             "sales_brief",
             "social_post",
             "ad_copy",
+            "quote_card",
             "signal_extraction",
             "faq_markdown",
             "faq_deflection_report",
@@ -196,6 +200,8 @@ class ContentOpsExecutionServices:
             social_post=self.social_post,
             # ad_copy stays as-is; it does not consume reasoning.
             ad_copy=self.ad_copy,
+            # quote_card stays as-is; it does not consume reasoning.
+            quote_card=self.quote_card,
             # signal_extraction stays as-is; it does not consume reasoning.
             signal_extraction=self.signal_extraction,
             # faq_markdown stays as-is; it does not consume reasoning.
@@ -677,6 +683,24 @@ async def _dispatch_ad_copy(
     )
 
 
+async def _dispatch_quote_card(
+    *,
+    step: GenerationPlanStep,
+    service: Any,
+    request: ContentOpsRequest,
+    scope: TenantScope,
+    filters: Mapping[str, Any] | None,
+) -> Any:
+    del filters
+    return await service.generate(
+        scope=scope,
+        target_mode=request.target_mode,
+        source_material=request.inputs.get("source_material"),
+        limit=request.limit,
+        max_text_chars=_step_config_int(step.config, "max_text_chars"),
+    )
+
+
 async def _dispatch_faq_markdown(
     *,
     step: GenerationPlanStep,
@@ -768,6 +792,7 @@ _DISPATCH: Mapping[str, Any] = {
     "blog_post": _dispatch_blog_post,
     "social_post": _dispatch_social_post,
     "ad_copy": _dispatch_ad_copy,
+    "quote_card": _dispatch_quote_card,
     "signal_extraction": _dispatch_signal_extraction,
     "faq_markdown": _dispatch_faq_markdown,
     "faq_deflection_report": _dispatch_faq_deflection_report,

--- a/extracted_content_pipeline/control_surfaces.py
+++ b/extracted_content_pipeline/control_surfaces.py
@@ -209,6 +209,17 @@ OUTPUT_CATALOG: Mapping[str, OutputDefinition] = MappingProxyType({
         reasoning_requirement="absent",
         default_parse_retry_attempts=0,
     ),
+    "quote_card": OutputDefinition(
+        id="quote_card",
+        label="Quote Cards",
+        description="Short quote-card drafts from source evidence.",
+        implemented=True,
+        estimated_unit_cost_usd=0.0,
+        required_inputs=("source_material",),
+        default_max_items=3,
+        reasoning_requirement="absent",
+        default_parse_retry_attempts=0,
+    ),
     "signal_extraction": OutputDefinition(
         id="signal_extraction",
         label="Signal Extraction",

--- a/extracted_content_pipeline/docs/control_surface_preview_api.md
+++ b/extracted_content_pipeline/docs/control_surface_preview_api.md
@@ -72,6 +72,7 @@ Current output ids:
 | `sales_brief` | Implemented | `optional_host_context` | Sales brief generation service path. |
 | `social_post` | Implemented | `absent` | Deterministic source-evidence social post drafts; no LLM call. |
 | `ad_copy` | Implemented | `absent` | Deterministic source-evidence ad-copy drafts; no LLM call. |
+| `quote_card` | Implemented | `absent` | Deterministic source-evidence quote-card drafts; no LLM call. |
 | `signal_extraction` | Implemented | `absent` | Deterministic source-row normalization into campaign opportunities; no LLM call. |
 
 Future outputs should be added to the catalog first, then exposed through
@@ -378,6 +379,7 @@ Runnable outputs dispatch to:
 | `sales_brief` | `SalesBriefGenerationService.generate(...)` |
 | `social_post` | `SocialPostGenerationService.generate(...)` |
 | `ad_copy` | `AdCopyGenerationService.generate(...)` |
+| `quote_card` | `QuoteCardGenerationService.generate(...)` |
 | `signal_extraction` | `SignalExtractionService.generate(...)` |
 
 Non-executable plans return HTTP 400 with the blocked execution result. Missing

--- a/extracted_content_pipeline/generation_plan.py
+++ b/extracted_content_pipeline/generation_plan.py
@@ -25,6 +25,7 @@ from .landing_page_generation import LandingPageGenerationConfig
 from .landing_page_repair_contract import (
     landing_page_quality_repair_attempts_from_inputs,
 )
+from .quote_card_generation import QuoteCardGenerationConfig
 from .reasoning_policy import (
     NOOP_REASONING_PRESETS,
     PACKAGED_REASONING_RUNTIME_OUTPUTS,
@@ -228,6 +229,17 @@ def _ad_copy_config_for_request(request: ContentOpsRequest) -> AdCopyGenerationC
     if max_text_chars is None:
         return config
     return AdCopyGenerationConfig(
+        limit=config.limit,
+        max_text_chars=max_text_chars,
+    )
+
+
+def _quote_card_config_for_request(request: ContentOpsRequest) -> QuoteCardGenerationConfig:
+    config = QuoteCardGenerationConfig(limit=request.limit)
+    max_text_chars = _positive_int_input(request.inputs, "source_max_text_chars")
+    if max_text_chars is None:
+        return config
+    return QuoteCardGenerationConfig(
         limit=config.limit,
         max_text_chars=max_text_chars,
     )
@@ -450,6 +462,17 @@ def _step_for_output(output: str, request: ContentOpsRequest) -> GenerationPlanS
         return GenerationPlanStep(
             output=output,
             runner="AdCopyGenerationService.generate",
+            status="runnable",
+            config={
+                "limit": config.limit,
+                "max_text_chars": config.max_text_chars,
+            },
+        )
+    if output == "quote_card":
+        config = _quote_card_config_for_request(request)
+        return GenerationPlanStep(
+            output=output,
+            runner="QuoteCardGenerationService.generate",
             status="runnable",
             config={
                 "limit": config.limit,

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -312,6 +312,9 @@
       "target": "extracted_content_pipeline/ad_copy_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/quote_card_generation.py"
+    },
+    {
       "target": "extracted_content_pipeline/social_post_export.py"
     },
     {

--- a/extracted_content_pipeline/quote_card_generation.py
+++ b/extracted_content_pipeline/quote_card_generation.py
@@ -1,0 +1,236 @@
+"""Deterministic quote-card drafts from Content Ops source material."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .campaign_customer_data import CampaignOpportunityWarning
+from .campaign_ports import TenantScope
+from .campaign_source_adapters import (
+    source_material_to_source_rows,
+    source_row_to_campaign_opportunity,
+)
+
+
+@dataclass(frozen=True)
+class QuoteCardGenerationConfig:
+    """Config for deterministic source-material quote cards."""
+
+    limit: int = 3
+    max_text_chars: int = 600
+    max_quote_chars: int = 180
+    max_headline_chars: int = 90
+    max_supporting_text_chars: int = 160
+
+
+@dataclass(frozen=True)
+class QuoteCardGenerationResult:
+    """Generated quote cards plus non-fatal source-material warnings."""
+
+    cards: tuple[dict[str, Any], ...]
+    warnings: tuple[CampaignOpportunityWarning, ...] = ()
+    target_mode: str = "vendor_retention"
+
+    @property
+    def generated(self) -> int:
+        return len(self.cards)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "generated": self.generated,
+            "target_mode": self.target_mode,
+            "cards": [dict(card) for card in self.cards],
+            "warnings": [warning.as_dict() for warning in self.warnings],
+        }
+
+
+class QuoteCardGenerationService:
+    """Build short, evidence-backed quote-card drafts from source material."""
+
+    def __init__(self, config: QuoteCardGenerationConfig | None = None) -> None:
+        self.config = config or QuoteCardGenerationConfig()
+
+    async def generate(
+        self,
+        *,
+        scope: TenantScope,
+        target_mode: str,
+        source_material: Any,
+        limit: int | None = None,
+        max_text_chars: int | None = None,
+        **kwargs: Any,
+    ) -> QuoteCardGenerationResult:
+        del scope, kwargs
+        resolved_limit = int(limit) if limit is not None else self.config.limit
+        if resolved_limit < 1:
+            raise ValueError("limit must be at least 1")
+        resolved_max_text_chars = (
+            int(max_text_chars)
+            if max_text_chars is not None
+            else self.config.max_text_chars
+        )
+        if resolved_max_text_chars < 1:
+            raise ValueError("max_text_chars must be at least 1")
+        return _generate_quote_cards(
+            _rows_from_source_material(source_material),
+            target_mode=target_mode,
+            limit=resolved_limit,
+            max_text_chars=resolved_max_text_chars,
+            max_quote_chars=self.config.max_quote_chars,
+            max_headline_chars=self.config.max_headline_chars,
+            max_supporting_text_chars=self.config.max_supporting_text_chars,
+        )
+
+
+def _generate_quote_cards(
+    rows: Sequence[Any],
+    *,
+    target_mode: str,
+    limit: int,
+    max_text_chars: int,
+    max_quote_chars: int,
+    max_headline_chars: int,
+    max_supporting_text_chars: int,
+) -> QuoteCardGenerationResult:
+    cards: list[dict[str, Any]] = []
+    warnings: list[CampaignOpportunityWarning] = []
+    for index, row in enumerate(rows, start=1):
+        if len(cards) >= limit:
+            break
+        if not isinstance(row, Mapping):
+            warnings.append(CampaignOpportunityWarning(
+                code="row_not_object",
+                row_index=index,
+                message="Skipped source row because it is not an object.",
+            ))
+            continue
+        opportunity, row_warnings = source_row_to_campaign_opportunity(
+            row,
+            row_index=index,
+            max_text_chars=max_text_chars,
+        )
+        warnings.extend(row_warnings)
+        card = _card_from_opportunity(
+            opportunity,
+            index=len(cards) + 1,
+            max_quote_chars=max_quote_chars,
+            max_headline_chars=max_headline_chars,
+            max_supporting_text_chars=max_supporting_text_chars,
+        )
+        if card is None:
+            warnings.append(CampaignOpportunityWarning(
+                code="missing_quote_card_evidence",
+                row_index=index,
+                message="Skipped source row because it did not contain usable evidence.",
+            ))
+            continue
+        cards.append(card)
+    return QuoteCardGenerationResult(
+        cards=tuple(cards),
+        warnings=tuple(warnings),
+        target_mode=target_mode,
+    )
+
+
+def _card_from_opportunity(
+    opportunity: Mapping[str, Any],
+    *,
+    index: int,
+    max_quote_chars: int,
+    max_headline_chars: int,
+    max_supporting_text_chars: int,
+) -> dict[str, Any] | None:
+    if not opportunity:
+        return None
+    evidence = _first_evidence(opportunity)
+    if not evidence:
+        return None
+    vendor = _clean(opportunity.get("vendor_name") or opportunity.get("vendor"))
+    company = _clean(opportunity.get("company_name"))
+    pain = _first_text(opportunity.get("pain_points"))
+    source_id = _clean(opportunity.get("source_id") or opportunity.get("target_id"))
+    headline = (
+        f"Customer proof for {vendor}"
+        if vendor
+        else "Customer proof"
+    )
+    supporting_parts = ["Use this quote"]
+    if pain:
+        supporting_parts.append(f"to frame {pain}")
+    elif vendor:
+        supporting_parts.append(f"to frame {vendor} buyer evidence")
+    else:
+        supporting_parts.append("to frame buyer evidence")
+    supporting_text = " ".join(supporting_parts) + "."
+    return {
+        "id": source_id or f"quote-card-{index}",
+        "theme": "customer_proof",
+        "quote": _truncate(evidence, max_quote_chars),
+        "attribution": company or "Customer evidence",
+        "headline": _truncate(headline, max_headline_chars),
+        "supporting_text": _truncate(
+            supporting_text,
+            max_supporting_text_chars,
+        ),
+        "source_id": source_id,
+        "source_type": _clean(opportunity.get("source_type")),
+        "target_id": _clean(opportunity.get("target_id")),
+        "company_name": company,
+        "vendor_name": vendor,
+        "pain_points": list(opportunity.get("pain_points") or ()),
+    }
+
+
+def _first_evidence(opportunity: Mapping[str, Any]) -> str:
+    raw = opportunity.get("evidence")
+    if isinstance(raw, Mapping):
+        return _clean(raw.get("text"))
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        for item in raw:
+            if isinstance(item, Mapping):
+                text = _clean(item.get("text"))
+                if text:
+                    return text
+            else:
+                text = _clean(item)
+                if text:
+                    return text
+    return _clean(raw)
+
+
+def _first_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            text = _clean(item)
+            if text:
+                return text
+    return _clean(value)
+
+
+def _rows_from_source_material(source_material: Any) -> list[Any]:
+    if isinstance(source_material, str):
+        text = source_material.strip()
+        return [{"text": text}] if text else []
+    return source_material_to_source_rows(source_material)
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 3)].rstrip() + "..."
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "QuoteCardGenerationConfig",
+    "QuoteCardGenerationResult",
+    "QuoteCardGenerationService",
+]

--- a/extracted_content_pipeline/reasoning_policy.py
+++ b/extracted_content_pipeline/reasoning_policy.py
@@ -170,6 +170,11 @@ OUTPUT_REASONING_POLICIES: Mapping[str, OutputReasoningPolicy] = MappingProxyTyp
         default_preset="none",
         supported_presets=("none",),
     ),
+    "quote_card": OutputReasoningPolicy(
+        output="quote_card",
+        default_preset="none",
+        supported_presets=("none",),
+    ),
     "faq_markdown": OutputReasoningPolicy(
         output="faq_markdown",
         default_preset="none",

--- a/plans/PR-Content-Ops-Marketer-Quote-Card-Output.md
+++ b/plans/PR-Content-Ops-Marketer-Quote-Card-Output.md
@@ -1,0 +1,148 @@
+# PR: Content Ops Marketer Quote Card Output
+
+## Why this slice exists
+
+The marketer reviews-as-input lane has completed the social-post and ad-copy
+generated asset paths. The remaining deferred marketer asset family from the
+sales-brief handoff is stat/quote cards: short visual-card source material that
+marketers can later export into designed creative. Operators can now produce
+short social copy and paid-media copy from reviews, but they still cannot turn a
+strong source quote into a bounded quote-card draft through the same Content Ops
+execution path.
+
+This slice adds the first quote-card vertical slice as a deterministic,
+source-evidence-only generator. It mirrors the first `social_post` and
+`ad_copy` output slices: register an executable output, generate bounded
+evidence-backed quote-card drafts from `source_material`, wire host execution,
+and prove preview/plan/run behavior. It deliberately does not touch #1268's
+plan-only output-variations lane.
+
+This PR may exceed the 400 LOC soft cap for the same indivisible first-output
+reason as the prior marketer-output slices: the service, manifest entry,
+catalog exposure, generation plan, executor dispatch, host wiring, reasoning
+no-op policy, UI fixture, and tests need to land together or `quote_card` is
+either invisible or not runnable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+
+Slice phase: Vertical slice
+
+1. Add a package-owned deterministic `QuoteCardGenerationService` that turns
+   source material into bounded quote-card drafts with source ids, quote text,
+   attribution, theme metadata, and non-fatal source-material warnings.
+2. Register `quote_card` in the control-surface catalog, generation plan,
+   executor service bundle, host service factory, and no-op reasoning policy.
+3. Keep quote-card generation source-evidence-only: no LLM prompt, persistence,
+   generated-asset review API/UI branch, package-default enrollment, or #1268
+   variant fan-out in this slice.
+4. Add focused tests for service output/warnings/limits, preview/plan mapping,
+   executor dispatch, host factory wiring, and catalog readiness.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Marketer-Quote-Card-Output.md`
+- `extracted_content_pipeline/quote_card_generation.py`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/control_surfaces.py`
+- `extracted_content_pipeline/docs/control_surface_preview_api.md`
+- `extracted_content_pipeline/generation_plan.py`
+- `extracted_content_pipeline/content_ops_execution.py`
+- `extracted_content_pipeline/reasoning_policy.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_quote_card_generation.py`
+- `tests/test_extracted_content_control_surfaces.py`
+- `tests/test_extracted_content_generation_plan.py`
+- `tests/test_extracted_content_ops_execution.py`
+- `tests/test_extracted_content_control_surface_api.py`
+- `tests/test_extracted_content_reasoning_policy.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json`
+
+## Mechanism
+
+`QuoteCardGenerationService.generate(...)` accepts `source_material`, expands
+the same source-material bundles as the shared Content Ops source adapter via
+`source_material_to_source_rows(...)`, normalizes each row through the existing
+`source_row_to_campaign_opportunity(...)` adapter, and emits one quote-card
+draft per usable opportunity up to `limit`. Each card has a stable
+evidence-linked shape:
+
+```python
+{
+    "id": source_id,
+    "quote": "Pricing became hard to justify after renewal.",
+    "attribution": "Acme Logistics",
+    "headline": "Customer proof for HubSpot",
+    "supporting_text": "Use this quote to frame pricing pressure.",
+    "theme": "customer_proof",
+    "source_id": source_id,
+    "source_type": "review",
+    "company_name": "...",
+    "vendor_name": "...",
+    "pain_points": [...],
+}
+```
+
+The generator is deterministic and no-cost. `source_max_text_chars` controls the
+existing source-row adapter text cap, matching `signal_extraction`,
+`social_post`, and `ad_copy`. `ContentOpsExecutionServices` gets a `quote_card`
+slot and dispatch handler that passes `scope`, `target_mode`,
+`source_material`, `limit`, and `max_text_chars` to the service.
+
+## Intentional
+
+- No persistence or generated-asset review branch. This first slice proves the
+  output can run from source evidence; durable review/export handoff should
+  follow only after the reviewer accepts the output shape.
+- No package-default enrollment yet. Review/competitive package defaults remain
+  unchanged until the `quote_card` output is executable and tested.
+- No #1268 output-variations work. `variant_count` and prompt-angle fan-out are
+  a separate plan-only lane and remain untouched.
+- No LLM design/creative prompt. This slice keeps quote cards bounded to real
+  source evidence and avoids visual-asset hallucination risk.
+- No `stat_card` yet. Quote cards are the narrower first card surface; stat-card
+  extraction needs numeric-claim selection and validation and should be its own
+  slice.
+
+## Deferred
+
+- Add `quote_card` to review and competitive input-package defaults in the next
+  quote-card handoff slice.
+- Persist generated quote-card drafts into the generated-assets review queue
+  after the output shape is accepted.
+- Add `stat_card` as a follow-up output with numeric-claim validation.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+Parked hardening: none.
+
+## Verification
+
+- `pytest tests/test_extracted_quote_card_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q` (326 passed, 1 skipped)
+- `python -m json.tool atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json >/dev/null` (passed)
+- `python -m py_compile extracted_content_pipeline/quote_card_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_quote_card_generation.py` (passed)
+- `git diff --check` (passed)
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (passed; 144 matching tests enrolled)
+- `bash scripts/validate_extracted_content_pipeline.sh` (passed)
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` (passed)
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` (passed; findings: 0)
+- `bash scripts/check_ascii_python.sh` (passed)
+- `cd atlas-intel-ui && npm run lint` (passed after `npm ci`)
+- `cd atlas-intel-ui && npm run build` (passed after `npm ci`)
+- `bash scripts/run_extracted_pipeline_checks.sh` (3009 passed, 10 skipped)
+- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>` (passed on review-fix commit; caller hints reviewed and covered by focused host/API tests in this slice)
+
+## Estimated diff size
+
+Actual: 17 files, +834 / -8. This is above the 400 LOC soft cap for the
+indivisible first-output wiring reason described in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Quote-card service | ~236 |
+| Catalog/plan/executor/host/reasoning/docs/fixture wiring | ~93 |
+| Focused tests | ~364 |
+| Plan doc | ~148 |
+| **Total** | **~840** |

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -19,6 +19,7 @@ the host has wired. Currently:
   customer-executable output lists while keeping it as the internal
   deflection-report source.
 - `social_post`: deterministic; persists when DB services are enabled.
+- `quote_card`: deterministic; always wired (stateless).
 - `faq_deflection_report` (this slice): always wired (stateless wrapper over
   `faq_markdown`).
 
@@ -28,7 +29,7 @@ infrastructure -- the canonical singletons trigger the heavy
 host init chain (torch / ollama / asyncpg) that dev envs may
 not have.
 
-Test inventory (22 tests):
+Test inventory (24 tests):
 
 1. `signal_extraction` runs through the full executor.
 2. `landing_page` populated when LLM + db enabled (E2 canary).
@@ -49,20 +50,23 @@ Test inventory (22 tests):
 14. `faq_markdown` persists when DB services are enabled.
 15. `social_post` persists when DB services are enabled.
 16. `ad_copy` persists when DB services are enabled.
-17. `faq_deflection_report` runs through the full executor.
-18. `social_post` is always wired.
-19. `ad_copy` is always wired.
-20. `configured_outputs()` with LLM + db enabled advertises
+17. `quote_card` runs through the full executor.
+18. `faq_deflection_report` runs through the full executor.
+19. `social_post` is always wired.
+20. `ad_copy` is always wired.
+21. `quote_card` is always wired.
+22. `configured_outputs()` with LLM + db enabled advertises
     every wired output: `(email_campaign, blog_post, report,
     landing_page, sales_brief, social_post, ad_copy,
-    signal_extraction, faq_markdown, faq_deflection_report)` -- order
+    quote_card, signal_extraction, faq_markdown,
+    faq_deflection_report)` -- order
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-21. `configured_outputs()` without an active LLM (even with
+23. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     deterministic outputs.
-22. The hosted paywall mode can hide `faq_markdown` while
+24. The hosted paywall mode can hide `faq_markdown` while
     retaining a runnable `faq_deflection_report`.
 """
 
@@ -306,6 +310,40 @@ async def test_ad_copy_persists_when_db_services_enabled() -> None:
 
 
 @pytest.mark.asyncio
+async def test_quote_card_runs_through_host_bundle() -> None:
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["quote_card"],
+            "inputs": {
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "reviewer_company": "Acme Logistics",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                    "pain_category": "pricing pressure",
+                }]
+            },
+        },
+        services=services,
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "quote_card"
+    assert step["status"] == "completed"
+    assert step["result"]["generated"] == 1
+    card = step["result"]["cards"][0]
+    assert card["source_id"] == "review-1"
+    assert card["headline"] == "Customer proof for HubSpot"
+
+
+@pytest.mark.asyncio
 async def test_faq_deflection_report_runs_through_host_bundle() -> None:
     services = build_content_ops_execution_services(
         llm_factory=_no_llm,
@@ -354,6 +392,7 @@ async def test_faq_markdown_can_be_hidden_while_deflection_report_runs() -> None
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_deflection_report",
     )
@@ -404,6 +443,7 @@ def test_landing_page_wired_when_llm_active_and_db_enabled() -> None:
         "sales_brief",
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -427,6 +467,7 @@ def test_landing_page_slot_stays_none_when_no_active_llm() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -454,6 +495,7 @@ def test_landing_page_slot_stays_none_when_pool_is_none() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -479,6 +521,7 @@ def test_landing_page_slot_stays_none_in_production_default() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -553,6 +596,19 @@ def test_ad_copy_is_always_wired() -> None:
     assert services.for_output("ad_copy") is services.ad_copy
 
 
+def test_quote_card_is_always_wired() -> None:
+    """Deterministic quote cards run without LLM or DB services."""
+
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=_make_pool_stub,
+        enable_db_services=False,
+    )
+    assert services.quote_card is not None
+    assert services.for_output("quote_card") is services.quote_card
+
+
 def test_e3_services_skip_together_when_no_active_llm() -> None:
     """E3 fallback: campaign / report / sales_brief slots all
     stay `None` when no LLM is active. Same short-circuit shape
@@ -571,6 +627,7 @@ def test_e3_services_skip_together_when_no_active_llm() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -598,6 +655,7 @@ def test_e3_services_skip_together_when_pool_is_none() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -636,6 +694,7 @@ def test_blog_post_slot_stays_none_when_no_active_llm() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -662,6 +721,7 @@ def test_bundle_only_advertises_wired_outputs_with_llm_and_db_enabled() -> None:
         "sales_brief",
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",
@@ -681,6 +741,7 @@ def test_bundle_only_advertises_wired_outputs_without_llm() -> None:
     assert services.configured_outputs() == (
         "social_post",
         "ad_copy",
+        "quote_card",
         "signal_extraction",
         "faq_markdown",
         "faq_deflection_report",

--- a/tests/test_extracted_content_control_surface_api.py
+++ b/tests/test_extracted_content_control_surface_api.py
@@ -331,9 +331,11 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert "faq_markdown" in output_ids
     assert "social_post" in output_ids
     assert "ad_copy" in output_ids
+    assert "quote_card" in output_ids
     assert outputs["signal_extraction"]["implemented"] is True
     assert outputs["social_post"]["implemented"] is True
     assert outputs["ad_copy"]["implemented"] is True
+    assert outputs["quote_card"]["implemented"] is True
     assert outputs["email_campaign"]["execution_configured"] is False
     assert outputs["email_campaign"]["can_execute"] is False
     assert outputs["email_campaign"]["estimated_unit_cost_usd"] == 0.18
@@ -395,6 +397,7 @@ async def test_describe_control_surfaces_route_returns_catalog_and_presets():
     assert outputs["blog_post"]["reasoning_requirement"] == "optional_host_context"
     assert outputs["social_post"]["reasoning_requirement"] == "absent"
     assert outputs["ad_copy"]["reasoning_requirement"] == "absent"
+    assert outputs["quote_card"]["reasoning_requirement"] == "absent"
     assert outputs["signal_extraction"]["reasoning_requirement"] == "absent"
     assert outputs["faq_markdown"]["reasoning_requirement"] == "absent"
     assert payload["execution"] == {
@@ -536,6 +539,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
             report=_CampaignService(),
             social_post=_CampaignService(),
             ad_copy=_CampaignService(),
+            quote_card=_CampaignService(),
             signal_extraction=_CampaignService(),
             faq_markdown=_CampaignService(),
         )
@@ -551,6 +555,7 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
                 "ad_copy",
                 "email_campaign",
                 "faq_markdown",
+                "quote_card",
                 "report",
                 "signal_extraction",
                 "social_post",
@@ -565,6 +570,8 @@ async def test_describe_control_surfaces_reports_configured_execution_services()
     assert outputs["social_post"]["can_execute"] is True
     assert outputs["ad_copy"]["execution_configured"] is True
     assert outputs["ad_copy"]["can_execute"] is True
+    assert outputs["quote_card"]["execution_configured"] is True
+    assert outputs["quote_card"]["can_execute"] is True
     assert outputs["signal_extraction"]["execution_configured"] is True
     assert outputs["signal_extraction"]["can_execute"] is True
     assert outputs["faq_markdown"]["execution_configured"] is True

--- a/tests/test_extracted_content_control_surfaces.py
+++ b/tests/test_extracted_content_control_surfaces.py
@@ -198,6 +198,24 @@ def test_preview_allows_ad_copy_when_source_material_present():
     assert preview["estimated_cost_usd"] == 0.0
 
 
+def test_preview_allows_quote_card_when_source_material_present():
+    preview = preview_from_mapping(
+        {
+            "outputs": ["quote_card"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [{"source_type": "review", "text": "Pricing pressure"}],
+            },
+        }
+    )
+
+    assert preview["can_run"] is True
+    assert preview["outputs"] == ["quote_card"]
+    assert preview["missing_inputs"] == []
+    assert preview["blocked_outputs"] == []
+    assert preview["estimated_cost_usd"] == 0.0
+
+
 def test_preview_allows_faq_markdown_when_source_material_present():
     preview = preview_from_mapping(
         {
@@ -439,6 +457,7 @@ def test_output_catalog_states_reasoning_requirement():
     assert OUTPUT_CATALOG["blog_post"].reasoning_requirement == "optional_host_context"
     assert OUTPUT_CATALOG["social_post"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["ad_copy"].reasoning_requirement == "absent"
+    assert OUTPUT_CATALOG["quote_card"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["signal_extraction"].reasoning_requirement == "absent"
     assert OUTPUT_CATALOG["faq_markdown"].reasoning_requirement == "absent"
 

--- a/tests/test_extracted_content_generation_plan.py
+++ b/tests/test_extracted_content_generation_plan.py
@@ -526,6 +526,33 @@ def test_plan_maps_ad_copy_to_ad_copy_service():
     }
 
 
+def test_plan_maps_quote_card_to_quote_card_service():
+    plan = build_generation_plan_from_mapping(
+        {
+            "outputs": ["quote_card"],
+            "limit": 3,
+            "inputs": {
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing pressure came up at renewal.",
+                    }
+                ],
+                "source_max_text_chars": 300,
+            },
+        }
+    )
+
+    assert plan["can_execute"] is True
+    assert plan["steps"][0]["runner"] == "QuoteCardGenerationService.generate"
+    assert plan["steps"][0]["status"] == "runnable"
+    assert plan["steps"][0]["config"] == {
+        "limit": 3,
+        "max_text_chars": 300,
+    }
+
+
 def test_plan_maps_faq_markdown_to_ticket_faq_service():
     plan = build_generation_plan_from_mapping(
         {

--- a/tests/test_extracted_content_ops_execution.py
+++ b/tests/test_extracted_content_ops_execution.py
@@ -20,6 +20,7 @@ from extracted_content_pipeline.content_ops_execution import (
     execute_content_ops_from_mapping,
 )
 from extracted_content_pipeline.faq_deflection_report import FAQDeflectionReportService
+from extracted_content_pipeline.quote_card_generation import QuoteCardGenerationService
 from extracted_content_pipeline.signal_extraction import SignalExtractionService
 from extracted_content_pipeline.social_post_generation import SocialPostGenerationService
 from extracted_content_pipeline.ticket_faq_markdown import TicketFAQMarkdownService
@@ -661,6 +662,45 @@ async def test_execute_runs_ad_copy_service_from_source_material() -> None:
     assert ad["source_id"] == "review-1"
     assert ad["vendor_name"] == "HubSpot"
     assert "Pricing is a problem" in ad["primary_text"]
+    assert result["plan"]["steps"][0]["config"] == {
+        "limit": 1,
+        "max_text_chars": 20,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_runs_quote_card_service_from_source_material() -> None:
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["quote_card"],
+            "limit": 1,
+            "inputs": {
+                "source_max_text_chars": 20,
+                "source_material": [
+                    {
+                        "review_id": "review-1",
+                        "company": "Acme",
+                        "vendor": "HubSpot",
+                        "review_text": "Pricing is a problem after renewal.",
+                        "pain_category": "pricing pressure",
+                    }
+                ],
+            },
+        },
+        services=ContentOpsExecutionServices(
+            quote_card=QuoteCardGenerationService()
+        ),
+    )
+
+    assert result["status"] == "completed"
+    step = result["steps"][0]
+    assert step["output"] == "quote_card"
+    assert step["runner"] == "QuoteCardGenerationService.generate"
+    assert step["result"]["generated"] == 1
+    card = step["result"]["cards"][0]
+    assert card["source_id"] == "review-1"
+    assert card["vendor_name"] == "HubSpot"
+    assert "Pricing is a problem" in card["quote"]
     assert result["plan"]["steps"][0]["config"] == {
         "limit": 1,
         "max_text_chars": 20,

--- a/tests/test_extracted_content_reasoning_policy.py
+++ b/tests/test_extracted_content_reasoning_policy.py
@@ -51,6 +51,7 @@ def test_output_policy_defaults_match_audit_recommendations() -> None:
         "signal_extraction": "none",
         "social_post": "none",
         "ad_copy": "none",
+        "quote_card": "none",
         "faq_markdown": "none",
         "faq_deflection_report": "none",
         "email_campaign": "single_pass",
@@ -111,6 +112,12 @@ def test_ad_copy_only_supports_no_reasoning() -> None:
     assert supported_reasoning_presets("ad_copy") == ("none",)
     with pytest.raises(ValueError, match="not supported"):
         resolve_reasoning_policy("ad_copy", "single_pass")
+
+
+def test_quote_card_only_supports_no_reasoning() -> None:
+    assert supported_reasoning_presets("quote_card") == ("none",)
+    with pytest.raises(ValueError, match="not supported"):
+        resolve_reasoning_policy("quote_card", "single_pass")
 
 
 def test_faq_markdown_only_supports_no_reasoning() -> None:

--- a/tests/test_extracted_quote_card_generation.py
+++ b/tests/test_extracted_quote_card_generation.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.quote_card_generation import (
+    QuoteCardGenerationConfig,
+    QuoteCardGenerationService,
+)
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_generates_evidence_backed_cards() -> None:
+    service = QuoteCardGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["target_mode"] == "vendor_retention"
+    assert payload["warnings"] == []
+    assert payload["cards"] == [
+        {
+            "id": "review-1",
+            "theme": "customer_proof",
+            "quote": "Pricing became hard to justify after renewal.",
+            "attribution": "Acme Logistics",
+            "headline": "Customer proof for HubSpot",
+            "supporting_text": "Use this quote to frame pricing pressure.",
+            "source_id": "review-1",
+            "source_type": "review",
+            "target_id": "review-1",
+            "company_name": "Acme Logistics",
+            "vendor_name": "HubSpot",
+            "pain_points": ["pricing pressure"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_skips_unusable_rows_with_warnings() -> None:
+    service = QuoteCardGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=["not a row", {"review_id": "missing-text"}],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 0
+    assert [warning["code"] for warning in payload["warnings"]] == [
+        "row_not_object",
+        "missing_source_text",
+        "missing_quote_card_evidence",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_expands_supported_source_material_bundles() -> None:
+    service = QuoteCardGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1"),
+        target_mode="vendor_retention",
+        source_material={
+            "vendor": "Zendesk",
+            "support_tickets": [
+                {
+                    "ticket_id": "ticket-1",
+                    "requester_company": "Acme Logistics",
+                    "message": "Macros still require too much manual triage.",
+                    "pain_category": "manual support triage",
+                }
+            ],
+        },
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["warnings"] == []
+    assert payload["cards"][0]["source_id"] == "ticket-1"
+    assert payload["cards"][0]["source_type"] == "support_ticket"
+    assert payload["cards"][0]["headline"] == "Customer proof for Zendesk"
+    assert payload["cards"][0]["attribution"] == "Acme Logistics"
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_keeps_fields_within_configured_bounds() -> None:
+    config = QuoteCardGenerationConfig(
+        max_quote_chars=40,
+        max_headline_chars=18,
+        max_supporting_text_chars=34,
+    )
+    service = QuoteCardGenerationService(config=config)
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-long",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "VeryLongVendorName",
+                "review_text": " ".join(["renewal pressure"] * 80),
+                "pain_category": "pricing pressure from enterprise renewals",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    card = payload["cards"][0]
+    assert len(card["quote"]) <= config.max_quote_chars
+    assert card["quote"].endswith("...")
+    assert len(card["headline"]) <= config.max_headline_chars
+    assert card["headline"].endswith("...")
+    assert len(card["supporting_text"]) <= config.max_supporting_text_chars
+    assert card["supporting_text"].endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_applies_limit_to_usable_rows() -> None:
+    service = QuoteCardGenerationService()
+
+    result = await service.generate(
+        scope=TenantScope(),
+        target_mode="vendor_retention",
+        limit=2,
+        source_material=[
+            {
+                "review_id": "review-1",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify.",
+                "pain_category": "pricing pressure",
+            },
+            {
+                "review_id": "review-2",
+                "vendor": "Zendesk",
+                "review_text": "Support queues took too long to triage.",
+                "pain_category": "slow support",
+            },
+            {
+                "review_id": "review-3",
+                "vendor": "Intercom",
+                "review_text": "Reporting did not explain where leads came from.",
+                "pain_category": "unclear reporting",
+            },
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 2
+    assert [card["source_id"] for card in payload["cards"]] == ["review-1", "review-2"]
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_rejects_invalid_limits() -> None:
+    service = QuoteCardGenerationService()
+
+    with pytest.raises(ValueError, match="limit must be at least 1"):
+        await service.generate(
+            scope=TenantScope(),
+            target_mode="vendor_retention",
+            source_material=[],
+            limit=0,
+        )
+
+    with pytest.raises(ValueError, match="max_text_chars must be at least 1"):
+        await service.generate(
+            scope=TenantScope(),
+            target_mode="vendor_retention",
+            source_material=[],
+            max_text_chars=0,
+        )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Marketer-Quote-Card-Output.md
Slice phase: Vertical slice

Adds the first quote-card generated output for the marketer reviews-as-input lane: a deterministic, source-evidence-only generator wired through the extracted catalog, generation plan, executor dispatch, host service bundle, no-op reasoning policy, and UI catalog fixture. The review update reuses the shared source-material bundle expander so supported bundles such as `support_tickets` produce quote cards instead of missing-text warnings.

## Intentional
- No persistence or generated-asset review branch. This first slice proves the output can run from source evidence; durable review/export handoff should follow only after the output shape is accepted.
- No package-default enrollment yet. Review/competitive package defaults remain unchanged until the `quote_card` output is executable and tested.
- No #1268 output-variations work. `variant_count` and prompt-angle fan-out are a separate plan-only lane and remain untouched.
- No LLM design/creative prompt. This slice keeps quote cards bounded to real source evidence and avoids visual-asset hallucination risk.
- No `stat_card` yet. Quote cards are the narrower first card surface; stat-card extraction needs numeric-claim selection and validation and should be its own slice.

## Deferred
- Add `quote_card` to review and competitive input-package defaults in the next quote-card handoff slice.
- Persist generated quote-card drafts into the generated-assets review queue after the output shape is accepted.
- Add `stat_card` as a follow-up output with numeric-claim validation.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_quote_card_generation.py tests/test_extracted_content_control_surfaces.py tests/test_extracted_content_generation_plan.py tests/test_extracted_content_ops_execution.py tests/test_extracted_content_reasoning_policy.py tests/test_extracted_content_control_surface_api.py tests/test_atlas_content_ops_execution_services.py -q` (326 passed, 1 skipped)
- `python -m json.tool atlas-intel-ui/src/api/__fixtures__/contentOps/catalog.json >/dev/null` (passed)
- `python -m py_compile extracted_content_pipeline/quote_card_generation.py extracted_content_pipeline/control_surfaces.py extracted_content_pipeline/generation_plan.py extracted_content_pipeline/content_ops_execution.py extracted_content_pipeline/reasoning_policy.py atlas_brain/_content_ops_services.py tests/test_extracted_quote_card_generation.py` (passed)
- `git diff --check` (passed)
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (passed; 144 matching tests enrolled)
- `bash scripts/validate_extracted_content_pipeline.sh` (passed)
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` (passed)
- `python scripts/audit_extracted_standalone.py --fail-on-debt` (passed; findings: 0)
- `bash scripts/check_ascii_python.sh` (passed)
- `cd atlas-intel-ui && npm run lint` (passed after `npm ci`)
- `cd atlas-intel-ui && npm run build` (passed after `npm ci`)
- `bash scripts/run_extracted_pipeline_checks.sh` (3009 passed, 10 skipped)
- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>` (passed on review-fix commit; caller hints reviewed and covered by focused host/API tests in this slice)

## Diff size
17 files, +834 / -8.