### PR TITLE
PR-Deflection-Teaser-Locked-Dedupe

### DIFF
--- a/extracted_content_pipeline/faq_deflection_report.py
+++ b/extracted_content_pipeline/faq_deflection_report.py
@@ -182,18 +182,21 @@ def build_deflection_snapshot(
             ),
             "customer_wording": _snapshot_customer_wording(item, question),
         })
+    teaser = _snapshot_teaser(items, preview_count=teaser_preview_count)
+    teaser_full_rank = _teaser_full_answer_rank(teaser)
     locked_questions = tuple(
         {
             "rank": rank,
             "ticket_count": _ticket_count(item),
         }
         for rank, item in enumerate(items[top_n:], start=top_n + 1)
+        if rank != teaser_full_rank
     )
     return DeflectionSnapshot(
         summary=snapshot_summary,
         top_questions=tuple(top_questions),
         locked_questions=locked_questions,
-        teaser=_snapshot_teaser(items, preview_count=teaser_preview_count),
+        teaser=teaser,
     )
 
 
@@ -596,6 +599,14 @@ def _snapshot_teaser(
         "full_answer": _teaser_full_answer(full_rank, full_item),
         "previews": previews,
     }
+
+
+def _teaser_full_answer_rank(teaser: Mapping[str, Any]) -> int | None:
+    full_answer = teaser.get("full_answer")
+    if not isinstance(full_answer, Mapping):
+        return None
+    rank = _int(full_answer.get("rank"))
+    return rank if rank > 0 else None
 
 
 def _is_teaser_eligible(item: Mapping[str, Any]) -> bool:

--- a/plans/PR-Deflection-Teaser-Locked-Dedupe.md
+++ b/plans/PR-Deflection-Teaser-Locked-Dedupe.md
@@ -1,0 +1,97 @@
+# PR-Deflection-Teaser-Locked-Dedupe
+
+## Why this slice exists
+
+PR #1288 changed the free snapshot teaser to expose the first eligible answer
+by rank. The reviewer called out a pre-existing contract edge that now matters
+for the portfolio render: if ranks 1 through `top_n` are not eligible and the
+teaser falls through to a later rank, that same rank can also appear in
+`locked_questions`.
+
+That produces an internally inconsistent snapshot: one surface exposes the
+rank's question and full answer while another marks the same rank as locked.
+The product wants the teaser to be free; the locked/FOMO rows should not claim
+that same full-answer rank is still withheld.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/faq-deflection-teaser
+Slice phase: Product polish
+
+1. Build the teaser before `locked_questions` so the selected full-answer rank
+   is known.
+2. Exclude only the selected full-answer rank from `locked_questions` when it
+   falls beyond `top_n`.
+3. Preserve the existing fail-closed teaser eligibility gate and body-withheld
+   previews.
+4. Add a focused regression test for a fall-through teaser rank that would
+   otherwise duplicate as locked.
+
+### Files touched
+
+- `plans/PR-Deflection-Teaser-Locked-Dedupe.md`
+- `extracted_content_pipeline/faq_deflection_report.py`
+- `tests/test_content_ops_deflection_report.py`
+
+## Mechanism
+
+`build_deflection_snapshot(...)` already delegates teaser eligibility to
+`_snapshot_teaser(...)`, which returns either one `full_answer` object or
+`None`. This slice stores that teaser payload once, extracts the selected
+`full_answer.rank`, and filters that rank out of the locked-row projection:
+
+```python
+teaser = _snapshot_teaser(items, preview_count=teaser_preview_count)
+teaser_full_rank = _teaser_full_answer_rank(teaser)
+locked_questions = tuple(
+    ...
+    for rank, item in enumerate(items[top_n:], start=top_n + 1)
+    if rank != teaser_full_rank
+)
+```
+
+If there is no full teaser answer, the extracted rank is `None` and
+`locked_questions` remains unchanged.
+
+## Intentional
+
+- This does not remove teaser previews from `locked_questions`. Previews remain
+  body-withheld, so they do not contradict the locked-answer claim the way the
+  full teaser answer does.
+- This does not add a new payload field. The existing `full_answer.rank` is the
+  real selection signal.
+- This stays backend-only. Portfolio copy/rendering can use the cleaner
+  snapshot payload in a separate frontend slice.
+- Cross-layer caller hints were inspected. The control-surface API only
+  forwards `build_deflection_snapshot(...)` output, and the docs example still
+  covers the unchanged producer shape without a fall-through teaser rank.
+
+## Deferred
+
+- Portfolio copy must read the real `teaser.full_answer.rank` instead of
+  hardcoding "#1"; that belongs to the portfolio renderer slice.
+- Help-center article card styling remains deferred to the frontend renderer.
+- Parked hardening: none. `HARDENING.md` has no current entry touching this
+  ownership lane or files.
+
+## Verification
+
+Ran before push:
+
+- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py` - passed
+- `pytest tests/test_content_ops_deflection_report.py -q` - 36 passed
+- `bash scripts/validate_extracted_content_pipeline.sh` - passed
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
+- `bash scripts/check_ascii_python.sh` - passed
+- `bash scripts/run_extracted_pipeline_checks.sh` - reasoning core 295 passed; extracted content pipeline 3004 passed, 10 skipped, 1 warning
+- `bash scripts/local_pr_review.sh --current-pr-body-file "$PR_BODY_FILE"` - passed
+
+## Estimated diff size
+
+| Area | Estimated LOC |
+|---|---:|
+| Plan doc | ~85 |
+| Snapshot builder | ~20 |
+| Focused test | ~35 |
+| **Total** | **~140** |

--- a/tests/test_content_ops_deflection_report.py
+++ b/tests/test_content_ops_deflection_report.py
@@ -617,6 +617,52 @@ def test_deflection_snapshot_teaser_falls_through_to_next_eligible_rank() -> Non
     assert "Third answer" not in encoded
 
 
+def test_deflection_snapshot_omits_full_teaser_rank_from_locked_rows() -> None:
+    result = TicketFAQMarkdownResult(
+        markdown="# FAQ",
+        source_count=4,
+        ticket_source_count=4,
+        output_checks={"condensed": True},
+        items=(
+            {
+                **_scoped_answer_item(
+                    1,
+                    "How do I export reports?",
+                    "Blocked top answer must not leak.",
+                ),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            {
+                **_scoped_answer_item(
+                    2,
+                    "How do I update billing?",
+                    "Blocked second answer must not leak.",
+                ),
+                "answer_evidence_status": "draft_needs_review",
+            },
+            _scoped_answer_item(3, "How do I enable SSO?", "Third answer"),
+            _scoped_answer_item(4, "How do I rotate tokens?", "Fourth answer"),
+        ),
+    )
+
+    snapshot = build_deflection_snapshot(
+        build_deflection_report_artifact(result),
+        top_n=1,
+        teaser_preview_count=1,
+    ).as_dict()
+    encoded = json.dumps(snapshot, sort_keys=True)
+
+    assert snapshot["teaser"]["full_answer"]["rank"] == 3
+    assert snapshot["locked_questions"] == [
+        {"rank": 2, "ticket_count": 1},
+        {"rank": 4, "ticket_count": 1},
+    ]
+    assert "Third answer" in encoded
+    assert "Blocked top answer must not leak" not in encoded
+    assert "Blocked second answer must not leak" not in encoded
+    assert "Fourth answer" not in encoded
+
+
 def test_deflection_snapshot_teaser_empty_when_no_scoped_resolution_evidence() -> None:
     result = TicketFAQMarkdownResult(
         markdown="# FAQ",


### PR DESCRIPTION
Plan: plans/PR-Deflection-Teaser-Locked-Dedupe.md
Slice phase: Product polish

PR #1288 exposed the first eligible teaser answer by rank. This PR closes the deferred backend hygiene edge from that review: when the selected full teaser answer falls beyond `top_n`, the same rank is removed from `locked_questions` so the snapshot does not show one surface as free and locked at the same time.

## Intentional
- Only the selected full-answer teaser rank is removed from `locked_questions`; body-withheld teaser previews remain unchanged.
- No new payload field is added. The existing `teaser.full_answer.rank` is the real selection signal.
- This stays backend-only; portfolio copy/rendering remains a frontend slice.
- Cross-layer caller hints were inspected. The control-surface API only forwards `build_deflection_snapshot(...)` output, and the docs example still covers the unchanged producer shape without a fall-through teaser rank.

## Deferred
- Portfolio copy must read the real `teaser.full_answer.rank` instead of hardcoding "#1".
- Help-center article card styling remains deferred to the frontend renderer.

## Parked hardening
- None. `HARDENING.md` has no current entry touching this ownership lane or files.

## Verification
- `python -m py_compile extracted_content_pipeline/faq_deflection_report.py tests/test_content_ops_deflection_report.py` - passed
- `pytest tests/test_content_ops_deflection_report.py -q` - 36 passed
- `bash scripts/validate_extracted_content_pipeline.sh` - passed
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` - passed
- `python scripts/audit_extracted_standalone.py --fail-on-debt` - passed
- `bash scripts/check_ascii_python.sh` - passed
- `bash scripts/run_extracted_pipeline_checks.sh` - reasoning core 295 passed; extracted content pipeline 3004 passed, 10 skipped, 1 warning
- `bash scripts/local_pr_review.sh --current-pr-body-file "$PR_BODY_FILE"` - passed

## Diff size
3 files, +155 / -1
