### PR TITLE
Plan: Content Ops Quote Card Package Handoff

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -166,13 +166,14 @@ _REVIEW_CAMPAIGN_OUTPUTS = (
     "sales_brief",
     "social_post",
     "ad_copy",
+    "quote_card",
 )
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
 _REVIEW_OFFER = (
     "Turn customer review themes into buyer-facing landing pages, blog posts, "
-    "sales briefs, social posts, and ad copy"
+    "sales briefs, social posts, ad copy, and quote cards"
 )
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
 _COMPETITIVE_CAMPAIGN_OUTPUTS = (
@@ -181,6 +182,7 @@ _COMPETITIVE_CAMPAIGN_OUTPUTS = (
     "sales_brief",
     "social_post",
     "ad_copy",
+    "quote_card",
 )
 _COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
 _COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
@@ -189,7 +191,7 @@ _COMPETITIVE_AUDIENCE = (
 )
 _COMPETITIVE_OFFER = (
     "Turn competitor and switching evidence into buyer-facing landing pages, "
-    "blog posts, sales briefs, social posts, and ad copy"
+    "blog posts, sales briefs, social posts, ad copy, and quote cards"
 )
 _COMPETITIVE_TARGET_KEYWORD = "competitive displacement content marketing"
 

--- a/plans/PR-Content-Ops-Quote-Card-Package-Handoff.md
+++ b/plans/PR-Content-Ops-Quote-Card-Package-Handoff.md
@@ -1,0 +1,96 @@
+# PR: Content Ops Quote Card Package Handoff
+
+## Why this slice exists
+
+PR #1289 added the deterministic `quote_card` output and deliberately deferred
+putting it into the review and competitive input-package defaults. Until this
+handoff lands, operators can run `quote_card` explicitly, but the productized
+review/competitive source modes still default only to landing pages, blog posts,
+sales briefs, social posts, and ad copy.
+
+This slice completes that handoff by making review and competitive source
+packages request quote cards by default, using the same normalized
+`source_material` already proven by #1289. It mirrors
+`plans/PR-Content-Ops-Social-Post-Package-Handoff.md` and
+`plans/PR-Content-Ops-Ad-Copy-Package-Handoff.md`, and does not overlap #1268's
+separate output-variations lane.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+
+Slice phase: Vertical slice
+
+1. Add `quote_card` to the review source-mode default outputs.
+2. Add `quote_card` to the competitive source-mode default outputs.
+3. Align the package offer copy with the expanded output set.
+4. Extend the existing host-provider tests to prove the default package outputs
+   and execution handoff include `quote_card`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Quote-Card-Package-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host input provider already builds normalized `source_material` for review
+and competitive source modes. `quote_card` consumes that same field, so this
+slice only expands the two output tuples:
+
+```python
+_REVIEW_CAMPAIGN_OUTPUTS = (..., "social_post", "ad_copy", "quote_card")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = (..., "social_post", "ad_copy", "quote_card")
+```
+
+The execution tests use the existing `_RunnableService` fake in the
+`quote_card` service slot. If the output is present but the dispatcher fails to
+hand off `source_material`, the tests fail on the quote-card step kwargs.
+
+## Intentional
+
+- No new source adapter or generator logic. #1289 already proved `quote_card`
+  runs from normalized source material and de-forked bundle handling onto the
+  shared source-material adapter.
+- No UI selector changes. The New Run source-mode path consumes these package
+  defaults automatically.
+- No persistence or generated-asset review branch. Durable quote-card review
+  remains a separate productization slice after this default handoff.
+- No changes to #1268 output variations; that open PR is a separate
+  workflow/process lane and remains untouched.
+- No `stat_card` output yet. Numeric-claim selection and validation should be
+  its own slice.
+
+## Deferred
+
+- Persist generated quote-card drafts into the generated-assets review queue
+  after the package-default handoff is accepted.
+- Add `stat_card` as a follow-up output with numeric-claim validation.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
+- `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
+- `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py` (passed)
+- `git diff --check` (passed)
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (passed; 144 matching tests enrolled)
+- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>` (passed; no non-diff caller references)
+
+## Estimated diff size
+
+Actual: 3 files, +114 / -2. This stays under the 400 LOC soft cap because it
+reuses the existing source-mode package and #1289's quote-card dispatcher.
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider defaults and copy | ~8 |
+| Host provider tests | ~16 |
+| Plan doc | ~90 |
+| **Total** | **~114** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -65,6 +65,7 @@ _MARKETER_OUTPUTS = (
     "sales_brief",
     "social_post",
     "ad_copy",
+    "quote_card",
 )
 
 
@@ -637,6 +638,7 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
+            quote_card=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -665,6 +667,11 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
     assert ad_copy_kwargs["source_material"][0]["target_id"] == "review-1"
     assert ad_copy_kwargs["target_mode"] == "vendor_retention"
 
+    quote_card_step = next(step for step in result.steps if step.output == "quote_card")
+    quote_card_kwargs = quote_card_step.result["kwargs"]
+    assert quote_card_kwargs["source_material"][0]["target_id"] == "review-1"
+    assert quote_card_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.asyncio
 async def test_competitive_input_evidence_reaches_landing_and_blog_generators() -> None:
@@ -688,6 +695,7 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
+            quote_card=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -716,6 +724,11 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
     assert ad_copy_kwargs["source_material"][0]["target_id"] == "competitive-1"
     assert ad_copy_kwargs["target_mode"] == "vendor_retention"
 
+    quote_card_step = next(step for step in result.steps if step.output == "quote_card")
+    quote_card_kwargs = quote_card_step.result["kwargs"]
+    assert quote_card_kwargs["source_material"][0]["target_id"] == "competitive-1"
+    assert quote_card_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.skipif(
     api_module.APIRouter is None,
@@ -732,6 +745,7 @@ async def test_plan_route_applies_review_input_provider() -> None:
             sales_brief=_RunnableService(),
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
+            quote_card=_RunnableService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-review-route"),
     )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Quote-Card-Package-Handoff.md
Slice phase: Vertical slice

Adds `quote_card` to the review and competitive source-mode default output packages now that #1289 made the output executable, and extends host-provider tests to prove package defaults and executor handoff include the quote-card service slot.

## Intentional
- No new source adapter or generator logic. #1289 already proved `quote_card` runs from normalized source material and de-forked bundle handling onto the shared source-material adapter.
- No UI selector changes. The New Run source-mode path consumes these package defaults automatically.
- No persistence or generated-asset review branch. Durable quote-card review remains a separate productization slice after this default handoff.
- No changes to #1268 output variations; that open PR is a separate workflow/process lane and remains untouched.
- No `stat_card` output yet. Numeric-claim selection and validation should be its own slice.

## Deferred
- Persist generated quote-card drafts into the generated-assets review queue after the package-default handoff is accepted.
- Add `stat_card` as a follow-up output with numeric-claim validation.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
- `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
- `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py` (passed)
- `git diff --check` (passed)
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (passed; 144 matching tests enrolled)
- `bash scripts/local_pr_review.sh --current-pr-body-file <body-file>` (passed; no non-diff caller references)

## Diff size
3 files, +114 / -2.