### PR TITLE
Content Ops Quote Card Generated Assets

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Test Content Ops ad copy review assets
         run: npm run test:content-ops-ad-copy-review-assets
 
+      - name: Test Content Ops quote card review assets
+        run: npm run test:content-ops-quote-card-review-assets
+
       - name: Test Content Ops review source selection
         run: npm run test:content-ops-review-source-selection
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -24,6 +24,7 @@
     "test:content-ops-blog-review-public-link": "node --test scripts/content-ops-blog-review-public-link.test.mjs",
     "test:content-ops-social-post-review-assets": "node --test scripts/content-ops-social-post-review-assets.test.mjs",
     "test:content-ops-ad-copy-review-assets": "node --test scripts/content-ops-ad-copy-review-assets.test.mjs",
+    "test:content-ops-quote-card-review-assets": "node --test scripts/content-ops-quote-card-review-assets.test.mjs",
     "test:content-ops-review-source-selection": "node --test scripts/content-ops-review-source-selection.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fetchGeneratedAssetDrafts,
+  reviewGeneratedAssetDraft,
+  reviewGeneratedAssetDrafts,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('quote-card generated asset list fetches the typed content-assets route', async () => {
+  const payload = {
+    count: 1,
+    limit: 5,
+    filters: { status: 'draft', theme: 'customer_proof' },
+    rows: [{
+      id: 'quote-card-1',
+      status: 'draft',
+      theme: 'customer_proof',
+      quote: 'Pricing became hard to justify after renewal.',
+      attribution: 'Acme Logistics',
+      headline: 'Customer proof for Zendesk',
+      supporting_text: 'Use this quote to frame pricing pressure.',
+    }],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchGeneratedAssetDrafts('quote_card', {
+    status: 'draft',
+    theme: 'customer_proof',
+    limit: 5,
+  })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/quote_card/drafts?status=draft&theme=customer_proof&limit=5`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('quote-card generated asset review actions post to typed routes', async () => {
+  const calls = installFetchResponder({
+    account_id: 'acct-1',
+    asset: 'quote_card',
+    id: 'quote-card-1',
+    status: 'approved',
+    updated: true,
+  })
+
+  await reviewGeneratedAssetDraft('quote_card', 'quote-card-1', 'approved')
+  await reviewGeneratedAssetDrafts('quote_card', ['quote-card-1'], 'rejected')
+
+  assert.equal(calls.length, 2)
+  assert.equal(
+    calls[0].url,
+    `${API_ORIGIN}/api/v1/content-assets/quote_card/drafts/review`,
+  )
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    id: 'quote-card-1',
+    status: 'approved',
+  })
+  assert.equal(
+    calls[1].url,
+    `${API_ORIGIN}/api/v1/content-assets/quote_card/drafts/review-batch`,
+  )
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    ids: ['quote-card-1'],
+    status: 'rejected',
+  })
+})
+
+test('asset review UI exposes quote-card tab and preview branches', () => {
+  assert.ok(reviewSource.includes("id: 'quote_card'"))
+  assert.ok(reviewSource.includes("label: 'Quote Cards'"))
+  assert.ok(reviewSource.includes("asset === 'quote_card'"))
+  assert.ok(reviewSource.includes('textValue(row.quote)'))
+  assert.ok(reviewSource.includes('textValue(row.supporting_text)'))
+  assert.ok(reviewSource.includes('quoteCardPainPointCount(row)'))
+  assert.ok(reviewSource.includes('pain: ${item}'))
+})
+
+test('completed quote-card runs link into generated asset review', () => {
+  assert.match(
+    newRunSource,
+    /const GENERATED_ASSET_OUTPUTS:[\s\S]*'quote_card'[\s\S]*\]/,
+  )
+  assert.ok(newRunSource.includes('function generatedAssetReviewHref'))
+  assert.ok(newRunSource.includes("params.set('asset', output)"))
+  assert.ok(newRunSource.includes('Review generated drafts'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -433,6 +433,7 @@ export type GeneratedAssetType =
   | 'sales_brief'
   | 'social_post'
   | 'ad_copy'
+  | 'quote_card'
   | 'faq_markdown'
 
 export interface GeneratedAssetRepairHistoryEntry {
@@ -472,6 +473,10 @@ export interface GeneratedAssetDraft {
   brief_type?: string
   channel?: string
   format?: string
+  theme?: string
+  quote?: string
+  attribution?: string
+  supporting_text?: string
   text?: string
   primary_text?: string
   source_id?: string
@@ -538,6 +543,7 @@ export interface GeneratedAssetListParams {
   topic_type?: string
   brief_type?: string
   channel?: string
+  theme?: string
   id?: string | string[]
   format?: string
   limit?: number

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -183,6 +183,11 @@ const ASSETS: Array<{
     description: 'Paid-social ad drafts generated from review and source evidence.',
   },
   {
+    id: 'quote_card',
+    label: 'Quote Cards',
+    description: 'Customer-proof quote card drafts generated from source evidence.',
+  },
+  {
     id: 'faq_markdown',
     label: 'FAQ Markdown',
     description: 'Grounded FAQ documents generated from support-ticket evidence.',
@@ -2112,6 +2117,16 @@ function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string
       'ad_copy draft'
     )
   }
+  if (asset === 'quote_card') {
+    return (
+      textValue(row.headline) ||
+      textValue(row.attribution) ||
+      textValue(row.company_name) ||
+      textValue(row.vendor_name) ||
+      excerpt(textValue(row.quote), 72) ||
+      'quote_card draft'
+    )
+  }
   return (
     textValue(row.title) ||
     textValue(row.headline) ||
@@ -2158,6 +2173,16 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
     return [
       row.channel,
       row.format,
+      row.company_name,
+      row.vendor_name,
+      row.source_type,
+      row.source_id,
+    ].map(textValue).filter(Boolean).join(' | ')
+  }
+  if (asset === 'quote_card') {
+    return [
+      row.theme,
+      row.attribution,
       row.company_name,
       row.vendor_name,
       row.source_type,
@@ -2236,6 +2261,15 @@ function addAssetSpecificFacts(
     addFact(facts, 'vendor', row.vendor_name)
     addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
     addFact(facts, 'pain points', adCopyPainPointCount(row))
+    return
+  }
+  if (asset === 'quote_card') {
+    addFact(facts, 'theme', row.theme)
+    addFact(facts, 'attribution', row.attribution)
+    addFact(facts, 'company', row.company_name)
+    addFact(facts, 'vendor', row.vendor_name)
+    addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
+    addFact(facts, 'pain points', quoteCardPainPointCount(row))
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -2328,6 +2362,19 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
         textValue(row.channel),
         textValue(row.format),
         cta ? `CTA: ${cta}` : '',
+        ...painPoints.map((item) => `pain: ${item}`),
+      ].filter(Boolean),
+    })
+  }
+  if (asset === 'quote_card') {
+    const painPoints = valueList(row.pain_points).slice(0, 3)
+    return previewOrNull({
+      heading: textValue(row.headline) || textValue(row.attribution),
+      body: excerpt(textValue(row.quote), 280),
+      meta: [
+        textValue(row.theme),
+        textValue(row.attribution),
+        textValue(row.supporting_text),
         ...painPoints.map((item) => `pain: ${item}`),
       ].filter(Boolean),
     })
@@ -2495,6 +2542,13 @@ function socialPostPainPointCount(row: GeneratedAssetDraft): number | string {
 }
 
 function adCopyPainPointCount(row: GeneratedAssetDraft): number | string {
+  if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
+    return row.pain_point_count
+  }
+  return valueList(row.pain_points).length || ''
+}
+
+function quoteCardPainPointCount(row: GeneratedAssetDraft): number | string {
   if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
     return row.pain_point_count
   }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -166,6 +166,7 @@ const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'faq_markdown',
   'social_post',
   'ad_copy',
+  'quote_card',
 ]
 const ID_FILTERED_REVIEW_OUTPUTS = new Set<string>([
   'blog_post',

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -14,7 +14,7 @@ Currently wired:
 - `ad_copy`: deterministic source-evidence ad-copy drafts
   with no external dependencies; persists when DB services are enabled.
 - `quote_card`: deterministic source-evidence quote-card drafts
-  with no external dependencies.
+  with no external dependencies; persists when DB services are enabled.
 - `landing_page` (E2, PR #454 + E2.5, PR #455): plugs the
   host LLM + Skill adapters from PR #453 +
   `PostgresLandingPageRepository` backed by the host's
@@ -88,6 +88,9 @@ from extracted_content_pipeline.landing_page_postgres import (
 )
 from extracted_content_pipeline.quote_card_generation import (
     QuoteCardGenerationService,
+)
+from extracted_content_pipeline.quote_card_postgres import (
+    PostgresQuoteCardRepository,
 )
 from extracted_content_pipeline.report_generation import (
     ReportGenerationService,
@@ -292,6 +295,16 @@ def _build_ad_copy_service(*, pool: Any) -> AdCopyGenerationService:
     )
 
 
+def _build_quote_card_service(*, pool: Any) -> QuoteCardGenerationService:
+    """Build quote-card generation with optional draft persistence."""
+
+    if pool is None:
+        return _QUOTE_CARD_SERVICE
+    return QuoteCardGenerationService(
+        quote_cards=PostgresQuoteCardRepository(pool=pool)
+    )
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -398,6 +411,7 @@ def build_content_ops_execution_services(
         )
         social_post = _build_social_post_service(pool=pool)
         ad_copy = _build_ad_copy_service(pool=pool)
+        quote_card = _build_quote_card_service(pool=pool)
         faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
         faq_deflection_report = FAQDeflectionReportService(

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -43,6 +43,8 @@ from ..landing_page_ports import LandingPageDraft, LandingPageSection
 from ..faq_macro_writeback import MacroPublishProvider
 from ..faq_macro_writeback_postgres import PostgresFAQMacroPublishAttemptRepository
 from ..faq_macro_writeback_publish import FAQMacroWritebackPublishService
+from ..quote_card_export import export_quote_card_drafts
+from ..quote_card_postgres import PostgresQuoteCardRepository
 from ..report_export import export_report_drafts
 from ..report_postgres import PostgresReportRepository
 from ..sales_brief_export import export_sales_brief_drafts
@@ -69,6 +71,7 @@ ASSET_CHOICES = (
     "sales_brief",
     "social_post",
     "ad_copy",
+    "quote_card",
     "faq_markdown",
 )
 logger = logging.getLogger(__name__)
@@ -293,6 +296,7 @@ def create_generated_asset_router(
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         channel: str | None = Query(None),
+        theme: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
     ) -> dict[str, Any]:
@@ -311,6 +315,7 @@ def create_generated_asset_router(
             topic_type=topic_type,
             brief_type=brief_type,
             channel=channel,
+            theme=theme,
             ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
@@ -327,6 +332,7 @@ def create_generated_asset_router(
         topic_type: str | None = Query(None),
         brief_type: str | None = Query(None),
         channel: str | None = Query(None),
+        theme: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
         format: str = Query("csv", description="csv or json"),
@@ -346,6 +352,7 @@ def create_generated_asset_router(
             topic_type=topic_type,
             brief_type=brief_type,
             channel=channel,
+            theme=theme,
             ids=ids,
             limit=_api_limit(limit, resolved_config),
         )
@@ -730,6 +737,7 @@ async def _export_for_asset(
     topic_type: str | None,
     brief_type: str | None,
     channel: str | None,
+    theme: str | None,
     ids: Sequence[str] | None,
     limit: int,
 ) -> Any:
@@ -793,6 +801,15 @@ async def _export_for_asset(
             channel=channel,
             limit=limit,
         )
+    if asset == "quote_card":
+        return await export_quote_card_drafts(
+            PostgresQuoteCardRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            theme=theme,
+            limit=limit,
+        )
     if asset == "faq_markdown":
         return await export_ticket_faq_drafts(
             PostgresTicketFAQRepository(pool),
@@ -824,6 +841,8 @@ async def _update_asset_status(
         return await PostgresSocialPostRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "ad_copy":
         return await PostgresAdCopyRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "quote_card":
+        return await PostgresQuoteCardRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_status(asset_id, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
@@ -849,6 +868,8 @@ async def _update_asset_statuses(
         return await PostgresSocialPostRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "ad_copy":
         return await PostgresAdCopyRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "quote_card":
+        return await PostgresQuoteCardRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -315,6 +315,9 @@
       "target": "extracted_content_pipeline/quote_card_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/quote_card_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/social_post_export.py"
     },
     {
@@ -337,6 +340,15 @@
     },
     {
       "target": "extracted_content_pipeline/storage/migrations/332_ad_copy_drafts.sql"
+    },
+    {
+      "target": "extracted_content_pipeline/quote_card_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/quote_card_postgres.py"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/333_quote_card_drafts.sql"
     },
     {
       "target": "extracted_content_pipeline/blog_ports.py"

--- a/extracted_content_pipeline/quote_card_export.py
+++ b/extracted_content_pipeline/quote_card_export.py
@@ -1,0 +1,128 @@
+"""Read-only quote-card draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any
+
+from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
+from .quote_card_ports import QuoteCardDraft, QuoteCardRepository
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "theme",
+    "company_name",
+    "vendor_name",
+    "source_id",
+    "source_type",
+    "pain_point_count",
+    "quote",
+    "attribution",
+    "headline",
+    "supporting_text",
+    "pain_points",
+    "metadata",
+    "id",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class QuoteCardDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_quote_card_drafts(
+    repository: QuoteCardRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    theme: str | None = None,
+    limit: int = 20,
+) -> QuoteCardDraftExportResult:
+    """Return generated quote-card drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    if theme:
+        filters["theme"] = theme
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        theme=theme,
+        limit=normalized_limit,
+    )
+    return QuoteCardDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: QuoteCardDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["pain_point_count"] = len(draft.pain_points)
+    return row
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "QuoteCardDraftExportResult",
+    "export_quote_card_drafts",
+]

--- a/extracted_content_pipeline/quote_card_generation.py
+++ b/extracted_content_pipeline/quote_card_generation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from .campaign_customer_data import CampaignOpportunityWarning
@@ -12,6 +12,7 @@ from .campaign_source_adapters import (
     source_material_to_source_rows,
     source_row_to_campaign_opportunity,
 )
+from .quote_card_ports import QuoteCardDraft, QuoteCardRepository
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ class QuoteCardGenerationResult:
     cards: tuple[dict[str, Any], ...]
     warnings: tuple[CampaignOpportunityWarning, ...] = ()
     target_mode: str = "vendor_retention"
+    saved_ids: tuple[str, ...] = ()
 
     @property
     def generated(self) -> int:
@@ -43,14 +45,21 @@ class QuoteCardGenerationResult:
             "target_mode": self.target_mode,
             "cards": [dict(card) for card in self.cards],
             "warnings": [warning.as_dict() for warning in self.warnings],
+            "saved_ids": list(self.saved_ids),
         }
 
 
 class QuoteCardGenerationService:
     """Build short, evidence-backed quote-card drafts from source material."""
 
-    def __init__(self, config: QuoteCardGenerationConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: QuoteCardGenerationConfig | None = None,
+        *,
+        quote_cards: QuoteCardRepository | None = None,
+    ) -> None:
         self.config = config or QuoteCardGenerationConfig()
+        self._quote_cards = quote_cards
 
     async def generate(
         self,
@@ -62,7 +71,7 @@ class QuoteCardGenerationService:
         max_text_chars: int | None = None,
         **kwargs: Any,
     ) -> QuoteCardGenerationResult:
-        del scope, kwargs
+        del kwargs
         resolved_limit = int(limit) if limit is not None else self.config.limit
         if resolved_limit < 1:
             raise ValueError("limit must be at least 1")
@@ -73,7 +82,7 @@ class QuoteCardGenerationService:
         )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be at least 1")
-        return _generate_quote_cards(
+        result = _generate_quote_cards(
             _rows_from_source_material(source_material),
             target_mode=target_mode,
             limit=resolved_limit,
@@ -82,6 +91,16 @@ class QuoteCardGenerationService:
             max_headline_chars=self.config.max_headline_chars,
             max_supporting_text_chars=self.config.max_supporting_text_chars,
         )
+        if self._quote_cards is None or not result.cards:
+            return result
+        saved_ids = tuple(
+            str(item)
+            for item in await self._quote_cards.save_drafts(
+                _drafts_from_cards(result.cards, target_mode=target_mode),
+                scope=scope,
+            )
+        )
+        return replace(result, saved_ids=saved_ids)
 
 
 def _generate_quote_cards(
@@ -200,6 +219,44 @@ def _first_evidence(opportunity: Mapping[str, Any]) -> str:
     return _clean(raw)
 
 
+def _drafts_from_cards(
+    cards: Sequence[Mapping[str, Any]],
+    *,
+    target_mode: str,
+) -> tuple[QuoteCardDraft, ...]:
+    drafts: list[QuoteCardDraft] = []
+    for card in cards:
+        source_id = _clean(card.get("source_id") or card.get("id"))
+        target_id = _clean(card.get("target_id")) or source_id
+        drafts.append(
+            QuoteCardDraft(
+                target_id=target_id,
+                target_mode=target_mode,
+                theme=_clean(card.get("theme")) or "customer_proof",
+                quote=_clean(card.get("quote")),
+                attribution=_clean(card.get("attribution")),
+                headline=_clean(card.get("headline")),
+                supporting_text=_clean(card.get("supporting_text")),
+                source_id=source_id,
+                source_type=_clean(card.get("source_type")),
+                company_name=_clean(card.get("company_name")),
+                vendor_name=_clean(card.get("vendor_name")),
+                pain_points=_pain_points_from_card(card.get("pain_points")),
+                metadata={"source_card": dict(card)},
+            )
+        )
+    return tuple(drafts)
+
+
+def _pain_points_from_card(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
+
+
 def _first_text(value: Any) -> str:
     if isinstance(value, str):
         return value.strip()
@@ -233,4 +290,6 @@ __all__ = [
     "QuoteCardGenerationConfig",
     "QuoteCardGenerationResult",
     "QuoteCardGenerationService",
+    "QuoteCardDraft",
+    "QuoteCardRepository",
 ]

--- a/extracted_content_pipeline/quote_card_ports.py
+++ b/extracted_content_pipeline/quote_card_ports.py
@@ -1,0 +1,95 @@
+"""Standalone ports for persisted quote-card drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class QuoteCardDraft:
+    """A generated, not-yet-approved quote-card draft."""
+
+    target_id: str
+    target_mode: str
+    theme: str
+    quote: str
+    attribution: str
+    headline: str
+    supporting_text: str
+    source_id: str = ""
+    source_type: str = ""
+    company_name: str = ""
+    vendor_name: str = ""
+    pain_points: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "theme": self.theme,
+            "quote": self.quote,
+            "attribution": self.attribution,
+            "headline": self.headline,
+            "supporting_text": self.supporting_text,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "company_name": self.company_name,
+            "vendor_name": self.vendor_name,
+            "pain_points": list(self.pain_points),
+            "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
+        }
+
+
+class QuoteCardRepository(Protocol):
+    """Persistence contract for generated quote-card drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[QuoteCardDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return assigned quote-card ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        theme: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[QuoteCardDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft status and return True on hit."""
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched scope."""
+
+
+__all__ = [
+    "QuoteCardDraft",
+    "QuoteCardRepository",
+]

--- a/extracted_content_pipeline/quote_card_postgres.py
+++ b/extracted_content_pipeline/quote_card_postgres.py
@@ -1,0 +1,198 @@
+"""Postgres repository adapter for generated quote-card drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .quote_card_ports import QuoteCardDraft
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_QUOTE_CARD_COLUMNS = (
+    "id, target_id, target_mode, theme, quote, attribution, headline, "
+    "supporting_text, source_id, source_type, company_name, vendor_name, "
+    "pain_points, metadata, status"
+)
+
+
+def _draft_metadata(draft: QuoteCardDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_string_sequence(value: Any) -> tuple[str, ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in decoded if str(item).strip())
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> QuoteCardDraft:
+    return QuoteCardDraft(
+        id=str(row.get("id") or ""),
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        theme=str(row.get("theme") or ""),
+        quote=str(row.get("quote") or ""),
+        attribution=str(row.get("attribution") or ""),
+        headline=str(row.get("headline") or ""),
+        supporting_text=str(row.get("supporting_text") or ""),
+        source_id=str(row.get("source_id") or ""),
+        source_type=str(row.get("source_type") or ""),
+        company_name=str(row.get("company_name") or ""),
+        vendor_name=str(row.get("vendor_name") or ""),
+        pain_points=_json_string_sequence(row.get("pain_points")),
+        metadata=_json_mapping(row.get("metadata")),
+        status=str(row.get("status") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresQuoteCardRepository:
+    """Async Postgres adapter for generated quote cards."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[QuoteCardDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            draft_id = await self.pool.fetchval(
+                """
+                INSERT INTO quote_card_drafts (
+                    account_id, target_id, target_mode, theme, quote,
+                    attribution, headline, supporting_text, source_id,
+                    source_type, company_name, vendor_name, pain_points,
+                    metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6, $7, $8, $9,
+                    $10, $11, $12, $13::jsonb,
+                    $14::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.theme,
+                draft.quote,
+                draft.attribution,
+                draft.headline,
+                draft.supporting_text,
+                draft.source_id,
+                draft.source_type,
+                draft.company_name,
+                draft.vendor_name,
+                json_dump_jsonb([str(item) for item in draft.pain_points]),
+                json_dump_jsonb(_draft_metadata(draft, scope)),
+            )
+            saved.append(str(draft_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        theme: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[QuoteCardDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if theme is not None:
+            params.append(theme)
+            clauses.append(f"theme = ${len(params)}")
+        sql = (
+            f"SELECT {_QUOTE_CARD_COLUMNS} "
+            "FROM quote_card_drafts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE quote_card_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1::uuid
+               AND account_id = $3
+            """,
+            draft_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in draft_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE quote_card_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+__all__ = [
+    "PostgresQuoteCardRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/333_quote_card_drafts.sql
+++ b/extracted_content_pipeline/storage/migrations/333_quote_card_drafts.sql
@@ -1,0 +1,37 @@
+-- Quote-card drafts: deterministic, evidence-backed customer-proof cards
+-- generated from Content Ops source material. One row is one reviewable
+-- quote-card draft.
+--
+-- The status lifecycle mirrors the other generated assets: drafts start at
+-- 'draft' and host workflows can move them through 'approved', 'rejected', or
+-- custom intermediate states without a CHECK constraint.
+
+CREATE TABLE IF NOT EXISTS quote_card_drafts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    theme TEXT NOT NULL DEFAULT 'customer_proof',
+    quote TEXT NOT NULL,
+    attribution TEXT NOT NULL DEFAULT '',
+    headline TEXT NOT NULL DEFAULT '',
+    supporting_text TEXT NOT NULL DEFAULT '',
+    source_id TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT '',
+    company_name TEXT NOT NULL DEFAULT '',
+    vendor_name TEXT NOT NULL DEFAULT '',
+    pain_points JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quote_card_drafts_target
+    ON quote_card_drafts (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_quote_card_drafts_status
+    ON quote_card_drafts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_quote_card_drafts_theme
+    ON quote_card_drafts (account_id, theme, created_at DESC);

--- a/plans/PR-Content-Ops-Quote-Card-Generated-Assets.md
+++ b/plans/PR-Content-Ops-Quote-Card-Generated-Assets.md
@@ -1,0 +1,148 @@
+# PR: Content Ops Quote Card Generated Assets
+
+## Why this slice exists
+
+PR #1289 added the deterministic `quote_card` output and PR #1292 put it into
+the review and competitive source-package defaults, but generated quote cards
+are still transient execution payloads. Operators can run the output, but they
+cannot revisit, approve, reject, or export quote-card drafts from the generated
+asset review queue.
+
+This slice completes the quote-card productization handoff deferred by #1292:
+generated quote-card drafts persist as tenant-scoped rows and become a
+first-class generated asset in the existing backend review API and
+`atlas-intel-ui` review screen.
+
+The diff is expected to exceed the 400 LOC soft cap for the same indivisible
+reason as the social-post/ad-copy review queue handoffs: schema, package port,
+Postgres adapter, generator save hook, host wiring, backend review/export
+switchboards, frontend type/UI branches, CI-enrolled frontend test, and focused
+backend tests need to land together or `quote_card` is only partially
+reviewable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add package-owned quote-card persistence types, Postgres adapter, export
+   helper, and migration for tenant-scoped review rows.
+2. Teach `QuoteCardGenerationService` to persist generated cards when a
+   repository is injected, returning `saved_ids` in the execution result.
+3. Wire the host DB-backed Content Ops service bundle to use the Postgres
+   quote-card repository when `enable_db_services=True`.
+4. Add `quote_card` to generated-assets backend switchboards for list,
+   CSV/JSON export, single review, and batch review.
+5. Add `quote_card` to the atlas-intel-ui API type surface, review tab, card
+   preview/facts/title branches, completed-run review CTA allowlist, and
+   CI-enrolled frontend test.
+6. Add focused package, host, backend API, and frontend tests proving
+   tenant-scoped persistence and review/export handoff.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Quote-Card-Generated-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/quote_card_ports.py`
+- `extracted_content_pipeline/quote_card_postgres.py`
+- `extracted_content_pipeline/quote_card_export.py`
+- `extracted_content_pipeline/quote_card_generation.py`
+- `extracted_content_pipeline/storage/migrations/333_quote_card_drafts.sql`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_quote_card_generation.py`
+- `tests/test_extracted_quote_card_postgres.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+
+## Mechanism
+
+`QuoteCardGenerationService` already turns normalized source material into
+bounded quote-card dictionaries. This slice mirrors the social-post/ad-copy
+persistence seam: convert each generated card into a `QuoteCardDraft`, then
+call:
+
+```python
+await quote_cards.save_drafts(drafts, scope=scope)
+```
+
+only when a repository is injected. The default constructor remains
+dependency-light, so extracted-package callers without DB services still get
+the same deterministic `cards` payload with an empty `saved_ids` list.
+
+`PostgresQuoteCardRepository` stores rows in `quote_card_drafts` with
+`account_id`, `target_mode`, source identity, quote text, attribution, headline,
+supporting text, pain-point JSON, metadata, and mutable status. The generated
+asset API uses the same export/review/update switchboard shape as
+`social_post` and `ad_copy`:
+
+```python
+if asset == "quote_card":
+    return await export_quote_card_drafts(PostgresQuoteCardRepository(pool), ...)
+```
+
+The frontend adds `quote_card` to the existing generated-assets registry and
+renders quote-card rows with attribution/vendor/source facts, quote preview, and
+supporting text metadata. The completed-run CTA links to the quote-card review
+tab without id filters, matching the social/ad-copy behavior because the first
+repository list path filters by status, target mode, and theme rather than ids.
+
+## Intentional
+
+- No hosted/public quote-card URLs. Quote cards are review/export assets in
+  this slice, not public pages.
+- No design/image rendering or repair workflow. This persists the evidence and
+  copy fields that a later creative export can consume.
+- No ID deep-link filter for `quote_card`. The first review queue follows the
+  social/ad-copy list filters; direct id filters can be added once a product
+  path needs exact run-result deep links.
+- No #1268 output-variations work. That PR remains outside this lane.
+
+## Deferred
+
+- Optional quote-card id deep links can be added after a product path needs
+  direct review links from generation results.
+- Visual template/export generation for quote cards remains a later product
+  polish slice after review/export rows exist.
+- `stat_card` remains a future output with numeric-claim validation.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_quote_card_generation.py tests/test_extracted_quote_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py -q` (114 passed)
+- Passed: `python -m py_compile extracted_content_pipeline/quote_card_generation.py extracted_content_pipeline/quote_card_ports.py extracted_content_pipeline/quote_card_postgres.py extracted_content_pipeline/quote_card_export.py extracted_content_pipeline/api/generated_assets.py atlas_brain/_content_ops_services.py tests/test_extracted_quote_card_generation.py tests/test_extracted_quote_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py`
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets` (4 passed)
+- Passed: `cd atlas-intel-ui && npm run lint`
+- Passed: `cd atlas-intel-ui && npm run build`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 144 matching tests are enrolled.)
+- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
+- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- Passed: `bash scripts/check_ascii_python.sh`
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (3019 passed, 10 skipped, 1 warning)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-quote-card-generated-assets-pr-body.md`
+
+## Estimated diff size
+
+Actual: 20 files, +1343 / -5. This is above the 400 LOC soft cap for the
+end-to-end handoff reasons named in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Quote-card port, adapter, migration, export helper, manifest | ~470 |
+| Generator save hook and host wiring | ~80 |
+| Backend review/export switchboard and tests | ~225 |
+| Frontend type/UI/test/workflow enrollment | ~230 |
+| Plan doc and CI test enrollment | ~338 |
+| **Total** | **~1343** |

--- a/plans/PR-Content-Ops-Quote-Card-Generated-Assets.md
+++ b/plans/PR-Content-Ops-Quote-Card-Generated-Assets.md
@@ -130,12 +130,12 @@ None.
 - Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
 - Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
 - Passed: `bash scripts/check_ascii_python.sh`
-- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (3019 passed, 10 skipped, 1 warning)
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (3026 passed, 10 skipped, 1 warning)
 - Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-quote-card-generated-assets-pr-body.md`
 
 ## Estimated diff size
 
-Actual: 20 files, +1343 / -5. This is above the 400 LOC soft cap for the
+Actual: 20 files, +1344 / -5. This is above the 400 LOC soft cap for the
 end-to-end handoff reasons named in **Why this slice exists**.
 
 | Area | Estimated LOC |
@@ -145,4 +145,4 @@ end-to-end handoff reasons named in **Why this slice exists**.
 | Backend review/export switchboard and tests | ~225 |
 | Frontend type/UI/test/workflow enrollment | ~230 |
 | Plan doc and CI test enrollment | ~338 |
-| **Total** | **~1343** |
+| **Total** | **~1344** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -82,6 +82,7 @@ pytest \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_reasoning_policy.py \
+  tests/test_extracted_quote_card_generation.py \
   tests/test_extracted_quote_card_postgres.py \
   tests/test_extracted_content_ops_cache_policy.py \
   tests/test_extracted_content_ops_input_provider.py \

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -82,6 +82,7 @@ pytest \
   tests/test_extracted_content_control_surfaces.py \
   tests/test_extracted_content_generation_plan.py \
   tests/test_extracted_content_reasoning_policy.py \
+  tests/test_extracted_quote_card_postgres.py \
   tests/test_extracted_content_ops_cache_policy.py \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_support_ticket_context_contract.py \

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -344,6 +344,52 @@ async def test_quote_card_runs_through_host_bundle() -> None:
 
 
 @pytest.mark.asyncio
+async def test_quote_card_persists_when_db_services_enabled() -> None:
+    pool = _FAQPoolStub(return_id="quote-card-uuid-1")
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["quote_card"],
+            "inputs": {
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "reviewer_company": "Acme Logistics",
+                    "review_text": "Pricing became hard to justify after renewal.",
+                    "pain_category": "pricing pressure",
+                }]
+            },
+        },
+        services=services,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "quote_card"
+    assert step["status"] == "completed"
+    assert step["result"]["saved_ids"] == ["quote-card-uuid-1"]
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO quote_card_drafts" in call["query"]
+    assert call["args"][:8] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "customer_proof",
+        step["result"]["cards"][0]["quote"],
+        "Acme Logistics",
+        "Customer proof for HubSpot",
+        "Use this quote to frame pricing pressure.",
+    )
+
+
+@pytest.mark.asyncio
 async def test_faq_deflection_report_runs_through_host_bundle() -> None:
     services = build_content_ops_execution_services(
         llm_factory=_no_llm,

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -465,6 +465,26 @@ def _ad_copy_row():
     }
 
 
+def _quote_card_row():
+    return {
+        "id": "quote-card-uuid-1",
+        "status": "draft",
+        "target_id": "review-1",
+        "target_mode": "review",
+        "theme": "customer_proof",
+        "quote": "Pricing became hard to justify after renewal.",
+        "attribution": "Acme",
+        "headline": "Customer proof for Zendesk",
+        "supporting_text": "Use this quote to frame slow response.",
+        "source_id": "source-1",
+        "source_type": "review",
+        "company_name": "Acme",
+        "vendor_name": "Zendesk",
+        "pain_points": ["slow response", "renewal pressure"],
+        "metadata": {"source_url": "https://example.test/reviews/1"},
+    }
+
+
 def _ticket_faq_row():
     return {
         "id": "faq-uuid-1",
@@ -1561,6 +1581,51 @@ def test_generated_asset_router_exports_ad_copy_csv() -> None:
     assert args == ("", "review", "paid_social", 20)
 
 
+def test_generated_asset_router_lists_quote_card_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_quote_card_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/quote_card/drafts"
+        "?target_mode=review&theme=customer_proof&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    row = body["rows"][0]
+    assert row["id"] == "quote-card-uuid-1"
+    assert row["theme"] == "customer_proof"
+    assert row["quote"] == "Pricing became hard to justify after renewal."
+    assert row["attribution"] == "Acme"
+    assert row["headline"] == "Customer proof for Zendesk"
+    assert row["pain_point_count"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM quote_card_drafts" in query
+    assert args == ("acct_1", "draft", "review", "customer_proof", 5)
+
+
+def test_generated_asset_router_exports_quote_card_csv() -> None:
+    pool = _Pool(rows=[_quote_card_row()])
+
+    response = _client(pool).get(
+        "/content-assets/quote_card/drafts/export"
+        "?format=csv&status=&target_mode=review&theme=customer_proof"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_quote_card.csv" in response.headers["content-disposition"]
+    assert "target_id,target_mode,theme" in response.text
+    assert "Pricing became hard to justify after renewal." in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM quote_card_drafts" in query
+    assert "status = " not in query
+    assert args == ("", "review", "customer_proof", 20)
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 
@@ -1626,6 +1691,27 @@ def test_generated_asset_router_reviews_ad_copy() -> None:
     query, args = pool.execute_calls[0]
     assert "UPDATE ad_copy_drafts" in query
     assert args == ("ad-copy-uuid-1", "approved", "acct_1")
+
+
+def test_generated_asset_router_reviews_quote_card() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/quote_card/drafts/review",
+        json={"id": "quote-card-uuid-1", "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct_1",
+        "asset": "quote_card",
+        "id": "quote-card-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE quote_card_drafts" in query
+    assert args == ("quote-card-uuid-1", "approved", "acct_1")
 
 
 def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
@@ -2011,6 +2097,31 @@ def test_generated_asset_router_batch_reviews_ad_copy() -> None:
     assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
     query, args = pool.fetch_calls[0]
     assert "UPDATE ad_copy_drafts" in query
+    assert "RETURNING id" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_reviews_quote_cards() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/quote_card/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
+            "status": "rejected",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset"] == "quote_card"
+    assert response.json()["updated"] == 2
+    assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE quote_card_drafts" in query
     assert "RETURNING id" in query
     assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
     assert pool.execute_calls == []

--- a/tests/test_extracted_quote_card_generation.py
+++ b/tests/test_extracted_quote_card_generation.py
@@ -7,6 +7,21 @@ from extracted_content_pipeline.quote_card_generation import (
     QuoteCardGenerationConfig,
     QuoteCardGenerationService,
 )
+from extracted_content_pipeline.quote_card_ports import QuoteCardDraft
+
+
+class _QuoteCardRepository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def save_drafts(
+        self,
+        drafts: list[QuoteCardDraft] | tuple[QuoteCardDraft, ...],
+        *,
+        scope: TenantScope,
+    ) -> tuple[str, ...]:
+        self.calls.append({"drafts": tuple(drafts), "scope": scope})
+        return ("quote-card-db-id-1",)
 
 
 @pytest.mark.asyncio
@@ -31,6 +46,7 @@ async def test_quote_card_service_generates_evidence_backed_cards() -> None:
     assert payload["generated"] == 1
     assert payload["target_mode"] == "vendor_retention"
     assert payload["warnings"] == []
+    assert payload["saved_ids"] == []
     assert payload["cards"] == [
         {
             "id": "review-1",
@@ -47,6 +63,48 @@ async def test_quote_card_service_generates_evidence_backed_cards() -> None:
             "pain_points": ["pricing pressure"],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_quote_card_service_persists_generated_drafts_when_repository_is_configured() -> None:
+    repository = _QuoteCardRepository()
+    service = QuoteCardGenerationService(quote_cards=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "HubSpot",
+                "review_text": "Pricing became hard to justify after renewal.",
+                "pain_category": "pricing pressure",
+            }
+        ],
+    )
+
+    assert result.saved_ids == ("quote-card-db-id-1",)
+    assert result.as_dict()["saved_ids"] == ["quote-card-db-id-1"]
+    assert len(repository.calls) == 1
+    call = repository.calls[0]
+    assert call["scope"] == TenantScope(account_id="acct-1", user_id="user-1")
+    drafts = call["drafts"]
+    assert isinstance(drafts, tuple)
+    draft = drafts[0]
+    assert draft.target_id == "review-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.theme == "customer_proof"
+    assert draft.quote == "Pricing became hard to justify after renewal."
+    assert draft.attribution == "Acme Logistics"
+    assert draft.headline == "Customer proof for HubSpot"
+    assert draft.supporting_text == "Use this quote to frame pricing pressure."
+    assert draft.source_id == "review-1"
+    assert draft.source_type == "review"
+    assert draft.company_name == "Acme Logistics"
+    assert draft.vendor_name == "HubSpot"
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata["source_card"]["id"] == "review-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_quote_card_postgres.py
+++ b/tests/test_extracted_quote_card_postgres.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.quote_card_ports import QuoteCardDraft
+from extracted_content_pipeline.quote_card_postgres import (
+    PostgresQuoteCardRepository,
+)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.fetchval_calls: list[dict[str, object]] = []
+        self.fetch_calls: list[dict[str, object]] = []
+        self.execute_calls: list[dict[str, object]] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return self.execute_result
+
+
+def _compact_sql(query: object) -> str:
+    return " ".join(str(query).split())
+
+
+def _draft() -> QuoteCardDraft:
+    return QuoteCardDraft(
+        target_id="review-1",
+        target_mode="vendor_retention",
+        theme="customer_proof",
+        quote="Pricing became hard to justify after renewal.",
+        attribution="Acme Logistics",
+        headline="Customer proof for HubSpot",
+        supporting_text="Use this quote to frame pricing pressure.",
+        source_id="review-1",
+        source_type="review",
+        company_name="Acme Logistics",
+        vendor_name="HubSpot",
+        pain_points=("pricing pressure",),
+        metadata={"confidence": 0.88},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_quote_cards_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["quote-card-uuid-1"]
+    repo = PostgresQuoteCardRepository(pool)
+
+    saved = await repo.save_drafts(
+        [_draft()],
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert saved == ("quote-card-uuid-1",)
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO quote_card_drafts" in call["query"]
+    args = call["args"]
+    assert args[:12] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "customer_proof",
+        "Pricing became hard to justify after renewal.",
+        "Acme Logistics",
+        "Customer proof for HubSpot",
+        "Use this quote to frame pricing pressure.",
+        "review-1",
+        "review",
+        "Acme Logistics",
+        "HubSpot",
+    )
+    assert json.loads(args[12]) == ["pricing pressure"]
+    metadata = json.loads(args[13])
+    assert metadata["target_id"] == "review-1"
+    assert metadata["target_mode"] == "vendor_retention"
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert metadata["confidence"] == 0.88
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_scope_status_target_mode_and_theme() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{
+        "id": "quote-card-uuid-1",
+        "target_id": "review-1",
+        "target_mode": "vendor_retention",
+        "theme": "customer_proof",
+        "quote": "Pricing became hard to justify after renewal.",
+        "attribution": "Acme Logistics",
+        "headline": "Customer proof for HubSpot",
+        "supporting_text": "Use this quote to frame pricing pressure.",
+        "source_id": "review-1",
+        "source_type": "review",
+        "company_name": "Acme Logistics",
+        "vendor_name": "HubSpot",
+        "pain_points": json.dumps(["pricing pressure"]),
+        "metadata": json.dumps({"confidence": 0.88}),
+        "status": "draft",
+    }]
+    repo = PostgresQuoteCardRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor_retention",
+        theme="customer_proof",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.id == "quote-card-uuid-1"
+    assert draft.theme == "customer_proof"
+    assert draft.quote == "Pricing became hard to justify after renewal."
+    assert draft.pain_points == ("pricing pressure",)
+    assert draft.metadata == {"confidence": 0.88}
+    call = pool.fetch_calls[0]
+    assert "FROM quote_card_drafts" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "draft",
+        "vendor_retention",
+        "customer_proof",
+        10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_status_is_tenant_scoped_and_reports_misses() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresQuoteCardRepository(pool)
+
+    updated = await repo.update_status(
+        "quote-card-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is False
+    call = pool.execute_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE quote_card_drafts" in sql
+    assert "WHERE id = $1::uuid AND account_id = $3" in sql
+    assert call["args"] == ("quote-card-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_returns_scoped_matches() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "quote-card-uuid-1"}]
+    repo = PostgresQuoteCardRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["quote-card-uuid-1", ""],
+        "rejected",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ("quote-card-uuid-1",)
+    call = pool.fetch_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE quote_card_drafts" in sql
+    assert "WHERE id = ANY($1::uuid[]) AND account_id = $3" in sql
+    assert call["args"] == (["quote-card-uuid-1"], "rejected", "acct-1")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Quote-Card-Generated-Assets.md
Slice phase: Vertical slice

Persist generated quote-card drafts as tenant-scoped generated assets, then expose quote_card through the existing generated-assets review/export API and atlas-intel-ui review queue.

## Intentional
- No hosted/public quote-card URLs. Quote cards are review/export assets in this slice, not public pages.
- No design/image rendering or repair workflow. This persists the evidence and copy fields that a later creative export can consume.
- No ID deep-link filter for quote_card. The first review queue follows the social/ad-copy list filters; direct id filters can be added once a product path needs exact run-result deep links.
- No #1268 output-variations work. That PR remains outside this lane.

## Deferred
- Optional quote-card id deep links can be added after a product path needs direct review links from generation results.
- Visual template/export generation for quote cards remains a later product polish slice after review/export rows exist.
- stat_card remains a future output with numeric-claim validation.

## Parked hardening
- None.

## Verification
- pytest tests/test_extracted_quote_card_generation.py tests/test_extracted_quote_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py -q (114 passed)
- pytest tests/test_extracted_quote_card_generation.py tests/test_extracted_quote_card_postgres.py -q (11 passed after CI-enrollment review fix)
- python -m py_compile extracted_content_pipeline/quote_card_generation.py extracted_content_pipeline/quote_card_ports.py extracted_content_pipeline/quote_card_postgres.py extracted_content_pipeline/quote_card_export.py extracted_content_pipeline/api/generated_assets.py atlas_brain/_content_ops_services.py tests/test_extracted_quote_card_generation.py tests/test_extracted_quote_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py (passed)
- cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets (4 passed)
- cd atlas-intel-ui && npm run lint (passed)
- cd atlas-intel-ui && npm run build (passed)
- git diff --check (passed)
- python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main (OK: 144 matching tests are enrolled.)
- bash scripts/validate_extracted_content_pipeline.sh (passed)
- python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline (passed)
- python scripts/audit_extracted_standalone.py --fail-on-debt (passed)
- bash scripts/check_ascii_python.sh (passed)
- bash scripts/run_extracted_pipeline_checks.sh (3026 passed, 10 skipped, 1 warning)
- bash scripts/local_pr_review.sh --current-pr-body-file <body-file> (passed)

## Diff size
20 files, +1344 / -5
