### PR TITLE
Content Ops Stat Card Package Handoff

### DIFF
--- a/atlas_brain/_content_ops_input_provider.py
+++ b/atlas_brain/_content_ops_input_provider.py
@@ -167,13 +167,14 @@ _REVIEW_CAMPAIGN_OUTPUTS = (
     "social_post",
     "ad_copy",
     "quote_card",
+    "stat_card",
 )
 _REVIEW_CAMPAIGN_NAME = "Review-Signal Campaign"
 _REVIEW_TOPIC = "Customer review themes worth turning into content"
 _REVIEW_AUDIENCE = "Marketing teams turning customer reviews into grounded content"
 _REVIEW_OFFER = (
     "Turn customer review themes into buyer-facing landing pages, blog posts, "
-    "sales briefs, social posts, ad copy, and quote cards"
+    "sales briefs, social posts, ad copy, quote cards, and stat cards"
 )
 _REVIEW_TARGET_KEYWORD = "customer review content marketing"
 _COMPETITIVE_CAMPAIGN_OUTPUTS = (
@@ -183,6 +184,7 @@ _COMPETITIVE_CAMPAIGN_OUTPUTS = (
     "social_post",
     "ad_copy",
     "quote_card",
+    "stat_card",
 )
 _COMPETITIVE_CAMPAIGN_NAME = "Competitive Displacement Campaign"
 _COMPETITIVE_TOPIC = "Competitive displacement themes worth turning into content"
@@ -191,7 +193,7 @@ _COMPETITIVE_AUDIENCE = (
 )
 _COMPETITIVE_OFFER = (
     "Turn competitor and switching evidence into buyer-facing landing pages, "
-    "blog posts, sales briefs, social posts, ad copy, and quote cards"
+    "blog posts, sales briefs, social posts, ad copy, quote cards, and stat cards"
 )
 _COMPETITIVE_TARGET_KEYWORD = "competitive displacement content marketing"
 

--- a/plans/PR-Content-Ops-Stat-Card-Package-Handoff.md
+++ b/plans/PR-Content-Ops-Stat-Card-Package-Handoff.md
@@ -1,0 +1,98 @@
+# PR: Content Ops Stat Card Package Handoff
+
+## Why this slice exists
+
+PR #1294 added the deterministic `stat_card` output and deliberately deferred
+putting it into the review and competitive input-package defaults. Until this
+handoff lands, operators can run `stat_card` explicitly, but the productized
+review/competitive source modes still default to landing pages, blog posts,
+sales briefs, social posts, ad copy, and quote cards.
+
+This slice completes that handoff by making review and competitive source
+packages request stat cards by default, using the same normalized
+`source_material` already proven by #1294. It mirrors
+`plans/PR-Content-Ops-Quote-Card-Package-Handoff.md` and does not overlap
+#1268's separate output-variations lane.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+
+Slice phase: Vertical slice
+
+1. Add `stat_card` to the review source-mode default outputs.
+2. Add `stat_card` to the competitive source-mode default outputs.
+3. Align the package offer copy with the expanded output set.
+4. Extend the existing host-provider tests to prove the default package outputs
+   and execution handoff include `stat_card`.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Stat-Card-Package-Handoff.md`
+- `atlas_brain/_content_ops_input_provider.py`
+- `tests/test_atlas_content_ops_review_input_provider.py`
+
+## Mechanism
+
+The host input provider already builds normalized `source_material` for review
+and competitive source modes. `stat_card` consumes that same field, so this
+slice only expands the two output tuples:
+
+```python
+_REVIEW_CAMPAIGN_OUTPUTS = (..., "ad_copy", "quote_card", "stat_card")
+_COMPETITIVE_CAMPAIGN_OUTPUTS = (..., "ad_copy", "quote_card", "stat_card")
+```
+
+The execution tests use the existing `_RunnableService` fake in the
+`stat_card` service slot. If the output is present but the dispatcher fails to
+hand off `source_material`, the tests fail on the stat-card step kwargs.
+
+## Intentional
+
+- No new source adapter or generator logic. #1294 already proved `stat_card`
+  runs from normalized source material and enforces numeric evidence.
+- No UI selector changes. The New Run source-mode path consumes these package
+  defaults automatically.
+- No persistence or generated-asset review branch. Durable stat-card review
+  remains a separate productization slice after this default handoff.
+- No visual template/export generation. This slice only makes the executable
+  source-mode package request the deterministic output.
+- No changes to #1268 output variations; that open PR is a separate lane and
+  remains untouched.
+
+## Deferred
+
+- Persist generated stat-card drafts into the generated-assets review queue
+  after the package-default handoff is accepted.
+- Add visual template/export generation for quote cards and stat cards after
+  review/export rows exist.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_atlas_content_ops_review_input_provider.py -q`
+  (22 passed)
+- Passed: `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q`
+  (46 passed, 1 warning)
+- Passed: `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  (OK: 146 matching tests are enrolled.)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-stat-card-package-handoff-pr-body.md`
+
+## Estimated diff size
+
+Actual: 3 files, +116 / -2. This stays under the 400 LOC soft cap because it reuses
+the existing source-mode package and #1294's stat-card dispatcher.
+
+| Area | Estimated LOC |
+|---|---:|
+| Host provider defaults and copy | ~8 |
+| Host provider tests | ~16 |
+| Plan doc | ~91 |
+| **Total** | **~115** |

--- a/tests/test_atlas_content_ops_review_input_provider.py
+++ b/tests/test_atlas_content_ops_review_input_provider.py
@@ -66,6 +66,7 @@ _MARKETER_OUTPUTS = (
     "social_post",
     "ad_copy",
     "quote_card",
+    "stat_card",
 )
 
 
@@ -639,6 +640,7 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
             quote_card=_RunnableService(),
+            stat_card=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -672,6 +674,11 @@ async def test_review_input_evidence_reaches_landing_blog_and_sales_brief_genera
     assert quote_card_kwargs["source_material"][0]["target_id"] == "review-1"
     assert quote_card_kwargs["target_mode"] == "vendor_retention"
 
+    stat_card_step = next(step for step in result.steps if step.output == "stat_card")
+    stat_card_kwargs = stat_card_step.result["kwargs"]
+    assert stat_card_kwargs["source_material"][0]["target_id"] == "review-1"
+    assert stat_card_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.asyncio
 async def test_competitive_input_evidence_reaches_landing_and_blog_generators() -> None:
@@ -696,6 +703,7 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
             quote_card=_RunnableService(),
+            stat_card=_RunnableService(),
         ),
         scope=TenantScope(account_id="acct-1"),
     )
@@ -729,6 +737,11 @@ async def test_competitive_input_evidence_reaches_landing_and_blog_generators() 
     assert quote_card_kwargs["source_material"][0]["target_id"] == "competitive-1"
     assert quote_card_kwargs["target_mode"] == "vendor_retention"
 
+    stat_card_step = next(step for step in result.steps if step.output == "stat_card")
+    stat_card_kwargs = stat_card_step.result["kwargs"]
+    assert stat_card_kwargs["source_material"][0]["target_id"] == "competitive-1"
+    assert stat_card_kwargs["target_mode"] == "vendor_retention"
+
 
 @pytest.mark.skipif(
     api_module.APIRouter is None,
@@ -746,6 +759,7 @@ async def test_plan_route_applies_review_input_provider() -> None:
             social_post=_RunnableService(),
             ad_copy=_RunnableService(),
             quote_card=_RunnableService(),
+            stat_card=_RunnableService(),
         ),
         scope_provider=lambda: TenantScope(account_id="acct-review-route"),
     )


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Stat-Card-Package-Handoff.md
Slice phase: Vertical slice

Adds `stat_card` to the productized review and competitive source-mode package defaults, mirroring the quote-card handoff now that #1294 landed the deterministic stat-card output.

## Intentional
- No new source adapter or generator logic. #1294 already proved `stat_card` runs from normalized source material and enforces numeric evidence.
- No UI selector changes. The New Run source-mode path consumes these package defaults automatically.
- No persistence or generated-asset review branch. Durable stat-card review remains a separate productization slice.
- No visual template/export generation.
- No changes to #1268 output variations.

## Deferred
- Persist generated stat-card drafts into the generated-assets review queue after this package-default handoff is accepted.
- Add visual template/export generation for quote cards and stat cards after review/export rows exist.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_atlas_content_ops_review_input_provider.py -q` (22 passed)
- Passed: `pytest tests/test_atlas_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py -q` (46 passed, 1 warning)
- Passed: `python -m py_compile atlas_brain/_content_ops_input_provider.py tests/test_atlas_content_ops_review_input_provider.py`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 146 matching tests are enrolled.)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-stat-card-package-handoff-pr-body.md`

## Diff size
3 files, +116 / -2