### PR TITLE
Content Ops Stat Card Generated Assets

### DIFF
--- a/.github/workflows/atlas_intel_ui_checks.yml
+++ b/.github/workflows/atlas_intel_ui_checks.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Test Content Ops quote card review assets
         run: npm run test:content-ops-quote-card-review-assets
 
+      - name: Test Content Ops stat card review assets
+        run: npm run test:content-ops-stat-card-review-assets
+
       - name: Test Content Ops review source selection
         run: npm run test:content-ops-review-source-selection
 

--- a/atlas-intel-ui/package.json
+++ b/atlas-intel-ui/package.json
@@ -25,6 +25,7 @@
     "test:content-ops-social-post-review-assets": "node --test scripts/content-ops-social-post-review-assets.test.mjs",
     "test:content-ops-ad-copy-review-assets": "node --test scripts/content-ops-ad-copy-review-assets.test.mjs",
     "test:content-ops-quote-card-review-assets": "node --test scripts/content-ops-quote-card-review-assets.test.mjs",
+    "test:content-ops-stat-card-review-assets": "node --test scripts/content-ops-stat-card-review-assets.test.mjs",
     "test:content-ops-review-source-selection": "node --test scripts/content-ops-review-source-selection.test.mjs",
     "test:blog-public-generated-posts": "node --test scripts/blog-public-generated-posts.test.mjs",
     "test:blog-generated-sitemap-prerender": "node --test scripts/blog-generated-sitemap-prerender.test.mjs",

--- a/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import ts from 'typescript'
+
+const API_ORIGIN = 'https://api.example.test'
+
+async function loadTsModule(path, replacements = []) {
+  let source = readFileSync(new URL(path, import.meta.url), 'utf8')
+  for (const [needle, replacement] of replacements) {
+    source = source.replace(needle, replacement)
+  }
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText
+
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+  return import(moduleUrl)
+}
+
+const {
+  fetchGeneratedAssetDrafts,
+  reviewGeneratedAssetDraft,
+  reviewGeneratedAssetDrafts,
+} = await loadTsModule('../src/api/contentOps.ts', [
+  [
+    "import { tryRefreshToken } from '../auth/AuthContext'\n",
+    'const tryRefreshToken = async () => null\n',
+  ],
+  [
+    "import { API_BASE } from './config'\n",
+    `const API_BASE = '${API_ORIGIN}'\n`,
+  ],
+])
+
+const reviewSource = readFileSync(
+  new URL('../src/pages/ContentOpsAssetsReview.tsx', import.meta.url),
+  'utf8',
+)
+const newRunSource = readFileSync(
+  new URL('../src/pages/ContentOpsNewRun.tsx', import.meta.url),
+  'utf8',
+)
+
+function installBrowserStubs() {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem(key) {
+        return key === 'atlas_token' ? 'test-token' : null
+      },
+      removeItem() {},
+    },
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { href: '' } },
+  })
+}
+
+function installFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+test.beforeEach(() => {
+  installBrowserStubs()
+})
+
+test('stat-card generated asset list fetches the typed content-assets route', async () => {
+  const payload = {
+    count: 1,
+    limit: 5,
+    filters: { status: 'draft', theme: 'customer_metric' },
+    rows: [{
+      id: 'stat-card-1',
+      status: 'draft',
+      theme: 'customer_metric',
+      metric_label: 'NPS score',
+      metric_value: 42,
+      metric_display: '42',
+      claim: 'NPS score: 42',
+      headline: 'Customer metric for Zendesk',
+      supporting_text: 'Use this stat to frame renewal dissatisfaction.',
+      evidence: 'NPS score dropped to 42 after renewal.',
+    }],
+  }
+  const calls = installFetchResponder(payload)
+
+  const result = await fetchGeneratedAssetDrafts('stat_card', {
+    status: 'draft',
+    theme: 'customer_metric',
+    limit: 5,
+  })
+
+  assert.deepEqual(result, payload)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/stat_card/drafts?status=draft&theme=customer_metric&limit=5`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
+test('stat-card generated asset review actions post to typed routes', async () => {
+  const calls = installFetchResponder({
+    account_id: 'acct-1',
+    asset: 'stat_card',
+    id: 'stat-card-1',
+    status: 'approved',
+    updated: true,
+  })
+
+  await reviewGeneratedAssetDraft('stat_card', 'stat-card-1', 'approved')
+  await reviewGeneratedAssetDrafts('stat_card', ['stat-card-1'], 'rejected')
+
+  assert.equal(calls.length, 2)
+  assert.equal(
+    calls[0].url,
+    `${API_ORIGIN}/api/v1/content-assets/stat_card/drafts/review`,
+  )
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    id: 'stat-card-1',
+    status: 'approved',
+  })
+  assert.equal(
+    calls[1].url,
+    `${API_ORIGIN}/api/v1/content-assets/stat_card/drafts/review-batch`,
+  )
+  assert.deepEqual(JSON.parse(calls[1].init.body), {
+    ids: ['stat-card-1'],
+    status: 'rejected',
+  })
+})
+
+test('asset review UI exposes stat-card tab and preview branches', () => {
+  assert.ok(reviewSource.includes("id: 'stat_card'"))
+  assert.ok(reviewSource.includes("label: 'Stat Cards'"))
+  assert.ok(reviewSource.includes("asset === 'stat_card'"))
+  assert.ok(reviewSource.includes('textValue(row.claim)'))
+  assert.ok(reviewSource.includes('textValue(row.evidence)'))
+  assert.ok(reviewSource.includes('statCardPainPointCount(row)'))
+  assert.ok(reviewSource.includes('pain: ${item}'))
+})
+
+test('completed stat-card runs link into generated asset review', () => {
+  assert.match(
+    newRunSource,
+    /const GENERATED_ASSET_OUTPUTS:[\s\S]*'stat_card'[\s\S]*\]/,
+  )
+  assert.ok(newRunSource.includes('function generatedAssetReviewHref'))
+  assert.ok(newRunSource.includes("params.set('asset', output)"))
+  assert.ok(newRunSource.includes('Review generated drafts'))
+})

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -434,6 +434,7 @@ export type GeneratedAssetType =
   | 'social_post'
   | 'ad_copy'
   | 'quote_card'
+  | 'stat_card'
   | 'faq_markdown'
 
 export interface GeneratedAssetRepairHistoryEntry {

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -188,6 +188,11 @@ const ASSETS: Array<{
     description: 'Customer-proof quote card drafts generated from source evidence.',
   },
   {
+    id: 'stat_card',
+    label: 'Stat Cards',
+    description: 'Evidence-backed metric card drafts generated from source evidence.',
+  },
+  {
     id: 'faq_markdown',
     label: 'FAQ Markdown',
     description: 'Grounded FAQ documents generated from support-ticket evidence.',
@@ -2127,6 +2132,16 @@ function assetTitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): string
       'quote_card draft'
     )
   }
+  if (asset === 'stat_card') {
+    return (
+      textValue(row.claim) ||
+      textValue(row.headline) ||
+      textValue(row.metric_display) ||
+      textValue(row.company_name) ||
+      textValue(row.vendor_name) ||
+      'stat_card draft'
+    )
+  }
   return (
     textValue(row.title) ||
     textValue(row.headline) ||
@@ -2183,6 +2198,17 @@ function assetSubtitle(row: GeneratedAssetDraft, asset: GeneratedAssetType): str
     return [
       row.theme,
       row.attribution,
+      row.company_name,
+      row.vendor_name,
+      row.source_type,
+      row.source_id,
+    ].map(textValue).filter(Boolean).join(' | ')
+  }
+  if (asset === 'stat_card') {
+    return [
+      row.theme,
+      row.metric_label,
+      row.metric_display,
       row.company_name,
       row.vendor_name,
       row.source_type,
@@ -2270,6 +2296,16 @@ function addAssetSpecificFacts(
     addFact(facts, 'vendor', row.vendor_name)
     addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
     addFact(facts, 'pain points', quoteCardPainPointCount(row))
+    return
+  }
+  if (asset === 'stat_card') {
+    addFact(facts, 'theme', row.theme)
+    addFact(facts, 'metric', row.metric_label)
+    addFact(facts, 'value', row.metric_display || row.metric_value)
+    addFact(facts, 'company', row.company_name)
+    addFact(facts, 'vendor', row.vendor_name)
+    addFact(facts, 'source', [row.source_type, row.source_id].map(textValue).filter(Boolean).join(':'))
+    addFact(facts, 'pain points', statCardPainPointCount(row))
     return
   }
   addFact(facts, 'brief', row.brief_type)
@@ -2374,6 +2410,20 @@ function assetPreview(row: GeneratedAssetDraft, asset: GeneratedAssetType): Asse
       meta: [
         textValue(row.theme),
         textValue(row.attribution),
+        textValue(row.supporting_text),
+        ...painPoints.map((item) => `pain: ${item}`),
+      ].filter(Boolean),
+    })
+  }
+  if (asset === 'stat_card') {
+    const painPoints = valueList(row.pain_points).slice(0, 3)
+    return previewOrNull({
+      heading: textValue(row.claim) || textValue(row.headline),
+      body: excerpt(textValue(row.evidence), 280),
+      meta: [
+        textValue(row.theme),
+        textValue(row.metric_label),
+        textValue(row.metric_display),
         textValue(row.supporting_text),
         ...painPoints.map((item) => `pain: ${item}`),
       ].filter(Boolean),
@@ -2549,6 +2599,13 @@ function adCopyPainPointCount(row: GeneratedAssetDraft): number | string {
 }
 
 function quoteCardPainPointCount(row: GeneratedAssetDraft): number | string {
+  if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
+    return row.pain_point_count
+  }
+  return valueList(row.pain_points).length || ''
+}
+
+function statCardPainPointCount(row: GeneratedAssetDraft): number | string {
   if (typeof row.pain_point_count === 'number' && Number.isFinite(row.pain_point_count)) {
     return row.pain_point_count
   }

--- a/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsNewRun.tsx
@@ -167,6 +167,7 @@ const GENERATED_ASSET_OUTPUTS: readonly GeneratedAssetType[] = [
   'social_post',
   'ad_copy',
   'quote_card',
+  'stat_card',
 ]
 const ID_FILTERED_REVIEW_OUTPUTS = new Set<string>([
   'blog_post',

--- a/atlas_brain/_content_ops_services.py
+++ b/atlas_brain/_content_ops_services.py
@@ -118,6 +118,9 @@ from extracted_content_pipeline.social_post_postgres import (
 from extracted_content_pipeline.stat_card_generation import (
     StatCardGenerationService,
 )
+from extracted_content_pipeline.stat_card_postgres import (
+    PostgresStatCardRepository,
+)
 from extracted_content_pipeline.ticket_faq_markdown import (
     TicketFAQMarkdownService,
 )
@@ -311,6 +314,16 @@ def _build_quote_card_service(*, pool: Any) -> QuoteCardGenerationService:
     )
 
 
+def _build_stat_card_service(*, pool: Any) -> StatCardGenerationService:
+    """Build stat-card generation with optional draft persistence."""
+
+    if pool is None:
+        return _STAT_CARD_SERVICE
+    return StatCardGenerationService(
+        stat_cards=PostgresStatCardRepository(pool=pool)
+    )
+
+
 def build_content_ops_execution_services(
     *,
     llm_factory: Callable[[], LLMClient | None] | None = None,
@@ -419,6 +432,7 @@ def build_content_ops_execution_services(
         social_post = _build_social_post_service(pool=pool)
         ad_copy = _build_ad_copy_service(pool=pool)
         quote_card = _build_quote_card_service(pool=pool)
+        stat_card = _build_stat_card_service(pool=pool)
         faq_markdown_service = _build_ticket_faq_service(pool=pool) or _FAQ_MARKDOWN_SERVICE
         faq_markdown = faq_markdown_service if expose_faq_markdown_output else None
         faq_deflection_report = FAQDeflectionReportService(

--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -51,6 +51,8 @@ from ..sales_brief_export import export_sales_brief_drafts
 from ..sales_brief_postgres import PostgresSalesBriefRepository
 from ..social_post_export import export_social_post_drafts
 from ..social_post_postgres import PostgresSocialPostRepository
+from ..stat_card_export import export_stat_card_drafts
+from ..stat_card_postgres import PostgresStatCardRepository
 from ..ticket_faq_export import export_ticket_faq_drafts
 from ..ticket_faq_postgres import PostgresTicketFAQRepository
 
@@ -72,6 +74,7 @@ ASSET_CHOICES = (
     "social_post",
     "ad_copy",
     "quote_card",
+    "stat_card",
     "faq_markdown",
 )
 logger = logging.getLogger(__name__)
@@ -810,6 +813,15 @@ async def _export_for_asset(
             theme=theme,
             limit=limit,
         )
+    if asset == "stat_card":
+        return await export_stat_card_drafts(
+            PostgresStatCardRepository(pool),
+            scope=scope,
+            status=status,
+            target_mode=target_mode,
+            theme=theme,
+            limit=limit,
+        )
     if asset == "faq_markdown":
         return await export_ticket_faq_drafts(
             PostgresTicketFAQRepository(pool),
@@ -843,6 +855,8 @@ async def _update_asset_status(
         return await PostgresAdCopyRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "quote_card":
         return await PostgresQuoteCardRepository(pool).update_status(asset_id, status, scope=scope)
+    if asset == "stat_card":
+        return await PostgresStatCardRepository(pool).update_status(asset_id, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_status(asset_id, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")
@@ -870,6 +884,8 @@ async def _update_asset_statuses(
         return await PostgresAdCopyRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "quote_card":
         return await PostgresQuoteCardRepository(pool).update_statuses(asset_ids, status, scope=scope)
+    if asset == "stat_card":
+        return await PostgresStatCardRepository(pool).update_statuses(asset_ids, status, scope=scope)
     if asset == "faq_markdown":
         return await PostgresTicketFAQRepository(pool).update_statuses(asset_ids, status, scope=scope)
     raise HTTPException(status_code=400, detail=f"unsupported asset: {asset}")

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -318,6 +318,9 @@
       "target": "extracted_content_pipeline/stat_card_generation.py"
     },
     {
+      "target": "extracted_content_pipeline/stat_card_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/quote_card_export.py"
     },
     {
@@ -352,6 +355,15 @@
     },
     {
       "target": "extracted_content_pipeline/storage/migrations/333_quote_card_drafts.sql"
+    },
+    {
+      "target": "extracted_content_pipeline/stat_card_ports.py"
+    },
+    {
+      "target": "extracted_content_pipeline/stat_card_postgres.py"
+    },
+    {
+      "target": "extracted_content_pipeline/storage/migrations/334_stat_card_drafts.sql"
     },
     {
       "target": "extracted_content_pipeline/blog_ports.py"

--- a/extracted_content_pipeline/stat_card_export.py
+++ b/extracted_content_pipeline/stat_card_export.py
@@ -1,0 +1,131 @@
+"""Read-only stat-card draft export helpers for AI Content Ops hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any
+
+from .campaign_ports import TenantScope
+from .csv_export import csv_cell_value as _csv_value
+from .stat_card_ports import StatCardDraft, StatCardRepository
+
+
+JsonDict = dict[str, Any]
+
+
+_EXPORT_COLUMNS = (
+    "target_id",
+    "target_mode",
+    "theme",
+    "company_name",
+    "vendor_name",
+    "source_id",
+    "source_type",
+    "metric_label",
+    "metric_value",
+    "metric_display",
+    "claim",
+    "headline",
+    "supporting_text",
+    "evidence",
+    "pain_point_count",
+    "pain_points",
+    "metadata",
+    "id",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class StatCardDraftExportResult:
+    rows: tuple[JsonDict, ...]
+    limit: int
+    filters: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "count": len(self.rows),
+            "limit": self.limit,
+            "filters": dict(self.filters),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+    def as_csv(self) -> str:
+        handle = StringIO()
+        writer = csv.DictWriter(handle, fieldnames=list(_EXPORT_COLUMNS))
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow({
+                column: _csv_value(row.get(column))
+                for column in _EXPORT_COLUMNS
+            })
+        return handle.getvalue()
+
+
+async def export_stat_card_drafts(
+    repository: StatCardRepository,
+    *,
+    scope: TenantScope | Mapping[str, Any] | None = None,
+    status: str | None = "draft",
+    target_mode: str | None = None,
+    theme: str | None = None,
+    limit: int = 20,
+) -> StatCardDraftExportResult:
+    """Return generated stat-card drafts for host review/export workflows."""
+
+    tenant = _tenant_scope(scope)
+    normalized_limit = _normalize_limit(limit)
+    filters: dict[str, Any] = {}
+    if status:
+        filters["status"] = status
+    if tenant.account_id:
+        filters["account_id"] = tenant.account_id
+    if target_mode:
+        filters["target_mode"] = target_mode
+    if theme:
+        filters["theme"] = theme
+    drafts = await repository.list_drafts(
+        scope=tenant,
+        status=status,
+        target_mode=target_mode,
+        theme=theme,
+        limit=normalized_limit,
+    )
+    return StatCardDraftExportResult(
+        rows=tuple(_draft_row(draft) for draft in drafts),
+        limit=normalized_limit,
+        filters=filters,
+    )
+
+
+def _draft_row(draft: StatCardDraft) -> JsonDict:
+    row = draft.as_dict()
+    row["pain_point_count"] = len(draft.pain_points)
+    return row
+
+
+def _normalize_limit(value: Any) -> int:
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return limit
+
+
+def _tenant_scope(value: TenantScope | Mapping[str, Any] | None) -> TenantScope:
+    if isinstance(value, TenantScope):
+        return value
+    if isinstance(value, Mapping):
+        return TenantScope(
+            account_id=str(value.get("account_id") or "") or None,
+            user_id=str(value.get("user_id") or "") or None,
+        )
+    return TenantScope()
+
+
+__all__ = [
+    "StatCardDraftExportResult",
+    "export_stat_card_drafts",
+]

--- a/extracted_content_pipeline/stat_card_generation.py
+++ b/extracted_content_pipeline/stat_card_generation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import re
 from typing import Any
 
@@ -13,6 +13,7 @@ from .campaign_source_adapters import (
     source_material_to_source_rows,
     source_row_to_campaign_opportunity,
 )
+from .stat_card_ports import StatCardDraft, StatCardRepository
 
 
 _NUMBER_RE = re.compile(r"(?<![\w.])-?\d+(?:,\d{3})*(?:\.\d+)?%?")
@@ -38,6 +39,7 @@ class StatCardGenerationResult:
     stats: tuple[dict[str, Any], ...]
     warnings: tuple[CampaignOpportunityWarning, ...] = ()
     target_mode: str = "vendor_retention"
+    saved_ids: tuple[str, ...] = ()
 
     @property
     def generated(self) -> int:
@@ -49,6 +51,7 @@ class StatCardGenerationResult:
             "target_mode": self.target_mode,
             "stats": [dict(stat) for stat in self.stats],
             "warnings": [warning.as_dict() for warning in self.warnings],
+            "saved_ids": list(self.saved_ids),
         }
 
 
@@ -74,8 +77,14 @@ _METRICS: tuple[_MetricDefinition, ...] = (
 class StatCardGenerationService:
     """Build short, evidence-backed stat-card drafts from source material."""
 
-    def __init__(self, config: StatCardGenerationConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: StatCardGenerationConfig | None = None,
+        *,
+        stat_cards: StatCardRepository | None = None,
+    ) -> None:
         self.config = config or StatCardGenerationConfig()
+        self._stat_cards = stat_cards
 
     async def generate(
         self,
@@ -87,7 +96,7 @@ class StatCardGenerationService:
         max_text_chars: int | None = None,
         **kwargs: Any,
     ) -> StatCardGenerationResult:
-        del kwargs, scope
+        del kwargs
         resolved_limit = int(limit) if limit is not None else self.config.limit
         if resolved_limit < 1:
             raise ValueError("limit must be at least 1")
@@ -98,7 +107,7 @@ class StatCardGenerationService:
         )
         if resolved_max_text_chars < 1:
             raise ValueError("max_text_chars must be at least 1")
-        return _generate_stat_cards(
+        result = _generate_stat_cards(
             source_material_to_source_rows(source_material),
             target_mode=target_mode,
             limit=resolved_limit,
@@ -108,6 +117,16 @@ class StatCardGenerationService:
             max_supporting_text_chars=self.config.max_supporting_text_chars,
             max_evidence_chars=self.config.max_evidence_chars,
         )
+        if self._stat_cards is None or not result.stats:
+            return result
+        saved_ids = tuple(
+            str(item)
+            for item in await self._stat_cards.save_drafts(
+                _drafts_from_stats(result.stats, target_mode=target_mode),
+                scope=scope,
+            )
+        )
+        return replace(result, saved_ids=saved_ids)
 
 
 def _generate_stat_cards(
@@ -325,6 +344,47 @@ def _first_evidence(opportunity: Mapping[str, Any]) -> str:
                 if text:
                     return text
     return _clean(raw)
+
+
+def _drafts_from_stats(
+    stats: Sequence[Mapping[str, Any]],
+    *,
+    target_mode: str,
+) -> tuple[StatCardDraft, ...]:
+    drafts: list[StatCardDraft] = []
+    for stat in stats:
+        source_id = _clean(stat.get("source_id") or stat.get("id"))
+        target_id = _clean(stat.get("target_id")) or source_id
+        drafts.append(
+            StatCardDraft(
+                target_id=target_id,
+                target_mode=target_mode,
+                theme=_clean(stat.get("theme")) or "customer_metric",
+                metric_label=_clean(stat.get("metric_label")),
+                metric_value=stat.get("metric_value"),
+                metric_display=_clean(stat.get("metric_display")),
+                claim=_clean(stat.get("claim")),
+                headline=_clean(stat.get("headline")),
+                supporting_text=_clean(stat.get("supporting_text")),
+                evidence=_clean(stat.get("evidence")),
+                source_id=source_id,
+                source_type=_clean(stat.get("source_type")),
+                company_name=_clean(stat.get("company_name")),
+                vendor_name=_clean(stat.get("vendor_name")),
+                pain_points=_pain_points_from_stat(stat.get("pain_points")),
+                metadata={"source_card": dict(stat)},
+            )
+        )
+    return tuple(drafts)
+
+
+def _pain_points_from_stat(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
 
 
 def _evidence_snippet_for_value(

--- a/extracted_content_pipeline/stat_card_ports.py
+++ b/extracted_content_pipeline/stat_card_ports.py
@@ -1,0 +1,101 @@
+"""Standalone ports for persisted stat-card drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+
+
+@dataclass(frozen=True)
+class StatCardDraft:
+    """A generated, not-yet-approved stat-card draft."""
+
+    target_id: str
+    target_mode: str
+    theme: str
+    metric_label: str
+    metric_value: Any
+    metric_display: str
+    claim: str
+    headline: str
+    supporting_text: str
+    evidence: str
+    source_id: str = ""
+    source_type: str = ""
+    company_name: str = ""
+    vendor_name: str = ""
+    pain_points: Sequence[str] = field(default_factory=tuple)
+    metadata: JsonDict = field(default_factory=dict)
+    id: str = ""
+    status: str = ""
+
+    def as_dict(self) -> JsonDict:
+        return {
+            "target_id": self.target_id,
+            "target_mode": self.target_mode,
+            "theme": self.theme,
+            "metric_label": self.metric_label,
+            "metric_value": self.metric_value,
+            "metric_display": self.metric_display,
+            "claim": self.claim,
+            "headline": self.headline,
+            "supporting_text": self.supporting_text,
+            "evidence": self.evidence,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "company_name": self.company_name,
+            "vendor_name": self.vendor_name,
+            "pain_points": list(self.pain_points),
+            "metadata": dict(self.metadata),
+            "id": self.id,
+            "status": self.status,
+        }
+
+
+class StatCardRepository(Protocol):
+    """Persistence contract for generated stat-card drafts."""
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[StatCardDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Persist drafts and return assigned stat-card ids."""
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        theme: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[StatCardDraft]:
+        """Return drafts filtered by tenant scope and optional facets."""
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        """Update a draft status and return True on hit."""
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        """Bulk-update draft statuses and return ids that matched scope."""
+
+
+__all__ = [
+    "StatCardDraft",
+    "StatCardRepository",
+]

--- a/extracted_content_pipeline/stat_card_postgres.py
+++ b/extracted_content_pipeline/stat_card_postgres.py
@@ -1,0 +1,204 @@
+"""Postgres repository adapter for generated stat-card drafts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .campaign_ports import JsonDict, TenantScope
+from .stat_card_ports import StatCardDraft
+from .storage._jsonb_helpers import (
+    decode_jsonb_field,
+    json_dump_jsonb,
+    parse_command_tag,
+    row_to_dict,
+)
+
+
+_STAT_CARD_COLUMNS = (
+    "id, target_id, target_mode, theme, metric_label, metric_value, "
+    "metric_display, claim, headline, supporting_text, evidence, source_id, "
+    "source_type, company_name, vendor_name, pain_points, metadata, status"
+)
+
+
+def _draft_metadata(draft: StatCardDraft, scope: TenantScope) -> JsonDict:
+    return {
+        **dict(draft.metadata or {}),
+        "target_id": draft.target_id,
+        "target_mode": draft.target_mode,
+        "scope": {
+            "account_id": scope.account_id,
+            "user_id": scope.user_id,
+        },
+    }
+
+
+def _json_mapping(value: Any) -> dict[str, Any]:
+    decoded = decode_jsonb_field(value, default={})
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _json_string_sequence(value: Any) -> tuple[str, ...]:
+    decoded = decode_jsonb_field(value, default=[])
+    if not isinstance(decoded, Sequence) or isinstance(decoded, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in decoded if str(item).strip())
+
+
+def _row_to_draft(row: Mapping[str, Any]) -> StatCardDraft:
+    return StatCardDraft(
+        id=str(row.get("id") or ""),
+        target_id=str(row.get("target_id") or ""),
+        target_mode=str(row.get("target_mode") or ""),
+        theme=str(row.get("theme") or ""),
+        metric_label=str(row.get("metric_label") or ""),
+        metric_value=row.get("metric_value"),
+        metric_display=str(row.get("metric_display") or ""),
+        claim=str(row.get("claim") or ""),
+        headline=str(row.get("headline") or ""),
+        supporting_text=str(row.get("supporting_text") or ""),
+        evidence=str(row.get("evidence") or ""),
+        source_id=str(row.get("source_id") or ""),
+        source_type=str(row.get("source_type") or ""),
+        company_name=str(row.get("company_name") or ""),
+        vendor_name=str(row.get("vendor_name") or ""),
+        pain_points=_json_string_sequence(row.get("pain_points")),
+        metadata=_json_mapping(row.get("metadata")),
+        status=str(row.get("status") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class PostgresStatCardRepository:
+    """Async Postgres adapter for generated stat cards."""
+
+    pool: Any
+
+    async def save_drafts(
+        self,
+        drafts: Sequence[StatCardDraft],
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        saved: list[str] = []
+        account_id = scope.account_id or ""
+        for draft in drafts:
+            draft_id = await self.pool.fetchval(
+                """
+                INSERT INTO stat_card_drafts (
+                    account_id, target_id, target_mode, theme, metric_label,
+                    metric_value, metric_display, claim, headline,
+                    supporting_text, evidence, source_id, source_type,
+                    company_name, vendor_name, pain_points, metadata, status
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6::jsonb, $7, $8, $9,
+                    $10, $11, $12, $13,
+                    $14, $15, $16::jsonb, $17::jsonb, 'draft'
+                )
+                RETURNING id
+                """,
+                account_id,
+                draft.target_id,
+                draft.target_mode,
+                draft.theme,
+                draft.metric_label,
+                json_dump_jsonb(draft.metric_value),
+                draft.metric_display,
+                draft.claim,
+                draft.headline,
+                draft.supporting_text,
+                draft.evidence,
+                draft.source_id,
+                draft.source_type,
+                draft.company_name,
+                draft.vendor_name,
+                json_dump_jsonb([str(item) for item in draft.pain_points]),
+                json_dump_jsonb(_draft_metadata(draft, scope)),
+            )
+            saved.append(str(draft_id))
+        return tuple(saved)
+
+    async def list_drafts(
+        self,
+        *,
+        scope: TenantScope,
+        status: str | None = None,
+        target_mode: str | None = None,
+        theme: str | None = None,
+        limit: int | None = None,
+    ) -> Sequence[StatCardDraft]:
+        clauses: list[str] = ["account_id = $1"]
+        params: list[Any] = [scope.account_id or ""]
+        if status is not None:
+            params.append(status)
+            clauses.append(f"status = ${len(params)}")
+        if target_mode is not None:
+            params.append(target_mode)
+            clauses.append(f"target_mode = ${len(params)}")
+        if theme is not None:
+            params.append(theme)
+            clauses.append(f"theme = ${len(params)}")
+        sql = (
+            f"SELECT {_STAT_CARD_COLUMNS} "
+            "FROM stat_card_drafts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY created_at DESC"
+        )
+        if limit is not None:
+            params.append(int(limit))
+            sql += f" LIMIT ${len(params)}"
+        rows = await self.pool.fetch(sql, *params)
+        return tuple(_row_to_draft(row_to_dict(row)) for row in rows)
+
+    async def update_status(
+        self,
+        draft_id: str,
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE stat_card_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = $1::uuid
+               AND account_id = $3
+            """,
+            draft_id,
+            status,
+            scope.account_id or "",
+        )
+        return parse_command_tag(result)
+
+    async def update_statuses(
+        self,
+        draft_ids: Sequence[str],
+        status: str,
+        *,
+        scope: TenantScope,
+    ) -> Sequence[str]:
+        ids = [str(item).strip() for item in draft_ids if str(item).strip()]
+        if not ids:
+            return ()
+        rows = await self.pool.fetch(
+            """
+            UPDATE stat_card_drafts
+               SET status = $2,
+                   updated_at = NOW()
+             WHERE id = ANY($1::uuid[])
+               AND account_id = $3
+            RETURNING id
+            """,
+            ids,
+            status,
+            scope.account_id or "",
+        )
+        return tuple(str(row_to_dict(row).get("id") or "") for row in rows)
+
+
+__all__ = [
+    "PostgresStatCardRepository",
+]

--- a/extracted_content_pipeline/storage/migrations/334_stat_card_drafts.sql
+++ b/extracted_content_pipeline/storage/migrations/334_stat_card_drafts.sql
@@ -1,0 +1,39 @@
+-- Stat-card drafts: deterministic, evidence-backed metric cards generated
+-- from Content Ops source material. One row is one reviewable stat-card draft.
+--
+-- The status lifecycle mirrors the other generated assets: drafts start at
+-- 'draft' and host workflows can move them through 'approved', 'rejected', or
+-- custom intermediate states without a CHECK constraint.
+
+CREATE TABLE IF NOT EXISTS stat_card_drafts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    target_mode TEXT NOT NULL,
+    theme TEXT NOT NULL DEFAULT 'customer_metric',
+    metric_label TEXT NOT NULL DEFAULT '',
+    metric_value JSONB NOT NULL DEFAULT 'null'::jsonb,
+    metric_display TEXT NOT NULL DEFAULT '',
+    claim TEXT NOT NULL,
+    headline TEXT NOT NULL DEFAULT '',
+    supporting_text TEXT NOT NULL DEFAULT '',
+    evidence TEXT NOT NULL DEFAULT '',
+    source_id TEXT NOT NULL DEFAULT '',
+    source_type TEXT NOT NULL DEFAULT '',
+    company_name TEXT NOT NULL DEFAULT '',
+    vendor_name TEXT NOT NULL DEFAULT '',
+    pain_points JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'draft',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stat_card_drafts_target
+    ON stat_card_drafts (account_id, target_mode, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_stat_card_drafts_status
+    ON stat_card_drafts (account_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_stat_card_drafts_theme
+    ON stat_card_drafts (account_id, theme, created_at DESC);

--- a/plans/PR-Content-Ops-Stat-Card-Generated-Assets.md
+++ b/plans/PR-Content-Ops-Stat-Card-Generated-Assets.md
@@ -1,0 +1,152 @@
+# PR: Content Ops Stat Card Generated Assets
+
+## Why this slice exists
+
+PR #1294 added the deterministic `stat_card` output and PR #1295 put it into
+the review and competitive source-package defaults, but generated stat cards
+are still transient execution payloads. Operators can run the output, but they
+cannot revisit, approve, reject, or export stat-card drafts from the generated
+asset review queue.
+
+This slice completes the stat-card productization handoff deferred by #1295:
+generated stat-card drafts persist as tenant-scoped rows and become a
+first-class generated asset in the existing backend review API and
+`atlas-intel-ui` review screen.
+
+The diff is expected to exceed the 400 LOC soft cap for the same indivisible
+reason as the quote-card review queue handoff: schema, package port, Postgres
+adapter, generator save hook, host wiring, backend review/export switchboards,
+frontend type/UI branches, CI-enrolled frontend test, and focused backend tests
+need to land together or `stat_card` is only partially reviewable.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Vertical slice
+
+1. Add package-owned stat-card persistence types, Postgres adapter, export
+   helper, and migration for tenant-scoped review rows.
+2. Teach `StatCardGenerationService` to persist generated stats when a
+   repository is injected, returning `saved_ids` in the execution result.
+3. Wire the host DB-backed Content Ops service bundle to use the Postgres
+   stat-card repository when `enable_db_services=True`.
+4. Add `stat_card` to generated-assets backend switchboards for list,
+   CSV/JSON export, single review, and batch review.
+5. Add `stat_card` to the atlas-intel-ui API type surface, review tab, card
+   preview/facts/title branches, completed-run review CTA allowlist, and
+   CI-enrolled frontend test.
+6. Add focused package, host, backend API, and frontend tests proving
+   tenant-scoped persistence and review/export handoff.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Stat-Card-Generated-Assets.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/stat_card_ports.py`
+- `extracted_content_pipeline/stat_card_postgres.py`
+- `extracted_content_pipeline/stat_card_export.py`
+- `extracted_content_pipeline/stat_card_generation.py`
+- `extracted_content_pipeline/storage/migrations/334_stat_card_drafts.sql`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `atlas_brain/_content_ops_services.py`
+- `tests/test_extracted_stat_card_generation.py`
+- `tests/test_extracted_stat_card_postgres.py`
+- `tests/test_extracted_content_asset_api.py`
+- `tests/test_atlas_content_ops_execution_services.py`
+- `scripts/run_extracted_pipeline_checks.sh`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsNewRun.tsx`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs`
+- `atlas-intel-ui/package.json`
+- `.github/workflows/atlas_intel_ui_checks.yml`
+
+## Mechanism
+
+`StatCardGenerationService` already turns normalized source material into
+bounded, evidence-backed stat dictionaries. This slice mirrors the quote-card
+persistence seam: convert each generated stat into a `StatCardDraft`, then
+call:
+
+```python
+await stat_cards.save_drafts(drafts, scope=scope)
+```
+
+only when a repository is injected. The default constructor remains
+dependency-light, so extracted-package callers without DB services still get
+the same deterministic `stats` payload with an empty `saved_ids` list.
+
+`PostgresStatCardRepository` stores rows in `stat_card_drafts` with
+`account_id`, `target_mode`, source identity, metric label/value/display,
+claim, headline, supporting text, evidence, pain-point JSON, metadata, and
+mutable status. The generated asset API uses the same export/review/update
+switchboard shape as `quote_card`:
+
+```python
+if asset == "stat_card":
+    return await export_stat_card_drafts(PostgresStatCardRepository(pool), ...)
+```
+
+The frontend adds `stat_card` to the existing generated-assets registry and
+renders stat-card rows with metric/source facts, claim preview, evidence, and
+supporting text. The completed-run CTA links to the stat-card review tab
+without id filters, matching quote-card behavior because the first repository
+list path filters by status, target mode, and theme rather than ids.
+
+## Intentional
+
+- No hosted/public stat-card URLs. Stat cards are review/export assets in this
+  slice, not public pages.
+- No design/image rendering or repair workflow. This persists the evidence and
+  copy fields that a later creative export can consume.
+- No ID deep-link filter for `stat_card`. The first review queue follows the
+  quote-card list filters; direct id filters can be added once a product path
+  needs exact run-result deep links.
+- No #1268 output-variations work. That PR remains outside this lane.
+
+## Deferred
+
+- Optional stat-card id deep links can be added after a product path needs
+  direct review links from generation results.
+- Visual template/export generation for quote cards and stat cards remains a
+  later product polish slice after review/export rows exist.
+- LLM/style/channel variants and #1268-style output variations remain future
+  product polish.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_stat_card_generation.py tests/test_extracted_stat_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py -q`
+  (124 passed)
+- Passed: `python -m py_compile extracted_content_pipeline/stat_card_generation.py extracted_content_pipeline/stat_card_ports.py extracted_content_pipeline/stat_card_postgres.py extracted_content_pipeline/stat_card_export.py extracted_content_pipeline/api/generated_assets.py atlas_brain/_content_ops_services.py tests/test_extracted_stat_card_generation.py tests/test_extracted_stat_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py`
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets`
+  (4 passed)
+- Passed: `cd atlas-intel-ui && npm run lint`
+- Passed: `cd atlas-intel-ui && npm run build`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  (OK: 146 matching tests are enrolled.)
+- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
+- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- Passed: `bash scripts/check_ascii_python.sh`
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
+  (3054 passed, 10 skipped, 1 warning)
+- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-stat-card-generated-assets-pr-body.md`
+
+## Estimated diff size
+
+Actual: 20 files, +1379 / -14. This is above the 400 LOC soft cap for the
+end-to-end handoff reasons named in **Why this slice exists**.
+
+| Area | Estimated LOC |
+|---|---:|
+| Stat-card port, adapter, migration, export helper, manifest | ~470 |
+| Generator save hook and host wiring | ~80 |
+| Backend review/export switchboard and tests | ~225 |
+| Frontend type/UI/test/workflow enrollment | ~230 |
+| Plan doc and CI test enrollment | ~325 |
+| **Total** | **~1,300** |

--- a/scripts/run_extracted_pipeline_checks.sh
+++ b/scripts/run_extracted_pipeline_checks.sh
@@ -85,6 +85,7 @@ pytest \
   tests/test_extracted_quote_card_generation.py \
   tests/test_extracted_stat_card_generation.py \
   tests/test_extracted_quote_card_postgres.py \
+  tests/test_extracted_stat_card_postgres.py \
   tests/test_extracted_content_ops_cache_policy.py \
   tests/test_extracted_content_ops_input_provider.py \
   tests/test_support_ticket_context_contract.py \

--- a/tests/test_atlas_content_ops_execution_services.py
+++ b/tests/test_atlas_content_ops_execution_services.py
@@ -19,8 +19,8 @@ the host has wired. Currently:
   customer-executable output lists while keeping it as the internal
   deflection-report source.
 - `social_post`: deterministic; persists when DB services are enabled.
-- `quote_card`: deterministic; always wired (stateless).
-- `stat_card`: deterministic; always wired (stateless).
+- `quote_card`: deterministic; persists when DB services are enabled.
+- `stat_card`: deterministic; persists when DB services are enabled.
 - `faq_deflection_report` (this slice): always wired (stateless wrapper over
   `faq_markdown`).
 
@@ -52,12 +52,13 @@ Test inventory (25 tests):
 15. `social_post` persists when DB services are enabled.
 16. `ad_copy` persists when DB services are enabled.
 17. `quote_card` runs through the full executor.
-18. `faq_deflection_report` runs through the full executor.
-19. `social_post` is always wired.
-20. `ad_copy` is always wired.
-21. `quote_card` is always wired.
-22. `stat_card` is always wired.
-23. `configured_outputs()` with LLM + db enabled advertises
+18. `stat_card` persists when DB services are enabled.
+19. `faq_deflection_report` runs through the full executor.
+20. `social_post` is always wired.
+21. `ad_copy` is always wired.
+22. `quote_card` is always wired.
+23. `stat_card` is always wired.
+24. `configured_outputs()` with LLM + db enabled advertises
     every wired output: `(email_campaign, blog_post, report,
     landing_page, sales_brief, social_post, ad_copy,
     quote_card, stat_card, signal_extraction, faq_markdown,
@@ -65,10 +66,10 @@ Test inventory (25 tests):
     follows the upstream
     `ContentOpsExecutionServices.configured_outputs`
     iteration (not alphabetical).
-24. `configured_outputs()` without an active LLM (even with
+25. `configured_outputs()` without an active LLM (even with
     `enable_db_services=True`) advertises only
     deterministic outputs.
-25. The hosted paywall mode can hide `faq_markdown` while
+26. The hosted paywall mode can hide `faq_markdown` while
     retaining a runnable `faq_deflection_report`.
 """
 
@@ -388,6 +389,56 @@ async def test_quote_card_persists_when_db_services_enabled() -> None:
         "Acme Logistics",
         "Customer proof for HubSpot",
         "Use this quote to frame pricing pressure.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stat_card_persists_when_db_services_enabled() -> None:
+    pool = _FAQPoolStub(return_id="stat-card-uuid-1")
+    services = build_content_ops_execution_services(
+        llm_factory=_no_llm,
+        skills_factory=_make_skill_store_stub,
+        pool_factory=lambda: pool,
+        enable_db_services=True,
+    )
+
+    result = await execute_content_ops_from_mapping(
+        {
+            "outputs": ["stat_card"],
+            "inputs": {
+                "source_material": [{
+                    "review_id": "review-1",
+                    "source_type": "review",
+                    "vendor": "HubSpot",
+                    "reviewer_company": "Acme Logistics",
+                    "review_text": "NPS score dropped to 42 after renewal.",
+                    "nps_score": 42,
+                    "pain_category": "pricing pressure",
+                }]
+            },
+        },
+        services=services,
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    step = result["steps"][0]
+    assert step["output"] == "stat_card"
+    assert step["status"] == "completed"
+    assert step["result"]["saved_ids"] == ["stat-card-uuid-1"]
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO stat_card_drafts" in call["query"]
+    assert call["args"][:11] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "customer_metric",
+        "NPS score",
+        "42",
+        "42",
+        "NPS score: 42",
+        "Customer metric for HubSpot",
+        "Use this stat to frame pricing pressure.",
+        "NPS score dropped to 42 after renewal.",
     )
 
 

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -485,6 +485,29 @@ def _quote_card_row():
     }
 
 
+def _stat_card_row():
+    return {
+        "id": "stat-card-uuid-1",
+        "status": "draft",
+        "target_id": "review-1",
+        "target_mode": "review",
+        "theme": "customer_metric",
+        "metric_label": "NPS score",
+        "metric_value": 42,
+        "metric_display": "42",
+        "claim": "NPS score: 42",
+        "headline": "Customer metric for Zendesk",
+        "supporting_text": "Use this stat to frame slow response.",
+        "evidence": "NPS score dropped to 42 after renewal.",
+        "source_id": "source-1",
+        "source_type": "review",
+        "company_name": "Acme",
+        "vendor_name": "Zendesk",
+        "pain_points": ["slow response", "renewal pressure"],
+        "metadata": {"source_url": "https://example.test/reviews/1"},
+    }
+
+
 def _ticket_faq_row():
     return {
         "id": "faq-uuid-1",
@@ -1626,6 +1649,52 @@ def test_generated_asset_router_exports_quote_card_csv() -> None:
     assert args == ("", "review", "customer_proof", 20)
 
 
+def test_generated_asset_router_lists_stat_card_drafts_with_filters() -> None:
+    pool = _Pool(rows=[_stat_card_row()])
+
+    response = _client(
+        pool,
+        scope=TenantScope(account_id="acct_1"),
+    ).get(
+        "/content-assets/stat_card/drafts"
+        "?target_mode=review&theme=customer_metric&limit=5"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    row = body["rows"][0]
+    assert row["id"] == "stat-card-uuid-1"
+    assert row["theme"] == "customer_metric"
+    assert row["metric_label"] == "NPS score"
+    assert row["metric_display"] == "42"
+    assert row["claim"] == "NPS score: 42"
+    assert row["evidence"] == "NPS score dropped to 42 after renewal."
+    assert row["pain_point_count"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM stat_card_drafts" in query
+    assert args == ("acct_1", "draft", "review", "customer_metric", 5)
+
+
+def test_generated_asset_router_exports_stat_card_csv() -> None:
+    pool = _Pool(rows=[_stat_card_row()])
+
+    response = _client(pool).get(
+        "/content-assets/stat_card/drafts/export"
+        "?format=csv&status=&target_mode=review&theme=customer_metric"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "content_assets_stat_card.csv" in response.headers["content-disposition"]
+    assert "target_id,target_mode,theme" in response.text
+    assert "NPS score: 42" in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM stat_card_drafts" in query
+    assert "status = " not in query
+    assert args == ("", "review", "customer_metric", 20)
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 
@@ -1712,6 +1781,27 @@ def test_generated_asset_router_reviews_quote_card() -> None:
     query, args = pool.execute_calls[0]
     assert "UPDATE quote_card_drafts" in query
     assert args == ("quote-card-uuid-1", "approved", "acct_1")
+
+
+def test_generated_asset_router_reviews_stat_card() -> None:
+    pool = _Pool()
+
+    response = _client(pool, scope={"account_id": "acct_1"}).post(
+        "/content-assets/stat_card/drafts/review",
+        json={"id": "stat-card-uuid-1", "status": "approved"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "account_id": "acct_1",
+        "asset": "stat_card",
+        "id": "stat-card-uuid-1",
+        "status": "approved",
+        "updated": True,
+    }
+    query, args = pool.execute_calls[0]
+    assert "UPDATE stat_card_drafts" in query
+    assert args == ("stat-card-uuid-1", "approved", "acct_1")
 
 
 def test_generated_asset_router_reviews_ticket_faq_with_host_defined_status() -> None:
@@ -2122,6 +2212,31 @@ def test_generated_asset_router_batch_reviews_quote_cards() -> None:
     assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
     query, args = pool.fetch_calls[0]
     assert "UPDATE quote_card_drafts" in query
+    assert "RETURNING id" in query
+    assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
+    assert pool.execute_calls == []
+
+
+def test_generated_asset_router_batch_reviews_stat_cards() -> None:
+    pool = _Pool(rows=[{"id": BATCH_REPORT_ID_1}, {"id": BATCH_REPORT_ID_2}])
+
+    response = _client(
+        pool,
+        scope={"account_id": "acct_1"},
+    ).post(
+        "/content-assets/stat_card/drafts/review-batch",
+        json={
+            "ids": [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2],
+            "status": "rejected",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["asset"] == "stat_card"
+    assert response.json()["updated"] == 2
+    assert response.json()["updated_ids"] == [BATCH_REPORT_ID_1, BATCH_REPORT_ID_2]
+    query, args = pool.fetch_calls[0]
+    assert "UPDATE stat_card_drafts" in query
     assert "RETURNING id" in query
     assert args == ([BATCH_REPORT_ID_1, BATCH_REPORT_ID_2], "rejected", "acct_1")
     assert pool.execute_calls == []

--- a/tests/test_extracted_stat_card_generation.py
+++ b/tests/test_extracted_stat_card_generation.py
@@ -9,6 +9,15 @@ from extracted_content_pipeline.stat_card_generation import (
 )
 
 
+class _StatCardRepository:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def save_drafts(self, drafts, *, scope):
+        self.calls.append({"drafts": tuple(drafts), "scope": scope})
+        return ("stat-card-uuid-1",)
+
+
 @pytest.mark.asyncio
 async def test_stat_card_service_generates_evidence_backed_stats() -> None:
     service = StatCardGenerationService()
@@ -31,6 +40,7 @@ async def test_stat_card_service_generates_evidence_backed_stats() -> None:
     payload = result.as_dict()
     assert payload["generated"] == 1
     assert payload["target_mode"] == "vendor_retention"
+    assert payload["saved_ids"] == []
     assert payload["warnings"] == []
     assert payload["stats"] == [
         {
@@ -51,6 +61,44 @@ async def test_stat_card_service_generates_evidence_backed_stats() -> None:
             "pain_points": ["renewal dissatisfaction"],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_stat_card_service_persists_generated_drafts_when_repository_is_configured() -> None:
+    repository = _StatCardRepository()
+    service = StatCardGenerationService(stat_cards=repository)
+
+    result = await service.generate(
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+        target_mode="vendor_retention",
+        source_material=[
+            {
+                "review_id": "review-1",
+                "reviewer_company": "Acme Logistics",
+                "vendor": "Zendesk",
+                "review_text": "NPS score dropped to 42 after renewal.",
+                "nps_score": 42,
+                "pain_category": "renewal dissatisfaction",
+            }
+        ],
+    )
+
+    payload = result.as_dict()
+    assert payload["generated"] == 1
+    assert payload["saved_ids"] == ["stat-card-uuid-1"]
+    call = repository.calls[0]
+    assert call["scope"] == TenantScope(account_id="acct-1", user_id="user-1")
+    draft = call["drafts"][0]
+    assert draft.target_id == "review-1"
+    assert draft.target_mode == "vendor_retention"
+    assert draft.theme == "customer_metric"
+    assert draft.metric_label == "NPS score"
+    assert draft.metric_value == 42
+    assert draft.metric_display == "42"
+    assert draft.claim == "NPS score: 42"
+    assert draft.evidence == "NPS score dropped to 42 after renewal."
+    assert draft.pain_points == ("renewal dissatisfaction",)
+    assert draft.metadata["source_card"]["source_id"] == "review-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_extracted_stat_card_postgres.py
+++ b/tests/test_extracted_stat_card_postgres.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from extracted_content_pipeline.campaign_ports import TenantScope
+from extracted_content_pipeline.stat_card_ports import StatCardDraft
+from extracted_content_pipeline.stat_card_postgres import (
+    PostgresStatCardRepository,
+)
+
+
+class _Pool:
+    def __init__(self) -> None:
+        self.fetchval_results: list[object] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.fetchval_calls: list[dict[str, object]] = []
+        self.fetch_calls: list[dict[str, object]] = []
+        self.execute_calls: list[dict[str, object]] = []
+        self.execute_result: object = "UPDATE 1"
+
+    async def fetchval(self, query, *args):
+        self.fetchval_calls.append({"query": str(query), "args": args})
+        return self.fetchval_results.pop(0)
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append({"query": str(query), "args": args})
+        return self.fetch_rows
+
+    async def execute(self, query, *args):
+        self.execute_calls.append({"query": str(query), "args": args})
+        return self.execute_result
+
+
+def _compact_sql(query: object) -> str:
+    return " ".join(str(query).split())
+
+
+def _draft() -> StatCardDraft:
+    return StatCardDraft(
+        target_id="review-1",
+        target_mode="vendor_retention",
+        theme="customer_metric",
+        metric_label="NPS score",
+        metric_value=42,
+        metric_display="42",
+        claim="NPS score: 42",
+        headline="Customer metric for Zendesk",
+        supporting_text="Use this stat to frame renewal dissatisfaction.",
+        evidence="NPS score dropped to 42 after renewal.",
+        source_id="review-1",
+        source_type="review",
+        company_name="Acme Logistics",
+        vendor_name="Zendesk",
+        pain_points=("renewal dissatisfaction",),
+        metadata={"confidence": 0.88},
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_drafts_persists_stat_cards_and_returns_ids() -> None:
+    pool = _Pool()
+    pool.fetchval_results = ["stat-card-uuid-1"]
+    repo = PostgresStatCardRepository(pool)
+
+    saved = await repo.save_drafts(
+        [_draft()],
+        scope=TenantScope(account_id="acct-1", user_id="user-1"),
+    )
+
+    assert saved == ("stat-card-uuid-1",)
+    call = pool.fetchval_calls[0]
+    assert "INSERT INTO stat_card_drafts" in call["query"]
+    args = call["args"]
+    assert args[:15] == (
+        "acct-1",
+        "review-1",
+        "vendor_retention",
+        "customer_metric",
+        "NPS score",
+        "42",
+        "42",
+        "NPS score: 42",
+        "Customer metric for Zendesk",
+        "Use this stat to frame renewal dissatisfaction.",
+        "NPS score dropped to 42 after renewal.",
+        "review-1",
+        "review",
+        "Acme Logistics",
+        "Zendesk",
+    )
+    assert json.loads(args[15]) == ["renewal dissatisfaction"]
+    metadata = json.loads(args[16])
+    assert metadata["target_id"] == "review-1"
+    assert metadata["target_mode"] == "vendor_retention"
+    assert metadata["scope"] == {"account_id": "acct-1", "user_id": "user-1"}
+    assert metadata["confidence"] == 0.88
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_scope_status_target_mode_and_theme() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{
+        "id": "stat-card-uuid-1",
+        "target_id": "review-1",
+        "target_mode": "vendor_retention",
+        "theme": "customer_metric",
+        "metric_label": "NPS score",
+        "metric_value": 42,
+        "metric_display": "42",
+        "claim": "NPS score: 42",
+        "headline": "Customer metric for Zendesk",
+        "supporting_text": "Use this stat to frame renewal dissatisfaction.",
+        "evidence": "NPS score dropped to 42 after renewal.",
+        "source_id": "review-1",
+        "source_type": "review",
+        "company_name": "Acme Logistics",
+        "vendor_name": "Zendesk",
+        "pain_points": json.dumps(["renewal dissatisfaction"]),
+        "metadata": json.dumps({"confidence": 0.88}),
+        "status": "draft",
+    }]
+    repo = PostgresStatCardRepository(pool)
+
+    drafts = await repo.list_drafts(
+        scope=TenantScope(account_id="acct-1"),
+        status="draft",
+        target_mode="vendor_retention",
+        theme="customer_metric",
+        limit=10,
+    )
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert draft.id == "stat-card-uuid-1"
+    assert draft.theme == "customer_metric"
+    assert draft.metric_label == "NPS score"
+    assert draft.metric_value == 42
+    assert draft.pain_points == ("renewal dissatisfaction",)
+    assert draft.metadata == {"confidence": 0.88}
+    call = pool.fetch_calls[0]
+    assert "FROM stat_card_drafts" in call["query"]
+    assert "account_id = $1" in call["query"]
+    assert call["args"] == (
+        "acct-1",
+        "draft",
+        "vendor_retention",
+        "customer_metric",
+        10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_status_is_tenant_scoped_and_reports_misses() -> None:
+    pool = _Pool()
+    pool.execute_result = "UPDATE 0"
+    repo = PostgresStatCardRepository(pool)
+
+    updated = await repo.update_status(
+        "stat-card-uuid-1",
+        "approved",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated is False
+    call = pool.execute_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE stat_card_drafts" in sql
+    assert "WHERE id = $1::uuid AND account_id = $3" in sql
+    assert call["args"] == ("stat-card-uuid-1", "approved", "acct-1")
+
+
+@pytest.mark.asyncio
+async def test_update_statuses_returns_scoped_matches() -> None:
+    pool = _Pool()
+    pool.fetch_rows = [{"id": "stat-card-uuid-1"}]
+    repo = PostgresStatCardRepository(pool)
+
+    updated = await repo.update_statuses(
+        ["stat-card-uuid-1", ""],
+        "rejected",
+        scope=TenantScope(account_id="acct-1"),
+    )
+
+    assert updated == ("stat-card-uuid-1",)
+    call = pool.fetch_calls[0]
+    sql = _compact_sql(call["query"])
+    assert "UPDATE stat_card_drafts" in sql
+    assert "WHERE id = ANY($1::uuid[]) AND account_id = $3" in sql
+    assert call["args"] == (["stat-card-uuid-1"], "rejected", "acct-1")


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Stat-Card-Generated-Assets.md
Slice phase: Vertical slice

Persists generated `stat_card` drafts as tenant-scoped generated assets and wires them into the existing review/export API plus atlas-intel-ui review workflow, completing the stat-card productization handoff after #1294 and #1295.

## Intentional
- No hosted/public stat-card URLs. Stat cards are review/export assets in this slice, not public pages.
- No design/image rendering or repair workflow. This persists the evidence and copy fields a later creative export can consume.
- No ID deep-link filter for `stat_card`; this follows quote-card review list behavior.
- No changes to #1268 output variations.

## Deferred
- Optional stat-card id deep links can be added after a product path needs direct review links from generation results.
- Visual template/export generation for quote cards and stat cards remains later product polish after review/export rows exist.
- LLM/style/channel variants and #1268-style output variations remain future product polish.

## Parked hardening
- None.

## Verification
- Passed: `pytest tests/test_extracted_stat_card_generation.py tests/test_extracted_stat_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py -q` (124 passed)
- Passed: `python -m py_compile extracted_content_pipeline/stat_card_generation.py extracted_content_pipeline/stat_card_ports.py extracted_content_pipeline/stat_card_postgres.py extracted_content_pipeline/stat_card_export.py extracted_content_pipeline/api/generated_assets.py atlas_brain/_content_ops_services.py tests/test_extracted_stat_card_generation.py tests/test_extracted_stat_card_postgres.py tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_execution_services.py`
- Passed: `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets` (4 passed)
- Passed: `cd atlas-intel-ui && npm run lint`
- Passed: `cd atlas-intel-ui && npm run build`
- Passed: `git diff --check`
- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 146 matching tests are enrolled.)
- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
- Passed: `bash scripts/check_ascii_python.sh`
- Passed: `bash scripts/run_extracted_pipeline_checks.sh` (3054 passed, 10 skipped, 1 warning)
- Passed: `bash scripts/local_pr_review.sh --current-pr-body-file /tmp/content-ops-stat-card-generated-assets-pr-body.md`

## Diff size
20 files, +1379 / -14