### PR TITLE
Content Ops Card Visual Export

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -28,6 +28,10 @@ from ..ad_copy_export import export_ad_copy_drafts
 from ..ad_copy_postgres import PostgresAdCopyRepository
 from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
+from ..card_visual_export import (
+    render_card_visual_html,
+    supports_card_visual_export,
+)
 from ..landing_page_export import (
     export_landing_page_drafts,
     landing_page_draft_export_row,
@@ -338,7 +342,7 @@ def create_generated_asset_router(
         theme: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
-        format: str = Query("csv", description="csv or json"),
+        format: str = Query("csv", description="csv, json, or html"),
     ) -> Any:
         asset_name = _asset_arg(asset)
         pool = await _resolve_pool(pool_provider)
@@ -362,8 +366,25 @@ def create_generated_asset_router(
         format_name = _clean(format).lower()
         if format_name == "json":
             return result.as_dict()
+        if format_name == "html":
+            if not supports_card_visual_export(asset_name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "format html is only supported for quote_card and stat_card"
+                    ),
+                )
+            filename = f"{_clean(resolved_config.export_filename_prefix)}_{asset_name}.html"
+            return Response(
+                content=render_card_visual_html(asset_name, result.rows),
+                media_type="text/html",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
         if format_name != "csv":
-            raise HTTPException(status_code=400, detail="format must be csv or json")
+            raise HTTPException(
+                status_code=400,
+                detail="format must be csv, json, or html",
+            )
         filename = f"{_clean(resolved_config.export_filename_prefix)}_{asset_name}.csv"
         return Response(
             content=result.as_csv(),

--- a/extracted_content_pipeline/card_visual_export.py
+++ b/extracted_content_pipeline/card_visual_export.py
@@ -116,11 +116,15 @@ def _pain_points(row: JsonDict) -> str:
 
 
 def _text(value: Any) -> str:
-    return _html_escape(str(value or "").strip())
+    if value is None:
+        return ""
+    return _html_escape(str(value).strip())
 
 
 def _attr(value: Any) -> str:
-    return _html_escape(str(value or "").strip(), quote=True)
+    if value is None:
+        return ""
+    return _html_escape(str(value).strip(), quote=True)
 
 
 def _plural(noun: str, count: int) -> str:

--- a/extracted_content_pipeline/card_visual_export.py
+++ b/extracted_content_pipeline/card_visual_export.py
@@ -1,0 +1,199 @@
+"""Static HTML visual exports for generated quote/stat card drafts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from html import escape as _html_escape
+from typing import Any
+
+
+JsonDict = Mapping[str, Any]
+
+_SUPPORTED_ASSETS = frozenset({"quote_card", "stat_card"})
+
+
+def supports_card_visual_export(asset: str) -> bool:
+    """Return True when an asset can be exported as static visual cards."""
+
+    return str(asset or "").strip() in _SUPPORTED_ASSETS
+
+
+def render_card_visual_html(asset: str, rows: Sequence[JsonDict]) -> str:
+    """Render quote/stat rows as a static, downloadable HTML document."""
+
+    asset_name = str(asset or "").strip()
+    if asset_name not in _SUPPORTED_ASSETS:
+        raise ValueError("visual card export supports quote_card and stat_card")
+
+    title = "Quote Cards" if asset_name == "quote_card" else "Stat Cards"
+    cards = "\n".join(_render_card(asset_name, row) for row in rows)
+    if not cards:
+        cards = '<p class="empty-state">No cards matched the selected filters.</p>'
+    return "\n".join((
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '<meta charset="utf-8">',
+        '<meta name="viewport" content="width=device-width, initial-scale=1">',
+        f"<title>{_text(title)} Visual Export</title>",
+        f"<style>{_styles()}</style>",
+        "</head>",
+        "<body>",
+        '<header class="export-header">',
+        '<p class="kicker">Content Ops visual export</p>',
+        f"<h1>{_text(title)}</h1>",
+        f'<p class="summary">{len(rows)} {_plural("card", len(rows))}</p>',
+        "</header>",
+        '<main class="card-grid">',
+        cards,
+        "</main>",
+        "</body>",
+        "</html>",
+        "",
+    ))
+
+
+def _render_card(asset: str, row: JsonDict) -> str:
+    if asset == "quote_card":
+        return _render_quote_card(row)
+    return _render_stat_card(row)
+
+
+def _render_quote_card(row: JsonDict) -> str:
+    source = _source_line(row)
+    pain_points = _pain_points(row)
+    return "\n".join((
+        f'<article class="visual-card quote-card" data-card-id="{_attr(row.get("id"))}">',
+        f'<p class="eyebrow">{_text(row.get("theme") or "customer_proof")}</p>',
+        f"<h2>{_text(row.get('headline') or 'Customer proof')}</h2>",
+        f"<blockquote>&quot;{_text(row.get('quote'))}&quot;</blockquote>",
+        f'<p class="attribution">{_text(row.get("attribution") or source)}</p>',
+        f'<p class="supporting-text">{_text(row.get("supporting_text"))}</p>',
+        f'<p class="source-line">{_text(source)}</p>',
+        pain_points,
+        "</article>",
+    ))
+
+
+def _render_stat_card(row: JsonDict) -> str:
+    source = _source_line(row)
+    pain_points = _pain_points(row)
+    metric_display = row.get("metric_display") or row.get("metric_value")
+    return "\n".join((
+        f'<article class="visual-card stat-card" data-card-id="{_attr(row.get("id"))}">',
+        f'<p class="eyebrow">{_text(row.get("metric_label") or row.get("theme") or "metric")}</p>',
+        f'<p class="metric">{_text(metric_display)}</p>',
+        f"<h2>{_text(row.get('claim') or row.get('headline') or 'Customer metric')}</h2>",
+        f'<p class="supporting-text">{_text(row.get("supporting_text"))}</p>',
+        f'<p class="evidence">{_text(row.get("evidence"))}</p>',
+        f'<p class="source-line">{_text(source)}</p>',
+        pain_points,
+        "</article>",
+    ))
+
+
+def _source_line(row: JsonDict) -> str:
+    parts = [
+        str(row.get("company_name") or "").strip(),
+        str(row.get("vendor_name") or "").strip(),
+        str(row.get("source_type") or "").strip(),
+    ]
+    return " / ".join(part for part in parts if part) or "Source evidence"
+
+
+def _pain_points(row: JsonDict) -> str:
+    raw = row.get("pain_points")
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return ""
+    items = [
+        f"<li>{_text(value)}</li>"
+        for value in raw
+        if str(value or "").strip()
+    ]
+    if not items:
+        return ""
+    return '<ul class="pain-points">' + "".join(items) + "</ul>"
+
+
+def _text(value: Any) -> str:
+    return _html_escape(str(value or "").strip())
+
+
+def _attr(value: Any) -> str:
+    return _html_escape(str(value or "").strip(), quote=True)
+
+
+def _plural(noun: str, count: int) -> str:
+    return noun if count == 1 else f"{noun}s"
+
+
+def _styles() -> str:
+    return """
+:root {
+  color: #172026;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f5f7f8;
+}
+* { box-sizing: border-box; }
+body { margin: 0; padding: 32px; }
+.export-header { max-width: 1120px; margin: 0 auto 24px; }
+.kicker { margin: 0 0 8px; color: #53616a; font-size: 13px; text-transform: uppercase; }
+h1 { margin: 0; font-size: 34px; line-height: 1.1; }
+.summary { margin: 8px 0 0; color: #53616a; }
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  max-width: 1120px;
+  margin: 0 auto;
+}
+.visual-card {
+  min-height: 420px;
+  border: 1px solid #d8e0e3;
+  border-radius: 8px;
+  padding: 28px;
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+.quote-card { border-top: 8px solid #087f8c; }
+.stat-card { border-top: 8px solid #bd5d38; }
+.eyebrow {
+  margin: 0 0 16px;
+  color: #53616a;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+h2 { margin: 0 0 18px; font-size: 24px; line-height: 1.2; }
+blockquote { margin: 0 0 18px; font-size: 30px; line-height: 1.16; font-weight: 700; }
+.metric { margin: 0 0 12px; font-size: 72px; line-height: 0.95; font-weight: 800; }
+.attribution { margin: 0 0 20px; font-weight: 700; }
+.supporting-text, .evidence, .source-line { line-height: 1.5; }
+.supporting-text { color: #33424a; }
+.evidence { color: #53616a; font-size: 14px; }
+.source-line { margin-top: 22px; color: #53616a; font-size: 13px; }
+.pain-points { display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 0; padding: 0; }
+.pain-points li {
+  display: block;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #eef3f4;
+  color: #33424a;
+  font-size: 12px;
+}
+.empty-state {
+  grid-column: 1 / -1;
+  border: 1px dashed #b7c3c7;
+  border-radius: 8px;
+  padding: 32px;
+  color: #53616a;
+  text-align: center;
+}
+""".strip()
+
+
+__all__ = [
+    "render_card_visual_html",
+    "supports_card_visual_export",
+]

--- a/extracted_content_pipeline/manifest.json
+++ b/extracted_content_pipeline/manifest.json
@@ -321,6 +321,9 @@
       "target": "extracted_content_pipeline/stat_card_export.py"
     },
     {
+      "target": "extracted_content_pipeline/card_visual_export.py"
+    },
+    {
       "target": "extracted_content_pipeline/quote_card_export.py"
     },
     {

--- a/plans/PR-Content-Ops-Card-Visual-Export.md
+++ b/plans/PR-Content-Ops-Card-Visual-Export.md
@@ -1,0 +1,108 @@
+# PR: Content Ops Card Visual Export
+
+## Why this slice exists
+
+PR #1293 and PR #1296 completed durable review/export lifecycles for
+`quote_card` and `stat_card`, but their exports are still data-only CSV/JSON
+rows. The deferred product-polish item from both plans is visual
+template/export generation for those cards after review rows exist.
+
+This slice adds the first visual artifact path without changing generation,
+review status, or #1268 output variations: approved or filtered quote/stat
+rows can be exported as self-contained HTML cards through the existing
+generated-assets export route.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Product polish
+
+1. Add a package-owned, dependency-light card visual renderer for
+   `quote_card` and `stat_card` rows.
+2. Extend `/content-assets/{asset}/drafts/export` with `format=html` only for
+   `quote_card` and `stat_card`, reusing the existing tenant scope, status,
+   target mode, theme, and limit filters.
+3. Return a downloadable `text/html` response with escaped row content and no
+   JavaScript.
+4. Add focused API tests proving quote/stat HTML output, HTML escaping, and
+   fail-closed rejection for unsupported asset types.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Card-Visual-Export.md`
+- `extracted_content_pipeline/manifest.json`
+- `extracted_content_pipeline/card_visual_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+
+## Mechanism
+
+The new renderer accepts rows already produced by the quote/stat export
+helpers:
+
+```python
+html = render_card_visual_html(asset_name, result.rows)
+```
+
+The API route continues to call `_export_for_asset(...)` first, so database
+access and tenant scoping remain exactly the same as CSV/JSON export. After
+that, `format=html` branches only when the asset is visual-card capable:
+
+```python
+if format_name == "html":
+    if not supports_card_visual_export(asset_name):
+        raise HTTPException(...)
+    return Response(content=render_card_visual_html(asset_name, result.rows), ...)
+```
+
+All row text is escaped with `html.escape`, the output is static HTML/CSS, and
+the renderer does not include metadata JSON blobs or script execution.
+
+## Intentional
+
+- No PNG/SVG rendering. Self-contained HTML is the first reviewable visual
+  artifact; raster export can follow once the template is accepted.
+- No atlas-intel-ui download button in this slice. The API path is enough to
+  validate the artifact contract; UI polish can call the same route later.
+- No change to default export status. The route keeps the existing `status`
+  filter behavior, so operators can request `status=approved` without a hidden
+  special case.
+- No #1268 output-variations work.
+
+## Deferred
+
+- Add an atlas-intel-ui visual export button for quote/stat cards after this
+  backend artifact contract is accepted.
+- Add PNG rendering or server-side image export after the HTML template has
+  been reviewed with real approved rows.
+- Optional quote/stat id deep links remain deferred until a product path needs
+  exact run-result links.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `pytest tests/test_extracted_content_asset_api.py -q`
+  (85 passed)
+- Passed: `pytest tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_generated_assets_api.py -q`
+  (99 passed, 1 warning)
+- Passed: `python -m py_compile extracted_content_pipeline/card_visual_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
+- Passed: `git diff --check`
+- Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
+  (OK: 146 matching tests are enrolled.)
+- Passed: `bash scripts/validate_extracted_content_pipeline.sh`
+- Passed: `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
+- Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
+- Passed: `bash scripts/check_ascii_python.sh`
+- Passed: `bash scripts/run_extracted_pipeline_checks.sh`
+  (3057 passed, 10 skipped, 1 warning)
+
+## Estimated diff size
+
+Actual git diff: 5 files, +392 / -3.
+
+| Area | LOC |
+|---|---:|
+| **Total** | **395** |

--- a/plans/PR-Content-Ops-Card-Visual-Export.md
+++ b/plans/PR-Content-Ops-Card-Visual-Export.md
@@ -12,6 +12,11 @@ review status, or #1268 output variations: approved or filtered quote/stat
 rows can be exported as self-contained HTML cards through the existing
 generated-assets export route.
 
+The final diff is slightly above the 400 LOC soft cap because the review fix
+for zero-valued stat metrics ships in the same slice with its regression test;
+splitting that fix would leave the new visual artifact knowingly corrupting a
+valid metric value.
+
 ## Scope (this PR)
 
 Ownership lane: content-ops/marketer-reviews-as-input
@@ -85,9 +90,9 @@ None.
 ## Verification
 
 - Passed: `pytest tests/test_extracted_content_asset_api.py -q`
-  (85 passed)
+  (86 passed)
 - Passed: `pytest tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_generated_assets_api.py -q`
-  (99 passed, 1 warning)
+  (100 passed, 1 warning)
 - Passed: `python -m py_compile extracted_content_pipeline/card_visual_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
 - Passed: `git diff --check`
 - Passed: `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main`
@@ -97,12 +102,12 @@ None.
 - Passed: `python scripts/audit_extracted_standalone.py --fail-on-debt`
 - Passed: `bash scripts/check_ascii_python.sh`
 - Passed: `bash scripts/run_extracted_pipeline_checks.sh`
-  (3057 passed, 10 skipped, 1 warning)
+  (3058 passed, 10 skipped, 1 warning)
 
 ## Estimated diff size
 
-Actual git diff: 5 files, +392 / -3.
+Actual git diff: 5 files, +415 / -5.
 
 | Area | LOC |
 |---|---:|
-| **Total** | **395** |
+| **Total** | **420** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1649,6 +1649,25 @@ def test_generated_asset_router_exports_quote_card_csv() -> None:
     assert args == ("", "review", "customer_proof", 20)
 
 
+def test_generated_asset_router_exports_quote_card_visual_html() -> None:
+    pool = _Pool(rows=[_quote_card_row()])
+
+    response = _client(pool).get(
+        "/content-assets/quote_card/drafts/export"
+        "?format=html&status=approved&target_mode=review&theme=customer_proof"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "content_assets_quote_card.html" in response.headers["content-disposition"]
+    assert '<article class="visual-card quote-card"' in response.text
+    assert "&quot;Pricing became hard to justify after renewal.&quot;" in response.text
+    assert "Customer proof for Zendesk" in response.text
+    query, args = pool.fetch_calls[0]
+    assert "FROM quote_card_drafts" in query
+    assert args == ("", "approved", "review", "customer_proof", 20)
+
+
 def test_generated_asset_router_lists_stat_card_drafts_with_filters() -> None:
     pool = _Pool(rows=[_stat_card_row()])
 
@@ -1693,6 +1712,33 @@ def test_generated_asset_router_exports_stat_card_csv() -> None:
     assert "FROM stat_card_drafts" in query
     assert "status = " not in query
     assert args == ("", "review", "customer_metric", 20)
+
+
+def test_generated_asset_router_exports_stat_card_visual_html_with_escaped_text() -> None:
+    row = _stat_card_row()
+    row["claim"] = "NPS <script>alert(1)</script>"
+    row["evidence"] = 'NPS used <img src=x onerror="alert(1)"> after renewal.'
+    pool = _Pool(rows=[row])
+
+    response = _client(pool).get(
+        "/content-assets/stat_card/drafts/export"
+        "?format=html&status=approved&target_mode=review&theme=customer_metric"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "content_assets_stat_card.html" in response.headers["content-disposition"]
+    assert '<article class="visual-card stat-card"' in response.text
+    assert "<script>" not in response.text
+    assert "<img" not in response.text
+    assert "NPS &lt;script&gt;alert(1)&lt;/script&gt;" in response.text
+    assert (
+        "NPS used &lt;img src=x onerror=&quot;alert(1)&quot;&gt; after renewal."
+        in response.text
+    )
+    query, args = pool.fetch_calls[0]
+    assert "FROM stat_card_drafts" in query
+    assert args == ("", "approved", "review", "customer_metric", 20)
 
 
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
@@ -2383,7 +2429,19 @@ def test_generated_asset_router_rejects_unknown_export_format() -> None:
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "format must be csv or json"
+    assert response.json()["detail"] == "format must be csv, json, or html"
+
+
+def test_generated_asset_router_rejects_visual_export_for_non_card_assets() -> None:
+    response = _client(_Pool(rows=[_report_row()])).get(
+        "/content-assets/report/drafts/export?format=html"
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "format html is only supported for quote_card and stat_card"
+    )
 
 
 def test_generated_asset_router_requires_database() -> None:

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -1741,6 +1741,23 @@ def test_generated_asset_router_exports_stat_card_visual_html_with_escaped_text(
     assert args == ("", "approved", "review", "customer_metric", 20)
 
 
+def test_generated_asset_router_preserves_zero_metric_in_stat_card_visual_html() -> None:
+    row = _stat_card_row()
+    row["metric_display"] = ""
+    row["metric_value"] = 0
+    row["claim"] = "NPS score: 0"
+    pool = _Pool(rows=[row])
+
+    response = _client(pool).get(
+        "/content-assets/stat_card/drafts/export"
+        "?format=html&status=approved&target_mode=review&theme=customer_metric"
+    )
+
+    assert response.status_code == 200
+    assert '<p class="metric">0</p>' in response.text
+    assert "NPS score: 0" in response.text
+
+
 def test_generated_asset_router_reviews_report_with_host_defined_status() -> None:
     pool = _Pool()
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Card-Visual-Export.md
Slice phase: Product polish

Adds the first visual artifact path for generated quote/stat cards: `format=html` on the existing generated-assets export route, reusing the same tenant-scoped row lookup and filters as CSV/JSON. The HTML renderer is package-owned, static, escaped, limited to `quote_card` / `stat_card`, and preserves zero-valued stat metrics.

## Intentional
- No PNG/SVG rendering; HTML is the first reviewable visual artifact.
- No atlas-intel-ui download button in this slice.
- No change to default export status; callers can request `status=approved`.
- No #1268 output-variations work.

## Deferred
- atlas-intel-ui visual export button for quote/stat cards.
- PNG/server-side image export after the HTML template is accepted.
- Optional quote/stat id deep links when a product path needs exact links.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_asset_api.py -q` (86 passed)
- `pytest tests/test_extracted_content_asset_api.py tests/test_atlas_content_ops_generated_assets_api.py -q` (100 passed, 1 warning)
- `python -m py_compile extracted_content_pipeline/card_visual_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py`
- `git diff --check`
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` (OK: 146 matching tests are enrolled.)
- `bash scripts/validate_extracted_content_pipeline.sh`
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline`
- `python scripts/audit_extracted_standalone.py --fail-on-debt`
- `bash scripts/check_ascii_python.sh`
- `bash scripts/run_extracted_pipeline_checks.sh` (3058 passed, 10 skipped, 1 warning)

## Diff size
5 files, +415 / -5