### PR TITLE
Content Ops Card Visual Export UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
@@ -23,6 +23,7 @@ async function loadTsModule(path, replacements = []) {
 }
 
 const {
+  exportGeneratedAssetDraftsHtml,
   fetchGeneratedAssetDrafts,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
@@ -69,6 +70,18 @@ function installFetchResponder(payload, status = 200) {
     return new Response(JSON.stringify(payload), {
       status,
       headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+function installTextFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(payload, {
+      status,
+      headers: { 'content-type': 'text/html' },
     })
   }
   return calls
@@ -143,10 +156,32 @@ test('quote-card generated asset review actions post to typed routes', async () 
   })
 })
 
+test('quote-card visual export fetches html from the typed content-assets route', async () => {
+  const calls = installTextFetchResponder('<!doctype html><h1>Quote Cards</h1>')
+
+  const result = await exportGeneratedAssetDraftsHtml('quote_card', {
+    status: 'approved',
+    limit: 20,
+  })
+
+  assert.equal(result, '<!doctype html><h1>Quote Cards</h1>')
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/quote_card/drafts/export?status=approved&limit=20&format=html`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
 test('asset review UI exposes quote-card tab and preview branches', () => {
   assert.ok(reviewSource.includes("id: 'quote_card'"))
   assert.ok(reviewSource.includes("label: 'Quote Cards'"))
   assert.ok(reviewSource.includes("asset === 'quote_card'"))
+  assert.ok(reviewSource.includes('assetSupportsVisualExport(asset)'))
+  assert.ok(reviewSource.includes('Export HTML'))
+  assert.ok(reviewSource.includes('exportGeneratedAssetDraftsHtml(asset, params)'))
   assert.ok(reviewSource.includes('textValue(row.quote)'))
   assert.ok(reviewSource.includes('textValue(row.supporting_text)'))
   assert.ok(reviewSource.includes('quoteCardPainPointCount(row)'))

--- a/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
@@ -23,6 +23,7 @@ async function loadTsModule(path, replacements = []) {
 }
 
 const {
+  exportGeneratedAssetDraftsHtml,
   fetchGeneratedAssetDrafts,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
@@ -69,6 +70,18 @@ function installFetchResponder(payload, status = 200) {
     return new Response(JSON.stringify(payload), {
       status,
       headers: { 'content-type': 'application/json' },
+    })
+  }
+  return calls
+}
+
+function installTextFetchResponder(payload, status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(payload, {
+      status,
+      headers: { 'content-type': 'text/html' },
     })
   }
   return calls
@@ -146,10 +159,32 @@ test('stat-card generated asset review actions post to typed routes', async () =
   })
 })
 
+test('stat-card visual export fetches html from the typed content-assets route', async () => {
+  const calls = installTextFetchResponder('<!doctype html><h1>Stat Cards</h1>')
+
+  const result = await exportGeneratedAssetDraftsHtml('stat_card', {
+    status: 'approved',
+    limit: 20,
+  })
+
+  assert.equal(result, '<!doctype html><h1>Stat Cards</h1>')
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/stat_card/drafts/export?status=approved&limit=20&format=html`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
 test('asset review UI exposes stat-card tab and preview branches', () => {
   assert.ok(reviewSource.includes("id: 'stat_card'"))
   assert.ok(reviewSource.includes("label: 'Stat Cards'"))
   assert.ok(reviewSource.includes("asset === 'stat_card'"))
+  assert.ok(reviewSource.includes('assetSupportsVisualExport(asset)'))
+  assert.ok(reviewSource.includes('Export HTML'))
+  assert.ok(reviewSource.includes('exportGeneratedAssetDraftsHtml(asset, params)'))
   assert.ok(reviewSource.includes('textValue(row.claim)'))
   assert.ok(reviewSource.includes('textValue(row.evidence)'))
   assert.ok(reviewSource.includes('statCardPainPointCount(row)'))

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -954,6 +954,14 @@ export function exportGeneratedAssetDraftsCsv(
   return getAssetText(asset, '/drafts/export', { ...params, format: 'csv' })
 }
 
+/** GET /content-assets/{asset}/drafts/export?format=html -- static visual cards. */
+export function exportGeneratedAssetDraftsHtml(
+  asset: GeneratedAssetType,
+  params: GeneratedAssetListParams = {},
+): Promise<string> {
+  return getAssetText(asset, '/drafts/export', { ...params, format: 'html' })
+}
+
 /** POST /content-assets/{asset}/drafts/review -- approve/reject a draft. */
 export function reviewGeneratedAssetDraft(
   asset: GeneratedAssetType,

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -28,6 +28,7 @@ import {
 import { clsx } from 'clsx'
 import {
   exportGeneratedAssetDraftsCsv,
+  exportGeneratedAssetDraftsHtml,
   fetchGeneratedAssetDrafts,
   fetchGeneratedFaqMacroPublishAttempts,
   publishGeneratedFaqMacros,
@@ -239,6 +240,10 @@ function assetSupportsIdFilter(asset: GeneratedAssetType): boolean {
   return ID_FILTERED_ASSETS.has(asset)
 }
 
+function assetSupportsVisualExport(asset: GeneratedAssetType): boolean {
+  return asset === 'quote_card' || asset === 'stat_card'
+}
+
 export default function ContentOpsAssetsReview() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [asset, setAsset] = useState<GeneratedAssetType>(() =>
@@ -371,7 +376,21 @@ export default function ContentOpsAssetsReview() {
     setActionError(null)
     try {
       const csv = await exportGeneratedAssetDraftsCsv(asset, params)
-      downloadCsv(csv, `${asset}_drafts.csv`)
+      downloadText(csv, `${asset}_drafts.csv`, 'text/csv;charset=utf-8')
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const handleVisualExport = async () => {
+    if (!assetSupportsVisualExport(asset)) return
+    setExporting(true)
+    setActionError(null)
+    try {
+      const html = await exportGeneratedAssetDraftsHtml(asset, params)
+      downloadText(html, `${asset}_visual_cards.html`, 'text/html;charset=utf-8')
     } catch (err) {
       setActionError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -637,6 +656,21 @@ export default function ContentOpsAssetsReview() {
               )}
               Export CSV
             </button>
+            {assetSupportsVisualExport(asset) && (
+              <button
+                type="button"
+                onClick={() => void handleVisualExport()}
+                disabled={exporting || loading}
+                className="inline-flex items-center gap-2 rounded-md border border-emerald-400/50 px-3 py-2 text-sm font-medium text-emerald-100 hover:bg-emerald-400/10 disabled:opacity-60"
+              >
+                {exporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+                Export HTML
+              </button>
+            )}
           </div>
         </div>
 
@@ -2732,8 +2766,8 @@ function excerpt(value: string, limit = 260): string {
   return `${clean.slice(0, limit - 3).trim()}...`
 }
 
-function downloadCsv(csv: string, filename: string): void {
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+function downloadText(value: string, filename: string, type: string): void {
+  const blob = new Blob([value], { type })
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = url

--- a/plans/PR-Content-Ops-Card-Visual-Export-UI.md
+++ b/plans/PR-Content-Ops-Card-Visual-Export-UI.md
@@ -1,0 +1,93 @@
+# PR: Content Ops Card Visual Export UI
+
+## Why this slice exists
+
+PR #1297 added the backend `format=html` contract for visual quote/stat card
+exports, but atlas-intel-ui still exposes only the CSV export action on the
+generated-assets review screen. Operators can now call the HTML artifact route
+directly, but they cannot download those visual cards from the UI where quote
+and stat drafts are reviewed.
+
+This slice completes the UI handoff deferred by #1297: quote-card and
+stat-card review tabs get a visible HTML export action that calls the existing
+tenant-scoped export endpoint.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Product polish
+
+1. Add a typed `exportGeneratedAssetDraftsHtml(...)` frontend API helper that
+   calls `/content-assets/{asset}/drafts/export?format=html`.
+2. Add an `Export HTML` action on the generated-assets review screen only for
+   `quote_card` and `stat_card`, using the same status/limit filters as CSV.
+3. Reuse the existing download helper shape with an HTML MIME type and a
+   deterministic filename.
+4. Extend the already-enrolled quote-card and stat-card review asset tests to
+   prove route shape, UI gating, and visible action text.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Card-Visual-Export-UI.md`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs`
+- `atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs`
+
+## Mechanism
+
+The API helper mirrors the existing CSV helper:
+
+```ts
+export function exportGeneratedAssetDraftsHtml(asset, params) {
+  return getAssetText(asset, '/drafts/export', { ...params, format: 'html' })
+}
+```
+
+The review screen keeps CSV available for every generated asset. A small
+`assetSupportsVisualExport(...)` predicate gates the HTML action to
+`quote_card` and `stat_card`, matching the backend allowlist from #1297. The
+handler downloads the returned static HTML with the same current `params`
+object used for CSV export, so the UI does not create a new filter surface or
+scope path.
+
+## Intentional
+
+- No PNG/SVG/server-side image export. This UI calls the HTML artifact contract
+  accepted in #1297.
+- No new frontend workflow step. The changed quote/stat test scripts are
+  already listed in `.github/workflows/atlas_intel_ui_checks.yml`.
+- No #1268 output-variations work.
+- No id-filter support for quote/stat visual exports; the current review tabs
+  do not support id filters for those assets.
+
+## Deferred
+
+- PNG/server-side image export remains a later product-polish slice after the
+  HTML artifact is used from the UI.
+- Optional quote/stat id deep links remain deferred until a product path needs
+  exact run-result links.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets`
+  (5 passed)
+- Passed: `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets`
+  (5 passed)
+- Passed: `cd atlas-intel-ui && npm run lint`
+- Passed: `cd atlas-intel-ui && npm run build`
+- Passed: `git diff --check`
+- Passed: `rg -n "test:content-ops-(quote-card|stat-card)-review-assets" atlas-intel-ui/package.json .github/workflows/atlas_intel_ui_checks.yml`
+  (both modified test scripts are already enrolled in the frontend CI workflow)
+
+## Estimated diff size
+
+Actual git diff: 5 files, +208 / -3.
+
+| Area | LOC |
+|---|---:|
+| **Total** | **211** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Card-Visual-Export-UI.md
Slice phase: Product polish

Adds the atlas-intel-ui handoff for #1297's `format=html` card export contract: quote-card and stat-card review tabs now expose an `Export HTML` action that downloads the static visual card artifact using the same current status/limit filters as CSV.

## Intentional
- No PNG/SVG/server-side image export.
- No new frontend workflow step; the changed quote/stat test scripts are already enrolled in `atlas_intel_ui_checks.yml`.
- No #1268 output-variations work.
- No quote/stat id-filter support.

## Deferred
- PNG/server-side image export after the HTML artifact is used from the UI.
- Optional quote/stat id deep links when a product path needs exact links.

## Parked hardening
- None.

## Verification
- `cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets` (5 passed)
- `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets` (5 passed)
- `cd atlas-intel-ui && npm run lint`
- `cd atlas-intel-ui && npm run build`
- `git diff --check`
- `rg -n "test:content-ops-(quote-card|stat-card)-review-assets" atlas-intel-ui/package.json .github/workflows/atlas_intel_ui_checks.yml`

## Diff size
5 files, +208 / -3