### PR TITLE
Content Ops Card PNG Export

### DIFF
--- a/extracted_content_pipeline/api/generated_assets.py
+++ b/extracted_content_pipeline/api/generated_assets.py
@@ -30,6 +30,7 @@ from ..blog_post_export import export_blog_post_drafts
 from ..blog_post_postgres import PostgresBlogPostRepository
 from ..card_visual_export import (
     render_card_visual_html,
+    render_card_visual_png,
     supports_card_visual_export,
 )
 from ..landing_page_export import (
@@ -342,7 +343,7 @@ def create_generated_asset_router(
         theme: str | None = Query(None),
         ids: list[str] | None = Query(None, alias="id"),
         limit: int | None = Query(None, ge=0),
-        format: str = Query("csv", description="csv, json, or html"),
+        format: str = Query("csv", description="csv, json, html, or png"),
     ) -> Any:
         asset_name = _asset_arg(asset)
         pool = await _resolve_pool(pool_provider)
@@ -380,10 +381,35 @@ def create_generated_asset_router(
                 media_type="text/html",
                 headers={"Content-Disposition": f'attachment; filename="{filename}"'},
             )
+        if format_name == "png":
+            if not supports_card_visual_export(asset_name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "format png is only supported for quote_card and stat_card"
+                    ),
+                )
+            filename = f"{_clean(resolved_config.export_filename_prefix)}_{asset_name}.png"
+            try:
+                content = await render_card_visual_png(asset_name, result.rows)
+            except RuntimeError as exc:
+                logger.warning(
+                    "card visual png export unavailable",
+                    extra={"asset": asset_name},
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail="PNG export renderer unavailable",
+                ) from exc
+            return Response(
+                content=content,
+                media_type="image/png",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
         if format_name != "csv":
             raise HTTPException(
                 status_code=400,
-                detail="format must be csv, json, or html",
+                detail="format must be csv, json, html, or png",
             )
         filename = f"{_clean(resolved_config.export_filename_prefix)}_{asset_name}.csv"
         return Response(

--- a/extracted_content_pipeline/card_visual_export.py
+++ b/extracted_content_pipeline/card_visual_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from html import escape as _html_escape
 from typing import Any
 
@@ -10,6 +11,23 @@ from typing import Any
 JsonDict = Mapping[str, Any]
 
 _SUPPORTED_ASSETS = frozenset({"quote_card", "stat_card"})
+
+
+@dataclass(frozen=True)
+class CardVisualPngConfig:
+    """Browser screenshot settings for card visual PNG export."""
+
+    viewport_width: int = 1280
+    viewport_height: int = 900
+    device_scale_factor: float = 2.0
+
+    def __post_init__(self) -> None:
+        if self.viewport_width <= 0:
+            raise ValueError("viewport_width must be positive")
+        if self.viewport_height <= 0:
+            raise ValueError("viewport_height must be positive")
+        if self.device_scale_factor <= 0:
+            raise ValueError("device_scale_factor must be positive")
 
 
 def supports_card_visual_export(asset: str) -> bool:
@@ -51,6 +69,61 @@ def render_card_visual_html(asset: str, rows: Sequence[JsonDict]) -> str:
         "</html>",
         "",
     ))
+
+
+async def render_card_visual_png(
+    asset: str,
+    rows: Sequence[JsonDict],
+    *,
+    browser: Any | None = None,
+    config: CardVisualPngConfig | None = None,
+) -> bytes:
+    """Render quote/stat rows as a PNG screenshot of the static HTML export."""
+
+    html = render_card_visual_html(asset, rows)
+    resolved_config = config or CardVisualPngConfig()
+    if browser is not None:
+        return await _screenshot_card_html(browser, html, resolved_config)
+
+    try:
+        from playwright.async_api import async_playwright  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - host dependency edge.
+        raise RuntimeError(
+            "Playwright is required for PNG card visual export."
+        ) from exc
+
+    try:
+        async with async_playwright() as playwright:
+            browser_instance = await playwright.chromium.launch()
+            try:
+                return await _screenshot_card_html(
+                    browser_instance,
+                    html,
+                    resolved_config,
+                )
+            finally:
+                await browser_instance.close()
+    except Exception as exc:
+        raise RuntimeError("PNG card visual export failed.") from exc
+
+
+async def _screenshot_card_html(
+    browser: Any,
+    html: str,
+    config: CardVisualPngConfig,
+) -> bytes:
+    page = await browser.new_page(
+        viewport={
+            "width": config.viewport_width,
+            "height": config.viewport_height,
+        },
+        device_scale_factor=config.device_scale_factor,
+    )
+    try:
+        await page.set_content(html, wait_until="networkidle")
+        return await page.screenshot(type="png", full_page=True)
+    finally:
+        await page.close()
 
 
 def _render_card(asset: str, row: JsonDict) -> str:
@@ -198,6 +271,8 @@ blockquote { margin: 0 0 18px; font-size: 30px; line-height: 1.16; font-weight: 
 
 
 __all__ = [
+    "CardVisualPngConfig",
     "render_card_visual_html",
+    "render_card_visual_png",
     "supports_card_visual_export",
 ]

--- a/plans/PR-Content-Ops-Card-PNG-Export.md
+++ b/plans/PR-Content-Ops-Card-PNG-Export.md
@@ -1,0 +1,94 @@
+# PR: Content Ops Card PNG Export
+
+## Why this slice exists
+
+PR #1297 added static HTML visual exports for quote/stat cards, and PR #1298
+put that export behind an atlas-intel-ui action. Those artifacts are useful
+for review, but marketers ultimately need image files they can upload into
+social, paid, and presentation workflows.
+
+This slice closes the next deferred visual-export step: `quote_card` and
+`stat_card` can be exported as PNG images through the same generated-assets
+export route, without changing generation, review state, tenant scoping, or
+#1268 output variations.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Product polish
+
+1. Add a lazy Playwright-backed PNG renderer that converts the existing static
+   HTML visual card document into a full-page screenshot.
+2. Extend `/content-assets/{asset}/drafts/export` with `format=png` only for
+   `quote_card` and `stat_card`, reusing the same tenant scope, status,
+   target mode, theme, and limit filters as CSV/JSON/HTML.
+3. Fail closed with a service-unavailable response when the optional PNG
+   renderer cannot run.
+4. Add focused tests that mock the browser boundary, prove route shape and
+   PNG response headers, and prove non-card assets cannot request PNG.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Card-PNG-Export.md`
+- `extracted_content_pipeline/card_visual_export.py`
+- `extracted_content_pipeline/api/generated_assets.py`
+- `tests/test_extracted_content_asset_api.py`
+
+## Mechanism
+
+The renderer reuses `render_card_visual_html(...)` so the PNG path inherits the
+same escaped static markup accepted by #1297. Playwright is imported lazily only
+when PNG rendering is requested:
+
+```python
+html = render_card_visual_html(asset, rows)
+async with async_playwright() as pw:
+    browser = await pw.chromium.launch()
+    png = await _screenshot_card_html(browser, html, config)
+```
+
+Tests supply a fake browser to the renderer helper and monkeypatch the API
+route's renderer function, so CI validates the real browser-boundary calls
+without requiring a live browser install. If Playwright is missing or browser
+startup fails in production, the route returns `503` rather than pretending to
+export a valid PNG.
+
+## Intentional
+
+- No frontend button in this slice. This PR establishes the backend PNG
+  contract first; the UI can add an `Export PNG` action after review accepts
+  the route and failure behavior.
+- No new dependency. Playwright is already in the repo requirements and stays a
+  lazy import.
+- No #1268 output-variations work.
+- No id-filter support for quote/stat exports.
+
+## Deferred
+
+- atlas-intel-ui `Export PNG` action for quote/stat cards after this backend
+  contract is accepted.
+- Optional quote/stat id deep links remain deferred until a product path needs
+  exact run-result links.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- `pytest tests/test_extracted_content_asset_api.py -q` -- 91 passed.
+- `python -m py_compile extracted_content_pipeline/card_visual_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py && git diff --check` -- passed.
+- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
+- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
+- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
+- `bash scripts/check_ascii_python.sh` -- passed.
+- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` -- OK: 146 matching tests are enrolled.
+- `bash scripts/run_extracted_pipeline_checks.sh` -- 3063 passed, 10 skipped.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan | +94 / -0 |
+| Product + tests | +251 / -3 |
+| **Total** | **~350** |

--- a/tests/test_extracted_content_asset_api.py
+++ b/tests/test_extracted_content_asset_api.py
@@ -18,6 +18,10 @@ from extracted_content_pipeline.api.generated_assets import (
 )
 import extracted_content_pipeline.api.generated_assets as asset_api
 from extracted_content_pipeline.campaign_ports import LLMResponse, TenantScope
+from extracted_content_pipeline.card_visual_export import (
+    CardVisualPngConfig,
+    render_card_visual_png,
+)
 from extracted_content_pipeline.faq_macro_writeback import (
     MacroPublishResult,
     MacroPublishStatus,
@@ -50,6 +54,36 @@ class _Pool:
     async def execute(self, query, *args):
         self.execute_calls.append((str(query), args))
         return self.execute_result
+
+
+class _PngPage:
+    def __init__(self) -> None:
+        self.set_content_calls: list[dict[str, object]] = []
+        self.screenshot_calls: list[dict[str, object]] = []
+        self.closed = False
+
+    async def set_content(self, html: str, *, wait_until: str) -> None:
+        self.set_content_calls.append({
+            "html": html,
+            "wait_until": wait_until,
+        })
+
+    async def screenshot(self, **kwargs) -> bytes:
+        self.screenshot_calls.append(dict(kwargs))
+        return b"\x89PNG\r\nvisual"
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _PngBrowser:
+    def __init__(self) -> None:
+        self.page = _PngPage()
+        self.new_page_calls: list[dict[str, object]] = []
+
+    async def new_page(self, **kwargs) -> _PngPage:
+        self.new_page_calls.append(dict(kwargs))
+        return self.page
 
 
 class _FAQMacroPublishHistoryPool(_Pool):
@@ -1668,6 +1702,107 @@ def test_generated_asset_router_exports_quote_card_visual_html() -> None:
     assert args == ("", "approved", "review", "customer_proof", 20)
 
 
+async def test_card_visual_png_renderer_screenshots_static_html() -> None:
+    browser = _PngBrowser()
+
+    png = await render_card_visual_png(
+        "stat_card",
+        [_stat_card_row()],
+        browser=browser,
+        config=CardVisualPngConfig(
+            viewport_width=800,
+            viewport_height=600,
+            device_scale_factor=1,
+        ),
+    )
+
+    assert png == b"\x89PNG\r\nvisual"
+    assert browser.new_page_calls == [{
+        "viewport": {"width": 800, "height": 600},
+        "device_scale_factor": 1,
+    }]
+    assert len(browser.page.set_content_calls) == 1
+    content_call = browser.page.set_content_calls[0]
+    assert content_call["wait_until"] == "networkidle"
+    assert "NPS score: 42" in str(content_call["html"])
+    assert browser.page.screenshot_calls == [{"type": "png", "full_page": True}]
+    assert browser.page.closed is True
+
+
+def test_generated_asset_router_exports_quote_card_visual_png(monkeypatch) -> None:
+    pool = _Pool(rows=[_quote_card_row()])
+    calls = []
+
+    async def fake_png(asset, rows):
+        calls.append({"asset": asset, "rows": rows})
+        return b"\x89PNG\r\nroute"
+
+    monkeypatch.setattr(asset_api, "render_card_visual_png", fake_png)
+
+    response = _client(pool).get(
+        "/content-assets/quote_card/drafts/export"
+        "?format=png&status=approved&target_mode=review&theme=customer_proof"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/png")
+    assert "content_assets_quote_card.png" in response.headers["content-disposition"]
+    assert response.content == b"\x89PNG\r\nroute"
+    assert len(calls) == 1
+    assert calls[0]["asset"] == "quote_card"
+    assert len(calls[0]["rows"]) == 1
+    assert calls[0]["rows"][0]["quote"] == (
+        "Pricing became hard to justify after renewal."
+    )
+    assert calls[0]["rows"][0]["pain_point_count"] == 2
+    query, args = pool.fetch_calls[0]
+    assert "FROM quote_card_drafts" in query
+    assert args == ("", "approved", "review", "customer_proof", 20)
+
+
+def test_generated_asset_router_returns_503_when_png_renderer_unavailable(
+    monkeypatch,
+) -> None:
+    async def unavailable_png(asset, rows):
+        raise RuntimeError("browser unavailable")
+
+    monkeypatch.setattr(asset_api, "render_card_visual_png", unavailable_png)
+
+    response = _client(_Pool(rows=[_quote_card_row()])).get(
+        "/content-assets/quote_card/drafts/export?format=png"
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "PNG export renderer unavailable"
+
+
+def test_generated_asset_router_exports_stat_card_visual_png(monkeypatch) -> None:
+    pool = _Pool(rows=[_stat_card_row()])
+    calls = []
+
+    async def fake_png(asset, rows):
+        calls.append({"asset": asset, "rows": rows})
+        return b"\x89PNG\r\nstat"
+
+    monkeypatch.setattr(asset_api, "render_card_visual_png", fake_png)
+
+    response = _client(pool).get(
+        "/content-assets/stat_card/drafts/export"
+        "?format=png&status=approved&target_mode=review&theme=customer_metric"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/png")
+    assert "content_assets_stat_card.png" in response.headers["content-disposition"]
+    assert response.content == b"\x89PNG\r\nstat"
+    assert len(calls) == 1
+    assert calls[0]["asset"] == "stat_card"
+    assert calls[0]["rows"][0]["claim"] == "NPS score: 42"
+    query, args = pool.fetch_calls[0]
+    assert "FROM stat_card_drafts" in query
+    assert args == ("", "approved", "review", "customer_metric", 20)
+
+
 def test_generated_asset_router_lists_stat_card_drafts_with_filters() -> None:
     pool = _Pool(rows=[_stat_card_row()])
 
@@ -2446,7 +2581,7 @@ def test_generated_asset_router_rejects_unknown_export_format() -> None:
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "format must be csv, json, or html"
+    assert response.json()["detail"] == "format must be csv, json, html, or png"
 
 
 def test_generated_asset_router_rejects_visual_export_for_non_card_assets() -> None:
@@ -2458,6 +2593,18 @@ def test_generated_asset_router_rejects_visual_export_for_non_card_assets() -> N
     assert (
         response.json()["detail"]
         == "format html is only supported for quote_card and stat_card"
+    )
+
+
+def test_generated_asset_router_rejects_png_export_for_non_card_assets() -> None:
+    response = _client(_Pool(rows=[_report_row()])).get(
+        "/content-assets/report/drafts/export?format=png"
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "format png is only supported for quote_card and stat_card"
     )
 
 


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Card-PNG-Export.md
Slice phase: Product polish

Adds backend PNG export for quote-card and stat-card generated assets by screenshotting the existing escaped static HTML visual export through a lazy Playwright renderer.

## Intentional
- No frontend button in this slice; this PR establishes the backend PNG contract first.
- No new dependency; Playwright remains a lazy import and the route returns 503 if the renderer is unavailable.
- No #1268 output-variations work.
- No id-filter support for quote/stat exports.

## Deferred
- atlas-intel-ui `Export PNG` action for quote/stat cards after this backend contract is accepted.
- Optional quote/stat id deep links remain deferred until a product path needs exact run-result links.

## Parked hardening
- None.

## Verification
- `pytest tests/test_extracted_content_asset_api.py -q` -- 91 passed.
- `python -m py_compile extracted_content_pipeline/card_visual_export.py extracted_content_pipeline/api/generated_assets.py tests/test_extracted_content_asset_api.py && git diff --check` -- passed.
- `bash scripts/validate_extracted_content_pipeline.sh` -- passed.
- `python extracted/_shared/scripts/forbid_atlas_reasoning_imports.py extracted_content_pipeline` -- passed.
- `python scripts/audit_extracted_standalone.py --fail-on-debt` -- passed.
- `bash scripts/check_ascii_python.sh` -- passed.
- `python scripts/audit_extracted_pipeline_ci_enrollment.py --atlas-brain-tests-from origin/main` -- OK: 146 matching tests are enrolled.
- `bash scripts/run_extracted_pipeline_checks.sh` -- 3063 passed, 10 skipped.

## Diff size
4 files, +345 / -3