### PR TITLE
Content Ops Live Smoke Model Route

### DIFF
--- a/docs/SESSION_BOOTSTRAP.md
+++ b/docs/SESSION_BOOTSTRAP.md
@@ -29,6 +29,7 @@ Both deliberately point at the live state docs for anything volatile and hardcod
 >    - **CI is truth:** "passed locally" ≠ green. Run the test the way CI does and check `gh pr checks` is green before claiming done.
 >    - **Fixtures must match real producer output**, not hand-crafted shapes.
 >    - **The PR body's stated safety claim must be *enforced in code*, not just named.**
+>    - **Content Ops live model route:** generated-content validation must use the configured cloud/OpenRouter route (currently Claude via OpenRouter), not local Ollama/qwen. For live smokes, set `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false` so a missing cloud route fails closed instead of silently falling back to a local model.
 >
 > 5. **Plan first** (`plans/PR-<Slice>.md`, the 7 sections, <400 LOC soft cap), open PRs ready-for-review (not draft), and run the per-package validation gauntlet before pushing (see CLAUDE.md "Per-package validation gauntlets").
 >

--- a/docs/extraction/validation/content_ops_live_smoke_model_route.md
+++ b/docs/extraction/validation/content_ops_live_smoke_model_route.md
@@ -1,0 +1,56 @@
+# Content Ops Live Smoke Model Route
+
+Issue #1299 requires a live end-to-end Content Ops smoke before more
+generated-asset surface lands. That smoke must validate the model path the
+product actually uses.
+
+## Required Route
+
+Content Ops generated content must run through the configured cloud LLM route:
+
+- Provider path: OpenRouter via `PipelineLLMClient`.
+- Current default model: `anthropic/claude-sonnet-4-5` unless the operator
+  explicitly sets `EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL`.
+- Credential source: the configured OpenRouter key.
+
+Local Ollama/qwen is not an acceptable substitute for the live smoke. It is a
+fallback path in the shared pipeline code, not the Content Ops validation
+target.
+
+## Fail-Closed Smoke Invocation
+
+Run live validation with local fallback disabled:
+
+```bash
+EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false \
+python scripts/smoke_content_ops_live_generation.py \
+  --account-id <real-account-id> \
+  --output blog_post \
+  --support-ticket-csv \
+  --export-saved-draft tmp/content_ops_live_blog_post_export.json \
+  --evaluate-generated-content \
+  --output-result tmp/content_ops_live_blog_post_result.json
+```
+
+If the cloud route is unavailable, the smoke should fail. Do not start Ollama
+or substitute a local model to make the smoke pass.
+
+## Deterministic Outputs
+
+Deterministic outputs such as `quote_card` and `stat_card` still need real
+Postgres validation and browser/export validation, but they are not evidence
+that the LLM generation path works. The #1299 acceptance bar requires both:
+
+- deterministic card path: real Postgres, tenant isolation, review/export, and
+  real browser rendering for PNG;
+- LLM path: real OpenRouter/Claude generation through `PipelineLLMClient`, with
+  local fallback disabled.
+
+## Reviewer Check
+
+Before accepting a live-validation doc for #1299, confirm it names:
+
+- provider/model actually used;
+- local fallback disabled (`EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false`);
+- no Ollama/qwen process used as substitute evidence;
+- result artifacts for the real DB/model/browser run.

--- a/docs/extraction/validation/content_ops_live_smoke_model_route.md
+++ b/docs/extraction/validation/content_ops_live_smoke_model_route.md
@@ -9,8 +9,10 @@ product actually uses.
 Content Ops generated content must run through the configured cloud LLM route:
 
 - Provider path: OpenRouter via `PipelineLLMClient`.
-- Current default model: `anthropic/claude-sonnet-4-5` unless the operator
-  explicitly sets `EXTRACTED_CAMPAIGN_LLM_OPENROUTER_MODEL`.
+- Model setting read by this host route:
+  `ATLAS_LLM_OPENROUTER_REASONING_MODEL` (or
+  `ATLAS_LLM__OPENROUTER_REASONING_MODEL`). The current default is
+  `anthropic/claude-sonnet-4-5`.
 - Credential source: the configured OpenRouter key.
 
 Local Ollama/qwen is not an acceptable substitute for the live smoke. It is a

--- a/plans/PR-Content-Ops-Live-Smoke-Model-Route.md
+++ b/plans/PR-Content-Ops-Live-Smoke-Model-Route.md
@@ -1,0 +1,75 @@
+# PR: Content Ops Live Smoke Model Route
+
+## Why this slice exists
+
+Issue #1299 correctly gates more Content Ops feature work behind a real live
+smoke, but its example wording mentioned local Ollama/qwen. That sent the
+builder toward the wrong model path. Content Ops generation is sold and tested
+as a cloud-generated product surface, and the host wiring routes generation
+through the pipeline LLM client with OpenRouter preferred.
+
+This slice makes the live-smoke contract explicit so future sessions validate
+the same route the product actually uses: configured cloud/OpenRouter/Claude,
+with local Ollama fallback disabled for validation.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input
+Slice phase: Workflow/process
+
+1. Update the builder bootstrap recurring-lapse checklist with the Content Ops
+   live-smoke model route.
+2. Add a focused validation note under `docs/extraction/validation/` for the
+   #1299 gate.
+3. Do not change generation code, model adapters, live-smoke execution logic,
+   #1300 PNG code, or #1268 output variations.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Live-Smoke-Model-Route.md`
+- `docs/SESSION_BOOTSTRAP.md`
+- `docs/extraction/validation/content_ops_live_smoke_model_route.md`
+
+## Mechanism
+
+The docs state the exact operational rule:
+
+```bash
+EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false \
+python scripts/smoke_content_ops_live_generation.py ...
+```
+
+The run must use the configured OpenRouter route and fail closed when the cloud
+route is unavailable. Local Ollama/qwen is not acceptable evidence for Content
+Ops generated-content validation.
+
+## Intentional
+
+- This PR is process/docs only. It does not attempt the #1299 live smoke.
+- The exact OpenRouter model is described as configuration-owned; the current
+  observed default is `anthropic/claude-sonnet-4-5`, but the invariant is the
+  cloud route, not a hardcoded model in code.
+- No #1300 changes. The held PNG PR should be resumed only after the live gate
+  proves real browser rendering and real cloud generation.
+
+## Deferred
+
+- The #1299 live-adapter smoke: real Postgres migrations through 334, real
+  OpenRouter/Claude generation, real browser PNG render, tenant isolation,
+  review/export UI, and validation doc from the actual run.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+- `git diff --check` -- passed.
+- `rg -n "qwen|Ollama|ollama|OpenRouter|EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA|claude-sonnet" docs/SESSION_BOOTSTRAP.md docs/extraction/validation/content_ops_live_smoke_model_route.md plans/PR-Content-Ops-Live-Smoke-Model-Route.md` -- verified route wording.
+- `gh issue view 1299 --json body,comments -q '{bodyHasOpenRouter: (.body | contains("configured cloud/OpenRouter model route")), bodyHasNoOllamaFallback: (.body | contains("EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false")), bodyHasPng: (.body | contains("real PNG/Chromium")), commentHasOpenRouter: (.comments[] | select(.id=="IC_kwDOQ5Uhrs8AAAABE0G38Q") | .body | contains("configured cloud/OpenRouter/Claude"))}'` -- all fields true.
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| **Total** | **~140** |

--- a/plans/PR-Content-Ops-Live-Smoke-Model-Route.md
+++ b/plans/PR-Content-Ops-Live-Smoke-Model-Route.md
@@ -65,11 +65,11 @@ None.
 ## Verification
 
 - `git diff --check` -- passed.
-- `rg -n "qwen|Ollama|ollama|OpenRouter|EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA|claude-sonnet" docs/SESSION_BOOTSTRAP.md docs/extraction/validation/content_ops_live_smoke_model_route.md plans/PR-Content-Ops-Live-Smoke-Model-Route.md` -- verified route wording.
+- `rg -n "qwen|Ollama|ollama|OpenRouter|ATLAS_LLM_OPENROUTER_REASONING_MODEL|ATLAS_LLM__OPENROUTER_REASONING_MODEL|EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA|claude-sonnet" docs/SESSION_BOOTSTRAP.md docs/extraction/validation/content_ops_live_smoke_model_route.md plans/PR-Content-Ops-Live-Smoke-Model-Route.md` -- verified route wording.
 - `gh issue view 1299 --json body,comments -q '{bodyHasOpenRouter: (.body | contains("configured cloud/OpenRouter model route")), bodyHasNoOllamaFallback: (.body | contains("EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false")), bodyHasPng: (.body | contains("real PNG/Chromium")), commentHasOpenRouter: (.comments[] | select(.id=="IC_kwDOQ5Uhrs8AAAABE0G38Q") | .body | contains("configured cloud/OpenRouter/Claude"))}'` -- all fields true.
 
 ## Estimated diff size
 
 | Area | LOC |
 |---|---:|
-| **Total** | **~140** |
+| **Total** | **~145** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Live-Smoke-Model-Route.md
Slice phase: Workflow/process

Makes the #1299 live-smoke model route explicit: Content Ops generated-content validation must use the configured cloud/OpenRouter/Claude path, with local Ollama fallback disabled.

## Intentional
- Process/docs only; this does not attempt the #1299 live smoke.
- The exact OpenRouter model remains configuration-owned. The current observed default is `anthropic/claude-sonnet-4-5`, but the invariant is the cloud route.
- No #1300 PNG code changes and no #1268 output-variations work.

## Deferred
- The #1299 live-adapter smoke: real Postgres migrations through 334, real OpenRouter/Claude generation, real browser PNG render, tenant isolation, review/export UI, and validation doc from the actual run.

## Parked hardening
- None.

## Verification
- `git diff --check` -- passed.
- `rg -n "qwen|Ollama|ollama|OpenRouter|ATLAS_LLM_OPENROUTER_REASONING_MODEL|ATLAS_LLM__OPENROUTER_REASONING_MODEL|EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA|claude-sonnet" docs/SESSION_BOOTSTRAP.md docs/extraction/validation/content_ops_live_smoke_model_route.md plans/PR-Content-Ops-Live-Smoke-Model-Route.md` -- verified route wording.
- `gh issue view 1299 --json body,comments -q '{bodyHasOpenRouter: (.body | contains("configured cloud/OpenRouter model route")), bodyHasNoOllamaFallback: (.body | contains("EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false")), bodyHasPng: (.body | contains("real PNG/Chromium")), commentHasOpenRouter: (.comments[] | select(.id=="IC_kwDOQ5Uhrs8AAAABE0G38Q") | .body | contains("configured cloud/OpenRouter/Claude"))}'` -- all fields true.

## Diff size
3 files, +134 / -0