### PR TITLE
Content Ops Live Adapter Smoke

### DIFF
--- a/docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md
+++ b/docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md
@@ -144,7 +144,7 @@ git diff --check
 
 Results:
 
-- `tests/test_smoke_content_ops_live_generation.py`: 38 passed
+- `tests/test_smoke_content_ops_live_generation.py`: 39 passed
 - `py_compile`: passed
 - `git diff --check`: passed
 
@@ -156,3 +156,7 @@ primary evidence above is the rerun with a real UUID account and clean durable
 trace rows.
 
 #1300 remains untouched and unmerged in this slice.
+
+A review follow-up added a fail-closed guard for the stat-card saved-draft
+export: if the filtered export rows omit any generated saved id, the smoke now
+fails instead of writing an empty/non-exact artifact.

--- a/docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md
+++ b/docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md
@@ -1,0 +1,158 @@
+# Content Ops Live Adapter Smoke - 2026-06-04
+
+Ownership lane: content-ops/marketer-reviews-as-input-live-smoke-gate
+
+## Environment
+
+- Worktree: `/home/juan-canfield/Desktop/Atlas/worktrees/content-ops-live-adapter-smoke`
+- Database: `localhost:5433/atlas` as user `atlas`
+- Env files loaded: `/home/juan-canfield/Desktop/Atlas/.env`, `/home/juan-canfield/Desktop/Atlas/.env.local`
+- Local model fallback: `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false`
+- Configured model route: OpenRouter, `anthropic/claude-sonnet-4-5`
+- Primary smoke account: `2b2b950d-f64b-4852-bc30-f92a34cdf169`
+- Second tenant isolation account: `e955ae18-903f-4604-9112-40345a80efe1`
+
+## Migrations
+
+The configured Postgres initially had 8 pending Content Ops migrations:
+
+- `067_b2b_campaigns_updated_at.sql`
+- `328_ticket_faq_macro_writebacks.sql`
+- `329_ticket_faq_macro_writebacks_pending.sql`
+- `330_ticket_faq_macro_publish_attempts.sql`
+- `331_social_posts.sql`
+- `332_ad_copy_drafts.sql`
+- `333_quote_card_drafts.sql`
+- `334_stat_card_drafts.sql`
+
+Applied with the packaged `apply_content_pipeline_migrations(pool)` runner.
+Post-apply dry-run reported 0 pending migrations, 37 skipped already-applied
+migrations, and versions 331-334 recorded in
+`content_pipeline_schema_migrations`.
+
+## Blog Post LLM Smoke
+
+Command:
+
+```bash
+EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false \
+python scripts/smoke_content_ops_live_generation.py \
+  --output blog_post \
+  --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 \
+  --user-id 11111111-1111-4111-8111-111111111111 \
+  --support-ticket-csv extracted_content_pipeline/examples/support_ticket_saas_demo_sources.csv \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --export-saved-draft tmp/content_ops_live_adapter_smoke_20260604/blog-post-draft-uuid.json \
+  --output-result tmp/content_ops_live_adapter_smoke_20260604/blog-post-result-uuid.json \
+  --evaluate-generated-content \
+  --json
+```
+
+Observed:
+
+- Exit status: 0
+- Saved blog draft id: `9c2cdf6c-9fbf-42db-8af8-6a59e850cf16`
+- Seeded blueprint id: `0da54d85-706c-43e9-aa59-036b182b2d87`
+- Generated title: `Support-Ticket Questions Customers Keep Asking: 36 Tickets, 9 Clusters, 6 Draft FAQ Shells`
+- Draft status: `draft`
+- Model recorded in draft metadata: `anthropic/claude-sonnet-4-5`
+- Generated content evaluator: `ok=true`, `errors=[]`, 11/11 checks passed
+- Draft metadata usage: 18,577 input tokens, 5,455 output tokens, 8,783 cache write tokens, 9,788 cached tokens, 6 billable input tokens
+
+Durable `llm_usage` rows for the smoke account:
+
+| Provider | Model | Endpoint | Input | Output | Total | Cost USD | Status |
+|---|---|---|---:|---:|---:|---:|---|
+| openrouter | anthropic/claude-sonnet-4-5 | `https://openrouter.ai/api/v1/chat/completions` | 7,710 | 2,771 | 10,481 | 0.053591 | completed |
+| openrouter | anthropic/claude-sonnet-4-5 | `https://openrouter.ai/api/v1/chat/completions` | 10,867 | 2,684 | 13,551 | 0.064125 | completed |
+
+Totals: 18,577 input tokens, 5,455 output tokens, 24,032 total tokens,
+`0.117716` USD.
+
+## Stat Card Smoke
+
+Command:
+
+```bash
+EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false \
+python scripts/smoke_content_ops_live_generation.py \
+  --output stat_card \
+  --account-id 2b2b950d-f64b-4852-bc30-f92a34cdf169 \
+  --user-id 11111111-1111-4111-8111-111111111111 \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env \
+  --env-file /home/juan-canfield/Desktop/Atlas/.env.local \
+  --export-saved-draft tmp/content_ops_live_adapter_smoke_20260604/stat-card-draft.json \
+  --output-result tmp/content_ops_live_adapter_smoke_20260604/stat-card-result.json \
+  --json
+```
+
+Observed:
+
+- Exit status: 0
+- Saved stat-card id: `91e74867-12e1-4113-9bd7-9472eab1aa84`
+- Claim: `NPS score: 42`
+- Metric label/display: `NPS score` / `42`
+- Evidence: `NPS score dropped to 42 after renewal because customers could not find clear export and account-change answers.`
+- Exact saved-draft export returned one row and filtered to that saved id.
+
+## Review, Export, And Tenant Isolation
+
+Direct SQL confirmed:
+
+- Blog draft visible to account A: true
+- Blog draft visible to account B: false
+- Stat card visible to account A: true
+- Stat card visible to account B: false
+- Wrong-account stat-card status update command: `UPDATE 0`
+- Final stat-card status: `approved`
+
+The generated-assets FastAPI router was also exercised through ASGI with the
+real asyncpg pool:
+
+- Account B `POST /content-assets/stat_card/drafts/review` returned `updated=false`.
+- Account A `POST /content-assets/stat_card/drafts/review` rejected the row, then approved it again with `updated=true`.
+- Account A `GET /content-assets/stat_card/drafts?status=approved` returned the generated id.
+- Account A JSON export returned the generated id.
+- Account A HTML export returned `text/html; charset=utf-8`, filename `content_assets_stat_card.html`, and contained both `NPS score: 42` and the `visual-card stat-card` article.
+- Account B approved list returned count 0 and did not include the generated id.
+
+## Browser Rendering
+
+The stat-card HTML export was rendered through headless Chromium with
+Playwright and captured to:
+
+- `tmp/content_ops_live_adapter_smoke_20260604/stat-card-visual.html`
+- `tmp/content_ops_live_adapter_smoke_20260604/stat-card-visual.png`
+
+Observed:
+
+- PNG bytes: 44,166
+- PNG header: `89504e470d0a1a0a`
+- Rendered card count: 1
+- Browser page title: `Stat Cards Visual Export`
+- Visual inspection: card rendered coherently with metric `42`, claim
+  `NPS score: 42`, supporting text, evidence, source, and tag visible.
+
+## Local Checks
+
+```bash
+python -m pytest tests/test_smoke_content_ops_live_generation.py -q
+python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py
+git diff --check
+```
+
+Results:
+
+- `tests/test_smoke_content_ops_live_generation.py`: 38 passed
+- `py_compile`: passed
+- `git diff --check`: passed
+
+## Notes
+
+An initial blog-post smoke used a non-UUID account id and completed generation,
+but trace persistence warned because `llm_usage.account_id` is UUID-typed. The
+primary evidence above is the rerun with a real UUID account and clean durable
+trace rows.
+
+#1300 remains untouched and unmerged in this slice.

--- a/plans/PR-Content-Ops-Live-Adapter-Smoke.md
+++ b/plans/PR-Content-Ops-Live-Adapter-Smoke.md
@@ -1,0 +1,158 @@
+# PR: Content Ops Live Adapter Smoke
+
+## Why this slice exists
+
+Issue #1299 blocks more Content Ops surface until the product path is exercised
+against real adapters instead of mocks. PR #1302 closed the model-route
+precondition; the remaining work is the actual run: real Postgres with Content
+Ops migrations through 334, configured OpenRouter/Claude generation with local
+Ollama fallback disabled, tenant isolation proven with real queries, and real
+browser rendering for the card visual path before #1300 is unblocked.
+
+The existing `scripts/smoke_content_ops_live_generation.py` can run
+`blog_post`/`landing_page`, but it cannot produce/export `stat_card`, which is
+the deterministic card path named in #1299. This slice extends that existing
+harness just enough to cover `stat_card`, then records the live run.
+
+This PR is intentionally above the normal 400 LOC target. The implementation
+delta is small, but #1299 requires a committed live validation artifact with
+the real migration, LLM trace, tenant-isolation, route export, and browser
+rendering evidence before #1300 can be unblocked.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input-live-smoke-gate
+Slice phase: Functional validation
+
+1. Extend `scripts/smoke_content_ops_live_generation.py` to accept
+   `--output stat_card`, using source-material rows that contain numeric
+   evidence and exporting the exact saved stat-card draft rows for the smoke.
+2. Add focused tests for the stat-card smoke path, export filtering, and
+   unsupported saved-draft export behavior.
+3. Apply/run against real Content Ops migrations through 334 on the configured
+   local Postgres, then run one LLM output (`blog_post`) with
+   `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false` and one deterministic
+   output (`stat_card`) for a real account.
+4. Prove tenant isolation with real SQL queries for the generated rows using a
+   second account id.
+5. Render the stat-card visual export through real headless Chromium and save
+   the evidence in a dated validation document.
+6. Do not merge, update, or modify #1300. Its PNG endpoint remains held until
+   this validation lands. Do not touch #1268.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Live-Adapter-Smoke.md`
+- `scripts/smoke_content_ops_live_generation.py`
+- `tests/test_smoke_content_ops_live_generation.py`
+- `docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md`
+
+## Mechanism
+
+The smoke continues to call the existing host execution bundle:
+
+```python
+services = build_content_ops_execution_services(enable_db_services=True)
+await execute_content_ops_from_mapping(payload, services=services, scope=scope)
+```
+
+For `stat_card`, the harness supplies source rows with a supported numeric
+metric whose value appears in the evidence text, so
+`StatCardGenerationService` can persist a real `stat_card_drafts` row through
+`PostgresStatCardRepository`.
+
+Saved-draft export remains exact for the smoke: the helper reuses the existing
+stat-card repository/export path and filters to the `saved_ids` returned by the
+execution result. This is smoke-only validation; it does not add product API id
+filters for quote/stat cards, which were explicitly deferred in earlier plans.
+
+The live validation doc will include commands and observed results for:
+
+- migrations applied/skipped through `334_stat_card_drafts.sql`;
+- `blog_post` generated via configured OpenRouter/Claude with local Ollama
+  fallback disabled;
+- `stat_card` persisted/exported from real Postgres;
+- account A visible/account B invisible query checks;
+- real Chromium screenshot details for the generated card visual HTML.
+
+## Intentional
+
+- This PR does not change #1300's PNG endpoint. The browser proof is a live
+  validation artifact for the card visual path, not an implementation change to
+  the held PR.
+- The stat-card harness export filters by returned saved ids locally rather
+  than adding product-level id filters; quote/stat id filters remain deferred
+  until a UI/product path needs them.
+- The validation run uses the existing local configured Postgres and env files;
+  secrets are loaded but not printed.
+- The live run may create durable smoke rows for unique smoke account ids. The
+  validation doc records those ids; cleanup is not part of this slice unless a
+  run fails before evidence is captured.
+
+## Deferred
+
+- Merge/review #1300 after this live-adapter smoke lands and the operator
+  gives the review signal.
+- atlas-intel-ui `Export PNG` action remains deferred until the backend PNG
+  contract in #1300 is accepted.
+- Optional quote/stat product API id filters remain deferred.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+Ran:
+
+- `python -m pytest tests/test_smoke_content_ops_live_generation.py -q`
+  - 38 passed.
+- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py`
+  - passed.
+- `git diff --check`
+  - passed.
+- Real migration runner against configured Postgres:
+  - 8 pending migrations applied, including `334_stat_card_drafts.sql`.
+  - Post-apply dry-run reported 0 pending migrations and 37 skipped.
+- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_live_generation.py --output blog_post ... --evaluate-generated-content --json`
+  - saved `blog_posts.id=9c2cdf6c-9fbf-42db-8af8-6a59e850cf16`;
+  - generated via OpenRouter `anthropic/claude-sonnet-4-5`;
+  - generated-content evaluator returned `ok=true`, `errors=[]`, 11/11
+    checks passed;
+  - durable `llm_usage` rows recorded 18,577 input tokens, 5,455 output
+    tokens, and `0.117716` USD.
+- `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false python scripts/smoke_content_ops_live_generation.py --output stat_card ... --json`
+  - saved `stat_card_drafts.id=91e74867-12e1-4113-9bd7-9472eab1aa84`;
+  - exact saved-draft export returned `NPS score: 42`.
+- Real SQL tenant-isolation query:
+  - account A sees the generated blog/stat rows;
+  - account B sees neither;
+  - wrong-account status update returned `UPDATE 0`.
+- Generated-assets FastAPI router via ASGI against the real asyncpg pool:
+  - account B review returned `updated=false`;
+  - account A reject/approve returned `updated=true`;
+  - JSON and HTML export included the generated stat-card id.
+- Real Playwright/Chromium screenshot of the generated stat-card HTML visual
+  export:
+  - PNG bytes: 44,166; PNG header: `89504e470d0a1a0a`.
+
+Validation artifact:
+
+- `docs/extraction/validation/content_ops_live_adapter_smoke_2026-06-04.md`
+
+Still to run before push:
+
+- `bash scripts/local_pr_review.sh`
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan | 153 |
+| Smoke harness and focused tests | 201 |
+| Validation doc from actual run | 158 |
+| **Total** | **521** |
+
+The slice is slightly above the normal 400 LOC target because the committed
+validation artifact carries the live run evidence that #1299 requires before
+#1300 can be unblocked.

--- a/plans/PR-Content-Ops-Live-Adapter-Smoke.md
+++ b/plans/PR-Content-Ops-Live-Adapter-Smoke.md
@@ -106,7 +106,7 @@ None.
 Ran:
 
 - `python -m pytest tests/test_smoke_content_ops_live_generation.py -q`
-  - 38 passed.
+  - 39 passed.
 - `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py`
   - passed.
 - `git diff --check`
@@ -132,6 +132,9 @@ Ran:
   - account B review returned `updated=false`;
   - account A reject/approve returned `updated=true`;
   - JSON and HTML export included the generated stat-card id.
+- Review follow-up:
+  - stat-card saved-draft export now fails closed if the filtered export rows
+    omit any generated saved id.
 - Real Playwright/Chromium screenshot of the generated stat-card HTML visual
   export:
   - PNG bytes: 44,166; PNG header: `89504e470d0a1a0a`.
@@ -142,16 +145,16 @@ Validation artifact:
 
 Still to run before push:
 
-- `bash scripts/local_pr_review.sh`
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-live-adapter-smoke.md`
 
 ## Estimated diff size
 
 | Area | LOC |
 |---|---:|
-| Plan | 153 |
-| Smoke harness and focused tests | 201 |
-| Validation doc from actual run | 158 |
-| **Total** | **521** |
+| Plan | 161 |
+| Smoke harness and focused tests | 231 |
+| Validation doc from actual run | 162 |
+| **Total** | **554** |
 
 The slice is slightly above the normal 400 LOC target because the committed
 validation artifact carries the live run evidence that #1299 requires before

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -68,6 +68,20 @@ DEFAULT_BLOG_TOPIC = (
     "Support ticket FAQ gaps: what 90 days of repeat tickets reveal"
 )
 DEFAULT_BLOG_TOPIC_TYPE = "content_ops_live_smoke"
+DEFAULT_STAT_CARD_SOURCE_MATERIAL: tuple[Mapping[str, Any], ...] = (
+    {
+        "review_id": "content-ops-live-stat-1",
+        "source_type": "review",
+        "vendor": "Atlas Helpdesk",
+        "reviewer_company": "Northstar Support",
+        "review_text": (
+            "NPS score dropped to 42 after renewal because customers could "
+            "not find clear export and account-change answers."
+        ),
+        "nps_score": 42,
+        "pain_category": "self-serve documentation gaps",
+    },
+)
 DEFAULT_SUPPORT_TICKET_CSV = (
     ROOT / "extracted_content_pipeline" / "examples" / "support_ticket_sources.csv"
 )
@@ -101,7 +115,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--output",
-        choices=("landing_page", "blog_post"),
+        choices=("landing_page", "blog_post", "stat_card"),
         default="landing_page",
         help="Content Ops output to smoke-test. Defaults to landing_page.",
     )
@@ -181,8 +195,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--export-saved-draft",
         type=Path,
         help=(
-            "Write a JSON export of the exact saved landing_page/blog_post "
-            "draft ids produced by this smoke run."
+            "Write a JSON export of the exact saved landing_page/blog_post/"
+            "stat_card draft ids produced by this smoke run."
         ),
     )
     parser.add_argument(
@@ -248,6 +262,8 @@ def _payload_from_args(args: argparse.Namespace) -> dict[str, Any]:
             "topic": DEFAULT_BLOG_TOPIC,
             "filters": {"topic_type": DEFAULT_BLOG_TOPIC_TYPE},
         }
+    elif output == "stat_card":
+        inputs = {"source_material": [dict(row) for row in DEFAULT_STAT_CARD_SOURCE_MATERIAL]}
     else:  # argparse enforces this for CLI callers; keep injected tests honest.
         raise SystemExit(f"unsupported --output: {output}")
     if args.input_json:
@@ -390,7 +406,7 @@ async def _export_saved_drafts(
     saved_ids: Sequence[str],
     scope: Any,
 ) -> Mapping[str, Any]:
-    if output not in {"landing_page", "blog_post"}:
+    if output not in {"landing_page", "blog_post", "stat_card"}:
         raise ValueError(f"saved draft export is unsupported for output: {output}")
 
     from atlas_brain.storage.database import get_db_pool  # noqa: PLC0415
@@ -405,6 +421,12 @@ async def _export_saved_drafts(
     )
     from extracted_content_pipeline.landing_page_postgres import (  # noqa: PLC0415
         PostgresLandingPageRepository,
+    )
+    from extracted_content_pipeline.stat_card_export import (  # noqa: PLC0415
+        export_stat_card_drafts,
+    )
+    from extracted_content_pipeline.stat_card_postgres import (  # noqa: PLC0415
+        PostgresStatCardRepository,
     )
 
     pool = get_db_pool()
@@ -428,6 +450,35 @@ async def _export_saved_drafts(
                 limit=len(saved_ids),
             )
         ).as_dict()
+    if output == "stat_card":
+        export = await export_stat_card_drafts(
+            PostgresStatCardRepository(pool),
+            scope=scope,
+            status=None,
+            limit=max(100, len(saved_ids)),
+        )
+        return _filter_saved_draft_export_rows(export.as_dict(), saved_ids)
+
+
+def _filter_saved_draft_export_rows(
+    export: Mapping[str, Any],
+    saved_ids: Sequence[str],
+) -> dict[str, Any]:
+    wanted = {str(item).strip() for item in saved_ids if str(item).strip()}
+    rows = [
+        dict(row)
+        for row in _export_rows(export)
+        if str(row.get("id") or "").strip() in wanted
+    ]
+    filters = dict(_as_mapping(export.get("filters")))
+    if wanted:
+        filters["id"] = [item for item in saved_ids if str(item).strip()]
+    return {
+        **dict(export),
+        "count": len(rows),
+        "filters": filters,
+        "rows": rows,
+    }
 
 
 _LANDING_PAGE_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS = (
@@ -475,6 +526,8 @@ def _expected_support_ticket_export_context(
     output: str,
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
+    if output not in {"landing_page", "blog_post"}:
+        return {}
     inputs = _as_mapping(payload.get("inputs"))
     context_keys = (
         _BLOG_POST_SUPPORT_TICKET_EXPORT_CONTEXT_KEYS

--- a/scripts/smoke_content_ops_live_generation.py
+++ b/scripts/smoke_content_ops_live_generation.py
@@ -464,15 +464,25 @@ def _filter_saved_draft_export_rows(
     export: Mapping[str, Any],
     saved_ids: Sequence[str],
 ) -> dict[str, Any]:
-    wanted = {str(item).strip() for item in saved_ids if str(item).strip()}
+    wanted_ids = tuple(
+        dict.fromkeys(str(item).strip() for item in saved_ids if str(item).strip())
+    )
+    wanted = set(wanted_ids)
     rows = [
         dict(row)
         for row in _export_rows(export)
         if str(row.get("id") or "").strip() in wanted
     ]
+    exported = {str(row.get("id") or "").strip() for row in rows}
+    missing = [saved_id for saved_id in wanted_ids if saved_id not in exported]
+    if missing:
+        raise ValueError(
+            "saved draft export did not include generated "
+            f"saved_ids: {', '.join(missing)}"
+        )
     filters = dict(_as_mapping(export.get("filters")))
-    if wanted:
-        filters["id"] = [item for item in saved_ids if str(item).strip()]
+    if wanted_ids:
+        filters["id"] = list(wanted_ids)
     return {
         **dict(export),
         "count": len(rows),

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -1266,6 +1266,22 @@ def test_filter_saved_draft_export_rows_keeps_only_saved_ids() -> None:
     }
 
 
+def test_filter_saved_draft_export_rows_fails_when_saved_id_is_missing() -> None:
+    with pytest.raises(
+        ValueError,
+        match="saved draft export did not include generated saved_ids: stat-card-missing",
+    ):
+        smoke._filter_saved_draft_export_rows(
+            {
+                "count": 1,
+                "limit": 100,
+                "filters": {"account_id": "acct-live-smoke"},
+                "rows": [{"id": "stat-card-live-smoke-1", "claim": "NPS score: 42"}],
+            },
+            ("stat-card-live-smoke-1", "stat-card-missing"),
+        )
+
+
 def test_support_ticket_export_context_is_ignored_for_stat_card() -> None:
     assert smoke._support_ticket_export_context_errors(
         output="stat_card",

--- a/tests/test_smoke_content_ops_live_generation.py
+++ b/tests/test_smoke_content_ops_live_generation.py
@@ -78,6 +78,27 @@ class _BlogPostService:
         }
 
 
+class _StatCardService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        return {
+            "generated": 1,
+            "target_mode": kwargs["target_mode"],
+            "stats": [{
+                "id": "content-ops-live-stat-1",
+                "metric_label": "NPS score",
+                "metric_value": 42,
+                "metric_display": "42",
+                "claim": "NPS score: 42",
+            }],
+            "warnings": [],
+            "saved_ids": ["stat-card-live-smoke-1"],
+        }
+
+
 def _args(**overrides: Any) -> argparse.Namespace:
     values = {
         "output": "landing_page",
@@ -763,6 +784,94 @@ async def test_live_generation_smoke_seeds_and_executes_blog_post_through_real_e
 
 
 @pytest.mark.asyncio
+async def test_live_generation_smoke_executes_stat_card_through_real_executor() -> None:
+    lifecycle = _Lifecycle()
+    service = _StatCardService()
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(output="stat_card"),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(stat_card=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert result["configured_outputs"] == ["stat_card"]
+    assert result["execution"]["status"] == "completed"
+    assert result["execution"]["steps"][0]["result"]["saved_ids"] == [
+        "stat-card-live-smoke-1"
+    ]
+    assert lifecycle.initialized is True
+    assert lifecycle.closed is True
+    assert len(service.calls) == 1
+
+    call = service.calls[0]
+    assert call["scope"].account_id == "acct-live-smoke"
+    assert call["scope"].user_id == "user-live-smoke"
+    assert call["target_mode"] == "vendor_retention"
+    assert call["limit"] == 1
+    assert call["source_material"] == [
+        dict(smoke.DEFAULT_STAT_CARD_SOURCE_MATERIAL[0])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_generation_smoke_exports_exact_saved_stat_card_draft(
+    tmp_path: Path,
+) -> None:
+    lifecycle = _Lifecycle()
+    service = _StatCardService()
+    export_calls: list[dict[str, Any]] = []
+
+    async def _export_saved_draft(
+        output: str,
+        saved_ids,
+        scope: TenantScope,
+    ) -> dict[str, Any]:
+        export_calls.append({
+            "output": output,
+            "saved_ids": tuple(saved_ids),
+            "scope": scope,
+        })
+        return {
+            "count": 1,
+            "rows": [{"id": saved_ids[0], "claim": "NPS score: 42"}],
+        }
+
+    code, result = await smoke.run_content_ops_live_generation_smoke(
+        _args(
+            output="stat_card",
+            export_saved_draft=tmp_path / "stat-card-draft.json",
+        ),
+        init_database_fn=lifecycle.init,
+        close_database_fn=lifecycle.close,
+        services_factory=lambda: ContentOpsExecutionServices(stat_card=service),
+        executor=execute_content_ops_from_mapping,
+        tenant_scope_cls=TenantScope,
+        draft_export_fn=_export_saved_draft,
+    )
+
+    assert code == 0
+    assert result["ok"] is True
+    assert result["saved_draft_export"] == {
+        "count": 1,
+        "rows": [{"id": "stat-card-live-smoke-1", "claim": "NPS score: 42"}],
+    }
+    assert export_calls == [{
+        "output": "stat_card",
+        "saved_ids": ("stat-card-live-smoke-1",),
+        "scope": TenantScope(
+            account_id="acct-live-smoke",
+            user_id="user-live-smoke",
+        ),
+    }]
+
+
+@pytest.mark.asyncio
 async def test_live_generation_smoke_packages_support_ticket_csv_for_blog_post(
     tmp_path: Path,
 ) -> None:
@@ -1128,6 +1237,41 @@ def test_saved_ids_for_output_strips_and_preserves_multiple_ids() -> None:
         },
         "blog_post",
     ) == ("blog-1", "blog-2")
+
+
+def test_filter_saved_draft_export_rows_keeps_only_saved_ids() -> None:
+    assert smoke._filter_saved_draft_export_rows(
+        {
+            "count": 3,
+            "limit": 100,
+            "filters": {"account_id": "acct-live-smoke"},
+            "rows": [
+                {"id": "stat-card-other", "claim": "Other"},
+                {"id": "stat-card-live-smoke-1", "claim": "NPS score: 42"},
+                {"id": "stat-card-live-smoke-2", "claim": "CSAT score: 81"},
+            ],
+        },
+        ("stat-card-live-smoke-1", "stat-card-live-smoke-2"),
+    ) == {
+        "count": 2,
+        "limit": 100,
+        "filters": {
+            "account_id": "acct-live-smoke",
+            "id": ["stat-card-live-smoke-1", "stat-card-live-smoke-2"],
+        },
+        "rows": [
+            {"id": "stat-card-live-smoke-1", "claim": "NPS score: 42"},
+            {"id": "stat-card-live-smoke-2", "claim": "CSAT score: 81"},
+        ],
+    }
+
+
+def test_support_ticket_export_context_is_ignored_for_stat_card() -> None:
+    assert smoke._support_ticket_export_context_errors(
+        output="stat_card",
+        payload={"inputs": {"source_row_count": 2}},
+        saved_draft_export={"rows": []},
+    ) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Live-Adapter-Smoke.md
Ownership lane: content-ops/marketer-reviews-as-input-live-smoke-gate
Slice phase: Functional validation

Extends the live Content Ops smoke harness to cover the deterministic
`stat_card` path and records the actual live run required before #1300 is
unblocked: real Postgres migrations through 334, configured OpenRouter/Claude
generation with local Ollama fallback disabled, tenant isolation, generated
assets review/export routes, and real Chromium rendering evidence.

## Intentional

- This PR does not change #1300's PNG endpoint. The browser proof is a live
  validation artifact for the existing visual export path.
- The stat-card harness export filters by returned saved ids locally rather
  than adding product-level quote/stat id filters, and now fails closed if the
  filtered rows omit a generated saved id.
- The validation run uses the existing local configured Postgres and env files;
  secrets are loaded but not printed.

## Deferred

- Merge/review #1300 after this live-adapter smoke lands and the operator
  gives the review signal.
- atlas-intel-ui `Export PNG` action remains deferred until #1300's backend
  PNG contract is accepted.
- Optional quote/stat product API id filters remain deferred.

## Parked hardening

- None.

## Verification

- `python -m pytest tests/test_smoke_content_ops_live_generation.py -q` (39 passed)
- `python -m py_compile scripts/smoke_content_ops_live_generation.py tests/test_smoke_content_ops_live_generation.py`
- `git diff --check`
- Real Postgres migrations through 334 applied; post-apply dry-run reported 0 pending.
- OpenRouter `blog_post` live smoke with `EXTRACTED_CAMPAIGN_LLM_AUTO_ACTIVATE_OLLAMA=false`; evaluator returned `ok=true`, `errors=[]`, 11/11 checks passed.
- `stat_card` live smoke persisted/exported `91e74867-12e1-4113-9bd7-9472eab1aa84`.
- Real SQL and ASGI generated-assets route probe proved tenant isolation, review, JSON export, and HTML export.
- Review follow-up: stat-card saved-draft export now fails closed when a generated saved id is missing from the export rows.
- Real Playwright/Chromium stat-card visual PNG rendered.
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-live-adapter-smoke.md`

## Diff size

4 files, +550 / -4. This is above the normal 400 LOC target because the
committed validation artifact carries the live evidence required by #1299.
