### PR TITLE
Content Ops Card PNG Export UI

### DIFF
--- a/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs
@@ -24,6 +24,7 @@ async function loadTsModule(path, replacements = []) {
 
 const {
   exportGeneratedAssetDraftsHtml,
+  exportGeneratedAssetDraftsPng,
   fetchGeneratedAssetDrafts,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
@@ -82,6 +83,18 @@ function installTextFetchResponder(payload, status = 200) {
     return new Response(payload, {
       status,
       headers: { 'content-type': 'text/html' },
+    })
+  }
+  return calls
+}
+
+function installPngFetchResponder(payload = new Uint8Array([137, 80, 78, 71]), status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(payload, {
+      status,
+      headers: { 'content-type': 'image/png' },
     })
   }
   return calls
@@ -175,13 +188,36 @@ test('quote-card visual export fetches html from the typed content-assets route'
   assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
 })
 
+test('quote-card png export fetches binary image from the typed content-assets route', async () => {
+  const calls = installPngFetchResponder()
+
+  const result = await exportGeneratedAssetDraftsPng('quote_card', {
+    status: 'approved',
+    limit: 20,
+  })
+
+  assert.equal(result.type, 'image/png')
+  assert.equal(result.size, 4)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/quote_card/drafts/export?status=approved&limit=20&format=png`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
 test('asset review UI exposes quote-card tab and preview branches', () => {
   assert.ok(reviewSource.includes("id: 'quote_card'"))
   assert.ok(reviewSource.includes("label: 'Quote Cards'"))
   assert.ok(reviewSource.includes("asset === 'quote_card'"))
   assert.ok(reviewSource.includes('assetSupportsVisualExport(asset)'))
+  assert.ok(reviewSource.includes('Export PNG'))
   assert.ok(reviewSource.includes('Export HTML'))
+  assert.ok(reviewSource.includes('exportGeneratedAssetDraftsPng(asset, params)'))
   assert.ok(reviewSource.includes('exportGeneratedAssetDraftsHtml(asset, params)'))
+  assert.ok(reviewSource.includes('downloadBlob(png, `${asset}_visual_cards.png`)'))
   assert.ok(reviewSource.includes('textValue(row.quote)'))
   assert.ok(reviewSource.includes('textValue(row.supporting_text)'))
   assert.ok(reviewSource.includes('quoteCardPainPointCount(row)'))

--- a/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
+++ b/atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs
@@ -24,6 +24,7 @@ async function loadTsModule(path, replacements = []) {
 
 const {
   exportGeneratedAssetDraftsHtml,
+  exportGeneratedAssetDraftsPng,
   fetchGeneratedAssetDrafts,
   reviewGeneratedAssetDraft,
   reviewGeneratedAssetDrafts,
@@ -82,6 +83,18 @@ function installTextFetchResponder(payload, status = 200) {
     return new Response(payload, {
       status,
       headers: { 'content-type': 'text/html' },
+    })
+  }
+  return calls
+}
+
+function installPngFetchResponder(payload = new Uint8Array([137, 80, 78, 71]), status = 200) {
+  const calls = []
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    return new Response(payload, {
+      status,
+      headers: { 'content-type': 'image/png' },
     })
   }
   return calls
@@ -178,13 +191,36 @@ test('stat-card visual export fetches html from the typed content-assets route',
   assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
 })
 
+test('stat-card png export fetches binary image from the typed content-assets route', async () => {
+  const calls = installPngFetchResponder()
+
+  const result = await exportGeneratedAssetDraftsPng('stat_card', {
+    status: 'approved',
+    limit: 20,
+  })
+
+  assert.equal(result.type, 'image/png')
+  assert.equal(result.size, 4)
+  assert.equal(calls.length, 1)
+  const [{ url, init }] = calls
+  assert.equal(
+    url,
+    `${API_ORIGIN}/api/v1/content-assets/stat_card/drafts/export?status=approved&limit=20&format=png`,
+  )
+  assert.equal(init.method, undefined)
+  assert.deepEqual(init.headers, { Authorization: 'Bearer test-token' })
+})
+
 test('asset review UI exposes stat-card tab and preview branches', () => {
   assert.ok(reviewSource.includes("id: 'stat_card'"))
   assert.ok(reviewSource.includes("label: 'Stat Cards'"))
   assert.ok(reviewSource.includes("asset === 'stat_card'"))
   assert.ok(reviewSource.includes('assetSupportsVisualExport(asset)'))
+  assert.ok(reviewSource.includes('Export PNG'))
   assert.ok(reviewSource.includes('Export HTML'))
+  assert.ok(reviewSource.includes('exportGeneratedAssetDraftsPng(asset, params)'))
   assert.ok(reviewSource.includes('exportGeneratedAssetDraftsHtml(asset, params)'))
+  assert.ok(reviewSource.includes('downloadBlob(png, `${asset}_visual_cards.png`)'))
   assert.ok(reviewSource.includes('textValue(row.claim)'))
   assert.ok(reviewSource.includes('textValue(row.evidence)'))
   assert.ok(reviewSource.includes('statCardPainPointCount(row)'))

--- a/atlas-intel-ui/src/api/contentOps.ts
+++ b/atlas-intel-ui/src/api/contentOps.ts
@@ -890,6 +890,21 @@ async function getAssetText(
   return rawText(res)
 }
 
+async function getAssetBlob(
+  asset: GeneratedAssetType,
+  path: string,
+  params: GeneratedAssetListParams = {},
+): Promise<Blob> {
+  const url = `${ASSETS_BASE}/${asset}${path}${queryString(params)}`
+  const doFetch = () => fetchWithApiFallback(url, { headers: authHeaders() })
+  const res = await withRefreshOn401(doFetch)
+  if (!res.ok) {
+    const body = await rawText(res)
+    throw new Error(`API ${res.status}: ${body || res.statusText}`)
+  }
+  return res.blob()
+}
+
 async function getPublicAssetJson<T>(path: string): Promise<T> {
   const url = `${ASSETS_BASE}${path}`
   const res = await fetchWithApiFallback(url)
@@ -960,6 +975,14 @@ export function exportGeneratedAssetDraftsHtml(
   params: GeneratedAssetListParams = {},
 ): Promise<string> {
   return getAssetText(asset, '/drafts/export', { ...params, format: 'html' })
+}
+
+/** GET /content-assets/{asset}/drafts/export?format=png -- visual card screenshot. */
+export function exportGeneratedAssetDraftsPng(
+  asset: GeneratedAssetType,
+  params: GeneratedAssetListParams = {},
+): Promise<Blob> {
+  return getAssetBlob(asset, '/drafts/export', { ...params, format: 'png' })
 }
 
 /** POST /content-assets/{asset}/drafts/review -- approve/reject a draft. */

--- a/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
+++ b/atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx
@@ -29,6 +29,7 @@ import { clsx } from 'clsx'
 import {
   exportGeneratedAssetDraftsCsv,
   exportGeneratedAssetDraftsHtml,
+  exportGeneratedAssetDraftsPng,
   fetchGeneratedAssetDrafts,
   fetchGeneratedFaqMacroPublishAttempts,
   publishGeneratedFaqMacros,
@@ -398,6 +399,20 @@ export default function ContentOpsAssetsReview() {
     }
   }
 
+  const handlePngExport = async () => {
+    if (!assetSupportsVisualExport(asset)) return
+    setExporting(true)
+    setActionError(null)
+    try {
+      const png = await exportGeneratedAssetDraftsPng(asset, params)
+      downloadBlob(png, `${asset}_visual_cards.png`)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setExporting(false)
+    }
+  }
+
   const handleAssetChange = (nextAsset: GeneratedAssetType) => {
     setAsset(nextAsset)
     setSearchParams(
@@ -657,19 +672,34 @@ export default function ContentOpsAssetsReview() {
               Export CSV
             </button>
             {assetSupportsVisualExport(asset) && (
-              <button
-                type="button"
-                onClick={() => void handleVisualExport()}
-                disabled={exporting || loading}
-                className="inline-flex items-center gap-2 rounded-md border border-emerald-400/50 px-3 py-2 text-sm font-medium text-emerald-100 hover:bg-emerald-400/10 disabled:opacity-60"
-              >
-                {exporting ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Eye className="h-4 w-4" />
-                )}
-                Export HTML
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={() => void handlePngExport()}
+                  disabled={exporting || loading}
+                  className="inline-flex items-center gap-2 rounded-md bg-emerald-500 px-3 py-2 text-sm font-medium text-slate-950 hover:bg-emerald-400 disabled:opacity-60"
+                >
+                  {exporting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Download className="h-4 w-4" />
+                  )}
+                  Export PNG
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleVisualExport()}
+                  disabled={exporting || loading}
+                  className="inline-flex items-center gap-2 rounded-md border border-emerald-400/50 px-3 py-2 text-sm font-medium text-emerald-100 hover:bg-emerald-400/10 disabled:opacity-60"
+                >
+                  {exporting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                  Export HTML
+                </button>
+              </>
             )}
           </div>
         </div>
@@ -2768,6 +2798,10 @@ function excerpt(value: string, limit = 260): string {
 
 function downloadText(value: string, filename: string, type: string): void {
   const blob = new Blob([value], { type })
+  downloadBlob(blob, filename)
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = url

--- a/plans/PR-Content-Ops-Card-PNG-Export-UI.md
+++ b/plans/PR-Content-Ops-Card-PNG-Export-UI.md
@@ -1,0 +1,105 @@
+# PR: Content Ops Card PNG Export UI
+
+## Why this slice exists
+
+PR #1300 landed the backend `format=png` contract for quote/stat card visual
+exports after #1303 proved the live browser path. The remaining deferred
+product step is the atlas-intel-ui action that lets marketers download those
+PNG images from the generated-assets review page instead of stopping at CSV or
+HTML.
+
+This slice keeps the UI change narrow: wire the existing quote/stat card
+visual-export controls to the new PNG format, preserve the existing HTML export
+action for review/debugging, and prove both card types through the already
+enrolled frontend tests.
+
+## Scope (this PR)
+
+Ownership lane: content-ops/marketer-reviews-as-input-card-png-ui
+Slice phase: Product polish
+
+1. Add a typed frontend API helper for
+   `GET /content-assets/{asset}/drafts/export?format=png`.
+2. Add an `Export PNG` action on the generated-assets review toolbar for
+   `quote_card` and `stat_card`, reusing the same filters and busy/error state
+   as CSV/HTML exports.
+3. Keep `Export HTML` available for quote/stat cards as a review/debug artifact.
+4. Extend the existing quote-card and stat-card review-asset tests to cover the
+   PNG helper route and UI wiring.
+
+### Files touched
+
+- `plans/PR-Content-Ops-Card-PNG-Export-UI.md`
+- `atlas-intel-ui/src/api/contentOps.ts`
+- `atlas-intel-ui/src/pages/ContentOpsAssetsReview.tsx`
+- `atlas-intel-ui/scripts/content-ops-quote-card-review-assets.test.mjs`
+- `atlas-intel-ui/scripts/content-ops-stat-card-review-assets.test.mjs`
+
+## Mechanism
+
+`contentOps.ts` already has text helpers for CSV and HTML exports. This slice
+adds a binary helper that calls the same asset export route with `format=png`
+and returns a `Blob`:
+
+```ts
+exportGeneratedAssetDraftsPng(asset, params)
+```
+
+`ContentOpsAssetsReview` then calls that helper from a new `Export PNG` button
+shown only when `assetSupportsVisualExport(asset)` is true. The download uses
+the browser's object URL path and a `.png` filename, while errors continue to
+surface through the existing `actionError` banner.
+
+The test changes stay inside the already enrolled quote/stat card review-asset
+scripts. They assert that the API helper requests `format=png`, that the UI
+source imports/calls the PNG helper, and that the `Export PNG` control is
+present for the card assets.
+
+## Intentional
+
+- No backend changes; #1300 is the accepted PNG contract.
+- No new test script. The quote/stat review-asset tests are already listed in
+  `.github/workflows/atlas_intel_ui_checks.yml`, which avoids the frontend CI
+  enrollment gap.
+- No id-filter support for quote/stat exports; this continues the #1300
+  deferral.
+- No live browser rerun in this UI slice; #1303 already captured the live
+  Chromium proof and #1300 added the backend contract tests.
+
+## Deferred
+
+- Optional quote/stat id deep links remain deferred until a product path needs
+  exact run-result links.
+- Product copy/toolbar grouping polish can follow after the action is available
+  to operators.
+
+## Parked hardening
+
+None.
+
+## Verification
+
+Ran:
+
+- `cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets`
+  - 6 passed.
+- `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets`
+  - 6 passed.
+- `cd atlas-intel-ui && npm run build`
+  - passed; Vite built 2,418 modules, generated sitemap, and pre-rendered 16
+    public routes.
+- `git diff --check`
+  - passed.
+
+Still to run before push:
+
+- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-card-png-export-ui.md`
+
+## Estimated diff size
+
+| Area | LOC |
+|---|---:|
+| Plan | 105 |
+| API + UI | 83 |
+| Existing frontend tests | 72 |
+| **Total** | **260** |


### PR DESCRIPTION
Plan: plans/PR-Content-Ops-Card-PNG-Export-UI.md
Ownership lane: content-ops/marketer-reviews-as-input-card-png-ui
Slice phase: Product polish

Adds the atlas-intel-ui `Export PNG` action for quote-card and stat-card
generated assets now that #1300 landed the backend PNG contract and #1303
proved the live browser path.

## Intentional

- No backend changes; #1300 is the accepted PNG contract.
- No new frontend test script. The existing quote/stat review-asset tests are
  already enrolled in `.github/workflows/atlas_intel_ui_checks.yml`.
- No id-filter support for quote/stat exports.
- No live browser rerun in this UI slice; #1303 already captured the live
  Chromium proof.

## Deferred

- Optional quote/stat id deep links remain deferred until a product path needs
  exact run-result links.
- Product copy/toolbar grouping polish can follow after operators use the
  action.

## Parked hardening

- None.

## Verification

- `cd atlas-intel-ui && npm run test:content-ops-quote-card-review-assets` (6 passed)
- `cd atlas-intel-ui && npm run test:content-ops-stat-card-review-assets` (6 passed)
- `cd atlas-intel-ui && npm run build` (passed)
- `git diff --check`
- `bash scripts/local_pr_review.sh --current-pr-body-file tmp/pr-body-content-ops-card-png-export-ui.md`

## Diff size

5 files, +247 / -13
